### PR TITLE
[Banner Ads] Banner ad spacing on podcast list

### DIFF
--- a/podcasts/PodcastListViewController+CollectionView.swift
+++ b/podcasts/PodcastListViewController+CollectionView.swift
@@ -186,7 +186,7 @@ extension PodcastListViewController: UICollectionViewDelegate, UICollectionViewD
             headerView.subviews.forEach { $0.removeFromSuperview() }
 
             if let bannerAdModel = bannerAdModel {
-                let bannerAdView = BannerAdView(model: bannerAdModel, colors: .podcastList(Theme.sharedTheme))
+                let bannerAdView = bannerAdView(bannerAdModel: bannerAdModel)
                 let hostingController = PCHostingController(rootView: bannerAdView)
                 hostingController.view.translatesAutoresizingMaskIntoConstraints = false
                 hostingController.view.backgroundColor = .clear
@@ -229,6 +229,19 @@ extension PodcastListViewController: UICollectionViewDelegate, UICollectionViewD
         return UICollectionReusableView()
     }
 
+    private func bannerAdView(bannerAdModel: BannerAdModel) -> some View {
+        let backgroundColor = (podcastsCollectionView as? ThemeableCollectionView)!.style
+        let isSameColor = ThemeColor.secondaryUi01() == AppTheme.colorForStyle(backgroundColor)
+
+        let additionalPadding: CGFloat = Settings.libraryType() == .list ? 16 : 0
+
+        return BannerAdView(model: bannerAdModel, colors: .podcastList(Theme.sharedTheme))
+            .padding(.top, !isSameColor ? 16 : 0)
+            .padding(.bottom, additionalPadding)
+            .padding(.horizontal, additionalPadding)
+            .environmentObject(Theme.sharedTheme)
+    }
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
 
         guard let bannerAdModel else {
@@ -236,7 +249,7 @@ extension PodcastListViewController: UICollectionViewDelegate, UICollectionViewD
         }
 
         // Use a separate view because fetching the view from UICollectionView isn't allowed until view is part of window hierarchy.
-        let sizingView = BannerAdView(model: bannerAdModel, colors: .podcastList(Theme.sharedTheme)).environmentObject(Theme.sharedTheme)
+        let sizingView = bannerAdView(bannerAdModel: bannerAdModel)
 
         let hostingController = UIHostingController(rootView: sizingView)
         let targetSize = CGSize(width: collectionView.bounds.width, height: UIView.layoutFittingCompressedSize.height)


### PR DESCRIPTION
| 📘 Part of: [Banner Ads](https://linear.app/a8c/project/banner-ads-apps-620298d02a83/overview) |
|:--:|

Fix [PCIOS-87](https://linear.app/a8c/issue/PCIOS-87/increase-top-padding-above-the-banner-ad)

Fixes the spacing of Banner Ads depending on the selected theme and list style

| Light Mode | Dark Mode |
|--|--|
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 17 33 57" src="https://github.com/user-attachments/assets/68748fbd-c318-4314-abae-de217c09c0b6" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 17 34 02" src="https://github.com/user-attachments/assets/ee19e853-33d7-4ddb-b8b9-5cf425d04e97" /> |

| Light Mode | Dark Mode |
|--|--|
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 17 34 21" src="https://github.com/user-attachments/assets/243b5183-aed5-48fa-9593-768efd494ebb" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-08 at 17 34 14" src="https://github.com/user-attachments/assets/6f9993f4-12a0-4cee-a9a4-436339e37baa" />

## To test

* Use no account or a non-plus account
* Enable the `bannerAds` feature flag & restart
* Go to the Podcast list
* ✅ Verify banner shows and that there is 16 pixels of spacing between the search bar and the ad
* Change themes to Dark Mode (or other themes)
* ✅ Verify banner shows and that there is 16 pixels of spacing between the search bar and the ad
* Change Podcast List to "List" style from "Grid"
* ✅ Verify banner shows and that there is 16 pixels of spacing between the search bar and the ad

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
