### PR TITLE
Add share_transcripts feature flag

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -227,6 +227,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Use the new upgrade screens for account creation
     case newOnboardingAccountCreation
 
+    /// Adds a sharing button to the transcript view
+    case shareTranscripts
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -383,6 +386,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .newOnboardingAccountCreation:
             false
+        case .shareTranscripts:
+            true
         }
     }
 

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -169,7 +169,9 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         stackView.addArrangedSubview(closeButton)
         stackView.addArrangedSubview(UIView())
 
-        stackView.addArrangedSubview(shareButton)
+        if FeatureFlag.shareTranscripts.enabled {
+            stackView.addArrangedSubview(shareButton)
+        }
 
         if showFromEpisode {
             stackView.addArrangedSubview(playButton)


### PR DESCRIPTION

| Feature Flag Disabled | Feature Flag Enabled |
|--|--|
| <img width="768" height="272" alt="CleanShot 2025-08-18 at 09 03 37@2x" src="https://github.com/user-attachments/assets/0b2bc860-90cf-4a57-993d-766c0cfe5ecf" /> | <img width="768" height="272" alt="CleanShot 2025-08-18 at 09 03 49@2x" src="https://github.com/user-attachments/assets/70e1c244-ad75-470c-818e-cf5fc7fd38c3" /> |

## To test

* Navigate to an episode with a transcript
* Open the transcript view
* Ensure the Share button appears by default
* Disable the `share_transcripts` feature flag
* Navigate back to the transcript
* Ensure the Share button disappears


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
