### PR TITLE
Header cell always have a minimum size of 44

### DIFF
--- a/podcasts/HeadingCell.xib
+++ b/podcasts/HeadingCell.xib
@@ -45,6 +45,9 @@
                                 </connections>
                             </button>
                         </subviews>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="44" id="rMW-Kn-y3c"/>
+                        </constraints>
                     </stackView>
                 </subviews>
                 <constraints>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes #3381 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR ensure that section header in episode list have a minimum 44 height so that the presence of the button does not make it without a margin

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-01 at 13 12 16" src="https://github.com/user-attachments/assets/ddc5a57b-002c-489f-842c-ed0a3031b30d" /> |  <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-01 at 13 40 39" src="https://github.com/user-attachments/assets/f89948dc-e74c-4314-8b10-6e628482658d" /> |

## To test

1. Start the app
2. Follow and open a Podcast without seasons. Ex: 99%invisible
3. Tap on ... Podcast options
4. Choose Group Episodes by Season
5. Check that the Extra section has enough padding to the separator line.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
