### PR TITLE
GRDB: remove database corruption recovery

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -47,16 +47,6 @@ public class DataManager {
             dbQueue = GRDBQueue(dbPool: dbPool, logger: Self.logger)
             DataManager.setDatabaseFileProtectionToNone()
             FileLog.shared.addMessage("[DataManager] Initialized using GRDB")
-
-            // Database corruption check
-            if Self.checkDatabaseCorruption(dbPool: dbPool) {
-                // If database is corrupted we start it again in a clean state
-                let dbPool = try! DatabasePool(path: DataManager.pathToDb(), configuration: config)
-                dbQueue = GRDBQueue(dbPool: dbPool, logger: Self.logger)
-                DataManager.setDatabaseFileProtectionToNone()
-                FileLog.shared.addMessage("[DataManager] Database is corrupted, recreated using GRDB")
-                Self.loginAgain = true
-            }
         } else {
             let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FILEPROTECTION_NONE
             dbQueue = FMDBQueue(fmdbQueue: FMDatabaseQueue(path: DataManager.pathToDb(), flags: flags)!)


### PR DESCRIPTION
We have two reports of the user not being able to open the app in the latest beta.

It's not clear whether this is related to the database corruption recovery but in doubt I think is safer to not release this to all users and discuss alternatives.

## To test

1. Code review is enough

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
