### PR TITLE
[Banner Ads] Report banner ad to Tracks AND Firebase

### DIFF
--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -172,6 +172,16 @@ class AnalyticsHelper {
         bumpStat("banner_ad_tapped", parameters: properties)
     }
 
+    class func bannerReport(adID: String, reason: String, source: Any) {
+        let properties = ["id": adID, "promotion": source]
+        Analytics.track(.bannerAdReport, properties: properties)
+        bumpStat("banner_ad_report", parameters: properties)
+        Analytics.track(.bannerAdReport, source: source, properties: [
+            "ad_id": adID,
+            "reason": reason
+        ])
+    }
+
     class func forceTouchPlay() {
         logEvent("play_force_touch", parameters: nil)
     }

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -173,13 +173,9 @@ class AnalyticsHelper {
     }
 
     class func bannerReport(adID: String, reason: String, source: Any) {
-        let properties = ["id": adID, "promotion": source]
+        let properties = ["ad_id": adID, "promotion": source, "reason": reason]
         Analytics.track(.bannerAdReport, properties: properties)
         bumpStat("banner_ad_report", parameters: properties)
-        Analytics.track(.bannerAdReport, source: source, properties: [
-            "ad_id": adID,
-            "reason": reason
-        ])
     }
 
     class func forceTouchPlay() {

--- a/podcasts/Common SwiftUI/BannerAdReporter.swift
+++ b/podcasts/Common SwiftUI/BannerAdReporter.swift
@@ -36,10 +36,7 @@ struct BannerAdReporter {
     /// Shows the ad reporting bottom sheet with options to report various problems with an ad
     static func show(for adID: String, from source: Any) {
         func handle(action: ReportActionType) {
-            Analytics.track(.bannerAdReport, source: source, properties: [
-                "ad_id": adID,
-                "reason": action.analyticsValue
-            ])
+            AnalyticsHelper.bannerReport(adID: adID, reason: action.analyticsValue, source: source)
             Toast.show(L10n.bannerAdsReportConfirmation)
         }
 


### PR DESCRIPTION
Sends `banner_ad_report` to Firebase as well as Tracks

## To test

* Enable `tracksLogging`
* Enable the `bannerAdPlayer` feature flag
* Open the player
* Tap the x button to report the ad
* ✅ After reporting, verify that `banner_ad_report` is logged

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
