### PR TITLE
Limit playback position changes when switching episodes

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -221,6 +221,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Whether to use database concurrent reads or not
     case concurrentDatabaseReads
 
+    /// Limit playback position changes when switching episodes
+    case limitPlaybackPositionChanges
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -373,6 +376,8 @@ public enum FeatureFlag: String, CaseIterable {
             #else
             false
             #endif
+        case .limitPlaybackPositionChanges:
+            true
         }
     }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -74,6 +74,9 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     private(set) var transcriptsAvailable = false
 
+    /// The time the episode was last switched as tracked by handleCurrentlyPlayingEpisodeUpdated
+    private var episodeSwitchTime: Date?
+
     init() {
         queue = PlaybackQueue()
         queue.loadPersistedQueue()
@@ -93,6 +96,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(refreshRemoteCommands), name: Constants.Notifications.remoteCommandSettingsChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateNowPlayingInfo), name: Constants.Notifications.userEpisodeUpdated, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateAllNowPlayingData), name: .episodeEmbeddedArtworkLoaded, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleCurrentlyPlayingEpisodeUpdated), name: Constants.Notifications.currentlyPlayingEpisodeUpdated, object: nil)
 
         // run these on a background queue because some of them might call our singleton instance back, causing a crash because PlaybackManager.shared is called from the init method
         DispatchQueue.global().async {
@@ -1731,7 +1735,17 @@ class PlaybackManager: ServerPlaybackDelegate {
                     if Settings.legacyBluetoothModeEnabled(), seekEvent.positionTime < 1 {
                         FileLog.shared.addMessage("Remote control: ignoring changePlaybackPositionCommand, it's to 0 and legacy bluetooth mode is on")
                     } else {
-                        FileLog.shared.addMessage("Remote control: changePlaybackPositionCommand")
+                        FileLog.shared.addMessage("Remote control: changePlaybackPositionCommand to \(seekEvent.positionTime)")
+
+                        if FeatureFlag.limitPlaybackPositionChanges.enabled {
+                            // Check if we're still in the limiting window after an episode change
+                            if let switchTime = episodeSwitchTime,
+                               Date().timeIntervalSince(switchTime) < 2.0 {
+                                FileLog.shared.addMessage("Remote control: ignoring changePlaybackPositionCommand due to recent episode switch")
+                                return .commandFailed
+                            }
+                        }
+
                         seekTo(time: seekEvent.positionTime)
                     }
 
@@ -2053,6 +2067,13 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         // update the cached copy of the now playing episode so we have the latest version of it
         queue.nowPlayingEpisodeChanged()
+    }
+
+    @objc private func handleCurrentlyPlayingEpisodeUpdated() {
+        // Update episode switch time when the currently playing episode changes
+        if FeatureFlag.limitPlaybackPositionChanges.enabled {
+            episodeSwitchTime = Date()
+        }
     }
 
     // MARK: - Interruptions

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1740,7 +1740,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                         if FeatureFlag.limitPlaybackPositionChanges.enabled {
                             // Check if we're still in the limiting window after an episode change
                             if let switchTime = episodeSwitchTime,
-                               Date().timeIntervalSince(switchTime) < 2.0 {
+                               Date.now.timeIntervalSince(switchTime) < 2.0 {
                                 FileLog.shared.addMessage("Remote control: ignoring changePlaybackPositionCommand due to recent episode switch")
                                 return .commandFailed
                             }


### PR DESCRIPTION
Fixes #1359

When the changes position command from the lock screen happens while we are switching episodes, it seems that we sometimes run into race conditions where the episode is skipped. The remote command doesn't give us any info about the media item but we can track when the episode changes from our own internal notifications. For now, I've set a delay of 2 seconds since that seems like a reasonable amount of time where trying again would work.

The `limitPlaybackPositionChanges` flag controls these changes.

## To test

### Episode switching
* Load several episodes in your Up Next queue. Ideally these should be unplayed so they aren't pre-cached. Also, make sure you know the order so you know whether one is skipped.
* Play the first
* Scrub to the end of the episode
* ✅ Ensure the next episode from the queue is played
* Repeat scrubbing and skipping
* Try this with and without Trim Silence enabled

### Normal scrubbing
* Play an episode
* Scrub from the lock screen
* ✅ Ensure scrubbing works as expected and seeks to the proper position

One way you can tell this is being caught without checking the logs is that the scrub command may provide haptic feedback when it fails, this should mean the new code caught the case and, if you try again, scrubbing will work.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
