### PR TITLE
GRDB: add `read`/`write` methods to `UpNextChangesDataManager`

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UpNextChangesDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UpNextChangesDataManager.swift
@@ -14,7 +14,7 @@ class UpNextChangesDataManager {
 
     func findReplaceAction(dbQueue: PCDBQueue) -> UpNextChanges? {
         var replaceAction: UpNextChanges?
-        dbQueue.inDatabase { db in
+        dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT * from \(DataManager.upNextChangesTableName) WHERE type = ?", values: [UpNextChanges.Actions.replace.rawValue])
                 defer { resultSet.close() }
@@ -32,7 +32,7 @@ class UpNextChangesDataManager {
 
     func findUpdateActions(dbQueue: PCDBQueue) -> [UpNextChanges] {
         var allUpdateActions = [UpNextChanges]()
-        dbQueue.inDatabase { db in
+        dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT * from \(DataManager.upNextChangesTableName) WHERE type != ?", values: [UpNextChanges.Actions.replace.rawValue])
                 defer { resultSet.close() }
@@ -68,7 +68,7 @@ class UpNextChangesDataManager {
     }
 
     func saveReplace(episodeList: [String], dbQueue: PCDBQueue) {
-        dbQueue.inDatabase { db in
+        dbQueue.write { db in
             do {
                 // a replace literally replaces everything that came before it, so empty the table out
                 try db.executeUpdate("DELETE FROM \(DataManager.upNextChangesTableName)", values: nil)
@@ -86,7 +86,7 @@ class UpNextChangesDataManager {
     }
 
     private func saveUpdate(action: UpNextChanges.Actions, episodeUuid: String, dbQueue: PCDBQueue) {
-        dbQueue.inDatabase { db in
+        dbQueue.write { db in
             do {
                 // an update replaces any other update that is for the same episode, so delete any that might exist
                 try db.executeUpdate("DELETE FROM \(DataManager.upNextChangesTableName) WHERE uuid = ?", values: [episodeUuid])
@@ -106,7 +106,7 @@ class UpNextChangesDataManager {
     // MARK: - Delete
 
     func deleteChangesOlderThan(utcTime: Int64, dbQueue: PCDBQueue) {
-        dbQueue.inDatabase { db in
+        dbQueue.write { db in
             do {
                 try db.executeUpdate("DELETE FROM \(DataManager.upNextChangesTableName) where utcTime <= ?", values: [utcTime])
             } catch {


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Add `read`/`write` methods to `UpNextChangesDataManager `.

**Thoroughly** review the code, ensuring that write database operations use `write` and read operations use `read`. A write operation **should never** use `read`.

I've double checked all the changes with AI but a human review is always good to have. :)

## To test

1. Login with an account in the simulator and on the Web Player (using the browser)
2. Add/remove stuff from your Up Next in the Simulator
3. Go to Profile > Refresh Now
4. ✅ Refresh the web player, your Up Next should be correctly there
5. On the web player, add/remove/move stuff
6. Go to the simulator, tap "Refresh Now" under profile
7. ✅ Your Up Next should be correctly displayed
8. ✅ No errors should be displayed in the debugger console

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
