### PR TITLE
[New Onboarding] Newsletter opt in on Notifications page

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -224,6 +224,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Limit playback position changes when switching episodes
     case limitPlaybackPositionChanges
 
+    /// Use the new upgrade screens for account creation
+    case newOnboardingAccountCreation
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -378,6 +381,8 @@ public enum FeatureFlag: String, CaseIterable {
             #endif
         case .limitPlaybackPositionChanges:
             true
+        case .newOnboardingAccountCreation:
+            false
         }
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1783,6 +1783,7 @@
 		F57BAC672C00CD9C007B24BD /* URLSession+Episode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */; };
 		F57BAC682C00E7E6007B24BD /* URLSession+Episode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */; };
 		F57CD7D92C2624AD0035269A /* MediaTrimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57CD7D82C2624AD0035269A /* MediaTrimView.swift */; };
+		F57D54B72E42C68E00C74EF7 /* SelectCircleButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D54B62E42C68E00C74EF7 /* SelectCircleButtonStyle.swift */; };
 		F57D8F142C66CA230004C4DF /* UnsafeWait.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F132C66CA230004C4DF /* UnsafeWait.swift */; };
 		F57D8F162C66CBB80004C4DF /* UnsafeTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F152C66CBB80004C4DF /* UnsafeTransfer.swift */; };
 		F57D8F182C66CDF40004C4DF /* View+CVPixelBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F172C66CDF40004C4DF /* View+CVPixelBuffer.swift */; };
@@ -4009,6 +4010,7 @@
 		F57626B52C8B56C7009C8225 /* String+SanitizedFileName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SanitizedFileName.swift"; sourceTree = "<group>"; };
 		F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Episode.swift"; sourceTree = "<group>"; };
 		F57CD7D82C2624AD0035269A /* MediaTrimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTrimView.swift; sourceTree = "<group>"; };
+		F57D54B62E42C68E00C74EF7 /* SelectCircleButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectCircleButtonStyle.swift; sourceTree = "<group>"; };
 		F57D8F132C66CA230004C4DF /* UnsafeWait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafeWait.swift; sourceTree = "<group>"; };
 		F57D8F152C66CBB80004C4DF /* UnsafeTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafeTransfer.swift; sourceTree = "<group>"; };
 		F57D8F172C66CDF40004C4DF /* View+CVPixelBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CVPixelBuffer.swift"; sourceTree = "<group>"; };
@@ -7591,6 +7593,7 @@
 		C74887782919DC7B00EBC926 /* SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				F57D54B62E42C68E00C74EF7 /* SelectCircleButtonStyle.swift */,
 				9A9004D22E2FF29B005879CB /* AsyncImageView.swift */,
 				FF0753952D721AAC00BE8B3B /* ModalMessage.swift */,
 				FF07538B2D6CC4F400BE8B3B /* CustomHorizontalMargin.swift */,
@@ -10186,6 +10189,7 @@
 				4053CDF7214B6B61001C92B1 /* EpisodeFilterOverlayController.swift in Sources */,
 				9ACB950C2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */,
 				F5FE747B2C223A6100DF2EAA /* ShareImageView.swift in Sources */,
+				F57D54B72E42C68E00C74EF7 /* SelectCircleButtonStyle.swift in Sources */,
 				BD998AD327B3430700B38857 /* ColorPreviewFolderView.swift in Sources */,
 				BD7C1FFD237D16C600B3353B /* PCAlwaysVisibleCastBtn.swift in Sources */,
 				BD9324712398BB50004F19A1 /* TourView.swift in Sources */,

--- a/podcasts/Notifications/NotificationsPermissionsView.swift
+++ b/podcasts/Notifications/NotificationsPermissionsView.swift
@@ -1,10 +1,63 @@
 import SwiftUI
+import PocketCastsUtils
+import PocketCastsServer
 
 class NotificationsPermissionsViewModel: ObservableObject {
+    @Published var newsletterOptIn: Bool = true
+    @Published var notificationsOptIn: Bool = false
 
     func setupPermissions() async {
         let coordinator = NotificationsCoordinator.shared
         await coordinator.requestAndSetupInitialPermissions()
+    }
+
+    func saveNewsletterOptIn() {
+        ServerSettings.setMarketingOptIn(newsletterOptIn)
+    }
+
+    func trackNewsletterOptIn() {
+        Analytics.track(.newsletterOptInChanged, properties: ["enabled": newsletterOptIn, "source": "notifications_permissions"])
+    }
+
+    enum NotificationOption: CaseIterable {
+        case newsletter
+        case notifications
+
+        var title: String {
+            switch self {
+            case .newsletter:
+                return "Subscribe to our Newsletter"
+            case .notifications:
+                return "Receive Notifications"
+            }
+        }
+
+        var subtitle: String {
+            switch self {
+            case .newsletter:
+                return "Once a month, all podcast goodness"
+            case .notifications:
+                return "Receive news, podcast suggestions and more"
+            }
+        }
+
+        func isSelected(_ viewModel: NotificationsPermissionsViewModel) -> Bool {
+            switch self {
+            case .newsletter:
+                return viewModel.newsletterOptIn
+            case .notifications:
+                return viewModel.notificationsOptIn
+            }
+        }
+
+        func toggle(_ viewModel: NotificationsPermissionsViewModel) {
+            switch self {
+            case .newsletter:
+                viewModel.newsletterOptIn.toggle()
+            case .notifications:
+                viewModel.notificationsOptIn.toggle()
+            }
+        }
     }
 
     static func makeController() -> UIViewController {
@@ -25,6 +78,36 @@ struct NotificationsPermissionsView: View {
 
     @StateObject var viewModel: NotificationsPermissionsViewModel = NotificationsPermissionsViewModel()
 
+    @ViewBuilder
+    private func optionRow(for option: NotificationsPermissionsViewModel.NotificationOption) -> some View {
+        Button {
+            option.toggle(viewModel)
+        } label: {
+            HStack(spacing: 17) {
+                Button {
+                    // This button is now only for the SelectCircleButtonStyle visual
+                } label: {
+                    EmptyView() // content is provided by the style
+                }
+                .buttonStyle(
+                    SelectCircleButtonStyle(selected: .constant(option.isSelected(viewModel)))
+                )
+                .environmentObject(Theme.sharedTheme)
+                .allowsHitTesting(false) // Disable interaction since parent button handles it
+                VStack(alignment: .leading) {
+                    Text(option.title)
+                        .font(style: .subheadline, weight: .medium)
+                        .foregroundStyle(theme.primaryText01)
+                    Text(option.subtitle)
+                        .font(.footnote)
+                        .foregroundStyle(theme.primaryText02)
+                }
+                Spacer()
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
     var body: some View {
         VStack {
             Button(action: {
@@ -43,20 +126,32 @@ struct NotificationsPermissionsView: View {
             Text(L10n.notificationsPermissionsTitle)
                 .textStyle(PrimaryText())
                 .font(.largeTitle.bold())
-            Spacer().frame(height: 16)
+            Spacer().frame(height: 20)
             Text(L10n.notificationsPermissionsBody)
                 .textStyle(SecondaryText())
                 .font(.body)
                 .multilineTextAlignment(.center)
             Spacer()
+            if FeatureFlag.newOnboardingAccountCreation.enabled {
+                VStack(alignment: .leading, spacing: 24) {
+                    optionRow(for: .newsletter)
+                    optionRow(for: .notifications)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 34)
+            }
             Button(action: {
                 Analytics.track(.notificationsPermissionsAllowTapped)
+                viewModel.saveNewsletterOptIn()
+                viewModel.trackNewsletterOptIn()
                 Task {
-                    await viewModel.setupPermissions()
+                    if viewModel.notificationsOptIn {
+                        await viewModel.setupPermissions()
+                    }
                     dismissAction()
                 }
             }) {
-                Text(L10n.notificationsPermissionsAction)
+                Text(FeatureFlag.newOnboardingAccountCreation.enabled ? L10n.notificationsPermissionsSavePreferences : L10n.notificationsPermissionsAction)
                 .textStyle(RoundedButton())
             }
         }

--- a/podcasts/Notifications/NotificationsPermissionsView.swift
+++ b/podcasts/Notifications/NotificationsPermissionsView.swift
@@ -26,18 +26,18 @@ class NotificationsPermissionsViewModel: ObservableObject {
         var title: String {
             switch self {
             case .newsletter:
-                return "Subscribe to our Newsletter"
+                return L10n.notificationsOnboardingNewsletterTitle
             case .notifications:
-                return "Receive Notifications"
+                return L10n.notificationsOnboardingNotificationsTitle
             }
         }
 
         var subtitle: String {
             switch self {
             case .newsletter:
-                return "Once a month, all podcast goodness"
+                return L10n.notificationsOnboardingNewsletterSubtitle
             case .notifications:
-                return "Receive news, podcast suggestions and more"
+                return L10n.notificationsOnboardingNotificationsSubtitle
             }
         }
 

--- a/podcasts/Notifications/NotificationsPermissionsView.swift
+++ b/podcasts/Notifications/NotificationsPermissionsView.swift
@@ -85,7 +85,7 @@ struct NotificationsPermissionsView: View {
         } label: {
             HStack(spacing: 17) {
                 Button {
-                    // This button is now only for the SelectCircleButtonStyle visual
+                    option.toggle(viewModel)
                 } label: {
                     EmptyView() // content is provided by the style
                 }
@@ -93,7 +93,6 @@ struct NotificationsPermissionsView: View {
                     SelectCircleButtonStyle(selected: .constant(option.isSelected(viewModel)))
                 )
                 .environmentObject(Theme.sharedTheme)
-                .allowsHitTesting(false) // Disable interaction since parent button handles it
                 VStack(alignment: .leading) {
                     Text(option.title)
                         .font(style: .subheadline, weight: .medium)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1896,6 +1896,8 @@ internal enum L10n {
   internal static var notificationsPermissionsNeedsAction: String { return L10n.tr("Localizable", "notifications_permissions_needs_action", fallback: "Please allow notifications in your device settings") }
   /// Notification button title to open device notification settings
   internal static var notificationsPermissionsOpenSettings: String { return L10n.tr("Localizable", "notifications_permissions_open_settings", fallback: "Open Settings") }
+  /// Notifications permissions screen action button text to save preferences for notifications and Newsletter
+  internal static var notificationsPermissionsSavePreferences: String { return L10n.tr("Localizable", "notifications_permissions_save_preferences", fallback: "Save Preferences") }
   /// Notifications permissions screen title text
   internal static var notificationsPermissionsTitle: String { return L10n.tr("Localizable", "notifications_permissions_title", fallback: "Stay up to date!") }
   /// Prompt to play the selected item now.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1868,6 +1868,14 @@ internal enum L10n {
   internal static var notificationsOnboardingImportBody: String { return L10n.tr("Localizable", "notifications_onboarding_import_body", fallback: "Switching from another app? Bring all your favorite shows to Pocket Casts.") }
   /// Notification title for import podcast onboarding message
   internal static var notificationsOnboardingImportTitle: String { return L10n.tr("Localizable", "notifications_onboarding_import_title", fallback: "Easily import your podcasts") }
+  /// Subtitle for Newsletter opt-in option in the Notifications screen during onboarding
+  internal static var notificationsOnboardingNewsletterSubtitle: String { return L10n.tr("Localizable", "notifications_onboarding_newsletter_subtitle", fallback: "Once a month, all podcast goodness") }
+  /// Title for Newsletter opt-in option in the Notifications screen during onboarding
+  internal static var notificationsOnboardingNewsletterTitle: String { return L10n.tr("Localizable", "notifications_onboarding_newsletter_title", fallback: "Subscribe to our Newsletter") }
+  /// Subtitle for Notifications opt-in option in the Notifications screen during onboarding
+  internal static var notificationsOnboardingNotificationsSubtitle: String { return L10n.tr("Localizable", "notifications_onboarding_notifications_subtitle", fallback: "Receive news, podcast suggestions and more") }
+  /// Title for Notifications opt-in option in the Notifications screen during onboarding
+  internal static var notificationsOnboardingNotificationsTitle: String { return L10n.tr("Localizable", "notifications_onboarding_notifications_title", fallback: "Receive Notifications") }
   /// Notification body for signup onboarding message
   internal static var notificationsOnboardingSignupBody: String { return L10n.tr("Localizable", "notifications_onboarding_signup_body", fallback: "Create a free account to sync your shows and listen anywhere.") }
   /// Notification title for signup onboarding message

--- a/podcasts/SwiftUI/SelectCircleButtonStyle.swift
+++ b/podcasts/SwiftUI/SelectCircleButtonStyle.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct SelectCircleButtonStyle: ButtonStyle {
+    @EnvironmentObject private var theme: Theme
+
+    @Binding var selected: Bool
+
+    var stroke: StrokeStyle = StrokeStyle(lineWidth: 2)
+    var multiSelectButtonSize: CGFloat = 24
+    var checkSize: CGFloat = 22
+
+    func makeBody(configuration: Configuration) -> some View {
+        Circle()
+            .inset(by: 1)
+            .stroke(style: stroke)
+            .frame(width: multiSelectButtonSize, height: multiSelectButtonSize)
+            .overlay(
+                ZStack {
+                    Circle().fill(theme.primaryIcon01)
+
+                    Image("discover_tick")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(height: checkSize)
+                        .foregroundStyle(theme.primaryInteractive02)
+                }
+                .opacity(selected ? 1 : 0)
+                .animation(.linear(duration: 0.1), value: selected)
+            )
+            .contentShape(Circle())
+            .onChange(of: configuration.isPressed) { pressed in
+                if pressed {
+                    selected.toggle()
+                }
+            }
+            .foregroundStyle(theme.primaryIcon01)
+    }
+}

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5164,6 +5164,9 @@
 /* Notifications permissions screen action button text*/
 "notifications_permissions_action" = "Allow Notifications";
 
+/* Notifications permissions screen action button text to save preferences for notifications and Newsletter */
+"notifications_permissions_save_preferences" = "Save Preferences";
+
 /* Title for modal explaining Creator Picks */
 "creator_pick_modal_title" = "What's a Creator Pick?";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5029,6 +5029,19 @@
 /* Notification body for onboarding to staff picks message */
 "notifications_onboarding_staff_picks_body" = "Perfectly ripe podcasts, picked just for you by real, podcast-loving humans.";
 
+/* Title for Newsletter opt-in option in the Notifications screen during onboarding */
+"notifications_onboarding_newsletter_title" = "Subscribe to our Newsletter";
+
+/* Subtitle for Newsletter opt-in option in the Notifications screen during onboarding */
+"notifications_onboarding_newsletter_subtitle" = "Once a month, all podcast goodness";
+
+/* Title for Notifications opt-in option in the Notifications screen during onboarding */
+"notifications_onboarding_notifications_title" = "Receive Notifications";
+
+/* Subtitle for Notifications opt-in option in the Notifications screen during onboarding */
+"notifications_onboarding_notifications_subtitle" = "Receive news, podcast suggestions and more";
+
+
 /* Notification permission banner title*/
 "notitifications_permission_banner_title" = "Allow Push Notifications";
 


### PR DESCRIPTION
| 📘 Part of: [New Onboarding: Account Creation](https://linear.app/a8c/project/new-onboarding-account-creation-changes-59e33598e1f7) |
|:---:|

Closes [PCIOS-81](https://linear.app/a8c/issue/PCIOS-81)

| Before | After |
|--|--|
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-06 at 20 28 45" src="https://github.com/user-attachments/assets/ddece276-accc-469d-b402-323473a83b25" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-06 at 20 29 37" src="https://github.com/user-attachments/assets/64892c7e-1a8d-4a32-af65-b29db3d80d8e" /> |

## To test

### Flag disabled
* Reinstall the app
* Dismiss the account creation
* Ensure that the Notifications page appears with no toggles, only a button

### Flag enabled
* Enable the `newOnboardingAccountCreation` flag in `FeatureFlag.swift`
* Reinstall the app
* Dismiss the account creation
* Ensure that the Notifications page appears with toggles for Notifications and Newsletter Opt-in

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
