### PR TITLE
Fix watch logging

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -28,7 +28,7 @@ actor LogBuffer {
     }
 
     #if os(watchOS)
-        private let maxFileSize = 250.kilobytes
+        private let maxFileSize = 65.kilobytes
     #else
         private let maxFileSize = 1.megabytes
     #endif

--- a/podcasts/WatchManager+Send.swift
+++ b/podcasts/WatchManager+Send.swift
@@ -26,13 +26,13 @@ extension WatchManager {
         // Hold a local reference so we don't potentially run into a deallocated `self` when the below blocks are run.
         let cachedLog = self.cachedLog
 
-        // since we don't know how long it takes for a send message to timeout, wait only 10 seconds for a watch response before giving up here
+        // since we don't know how long it takes for a send message to timeout, wait only 5 seconds for a watch response before giving up here
         var haveCalledCompletion = false
-        logFileRequestTimedAction.startTimer(for: 5.seconds) { [cachedLog] in
+        logFileRequestTask = Task { [cachedLog] in
+            try? await Task.sleep(for: .seconds(5))
             if haveCalledCompletion { return }
 
             haveCalledCompletion = true
-
             completion(cachedLog)
         }
 
@@ -42,7 +42,7 @@ extension WatchManager {
             if haveCalledCompletion { return }
             haveCalledCompletion = true
 
-            self?.logFileRequestTimedAction.cancelTimer()
+            self?.logFileRequestTask?.cancel()
             if let logContents = response[WatchConstants.Messages.LogFileRequest.logContents] as? String {
                 self?.cachedLog = logContents
                 if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {

--- a/podcasts/WatchManager+Send.swift
+++ b/podcasts/WatchManager+Send.swift
@@ -53,9 +53,11 @@ extension WatchManager {
                 completion(cachedLog)
             }
 
-        }) { _ in
+        }) { error in
             if haveCalledCompletion { return }
             haveCalledCompletion = true
+
+            FileLog.shared.addMessage("WatchManager: Failed log collection \(error)")
 
             completion(cachedLog)
         }

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -401,6 +401,13 @@ class WatchManager: NSObject, WCSessionDelegate {
         DispatchQueue.global(qos: .background).async { [weak self] in
             guard let self else { return }
             sendStateToWatch()
+            if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
+                FileLog.shared.addMessage("WatchManager: Collecting Watch logs in sendStateToWatchInBackground")
+                WatchManager.shared.requestLogFile { _ in
+                    // We do nothing here, the log file will be cached as a result of requesting
+                    FileLog.shared.addMessage("WatchManager: Collected Watch logs in sendStateToWatchInBackground")
+                }
+            }
         }
     }
 

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -7,7 +7,7 @@ import WatchConnectivity
 class WatchManager: NSObject, WCSessionDelegate {
     static let shared = WatchManager()
 
-    let logFileRequestTimedAction = TimedActionHelper()
+    var logFileRequestTask: Task<Void, Never>?
 
     // The last retrieved log is cached here for the duration of this session
     var cachedLog: String? = nil

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -403,9 +403,9 @@ class WatchManager: NSObject, WCSessionDelegate {
             sendStateToWatch()
             if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
                 FileLog.shared.addMessage("WatchManager: Collecting Watch logs in sendStateToWatchInBackground")
-                WatchManager.shared.requestLogFile { _ in
+                WatchManager.shared.requestLogFile { log in
                     // We do nothing here, the log file will be cached as a result of requesting
-                    FileLog.shared.addMessage("WatchManager: Collected Watch logs in sendStateToWatchInBackground")
+                    FileLog.shared.addMessage("WatchManager: Collected Watch logs in sendStateToWatchInBackground isEmpty \(log?.isEmpty ?? true)")
                 }
             }
         }


### PR DESCRIPTION
* Re-adds [a change made](https://github.com/Automattic/pocket-casts-ios/pull/3020) to proactively sync watch logs
* Switches from `TimedActionHelper` to `Task`. This should help with crashes from the original change.
* Adds error logging when log collection fails
* Add isEmpty logging to check that the logs contain something
* Change the maximum watch file size to 65 kilobytes (this was changed [a few months ago](https://github.com/Automattic/pocket-casts-ios/commit/99536493c5a825d40881b92a71b25da351e325bb)) which is the maximum payload size for `WCSession.sendMessage`

## To test

* Use the iPhone and Apple Watch apps together for a while.
* Close the Apple Watch app
* Go to Help & Feedback > Export Database
* Check that watchos-logs file exists with some contents

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
