### PR TITLE
Use episode artwork when sharing

### DIFF
--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -5,8 +5,9 @@ struct ShareImageInfo {
     let name: String
     let title: String
     let description: String
-    let artwork: URL
     let gradient: Gradient
+    let podcastUuid: String?
+    let episodeUuid: String?
 }
 
 enum ShareImageStyle: CaseIterable {
@@ -136,9 +137,17 @@ struct ShareImageView: View {
     }
 
     @ViewBuilder func image() -> some View {
-        KFImage(info.artwork)
-            .resizable()
-            .clipShape(RoundedRectangle(cornerRadius: 8))
+        if let episodeUuid = info.episodeUuid,
+           ImageManager.sharedManager.subscribedPodcastsCache.isCached(forKey: episodeUuid) {
+            let path = ImageManager.sharedManager.subscribedPodcastsCache.cachePath(forKey: episodeUuid)
+            KFImage(URL(fileURLWithPath: path))
+                .resizable()
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        } else if let podcastUuid = info.podcastUuid {
+            KFImage(ImageManager.sharedManager.podcastUrl(imageSize: .page, uuid: podcastUuid))
+                .resizable()
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
     }
 
     @ViewBuilder func text(alignment: HorizontalAlignment = .center, textAlignment: TextAlignment = .center, lineLimit: Int = 2) -> some View {
@@ -201,7 +210,7 @@ extension View {
         return itemProvider
     }
 }
-let previewInfo = ShareImageInfo(name: "This American Life", title: "Dylan Field, Figma Co-founder, Talks Design, Economy, and life after failed Adobe acquisitions", description: Date().formatted(), artwork: URL(string: "https://static.pocketcasts.com/discover/images/280/3782b780-0bc5-012e-fb02-00163e1b201c.jpg")!, gradient: Gradient(colors: [Color.red, Color(hex: "620603")]))
+let previewInfo = ShareImageInfo(name: "This American Life", title: "Dylan Field, Figma Co-founder, Talks Design, Economy, and life after failed Adobe acquisitions", description: Date().formatted(), gradient: Gradient(colors: [Color.red, Color(hex: "620603")]), podcastUuid: nil, episodeUuid: nil)
 
 #Preview("large") {
     ShareImageView(info: previewInfo, style: .large, angle: .constant(0))

--- a/podcasts/Sharing/ShareImageView.swift
+++ b/podcasts/Sharing/ShareImageView.swift
@@ -137,7 +137,8 @@ struct ShareImageView: View {
     }
 
     @ViewBuilder func image() -> some View {
-        if let episodeUuid = info.episodeUuid,
+        if Settings.loadEmbeddedImages,
+            let episodeUuid = info.episodeUuid,
            ImageManager.sharedManager.subscribedPodcastsCache.isCached(forKey: episodeUuid) {
             let path = ImageManager.sharedManager.subscribedPodcastsCache.cachePath(forKey: episodeUuid)
             KFImage(URL(fileURLWithPath: path))

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -1,6 +1,7 @@
 import PocketCastsDataModel
 import SwiftUI
 import PocketCastsUtils
+import AVFoundation
 
 enum SharingModal {
 
@@ -189,12 +190,12 @@ extension SharingModal.Option {
             Color(uiColor: ColorManager.lightThemeTintForPodcast(podcast)),
             Color(uiColor: UIColor.calculateColor(orgColor: UIColor.black, overlayColor: ColorManager.lightThemeTintForPodcast(podcast).withAlphaComponent(0.8))),
         ])
-        let artwork = ImageManager.sharedManager.podcastUrl(imageSize: .page, uuid: podcast.uuid)
         let imageInfo = ShareImageInfo(name: name ?? "",
                                        title: title ?? "",
                                        description: description ?? "",
-                                       artwork: artwork,
-                                       gradient: gradient)
+                                       gradient: gradient,
+                                       podcastUuid: podcast.uuid,
+                                       episodeUuid: episode?.uuid)
         return imageInfo
     }
 


### PR DESCRIPTION
Fixes [PCIOS-72](https://linear.app/a8c/issue/PCIOS-72/fix-sharing-episode-artwork)

| Before | After |
|--|--|
| <img width="300" src="https://github.com/user-attachments/assets/3881a8c0-032d-41e8-b4d9-90ceb2748c4d" /> | <img width="300" src="https://github.com/user-attachments/assets/71c2db85-0b50-40c7-a336-5d9a0d27d048" /> |

## To test

* Enable Settings > Appearance > "Use Episode Artwork"

### Currently Playing
* Play an episode with episode artwork. Like the most recent The Joe Rogan Experience episodes.
* Share the currently playing episode 
* Select the "Episode" share type
* Verify that the image shown is the episode and not podcast artwork

### Random Episode
* Navigate to an episode from the Podcast page
* Select the "Episode" share type
* Verify that the image shown is the episode and not podcast artwork

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
