### PR TITLE
[New Onboarding] Account Creation Recommendations Analytics updates

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -758,6 +758,7 @@ enum AnalyticsEvent: String {
     case recommendationsDismissed
     case recommendationsSearchTapped
     case recommendationsMoreTapped
+    case recommendationsContinueTapped
     case recommendationsImportTapped
 
     // MARK: - Cancel

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -758,6 +758,7 @@ enum AnalyticsEvent: String {
     case recommendationsDismissed
     case recommendationsSearchTapped
     case recommendationsMoreTapped
+    case recommendationsImportTapped
 
     // MARK: - Cancel
     case cancelConfirmationViewShown

--- a/podcasts/Onboarding/DiscoverPodcastsGridView.swift
+++ b/podcasts/Onboarding/DiscoverPodcastsGridView.swift
@@ -33,7 +33,7 @@ struct DiscoverPodcastsGridView: View {
 
             if podcasts.count > visibleCount {
                 Button(action: {
-                    OnboardingFlow.shared.track(.recommendationsMoreTapped)
+                    OnboardingFlow.shared.track(.recommendationsMoreTapped, properties: ["title": category.name ?? "Unknown", "number_visible": visibleCount])
                     visibleCount = min(visibleCount + 6, podcasts.count)
                 }) {
                     Text("More \(category.name ?? "Unknown")")

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -109,6 +109,9 @@ struct OnboardingRecommendationsView: View {
         }
         .background(theme.primaryInteractive02)
         .environmentObject(SearchAnalyticsHelper(source: .recommendations))
+        .onDisappear {
+            Analytics.track(.recommendationsDismissed, properties: ["subscriptions": DataManager.sharedManager.podcastCount()])
+        }
     }
 
     private func performSearch(term: String) {

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -102,6 +102,7 @@ struct OnboardingRecommendationsView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(L10n.import) {
                     showingImport = true
+                    Analytics.track(.recommendationsImportTapped)
                 }
                 .tint(theme.primaryInteractive01)
             }

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -61,7 +61,7 @@ struct OnboardingRecommendationsView: View {
 
                     VStack {
                         Button(action: {
-                            OnboardingFlow.shared.track(.recommendationsDismissed)
+                            OnboardingFlow.shared.track(.recommendationsContinueTapped, properties: ["subscriptions": DataManager.sharedManager.podcastCount()])
                             coordinator.recommendationsContinueTapped()
                         }) {
                             Text(L10n.continue)


### PR DESCRIPTION
Fixes [PCIOS-113](https://linear.app/a8c/issue/PCIOS-113/add-additional-tracking-for-category-id-to-more-tapped-event)

* Adds the `recommendationsImportTapped` event
* Adds the `recommendationsContinueTapped` event
* Adds `title` and `number_visible` properties to `recommendationsMoreTapped`

## To test

* Enable `tracksLogging` and `newOnboardingAccountCreation` flags in code
* Fresh install of the app
* Navigate to the Recommendations screen
* Tap the "More" button under a category
* ✅ Ensure that the `recommendationsMoreTapped` event is logged with `title` and `number_visible` logged
* Tap the Import button
* ✅ Ensure the `recommendationsImportTapped` event is logged
* Tap the Continue button
* ✅ Ensure the `recommendationsContinueTapped` event is logged
* Navigate back to Recommendations and then tap back again to get to Intro carousel
* ✅ Verify that `recommendationsDismissed` event is logged with `subscriptions`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
