### PR TITLE
Add logging when we update schema version

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -14,6 +14,7 @@ class DatabaseHelper {
                 upgradeIfRequired(schemaVersion: &newSchemaVersion, db: db)
 
                 if newSchemaVersion != startingSchemaVersion {
+                    FileLog.shared.addMessage("Schema update from \(startingSchemaVersion) to \(newSchemaVersion)")
                     try db.executeUpdate("PRAGMA user_version = \(newSchemaVersion)", values: nil)
                 }
             } catch {


### PR DESCRIPTION
I recently ran into an issue where it seemed the schema version of my database had been updated but the relevant commands may not have run. While my logs went back to July 3rd, before this change should have occurred, there were no logs for Schema updates. We should log those to at least receive some information when the schema is updated.

## To test

This is just logging so doesn't need too much checking but you can do a fresh install to see if the upgrades run.


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
