### PR TITLE
[Banner Ads] Enable Feature Flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 7.97
 -----
-
+- Enable Banner Ads in the Podcasts list and Player for free users [#3459](https://github.com/Automattic/pocket-casts-ios/pull/3459)
 
 7.96
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -372,9 +372,9 @@ public enum FeatureFlag: String, CaseIterable {
         case .episodeDetailTranscript:
             true
         case .bannerAdPodcasts:
-            false
+            true
         case .bannerAdPlayer:
-            false
+            true
         case .streamingCustomSessionConfiguration:
             true
         case .guestListsNetworkHighlightsRedesign:


### PR DESCRIPTION
Enable the feature flags for Banner Ads

## To test

* Log in with a free user or don't log in
* Open the Podcasts list
* ✅ Ensure a banner ad appears at the top of the list
* Open the Player
*  ✅ Ensure a banner ad appears at the top of the player

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
