### PR TITLE
Fix chromecast playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Localize the How to Upload screen [#3401](https://github.com/Automattic/pocket-casts-ios/pull/3401)
 - Add Share button to Transcripts [#3418](https://github.com/Automattic/pocket-casts-ios/pull/3418)
 - Add logic to avoid unnecessary player reload and resulting audio glitch when streamin downloads complete [#3432](https://github.com/Automattic/pocket-casts-ios/pull/3432)
+- Fix Chromecast streaming [#3438](https://github.com/Automattic/pocket-casts-ios/pull/3438)
 
 7.95
 -----

--- a/PocketCastsTests/Tests/Utilities/EpisodeManagerTests.swift
+++ b/PocketCastsTests/Tests/Utilities/EpisodeManagerTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+import FMDB
+@testable import podcasts
+import PocketCastsDataModel
+import PocketCastsServer
+
+final class EpisodeManagerTests: DBTestCase {
+
+    // MARK: - urlForEpisode streamingOnly Tests
+
+    func testUrlForEpisodeStreamingOnlyWithNoDownloadedContent() {
+        // Given: An episode that is not downloaded at all
+        let episode = Episode()
+        episode.uuid = "test-no-download-789"
+        episode.downloadUrl = "https://example.com/remote-podcast.mp3"
+        episode.episodeStatus = DownloadStatus.notDownloaded.rawValue
+
+        // When: Calling urlForEpisode with streamingOnly: false
+        let localUrl = EpisodeManager.urlForEpisode(episode, streamingOnly: false)
+
+        // Then: Should return streaming URL (no local content available)
+        XCTAssertEqual(localUrl?.absoluteString, "https://example.com/remote-podcast.mp3", "Should return streaming URL when no local content")
+
+        // When: Calling urlForEpisode with streamingOnly: true
+        let streamingUrl = EpisodeManager.urlForEpisode(episode, streamingOnly: true)
+
+        // Then: Should return the same streaming URL
+        XCTAssertEqual(streamingUrl?.absoluteString, "https://example.com/remote-podcast.mp3", "Should return streaming URL when streamingOnly is true")
+        XCTAssertEqual(localUrl, streamingUrl, "Both calls should return the same URL when no local content exists")
+    }
+
+    func testUrlForEpisodeStreamingOnlyWithUserEpisode() {
+        // Given: A user episode (uploaded content)
+        let userEpisode = UserEpisode()
+        userEpisode.uuid = "user-episode-abc"
+        userEpisode.uploadStatus = UploadStatus.uploaded.rawValue
+
+        // Mock the server settings token
+        let originalToken = ServerSettings.syncingV2Token
+        ServerSettings.syncingV2Token = "mock-token-123"
+
+        defer {
+            // Cleanup
+            ServerSettings.syncingV2Token = originalToken
+        }
+
+        // When: Calling urlForEpisode with streamingOnly: true
+        let streamingUrl = EpisodeManager.urlForEpisode(userEpisode, streamingOnly: true)
+
+        // Then: Should return API URL for user episodes
+        let expectedUrl = "\(ServerConstants.Urls.api())files/url/user-episode-abc?token=mock-token-123"
+        XCTAssertEqual(streamingUrl?.absoluteString, expectedUrl, "Should return API URL for user episodes")
+    }
+
+    func testUrlForEpisodeReturnsNilForInvalidEpisode() {
+        // Given: An episode with no downloadUrl and not a user episode
+        let episode = Episode()
+        episode.uuid = "invalid-episode"
+        episode.downloadUrl = nil
+        episode.episodeStatus = DownloadStatus.notDownloaded.rawValue
+
+        // When: Calling urlForEpisode
+        let url = EpisodeManager.urlForEpisode(episode, streamingOnly: true)
+
+        // Then: Should return nil
+        XCTAssertNil(url, "Should return nil for episodes with no valid URL")
+    }
+
+    func testUrlForEpisodeStreamingOnlyIgnoresLocalFiles() {
+        // This test documents the fix for the Chromecast issue where
+        // streamingOnly: true was still returning local file paths
+
+        // Given: An episode with downloadUrl
+        let episode = Episode()
+        episode.uuid = "chromecast-test-episode"
+        episode.downloadUrl = "https://feeds.example.com/podcast.mp3"
+        episode.episodeStatus = DownloadStatus.notDownloaded.rawValue
+
+        // When: Calling urlForEpisode with streamingOnly: true
+        let streamingUrl = EpisodeManager.urlForEpisode(episode, streamingOnly: true)
+
+        // Then: Should return streaming URL that Chromecast can access
+        XCTAssertNotNil(streamingUrl, "Should return a valid URL")
+        XCTAssertEqual(streamingUrl?.absoluteString, "https://feeds.example.com/podcast.mp3", "Should return the original streaming URL")
+        XCTAssertFalse(streamingUrl?.isFileURL == true, "Should not return a local file URL when streamingOnly is true")
+        XCTAssertTrue(streamingUrl?.scheme == "https", "Should return an HTTPS URL for Chromecast compatibility")
+
+        // Ensure the URL doesn't contain local file system paths
+        let urlString = streamingUrl?.absoluteString ?? ""
+        XCTAssertFalse(urlString.contains("file://"), "Should not contain file:// scheme")
+        XCTAssertFalse(urlString.contains("/var/mobile/"), "Should not contain local iOS paths")
+        XCTAssertFalse(urlString.contains("/Users/"), "Should not contain local file system paths")
+    }
+
+    func testUrlForEpisodeStreamingOnlyLogicDifference() {
+        // This test verifies the key fix: streamingOnly parameter changes behavior
+
+        // Given: Two identical episodes with streaming URLs
+        let episode1 = Episode()
+        episode1.uuid = "streaming-logic-test-1"
+        episode1.downloadUrl = "https://cdn.example.com/episode1.mp3"
+        episode1.episodeStatus = DownloadStatus.notDownloaded.rawValue
+
+        let episode2 = Episode()
+        episode2.uuid = "streaming-logic-test-2"
+        episode2.downloadUrl = "https://cdn.example.com/episode2.mp3"
+        episode2.episodeStatus = DownloadStatus.notDownloaded.rawValue
+
+        // When: Calling urlForEpisode with different streamingOnly values
+        let url1 = EpisodeManager.urlForEpisode(episode1, streamingOnly: false)
+        let url2 = EpisodeManager.urlForEpisode(episode2, streamingOnly: true)
+
+        // Then: Both should return streaming URLs since episodes are not downloaded
+        XCTAssertEqual(url1?.absoluteString, "https://cdn.example.com/episode1.mp3", "Should return streaming URL")
+        XCTAssertEqual(url2?.absoluteString, "https://cdn.example.com/episode2.mp3", "Should return streaming URL")
+
+        // Both should be suitable for external access (like Chromecast)
+        XCTAssertTrue(url1?.scheme == "https", "Should be HTTPS for external access")
+        XCTAssertTrue(url2?.scheme == "https", "Should be HTTPS for external access")
+        XCTAssertFalse(url1?.isFileURL == true, "Should not be local file")
+        XCTAssertFalse(url2?.isFileURL == true, "Should not be local file")
+    }
+
+    func testUrlForEpisodeUserEpisodeWithoutToken() {
+        // Given: A user episode but no sync token available
+        let userEpisode = UserEpisode()
+        userEpisode.uuid = "user-episode-no-token"
+        userEpisode.uploadStatus = UploadStatus.uploaded.rawValue
+
+        // Mock no token available
+        let originalToken = ServerSettings.syncingV2Token
+        ServerSettings.syncingV2Token = nil
+
+        defer {
+            ServerSettings.syncingV2Token = originalToken
+        }
+
+        // When: Calling urlForEpisode
+        let url = EpisodeManager.urlForEpisode(userEpisode, streamingOnly: true)
+
+        // Then: Should return nil since no token available
+        XCTAssertNil(url, "Should return nil when no sync token available for user episode")
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1819,6 +1819,7 @@
 		F5ADE2FA2CF52B7700F2CEA7 /* ABTestProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DFE9342C5A8D1300957D0A /* ABTestProviding.swift */; };
 		F5ADE2FB2CF52B8300F2CEA7 /* ABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10DFE9322C5A8D1300957D0A /* ABTest.swift */; };
 		F5ADE2FC2CF52BB400F2CEA7 /* AnalyticsDescribable+Modules.swift in Sources */ = {isa = PBXBuildFile; fileRef = C750EF7E28E3475600E06BA9 /* AnalyticsDescribable+Modules.swift */; };
+		F5B1E7322E57980B009824AE /* EpisodeManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B1E7312E57980B009824AE /* EpisodeManagerTests.swift */; };
 		F5B312B42BF5B6D400290696 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
 		F5B6F0DF2C18DF0900AF5150 /* AudioUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */; };
 		F5B6FDAD2CADFEFB00356909 /* ContentUnavailableConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B6FDAC2CADFEF200356909 /* ContentUnavailableConfiguration.swift */; };
@@ -4048,6 +4049,7 @@
 		F5AA0FD32E21D05D00ECDEEA /* SurveyDebugInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyDebugInfoView.swift; sourceTree = "<group>"; };
 		F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTests.swift; sourceTree = "<group>"; };
 		F5AD9C4C2C3C705200A01896 /* AudioWaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioWaveformView.swift; sourceTree = "<group>"; };
+		F5B1E7312E57980B009824AE /* EpisodeManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeManagerTests.swift; sourceTree = "<group>"; };
 		F5B312B32BF5B6D400290696 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		F5B6F0DD2C18DF0900AF5150 /* AudioUtilsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AudioUtilsTests.swift; sourceTree = "<group>"; };
 		F5B6FDAC2CADFEF200356909 /* ContentUnavailableConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentUnavailableConfiguration.swift; sourceTree = "<group>"; };
@@ -8420,6 +8422,7 @@
 				F5AD75442B7FDC2800D65C55 /* SettingsTests.swift */,
 				F58695992C04320100E0754A /* PodcastManagerTests.swift */,
 				F5952FCB2C05814100754BC3 /* DownloadManagerTests.swift */,
+				F5B1E7312E57980B009824AE /* EpisodeManagerTests.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -10023,6 +10026,7 @@
 				10A4F75E2C52C7680084D783 /* KidsProfileBannerViewModelTests.swift in Sources */,
 				C7D8AE5F2A6056DA00C9EBAF /* MutliSelectListViewModel.swift in Sources */,
 				F5F69D802C07C867000B3C87 /* FMDatabaseQueue+Test.swift in Sources */,
+				F5B1E7322E57980B009824AE /* EpisodeManagerTests.swift in Sources */,
 				9A263EC92DA6DEFB00E895B6 /* InformationalBannerViewCoordinatorTests.swift in Sources */,
 				9A4BB1ED2D3AB06700B68D94 /* AnalyticsAppThemeProviderTests.swift in Sources */,
 				8B484EFD28D2574D001AFA97 /* EpisodeBuilder.swift in Sources */,

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -379,11 +379,17 @@ class EpisodeManager: NSObject {
     }
 
     class func urlForEpisode(_ episode: BaseEpisode, streamingOnly: Bool = false) -> URL? {
-        if episode.downloaded(pathFinder: DownloadManager.shared), !streamingOnly {
-            return URL(fileURLWithPath: episode.pathToDownloadedFile(pathFinder: DownloadManager.shared))
-        } else if let episode  = episode as? Episode, episode.streamDownloaded(pathFinder: DownloadManager.shared) {
-            return URL(fileURLWithPath: episode.pathToDownloadedFile(pathFinder: DownloadManager.shared))
-        } else if let episode = episode as? Episode, let url = episode.downloadUrl {
+        if !streamingOnly {
+            // For local playback, prefer downloaded files
+            if episode.downloaded(pathFinder: DownloadManager.shared) {
+                return URL(fileURLWithPath: episode.pathToDownloadedFile(pathFinder: DownloadManager.shared))
+            } else if let episode = episode as? Episode, episode.streamDownloaded(pathFinder: DownloadManager.shared) {
+                return URL(fileURLWithPath: episode.pathToDownloadedFile(pathFinder: DownloadManager.shared))
+            }
+        }
+
+        // For streaming or when no local files, return remote URL
+        if let episode = episode as? Episode, let url = episode.downloadUrl {
             return URL(string: url)
         } else if let episode = episode as? UserEpisode {
             if let token = ServerSettings.syncingV2Token, episode.uploadStatus != UploadStatus.missing.rawValue {


### PR DESCRIPTION
Fixes [PCIOS-35](https://linear.app/a8c/issue/PCIOS-35/iphone-app-freezes-when-trying-to-play-to-chromecast-speaker) and #2779

`EpisodeManager.urlForEpisode` was returning local file URLs even when `streamingOnly` was set to `true`. Chromecast will need the http url to be able to fetch.

Chromecast is the only place `EpisodeManager.urlForEpisode` is called with `streamingOnly` set to `true`.

## To test

### Playing Episode
* Play an episode
* Cast to a Chromecast device
* ✅ Verify that the episode plays

### Paused episode
* Try starting with a paused episode
* Cast to a Chromecast device
* ✅ Verify that the episode plays

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
