### PR TITLE
[Banner Ads] Change `promotion` to `location` in Blaze promotions

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
@@ -6,6 +6,8 @@ public struct BlazePromotion: Decodable {
     public let imageURL: URL
     public let urlTitle: String
     public let url: URL
+    public let urlAndroid: URL
+    public let urlApple: URL
     public let location: Location
 
     public enum Location: String, Decodable {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
@@ -6,9 +6,9 @@ public struct BlazePromotion: Decodable {
     public let imageURL: URL
     public let urlTitle: String
     public let url: URL
-    public let promotion: PromotionType
+    public let location: Location
 
-    public enum PromotionType: String, Decodable {
+    public enum Location: String, Decodable {
         case podcastList
         case player
         case unknown
@@ -33,7 +33,7 @@ extension DiscoverServerHandler {
         return promotions.promotions
     }
 
-    public func blazePromotion(for promotion: BlazePromotion.PromotionType) async -> BlazePromotion? {
-        await blazePromotions()?.first(where: { $0.promotion == promotion })
+    public func blazePromotion(for location: BlazePromotion.Location) async -> BlazePromotion? {
+        await blazePromotions()?.first(where: { $0.location == location })
     }
 }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -517,7 +517,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         guard let stackView = episodeImage.superview as? UIStackView else { return }
 
         let model = BannerAdModel(promotion: promotion, source: AnalyticsSource.player.rawValue) {
-            UIApplication.shared.openSafariVCIfPossible(promotion.url)
+            UIApplication.shared.openSafariVCIfPossible(promotion.urlApple)
         }
 
         let adView = BannerAdView(model: model, colors: .playerColors(Theme.sharedTheme)).padding(16)

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -454,7 +454,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
 
     private func setupBannerAd(promotion: BlazePromotion) {
         bannerAdModel = BannerAdModel(promotion: promotion, source: AnalyticsSource.podcastsList.rawValue) {
-            UIApplication.shared.openSafariVCIfPossible(promotion.url)
+            UIApplication.shared.openSafariVCIfPossible(promotion.urlApple)
         }
         isAnimatingBannerAd = true
 


### PR DESCRIPTION
Completes [PCIOS-110](https://linear.app/a8c/issue/PCIOS-110/change-promotion-property-to-location)

Also adds the new platform specific URLs for Android and Apple and uses the Apple one for our URL handling. 

## To test

### Player
* Enable the `bannerAds` feature flag
* Go to the player
* Tap the banner
* ✅ Verify that the upgrade screen is shown

### Podcasts
* Go to the Podcasts tab
* Tap the banner
* ✅ Verify that the upgrade screen is shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
