### PR TITLE
GRDB: enable concurrent reads for all builds

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -380,11 +380,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .userSatisfactionSurvey:
             true
         case .concurrentDatabaseReads:
-            #if DEBUG
             true
-            #else
-            BuildEnvironment.current == .testFlight
-            #endif
         case .limitPlaybackPositionChanges:
             true
         case .newOnboardingAccountCreation:


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

Enables concurrent reads for all builds — including the upcoming 7.96 release in App Store.

If we need to revert this change we can do it through a remote `concurrent_database_reads` feature flag set to `false`.

## To test

1. Code review

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
