### PR TITLE
Don't ask for full Notification permissions on AppClip startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Localize the How to Upload screen [#3401](https://github.com/Automattic/pocket-casts-ios/pull/3401)
 - Add Share button to Transcripts [#3418](https://github.com/Automattic/pocket-casts-ios/pull/3418)
 - Add logic to avoid unnecessary player reload and resulting audio glitch when streamin downloads complete [#3432](https://github.com/Automattic/pocket-casts-ios/pull/3432)
+- Fix playback on AppClip [#3437](https://github.com/Automattic/pocket-casts-ios/pull/3437)
+- Fix notification permission request on AppClip [#3439](https://github.com/Automattic/pocket-casts-ios/pull/3439)
 
 7.95
 -----

--- a/Pocket Casts App Clip/NowPlayingView.swift
+++ b/Pocket Casts App Clip/NowPlayingView.swift
@@ -163,7 +163,7 @@ struct NowPlayingView: View {
         Task {
             do {
                 let settings = await notificationCenter.notificationSettings()
-                let granted = settings.authorizationStatus == .ephemeral                
+                let granted = settings.authorizationStatus == .ephemeral
                 guard granted else {
                     let settings = await notificationCenter.notificationSettings()
                     FileLog.shared.addMessage("App Clip: Notification status: \(settings.authorizationStatus)")

--- a/Pocket Casts App Clip/NowPlayingView.swift
+++ b/Pocket Casts App Clip/NowPlayingView.swift
@@ -162,7 +162,8 @@ struct NowPlayingView: View {
         let notificationCenter = UNUserNotificationCenter.current()
         Task {
             do {
-                let granted = try await notificationCenter.requestAuthorization(options: [.alert, .sound, .badge])
+                let settings = await notificationCenter.notificationSettings()
+                let granted = settings.authorizationStatus == .ephemeral                
                 guard granted else {
                     let settings = await notificationCenter.notificationSettings()
                     FileLog.shared.addMessage("App Clip: Notification status: \(settings.authorizationStatus)")


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Convert the notification request to check for ephemeral permission that is given to AppClips

This way we avoid to ask for full blow notification permission on AppClip startup.

Apple Info about this topic can found [here](https://developer.apple.com/documentation/AppClip/enabling-notifications-in-app-clips)

## To test

1. Select the App Clip scheme
2. Ensure that  you don't have the AppClip or the full app installed on the device
3. Select a real device to run the AppClip
4. Start it
5. Check that you are not asked for notification permissions at startup of the AppClip
6. Check if the notification shows up after the time schedule is run ( You may want to change the time set on the `scheduleNotification()` method on the `NowPlayingView` to something like 30.seconds)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
