### PR TITLE
Fix Up Next History restore when missing episodes from DB

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UpNextHistoryManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UpNextHistoryManager.swift
@@ -39,22 +39,32 @@ public class UpNextHistoryManager {
         return entries
     }
 
-    func episodes(entry: Date, dbQueue: PCDBQueue) -> [String] {
-        var episodesUuid: [String] = []
+    public struct EntryEpisode {
+        public let episodeUuid: String
+        public let podcastUuid: String
+    }
+
+    func episodes(entry: Date, dbQueue: PCDBQueue) -> [EntryEpisode] {
+        var results: [EntryEpisode] = []
         dbQueue.read { db in
             do {
-                let resultSet = try db.executeQuery("SELECT episodeUuid FROM PlaylistEpisodeHistory WHERE date = ? ORDER BY episodePosition ASC", values: [entry])
+                let resultSet = try db.executeQuery(
+                    "SELECT episodeUuid, podcastUuid FROM PlaylistEpisodeHistory WHERE date = ? ORDER BY episodePosition ASC",
+                    values: [entry]
+                )
                 defer { resultSet.close() }
 
-                while resultSet.next(), let episodeUuid = resultSet.string(forColumn: "episodeUuid") {
-                    episodesUuid.append(episodeUuid)
+                while resultSet.next(),
+                      let episodeUuid = resultSet.string(forColumn: "episodeUuid"),
+                      let podcastUuid = resultSet.string(forColumn: "podcastUuid") {
+                    results.append(EntryEpisode(episodeUuid: episodeUuid, podcastUuid: podcastUuid))
                 }
             } catch {
                 FileLog.shared.addMessage("UpNextHistoryManager.episodes error: \(error)")
             }
         }
 
-        return episodesUuid
+        return results
     }
 
     public struct UpNextHistoryEntry: Hashable, Identifiable {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1111,7 +1111,7 @@ public class DataManager {
         upNextHistoryManager.entries(dbQueue: dbQueue)
     }
 
-    public func upNextHistoryEpisodes(entry: Date) -> [String] {
+    public func upNextHistoryEpisodes(entry: Date) -> [UpNextHistoryManager.EntryEpisode] {
         upNextHistoryManager.episodes(entry: entry, dbQueue: dbQueue)
     }
 

--- a/podcasts/Up Next History/UpNextHistoryModel.swift
+++ b/podcasts/Up Next History/UpNextHistoryModel.swift
@@ -23,19 +23,28 @@ class UpNextHistoryModel: ObservableObject {
     func loadEpisodes(for entry: Date) {
         Task {
             let episodesUuid = dataManager.upNextHistoryEpisodes(entry: entry)
-            episodes = episodesUuid.compactMap { dataManager.findBaseEpisode(uuid: $0) }
+            episodes = episodesUuid.compactMap { dataManager.findBaseEpisode(uuid: $0.episodeUuid) }
         }
     }
 
     func reAddMissingItems(entry: Date) {
         Task {
-            let episodesUuid = dataManager.upNextHistoryEpisodes(entry: entry)
-            FileLog.shared.addMessage("UpNextHistory: Restoring entries from \(entry) with episodes: [\(episodesUuid.joined(separator: ","))]")
-            episodesUuid.forEach { episodeUuid in
-                if let episode = dataManager.findBaseEpisode(uuid: episodeUuid) {
+            let episodes = dataManager.upNextHistoryEpisodes(entry: entry)
+            FileLog.shared.addMessage("UpNextHistory: Restoring entries from \(entry) with episodes: [\(episodes.map(\.episodeUuid).joined(separator: ","))]")
+
+            episodes.forEach { entry in
+                if let episode = dataManager.findBaseEpisode(uuid: entry.episodeUuid) {
                     PlaybackManager.shared.addToUpNext(episode: episode, userInitiated: false)
+                } else {
+                    if let episode = ServerPodcastManager.shared.addMissingEpisode(episodeUuid: entry.episodeUuid, podcastUuid: entry.podcastUuid) {
+                        PlaybackManager.shared.addToUpNext(episode: episode, userInitiated: false)
+                    } else {
+                        assertionFailure("Couldn't find or restore episode \(entry.episodeUuid) for podcast \(entry.podcastUuid)")
+                        FileLog.shared.addMessage("UpNextHistory: Couldn't find or restore episode \(entry.episodeUuid) for podcast \(entry.podcastUuid)")
+                    }
                 }
             }
+
             PlaybackManager.shared.queue.bulkOperationDidComplete()
             PlaybackManager.shared.queue.refreshList(checkForAutoDownload: false)
         }


### PR DESCRIPTION
Fixes [PCIOS-103](https://linear.app/a8c/issue/PCIOS-103/user-unable-to-load-up-next-history-due-to-sync-error)

When restoring from an Up Next Queue History event, we were only loading episodes which had already been added locally. In theory, there _shouldn't_ be episodes in an Up Next Queue History event which aren't in the database, but they might get cleared as part of some other process. We have the information to add an episode so we might as well try it here.

## To test



## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
