### PR TITLE
[Playlists] Empty State

### DIFF
--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -234,12 +234,12 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
     private func addEmptyStateView() {
         let emptyState = EmptyStateView(
-            title: "Organize episodes your way",
-            message: "Playlists let you organize episodes manually or automatically with Smart Rules.",
+            title: L10n.playlistsEmptyStateTitle,
+            message: L10n.playlistsEmptyStateDescription,
             icon: { Image("filter_list") },
             actions: [
                 .init(
-                    title: "New Playlist",
+                    title: L10n.playlistsEmptyStateButton,
                     action: { [weak self] in
                         self?.addNewFilter()
                     })

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -24,7 +24,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         didSet {
             if FeatureFlag.playlistsRebranding.enabled {
                 DispatchQueue.main.async { [weak self] in
-                    self?.showEmptyStateIfNeeded()
+                    self?.refreshContentUnavailable()
                 }
             }
         }
@@ -56,7 +56,6 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     var newFilterTip: UIViewController? = nil
 
     private var firstTimeLoading = true
-    private var emptyStateView: UIView?
 
     lazy private var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
         let bannerType: InformationalBannerType = FeatureFlag.playlistsRebranding.enabled ? .playlists : .filters
@@ -69,12 +68,9 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         super.viewDidLoad()
 
         if FeatureFlag.playlistsRebranding.enabled {
-            addEmptyStateView()
             customRightBtn = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addNewFilter))
         } else {
             customRightBtn = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(editTapped))
-            self.emptyStateView?.removeFromSuperview()
-            self.emptyStateView = nil
         }
         customRightBtn?.accessibilityLabel = L10n.accessibilityMoreActions
 
@@ -113,7 +109,6 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         super.viewWillAppear(animated)
         reloadFilters()
         setupInformationalBanner()
-        removeEptyStateViewIfNeeded()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -232,46 +227,44 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         present(vc, animated: true)
     }
 
-    private func addEmptyStateView() {
-        let emptyState = EmptyStateView(
-            title: L10n.playlistsEmptyStateTitle,
-            message: L10n.playlistsEmptyStateDescription,
-            icon: { Image("filter_list") },
-            actions: [
+    private func refreshContentUnavailable() {
+        guard FeatureFlag.playlistsRebranding.enabled else {
+            set(configuration: nil)
+            return
+        }
+
+        customRightBtn?.isHidden = playlists.isEmpty
+
+        var config: UIContentConfiguration?
+
+        if playlists.isEmpty {
+            // Empty State when playlists is empty
+            let title = L10n.playlistsEmptyStateTitle
+            let message = L10n.playlistsEmptyStateDescription
+            config = ContentUnavailableConfiguration.emptyState(
+                title: title,
+                message: message,
+                icon: {
+                    Image("filter_list")
+                },
+                actions: [
                 .init(
                     title: L10n.playlistsEmptyStateButton,
                     action: { [weak self] in
-                        self?.addNewFilter()
-                    })
-            ],
-            style: .defaultStyle).themedUIView
-        emptyState.translatesAutoresizingMaskIntoConstraints = false
-        emptyState.isHidden = true
-        view.insertSubview(emptyState, belowSubview: filtersTable)
-        NSLayoutConstraint.activate([
-            emptyState.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            emptyState.topAnchor.constraint(equalTo: view.topAnchor, constant: 175),
-            emptyState.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            emptyState.trailingAnchor.constraint(equalTo: view.trailingAnchor)
-        ])
-        self.emptyStateView = emptyState
-    }
-
-    func removeEptyStateViewIfNeeded() {
-        if FeatureFlag.playlistsRebranding.enabled ||
-            emptyStateView == nil {
-            return
+                    self?.addNewFilter()
+                    }
+                )
+            ])
         }
-        emptyStateView?.removeFromSuperview()
-        emptyStateView = nil
-        customRightBtn?.isHidden = false
-        filtersTable.isHidden = false
+        set(configuration: config)
     }
 
-    private func showEmptyStateIfNeeded() {
-        filtersTable.isHidden = playlists.isEmpty
-        emptyStateView?.isHidden = !playlists.isEmpty
-        customRightBtn?.isHidden = playlists.isEmpty
+    private func set(configuration: UIContentConfiguration?) {
+        if #available(iOS 17.0, *) {
+            self.contentUnavailableConfiguration = configuration
+        } else {
+            self.setContentUnavailableConfiguration(configuration)
+        }
     }
 
     // MARK: - FilterCreationDelegate

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -20,10 +20,19 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         }
     }
 
-    var playlists = [EpisodeFilter]()
+    var playlists = [EpisodeFilter]() {
+        didSet {
+            if FeatureFlag.playlistsRebranding.enabled {
+                DispatchQueue.main.async { [weak self] in
+                    self?.showEmptyStateIfNeeded()
+                }
+            }
+        }
+    }
 
     var sourceIndexPath: IndexPath?
     var snapshot: UIView?
+
     @IBOutlet var footerView: ThemeableView! {
         didSet {
             footerView.style = .primaryUi04
@@ -47,6 +56,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     var newFilterTip: UIViewController? = nil
 
     private var firstTimeLoading = true
+    private var emptyStateView: UIView?
 
     lazy private var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
         let bannerType: InformationalBannerType = FeatureFlag.playlistsRebranding.enabled ? .playlists : .filters
@@ -59,9 +69,12 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         super.viewDidLoad()
 
         if FeatureFlag.playlistsRebranding.enabled {
+            addEmptyStateView()
             customRightBtn = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addNewFilter))
         } else {
             customRightBtn = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(editTapped))
+            self.emptyStateView?.removeFromSuperview()
+            self.emptyStateView = nil
         }
         customRightBtn?.accessibilityLabel = L10n.accessibilityMoreActions
 
@@ -100,6 +113,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         super.viewWillAppear(animated)
         reloadFilters()
         setupInformationalBanner()
+        removeEptyStateViewIfNeeded()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -153,6 +167,9 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         updateNavTintColors()
         newFilterButton.layer.borderColor = ThemeColor.primaryInteractive01().cgColor
         newFilterButton.titleLabel?.textColor = ThemeColor.primaryInteractive01()
+        if FeatureFlag.playlistsRebranding.enabled {
+            view.backgroundColor = ThemeColor.primaryUi01()
+        }
     }
 
     private func updateNavTintColors() {
@@ -213,6 +230,45 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
             )
         )
         present(vc, animated: true)
+    }
+
+    private func addEmptyStateView() {
+        let emptyState = EmptyStateView(
+            title: "Organize episodes your way",
+            message: "Playlists let you organize episodes manually or automatically with Smart Rules.",
+            icon: { Image("filter_list") },
+            actions: [
+                .init(
+                    title: "New Playlist",
+                    action: { [weak self] in
+                        self?.addNewFilter()
+                    })
+            ],
+            style: .defaultStyle).themedUIView
+        emptyState.translatesAutoresizingMaskIntoConstraints = false
+        emptyState.isHidden = true
+        view.insertSubview(emptyState, belowSubview: filtersTable)
+        NSLayoutConstraint.activate([
+            emptyState.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            emptyState.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            emptyState.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyState.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        self.emptyStateView = emptyState
+    }
+
+    func removeEptyStateViewIfNeeded() {
+        if FeatureFlag.playlistsRebranding.enabled ||
+            emptyStateView == nil {
+            return
+        }
+        emptyStateView?.removeFromSuperview()
+        emptyStateView = nil
+    }
+
+    private func showEmptyStateIfNeeded() {
+        filtersTable.isHidden = playlists.isEmpty
+        emptyStateView?.isHidden = !playlists.isEmpty
     }
 
     // MARK: - FilterCreationDelegate

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -264,11 +264,14 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         }
         emptyStateView?.removeFromSuperview()
         emptyStateView = nil
+        customRightBtn?.isHidden = false
+        filtersTable.isHidden = false
     }
 
     private func showEmptyStateIfNeeded() {
         filtersTable.isHidden = playlists.isEmpty
         emptyStateView?.isHidden = !playlists.isEmpty
+        customRightBtn?.isHidden = playlists.isEmpty
     }
 
     // MARK: - FilterCreationDelegate

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -168,7 +168,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         newFilterButton.layer.borderColor = ThemeColor.primaryInteractive01().cgColor
         newFilterButton.titleLabel?.textColor = ThemeColor.primaryInteractive01()
         if FeatureFlag.playlistsRebranding.enabled {
-            view.backgroundColor = ThemeColor.primaryUi01()
+            view.backgroundColor = ThemeColor.primaryUi04()
         }
     }
 
@@ -250,7 +250,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         view.insertSubview(emptyState, belowSubview: filtersTable)
         NSLayoutConstraint.activate([
             emptyState.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            emptyState.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            emptyState.topAnchor.constraint(equalTo: view.topAnchor, constant: 175),
             emptyState.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             emptyState.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2251,6 +2251,12 @@ internal enum L10n {
   internal static var playerUserEpisodeUploadError: String { return L10n.tr("Localizable", "player_user_episode_upload_error", fallback: "Upload Error") }
   /// A common string used throughout the app. Often refers to the Playlists screen.
   internal static var playlists: String { return L10n.tr("Localizable", "playlists", fallback: "Playlists") }
+  /// Playlists Empty State: button title for the empty state visible when no playlists are displayed
+  internal static var playlistsEmptyStateButton: String { return L10n.tr("Localizable", "playlists_empty_state_button", fallback: "New Playlist") }
+  /// Playlists Empty State: description for the empty state visible when no playlists are displayed
+  internal static var playlistsEmptyStateDescription: String { return L10n.tr("Localizable", "playlists_empty_state_description", fallback: "Playlists let you organize episodes manually or automatically with Smart Rules.") }
+  /// Playlists Empty State: title for the empty state visible when no playlists are displayed
+  internal static var playlistsEmptyStateTitle: String { return L10n.tr("Localizable", "playlists_empty_state_title", fallback: "Organize episodes your way") }
   /// Playlists Onboarding screen: description for the manual playlist card
   internal static var playlistsOnboardingManualDescription: String { return L10n.tr("Localizable", "playlists_onboarding_manual_description", fallback: "Want more control? Manual Playlists let you build custom queues, great for trips, themes, or just your current vibe. Whether Smart or Manual, playlists work the way you do.") }
   /// Playlists Onboarding screen: title for the manual playlist card

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5274,11 +5274,14 @@
 /* Playlists Onboarding screen: description for the manual playlist card */
 "playlists_onboarding_manual_description" = "Want more control? Manual Playlists let you build custom queues, great for trips, themes, or just your current vibe. Whether Smart or Manual, playlists work the way you do.";
 
-"playlists_empty_state_title" = "";
+/* Playlists Empty State: title for the empty state visible when no playlists are displayed */
+"playlists_empty_state_title" = "Organize episodes your way";
 
-"playlists_empty_state_description" = "";
+/* Playlists Empty State: description for the empty state visible when no playlists are displayed */
+"playlists_empty_state_description" = "Playlists let you organize episodes manually or automatically with Smart Rules.";
 
-"playlists_empty_state_button" = "";
+/* Playlists Empty State: button title for the empty state visible when no playlists are displayed */
+"playlists_empty_state_button" = "New Playlist";
 
 /* A title shown for the user satisfaction survey to ask whether a user enjoys the app */
 "user_satisfaction_survey_title" = "Enjoying Pocket Casts?";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5270,6 +5270,12 @@
 
 "playlists_onboarding_manual_description" = "Want more control? Manual Playlists let you build custom queues, great for trips, themes, or just your current vibe. Whether Smart or Manual, playlists work the way you do.";
 
+"playlists_empty_state_title" = "";
+
+"playlists_empty_state_description" = "";
+
+"playlists_empty_state_button" = "";
+
 /* A title shown for the user satisfaction survey to ask whether a user enjoys the app */
 "user_satisfaction_survey_title" = "Enjoying Pocket Casts?";
 


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-b287949437df/overview)
|:---:|

Fixes PCIOS-24

This PR introduces the Empty State showed when the playlists count is 0.

| Light | Dark |
| :-------: | :-------: |
| <img width="1179" height="2556" alt="IMG_0279" src="https://github.com/user-attachments/assets/ad83991a-b971-4847-8e2a-6ea513494122" /> | <img width="1179" height="2556" alt="IMG_0278" src="https://github.com/user-attachments/assets/3ddfe574-0a88-461a-bd4e-7d035d37b965" /> |


## To test

- Run this branch and make sure the `playlistsRebranding` FF is on
- Go to Playlists tab
- If Playlists are present, delete all
- Confirm you see the Empty State and the + button in the navigation bar is hidden
- Add a new Playlist
- Confirm the Empty State will be hidden and the + button is visible and functional 
- Switch off the FF and restart the app
- Make sure everything still work as before
- Deleting all filters should keep the table visible including the footer button

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
