### PR TITLE
GRDB: add `read`/`write` methods to `BookmarkDataManager`

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/FMDatabaseQueue+Async.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/FMDatabaseQueue+Async.swift
@@ -16,7 +16,7 @@ extension PCDBQueue {
     ///
     func perform<T>(_ action: (PCDatabase) throws -> T) async -> Result<T, Error> {
         await withCheckedContinuation { continuation in
-            inDatabase { db in
+            write { db in
                 do {
                     continuation.resume(returning: .success(try action(db)))
                 } catch {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -28,7 +28,7 @@ public struct BookmarkDataManager {
     public func add(uuid: String? = nil, episodeUuid: String, podcastUuid: String?, title: String, time: TimeInterval, dateCreated: Date = Date(), syncStatus: SyncStatus = .notSynced) -> String? {
         var bookmarkUuid: String? = nil
 
-        dbQueue.inDatabase { db in
+        dbQueue.write { db in
             do {
                 let uuid = uuid ?? UUID().uuidString.lowercased()
                 let created = dateCreated.timeIntervalSince1970
@@ -130,7 +130,7 @@ public struct BookmarkDataManager {
         let query = "SELECT COUNT(*) FROM \(Self.tableName) WHERE \(whereString)"
 
         var count = 0
-        dbQueue.inDatabase { db in
+        dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: [episodeUuid])
                 resultSet.next()
@@ -204,7 +204,7 @@ public struct BookmarkDataManager {
             WHERE \(Column.uuid) IN (\(uuids))
             """
 
-            dbQueue.inDatabase { db in
+            dbQueue.write { db in
                 do {
                     try db.executeUpdate(query, values: nil)
                     continuation.resume(returning: true)
@@ -272,7 +272,7 @@ private extension BookmarkDataManager {
 
         var results: [Bookmark] = []
 
-        dbQueue.inDatabase { db in
+        dbQueue.read { db in
             do {
                 let query = """
                     SELECT \(selectColumns.columnString)


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Add `read`/`write` methods to `BookmarkDataManager `.

`BookmarksDataManager` is a bit different from the other `DataManager` — which is not a good thing IMHO. We'll end up with read stuff using `write` — which is fine. I don't think we should change the code in this PR though.

**Thoroughly** review the code, ensuring that write database operations use `write` and read operations use `read`. A write operation **should never** use `read`.

I've double checked all the changes with AI but a human review is always good to have. :)

## To test

1. Login to an account with Bookmarks
2. ✅ Check that they all appear correctly
3. Create/add/edit/remove bookmarks
4. ✅ It all should work correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
