### PR TITLE
Apple Watch Logging crash fix

### DIFF
--- a/podcasts/WatchManager+Send.swift
+++ b/podcasts/WatchManager+Send.swift
@@ -17,55 +17,71 @@ extension WatchManager {
 
         let session = WCSession.default
         if session.activationState != .activated || session.isPaired == false || session.isWatchAppInstalled == false {
-            completion(cachedLog)
+            Task {
+                let log = await logCache.getCachedLog()
+                completion(log)
+            }
             return
         }
 
         // Hold a local reference so we don't potentially run into a deallocated `self` when the below blocks are run.
-        let cachedLog = self.cachedLog
+        Task { [weak self] in
+            guard let self else { return }
+            let cachedLog = await self.logCache.getCachedLog()
 
-        // Use an actor to ensure thread-safe completion handling
-        let completionHandler = CompletionHandler(cachedLog: cachedLog, completion: completion)
+            // Use an actor to ensure thread-safe completion handling
+            let completionHandler = CompletionHandler(cachedLog: cachedLog, completion: completion)
 
-        // since we don't know how long it takes for a send message to timeout, wait only 5 seconds for a watch response before giving up here
-        let task = Task { [weak self, completionHandler] in
-            try? await Task.sleep(for: .seconds(5))
-            await completionHandler.callCompletionIfNeeded(with: cachedLog)
-            await self?.logTaskManager.clearTask()
-        }
-        
-        Task {
+            // since we don't know how long it takes for a send message to timeout, wait only 5 seconds for a watch response before giving up here
+            let task = Task { [weak self, completionHandler] in
+                try? await Task.sleep(for: .seconds(5))
+                let cachedLogForTimeout = await self?.logCache.getCachedLog()
+                await completionHandler.callCompletionIfNeeded(with: cachedLogForTimeout)
+                await self?.logTaskManager.clearTask()
+            }
+
             await logTaskManager.setTask(task)
-        }
 
-        // if we get here then it's likely we'll be able to ask the watch for a log file, so let's try
-        let logRequestMessage = [WatchConstants.Messages.messageType: WatchConstants.Messages.LogFileRequest.type]
-        session.sendMessage(logRequestMessage, replyHandler: { [weak self] response in
-            Task { [weak self, completionHandler] in
-                await self?.logTaskManager.cancelCurrentTask()
+            // if we get here then it's likely we'll be able to ask the watch for a log file, so let's try
+            let logRequestMessage = [WatchConstants.Messages.messageType: WatchConstants.Messages.LogFileRequest.type]
+            session.sendMessage(logRequestMessage, replyHandler: { [weak self] response in
+                Task { [weak self, completionHandler] in
+                    await self?.logTaskManager.cancelCurrentTask()
 
-                if let logContents = response[WatchConstants.Messages.LogFileRequest.logContents] as? String {
-                    self?.cachedLog = logContents
-                    if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
-                        self?.saveLog(contents: logContents)
+                    if let logContents = response[WatchConstants.Messages.LogFileRequest.logContents] as? String {
+                        await self?.logCache.setCachedLog(logContents)
+                        if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
+                            self?.saveLog(contents: logContents)
+                        }
+                        await completionHandler.callCompletionIfNeeded(with: logContents)
+                    } else {
+                        let cachedLog = await self?.logCache.getCachedLog()
+                        await completionHandler.callCompletionIfNeeded(with: cachedLog)
                     }
-                    await completionHandler.callCompletionIfNeeded(with: logContents)
-                } else {
+                }
+            }) { [weak self] error in
+                Task { [weak self, completionHandler] in
+                    await self?.logTaskManager.cancelCurrentTask()
+
+                    // To avoid spamming the logs, we'll only log errors unrelated to unreachable
+                    let nsError = error as NSError
+                    if nsError.domain == WCErrorDomain,
+                       nsError.code == WCError.Code.notReachable.rawValue {
+                        FileLog.shared.addMessage("WatchManager: Failed log collection \(error)")
+                    }
+
+                    let cachedLog = await self?.logCache.getCachedLog()
                     await completionHandler.callCompletionIfNeeded(with: cachedLog)
                 }
             }
-        }) { [weak self] error in
-            Task { [weak self, completionHandler] in
-                await self?.logTaskManager.cancelCurrentTask()
+        }
+    }
 
-                // To avoid spamming the logs, we'll only log errors unrelated to unreachable
-                let nsError = error as NSError
-                if nsError.domain == WCErrorDomain,
-                   nsError.code == WCError.Code.notReachable.rawValue {
-                    FileLog.shared.addMessage("WatchManager: Failed log collection \(error)")
-                }
-
-                await completionHandler.callCompletionIfNeeded(with: cachedLog)
+    /// Async wrapper for requestLogFile for cleaner call sites
+    func requestLogFile() async -> String? {
+        await withCheckedContinuation { continuation in
+            requestLogFile { result in
+                continuation.resume(returning: result)
             }
         }
     }

--- a/podcasts/WatchManager+Send.swift
+++ b/podcasts/WatchManager+Send.swift
@@ -66,7 +66,7 @@ extension WatchManager {
                     // To avoid spamming the logs, we'll only log errors unrelated to unreachable
                     let nsError = error as NSError
                     if nsError.domain == WCErrorDomain,
-                       nsError.code == WCError.Code.notReachable.rawValue {
+                       nsError.code != WCError.Code.notReachable.rawValue {
                         FileLog.shared.addMessage("WatchManager: Failed log collection \(error)")
                     }
 

--- a/podcasts/WatchManager+Send.swift
+++ b/podcasts/WatchManager+Send.swift
@@ -28,18 +28,21 @@ extension WatchManager {
         let completionHandler = CompletionHandler(cachedLog: cachedLog, completion: completion)
 
         // since we don't know how long it takes for a send message to timeout, wait only 5 seconds for a watch response before giving up here
-        logFileRequestTask = Task { [weak self, completionHandler] in
+        let task = Task { [weak self, completionHandler] in
             try? await Task.sleep(for: .seconds(5))
             await completionHandler.callCompletionIfNeeded(with: cachedLog)
-            self?.logFileRequestTask = nil
+            await self?.logTaskManager.clearTask()
+        }
+        
+        Task {
+            await logTaskManager.setTask(task)
         }
 
         // if we get here then it's likely we'll be able to ask the watch for a log file, so let's try
         let logRequestMessage = [WatchConstants.Messages.messageType: WatchConstants.Messages.LogFileRequest.type]
         session.sendMessage(logRequestMessage, replyHandler: { [weak self] response in
             Task { [weak self, completionHandler] in
-                self?.logFileRequestTask?.cancel()
-                self?.logFileRequestTask = nil
+                await self?.logTaskManager.cancelCurrentTask()
 
                 if let logContents = response[WatchConstants.Messages.LogFileRequest.logContents] as? String {
                     self?.cachedLog = logContents
@@ -53,8 +56,7 @@ extension WatchManager {
             }
         }) { [weak self] error in
             Task { [weak self, completionHandler] in
-                self?.logFileRequestTask?.cancel()
-                self?.logFileRequestTask = nil
+                await self?.logTaskManager.cancelCurrentTask()
 
                 // To avoid spamming the logs, we'll only log errors unrelated to unreachable
                 let nsError = error as NSError

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -8,9 +8,7 @@ class WatchManager: NSObject, WCSessionDelegate {
     static let shared = WatchManager()
 
     let logTaskManager = LogTaskManager()
-
-    // The last retrieved log is cached here for the duration of this session
-    var cachedLog: String? = nil
+    let logCache = LogCache()
 
     // Serial queue for WCSession operations to ensure thread safety
     private let sessionQueue = DispatchQueue(label: "com.pocketcasts.watchmanager.session", qos: .userInitiated)
@@ -58,7 +56,10 @@ class WatchManager: NSObject, WCSessionDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(playbackStateChanged), name: Constants.Notifications.podcastChapterChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(playbackStateChanged), name: Constants.Notifications.podcastChaptersDidUpdate, object: nil)
 
-        cachedLog = WatchManager.shared.readLogFile()
+        Task {
+            let log = WatchManager.shared.readLogFile()
+            await logCache.setCachedLog(log)
+        }
     }
 
     deinit {
@@ -609,18 +610,34 @@ class WatchManager: NSObject, WCSessionDelegate {
 // MARK: - Actor for Thread-Safe Task Management
 actor LogTaskManager {
     private var currentTask: Task<Void, Never>?
-    
+
     func setTask(_ task: Task<Void, Never>) {
-        cancelCurrentTask()
-        currentTask = task
+        replaceTask(with: task)
     }
-    
+
     func cancelCurrentTask() {
-        currentTask?.cancel()
-        currentTask = nil
+        replaceTask(with: nil)
     }
-    
+
     func clearTask() {
-        currentTask = nil
+        replaceTask(with: nil)
+    }
+
+    private func replaceTask(with newTask: Task<Void, Never>?) {
+        currentTask?.cancel()
+        currentTask = newTask
+    }
+}
+
+// MARK: - Actor for Thread-Safe Log Caching
+actor LogCache {
+    private var cachedLog: String? = nil
+
+    func getCachedLog() -> String? {
+        return cachedLog
+    }
+
+    func setCachedLog(_ log: String?) {
+        cachedLog = log
     }
 }

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -7,7 +7,7 @@ import WatchConnectivity
 class WatchManager: NSObject, WCSessionDelegate {
     static let shared = WatchManager()
 
-    var logFileRequestTask: Task<Void, Never>?
+    let logTaskManager = LogTaskManager()
 
     // The last retrieved log is cached here for the duration of this session
     var cachedLog: String? = nil
@@ -603,5 +603,24 @@ class WatchManager: NSObject, WCSessionDelegate {
         }
 
         return nil
+    }
+}
+
+// MARK: - Actor for Thread-Safe Task Management
+actor LogTaskManager {
+    private var currentTask: Task<Void, Never>?
+    
+    func setTask(_ task: Task<Void, Never>) {
+        cancelCurrentTask()
+        currentTask = task
+    }
+    
+    func cancelCurrentTask() {
+        currentTask?.cancel()
+        currentTask = nil
+    }
+    
+    func clearTask() {
+        currentTask = nil
     }
 }


### PR DESCRIPTION
Fixes [PCIOS-106](https://linear.app/a8c/issue/PCIOS-106/sentry-crash-apple-watch-log-file-request-task)

Adds further actor isolation to the logTask and cachedLog.

## To test

* Run the app on your iPhone attached to an Apple Watch
* Open the watch app as well
* Run and perform a few actions that trigger the syncing like changing the UP Next queue
* Export the database from Help & Feedback > ⋯
* Verify that the watchOS.txt log file appears with recent log messages

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
