### PR TITLE
[Banner Ads] Only show Banner Ads for non-subscribers

### DIFF
--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -246,7 +246,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     private func loadBannerAd() {
 #if !APPCLIP
-        if FeatureFlag.bannerAds.enabled {
+        if FeatureFlag.bannerAds.enabled && !SubscriptionHelper.hasActiveSubscription() {
             bannerTask = Task { [weak self] in
                 if let promotion = await DiscoverServerHandler.shared.blazePromotion(for: .player) {
                     guard Task.isCancelled == false else { return }

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -161,7 +161,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     }
 
     private func loadBannerAd() {
-        if FeatureFlag.bannerAds.enabled {
+        if FeatureFlag.bannerAds.enabled && !SubscriptionHelper.hasActiveSubscription() {
             bannerTask?.cancel()
             bannerTask = Task { [weak self] in
                 if let promotion = await DiscoverServerHandler.shared.blazePromotion(for: .podcastList) {


### PR DESCRIPTION
| 📘 Part of: [Banner Ads](https://linear.app/a8c/project/banner-ads-apps-620298d02a83/overview) |
|:---:|

I forgot to include this in the initial implementation. Since we could conceivably enable the flag remotely, it's probably best to include this as soon as possible.

## To test

### Free Account

* Use a non-plus account
* Enable the `bannerAds` feature flag
* Restart the app
* Navigate to the Podcasts
* ✅ Verify that the banner ad appears at the top
* Navigate to the Player
* ✅ Verify that the banner ad appears at the top
* Use a non-plus account

### Plus Accounts

* Navigate to the Podcasts
* ✅ Verify that the banner ad appears at the top
* Navigate to the Player
* ✅ Verify that the banner ad appears at the top

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
