### PR TITLE
Handle upsell deep link using subscriptionRequiredPage

### DIFF
--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -431,9 +431,10 @@ extension AppDelegate {
             return true
         }
 
-        JLRoutes.global().addRoute("/upsell") {[weak self] parameters -> Bool in
-            guard self != nil else { return false }
-            NavigationManager.sharedManager.navigateTo(NavigationManager.settingsPageKey, data: [NavigationManager.settingsRowKey: SettingsViewController.TableRow.pocketCastsPlus])
+        JLRoutes.global().addRoute("/upsell") { parameters -> Bool in
+            guard let viewController = SceneHelper.rootViewController() else { return false }
+            let source = PlusUpgradeViewSource(rawValue: ["source"] as? String ?? PlusUpgradeViewSource.deepLink.rawValue) ?? .unknown
+            NavigationManager.sharedManager.navigateTo(NavigationManager.subscriptionRequiredPageKey, data: ["source": source, NavigationManager.subscriptionUpgradeVCKey: viewController])
             return true
         }
     }

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -434,6 +434,7 @@ enum PlusUpgradeViewSource: String {
     case bookmarksShelfAction = "bookmarks_shelf_action"
     case whatsNew
     case sonosLink = "sonos_link"
+    case deepLink
 
     /// Converts the enum into a Firebase promotionId, this matches the values set on Android
     func promotionId() -> String {


### PR DESCRIPTION
Fixes an issue with opening `pktc://upsell` links to avoid switching to Settings before opening upsell.

We could also use the `showUpsellView` method instead of `navigateTo` + `subscriptionRequiredPageKey`. I wasn't 100% sure which one made the most sense but `navigateTo` seems more deeplinky to me.
```
NavigationManager.sharedManager.showUpsellView(from: viewController, source: .deepLink)
```

## To test

* Enable the `bannerAd` feature flag
* Restart the app
* Once the banner ad loads, tap it
* ✅ Verify that the upsell screen is shown
* Close the banner ad
* ✅ Verify that you are still in the tab you expect to be in (not Settings)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
