### PR TITLE
GRDB: add `read`/`write` methods to `AutoAddCandidatesDataManager `

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/AutoAddQueueDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/AutoAddQueueDataManager.swift
@@ -10,7 +10,7 @@ public struct AutoAddCandidatesDataManager {
 
     /// Adds a new auto add candidate to the database
     public func add(podcastUUID: String, episodeUUID: String) {
-        dbQueue.inDatabase { db in
+        dbQueue.write { db in
             do {
                 try db.executeUpdate("INSERT INTO \(Constants.tableName) (episode_uuid, podcast_uuid) VALUES (?, ?)", values: [episodeUUID, podcastUUID])
             } catch {
@@ -21,7 +21,7 @@ public struct AutoAddCandidatesDataManager {
 
     /// Removes a single candidate from the DB
     public func remove(_ candidate: AutoAddCandidate) {
-        dbQueue.inDatabase { db in
+        dbQueue.write { db in
             do {
                 try db.executeUpdate("""
                 DELETE FROM \(Constants.tableName) WHERE id = ? LIMIT 1
@@ -34,7 +34,7 @@ public struct AutoAddCandidatesDataManager {
 
     /// Reset the the entire candidates table
     public func clearAll() {
-        dbQueue.inDatabase { db in
+        dbQueue.write { db in
             do {
                 try db.executeUpdate("DELETE FROM \(Constants.tableName)", values: nil)
             } catch {
@@ -48,7 +48,7 @@ public struct AutoAddCandidatesDataManager {
     public func candidates() -> [AutoAddCandidate] {
         var results: [AutoAddCandidate] = []
 
-        dbQueue.inDatabase { db in
+        dbQueue.read { db in
             do {
 
                 let query: String


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Add `read`/`write` methods to `AutoAddCandidatesDataManager `.

**Thoroughly** review the code, ensuring that write database operations use `write` and read operations use `read`. A write operation **should never** use `read`.

I've double checked all the changes with AI but a human review is always good to have. :)

## To test

Testing this one requires fetching new episodes for existing podcasts, which is a bit tricky to reproduce without manipulating responses. Given the code changes are small, just thoroughly review them.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
