### PR TITLE
Add a share button to Transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.96
 -----
 - Localize the How to Upload screen [#3401](https://github.com/Automattic/pocket-casts-ios/pull/3401)
+- Add Share button to Transcripts [#3418](https://github.com/Automattic/pocket-casts-ios/pull/3418)
 
 7.95
 -----

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -826,6 +826,7 @@ enum AnalyticsEvent: String {
     case episodeDetailTranscriptCardShown
     case episodeDetailTranscriptCardTapped
     case episodeTranscriptShown
+    case transcriptShared
 
     // MARK: - Widgets
 

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -169,6 +169,8 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         stackView.addArrangedSubview(closeButton)
         stackView.addArrangedSubview(UIView())
 
+        stackView.addArrangedSubview(shareButton)
+
         if showFromEpisode {
             stackView.addArrangedSubview(playButton)
         }
@@ -238,6 +240,21 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     @objc private func playEpisode() {
         playButton.buttonState = playbackManager.isPlayingEpisode ? .play : .pause
         playButtonTapped?(playbackManager.isPlayingEpisode)
+    }
+
+    @objc private func shareEpisode() {
+        guard let transcript = transcript else { return }
+
+        let transcriptText = transcript.attributedText.string
+        let activityViewController = UIActivityViewController(activityItems: [transcriptText], applicationActivities: nil)
+
+        if let popover = activityViewController.popoverPresentationController {
+            popover.sourceView = shareButton
+            popover.sourceRect = shareButton.bounds
+        }
+
+        present(activityViewController, animated: true)
+        track(.transcriptShared)
     }
 
     private func dismissSearch() {
@@ -343,6 +360,25 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         playButton.addTarget(self, action: #selector(playEpisode), for: .touchUpInside)
         playButton.titleLabel?.adjustsFontForContentSizeCategory = true
         return playButton
+    }()
+
+    private lazy var shareButton: RoundButton = {
+        let titleColor = showFromEpisode ? ThemeColor.primaryText01() : .white
+        let tintColor = showFromEpisode ? ThemeColor.primaryUi05() : .white.withAlphaComponent(0.2)
+
+        var configuration = UIButton.Configuration.filled()
+        configuration.contentInsets = .init(top: 4, leading: 12, bottom: 4, trailing: 12)
+
+        let shareButton = RoundButton(type: .system)
+        shareButton.setTitle(L10n.share, for: .normal)
+        shareButton.addTarget(self, action: #selector(shareEpisode), for: .touchUpInside)
+        shareButton.setTitleColor(titleColor, for: .normal)
+        shareButton.tintColor = tintColor
+        shareButton.layer.masksToBounds = true
+        shareButton.configuration = configuration
+        shareButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
+        shareButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        return shareButton
     }()
 
     private lazy var hiddenTextView: UITextField = {


### PR DESCRIPTION
Implements [PCIOS-89](https://linear.app/a8c/issue/PCIOS-89/add-a-way-to-copy-or-share-the-transcript-text)

Fixes PCIOS-89

This allows the user to share to other apps or copy to the clipboard.

| Episode Detail | Player |
|--|--|
| <img src="https://github.com/user-attachments/assets/27599c7d-ea61-4c15-90c3-66b30bf8ba62" /> | <img  src="https://github.com/user-attachments/assets/f967d402-8f66-4420-8a91-adb4bfed47e5" /> |

https://github.com/user-attachments/assets/887b4ddd-5f1d-47ed-81d9-5027746f5528

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
