### PR TITLE
[New Onboarding] Analytics updates for the Account Creation onboarding changes

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -47,6 +47,11 @@ enum AnalyticsEvent: String {
     case setupAccountDismissed
     case setupAccountButtonTapped
 
+    // MARK: - Onboarding
+
+    case onboardingCarouselShown
+    case onboardingGetStarted
+
     // MARK: - Sign in View
 
     case signInShown

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -752,6 +752,13 @@ enum AnalyticsEvent: String {
     case onboardingImportOpenAppTapped
     case onboardingImportDismissed
 
+    // MARK: - Recommendations
+
+    case recommendationsShown
+    case recommendationsDismissed
+    case recommendationsSearchTapped
+    case recommendationsMoreTapped
+
     // MARK: - Cancel
     case cancelConfirmationViewShown
     case cancelConfirmationViewDismissed

--- a/podcasts/Onboarding/DiscoverPodcastsGridView.swift
+++ b/podcasts/Onboarding/DiscoverPodcastsGridView.swift
@@ -33,6 +33,7 @@ struct DiscoverPodcastsGridView: View {
 
             if podcasts.count > visibleCount {
                 Button(action: {
+                    OnboardingFlow.shared.track(.recommendationsMoreTapped)
                     visibleCount = min(visibleCount + 6, podcasts.count)
                 }) {
                     Text("More \(category.name ?? "Unknown")")

--- a/podcasts/Onboarding/Intro Carousel/IntroCarouselView.swift
+++ b/podcasts/Onboarding/Intro Carousel/IntroCarouselView.swift
@@ -110,6 +110,7 @@ struct IntroCarouselView: View {
 
             VStack(spacing: 16) {
                 Button(L10n.eacInformationalViewModalGetStartedButton) {
+                    OnboardingFlow.shared.track(.onboardingGetStarted)
                     coordinator.getStartedTapped()
                 }
                 .buttonStyle(RoundedButtonStyle(theme: theme))
@@ -124,6 +125,9 @@ struct IntroCarouselView: View {
             .padding(.bottom, 10)
         }
         .modifier(DefaultThemeSettings())
+        .onAppear {
+            OnboardingFlow.shared.track(.onboardingCarouselShown)
+        }
     }
 }
 

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -75,6 +75,7 @@ class LoginCoordinator: NSObject, OnboardingModel {
     }
 
     func getStartedTapped() {
+        OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "get_started"])
         let view = OnboardingRecommendationsView(coordinator: self)
         let hostingController = UIHostingController(rootView: view.setupDefaultEnvironment())
         hostingController.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
@@ -83,7 +84,7 @@ class LoginCoordinator: NSObject, OnboardingModel {
 
     func recommendationsContinueTapped() {
         socialAuthProvider = nil
-        OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "create_account"])
+        OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "recommendations_continue"])
         let view = LoginLandingView(coordinator: self, fullScreenMode: FeatureFlag.fullScreenLogin.enabled)
         let hostingController = LoginLandingHostingController(rootView: view.setupDefaultEnvironment())
         hostingController.viewModel = self

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -61,6 +61,7 @@ struct OnboardingRecommendationsView: View {
 
                     VStack {
                         Button(action: {
+                            OnboardingFlow.shared.track(.recommendationsDismissed)
                             coordinator.recommendationsContinueTapped()
                         }) {
                             Text(L10n.continue)
@@ -91,6 +92,8 @@ struct OnboardingRecommendationsView: View {
                         categories = await DiscoverServerHandler.shared.discoverCategories(source: categoriesItem.source ?? "", authenticated: categoriesItem.isAuthenticated)
                         self.layout = layout
 
+                        OnboardingFlow.shared.track(.recommendationsShown)
+
                         await loadCategoryPodcasts(layout: layout)
                     }
             }
@@ -114,6 +117,8 @@ struct OnboardingRecommendationsView: View {
             searchResults = []
             return
         }
+
+        OnboardingFlow.shared.track(.recommendationsSearchTapped)
 
         searchTask = Task {
             do {


### PR DESCRIPTION
Completes [PCIOS-100](https://linear.app/a8c/issue/PCIOS-100/align-onboarding-phase-ii-analytics-with-android)

Add analytics tracking to the updated onboarding flow.

### Intro Carousel
  - `onboardingCarouselShown` - Tracks when the intro carousel is displayed to users
  - `onboardingGetStarted` - Tracks when users tap the "Get Started" button

### Recommendations
  - `recommendationsShown` - Tracks when the recommendations view loads and displays podcast categories
  - `recommendationsSearchTapped` - Tracks when users search for podcasts in the recommendations view
  - `recommendationsDismissed` - Tracks when users tap the "Continue" button to proceed from recommendations
  - `recommendationsMoreTapped` - Tracks when users tap "More [Category]" to load additional podcasts

## To test

* Enable the `tracksLogging` feature flag in the code
* ✅ Verify `onboardingCarouselShown` fires when intro carousel appears
* ✅ Verify `onboardingGetStarted` fires when "Get Started" button is tapped
* ✅ Verify `recommendationsShown` fires when recommendations view loads
* ✅ Verify `recommendationsSearchTapped` fires when user searches for podcasts
* ✅ Verify `recommendationsMoreTapped` fires when "More [Category]" button is tapped
* ✅ Verify `recommendationsDismissed` fires when "Continue" button is tapped

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
