### PR TITLE
[Playlists] Filters setting overlay

### DIFF
--- a/podcasts/DownloadFilterOverlayController.swift
+++ b/podcasts/DownloadFilterOverlayController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import PocketCastsUtils
 
 class DownloadFilterOverlayController: FilterSettingsOverlayController, UITableViewDataSource, UITableViewDelegate {
     private static let downloadCellId = "RadioButtonCellId"
@@ -28,6 +29,12 @@ class DownloadFilterOverlayController: FilterSettingsOverlayController, UITableV
         setCurrentDownloadStatus()
         navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
         addCloseButton()
+
+        if FeatureFlag.playlistsRebranding.enabled {
+            handleThemeChanged()
+
+            saveButton.setTitle(L10n.playlistSmartRuleSaveButton, for: .normal)
+        }
     }
 
     // MARK: - TableView DataSource
@@ -47,7 +54,13 @@ class DownloadFilterOverlayController: FilterSettingsOverlayController, UITableV
         cell.title.setLetterSpacing(-0.2)
         cell.setSelectState(selectedRow == row)
         let filterTintColor = filterToEdit.playlistColor()
-        cell.setTintColor(color: filterTintColor)
+        if FeatureFlag.playlistsRebranding.enabled {
+            cell.title.font = .systemFont(ofSize: 17, weight: .semibold)
+            cell.setTintColor(color: AppTheme.colorForStyle(.primaryInteractive01))
+        } else {
+            cell.title.font = .systemFont(ofSize: 16, weight: .medium)
+            cell.setTintColor(color: filterToEdit.playlistColor())
+        }
         cell.style = .primaryUi01
         cell.selectButton.tag = indexPath.row
         cell.selectButton.addTarget(self, action: #selector(selectButtonTapped), for: .touchUpInside)
@@ -60,7 +73,7 @@ class DownloadFilterOverlayController: FilterSettingsOverlayController, UITableV
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        51
+        FeatureFlag.playlistsRebranding.enabled ? 46 : 51
     }
 
     // MARK: - Helper functions
@@ -105,6 +118,15 @@ class DownloadFilterOverlayController: FilterSettingsOverlayController, UITableV
             return L10n.statusDownloaded
         case .notDownloaded:
             return L10n.statusNotDownloaded
+        }
+    }
+
+    override func handleThemeChanged() {
+        super.handleThemeChanged()
+
+        if FeatureFlag.playlistsRebranding.enabled {
+            saveButton.backgroundColor = AppTheme.colorForStyle(.primaryInteractive01)
+            changeNavTint(titleColor: nil, iconsColor: AppTheme.colorForStyle(.primaryIcon03))
         }
     }
 }

--- a/podcasts/EpisodeFilterOverlayController.swift
+++ b/podcasts/EpisodeFilterOverlayController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import PocketCastsUtils
 
 class EpisodeFilterOverlayController: FilterSettingsOverlayController, UITableViewDataSource, UITableViewDelegate {
     static let episodeCellId = "CheckboxCellId"
@@ -31,6 +32,12 @@ class EpisodeFilterOverlayController: FilterSettingsOverlayController, UITableVi
 
         navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
         addCloseButton()
+
+        if FeatureFlag.playlistsRebranding.enabled {
+            handleThemeChanged()
+
+            saveButton.setTitle(L10n.playlistSmartRuleSaveButton, for: .normal)
+        }
     }
 
     // MARK: - TableView DataSource
@@ -63,12 +70,18 @@ class EpisodeFilterOverlayController: FilterSettingsOverlayController, UITableVi
         cell.episodeTitle.setLetterSpacing(-0.2)
         cell.selectButton.tag = tableRow.rawValue
         cell.selectButton.addTarget(self, action: #selector(selectButtonTapped), for: .touchUpInside)
-        cell.filterColor = filterToEdit.playlistColor()
+        if FeatureFlag.playlistsRebranding.enabled {
+            cell.episodeTitle.font = .systemFont(ofSize: 18, weight: .semibold)
+            cell.filterColor = AppTheme.colorForStyle(.primaryInteractive01)
+        } else {
+            cell.episodeTitle.font = .systemFont(ofSize: 16, weight: .medium)
+            cell.filterColor = filterToEdit.playlistColor()
+        }
         return cell
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        51
+        FeatureFlag.playlistsRebranding.enabled ? 48 : 51
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -93,10 +106,18 @@ class EpisodeFilterOverlayController: FilterSettingsOverlayController, UITableVi
 
         if filterFinished || filterUnplayed || filterPartiallyPlayed {
             saveButton.isEnabled = true
-            saveButton.backgroundColor = filterToEdit.playlistColor()
+            if FeatureFlag.playlistsRebranding.enabled {
+                saveButton.alpha = 1
+            } else {
+                saveButton.backgroundColor = filterToEdit.playlistColor()
+            }
         } else {
             saveButton.isEnabled = false
-            saveButton.backgroundColor = AppTheme.disabledButtonColor()
+            if FeatureFlag.playlistsRebranding.enabled {
+                saveButton.alpha = 0.4
+            } else {
+                saveButton.backgroundColor = AppTheme.disabledButtonColor()
+            }
         }
         tableView.reloadData()
     }
@@ -113,5 +134,14 @@ class EpisodeFilterOverlayController: FilterSettingsOverlayController, UITableVi
         filterToEdit.filterPartiallyPlayed = filterPartiallyPlayed
 
         super.saveFilter()
+    }
+
+    override func handleThemeChanged() {
+        super.handleThemeChanged()
+
+        if FeatureFlag.playlistsRebranding.enabled {
+            saveButton.backgroundColor = AppTheme.colorForStyle(.primaryInteractive01)
+            changeNavTint(titleColor: nil, iconsColor: AppTheme.colorForStyle(.primaryIcon03))
+        }
     }
 }

--- a/podcasts/FilterDurationViewController.swift
+++ b/podcasts/FilterDurationViewController.swift
@@ -7,7 +7,51 @@ class FilterDurationViewController: PCViewController {
 
     @IBOutlet var longerThanLabel: ThemeableLabel! {
         didSet {
-            longerThanLabel.style = .primaryText02
+            if FeatureFlag.playlistsRebranding.enabled {
+                longerThanLabel.style = .primaryText02
+                longerThanLabel.font = .systemFont(ofSize: 15.0, weight: .medium)
+            } else {
+                longerThanLabel.style = .primaryText01
+                longerThanLabel.font = .systemFont(ofSize: 17.0, weight: .regular)
+            }
+        }
+    }
+
+    @IBOutlet var longerThanDescription: ThemeableLabel! {
+        didSet {
+            if FeatureFlag.playlistsRebranding.enabled {
+                longerThanDescription.style = .primaryText02
+                longerThanDescription.font = .systemFont(ofSize: 15.0, weight: .medium)
+            } else {
+                longerThanDescription.style = .primaryText01
+                longerThanDescription.font = .systemFont(ofSize: 17.0, weight: .regular)
+            }
+            longerThanDescription.text = L10n.filterLongerThanLabel
+        }
+    }
+
+    @IBOutlet var shorterThanLabel: ThemeableLabel! {
+        didSet {
+            if FeatureFlag.playlistsRebranding.enabled {
+                shorterThanLabel.style = .primaryText02
+                shorterThanLabel.font = .systemFont(ofSize: 15.0, weight: .medium)
+            } else {
+                shorterThanLabel.style = .primaryText01
+                shorterThanLabel.font = .systemFont(ofSize: 17.0, weight: .regular)
+            }
+        }
+    }
+
+    @IBOutlet var shorterThanDescription: ThemeableLabel! {
+        didSet {
+            if FeatureFlag.playlistsRebranding.enabled {
+                shorterThanDescription.style = .primaryText02
+                shorterThanDescription.font = .systemFont(ofSize: 15.0, weight: .medium)
+            } else {
+                shorterThanDescription.style = .primaryText01
+                shorterThanDescription.font = .systemFont(ofSize: 17.0, weight: .regular)
+            }
+            shorterThanDescription.text = L10n.filterShorterThanLabel
         }
     }
 
@@ -18,28 +62,10 @@ class FilterDurationViewController: PCViewController {
         }
     }
 
-    @IBOutlet var longerThanDescription: ThemeableLabel! {
-        didSet {
-            longerThanDescription.text = L10n.filterLongerThanLabel
-        }
-    }
-
-    @IBOutlet var shorterThanLabel: ThemeableLabel! {
-        didSet {
-            shorterThanLabel.style = .primaryText02
-        }
-    }
-
     @IBOutlet var shorterThanStepper: CustomTimeStepper! {
         didSet {
             shorterThanStepper.minimumValue = 5.minutes
             shorterThanStepper.maximumValue = 10.hours
-        }
-    }
-
-    @IBOutlet var shorterThanDescription: ThemeableLabel! {
-        didSet {
-            shorterThanDescription.text = L10n.filterShorterThanLabel
         }
     }
 
@@ -56,13 +82,48 @@ class FilterDurationViewController: PCViewController {
             saveBtn.backgroundColor = filter.playlistColor()
             saveBtn.layer.cornerRadius = 12
             saveBtn.setTitleColor(ThemeColor.primaryInteractive02(), for: .normal)
-            saveBtn.setTitle(L10n.filterUpdate, for: .normal)
+            if FeatureFlag.playlistsRebranding.enabled {
+                saveBtn.setTitle(L10n.playlistSmartRuleSaveButton, for: .normal)
+            } else {
+                saveBtn.setTitle(L10n.filterUpdate, for: .normal)
+            }
         }
     }
 
     @IBOutlet var filterDurationLabel: ThemeableLabel! {
         didSet {
+            if FeatureFlag.playlistsRebranding.enabled {
+                filterDurationLabel.font = .systemFont(ofSize: 18.0, weight: .semibold)
+            } else {
+                filterDurationLabel.font = .systemFont(ofSize: 18.0, weight: .regular)
+            }
             filterDurationLabel.text = L10n.episodeFilterByDurationLabel
+        }
+    }
+
+    @IBOutlet weak var dividerView: ThemeDividerView! {
+        didSet {
+            dividerView.isHidden = FeatureFlag.playlistsRebranding.enabled
+        }
+    }
+    @IBOutlet weak var dividerTopConstraint: NSLayoutConstraint! {
+        didSet {
+            dividerTopConstraint.constant = FeatureFlag.playlistsRebranding.enabled ? 16.0 : 20.0
+        }
+    }
+    @IBOutlet weak var dividerBottomConstraint: NSLayoutConstraint! {
+        didSet {
+            dividerBottomConstraint.constant = FeatureFlag.playlistsRebranding.enabled ? 16.0 : 20.0
+        }
+    }
+    @IBOutlet weak var linesSpacing: NSLayoutConstraint! {
+        didSet {
+            linesSpacing.constant = FeatureFlag.playlistsRebranding.enabled ? 30.0 : 36.0
+        }
+    }
+    @IBOutlet weak var topShadowView: TopShadowView! {
+        didSet {
+            topShadowView.hideShadow = FeatureFlag.playlistsRebranding.enabled
         }
     }
 
@@ -104,7 +165,13 @@ class FilterDurationViewController: PCViewController {
     override func handleThemeChanged() {
         setupNavigationBar()
 
-        let playlistColor = filter.playlistColor()
+        let playlistColor: UIColor
+        if FeatureFlag.playlistsRebranding.enabled {
+            playlistColor = AppTheme.colorForStyle(.primaryInteractive01)
+        } else {
+            playlistColor = filter.playlistColor()
+        }
+
         saveBtn.backgroundColor = playlistColor
         filterSwitch.onTintColor = playlistColor
         shorterThanStepper.tintColor = playlistColor
@@ -113,7 +180,11 @@ class FilterDurationViewController: PCViewController {
 
     private func setupNavigationBar() {
         title = L10n.filterOptionEpisodeDuration
-        changeNavTint(titleColor: nil, iconsColor: ThemeColor.primaryIcon02())
+        if FeatureFlag.playlistsRebranding.enabled {
+            changeNavTint(titleColor: nil, iconsColor: AppTheme.colorForStyle(.primaryIcon03))
+        } else {
+            changeNavTint(titleColor: nil, iconsColor: AppTheme.colorForStyle(.primaryIcon02))
+        }
 
         let navigationBar = navigationController?.navigationBar
         navigationBar?.prefersLargeTitles = true

--- a/podcasts/FilterDurationViewController.xib
+++ b/podcasts/FilterDurationViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,9 +11,13 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="FilterDurationViewController" customModule="podcasts" customModuleProvider="target">
             <connections>
+                <outlet property="dividerBottomConstraint" destination="Q96-QQ-X6m" id="LhR-0m-g4J"/>
+                <outlet property="dividerTopConstraint" destination="wyC-Yi-UN6" id="t8I-9J-IFp"/>
+                <outlet property="dividerView" destination="qmv-fg-ZEx" id="kmJ-tx-3zf"/>
                 <outlet property="durationConfigView" destination="e89-rD-l86" id="feg-cP-tu6"/>
                 <outlet property="filterDurationLabel" destination="ZaL-Yo-lbb" id="f8I-N1-zEx"/>
                 <outlet property="filterSwitch" destination="Rrc-db-3fy" id="jVl-GT-FyI"/>
+                <outlet property="linesSpacing" destination="IyF-fn-FAq" id="FPD-0r-JP7"/>
                 <outlet property="longerThanDescription" destination="8XS-u3-vvZ" id="7gX-pw-Wj7"/>
                 <outlet property="longerThanLabel" destination="ZUI-Nj-eNz" id="BC3-hK-RD6"/>
                 <outlet property="longerThanStepper" destination="vBK-gb-mUn" id="1gG-Vs-1na"/>
@@ -21,6 +25,7 @@
                 <outlet property="shorterThanDescription" destination="3gv-4P-y7p" id="jqZ-Zt-3fP"/>
                 <outlet property="shorterThanLabel" destination="CTM-qF-WZF" id="fHL-eM-EXj"/>
                 <outlet property="shorterThanStepper" destination="cuO-fW-Vwb" id="y24-fc-fDQ"/>
+                <outlet property="topShadowView" destination="g9i-cH-zil" id="Rbq-lq-sLd"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -33,26 +38,26 @@
                     <rect key="frame" x="0.0" y="0.0" width="414" height="791"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Filter by duration" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZaL-Yo-lbb" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="18" y="72" width="135.5" height="22"/>
+                            <rect key="frame" x="18" y="124" width="135.5" height="22"/>
                             <fontDescription key="fontDescription" type="system" pointSize="18"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Rrc-db-3fy" customClass="ThemeableSwitch" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="347" y="67.5" width="51" height="31"/>
+                            <rect key="frame" x="347" y="119.5" width="51" height="31"/>
                             <connections>
                                 <action selector="filterSwitchChanged:" destination="-1" eventType="valueChanged" id="vGZ-YO-bDs"/>
                             </connections>
                         </switch>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qmv-fg-ZEx" customClass="ThemeDividerView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="114" width="414" height="1"/>
+                            <rect key="frame" x="0.0" y="166" width="414" height="1"/>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="jdl-nw-jjC"/>
                             </constraints>
                         </view>
                         <view alpha="0.40000000000000002" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e89-rD-l86">
-                            <rect key="frame" x="0.0" y="125" width="414" height="128"/>
+                            <rect key="frame" x="0.0" y="177" width="414" height="128"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Longer than" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8XS-u3-vvZ" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                     <rect key="frame" x="18" y="20" width="92" height="20.5"/>

--- a/podcasts/MediaFilterOverlayController.swift
+++ b/podcasts/MediaFilterOverlayController.swift
@@ -1,4 +1,5 @@
 import PocketCastsDataModel
+import PocketCastsUtils
 import UIKit
 
 extension AudioVideoFilter {
@@ -40,6 +41,12 @@ class MediaFilterOverlayController: FilterSettingsOverlayController, UITableView
         navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
         addCloseButton()
         addTableViewHeader()
+
+        if FeatureFlag.playlistsRebranding.enabled {
+            handleThemeChanged()
+
+            saveButton.setTitle(L10n.playlistSmartRuleSaveButton, for: .normal)
+        }
     }
 
     // MARK: - TableView DataSource
@@ -58,8 +65,13 @@ class MediaFilterOverlayController: FilterSettingsOverlayController, UITableView
         cell.title.setLetterSpacing(-0.2)
         cell.style = .primaryUi01
         cell.setSelectState(selectedIndex == indexPath.row)
-        let filterTintColor = filterToEdit.playlistColor()
-        cell.setTintColor(color: filterTintColor)
+        if FeatureFlag.playlistsRebranding.enabled {
+            cell.title.font = .systemFont(ofSize: 17, weight: .semibold)
+            cell.setTintColor(color: AppTheme.colorForStyle(.primaryInteractive01))
+        } else {
+            cell.title.font = .systemFont(ofSize: 16, weight: .medium)
+            cell.setTintColor(color: filterToEdit.playlistColor())
+        }
         cell.selectButton.tag = indexPath.row
         cell.selectButton.addTarget(self, action: #selector(selectButtonTapped), for: .touchUpInside)
         return cell
@@ -71,7 +83,7 @@ class MediaFilterOverlayController: FilterSettingsOverlayController, UITableView
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        51
+        FeatureFlag.playlistsRebranding.enabled ? 46 : 51
     }
 
     // MARK: - Helper functions
@@ -86,5 +98,14 @@ class MediaFilterOverlayController: FilterSettingsOverlayController, UITableView
 
         selectedIndex = buttonTag
         tableView.reloadData()
+    }
+
+    override func handleThemeChanged() {
+        super.handleThemeChanged()
+
+        if FeatureFlag.playlistsRebranding.enabled {
+            saveButton.backgroundColor = AppTheme.colorForStyle(.primaryInteractive01)
+            changeNavTint(titleColor: nil, iconsColor: AppTheme.colorForStyle(.primaryIcon03))
+        }
     }
 }

--- a/podcasts/ReleaseDateFilterOverlayController.swift
+++ b/podcasts/ReleaseDateFilterOverlayController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import PocketCastsUtils
 
 enum ReleaseDateFilterOption: Int32, AnalyticsDescribable {
     case anytime = 0
@@ -63,6 +64,13 @@ class ReleaseDateFilterOverlayController: FilterSettingsOverlayController, UITab
 
         setCurrentReleaseDate()
         setupLargeTitle()
+
+        if FeatureFlag.playlistsRebranding.enabled {
+            handleThemeChanged()
+
+            saveButton.setTitle(L10n.playlistSmartRuleSaveButton, for: .normal)
+        }
+
         title = L10n.filterReleaseDate
         tableView.contentInsetAdjustmentBehavior = .never
 
@@ -87,8 +95,13 @@ class ReleaseDateFilterOverlayController: FilterSettingsOverlayController, UITab
         cell.title.setLetterSpacing(-0.2)
         cell.style = .primaryUi01
         cell.setSelectState(selectedIndex == indexPath.row)
-        let filterTintColor = filterToEdit.playlistColor()
-        cell.setTintColor(color: filterTintColor)
+        if FeatureFlag.playlistsRebranding.enabled {
+            cell.title.font = .systemFont(ofSize: 17, weight: .semibold)
+            cell.setTintColor(color: AppTheme.colorForStyle(.primaryInteractive01))
+        } else {
+            cell.title.font = .systemFont(ofSize: 16, weight: .medium)
+            cell.setTintColor(color: filterToEdit.playlistColor())
+        }
         cell.selectButton.tag = indexPath.row
         cell.selectButton.addTarget(self, action: #selector(selectButtonTapped), for: .touchUpInside)
         return cell
@@ -100,7 +113,7 @@ class ReleaseDateFilterOverlayController: FilterSettingsOverlayController, UITab
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        51
+        FeatureFlag.playlistsRebranding.enabled ? 46 : 51
     }
 
     // MARK: - Helper functions
@@ -124,5 +137,14 @@ class ReleaseDateFilterOverlayController: FilterSettingsOverlayController, UITab
 
         selectedIndex = buttonTag
         tableView.reloadData()
+    }
+
+    override func handleThemeChanged() {
+        super.handleThemeChanged()
+
+        if FeatureFlag.playlistsRebranding.enabled {
+            saveButton.backgroundColor = AppTheme.colorForStyle(.primaryInteractive01)
+            changeNavTint(titleColor: nil, iconsColor: AppTheme.colorForStyle(.primaryIcon03))
+        }
     }
 }


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-b287949437df/view/ios-tasks-8039e91058ba?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-50
Fixes PCIOS-51
Fixes PCIOS-47
Fixes PCIOS-48

This PR updates the following screens:
• Episode Status
• Release Date
• Download Status
• Media Type

| Episode Status | Release Date | Download Status | Media Type |
| :-------: | :-------: | :-------: | :-------: |
| <img width="1179" height="2556" alt="IMG_0286" src="https://github.com/user-attachments/assets/6a1c6d05-f536-4306-ac40-7fa8303f1091" /> | <img width="1179" height="2556" alt="IMG_0288" src="https://github.com/user-attachments/assets/1f8c8561-773d-431f-a7a7-2e9ae97e46ba" /> | <img width="1179" height="2556" alt="IMG_0287" src="https://github.com/user-attachments/assets/82c31cf3-c2dc-4523-960b-2863e9605b4b" /> | <img width="1179" height="2556" alt="IMG_0289" src="https://github.com/user-attachments/assets/a105737d-bd07-4733-a70d-07e744278b4e" /> |

## To test

- Make sure the playlist rebranding FF is on
- Go to Playlists
- Add a new filter
- Tap on the following rules:
  - Episode Status
  - Release Date
  - Download Status
  - Media Type
- Confirm the design matches the screenshot
- Confirm the functionality still work
- Switch off the FF and test everything still work

**Note: I didn't change the presentation style here as it will be changed in a separate PR**

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
