### PR TITLE
GRDB: guard against ghost episodes

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBResultSet.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBResultSet.swift
@@ -57,7 +57,7 @@ class GRDBResultSet: PCDBResultSet {
     }
 
     func longLongInt(forColumn: String) -> Int64 {
-        row[forColumn]
+        row[forColumn] ?? 0
     }
 
     func bool(forColumn: String) -> Bool {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -199,8 +199,9 @@ class EpisodeDataManager {
                 defer { resultSet.close() }
 
                 while resultSet.next() {
-                    let episode = self.createEpisodeFrom(resultSet: resultSet)
-                    episodes.append(episode)
+                    if let episode = self.createEpisodeFrom(resultSet: resultSet) {
+                        episodes.append(episode)
+                    }
                 }
             } catch {
                 FileLog.shared.addMessage("EpisodeDataManager.loadMultiple Episode error: \(error)")
@@ -1004,7 +1005,7 @@ class EpisodeDataManager {
 
     // MARK: - Conversion
 
-    private func createEpisodeFrom(resultSet rs: PCDBResultSet) -> Episode {
+    private func createEpisodeFrom(resultSet rs: PCDBResultSet) -> Episode? {
         Episode.from(resultSet: rs)
     }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode+fromDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode+fromDatabase.swift
@@ -2,7 +2,11 @@ import Foundation
 import FMDB
 
 extension Episode {
-    static func from(resultSet rs: PCDBResultSet) -> Episode {
+    static func from(resultSet rs: PCDBResultSet) -> Episode? {
+        guard rs.longLongInt(forColumn: "id") != 0 else {
+            return nil
+        }
+
         let episode = Episode()
         episode.id = rs.longLongInt(forColumn: "id")
         episode.addedDate = DBUtils.convertDate(value: rs.double(forColumn: "addedDate"))


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

After we released GRDB we had a change in the way we convert database results into models. With `FMDB` if any row had a `NULL` value it would return something: `0`, an empty string `""`, etc.

`GRDB` is not lenient about this and it crashes — as it should.

One of the ~16 users affected contacted us and I could check that their database is corrupted. Specifically the episode index. This makes some queries to return "ghost episodes": episodes with all columns with `NULL` values.

This is a workaround solution: for episodes, we check if their `id` is valid, and if not we just don't return and don't parse them. This doesn't fix the underlying issue that is a user with a corrupted database, the other approach would be to delete their database — but that would cause data loss as some settings are saved there.

Copying database data to a non-corrupted database would be a proper solution but it's way more complex and I think it goes beyond of the scope of the GRDB migration — as GRDB is not the culprit here at all.

## To test

1. ✅  Run the app and check that episodes appear correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
