### PR TITLE
[Playlists] Increase max filter items limit

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -285,7 +285,7 @@ struct Constants {
             static let watchListItems = 50
         #else
             static let maxListItemsToSendToWatch = 50
-            static let maxFilterItems = 500
+            static let maxFilterItems = FeatureFlag.playlistsRebranding.enabled ? 1000 : 500
             static let maxCarplayItems = 100
             static let maxBulkDownloads = 100
             static let maxSubscriptionExpirySeconds: TimeInterval = 30.days


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/initiative/playlists-f7f3c1cddf7c/overview)
|:---:|

Fixes PCIOS-94

This PR increases the limit of the displayed episodes for Playlists

## To test

- Make sure you have the rebranding ff on
- Make sure you have a big database with many podcasts to reach more than 1000 episodes
- Create a filter with all podcasts
- The limit should be 1000
- Do the test with the FF off and confirm the limit status at 500
- To check the limit add a breakpoint in `func queryFor(filter: EpisodeFilter, episodeUuidToAdd: String?, limit: Int) -> String`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
