### PR TITLE
Do not switch file if we already have the streamed file being played

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -230,6 +230,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Adds a sharing button to the transcript view
     case shareTranscripts
 
+    /// Skips switching player to downloaded file if already playing from the same cached streamed file
+    case doNotSwitchToDownloadedFile
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -388,6 +391,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .shareTranscripts:
             true
+        case .doNotSwitchToDownloadedFile:
+            false
         }
     }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2055,6 +2055,18 @@ class PlaybackManager: ServerPlaybackDelegate {
             // the current episode we were playing has downloaded, switch to playing the downloaded version
             let currentlyPlaying = playing()
             recordPlaybackPosition(sendToServerImmediately: false, fireNotifications: true)
+
+            let episodeIsChanging = refreshedEpisode.uuid != currentEpisode()?.uuid
+
+            if FeatureFlag.doNotSwitchToDownloadedFile.enabled,
+               FeatureFlag.streamAndCachePlayingEpisode.enabled,
+               !episodeIsChanging,
+               effects().trimSilence == .off,
+               !playerSwitchRequired(),
+               !refreshedEpisode.videoPodcast() {
+                return
+            }
+
             load(episode: refreshedEpisode, autoPlay: currentlyPlaying, overrideUpNext: false, saveCurrentEpisode: false)
             if refreshedEpisode.videoPodcast() {
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.videoPlaybackEngineSwitched)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2056,14 +2056,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             let currentlyPlaying = playing()
             recordPlaybackPosition(sendToServerImmediately: false, fireNotifications: true)
 
-            let episodeIsChanging = refreshedEpisode.uuid != currentEpisode()?.uuid
-
-            if FeatureFlag.doNotSwitchToDownloadedFile.enabled,
-               FeatureFlag.streamAndCachePlayingEpisode.enabled,
-               !episodeIsChanging,
-               effects().trimSilence == .off,
-               !playerSwitchRequired(),
-               !refreshedEpisode.videoPodcast() {
+            if !needsToReloadPlayingEpisode(refreshedEpisode) {
                 return
             }
 
@@ -2071,6 +2064,24 @@ class PlaybackManager: ServerPlaybackDelegate {
             if refreshedEpisode.videoPodcast() {
                 NotificationCenter.postOnMainThread(notification: Constants.Notifications.videoPlaybackEngineSwitched)
             }
+        }
+    }
+
+    func needsToReloadPlayingEpisode(_ refreshedEpisode: BaseEpisode) -> Bool {
+        let episodeIsChanging = refreshedEpisode.uuid != currentEpisode()?.uuid
+
+        if FeatureFlag.doNotSwitchToDownloadedFile.enabled,
+           FeatureFlag.streamAndCachePlayingEpisode.enabled,
+           !episodeIsChanging,
+           effects().trimSilence == .off,
+           !playerSwitchRequired(),
+           !refreshedEpisode.videoPodcast() {
+            return false
+        } else {
+            if !episodeIsChanging {
+                FileLog.shared.addMessage("Playback Manager: Needs to reload current episode [\(refreshedEpisode.title ?? "") - \(refreshedEpisode.uuid)].\n Possible Reasons: Trim silence: \(effects().trimSilence), Player switch required: \(playerSwitchRequired()), Video podcast: \(refreshedEpisode.videoPodcast())")
+            }
+            return true
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-55 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start
2. Enable the FF `doNotSwitchToDownloadedFile` in the Profile -> Settings -> Beta Features menu
3. Ensure that you do not have Trim Silence active
4. Start playing an episode of a podcast that you still didn't download
5. Check if you hear any "pop" sound when the episode downloads. You can start the download of episode after you start playing it to check the exact moment
6. Enable "Trim Silence" globally
7. Play another episode that is not downloaded
8. Check that this time your hear the "pop" when the download is finished. this is because the app needs to switch to the EffectsPlayer
9. Now disable the Trim Silence effect while the episode is playing
10. Switch to another episode that you didn't played before
11. Check that it plays correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
