### PR TITLE
GRDB: corruption recovery

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBQueue.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBQueue.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 import Foundation
 
 class GRDBQueue: PCDBQueue {
-    private let dbPool: DatabasePool
+    public let dbPool: DatabasePool
     private let logger: ErrorLogger?
 
     init(dbPool: DatabasePool, logger: ErrorLogger? = nil) {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -33,6 +33,8 @@ public class DataManager {
 
     public static var logger: ErrorLogger?
 
+    public static var loginAgain = false
+
     /// Creates a DataManager using a queue that is persisted to a local SQLIte file
     public convenience init() {
         DataManager.ensureDbFolderExists()
@@ -53,6 +55,7 @@ public class DataManager {
                 dbQueue = GRDBQueue(dbPool: dbPool, logger: Self.logger)
                 DataManager.setDatabaseFileProtectionToNone()
                 FileLog.shared.addMessage("[DataManager] Database is corrupted, recreated using GRDB")
+                Self.loginAgain = true
             }
         } else {
             let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1231,21 +1231,24 @@ extension DataManager {
 // MARK: - GRDB: Database corruption
 
 extension DataManager {
-    public func copyAllData() throws {
-        let sourceDbQueue = try DatabaseQueue(path: DataManager.pathToDbBackup())
+    public func copyAllData() {
+        guard let sourceDbQueue = try? DatabaseQueue(path: DataManager.pathToDbBackup()) else {
+            return
+        }
+
         let destinationDbQueue = (dbQueue as? GRDBQueue)!.dbPool
 
         // Fetch all table names (excluding SQLite internal tables and SJEpisode)
-        let tableNames: [String] = try sourceDbQueue.read { db in
-            try String.fetchAll(db,
+        let tableNames: [String]? = try? sourceDbQueue.read { db in
+            try? String.fetchAll(db,
                 sql: """
                 SELECT name FROM sqlite_master
                 WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'SJEpisode'
                 """)
         }
 
-        for tableName in tableNames {
-            try sourceDbQueue.read { sourceDb in
+        for tableName in tableNames ?? [] {
+            try? sourceDbQueue.read { sourceDb in
                 // Fetch first row to get column names
                 let previewCursor = try Row.fetchCursor(sourceDb, sql: "SELECT * FROM \(tableName.quotedDatabaseIdentifier)")
                 guard let firstRow = try previewCursor.next() else { return }
@@ -1259,7 +1262,7 @@ extension DataManager {
                 let placeholders = Array(repeating: "?", count: columnNames.count).joined(separator: ", ")
                 let insertSQL = "INSERT OR REPLACE INTO \(tableName.quotedDatabaseIdentifier) (\(columnsList)) VALUES (\(placeholders))"
 
-                try destinationDbQueue.write { destDb in
+                try? destinationDbQueue.write { destDb in
                     while let row = try rowCursor.next() {
                         // Any podcast we copy we set lastUpdateddAt to nil so all episodes are fetch
                         let values: [DatabaseValueConvertible?] = columnNames.map { columnName in
@@ -1270,7 +1273,7 @@ extension DataManager {
                             }
                         }
 
-                        try destDb.execute(sql: insertSQL, arguments: StatementArguments(values))
+                        try? destDb.execute(sql: insertSQL, arguments: StatementArguments(values))
                     }
                 }
             }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1227,3 +1227,55 @@ extension DataManager {
         }
     }
 }
+
+// MARK: - GRDB: Database corruption
+
+extension DataManager {
+    public func copyAllData() throws {
+        let sourceDbQueue = try DatabaseQueue(path: DataManager.pathToDbBackup())
+        let destinationDbQueue = (dbQueue as? GRDBQueue)!.dbPool
+
+        // Fetch all table names (excluding SQLite internal tables and SJEpisode)
+        let tableNames: [String] = try sourceDbQueue.read { db in
+            try String.fetchAll(db,
+                sql: """
+                SELECT name FROM sqlite_master
+                WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'SJEpisode'
+                """)
+        }
+
+        for tableName in tableNames {
+            try sourceDbQueue.read { sourceDb in
+                // Fetch first row to get column names
+                let previewCursor = try Row.fetchCursor(sourceDb, sql: "SELECT * FROM \(tableName.quotedDatabaseIdentifier)")
+                guard let firstRow = try previewCursor.next() else { return }
+                let columnNames = firstRow.columnNames
+
+                // Re-create the cursor to read all rows again
+                let rowCursor = try Row.fetchCursor(sourceDb, sql: "SELECT * FROM \(tableName.quotedDatabaseIdentifier)")
+
+                // Prepare insert SQL
+                let columnsList = columnNames.map { $0.quotedDatabaseIdentifier }.joined(separator: ", ")
+                let placeholders = Array(repeating: "?", count: columnNames.count).joined(separator: ", ")
+                let insertSQL = "INSERT OR REPLACE INTO \(tableName.quotedDatabaseIdentifier) (\(columnsList)) VALUES (\(placeholders))"
+
+                try destinationDbQueue.write { destDb in
+                    while let row = try rowCursor.next() {
+                        // Any podcast we copy we set lastUpdateddAt to nil so all episodes are fetch
+                        let values: [DatabaseValueConvertible?] = columnNames.map { columnName in
+                            if tableName == "SJPodcast" && columnName == "lastUpdatedAt" {
+                                return nil
+                            } else {
+                                return row[columnName]
+                            }
+                        }
+
+                        try destDb.execute(sql: insertSQL, arguments: StatementArguments(values))
+                    }
+                }
+            }
+        }
+
+        try? sourceDbQueue.close()
+    }
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -41,9 +41,19 @@ public class DataManager {
         if FeatureFlag.grdb.enabled {
             var config = Configuration()
             config.busyMode = .timeout(10)
-            dbQueue = GRDBQueue(dbPool: try! DatabasePool(path: DataManager.pathToDb(), configuration: config), logger: Self.logger)
+            let dbPool = try! DatabasePool(path: DataManager.pathToDb(), configuration: config)
+            dbQueue = GRDBQueue(dbPool: dbPool, logger: Self.logger)
             DataManager.setDatabaseFileProtectionToNone()
             FileLog.shared.addMessage("[DataManager] Initialized using GRDB")
+
+            // Database corruption check
+            if Self.checkDatabaseCorruption(dbPool: dbPool) {
+                // If database is corrupted we start it again in a clean state
+                let dbPool = try! DatabasePool(path: DataManager.pathToDb(), configuration: config)
+                dbQueue = GRDBQueue(dbPool: dbPool, logger: Self.logger)
+                DataManager.setDatabaseFileProtectionToNone()
+                FileLog.shared.addMessage("[DataManager] Database is corrupted, recreated using GRDB")
+            }
         } else {
             let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
             dbQueue = FMDBQueue(fmdbQueue: FMDatabaseQueue(path: DataManager.pathToDb(), flags: flags)!)
@@ -51,6 +61,35 @@ public class DataManager {
         }
 
         self.init(dbQueue: dbQueue)
+    }
+
+    static func checkDatabaseCorruption(dbPool: DatabasePool) -> Bool {
+        var isDatabaseCorrupted = false
+        try? dbPool.write { db in
+            do {
+                let rows = try Row.fetchAll(db, sql: "PRAGMA integrity_check")
+                    for row in rows {
+                        let result: String = row[0]
+                        if result != "ok" {
+                            isDatabaseCorrupted = true
+                        }
+                    }
+            } catch {
+                if error.localizedDescription.contains("image is malformed") {
+                    isDatabaseCorrupted = true
+                }
+            }
+        }
+
+        if isDatabaseCorrupted {
+            try? dbPool.close()
+
+            try? FileManager.default.moveItem(at: URL(fileURLWithPath: DataManager.pathToDb()), to: URL(fileURLWithPath: DataManager.pathToDbBackup()))
+            try? FileManager.default.moveItem(at: URL(fileURLWithPath: "\(DataManager.pathToDb())-shm"), to: URL(fileURLWithPath: "\(DataManager.pathToDbBackup())-shm"))
+            try? FileManager.default.moveItem(at: URL(fileURLWithPath: "\(DataManager.pathToDb())-wal"), to: URL(fileURLWithPath: "\(DataManager.pathToDbBackup())-wal"))
+        }
+
+        return isDatabaseCorrupted
     }
 
     /// Creates a DataManager using the given `PCDBQueue`.
@@ -1020,6 +1059,12 @@ public class DataManager {
         let folderPath = pathToDbFolder() as NSString
 
         return folderPath.appendingPathComponent("podcast_newDB.sqlite3")
+    }
+
+    public static func pathToDbBackup() -> String {
+        let folderPath = pathToDbFolder() as NSString
+
+        return folderPath.appendingPathComponent("podcast_newDB_backup.sqlite3")
     }
 
     private static func pathToDbFolder() -> String {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -28,6 +28,15 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     /// Displayed during database migrations
     var alert: ShiftyLoadingAlert?
 
+    func loginAgain() {
+        SyncManager.syncReason = .login
+        ServerSettings.clearLastSyncTime()
+        UserDefaults.standard.removeObject(forKey: "PCLastModifiedServerDate")
+        let controller = SyncSigninViewController()
+        controller.loginAgain = true
+        SceneHelper.rootViewController()?.present(controller, animated: true, completion: nil)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -105,6 +114,10 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         updateDatabaseIndexes()
         optimizeDatabaseIfNeeded()
+
+        if DataManager.loginAgain {
+            loginAgain()
+        }
     }
 
     /// Update database indexes and delete unused columns

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -29,12 +29,23 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     var alert: ShiftyLoadingAlert?
 
     func loginAgain() {
+        // Ensure the new sync is a full sync (so podcasts and episodes are retrieved)
         SyncManager.syncReason = .login
         ServerSettings.clearLastSyncTime()
         UserDefaults.standard.removeObject(forKey: "PCLastModifiedServerDate")
-        let controller = SyncSigninViewController()
-        controller.loginAgain = true
-        SceneHelper.rootViewController()?.present(controller, animated: true, completion: nil)
+
+        // Copy data from the previous corrupted database (if possible)
+        alert = ShiftyLoadingAlert(title: "Corrupted database. Recovering...")
+        alert?.showAlert(self, hasProgress: false, completion: nil)
+        try? DataManager.sharedManager.copyAllData()
+
+        alert?.hideAlert(true, completion: {
+            // Start the full sync
+            let controller = SyncSigninViewController()
+            controller.loginAgain = true
+            SceneHelper.rootViewController()?.dismiss(animated: true)
+            SceneHelper.rootViewController()?.present(controller, animated: true, completion: nil)
+        })
     }
 
     override func viewDidLoad() {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -37,7 +37,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         // Copy data from the previous corrupted database (if possible)
         alert = ShiftyLoadingAlert(title: "Corrupted database. Recovering...")
         alert?.showAlert(self, hasProgress: false, completion: nil)
-        try? DataManager.sharedManager.copyAllData()
+        DataManager.sharedManager.copyAllData()
 
         alert?.hideAlert(true, completion: {
             // Start the full sync

--- a/podcasts/SyncSigninViewController.swift
+++ b/podcasts/SyncSigninViewController.swift
@@ -87,6 +87,9 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
 
     private var totalPodcastsToImport = -1
 
+    // If set to true it will login and start a full sync right away
+    var loginAgain = false
+
     // MARK: - UIView Methods
 
     override func viewDidLoad() {
@@ -129,6 +132,10 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
         addCustomObserver(ServerNotifications.syncCompleted, selector: #selector(syncCompleted))
         addCustomObserver(ServerNotifications.syncFailed, selector: #selector(syncCompleted))
         addCustomObserver(ServerNotifications.podcastRefreshFailed, selector: #selector(syncCompleted))
+
+        if loginAgain, let syncingEmail = ServerSettings.syncingEmail(), let password = ServerSettings.syncingPassword() {
+            startSignIn(syncingEmail, password: password)
+        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -209,6 +216,10 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
             } else {
                 // if there's no delegate registered to handle a sign in finishing, just dismiss
                 self.closeTapped()
+            }
+
+            if loginAgain {
+                dismiss(animated: true)
             }
         }
     }


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

We have a small set of users with corrupted databases. When the database is in this state we need to remove (or rebuild it). This PR adds code to:

1. Check if the database is corrupted
2. If it is, starts a "recovery"

The way this recover works is as it follows:

1. First it renames the file
2. Then it creates a new, healthy, empty database
3. It copies all the data that it can from the previous database (excluding `SJEpisode` which seems to be the culprit for all crashes)
4. It starts a login with the user credentials so all their data is correctly synced back to the device

In the end, the user has the same podcasts with the same settings. They lose per-episode details tho, as this table is not recoverable.

## To test

Best way to test that is a bit involved but it aims at reproducing the issue. You'll need a corrupted database to test though.

1. Login with an account that has the same podcasts as your corrupted database
2. Replace the database of your simulator with the corrupted database
3. Re-run the app
4. ✅ The app should detect the corrupted database and backup your data and login you again
5. ✅ Check that you didn't lose per-podcast settings (Profile > Settings > Auto Download and Auto Add to Up Next)
6. Re-run the app
7. It shouldn't do the same process again as your database is now healthy

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
