### PR TITLE
[New Onboarding] Recommendations screen

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -37,15 +37,24 @@ public class DiscoverServerHandler: DiscoverServerHandling {
         "\(ServerConstants.Urls.discover())images/\(size)/\(podcast).jpg"
     }
 
-    public func discoverPage(completion: @escaping (DiscoverLayout?, Bool) -> Void) {
+    public func discoverPage() async -> (DiscoverLayout?, Bool) {
         let contentPath: String
         if FeatureFlag.recommendations.enabled {
             contentPath = "ios/content_v3.json"
         } else {
             contentPath = "ios/content_v2.json"
         }
-        discoverRequest(path: ServerConstants.Urls.discover() + contentPath, type: DiscoverLayout.self, authenticated: nil) { discoverItems, cachedResponse in
-            completion(discoverItems, cachedResponse)
+        return await withCheckedContinuation { continuation in
+            discoverRequest(path: ServerConstants.Urls.discover() + contentPath, type: DiscoverLayout.self, authenticated: nil) { discoverItems, cachedResponse in
+                continuation.resume(returning: (discoverItems, cachedResponse))
+            }
+        }
+    }
+
+    public func discoverPage(completion: @escaping (DiscoverLayout?, Bool) -> Void) {
+        Task {
+            let page = await discoverPage()
+            completion(page.0, page.1)
         }
     }
 
@@ -69,7 +78,7 @@ public class DiscoverServerHandler: DiscoverServerHandling {
 
     public func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
         await withCheckedContinuation { continuation in
-            DiscoverServerHandler.shared.discoverCategories(source: source, authenticated: authenticated) { result in
+            discoverCategories(source: source, authenticated: authenticated) { result in
                 continuation.resume(returning: result ?? [])
             }
         }
@@ -78,6 +87,14 @@ public class DiscoverServerHandler: DiscoverServerHandling {
     public func discoverCategoryDetails(source: String, authenticated: Bool?, completion: @escaping (DiscoverCategoryDetails?) -> Void) {
         discoverRequest(path: source, type: DiscoverCategoryDetails.self, authenticated: authenticated) { categoryDetails, _ in
             completion(categoryDetails)
+        }
+    }
+
+    public func discoverCategoryDetails(source: String, authenticated: Bool?) async -> DiscoverCategoryDetails? {
+        await withCheckedContinuation { continuation in
+            discoverCategoryDetails(source: source, authenticated: authenticated) { result in
+                continuation.resume(returning: result)
+            }
         }
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1759,6 +1759,8 @@
 		F55449422B758E8300F68AE9 /* PocketCastsUtils in Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; };
 		F55449432B758E8300F68AE9 /* PocketCastsUtils in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F55449412B758E8300F68AE9 /* PocketCastsUtils */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F55449452B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */; };
+		F554B0182E445E0D00056CDF /* OnboardingRecommendationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F554B0172E445E0700056CDF /* OnboardingRecommendationsView.swift */; };
+		F554B01A2E44682500056CDF /* FadeGradientModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F554B0192E44682500056CDF /* FadeGradientModifier.swift */; };
 		F55566FF2D14E3D000231367 /* VideoViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD14E792214642B80082FD5F /* VideoViewController.xib */; };
 		F555980B2C50242800C02EEB /* VideoExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F555980A2C50242800C02EEB /* VideoExporter.swift */; };
 		F555980F2C503F1700C02EEB /* AnimatedShareImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F555980E2C503F1700C02EEB /* AnimatedShareImageView.swift */; };
@@ -1844,6 +1846,8 @@
 		F5E3DAA72BDD5567002BD4E4 /* PCBundleDoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E3DAA62BDD5567002BD4E4 /* PCBundleDoc.swift */; };
 		F5E431D62B50888500A71DB3 /* PlusLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E431D52B50888500A71DB3 /* PlusLabel.swift */; };
 		F5E63CAE2DEA0660000B9EBD /* NonEditableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E63CAD2DEA0660000B9EBD /* NonEditableTextView.swift */; };
+		F5E704192E4ED6FE00C39FA4 /* PodcastSubscribeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E704182E4ED6FE00C39FA4 /* PodcastSubscribeButton.swift */; };
+		F5E7041B2E4ED71A00C39FA4 /* DiscoverPodcastsGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E7041A2E4ED71A00C39FA4 /* DiscoverPodcastsGridView.swift */; };
 		F5E949DA2B61762E002DAFC3 /* TokenHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */; };
 		F5EA21F22CC1CD040043C780 /* EndOfYearDeveloperMenuButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EA21F12CC1CD040043C780 /* EndOfYearDeveloperMenuButton.swift */; };
 		F5EA21F42CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5EA21F32CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift */; };
@@ -3999,6 +4003,8 @@
 		F55275B72CB74E230012B705 /* EndOfYear2023Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2023Story.swift; sourceTree = "<group>"; };
 		F55275B92CB74EB30012B705 /* EndOfYear2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2024Story.swift; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
+		F554B0172E445E0700056CDF /* OnboardingRecommendationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRecommendationsView.swift; sourceTree = "<group>"; };
+		F554B0192E44682500056CDF /* FadeGradientModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadeGradientModifier.swift; sourceTree = "<group>"; };
 		F555980A2C50242800C02EEB /* VideoExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoExporter.swift; sourceTree = "<group>"; };
 		F555980E2C503F1700C02EEB /* AnimatedShareImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedShareImageView.swift; sourceTree = "<group>"; };
 		F55598102C534D4100C02EEB /* CMTimeScale+Common.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMTimeScale+Common.swift"; sourceTree = "<group>"; };
@@ -4061,6 +4067,8 @@
 		F5E3DAA62BDD5567002BD4E4 /* PCBundleDoc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCBundleDoc.swift; sourceTree = "<group>"; };
 		F5E431D52B50888500A71DB3 /* PlusLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusLabel.swift; sourceTree = "<group>"; };
 		F5E63CAD2DEA0660000B9EBD /* NonEditableTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonEditableTextView.swift; sourceTree = "<group>"; };
+		F5E704182E4ED6FE00C39FA4 /* PodcastSubscribeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastSubscribeButton.swift; sourceTree = "<group>"; };
+		F5E7041A2E4ED71A00C39FA4 /* DiscoverPodcastsGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverPodcastsGridView.swift; sourceTree = "<group>"; };
 		F5E949D92B61762E002DAFC3 /* TokenHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenHelperTests.swift; sourceTree = "<group>"; };
 		F5EA21F12CC1CD040043C780 /* EndOfYearDeveloperMenuButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYearDeveloperMenuButton.swift; sourceTree = "<group>"; };
 		F5EA21F32CC1DBFE0043C780 /* EndOfYear2023StoriesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2023StoriesModel.swift; sourceTree = "<group>"; };
@@ -7765,6 +7773,9 @@
 		C7B3C618291AD03400054145 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				F5E7041A2E4ED71A00C39FA4 /* DiscoverPodcastsGridView.swift */,
+				F554B0172E445E0700056CDF /* OnboardingRecommendationsView.swift */,
+				F5E704182E4ED6FE00C39FA4 /* PodcastSubscribeButton.swift */,
 				C7F0EEE6291D9A770007C148 /* LoginCoordinator.swift */,
 				C72223D5292CAE92006B3B55 /* OnboardingFlow.swift */,
 				C7AF7B982926B307002F0025 /* OnboardingHostingViewController.swift */,
@@ -7776,6 +7787,7 @@
 				C7BDECB12A15324C00BECF02 /* Patron */,
 				C7B3C619291AD03A00054145 /* Plus */,
 				C7A110F3291F48C100887A90 /* Welcome */,
+				F554B0192E44682500056CDF /* FadeGradientModifier.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -10319,6 +10331,7 @@
 				C7B7123C29DF49BC00965BF7 /* HorizontalCarousel.swift in Sources */,
 				4041FE572181751F0089D4A1 /* SiriShortcutsManager.swift in Sources */,
 				10A4F75B2C5286560084D783 /* KidsProfileBannerViewModel.swift in Sources */,
+				F5E704192E4ED6FE00C39FA4 /* PodcastSubscribeButton.swift in Sources */,
 				4053CDFB214F374B001C92B1 /* ReleaseDateFilterOverlayController.swift in Sources */,
 				BD26AFD427BDFD18008CC973 /* Folder+Formatting.swift in Sources */,
 				40F0DE8922E42AD2001DAA52 /* PlusLockedInfoView.swift in Sources */,
@@ -10614,6 +10627,7 @@
 				C797D7C32A7A13AA004D7419 /* BookmarkCardTitleView.swift in Sources */,
 				FF1DF0252C8F4E2F0028B8D8 /* ReferralsClaimBannerView.swift in Sources */,
 				BD2B50B0201077150099B79D /* PodcastSettingsViewController+Table.swift in Sources */,
+				F5E7041B2E4ED71A00C39FA4 /* DiscoverPodcastsGridView.swift in Sources */,
 				4007B053230E3115008DDCF5 /* WhatsNewPageView.swift in Sources */,
 				BDCF3C8024283B0F005B6933 /* ListeningHistoryViewController+Swipe.swift in Sources */,
 				BD7641332588272B0070CBF3 /* ThemeableSwitch.swift in Sources */,
@@ -10657,6 +10671,7 @@
 				BD9D923C21342CC50070D4FD /* ListEpisode.swift in Sources */,
 				C781EA432A6B7BF9001DBFCC /* BookmarkRowViewModel.swift in Sources */,
 				BDF4D30F2175AA830086463E /* StarredViewController+Table.swift in Sources */,
+				F554B0182E445E0D00056CDF /* OnboardingRecommendationsView.swift in Sources */,
 				C73CCBC929C590100075EFFD /* View+UIView.swift in Sources */,
 				C7891DC82A6AFE26009DA661 /* SearchField.swift in Sources */,
 				C761300B28E4CA4F0044C6C2 /* AnalyticsCoordinator.swift in Sources */,
@@ -10866,6 +10881,7 @@
 				9A9B83BC2DCBC2A4002CE179 /* CancelSubscriptionSurveyViewModel.swift in Sources */,
 				FF7F89F12C2C0FD600FC0ED5 /* TranscriptModel.swift in Sources */,
 				C7B3C60E2919DD1700054145 /* ContentSizeReader.swift in Sources */,
+				F554B01A2E44682500056CDF /* FadeGradientModifier.swift in Sources */,
 				BD583AF421AE5F9E0048D78D /* EpisodeDateHelper.swift in Sources */,
 				8B67A26B29A7D8820076886D /* ThemeableListHeader.swift in Sources */,
 				BDC940B61BA7F5FB008CC635 /* BouncyButton.swift in Sources */,

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -57,6 +57,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case handleUserActivity = "handle_user_activity"
     case suggestedFolderPopup = "popup"
     case userSatisfactionSurvey = "user_satisfaction_survey"
+    case recommendations
     case unknown
 
     var analyticsDescription: String { rawValue }

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -353,6 +353,18 @@ struct DeveloperMenu: View {
             }
 
             Section {
+                Button("Show Onboarding Recommendations") {
+                    showing = true
+                }
+                .sheet(isPresented: $showing) {
+                    OnboardingRecommendationsView()
+                        .environmentObject(Theme.sharedTheme)
+                }
+            } header: {
+                Text("Onboarding")
+            }
+
+            Section {
                 Text(Bundle.main.identifier)
             } header: {
                 Text("Bundle ID")

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -6,7 +6,8 @@ import PocketCastsUtils
 struct DeveloperMenu: View {
     @State var showingImporter = false
     @State var showingExporter = false
-    @State var showing = false
+    @State var showingPlaylistsOnboarding = false
+    @State var showingRecommendationsOnboarding = false
     @State var showSurvey = false
 
     var body: some View {
@@ -341,11 +342,11 @@ struct DeveloperMenu: View {
 
             Section {
                 Button("Show Playlists Onboarding") {
-                    showing = true
+                    showingPlaylistsOnboarding = true
                 }
-                .sheet(isPresented: $showing) {
+                .sheet(isPresented: $showingPlaylistsOnboarding) {
                     PlaylistsOnboardingView(onClose: {
-                        showing = false
+                        showingPlaylistsOnboarding = false
                     })
                 }
             } header: {
@@ -354,11 +355,13 @@ struct DeveloperMenu: View {
 
             Section {
                 Button("Show Onboarding Recommendations") {
-                    showing = true
+                    showingRecommendationsOnboarding = true
                 }
-                .sheet(isPresented: $showing) {
-                    OnboardingRecommendationsView()
-                        .environmentObject(Theme.sharedTheme)
+                .sheet(isPresented: $showingRecommendationsOnboarding) {
+                    NavigationStack {
+                        OnboardingRecommendationsView()
+                            .environmentObject(Theme.sharedTheme)
+                    }
                 }
             } header: {
                 Text("Onboarding")

--- a/podcasts/Onboarding/DiscoverPodcastsGridView.swift
+++ b/podcasts/Onboarding/DiscoverPodcastsGridView.swift
@@ -5,9 +5,17 @@ struct DiscoverPodcastsGridView: View {
     let category: DiscoverCategory
     let podcasts: [DiscoverPodcast]
 
+    enum Constants {
+        static let itemHeight: CGFloat = 148
+        static let gridSpacing: CGFloat = 16
+        static let itemSpacing: CGFloat = 8
+        static let coverSize: CGFloat = 108
+        static let textHeight: CGFloat = 32
+    }
+
     let columns = [
-        GridItem(.flexible(), spacing: 8),
-        GridItem(.flexible(), spacing: 8),
+        GridItem(.flexible(), spacing: Constants.itemSpacing),
+        GridItem(.flexible(), spacing: Constants.itemSpacing),
         GridItem(.flexible())
     ]
 
@@ -16,7 +24,7 @@ struct DiscoverPodcastsGridView: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            LazyVGrid(columns: columns, spacing: 16) {
+            LazyVGrid(columns: columns, spacing: Constants.gridSpacing) {
                 ForEach(Array(podcasts.prefix(visibleCount)), id: \.uuid) { podcast in
                     podcastItem(podcast)
                 }
@@ -36,9 +44,9 @@ struct DiscoverPodcastsGridView: View {
     }
 
     @ViewBuilder func podcastItem(_ podcast: DiscoverPodcast) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: Constants.itemSpacing) {
             PodcastCover(podcastUuid: podcast.uuid ?? "")
-                .frame(width: 108, height: 108)
+                .frame(width: Constants.coverSize, height: Constants.coverSize)
                 .cornerRadius(8)
                 .overlay {
                     PodcastSubscribeButton(podcast: podcast)
@@ -48,10 +56,10 @@ struct DiscoverPodcastsGridView: View {
                 .font(.caption.weight(.semibold))
                 .lineLimit(2)
                 .multilineTextAlignment(.leading)
-                .frame(height: 32, alignment: .top)
+                .frame(height: Constants.textHeight, alignment: .top)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: 148)
+        .frame(height: Constants.itemHeight)
     }
 
 }

--- a/podcasts/Onboarding/DiscoverPodcastsGridView.swift
+++ b/podcasts/Onboarding/DiscoverPodcastsGridView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import PocketCastsServer
+
+struct DiscoverPodcastsGridView: View {
+    let category: DiscoverCategory
+    let podcasts: [DiscoverPodcast]
+
+    let columns = [
+        GridItem(.flexible(), spacing: 8),
+        GridItem(.flexible(), spacing: 8),
+        GridItem(.flexible())
+    ]
+
+    @State var visibleCount: Int = 6
+    @EnvironmentObject var theme: Theme
+
+    var body: some View {
+        VStack(spacing: 20) {
+            LazyVGrid(columns: columns, spacing: 16) {
+                ForEach(Array(podcasts.prefix(visibleCount)), id: \.uuid) { podcast in
+                    podcastItem(podcast)
+                }
+            }
+            .padding(.horizontal, 20)
+
+            if podcasts.count > visibleCount {
+                Button(action: {
+                    visibleCount = min(visibleCount + 6, podcasts.count)
+                }) {
+                    Text("More \(category.name ?? "Unknown")")
+                        .textStyle(BorderButton())
+                }
+                .padding(.horizontal, 20)
+            }
+        }
+    }
+
+    @ViewBuilder func podcastItem(_ podcast: DiscoverPodcast) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            PodcastCover(podcastUuid: podcast.uuid ?? "")
+                .frame(width: 108, height: 108)
+                .cornerRadius(8)
+                .overlay {
+                    PodcastSubscribeButton(podcast: podcast)
+                }
+
+            Text(podcast.title ?? "")
+                .font(.caption.weight(.semibold))
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+                .frame(height: 32, alignment: .top)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: 148)
+    }
+
+}

--- a/podcasts/Onboarding/DiscoverPodcastsGridView.swift
+++ b/podcasts/Onboarding/DiscoverPodcastsGridView.swift
@@ -47,6 +47,7 @@ struct DiscoverPodcastsGridView: View {
         VStack(alignment: .leading, spacing: Constants.itemSpacing) {
             PodcastCover(podcastUuid: podcast.uuid ?? "")
                 .frame(width: Constants.coverSize, height: Constants.coverSize)
+
                 .cornerRadius(8)
                 .overlay {
                     PodcastSubscribeButton(podcast: podcast)
@@ -54,6 +55,7 @@ struct DiscoverPodcastsGridView: View {
 
             Text(podcast.title ?? "")
                 .font(.caption.weight(.semibold))
+                .foregroundStyle(theme.primaryText01)
                 .lineLimit(2)
                 .multilineTextAlignment(.leading)
                 .frame(height: Constants.textHeight, alignment: .top)

--- a/podcasts/Onboarding/FadeGradientModifier.swift
+++ b/podcasts/Onboarding/FadeGradientModifier.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct FadeGradientModifier: ViewModifier {
+    @EnvironmentObject var theme: Theme
+
+    let height: CGFloat
+    let opacity: Double
+    let isVisible: Bool
+    let bottomOffset: CGFloat
+
+    init(
+        height: CGFloat = 100,
+        opacity: Double = 0.8,
+        isVisible: Bool = true,
+        bottomOffset: CGFloat = 0
+    ) {
+        self.height = height
+        self.opacity = opacity
+        self.isVisible = isVisible
+        self.bottomOffset = bottomOffset
+    }
+
+    func body(content: Content) -> some View {
+        content.overlay(alignment: .bottom) {
+            if isVisible {
+                LinearGradient(
+                    colors: [theme.primaryUi01.opacity(0), theme.primaryUi01],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .opacity(opacity)
+                .frame(height: height)
+                .padding(.bottom, bottomOffset)
+                .allowsHitTesting(false)
+            }
+        }
+    }
+}
+
+extension View {
+    func fadeGradient(
+        height: CGFloat = 100,
+        opacity: Double = 0.8,
+        isVisible: Bool = true,
+        bottomOffset: CGFloat = 0
+    ) -> some View {
+        modifier(
+            FadeGradientModifier(
+                height: height,
+                opacity: opacity,
+                isVisible: isVisible,
+                bottomOffset: bottomOffset
+            )
+        )
+    }
+}

--- a/podcasts/Onboarding/Import/ImportLandingView.swift
+++ b/podcasts/Onboarding/Import/ImportLandingView.swift
@@ -24,9 +24,10 @@ struct ImportLandingView: View {
 
                     VStack(alignment: .leading, spacing: 16) {
                         ForEach(viewModel.availableSources) { importSource in
-                            ImportSourceRow(importSource: importSource) {
-                                viewModel.didSelect(importSource)
+                            NavigationLink(destination: ImportDetailsView(importSource: importSource, viewModel: viewModel)) {
+                                ImportSourceRowContent(importSource: importSource)
                             }
+                            .buttonStyle(PlainButtonStyle())
                         }
                     }
 
@@ -51,30 +52,39 @@ private struct ImportSourceRow: View {
         Button {
             action()
         } label: {
-            HStack(spacing: 12) {
-                Image(importSource.iconName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 56, height: 56)
-                    .cornerRadius(16)
-                    .shadow(color: .black.opacity(0.2), radius: 3, x: 0, y: 1)
-
-                Text(L10n.importInstructionsImportFrom(importSource.displayName))
-                    .multilineTextAlignment(.leading)
-                    .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
-                    .fixedSize(horizontal: false, vertical: true)
-                    .font(style: .subheadline, weight: .medium, maxSizeCategory: .extraExtraExtraLarge)
-
-                Spacer()
-
-                Image(systemName: "chevron.right")
-                    .frame(minHeight: 14)
-                    .font(style: .subheadline, weight: .medium, maxSizeCategory: .extraExtraExtraLarge)
-                    .foregroundColor(AppTheme.color(for: .primaryIcon02, theme: theme))
-            }
-            .contentShape(Rectangle())
+            ImportSourceRowContent(importSource: importSource)
         }
         .buttonStyle(ClickyButton())
+    }
+}
+
+private struct ImportSourceRowContent: View {
+    @EnvironmentObject var theme: Theme
+    let importSource: ImportViewModel.ImportSource
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(importSource.iconName)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 56, height: 56)
+                .cornerRadius(16)
+                .shadow(color: .black.opacity(0.2), radius: 3, x: 0, y: 1)
+
+            Text(L10n.importInstructionsImportFrom(importSource.displayName))
+                .multilineTextAlignment(.leading)
+                .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
+                .fixedSize(horizontal: false, vertical: true)
+                .font(style: .subheadline, weight: .medium, maxSizeCategory: .extraExtraExtraLarge)
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .frame(minHeight: 14)
+                .font(style: .subheadline, weight: .medium, maxSizeCategory: .extraExtraExtraLarge)
+                .foregroundColor(AppTheme.color(for: .primaryIcon02, theme: theme))
+        }
+        .contentShape(Rectangle())
     }
 }
 

--- a/podcasts/Onboarding/Import/ImportViewModel.swift
+++ b/podcasts/Onboarding/Import/ImportViewModel.swift
@@ -63,7 +63,7 @@ class ImportViewModel: OnboardingModel {
         }
     }
 
-    struct ImportSource: Identifiable, CustomDebugStringConvertible {
+    struct ImportSource: Identifiable, CustomDebugStringConvertible, Hashable {
         let id: ImportSourceId
         let displayName: String
         let steps: String

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -34,7 +34,7 @@ struct OnboardingRecommendationsView: View {
                                             category: category,
                                             podcasts: categoryPodcasts[category.id ?? 0] ?? []
                                         )
-                                        .frame(minHeight: 316) // Reserve space for 2 rows: (148 * 2) + 16 spacing + 4 padding
+                                        .frame(minHeight: (DiscoverPodcastsGridView.Constants.itemHeight * 2) + DiscoverPodcastsGridView.Constants.gridSpacing + 4)
                                     }
                                 }
                             } else {

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -132,10 +132,10 @@ struct OnboardingRecommendationsView: View {
             .padding(.horizontal, 20)
 
             VStack(alignment: .center, spacing: 16) {
-                Text("We hope you love these suggestions!")
+                Text(L10n.onboardingRecommendationsTitle)
                     .font(.title.weight(.bold))
                     .multilineTextAlignment(.center)
-                Text("Here are some great shows to start with. Tap to follow, search or import from other apps.")
+                Text(L10n.onboardingRecommendationsSubtitle)
                     .font(.body)
                     .multilineTextAlignment(.center)
                     .foregroundColor(.secondary)

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -3,6 +3,8 @@ import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 
+
+
 struct OnboardingRecommendationsView: View {
 
     @State var categories: [DiscoverCategory] = []
@@ -183,6 +185,9 @@ struct OnboardingRecommendationsView: View {
                             }
                             .foregroundColor(theme.primaryInteractive01)
                         }
+                    }
+                    .onAppear {
+                        OnboardingFlow.shared.track(.onboardingImportShown)
                     }
             }
             .environmentObject(theme)

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -14,6 +14,7 @@ struct OnboardingRecommendationsView: View {
     @State var searchTerm: String = ""
 
     @State var searchResults = [PodcastFolderSearchResult]()
+    @State var searchTask: Task<Void, Never>?
 
     var body: some View {
         Group {
@@ -41,14 +42,13 @@ struct OnboardingRecommendationsView: View {
                                 if #available(iOS 17.0, *) {
                                     podcastList()
                                         .onChange(of: searchTerm) { oldValue, newValue in
-                                            Task {
-                                                let podcastSearch = PodcastSearchTask()
-                                                let results = try await podcastSearch.search(term: newValue)
-                                                searchResults = results
-                                            }
+                                            performSearch(term: newValue)
                                         }
                                 } else {
                                     podcastList()
+                                        .onChange(of: searchTerm) { newValue in
+                                            performSearch(term: newValue)
+                                        }
                                 }
                             }
                         }
@@ -93,6 +93,34 @@ struct OnboardingRecommendationsView: View {
             }
         }
         .environmentObject(SearchAnalyticsHelper(source: .recommendations))
+    }
+
+    private func performSearch(term: String) {
+        searchTask?.cancel()
+
+        guard !term.isEmpty else {
+            searchResults = []
+            return
+        }
+
+        searchTask = Task {
+            do {
+                let podcastSearch = PodcastSearchTask()
+                let results = try await podcastSearch.search(term: term)
+
+                if !Task.isCancelled {
+                    await MainActor.run {
+                        searchResults = results
+                    }
+                }
+            } catch {
+                if !Task.isCancelled {
+                    await MainActor.run {
+                        searchResults = []
+                    }
+                }
+            }
+        }
     }
 
     private func regionCode(for layout: DiscoverLayout) -> String {

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -1,0 +1,182 @@
+import SwiftUI
+import PocketCastsDataModel
+import PocketCastsServer
+import PocketCastsUtils
+
+struct OnboardingRecommendationsView: View {
+
+    @State var categories: [DiscoverCategory] = []
+    @State var layout: DiscoverLayout?
+    @State var categoryPodcasts: [Int: [DiscoverPodcast]] = [:]
+    @State var showingImport = false
+
+    @EnvironmentObject var theme: Theme
+    @State var searchTerm: String = ""
+
+    @State var searchResults = [PodcastFolderSearchResult]()
+
+    var body: some View {
+        Group {
+            if layout != nil {
+                ZStack(alignment: .bottom) {
+                    ScrollView(.vertical) {
+                        VStack(spacing: 16) {
+                            header()
+                            searchBar()
+                            if searchTerm.isEmpty {
+                                ForEach(categories, id: \.id) { category in
+                                    VStack(alignment: .leading, spacing: 16) {
+                                        Text(category.name ?? "Unknown")
+                                            .font(.title2.weight(.bold))
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                            .padding(.horizontal, 20)
+                                        DiscoverPodcastsGridView(
+                                            category: category,
+                                            podcasts: categoryPodcasts[category.id ?? 0] ?? []
+                                        )
+                                        .frame(minHeight: 316) // Reserve space for 2 rows: (148 * 2) + 16 spacing + 4 padding
+                                    }
+                                }
+                            } else {
+                                if #available(iOS 17.0, *) {
+                                    podcastList()
+                                        .onChange(of: searchTerm) { oldValue, newValue in
+                                            Task {
+                                                let podcastSearch = PodcastSearchTask()
+                                                let results = try await podcastSearch.search(term: newValue)
+                                                searchResults = results
+                                            }
+                                        }
+                                } else {
+                                    podcastList()
+                                }
+                            }
+                        }
+                        .padding(.bottom, 120)
+                    }
+                    .fadeGradient(bottomOffset: 50)
+
+                    VStack {
+                        Button(action: {
+                            //TODO: Implement this
+                        }) {
+                            Text(L10n.continue)
+                                .textStyle(RoundedButton())
+                        }
+                        .padding(.horizontal)
+                        .padding(.top, 2)
+                        .padding(.bottom)
+                    }
+                    .background(Color(UIColor.systemBackground))
+                    .background(.ultraThinMaterial)
+                }
+            } else {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: theme.primaryIcon01))
+                    .task {
+                        let page = await DiscoverServerHandler.shared.discoverPage()
+                        guard let layout = page.0 else {
+                            return
+                        }
+
+                        let categoriesItem = layout.layout?.first { item in
+                            item.type == "categories"
+                        }
+                        guard let categoriesItem else {
+                            return
+                        }
+                        categories = await DiscoverServerHandler.shared.discoverCategories(source: categoriesItem.source ?? "", authenticated: categoriesItem.isAuthenticated)
+                        self.layout = layout
+
+                        await loadCategoryPodcasts(layout: layout)
+                    }
+            }
+        }
+        .environmentObject(SearchAnalyticsHelper(source: .recommendations))
+    }
+
+    private func regionCode(for layout: DiscoverLayout) -> String {
+        let currentRegionCode = Settings.discoverRegion(discoverLayout: layout)
+        let serverRegion = layout.regions?[currentRegionCode]?.code ?? "us"
+        return serverRegion
+    }
+
+    private func loadCategoryPodcasts(layout: DiscoverLayout) async {
+        let regionCode = regionCode(for: layout)
+
+        await withTaskGroup(of: Void.self) { group in
+            for category in categories {
+                group.addTask {
+                    let source = category.source?.replacingOccurrences(of: layout.regionCodeToken, with: regionCode)
+                    let podcasts = await DiscoverServerHandler.shared.discoverCategoryDetails(source: source ?? "", authenticated: false)?.podcasts ?? []
+
+                    await MainActor.run {
+                        self.categoryPodcasts[category.id ?? 0] = podcasts
+                    }
+                }
+            }
+        }
+    }
+
+
+    @ViewBuilder func header() -> some View {
+        VStack(spacing: 16) {
+            HStack {
+                Spacer()
+                Button(L10n.import) {
+                    showingImport = true
+                    OnboardingFlow.shared.track(.onboardingImportAppSelected, properties: ["app": "recommendations_header"])
+                }
+                .tint(theme.primaryInteractive01)
+            }
+            .padding(.horizontal, 20)
+
+            VStack(alignment: .center, spacing: 16) {
+                Text("We hope you love these suggestions!")
+                    .font(.title.weight(.bold))
+                    .multilineTextAlignment(.center)
+                Text("Here are some great shows to start with. Tap to follow, search or import from other apps.")
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 30)
+        }
+        .padding(.top, 20)
+        .sheet(isPresented: $showingImport) {
+            NavigationStack {
+                ImportLandingView(viewModel: ImportViewModel())
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            Button(L10n.accessibilityDismiss) {
+                                showingImport = false
+                                OnboardingFlow.shared.track(.onboardingImportDismissed)
+                            }
+                            .foregroundColor(theme.primaryInteractive01)
+                        }
+                    }
+            }
+            .environmentObject(theme)
+        }
+    }
+
+    @ViewBuilder func searchBar() -> some View {
+        PCSearchView(searchTerm: $searchTerm)
+            .frame(height: PCSearchView.defaultHeight)
+    }
+
+    @ViewBuilder func podcastList() -> some View {
+        LazyVStack(spacing: 0) {
+            ForEach(searchResults) { podcast in
+                SearchResultCell(episode: nil, result: podcast, played: false)
+            }
+        }
+        .padding(.horizontal, 20)
+    }
+}
+
+#Preview("Live") {
+    OnboardingRecommendationsView()
+        .environmentObject(Theme.sharedTheme)
+}

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -31,6 +31,7 @@ struct OnboardingRecommendationsView: View {
                                     VStack(alignment: .leading, spacing: 16) {
                                         Text(category.name ?? "Unknown")
                                             .font(.title2.weight(.bold))
+                                            .foregroundStyle(theme.primaryText01)
                                             .frame(maxWidth: .infinity, alignment: .leading)
                                             .padding(.horizontal, 20)
                                         DiscoverPodcastsGridView(
@@ -69,7 +70,7 @@ struct OnboardingRecommendationsView: View {
                         .padding(.top, 2)
                         .padding(.bottom)
                     }
-                    .background(Color(UIColor.systemBackground))
+                    .background(theme.primaryInteractive02)
                     .background(.ultraThinMaterial)
                 }
             } else {
@@ -94,6 +95,7 @@ struct OnboardingRecommendationsView: View {
                     }
             }
         }
+        .background(theme.primaryInteractive02)
         .environmentObject(SearchAnalyticsHelper(source: .recommendations))
     }
 
@@ -165,10 +167,11 @@ struct OnboardingRecommendationsView: View {
                 Text(L10n.onboardingRecommendationsTitle)
                     .font(.title.weight(.bold))
                     .multilineTextAlignment(.center)
+                    .foregroundColor(theme.primaryText01)
                 Text(L10n.onboardingRecommendationsSubtitle)
                     .font(.body)
                     .multilineTextAlignment(.center)
-                    .foregroundColor(.secondary)
+                    .foregroundColor(theme.primaryText02)
             }
             .padding(.horizontal, 30)
         }
@@ -212,5 +215,5 @@ struct OnboardingRecommendationsView: View {
 
 #Preview("Live") {
     OnboardingRecommendationsView()
-        .environmentObject(Theme.sharedTheme)
+        .environmentObject(Theme(previewTheme: .extraDark))
 }

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -172,6 +172,7 @@ struct OnboardingRecommendationsView: View {
                 SearchResultCell(episode: nil, result: podcast, played: false)
             }
         }
+        .environmentObject(SearchHistoryModel.shared)
         .padding(.horizontal, 20)
     }
 }

--- a/podcasts/Onboarding/PodcastSubscribeButton.swift
+++ b/podcasts/Onboarding/PodcastSubscribeButton.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+import PocketCastsServer
+import PocketCastsDataModel
+import PocketCastsUtils
+
+struct PodcastSubscribeButton: View {
+    let podcast: DiscoverPodcast
+
+    @State private var isSubscribed: Bool = false
+    @State private var scale: CGFloat = 1.0
+
+    @EnvironmentObject var theme: Theme
+    @EnvironmentObject var searchAnalyticsHelper: SearchAnalyticsHelper
+
+    var body: some View {
+        Button(action: {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                scale = 0.7
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                toggleSubscription()
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    scale = 1.0
+                }
+            }
+        }) {
+            Color.clear
+        }
+        .overlay(alignment: .bottomTrailing) {
+            Image(isSubscribed ? "discover_subscribed_dark" : "discover_subscribe_dark")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(ThemeColor.contrast01(for: theme.activeTheme).color)
+                .frame(width: 28, height: 28)
+                .background(ThemeColor.veil(for: theme.activeTheme).color)
+                .clipShape(Circle())
+                .scaleEffect(scale)
+                .offset(x: -4, y: -4)
+        }
+        .accessibilityLabel(isSubscribed ?
+            (FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed) :
+            (FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe)
+        )
+    }
+
+    private func toggleSubscription() {
+        if isSubscribed {
+            unsubscribe()
+        } else {
+            subscribe()
+        }
+    }
+
+    private func subscribe() {
+        guard let uuid = podcast.uuid else { return }
+
+        isSubscribed = true
+
+        if podcast.iTunesOnly() {
+            if let iTunesId = podcast.iTunesId, let iTunesIdInt = Int(iTunesId) {
+                ServerPodcastManager.shared.subscribeFromItunesId(iTunesIdInt, completion: nil)
+            }
+        } else {
+            ServerPodcastManager.shared.subscribe(to: uuid, completion: nil)
+        }
+
+        HapticsHelper.triggerSubscribedHaptic()
+
+        let analyticsUuid = podcast.uuid ?? podcast.iTunesId ?? "unknown"
+        Analytics.track(.podcastSubscribed, properties: ["source": searchAnalyticsHelper.source, "uuid": analyticsUuid])
+    }
+
+    private func unsubscribe() {
+        guard let uuid = podcast.uuid else { return }
+
+        guard let podcast = DataManager.sharedManager.findPodcast(uuid: uuid) else { return }
+
+        isSubscribed = false
+
+        PodcastManager.shared.unsubscribe(podcast: podcast)
+
+        Analytics.track(.podcastUnsubscribed, properties: ["source": searchAnalyticsHelper.source, "uuid": podcast.uuid])
+    }
+}

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1966,6 +1966,10 @@ internal enum L10n {
   internal static var off: String { return L10n.tr("Localizable", "off", fallback: "Off") }
   /// A common string used throughout the app. Used as a confirmation or acceptance.
   internal static var ok: String { return L10n.tr("Localizable", "ok", fallback: "OK") }
+  /// Subtitle shown for the recommendations sreen during onboarding
+  internal static var onboardingRecommendationsSubtitle: String { return L10n.tr("Localizable", "onboarding_recommendations_subtitle", fallback: "Here are some great shows to start with. Tap to follow, search or import from other apps.") }
+  /// Title shown for the recommendations sreen during onboarding
+  internal static var onboardingRecommendationsTitle: String { return L10n.tr("Localizable", "onboarding_recommendations_title", fallback: "We hope you love these suggestions!") }
   /// Only on Unmetered Wifi
   internal static var onlyOnUnmeteredWifi: String { return L10n.tr("Localizable", "only_on_unmetered_wifi", fallback: "Only on Unmetered Wifi") }
   /// Only on Unmetered Wifi detail information

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5067,6 +5067,12 @@
 /* Notification title for weekly reengagement message */
 "notifications_reengagement_weekly_title" = "We miss you!";
 
+/* Title shown for the recommendations sreen during onboarding */
+"onboarding_recommendations_title" = "We hope you love these suggestions!";
+
+/* Subtitle shown for the recommendations sreen during onboarding */
+"onboarding_recommendations_subtitle" = "Here are some great shows to start with. Tap to follow, search or import from other apps.";
+
 /* Notification body for weekly reengagement message */
 "notifications_reengagement_weekly_body" = "It’s been awhile since you’ve listened. Jump back in and enjoy!";
 


### PR DESCRIPTION
Completes [PCIOS-78](https://linear.app/a8c/issue/PCIOS-78/add-old-version-of-the-recommendations-screen)

This implements the current iteration of the Recommendations screen.

Recommendations are fetched from the Discover endpoint.

| Recommendations | Search |
|--|--|
| <img width="300" src="https://github.com/user-attachments/assets/518a6d37-3b1d-49ce-9628-fc3649993d9f" /> | <img width="300" src="https://github.com/user-attachments/assets/825455ec-a9cb-4ec6-a2ea-9200d0e2a4fc" /> |

## Test

* Open the Developer Menu
* Tap on the "Show Onboarding Recommendations" option
* ✅ Verify that tapping shows subscribes to them
* Try the Search
* ✅ Verify that searching opens results
* Tap Podcasts
* ✅ Verify that shows can be subscribed to
* Tap the Import button
* ✅ Verify that the Import instructions screen is shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
