### PR TITLE
Watch Logging crash fix

### DIFF
--- a/podcasts/WatchManager+Send.swift
+++ b/podcasts/WatchManager+Send.swift
@@ -56,7 +56,13 @@ extension WatchManager {
                 self?.logFileRequestTask?.cancel()
                 self?.logFileRequestTask = nil
 
-                FileLog.shared.addMessage("WatchManager: Failed log collection \(error)")
+                // To avoid spamming the logs, we'll only log errors unrelated to unreachable
+                let nsError = error as NSError
+                if nsError.domain == WCErrorDomain,
+                   nsError.code == WCError.Code.notReachable.rawValue {
+                    FileLog.shared.addMessage("WatchManager: Failed log collection \(error)")
+                }
+
                 await completionHandler.callCompletionIfNeeded(with: cachedLog)
             }
         }

--- a/podcasts/WatchManager+Send.swift
+++ b/podcasts/WatchManager+Send.swift
@@ -12,54 +12,53 @@ extension WatchManager {
         // check that the user actually has a watch and it's connected
         guard WCSession.isSupported() else {
             completion(nil)
-
             return
         }
 
         let session = WCSession.default
         if session.activationState != .activated || session.isPaired == false || session.isWatchAppInstalled == false {
             completion(cachedLog)
-
             return
         }
 
         // Hold a local reference so we don't potentially run into a deallocated `self` when the below blocks are run.
         let cachedLog = self.cachedLog
 
-        // since we don't know how long it takes for a send message to timeout, wait only 5 seconds for a watch response before giving up here
-        var haveCalledCompletion = false
-        logFileRequestTask = Task { [cachedLog] in
-            try? await Task.sleep(for: .seconds(5))
-            if haveCalledCompletion { return }
+        // Use an actor to ensure thread-safe completion handling
+        let completionHandler = CompletionHandler(cachedLog: cachedLog, completion: completion)
 
-            haveCalledCompletion = true
-            completion(cachedLog)
+        // since we don't know how long it takes for a send message to timeout, wait only 5 seconds for a watch response before giving up here
+        logFileRequestTask = Task { [weak self, completionHandler] in
+            try? await Task.sleep(for: .seconds(5))
+            await completionHandler.callCompletionIfNeeded(with: cachedLog)
+            self?.logFileRequestTask = nil
         }
 
         // if we get here then it's likely we'll be able to ask the watch for a log file, so let's try
         let logRequestMessage = [WatchConstants.Messages.messageType: WatchConstants.Messages.LogFileRequest.type]
         session.sendMessage(logRequestMessage, replyHandler: { [weak self] response in
-            if haveCalledCompletion { return }
-            haveCalledCompletion = true
+            Task { [weak self, completionHandler] in
+                self?.logFileRequestTask?.cancel()
+                self?.logFileRequestTask = nil
 
-            self?.logFileRequestTask?.cancel()
-            if let logContents = response[WatchConstants.Messages.LogFileRequest.logContents] as? String {
-                self?.cachedLog = logContents
-                if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
-                    self?.saveLog(contents: logContents)
+                if let logContents = response[WatchConstants.Messages.LogFileRequest.logContents] as? String {
+                    self?.cachedLog = logContents
+                    if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
+                        self?.saveLog(contents: logContents)
+                    }
+                    await completionHandler.callCompletionIfNeeded(with: logContents)
+                } else {
+                    await completionHandler.callCompletionIfNeeded(with: cachedLog)
                 }
-                completion(logContents)
-            } else {
-                completion(cachedLog)
             }
+        }) { [weak self] error in
+            Task { [weak self, completionHandler] in
+                self?.logFileRequestTask?.cancel()
+                self?.logFileRequestTask = nil
 
-        }) { error in
-            if haveCalledCompletion { return }
-            haveCalledCompletion = true
-
-            FileLog.shared.addMessage("WatchManager: Failed log collection \(error)")
-
-            completion(cachedLog)
+                FileLog.shared.addMessage("WatchManager: Failed log collection \(error)")
+                await completionHandler.callCompletionIfNeeded(with: cachedLog)
+            }
         }
     }
 
@@ -79,5 +78,23 @@ extension WatchManager {
         } catch let error {
             FileLog.shared.addMessage("Failed to save cached watch log file: \(error.localizedDescription)")
         }
+    }
+}
+
+// MARK: - Helper Actor for Thread-Safe Completion Handling
+actor CompletionHandler {
+    private var hasCalledCompletion = false
+    private let cachedLog: String?
+    private let completion: (String?) -> Void
+
+    init(cachedLog: String?, completion: @escaping (String?) -> Void) {
+        self.cachedLog = cachedLog
+        self.completion = completion
+    }
+
+    func callCompletionIfNeeded(with result: String?) {
+        guard !hasCalledCompletion else { return }
+        hasCalledCompletion = true
+        completion(result)
     }
 }

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -445,10 +445,8 @@ class WatchManager: NSObject, WCSessionDelegate {
             guard let self else { return }
             self.sendStateToWatch()
             if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
-                FileLog.shared.addMessage("WatchManager: Collecting Watch logs in sendStateToWatchInBackground")
                 WatchManager.shared.requestLogFile { log in
                     // We do nothing here, the log file will be cached as a result of requesting
-                    FileLog.shared.addMessage("WatchManager: Collected Watch logs in sendStateToWatchInBackground isEmpty \(log?.isEmpty ?? true)")
                 }
             }
         }

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -12,15 +12,34 @@ class WatchManager: NSObject, WCSessionDelegate {
     // The last retrieved log is cached here for the duration of this session
     var cachedLog: String? = nil
 
+    // Serial queue for WCSession operations to ensure thread safety
+    private let sessionQueue = DispatchQueue(label: "com.pocketcasts.watchmanager.session", qos: .userInitiated)
+    private var isSettingUp = false
+
     var isWatchAppInstalled: Bool {
         return WCSession.isSupported() && WCSession.default.isWatchAppInstalled
     }
 
     func setup() {
-        if !WCSession.isSupported() { return }
+        guard WCSession.isSupported() else { return }
 
-        WCSession.default.delegate = self
-        WCSession.default.activate()
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            // Prevent multiple setup calls
+            guard !self.isSettingUp else { return }
+            self.isSettingUp = true
+
+            let session = WCSession.default
+
+            // Only set delegate and activate if not already active
+            if session.delegate == nil || session.activationState != .activated {
+                session.delegate = self
+                session.activate()
+            }
+
+            self.isSettingUp = false
+        }
 
         NotificationCenter.default.addObserver(self, selector: #selector(updateWatchData), name: Constants.Notifications.filterChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(podcastsDidRefresh), name: ServerNotifications.podcastsRefreshed, object: nil)
@@ -58,7 +77,14 @@ class WatchManager: NSObject, WCSessionDelegate {
 
     func sessionDidDeactivate(_ session: WCSession) {
         // Begin the activation process for the new Apple Watch.
-        WCSession.default.activate()
+        sessionQueue.async {
+            // Add a small delay to avoid immediate reactivation issues
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                if WCSession.default.activationState != .activated {
+                    WCSession.default.activate()
+                }
+            }
+        }
     }
 
     func sessionWatchStateDidChange(_ session: WCSession) {
@@ -66,7 +92,10 @@ class WatchManager: NSObject, WCSessionDelegate {
     }
 
     func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
-        guard let messageType = message[WatchConstants.Messages.messageType] as? String else { return }
+        guard let messageType = message[WatchConstants.Messages.messageType] as? String else {
+            FileLog.shared.addMessage("WatchManager: Received message without messageType")
+            return
+        }
 
         if WatchConstants.Messages.DataRequest.type == messageType {
             updateWatchData()
@@ -178,7 +207,11 @@ class WatchManager: NSObject, WCSessionDelegate {
     }
 
     func session(_ session: WCSession, didReceiveMessage message: [String: Any], replyHandler: @escaping ([String: Any]) -> Void) {
-        guard let messageType = message[WatchConstants.Messages.messageType] as? String else { return }
+        guard let messageType = message[WatchConstants.Messages.messageType] as? String else {
+            FileLog.shared.addMessage("WatchManager: Received message without messageType (with reply handler)")
+            replyHandler([String: Any]())
+            return
+        }
 
         if WatchConstants.Messages.FilterRequest.type == messageType {
             if let filterUuid = message[WatchConstants.Messages.FilterRequest.filterUuid] as? String {
@@ -197,6 +230,7 @@ class WatchManager: NSObject, WCSessionDelegate {
         }
 
         // send blank response to messages we don't know about or for things we can't find info on
+        FileLog.shared.addMessage("WatchManager: Unknown message type: \(messageType)")
         replyHandler([String: Any]())
     }
 
@@ -204,38 +238,45 @@ class WatchManager: NSObject, WCSessionDelegate {
 
     private func handleDownload(episodeUuid: String) {
         DownloadManager.shared.addToQueue(episodeUuid: episodeUuid, fireNotification: true, autoDownloadStatus: .notSpecified)
-        sendStateToWatch()
+        sendStateToWatchInBackground()
     }
 
     private func handleStopDownload(episodeUuid: String) {
         DownloadManager.shared.removeFromQueue(episodeUuid: episodeUuid, fireNotification: true, userInitiated: true)
-        sendStateToWatch()
+        sendStateToWatchInBackground()
     }
 
     private func handleDeleteDownload(episodeUuid: String) {
-        guard let baseEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else { return }
-
-        if let userEpisode = baseEpisode as? UserEpisode {
-            UserEpisodeManager.deleteFromDevice(userEpisode: userEpisode)
-        } else if let episode = baseEpisode as? Episode {
-            EpisodeManager.deleteDownloadedFiles(episode: episode, userInitated: true)
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid)
+        guard let baseEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else {
+            FileLog.shared.addMessage("WatchManager: Could not find episode for delete download: \(episodeUuid)")
+            return
         }
-        sendStateToWatch()
+
+        do {
+            if let userEpisode = baseEpisode as? UserEpisode {
+                UserEpisodeManager.deleteFromDevice(userEpisode: userEpisode)
+            } else if let episode = baseEpisode as? Episode {
+                EpisodeManager.deleteDownloadedFiles(episode: episode, userInitated: true)
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid)
+            }
+            sendStateToWatchInBackground()
+        } catch {
+            FileLog.shared.addMessage("WatchManager: Error deleting download for episode \(episodeUuid): \(error)")
+        }
     }
 
     private func handleArchive(episodeUuid: String) {
         guard let episode = DataManager.sharedManager.findEpisode(uuid: episodeUuid) else { return }
 
         EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
-        sendStateToWatch()
+        sendStateToWatchInBackground()
     }
 
     private func handleUnarchive(episodeUuid: String) {
         guard let episode = DataManager.sharedManager.findEpisode(uuid: episodeUuid) else { return }
 
         EpisodeManager.unarchiveEpisode(episode: episode, fireNotification: true)
-        sendStateToWatch()
+        sendStateToWatchInBackground()
     }
 
     private func handleChangeChapter(next: Bool) {
@@ -250,14 +291,14 @@ class WatchManager: NSObject, WCSessionDelegate {
         guard let episode = DataManager.sharedManager.findEpisode(uuid: episodeUuid) else { return }
 
         EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
-        sendStateToWatch()
+        sendStateToWatchInBackground()
     }
 
     private func handleMarkUnplayed(episodeUuid: String) {
         guard let episode = DataManager.sharedManager.findEpisode(uuid: episodeUuid) else { return }
 
         EpisodeManager.markAsUnplayed(episode: episode, fireNotification: true)
-        sendStateToWatch()
+        sendStateToWatchInBackground()
     }
 
     private func handleAddToUpnext(episodeUuid: String, toTop: Bool) {
@@ -281,11 +322,17 @@ class WatchManager: NSObject, WCSessionDelegate {
     }
 
     private func handlePlayRequest(episodeUuid: String, playlist: AutoplayHelper.Playlist?) {
-        guard let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else { return }
+        guard let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else {
+            FileLog.shared.addMessage("WatchManager: Could not find episode for play request: \(episodeUuid)")
+            return
+        }
 
-        AutoplayHelper.shared.playedFrom(playlist: playlist)
-
-        PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
+        do {
+            AutoplayHelper.shared.playedFrom(playlist: playlist)
+            PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
+        } catch {
+            FileLog.shared.addMessage("WatchManager: Error playing episode \(episodeUuid): \(error)")
+        }
     }
 
     private func handleFilterRequest(filterUuid: String) -> [String: Any] {
@@ -394,13 +441,9 @@ class WatchManager: NSObject, WCSessionDelegate {
     }
 
     private func sendStateToWatchInBackground() {
-        guard Thread.isMainThread else {
-            sendStateToWatch()
-            return
-        }
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        sessionQueue.async { [weak self] in
             guard let self else { return }
-            sendStateToWatch()
+            self.sendStateToWatch()
             if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
                 FileLog.shared.addMessage("WatchManager: Collecting Watch logs in sendStateToWatchInBackground")
                 WatchManager.shared.requestLogFile { log in
@@ -412,6 +455,9 @@ class WatchManager: NSObject, WCSessionDelegate {
     }
 
     private func sendStateToWatch() {
+        // This method should only be called from sessionQueue to ensure thread safety
+        dispatchPrecondition(condition: .onQueue(sessionQueue))
+
         guard WCSession.isSupported() else { return }
 
         let session = WCSession.default
@@ -441,6 +487,7 @@ class WatchManager: NSObject, WCSessionDelegate {
 
         applicationDict[WatchConstants.Keys.upNextDownloadEpisodeCount] = Settings.watchAutoDownloadUpNextEnabled() == true ? Settings.watchAutoDownloadUpNextCount() : 0
         applicationDict[WatchConstants.Keys.upNextAutoDeleteEpisodeCount] = Settings.watchAutoDeleteUpNext() == true ? Settings.watchAutoDownloadUpNextCount() : 25
+
         do {
             try session.updateApplicationContext(applicationDict)
         } catch {


### PR DESCRIPTION
Fixes [PCIOS-106](https://linear.app/a8c/issue/PCIOS-106/sentry-crash-apple-watch-log-file-request-task)

The primary change here is to add a single dispatch queue which wraps the `logFileRequestTask`.

This also reduces some of the logging related to the watch log fetching which was cluttering our existing logs. We mostly don't care to know EVERY time logs are exchanged since this can happen frequently.

## To test

I don't have an exact reproduction scenario but here's an example check:

* Apply this patch: [dispatch_queue_watch_session.patch](https://github.com/user-attachments/files/22011061/dispatch_queue_watch_session.patch) - it contains a `DispatchQueue.current` API to fetch the current queue using private API and disables a check for the `WCSession` to ensure the watch code is artificially called.
* Run the app
* Set a breakpoint at the top of `requestLogFile(completion)`
* Perform an action that triggers watch sync
* On breakpoint pause, run this command in LLDB: `po DispatchQueue.current.label`
* ✅ Verify this returns `com.pocketcasts.watchmanager.session`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
