### PR TITLE
Add options to "extra" season grouping

### DIFF
--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -46,9 +46,9 @@ class EpisodesDataManager {
         case .season:
             let groupedEpisodes = EpisodeTableHelper.loadSortedSectionedEpisodes(query: createEpisodesQuery(podcast, uuidsToFilter: uuidsToFilter), arguments: nil, sectionComparator: { name1, name2 -> Bool in
                 if sortOrder == .serial {
-                    if name2 == L10n.podcastNoSeason {
+                    if name2 == L10n.podcastExtras {
                         return true
-                    } else if name1 == L10n.podcastNoSeason {
+                    } else if name1 == L10n.podcastExtras {
                         return false
                     } else {
                         return name2.digits > name1.digits

--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -185,7 +185,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
             } else if let heading = itemAtRow as? ListHeader {
                 let cell = tableView.dequeueReusableCell(withIdentifier: PodcastViewController.groupHeadingCellId, for: indexPath) as! HeadingCell
                 cell.heading.text = heading.headerTitle
-                if heading.sectionNumber > 0 {
+                if podcast?.episodeGrouping == PodcastGrouping.season.rawValue {
                     cell.button.isHidden = false
                     cell.button.isEnabled = !isMultiSelectEnabled
                     cell.action = { [weak self] in

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2560,7 +2560,7 @@ internal enum L10n {
   /// Used to indicate no date was provided.
   internal static var podcastNoDate: String { return L10n.tr("Localizable", "podcast_no_date", fallback: "Date Not Set") }
   /// Label used to indicate that the podcast episode isn't grouped into a season.
-  internal static var podcastNoSeason: String { return L10n.tr("Localizable", "podcast_no_season", fallback: "Extras") }
+  internal static var podcastNoSeason: String { return L10n.tr("Localizable", "podcast_no_season", fallback: "No Season") }
   /// Accessibility label to prompt to pause an active download.
   internal static var podcastPauseDownload: String { return L10n.tr("Localizable", "podcast_pause_download", fallback: "Pause download") }
   /// Accessibility label to prompt to pause a playback.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1885,7 +1885,7 @@
 "podcast_no_date" = "Date Not Set";
 
 /* Label used to indicate that the podcast episode isn't grouped into a season. */
-"podcast_no_season" = "Extras";
+"podcast_no_season" = "No Season";
 
 /* Accessibility label to prompt to pause an active download. */
 "podcast_pause_download" = "Pause download";


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes # <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds the `...` More button to the `Extra` section when using Serial order and Grouping by Season

 
<img width="320" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-01 at 17 03 53" src="https://github.com/user-attachments/assets/1a59a9ee-489a-44bf-b215-27b4a1d396f6" />


## To test

1. Start the app
2. Open a podcast with Serial Support. Ex: White Vault
3. Follow it
4. Ensure you have Group by Season and Sort by Serial sort options in the podcast
5. Check if you see on the Extra season the ... button
6. Smoke test the option in the ... button

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
