### PR TITLE
[Banner Ads] Design Review tweaks

### DIFF
--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -91,8 +91,7 @@ struct BannerAdView: View {
 
             adContent()
         }
-
-        .padding(.vertical, 10)
+        .padding(.vertical, 4)
         .onAppear {
             AnalyticsHelper.bannerImpression(adID: model.adID, source: model.source)
         }
@@ -139,7 +138,7 @@ struct BannerAdView: View {
     }
 
     @ViewBuilder func text() -> some View {
-        VStack(alignment: .leading, spacing: 5) {
+        VStack(alignment: .leading) {
             Text(model.adText)
                 .font(size: 14, style: .subheadline, weight: .medium, maxSizeCategory: maxSizeCategory)
                 .lineSpacing(-1)
@@ -155,7 +154,7 @@ struct BannerAdView: View {
                     .padding(.horizontal, 3)
                     .padding(.vertical, 2)
                     .background(colors.adLabelBackground)
-                    .cornerRadius(4)
+                    .cornerRadius(2)
 
                 Text(model.titleLabel)
                     .font(size: 12, style: .footnote, weight: .semibold, maxSizeCategory: maxSizeCategory)

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -55,7 +55,7 @@ struct BannerAdView: View {
 
         static func podcastList(_ theme: Theme) -> Self {
             return Self(
-                background: theme.primaryUi06,
+                background: .clear,
                 adText: theme.primaryText01,
                 titleLabel: theme.primaryInteractive01,
                 adLabelBackground: theme.primaryInteractive01,

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -520,7 +520,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             UIApplication.shared.openSafariVCIfPossible(promotion.url)
         }
 
-        let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).padding(8)
+        let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).padding(EdgeInsets(top: 16, leading: 16, bottom: 24, trailing: 16))
         let hostingController = PCHostingController(rootView: AnyView(adView))
 
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -520,7 +520,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             UIApplication.shared.openSafariVCIfPossible(promotion.url)
         }
 
-        let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).padding(EdgeInsets(top: 16, leading: 16, bottom: 24, trailing: 16))
+        let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).padding(16)
         let hostingController = PCHostingController(rootView: AnyView(adView))
 
         hostingController.view.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Fixes a few padding and color issues with the banner.

| Before | After |
|--|--|
| <img width="300" alt="CleanShot 2025-07-30 at 18 13 02@2x" src="https://github.com/user-attachments/assets/a3dbd2f3-6d26-49dd-bc9e-0179d4014db6" /> | <img width="300" alt="Simulator Screenshot - iPhone 16 - 2025-07-30 at 13 31 39" src="https://github.com/user-attachments/assets/b0c98db7-a9b0-44d5-8180-8c67455f1340" /> |

| Before | After |
|--|--|
| <img width="300" alt="CleanShot 2025-07-30 at 18 13 41@2x" src="https://github.com/user-attachments/assets/ad5f4b5d-d8ef-4049-8ce3-1c77d56d80cd" /> | <img width="300" src="https://github.com/user-attachments/assets/8256e761-2e72-4434-a5d7-b07f43241b5b" /> | 

## To test

* Enable the `bannerAds` feature flag
* Restart the app
* Visit the Player
* ✅ Verify that the ad appears similar to the screenshot layout
* Visit the Podcast List
* ✅ Verify that the ad appears similar to the screenshot layout

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
