### PR TITLE
GRDB: add `read`/`write` methods to `DataHelper`

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/DataHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/DataHelper.swift
@@ -12,7 +12,7 @@ class DataHelper {
     }
 
     class func run(query: String, values: [Any]?, methodName: String, onQueue: PCDBQueue) {
-        onQueue.inTransaction { db, _ in
+        onQueue.write { db in
             do {
                 try db.executeUpdate(query, values: values)
             } catch {


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Add `read`/`write` methods to `DataHelper `.

All calls to `DataHelper` do `write` operations as far as I can see, so I just renamed the method.

## To test

1. Code review is enough

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
