### PR TITLE
GRDB: enable concurrent reads only for TestFlight

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -377,7 +377,7 @@ public enum FeatureFlag: String, CaseIterable {
             #if DEBUG
             true
             #else
-            false
+            BuildEnvironment.current == .testFlight
             #endif
         case .limitPlaybackPositionChanges:
             true


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Enables concurrent reads for TestFlight only — besides the debug builds.

## To test

1. Go to `FeatureFlag.swift` and change `concurrentDatabaseReads` to `BuildEnvironment.current == .testFlight` (remove the `#if DEBUG` condition)
2. In `GRDBQueue.swift` add a breakpoint in lines `42` and `47`
3. Run the app
4. ✅ Only the breakpoint in line `42` should hit, meaning concurrent reads are disabled
5. Go to `BuildEnvironment.swift` and change line 24 to `return .testFlight` (to simulate a TestFlight build)
6. Re-run the app
7. ✅ Only the breakpoint in line `47` should hit, meaning current reads are enabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
