### PR TITLE
Add FF to enable theme properties

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -5,6 +5,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Whether logging of Tracks events in console are enabled
     case tracksLogging
 
+    /// Whether logging the theme properties in the Tracks events
+    case appThemePropertiesLogging
+
     /// Whether logging of Firebase events in console are enabled
     case firebaseLogging
 
@@ -245,6 +248,12 @@ public enum FeatureFlag: String, CaseIterable {
         switch self {
         case .tracksLogging:
             false
+        case .appThemePropertiesLogging:
+            if BuildEnvironment.current == .debug {
+                false
+            } else {
+                true
+            }
         case .firebaseLogging:
             false
         case .appsFlyerLogging:

--- a/podcasts/Analytics/Analytics.swift
+++ b/podcasts/Analytics/Analytics.swift
@@ -43,8 +43,10 @@ class Analytics {
     func track(_ event: AnalyticsEvent, properties: [AnyHashable: Any]? = nil) {
         var newProperties = (properties ?? [:]).mapValues { (($0 as? AnalyticsDescribable)?.analyticsDescription) ?? $0 }
 #if !os(watchOS) && !APPCLIP
-        analyticsAppThemeProvider?.appThemeProperties.forEach { key, value in
-            newProperties[key] = value
+        if FeatureFlag.appThemePropertiesLogging.enabled {
+            analyticsAppThemeProvider?.appThemeProperties.forEach { key, value in
+                newProperties[key] = value
+            }
         }
 #endif
         adapters?.forEach {


### PR DESCRIPTION
This PR uses a FF to enable/disable the theme properties added to each track event.
In `debug` by default the flag is off. If the build is `testFlight` or `App Store` the flag is enabled.

## To test

- Run this branch
- Enable `tracksLogging`
- Confirm you start seeing the event tracked with no default references to themes
- Example: `🔵 Tracked: podcasts_tab_opened ["initial": false]`
- Enable `appThemePropertiesLogging`
- Confirm you will start seeing also the properties added
- Example: `🔵 Tracked: podcasts_tab_opened ["theme_use_system_settings": true, "theme_light_preference": "default_light", "initial": false, "theme_selected": "default_dark", "theme_dark_preference": "default_dark"]`
- Switch off `appThemePropertiesLogging` flag
- Stop the branch, go to `BuildEnvironment` and force returning `testFlight` in `determineCurrentEnvironment`
- Confirm the `appThemePropertiesLogging` flag is on and the theme properties are added
- Stop the branch, go to `BuildEnvironment` and force returning `appStore` in `determineCurrentEnvironment`
- Confirm the `appThemePropertiesLogging` flag is on and the theme properties are added
- Stop the branch, go to `BuildEnvironment` and force returning `debug` in `determineCurrentEnvironment`
- Confirm the `appThemePropertiesLogging` flag is off and the theme properties are not added


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
