### PR TITLE
[Playlists] UI adjustments

### DIFF
--- a/podcasts/DownloadFilterOverlayController.swift
+++ b/podcasts/DownloadFilterOverlayController.swift
@@ -15,7 +15,9 @@ class DownloadFilterOverlayController: FilterSettingsOverlayController, UITableV
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        if FeatureFlag.playlistsRebranding.enabled {
+            largeTitleFont = UIFont.systemFont(ofSize: 22, weight: .bold)
+        }
         tableView.delegate = self
         tableView.dataSource = self
 
@@ -35,6 +37,18 @@ class DownloadFilterOverlayController: FilterSettingsOverlayController, UITableV
 
             saveButton.setTitle(L10n.playlistSmartRuleSaveButton, for: .normal)
         }
+    }
+
+    override func addTableViewHeader() {
+        let headerView = ThemeableView()
+        headerView.style = .primaryUi01
+        if FeatureFlag.playlistsRebranding.enabled {
+            headerView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 10)
+        } else {
+            headerView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 26)
+        }
+        headerView.layoutIfNeeded()
+        tableView.tableHeaderView = headerView
     }
 
     // MARK: - TableView DataSource

--- a/podcasts/EpisodeFilterOverlayController.swift
+++ b/podcasts/EpisodeFilterOverlayController.swift
@@ -17,6 +17,9 @@ class EpisodeFilterOverlayController: FilterSettingsOverlayController, UITableVi
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        if FeatureFlag.playlistsRebranding.enabled {
+            largeTitleFont = UIFont.systemFont(ofSize: 22, weight: .bold)
+        }
         tableView.register(UINib(nibName: "CheckboxCell", bundle: nil), forCellReuseIdentifier: EpisodeFilterOverlayController.episodeCellId)
 
         tableView.delegate = self
@@ -38,6 +41,18 @@ class EpisodeFilterOverlayController: FilterSettingsOverlayController, UITableVi
 
             saveButton.setTitle(L10n.playlistSmartRuleSaveButton, for: .normal)
         }
+    }
+
+    override func addTableViewHeader() {
+        let headerView = ThemeableView()
+        headerView.style = .primaryUi01
+        if FeatureFlag.playlistsRebranding.enabled {
+            headerView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 10)
+        } else {
+            headerView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 26)
+        }
+        headerView.layoutIfNeeded()
+        tableView.tableHeaderView = headerView
     }
 
     // MARK: - TableView DataSource

--- a/podcasts/EpisodePreviewCell.swift
+++ b/podcasts/EpisodePreviewCell.swift
@@ -17,6 +17,8 @@ class EpisodePreviewCell: ThemeableCell {
         }
     }
 
+    @IBOutlet weak var imageLeftPadding: NSLayoutConstraint!
+
     func populateFrom(episode: BaseEpisode) {
         episodeTitle.text = episode.title
         if let userEpisode = episode as? UserEpisode {

--- a/podcasts/EpisodePreviewCell.xib
+++ b/podcasts/EpisodePreviewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -77,6 +77,7 @@
                 <outlet property="durationLabel" destination="YJN-Qw-uM8" id="mAd-VC-m8x"/>
                 <outlet property="episodeImage" destination="010-IG-2z2" id="yD2-K9-GPE"/>
                 <outlet property="episodeTitle" destination="sfS-Mm-mS6" id="lc7-6p-f8O"/>
+                <outlet property="imageLeftPadding" destination="6Sh-2H-Yvn" id="dEV-UP-BWN"/>
             </connections>
             <point key="canvasLocation" x="-56.521739130434788" y="111.16071428571428"/>
         </tableViewCell>

--- a/podcasts/FilterChipCollectionView.swift
+++ b/podcasts/FilterChipCollectionView.swift
@@ -65,11 +65,7 @@ class FilterChipCollectionView: UICollectionView, UICollectionViewDelegate, UICo
             filterSettingsVC.analyticsSource = .filters
             filterSettingsVC.filterToEdit = filter
             let navVC = SJUIUtils.navController(for: filterSettingsVC)
-            if FeatureFlag.playlistsRebranding.enabled {
-                chipActionDelegate?.presentingViewController().navigationController?.pushViewController(filterSettingsVC, animated: true)
-            } else {
-                chipActionDelegate?.presentingViewController().present(navVC, animated: true, completion: nil)
-            }
+            chipActionDelegate?.presentingViewController().present(navVC, animated: true, completion: nil)
 
         case .downloadStatus:
             let filterSettingsVC = DownloadFilterOverlayController(nibName: "FilterSettingsOverlayController", bundle: nil)

--- a/podcasts/FilterDurationViewController.swift
+++ b/podcasts/FilterDurationViewController.swift
@@ -74,6 +74,11 @@ class FilterDurationViewController: PCViewController {
             filterSwitch.isOn = filter.filterDuration
         }
     }
+    @IBOutlet weak var filterSwitchTopConstraint: NSLayoutConstraint! {
+        didSet {
+            filterSwitchTopConstraint.constant = FeatureFlag.playlistsRebranding.enabled ? 10 : 20
+        }
+    }
 
     @IBOutlet var durationConfigView: UIView!
 
@@ -108,7 +113,7 @@ class FilterDurationViewController: PCViewController {
     }
     @IBOutlet weak var dividerTopConstraint: NSLayoutConstraint! {
         didSet {
-            dividerTopConstraint.constant = FeatureFlag.playlistsRebranding.enabled ? 16.0 : 20.0
+            dividerTopConstraint.constant = FeatureFlag.playlistsRebranding.enabled ? 10.0 : 20.0
         }
     }
     @IBOutlet weak var dividerBottomConstraint: NSLayoutConstraint! {
@@ -140,7 +145,9 @@ class FilterDurationViewController: PCViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        if FeatureFlag.playlistsRebranding.enabled {
+            largeTitleFont = UIFont.systemFont(ofSize: 22, weight: .bold)
+        }
         let closeButton = createStandardCloseButton(imageName: "cancel")
         closeButton.addTarget(self, action: #selector(closeTapped(_:)), for: .touchUpInside)
         let backButtonItem = UIBarButtonItem(customView: closeButton)

--- a/podcasts/FilterDurationViewController.xib
+++ b/podcasts/FilterDurationViewController.xib
@@ -17,6 +17,7 @@
                 <outlet property="durationConfigView" destination="e89-rD-l86" id="feg-cP-tu6"/>
                 <outlet property="filterDurationLabel" destination="ZaL-Yo-lbb" id="f8I-N1-zEx"/>
                 <outlet property="filterSwitch" destination="Rrc-db-3fy" id="jVl-GT-FyI"/>
+                <outlet property="filterSwitchTopConstraint" destination="zaU-xW-y4b" id="uWu-9k-GeD"/>
                 <outlet property="linesSpacing" destination="IyF-fn-FAq" id="FPD-0r-JP7"/>
                 <outlet property="longerThanDescription" destination="8XS-u3-vvZ" id="7gX-pw-Wj7"/>
                 <outlet property="longerThanLabel" destination="ZUI-Nj-eNz" id="BC3-hK-RD6"/>

--- a/podcasts/MediaFilterOverlayController.swift
+++ b/podcasts/MediaFilterOverlayController.swift
@@ -27,7 +27,9 @@ class MediaFilterOverlayController: FilterSettingsOverlayController, UITableView
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        if FeatureFlag.playlistsRebranding.enabled {
+            largeTitleFont = UIFont.systemFont(ofSize: 22, weight: .bold)
+        }
         tableView.delegate = self
         tableView.dataSource = self
 
@@ -47,6 +49,18 @@ class MediaFilterOverlayController: FilterSettingsOverlayController, UITableView
 
             saveButton.setTitle(L10n.playlistSmartRuleSaveButton, for: .normal)
         }
+    }
+
+    override func addTableViewHeader() {
+        let headerView = ThemeableView()
+        headerView.style = .primaryUi01
+        if FeatureFlag.playlistsRebranding.enabled {
+            headerView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 10)
+        } else {
+            headerView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 26)
+        }
+        headerView.layoutIfNeeded()
+        tableView.tableHeaderView = headerView
     }
 
     // MARK: - TableView DataSource

--- a/podcasts/PCViewController.swift
+++ b/podcasts/PCViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 
 class PCViewController: SimpleNotificationsViewController {
     var supportsGoogleCast = false
+    var largeTitleFont = UIFont.systemFont(ofSize: 31, weight: .bold)
 
     var googleCastBtn: UIBarButtonItem?
     var customRightBtn: UIBarButtonItem? {
@@ -157,7 +158,7 @@ class PCViewController: SimpleNotificationsViewController {
         appearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: titleColor]
         appearance.largeTitleTextAttributes = [
             NSAttributedString.Key.foregroundColor: titleColor,
-            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 31, weight: .bold)
+            NSAttributedString.Key.font: largeTitleFont
         ]
         appearance.shadowColor = nil
 

--- a/podcasts/PlaylistCell.swift
+++ b/podcasts/PlaylistCell.swift
@@ -6,6 +6,12 @@ class PlaylistCell: ThemeableCell {
     static let reuseIdentifier = "PlaylistCell"
     static let cellHeight = 81.0
 
+    lazy var separatorView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
@@ -16,7 +22,17 @@ class PlaylistCell: ThemeableCell {
 
         updateColor()
 
-        separatorInset = UIEdgeInsets(top: 0, left: 16.0, bottom: 0, right: 0)
+        separatorInset = UIEdgeInsets(top: 0, left: .greatestFiniteMagnitude, bottom: 0, right: 0)
+        layoutMargins = .zero
+        preservesSuperviewLayoutMargins = false
+
+        addSubview(separatorView)
+        NSLayoutConstraint.activate([
+            separatorView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            separatorView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16.0),
+            separatorView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: 1.0)
+        ])
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -39,7 +55,7 @@ class PlaylistCell: ThemeableCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(playlist: EpisodeFilter) {
+    func configure(playlist: EpisodeFilter, isLastRow: Bool) {
         contentConfiguration = UIHostingConfiguration {
             PlaylistCellView(viewModel: PlaylistCellViewModel(playlist: playlist))
                 .environmentObject(Theme.sharedTheme)
@@ -47,5 +63,9 @@ class PlaylistCell: ThemeableCell {
         }
         .margins(.horizontal, 0)
         .margins(.vertical, 0)
+
+        separatorView.isHidden = isLastRow
+        separatorView.backgroundColor = AppTheme.colorForStyle(.primaryUi05)
+        bringSubviewToFront(separatorView)
     }
 }

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -30,7 +30,7 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
         if FeatureFlag.playlistsRebranding.enabled {
             let cell = tableView.dequeueReusableCell(withIdentifier: PlaylistCell.reuseIdentifier, for: indexPath) as! PlaylistCell
             if let playlist = playlists[safe: indexPath.row] {
-                cell.configure(playlist: playlist)
+                cell.configure(playlist: playlist, isLastRow: indexPath.row == playlists.count - 1)
             }
             return cell
         }

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -12,6 +12,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
                 filtersTable.themeStyle = .primaryUi01
                 filtersTable.dragDelegate = self
                 filtersTable.dropDelegate = self
+                filtersTable.separatorStyle = .none
             } else {
                 filtersTable.themeStyle = .primaryUi04
                 filtersTable.dragDelegate = nil

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -24,6 +24,9 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        if FeatureFlag.playlistsRebranding.enabled {
+            largeTitleFont = UIFont.systemFont(ofSize: 22, weight: .bold)
+        }
         delegate = self
         podcastTable.delegate = self
         podcastTable.dataSource = self
@@ -89,9 +92,6 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
     }
 
     func setupCloseButton() {
-        if FeatureFlag.playlistsRebranding.enabled {
-            return
-        }
         let closeButton = createStandardCloseButton(imageName: "cancel")
         closeButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
 

--- a/podcasts/ReleaseDateFilterOverlayController.swift
+++ b/podcasts/ReleaseDateFilterOverlayController.swift
@@ -55,7 +55,9 @@ class ReleaseDateFilterOverlayController: FilterSettingsOverlayController, UITab
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        if FeatureFlag.playlistsRebranding.enabled {
+            largeTitleFont = UIFont.systemFont(ofSize: 22, weight: .bold)
+        }
         tableView.delegate = self
         tableView.dataSource = self
 
@@ -77,6 +79,18 @@ class ReleaseDateFilterOverlayController: FilterSettingsOverlayController, UITab
         navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
         addCloseButton()
         addTableViewHeader()
+    }
+
+    override func addTableViewHeader() {
+        let headerView = ThemeableView()
+        headerView.style = .primaryUi01
+        if FeatureFlag.playlistsRebranding.enabled {
+            headerView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 10)
+        } else {
+            headerView.frame = CGRect(x: 0, y: 0, width: tableView.bounds.width, height: 26)
+        }
+        headerView.layoutIfNeeded()
+        tableView.tableHeaderView = headerView
     }
 
     // MARK: - TableView DataSource

--- a/podcasts/SmartRuleToggleHeaderView.swift
+++ b/podcasts/SmartRuleToggleHeaderView.swift
@@ -38,6 +38,7 @@ struct SmartRuleToggleHeaderView: View {
         }
         .background(theme.primaryUi01)
         .padding(.horizontal, 16.0)
-        .padding(.vertical, 22.0)
+        .padding(.top, 10.0)
+        .padding(.bottom, 22.0)
     }
 }

--- a/podcasts/StarredFilterOverlayController.swift
+++ b/podcasts/StarredFilterOverlayController.swift
@@ -173,6 +173,7 @@ extension StarredFilterOverlayController: UITableViewDataSource, UITableViewDele
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.section == 0 {
             let cell = tableView.dequeueReusableCell(withIdentifier: Self.smartRuleHeaderCellId)!
+            cell.backgroundColor = AppTheme.colorForStyle(.primaryUi01)
             cell.contentView.backgroundColor = AppTheme.colorForStyle(.primaryUi01)
             cell.contentConfiguration = UIHostingConfiguration {
                 SmartRuleToggleHeaderView(viewModel: viewModel)
@@ -185,6 +186,7 @@ extension StarredFilterOverlayController: UITableViewDataSource, UITableViewDele
         }
 
         let cell = tableView.dequeueReusableCell(withIdentifier: FilterPreviewViewController.previewCellId, for: indexPath) as! EpisodePreviewCell
+        cell.imageLeftPadding.constant = 16.0
         cell.style = .primaryUi01
         if let listEpisode = episodes[safe: indexPath.row] {
             cell.populateFrom(episode: listEpisode.episode)

--- a/podcasts/StarredFilterOverlayController.swift
+++ b/podcasts/StarredFilterOverlayController.swift
@@ -62,6 +62,8 @@ class StarredFilterOverlayController: PCViewController {
     }
 
     private func setupNavBar() {
+        largeTitleFont = UIFont.systemFont(ofSize: 22, weight: .bold)
+
         title = L10n.statusStarred
         navigationController?.navigationBar.prefersLargeTitles = true
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2272,7 +2272,7 @@ internal enum L10n {
   /// Playlists Empty State: title for the empty state visible when no playlists are displayed
   internal static var playlistsEmptyStateTitle: String { return L10n.tr("Localizable", "playlists_empty_state_title", fallback: "Organize episodes your way") }
   /// Playlists Onboarding screen: description for the manual playlist card
-  internal static var playlistsOnboardingManualDescription: String { return L10n.tr("Localizable", "playlists_onboarding_manual_description", fallback: "Want more control? Manual Playlists let you build custom queues, great for trips, themes, or just your current vibe. Whether Smart or Manual, playlists work the way you do.") }
+  internal static var playlistsOnboardingManualDescription: String { return L10n.tr("Localizable", "playlists_onboarding_manual_description", fallback: "Take control of your listening. Build custom playlists for trips, themes, or whatever vibe you’re in. Whether Smart or custom, playlists fit the way you listen.") }
   /// Playlists Onboarding screen: title for the manual playlist card
   internal static var playlistsOnboardingManualTitle: String { return L10n.tr("Localizable", "playlists_onboarding_manual_title", fallback: "Introducing Playlists") }
   /// Playlists Onboarding screen: description for the smart playlist card

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5284,7 +5284,7 @@
 "playlists_onboarding_manual_title" = "Introducing Playlists";
 
 /* Playlists Onboarding screen: description for the manual playlist card */
-"playlists_onboarding_manual_description" = "Want more control? Manual Playlists let you build custom queues, great for trips, themes, or just your current vibe. Whether Smart or Manual, playlists work the way you do.";
+"playlists_onboarding_manual_description" = "Take control of your listening. Build custom playlists for trips, themes, or whatever vibe you’re in. Whether Smart or custom, playlists fit the way you listen.";
 
 /* Playlists Empty State: title for the empty state visible when no playlists are displayed */
 "playlists_empty_state_title" = "Organize episodes your way";


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/overview)
|:---:|

| 1 | 2 | 3 | 4 |
| :-------: | :-------: | :-------: | :-------: |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 11 04 13" src="https://github.com/user-attachments/assets/f95e4318-ac93-47d3-849a-bfce34d89218" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 11 04 17" src="https://github.com/user-attachments/assets/55adf4f7-74b6-40c3-a78c-e0616129afd4" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 11 04 21" src="https://github.com/user-attachments/assets/9255ecfb-9245-48b6-aa84-cbddd0f2993e" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 11 04 48" src="https://github.com/user-attachments/assets/82bff596-1ece-4663-b173-62ec9fd361b6" /> |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 11 04 52" src="https://github.com/user-attachments/assets/75108794-c3d4-41b8-ac32-71afa43b12a3" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 11 04 58" src="https://github.com/user-attachments/assets/4df0d40b-87fc-435d-bf6c-397177477220" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 11 10 20" src="https://github.com/user-attachments/assets/a1c2eb10-29f2-4156-bdf4-86dedb51c740" /> |




Some UI adjustments:
• Title font size
• Some paddings

## To test

- Make sure the rebranding playlist FF is on
- Run this branch
- Open all rules and make sure they matches the design above

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
