### PR TITLE
CarPlay + Route logging

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -402,7 +402,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         let role = connectingSceneSession.role
 
-        if role == UISceneSession.Role.carTemplateApplication {
+        if role == .carTemplateApplication {
+            FileLog.shared.addMessage("AppDelegate: CarPlay isConnected")
             return UISceneConfiguration(name: "Pocket Casts Car", sessionRole: UISceneSession.Role.carTemplateApplication)
         }
 
@@ -413,6 +414,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+        let includesCarPlay = sceneSessions.contains(where: { $0.role == .carTemplateApplication })
+
+        if includesCarPlay {
+            FileLog.shared.addMessage("AppDelegate: CarPlay didDiscard")
+        }
     }
 
     // MARK: Secrets

--- a/podcasts/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlaySceneDelegate.swift
@@ -3,6 +3,7 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
 import UIKit
+import PocketCastsUtils
 
 class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, CPNowPlayingTemplateObserver {
     var interfaceController: CPInterfaceController?
@@ -12,6 +13,8 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     weak var visibleTemplate: CPTemplate?
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didConnect interfaceController: CPInterfaceController) {
+        FileLog.shared.addMessage("CarPlay: didConnect")
+
         self.interfaceController = interfaceController
         interfaceController.delegate = self
 
@@ -23,6 +26,7 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     }
 
     func templateApplicationScene(_ templateApplicationScene: CPTemplateApplicationScene, didDisconnectInterfaceController interfaceController: CPInterfaceController) {
+        FileLog.shared.addMessage("CarPlay: didDisconnect")
         removeAllCustomObservers()
         self.interfaceController?.delegate = nil
         self.interfaceController = nil

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1898,6 +1898,8 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         guard let userInfo = notification.userInfo, let changeReason = userInfo[AVAudioSessionRouteChangeReasonKey] as? NSNumber else { return }
 
+        logRouteChange(userInfo: userInfo)
+
         let reason = changeReason.uintValue
         if let currEpisode = currentEpisode(), playingOverAirplay() && playerSwitchRequired() {
             load(episode: currEpisode, autoPlay: true, overrideUpNext: false)
@@ -1905,6 +1907,20 @@ class PlaybackManager: ServerPlaybackDelegate {
             player?.routeDidChange(shouldPause: true)
         } else if reason == AVAudioSession.RouteChangeReason.newDeviceAvailable.rawValue || reason == AVAudioSession.RouteChangeReason.override.rawValue {
             player?.routeDidChange(shouldPause: false)
+        }
+    }
+
+    private func logRouteChange(userInfo: [AnyHashable: Any]) {
+        guard let changeReason = userInfo[AVAudioSessionRouteChangeReasonKey] as? NSNumber,
+              let previousRoute = userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription,
+              let currentRoute = AVAudioSession.sharedInstance().currentRoute as AVAudioSessionRouteDescription? else {
+            return
+        }
+
+        let previousOutputDescriptions = previousRoute.outputs.map { $0.portName }.joined(separator: ", ")
+        let currentOutputDescriptions = currentRoute.outputs.map { $0.portName }.joined(separator: ", ")
+        if let reason = AVAudioSession.RouteChangeReason(rawValue: UInt(changeReason.intValue)) {
+            FileLog.shared.addMessage("PlaybackManager: Handle route change \(reason) | Previous Outputs: [\(previousOutputDescriptions)] | Current Outputs: [\(currentOutputDescriptions)]")
         }
     }
 


### PR DESCRIPTION
To help us debug CarPlay issues, I've added logging whenever a CarPlay scene is detected (the app is opened on CarPlay) and also some additional info about route changes. Hopefully we can use this to determine _what_ may be interrupting CarPlay playback sessions in some user reports.

## To test

### CarPlay
* Connect to CarPlay
* Open Pocket Casts in CarPlay
* ✅ Verify that `CarPlay isConnected` is logged

### Routes
* Connect to a bluetooth device
* ✅ Verify that `Handle route change` is logged with information about the routes
```
2025-08-29 13:45:24 PlaybackManager: Handle route change AVAudioSessionRouteChangeReason(rawValue: 3) 1 Previous Outputs: [Speaker] | Current Outputs: [CarPlay]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
