### PR TITLE
[Banner Ads] Split feature flag for podcast & player

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -188,8 +188,11 @@ public enum FeatureFlag: String, CaseIterable {
     /// Shows transcript excerpt in episode detail
     case episodeDetailTranscript
 
-    /// Include banner ads in the player and podcasts list. This is fetched from ths server so can be disabled from there as well.
-    case bannerAds
+    /// Include banner ad atop the podcasts list. This is fetched from ths server so can be disabled from there as well.
+    case bannerAdPodcasts
+
+    /// Include the banner ad atop the player screen. This is fetched from ths server so can be disabled from there as well.
+    case bannerAdPlayer
 
     /// Improves configuration for the streaming requet download session
     case streamingCustomSessionConfiguration
@@ -359,7 +362,9 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .episodeDetailTranscript:
             true
-        case .bannerAds:
+        case .bannerAdPodcasts:
+            false
+        case .bannerAdPlayer:
             false
         case .streamingCustomSessionConfiguration:
             true

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -322,9 +322,9 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
                 process: tapProcess
             )
 
-            var audioProcessingTap: Unmanaged<MTAudioProcessingTap>?
+            var audioProcessingTap: MTAudioProcessingTap?
             if noErr == MTAudioProcessingTapCreate(kCFAllocatorDefault, &callbacks, kMTAudioProcessingTapCreationFlag_PreEffects, &audioProcessingTap) {
-                audioMixInputParameters.audioTapProcessor = audioProcessingTap?.takeRetainedValue()
+                audioMixInputParameters.audioTapProcessor = audioProcessingTap
                 mutableMix.inputParameters = [audioMixInputParameters]
                 audioMix = mutableMix
             }

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -322,9 +322,9 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
                 process: tapProcess
             )
 
-            var audioProcessingTap: MTAudioProcessingTap?
+            var audioProcessingTap: Unmanaged<MTAudioProcessingTap>?
             if noErr == MTAudioProcessingTapCreate(kCFAllocatorDefault, &callbacks, kMTAudioProcessingTapCreationFlag_PreEffects, &audioProcessingTap) {
-                audioMixInputParameters.audioTapProcessor = audioProcessingTap
+                audioMixInputParameters.audioTapProcessor = audioProcessingTap?.takeRetainedValue()
                 mutableMix.inputParameters = [audioMixInputParameters]
                 audioMix = mutableMix
             }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -246,7 +246,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     private func loadBannerAd() {
 #if !APPCLIP
-        if FeatureFlag.bannerAds.enabled && !SubscriptionHelper.hasActiveSubscription() {
+        if FeatureFlag.bannerAdPlayer.enabled && !SubscriptionHelper.hasActiveSubscription() {
             bannerTask = Task { [weak self] in
                 if let promotion = await DiscoverServerHandler.shared.blazePromotion(for: .player) {
                     guard Task.isCancelled == false else { return }
@@ -275,7 +275,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         resizeControls()
 
         #if !APPCLIP
-        if FeatureFlag.bannerAds.enabled {
+        if FeatureFlag.bannerAdPlayer.enabled {
             updateBannerAdHeight()
         }
         #endif
@@ -308,7 +308,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         removeAllCustomObservers()
 
         #if !APPCLIP
-        if FeatureFlag.bannerAds.enabled {
+        if FeatureFlag.bannerAdPlayer.enabled {
             removeBannerAd()
         }
         #endif
@@ -323,7 +323,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         super.traitCollectionDidChange(previousTraitCollection)
 
         #if !APPCLIP
-        if FeatureFlag.bannerAds.enabled {
+        if FeatureFlag.bannerAdPlayer.enabled {
             // Update banner height when text size category changes
             if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
                 updateBannerAdHeight()

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -247,6 +247,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     private func loadBannerAd() {
 #if !APPCLIP
         if FeatureFlag.bannerAdPlayer.enabled && !SubscriptionHelper.hasActiveSubscription() {
+            removeBannerAd()
             bannerTask = Task { [weak self] in
                 if let promotion = await DiscoverServerHandler.shared.blazePromotion(for: .player) {
                     guard Task.isCancelled == false else { return }
@@ -512,8 +513,6 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     // MARK: Banner Ad
 
     func addAdBanner(promotion: BlazePromotion) {
-        removeBannerAd()
-
         guard let stackView = episodeImage.superview as? UIStackView else { return }
 
         let model = BannerAdModel(promotion: promotion, source: AnalyticsSource.player.rawValue) {

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -115,7 +115,7 @@ struct PlusAccountUpgradePrompt: View {
 
     private let productFeatures: [IAPProductID: [Feature]] = [
         .yearly: ([
-            FeatureFlag.bannerAds.enabled ? .init(iconName: "unsubscribe", title: L10n.plusMarketingNoBannerAds) : nil,
+            (FeatureFlag.bannerAdPodcasts.enabled || FeatureFlag.bannerAdPlayer.enabled) ? .init(iconName: "unsubscribe", title: L10n.plusMarketingNoBannerAds) : nil,
             .init(iconName: "plus-feature-folders", title: L10n.plusMarketingFoldersTitle),
             .init(iconName: "plus-feature-up-next-shuffle", title: L10n.plusMarketingUpNextShuffle),
             .init(iconName: "plus-feature-bookmarks", title: L10n.plusMarketingBookmarksTitle),

--- a/podcasts/Onboarding/Plus/UpgradeTier.swift
+++ b/podcasts/Onboarding/Plus/UpgradeTier.swift
@@ -111,7 +111,7 @@ extension UpgradeTier {
     }
 
     static var bannerAdsFeature: UpgradeTier.TierFeature? {
-        FeatureFlag.bannerAds.enabled ? .init(iconName: "unsubscribe", title: L10n.plusMarketingNoBannerAds) : nil
+        (FeatureFlag.bannerAdPodcasts.enabled || FeatureFlag.bannerAdPlayer.enabled) ? .init(iconName: "unsubscribe", title: L10n.plusMarketingNoBannerAds) : nil
     }
 
     static var foldersFeature: UpgradeTier.TierFeature {

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -161,7 +161,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     }
 
     private func loadBannerAd() {
-        if FeatureFlag.bannerAds.enabled && !SubscriptionHelper.hasActiveSubscription() {
+        if FeatureFlag.bannerAdPodcasts.enabled && !SubscriptionHelper.hasActiveSubscription() {
             bannerTask?.cancel()
             bannerTask = Task { [weak self] in
                 if let promotion = await DiscoverServerHandler.shared.blazePromotion(for: .podcastList) {


### PR DESCRIPTION
Implements [PCIOS-107](https://linear.app/a8c/issue/PCIOS-107/add-separate-feature-flags-for-podcasts-and-player-screens)

## To test

### Podcasts
* Enable the `bannerAdPodcasts`
* Navigate to the Podcasts tab
* ✅ Verify the banner ad appears atop the list

### Player
* Enable the `bannerAdPlayer`
* Navigate to the Podcasts tab
* ✅ Verify the banner ad appears atop the list

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
