### PR TITLE
Fix database export when using GRDB

### DIFF
--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -44,8 +44,8 @@ extension AppDelegate {
                 let alert = UIAlertController(title: "Import Podcasts and Settings", message: "Do you want to reset your podcasts and settings to this file?", preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: "Import", style: .default) { _ in
                     Task {
-                        let fileWrapper = try FileWrapper(url: url)
                         do {
+                            let fileWrapper = try FileWrapper(url: url)
                             try PCBundleDoc.performImport(from: fileWrapper)
                         } catch {
                             FileLog.shared.addMessage("File Import failed with error \(error)")

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -45,7 +45,11 @@ extension AppDelegate {
                 alert.addAction(UIAlertAction(title: "Import", style: .default) { _ in
                     Task {
                         let fileWrapper = try FileWrapper(url: url)
-                        try PCBundleDoc.performImport(from: fileWrapper)
+                        do {
+                            try PCBundleDoc.performImport(from: fileWrapper)
+                        } catch {
+                            FileLog.shared.addMessage("File Import failed with error \(error)")
+                        }
                     }
                 })
                 alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))

--- a/podcasts/PCBundleDoc.swift
+++ b/podcasts/PCBundleDoc.swift
@@ -10,7 +10,7 @@ struct PCBundleDoc: FileDocument {
     static var readableContentTypes = [UTType.pcasts]
 
     enum Constants {
-        static let databaseFilename = "database.sqlite"
+        static let databaseFilename = "database.sqlite3"
         static let preferencesFilename = "preferences.plist"
     }
 

--- a/podcasts/PCBundleDoc.swift
+++ b/podcasts/PCBundleDoc.swift
@@ -11,6 +11,7 @@ struct PCBundleDoc: FileDocument {
 
     enum Constants {
         static let databaseFilename = "database.sqlite3"
+        static var databaseWalSuffix = "-wal"
         static let preferencesFilename = "preferences.plist"
     }
 
@@ -29,6 +30,11 @@ struct PCBundleDoc: FileDocument {
         let databaseDestination = FileManager.databaseURL
         if let database = wrapper.fileWrappers?.first(where: { $0.key == Constants.databaseFilename }) {
             try database.value.write(to: databaseDestination, originalContentsURL: nil)
+        }
+
+        let databaseWALDestination = URL(fileURLWithPath: DataManager.pathToDb().appending("-wal"))
+        if let database = wrapper.fileWrappers?.first(where: { $0.key == Constants.databaseFilename.appending("-wal") }) {
+            try database.value.write(to: databaseWALDestination, originalContentsURL: nil)
         }
 
         // Import Preferences
@@ -60,6 +66,11 @@ struct PCBundleDoc: FileDocument {
         let databaseFileWrapper = try FileWrapper(url: FileManager.databaseURL)
         databaseFileWrapper.preferredFilename = Constants.databaseFilename
         wrapper.addFileWrapper(databaseFileWrapper)
+
+        let walURL = DataManager.pathToDb().appending(Constants.databaseWalSuffix)
+        let databaseWALFileWrapper = try FileWrapper(url: URL(fileURLWithPath: walURL))
+        databaseWALFileWrapper.preferredFilename = Constants.databaseFilename.appending(Constants.databaseWalSuffix)
+        wrapper.addFileWrapper(databaseWALFileWrapper)
 
         if let prefURL = FileManager.preferencesURL {
             let preferencesFileWrapper = try FileWrapper(url: prefURL)


### PR DESCRIPTION
Fixes [PCIOS-85](https://linear.app/a8c/issue/PCIOS-85)

I think this is safe to include in the beta release because we still have some time and this _only_ affects the mostly debug export feature.

The `sqlite3-wal` file is also included:

> The WAL file exists for as long as any [database connection](https://www.sqlite.org/c3ref/sqlite3.html) has the database open. Usually, the WAL file is deleted automatically when the last connection to the database closes. However, if the last process to have the database open exits without cleanly shutting down the database connection, or if the [SQLITE_FCNTL_PERSIST_WAL](https://www.sqlite.org/c3ref/c_fcntl_begin_atomic_write.html#sqlitefcntlpersistwal) [file control](https://www.sqlite.org/c3ref/file_control.html) is used, then the WAL file might be retained on disk after all connections to the database have been closed. The WAL file is part of the persistent state of the database and should be kept with the database if the database is copied or moved.

via [sqlite.org](https://www.sqlite.org/wal.html)

## To test

* Profile > Help & Feedback > ⋯ > Export Database
* Delete the app
* Re-import that file by opening from Files or drag and dropping it to the simulator
* Import database file
* Ensure that Podcasts and Settings are re-imported

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
