### PR TITLE
[Banner Ads] Add `bannerAdReport` tracks event

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -921,4 +921,5 @@ enum AnalyticsEvent: String {
     // MARK: - Banner Ads
     case bannerAdImpression
     case bannerAdTapped
+    case bannerAdReport
 }

--- a/podcasts/Common SwiftUI/BannerAdReporter.swift
+++ b/podcasts/Common SwiftUI/BannerAdReporter.swift
@@ -40,6 +40,7 @@ struct BannerAdReporter {
                 "ad_id": adID,
                 "reason": action.analyticsValue
             ])
+            Toast.show(L10n.bannerAdsReportConfirmation)
         }
 
         let reportOptions = OptionsPicker(title: nil)

--- a/podcasts/Common SwiftUI/BannerAdReporter.swift
+++ b/podcasts/Common SwiftUI/BannerAdReporter.swift
@@ -18,12 +18,28 @@ struct BannerAdReporter {
                 return L10n.bannerAdsReportOther
             }
         }
+
+        var analyticsValue: String {
+            switch self {
+            case .broken:
+                "broken"
+            case .malicious:
+                "malicious"
+            case .tooOften:
+                "too_often"
+            case .other:
+                "other"
+            }
+        }
     }
 
     /// Shows the ad reporting bottom sheet with options to report various problems with an ad
-    static func show() {
+    static func show(for adID: String, from source: Any) {
         func handle(action: ReportActionType) {
-            // Handling will be added in a separate PR
+            Analytics.track(.bannerAdReport, source: source, properties: [
+                "ad_id": adID,
+                "reason": action.analyticsValue
+            ])
         }
 
         let reportOptions = OptionsPicker(title: nil)

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -166,7 +166,7 @@ struct BannerAdView: View {
     @ViewBuilder func closeButton() -> some View {
         VStack {
             Button(action: {
-                BannerAdReporter.show()
+                BannerAdReporter.show(for: model.adID, from: model.source)
             }) {
                 Image(systemName: "xmark")
                     .font(.system(size: 12))

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -320,6 +320,8 @@ internal enum L10n {
   internal static var bannerAdsReportAdTitle: String { return L10n.tr("Localizable", "banner_ads_report_ad_title", fallback: "Why are you reporting this ad?") }
   /// The title of an option to report a specific banner ad for one of several reasons.
   internal static var bannerAdsReportBroken: String { return L10n.tr("Localizable", "banner_ads_report_broken", fallback: "This ad seems broken") }
+  /// The title shown in a Toast after reporting a banner ad.
+  internal static var bannerAdsReportConfirmation: String { return L10n.tr("Localizable", "banner_ads_report_confirmation", fallback: "You reported this ad.") }
   /// The title of an option to report a banner ad as malicious.
   internal static var bannerAdsReportMalicious: String { return L10n.tr("Localizable", "banner_ads_report_malicious", fallback: "This is a malicious ad") }
   /// The title of an option to report a banner ad as "other".

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5280,6 +5280,9 @@
 /* The title of an option to report a banner ad as occurring too often. */
 "banner_ads_report_too_often" = "See this ad too often";
 
+/* The title shown in a Toast after reporting a banner ad. */
+"banner_ads_report_confirmation" = "You reported this ad.";
+
 /* The title of an option to report a banner ad as "other". */
 "banner_ads_report_other" = "Other";
 /* Episodes will be displayed in based on season and episode numbers*/


### PR DESCRIPTION
Completes [PCIOS-111](https://linear.app/a8c/issue/PCIOS-111/send-report-ad-tracks-event)
Completes [PCIOS-112](https://linear.app/a8c/issue/PCIOS-112/show-toast-after-reporting-a-banner-ad)

## To test

* Enable `tracksLogging` and `bannerAds` feature flags
* Navigate to Player
* Tap the banner ad
* Tap the "x" to report the ad
* ✅ Verify the `banner_ad_report` event is logged:
```
🔵 Tracked: banner_ad_report ["source": "player", "ad_id": "7d972870-4509-013e-6964-3697f02c49bb", "reason": "malicious"]
```
* ✅ Verify that the Toast is shown:
<img width=300 src="https://github.com/user-attachments/assets/fa3173ed-659c-4925-8ab8-b8b1a95c4510">

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
