### PR TITLE
App Clips: add `pocketcasts.net` for testing

### DIFF
--- a/podcasts/podcasts.entitlements
+++ b/podcasts/podcasts.entitlements
@@ -26,6 +26,7 @@
 		<string>applinks:play.pocketcasts.com</string>
 		<string>appclips:play.pocketcasts.com</string>
 		<string>appclips:play.pocketcasts.net</string>
+		<string>appclips:pocketcasts.net</string>
 	</array>
 	<key>com.apple.developer.carplay-audio</key>
 	<true/>

--- a/podcasts/podcasts.prototype.entitlements
+++ b/podcasts/podcasts.prototype.entitlements
@@ -20,6 +20,7 @@
 		<string>applinks:play.pocketcasts.com</string>
 		<string>appclips:play.pocketcasts.com</string>
 		<string>appclips:play.pocketcasts.net</string>
+		<string>appclips:pocketcasts.net</string>
 	</array>
 	<key>com.apple.developer.networking.wifi-info</key>
 	<true/>

--- a/podcasts/podcastsDebug.entitlements
+++ b/podcasts/podcastsDebug.entitlements
@@ -24,6 +24,7 @@
 		<string>applinks:play.pocketcasts.com</string>
 		<string>appclips:play.pocketcasts.com</string>
 		<string>appclips:play.pocketcasts.net</string>
+		<string>appclips:pocketcasts.net</string>
 	</array>
 	<key>com.apple.developer.carplay-audio</key>
 	<true/>


### PR DESCRIPTION
When working on App Clips it would be good to be able to use `pocketcasts.net` (Staging) for testing. Since this was missing I added.

## To test

Just code review.