### PR TITLE
[New onboarding] Interests screen analytics

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -759,6 +759,13 @@ enum AnalyticsEvent: String {
     case recommendationsSearchTapped
     case recommendationsMoreTapped
 
+    // MARK: - Interests
+    case onboardingInterestsShown
+    case onboardingInterestsNotNowTapped
+    case onboardingInterestsCategorySelected
+    case onboardingInterestsShownMoreTapped
+    case onboardingInterestsContinueTapped
+
     // MARK: - Cancel
     case cancelConfirmationViewShown
     case cancelConfirmationViewDismissed

--- a/podcasts/Onboarding/InterestsView.swift
+++ b/podcasts/Onboarding/InterestsView.swift
@@ -102,6 +102,9 @@ struct InterestsView: View {
             } else {
                 ProgressView()
                     .progressViewStyle(CircularProgressViewStyle(tint: theme.primaryIcon01))
+                    .onAppear {
+                        OnboardingFlow.shared.track(.onboardingInterestsShown)
+                    }
                     .task {
                         await viewModel.load()
                     }
@@ -114,6 +117,7 @@ struct InterestsView: View {
             HStack {
                 Spacer()
                 Button(L10n.eoyNotNow) {
+                    OnboardingFlow.shared.track(.onboardingInterestsNotNowTapped)
                     dismiss()
                 }
                 .tint(theme.primaryInteractive01)
@@ -147,6 +151,7 @@ struct InterestsView: View {
     @ViewBuilder func categoryButton(for category: DiscoverCategory, index: Int) -> some View {
         let isSelected = viewModel.isSelectedCategory(category)
         InterestButton(name: category.name ?? "", icon: category.icon, isSelected: isSelected, style: InterestButton.Style.allCases[index % InterestButton.Style.allCases.count]) {
+            OnboardingFlow.shared.track(.onboardingInterestsCategorySelected, properties: ["category_id": "\(category.id ?? -1)", "name": category.name ?? "", "is_selected": isSelected ? "true" : "false"])
             withAnimation() {
                 viewModel.toggleSelectionOfCategory(category)
             }
@@ -174,6 +179,7 @@ struct InterestsView: View {
         HStack {
             Spacer()
             Button(L10n.interestsShowMoreCategories) {
+                OnboardingFlow.shared.track(.onboardingInterestsShownMoreTapped)
                 showMore.toggle()
                 withAnimation() {
                     viewModel.showAll()
@@ -189,6 +195,7 @@ struct InterestsView: View {
         VStack {
             Button(action: {
                 //TODO: Implement this
+                OnboardingFlow.shared.track(.onboardingInterestsContinueTapped, properties: ["categories": Array(viewModel.selectedCategories)])
             }) {
                 Text(viewModel.isMinimumSelectionDone ? L10n.continue : L10n.interestsSelectAtLeast(viewModel.minimumSelectionCount))
                     .textStyle(RoundedButton())

--- a/podcasts/Onboarding/InterestsView.swift
+++ b/podcasts/Onboarding/InterestsView.swift
@@ -151,7 +151,7 @@ struct InterestsView: View {
     @ViewBuilder func categoryButton(for category: DiscoverCategory, index: Int) -> some View {
         let isSelected = viewModel.isSelectedCategory(category)
         InterestButton(name: category.name ?? "", icon: category.icon, isSelected: isSelected, style: InterestButton.Style.allCases[index % InterestButton.Style.allCases.count]) {
-            OnboardingFlow.shared.track(.onboardingInterestsCategorySelected, properties: ["category_id": "\(category.id ?? -1)", "name": category.name ?? "", "is_selected": isSelected ? "true" : "false"])
+            OnboardingFlow.shared.track(.onboardingInterestsCategorySelected, properties: ["category_id": "\(category.id ?? -1)", "name": category.name ?? "", "is_selected": !isSelected])
             withAnimation() {
                 viewModel.toggleSelectionOfCategory(category)
             }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes POC-149 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds the following tracking events for the interests screen:

- onboarding_interests_shown
- onboarding_interests_not_now_tapped
- onboarding_interests_category_selected
- onboarding_interests_show_more_tapped
- onboarding_interests_continue_tapped

## To test

1. Start the app
2. Ensure that you have the Tracking Analytics FF active
3. Go to Profile -> Settings -> Developer -> Interests
4. Tap on the following places and see if the events are tracked:
   1. Opening the screen:  `onboarding_interests_shown`
   2. Select categories: `onboarding_interests_category_selected`
   3. Tap on Show More: `onboarding_interests_show_more_tapped`
   4. Tap on Continue: `onboarding_interests_continue_tapped` with the properties having the categories ids selected under


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
