### PR TITLE
[New onboarding] Interests button animation

### DIFF
--- a/podcasts/Onboarding/InterestButton.swift
+++ b/podcasts/Onboarding/InterestButton.swift
@@ -11,6 +11,8 @@ struct InterestButton: View {
     let style: Style
     let action: (() -> Void)?
 
+    @State private var isAnimatingSelection = false
+
     init(name: String, icon: String?, isSelected: Bool = false, style: Style = .red, action: (() -> Void)? = nil) {
         self.name = name
         self.icon = icon
@@ -21,7 +23,7 @@ struct InterestButton: View {
 
     var body: some View {
         Button(action: {
-            action?()
+            doAnimationAndAction()
         }) {
             HStack {
                 if let icon = icon, let url = URL(string: icon) {
@@ -66,6 +68,22 @@ struct InterestButton: View {
                 .stroke(isSelected ? .clear : theme.primaryUi05, lineWidth: 2)
         )
         .clipShape(RoundedRectangle(cornerRadius: Constants.cornerRadius))
+        .scaleEffect(isAnimatingSelection ? 1.2 : 1)
+        .rotationEffect(Angle(degrees: isAnimatingSelection ? -3 : 0))
+    }
+
+    private func doAnimationAndAction() {
+        if isSelected {
+            action?()
+        } else {
+            withAnimation(.easeOut(duration: 0.1)) {
+                isAnimatingSelection.toggle()
+            }
+            withAnimation(.interpolatingSpring(stiffness: 600, damping: 15).delay(0.1)) {
+                action?()
+                isAnimatingSelection.toggle()
+            }
+        }
     }
 
     enum Style: Int, CaseIterable {

--- a/podcasts/Onboarding/InterestsView.swift
+++ b/podcasts/Onboarding/InterestsView.swift
@@ -130,7 +130,7 @@ struct InterestsView: View {
                         Spacer().frame(height: 40)
                         WrappingHStack(alignment: .center, horizontalSpacing: 8, verticalSpacing: 8, fitContentWidth: false) {
                             ForEach(viewModel.categories, id: \.self) { category in
-                                categoryButton(for: category, index: viewModel.positionOfCategory(category) ?? 0).transition(.move(edge: .bottom))
+                                categoryButton(for: category, index: viewModel.positionOfCategory(category) ?? 0).transition(.fade)
                             }
                         }
                         if !showMore {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes POC-42 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds the interest button animation when selecting.

It also switch the show more animation to a fade instead of a scroll up to match Android


https://github.com/user-attachments/assets/c56c7650-5d32-4407-80bd-97609c3ce16a


## To test

1. Start the app
2. Go to Profile -> Settings -> Developer Menu
3. Tap on Interests
4. Select items on the Interests, and check the animation
5. Tap on Show more to see the new fade animation to show more elements

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
