### PR TITLE
Up Next History Restore: Ignore Limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix Chromecast streaming [#3438](https://github.com/Automattic/pocket-casts-ios/pull/3438)
 - Fix playback on AppClip [#3437](https://github.com/Automattic/pocket-casts-ios/pull/3437)
 - Fix notification permission request on AppClip [#3439](https://github.com/Automattic/pocket-casts-ios/pull/3439)
+- Ignore the Auto Add to Up Next limit when restoring from Up Next Queue History [#3444](https://github.com/Automattic/pocket-casts-ios/pull/3444)
 
 7.95
 -----

--- a/podcasts/Up Next History/UpNextHistoryModel.swift
+++ b/podcasts/Up Next History/UpNextHistoryModel.swift
@@ -33,7 +33,7 @@ class UpNextHistoryModel: ObservableObject {
             FileLog.shared.addMessage("UpNextHistory: Restoring entries from \(entry) with episodes: [\(episodesUuid.joined(separator: ","))]")
             episodesUuid.forEach { episodeUuid in
                 if let episode = dataManager.findBaseEpisode(uuid: episodeUuid) {
-                    PlaybackManager.shared.addToUpNext(episode: episode, userInitiated: false)
+                    PlaybackManager.shared.addToUpNext(episode: episode, ignoringQueueLimit: true, userInitiated: false)
                 }
             }
             PlaybackManager.shared.queue.bulkOperationDidComplete()

--- a/podcasts/Up Next History/UpNextHistoryModel.swift
+++ b/podcasts/Up Next History/UpNextHistoryModel.swift
@@ -38,6 +38,9 @@ class UpNextHistoryModel: ObservableObject {
             }
             PlaybackManager.shared.queue.bulkOperationDidComplete()
             PlaybackManager.shared.queue.refreshList(checkForAutoDownload: false)
+
+            let upNextQueueCount = PlaybackManager.shared.upNextQueueCount()
+            FileLog.shared.addMessage("UpNextHistory: Restored Up Next Queue to \(upNextQueueCount) episodes")
         }
     }
 }


### PR DESCRIPTION
Fixes [PCIOS-103](https://linear.app/a8c/issue/PCIOS-103/user-unable-to-load-up-next-history-due-to-sync-error)

Previously, the Up Next History restore was respecting the Auto Add to Up Next limit. This doesn't really make sense because users will always want to restore ALL of their Up Next queue and not only up to the set limit.

## To test

* Ask me for a test database
* Import the database
* Go to the Up Next History
* Attempt to restore the 400+ episode from the queue
* Ensure that the restore completes and adds all episodes to the queue

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
