### PR TITLE
GRDB: remove remaining `inDatabase` calls

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -120,7 +120,7 @@ public class DataManager {
 
         FileLog.shared.addMessage("VACUUM -> Start")
         let duration =  DBUtils.measureTime {
-            dbQueue.inDatabase { db in
+            dbQueue.write { db in
                 do {
                     try db.executeUpdate("VACUUM;", values: nil)
                 } catch {
@@ -999,7 +999,7 @@ public class DataManager {
 
     public func count(query: String, values: [Any]?) -> Int {
         var count = 0
-        dbQueue.inDatabase { db in
+        dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: values)
                 if resultSet.next() {
@@ -1105,7 +1105,7 @@ public extension DataManager {
     }
 
     func deleteGhostsEpisodes(uuids: [String]) {
-        dbQueue.inDatabase { db in
+        dbQueue.write { db in
             let query = "DELETE FROM \(Self.episodeTableName) WHERE uuid IN (\(uuids.joined(separator: ",")))"
 
             try? db.executeUpdate(query, values: nil)

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -11,9 +11,9 @@ final class BookmarkDataManagerTests: XCTestCase {
         dbQueue = FMDBQueue(fmdbQueue: FMDatabaseQueue())
 
         // Create the schema
-        // the inDatabase call doesn't let you throw, so we'll track if there's an error here then pass it to the completion
+        // the write call doesn't let you throw, so we'll track if there's an error here then pass it to the completion
         var createError: Error? = nil
-        dbQueue.inDatabase { db in
+        dbQueue.write { db in
             do {
                 try BookmarkDataManager.createTable(in: db)
             } catch {


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Remove remaining calls to `inDatabase`.

## To test

1. Check that `write` was used for write operations and `read` for read operations

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
