### PR TITLE
Fix PlaylistRefreshOperation by removing the unused tableView

### DIFF
--- a/podcasts/FilterPreviewViewController.swift
+++ b/podcasts/FilterPreviewViewController.swift
@@ -196,7 +196,7 @@ class FilterPreviewViewController: LargeNavBarViewController, FilterChipActionDe
     }
 
     func refreshEpisodes(animated: Bool) {
-        let refreshOperation = PlaylistRefreshOperation(tableView: previewTable, filter: newFilter) { [weak self] newData in
+        let refreshOperation = PlaylistRefreshOperation(filter: newFilter) { [weak self] newData in
             guard let strongSelf = self else { return }
             strongSelf.previewTable.isHidden = (newData.count == 0)
             strongSelf.noEpisodeView.isHidden = (newData.count != 0)

--- a/podcasts/New Creation/New Preview/PlaylistPreviewViewModel.swift
+++ b/podcasts/New Creation/New Preview/PlaylistPreviewViewModel.swift
@@ -150,7 +150,7 @@ class PlaylistPreviewViewModel: ObservableObject {
             operationQueue.cancelAllOperations()
             episodes.removeAll()
         }
-        let refreshOperation = PlaylistRefreshOperation(tableView: UITableView(), filter: newPlaylist) { [weak self] newData in
+        let refreshOperation = PlaylistRefreshOperation(filter: newPlaylist) { [weak self] newData in
             self?.episodes = newData
             DispatchQueue.main.async {
                 self?.newPlaylistHasChanged = true

--- a/podcasts/PlaylistRefreshOperation.swift
+++ b/podcasts/PlaylistRefreshOperation.swift
@@ -3,13 +3,11 @@ import PocketCastsDataModel
 
 class PlaylistRefreshOperation: Operation {
     private let episodesDataManager: EpisodesDataManager
-    private let tableView: UITableView
     private let filter: EpisodeFilter
     private let completion: ([ListEpisode]) -> Void
 
-    init(episodesDataManager: EpisodesDataManager = .init(), tableView: UITableView, filter: EpisodeFilter, completion: @escaping (([ListEpisode]) -> Void)) {
+    init(episodesDataManager: EpisodesDataManager = .init(), filter: EpisodeFilter, completion: @escaping (([ListEpisode]) -> Void)) {
         self.episodesDataManager = episodesDataManager
-        self.tableView = tableView
         self.filter = filter
         self.completion = completion
 

--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -482,7 +482,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
     }
 
     func refreshEpisodes(animated: Bool) {
-        let refreshOperation = PlaylistRefreshOperation(tableView: tableView, filter: filter) { [weak self] newData in
+        let refreshOperation = PlaylistRefreshOperation(filter: filter) { [weak self] newData in
             guard let strongSelf = self else { return }
 
             strongSelf.firstTimeLoading = false

--- a/podcasts/StarredFilterOverlayController.swift
+++ b/podcasts/StarredFilterOverlayController.swift
@@ -108,7 +108,7 @@ class StarredFilterOverlayController: PCViewController {
             tableView.reloadSections(IndexSet(integer: 1), with: .automatic)
             return
         }
-        let refreshOperation = PlaylistRefreshOperation(tableView: tableView, filter: filterToEdit) { [weak self] newData in
+        let refreshOperation = PlaylistRefreshOperation(filter: filterToEdit) { [weak self] newData in
             guard let strongSelf = self, strongSelf.viewModel.toggleIsOn else { return }
             strongSelf.episodes = newData
             strongSelf.tableView.reloadSections(IndexSet(integer: 1), with: .automatic)


### PR DESCRIPTION
Fix PlaylistRefreshOperation by removing the unused tableView reference 

## To test

- Make sure the playlist rebranding FF is on
- Create a new smart playlist
- Make sure the preview works as expected using all rules
- Switch off the FF
- Do the same test with the legacy Filters

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
