### PR TITLE
[New Onboarding] Interests recommendations integration

### DIFF
--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -9,8 +9,11 @@ struct DeveloperMenu: View {
     @State var showingPlaylistsOnboarding = false
     @State var showingRecommendationsOnboarding = false
     @State var showingInterestsOnboarding = false
+    @State var showingRecommendationsOnboardingSelected = false
     @State var showSurvey = false
     @State var showIntroCarousel = false
+
+    @StateObject var recommendationsViewModel = RecommendationsViewModel(configuration: .all)
 
     var body: some View {
         List {
@@ -376,7 +379,13 @@ struct DeveloperMenu: View {
                     showingInterestsOnboarding = true
                 }
                 .sheet(isPresented: $showingInterestsOnboarding) {
-                    InterestsView()
+                    InterestsView(continueCallback: { categories in
+                        showInterestRecommendations(categories: categories)
+                    })
+                        .environmentObject(Theme.sharedTheme)
+                }
+                .sheet(isPresented: $showingRecommendationsOnboardingSelected) {
+                    OnboardingRecommendationsView(coordinator: LoginCoordinator(), viewModel: self.recommendationsViewModel)
                         .environmentObject(Theme.sharedTheme)
                 }
             } header: {
@@ -390,6 +399,12 @@ struct DeveloperMenu: View {
             }
         }
         .miniPlayerSafeAreaInset()
+    }
+
+    func showInterestRecommendations(categories: [DiscoverCategory]) {
+        showingInterestsOnboarding = false
+        recommendationsViewModel.configuration = .preselected(categories)
+        showingRecommendationsOnboardingSelected = true
     }
 }
 

--- a/podcasts/Onboarding/InterestsView.swift
+++ b/podcasts/Onboarding/InterestsView.swift
@@ -36,6 +36,10 @@ class InterestsViewModel: ObservableObject, @unchecked Sendable {
     @Published var isLoaded: Bool = false
     @Published var selectedCategories: Set<Int> = []
 
+    var fullSelectedCategories: [DiscoverCategory] {
+        return categories.filter { selectedCategories.contains($0.id ?? -1) }
+    }
+
     func load() async {
         let page = await DiscoverServerHandler.shared.discoverPage()
         guard let layout = page.0 else {
@@ -94,6 +98,8 @@ struct InterestsView: View {
     @EnvironmentObject var theme: Theme
 
     @Environment(\.dismiss) var dismiss
+
+    let continueCallback: (([DiscoverCategory]) -> ())?
 
     var body: some View {
         Group {
@@ -194,7 +200,7 @@ struct InterestsView: View {
     var continueButton: some View {
         VStack {
             Button(action: {
-                //TODO: Implement this
+                continueCallback?(viewModel.fullSelectedCategories)
                 OnboardingFlow.shared.track(.onboardingInterestsContinueTapped, properties: ["categories": Array(viewModel.selectedCategories)])
             }) {
                 Text(viewModel.isMinimumSelectionDone ? L10n.continue : L10n.interestsSelectAtLeast(viewModel.minimumSelectionCount))
@@ -211,6 +217,6 @@ struct InterestsView: View {
 }
 
 #Preview("Live") {
-    InterestsView()
+    InterestsView(continueCallback: nil)
         .environmentObject(Theme(previewTheme: .light))
 }

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -3,13 +3,105 @@ import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 
+class RecommendationsViewModel: ObservableObject {
+
+    enum Configuration {
+        case all
+        case preselected([DiscoverCategory])
+    }
+
+    @Published var categories: [DiscoverCategory] = []
+    private var layout: DiscoverLayout?
+    @Published var categoryPodcasts: [Int: [DiscoverPodcast]] = [:]
+    @Published var isLoaded: Bool = false
+
+    var configuration: Configuration {
+        didSet {
+            Task {
+                await load()
+            }
+        }
+    }
+
+    init(configuration: Configuration = .all) {
+        self.configuration = configuration
+    }
+
+    func load() async {
+        switch configuration {
+            case .all:
+                let page = await DiscoverServerHandler.shared.discoverPage()
+                guard let layout = page.0 else {
+                    return
+                }
+
+                let categoriesItem = layout.layout?.first { item in
+                    item.type == "categories"
+                }
+                guard let categoriesItem else {
+                    return
+                }
+                let categories = await DiscoverServerHandler.shared.discoverCategories(source: categoriesItem.source ?? "", authenticated: categoriesItem.isAuthenticated)
+                self.layout = layout
+                await MainActor.run {
+                    self.categories = categories
+                    self.isLoaded = true
+                }
+                await loadCategoryPodcasts(layout: layout)
+            case .preselected(let categories):
+                await MainActor.run {
+                    self.categories = categories
+                    self.isLoaded = true
+                }
+                await loadOnboardingPodcasts()
+        }
+    }
+
+    private func regionCode(for layout: DiscoverLayout) -> String {
+        let currentRegionCode = Settings.discoverRegion(discoverLayout: layout)
+        let serverRegion = layout.regions?[currentRegionCode]?.code ?? "us"
+        return serverRegion
+    }
+
+    private func loadCategoryPodcasts(layout: DiscoverLayout) async {
+        let regionCode = regionCode(for: layout)
+
+        await withTaskGroup(of: Void.self) { group in
+            for category in categories {
+                group.addTask {
+                    let source = category.source?.replacingOccurrences(of: layout.regionCodeToken, with: regionCode)
+                    let podcasts = await DiscoverServerHandler.shared.discoverCategoryDetails(source: source ?? "", authenticated: false)?.podcasts ?? []
+
+                    await MainActor.run {
+                        self.categoryPodcasts[category.id ?? 0] = podcasts
+                    }
+                }
+            }
+        }
+    }
+
+    private func loadOnboardingPodcasts() async {
+        await withTaskGroup(of: Void.self) { group in
+            for category in categories {
+                group.addTask {
+                    let source = category.sourceOnboarding
+                    let podcasts = await DiscoverServerHandler.shared.discoverCategoryDetails(source: source ?? "", authenticated: false)?.podcasts ?? []
+
+                    await MainActor.run {
+                        self.categoryPodcasts[category.id ?? 0] = podcasts
+                    }
+                }
+            }
+        }
+    }
+}
+
 struct OnboardingRecommendationsView: View {
 
     let coordinator: LoginCoordinator
 
-    @State var categories: [DiscoverCategory] = []
-    @State var layout: DiscoverLayout?
-    @State var categoryPodcasts: [Int: [DiscoverPodcast]] = [:]
+    @ObservedObject var viewModel: RecommendationsViewModel
+
     @State var showingImport = false
 
     @EnvironmentObject var theme: Theme
@@ -18,16 +110,21 @@ struct OnboardingRecommendationsView: View {
     @State var searchResults = [PodcastFolderSearchResult]()
     @State var searchTask: Task<Void, Never>?
 
+    init(coordinator: LoginCoordinator, viewModel: RecommendationsViewModel = RecommendationsViewModel(configuration: .all)) {
+        self.coordinator = coordinator
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         Group {
-            if layout != nil {
+            if viewModel.isLoaded {
                 ZStack(alignment: .bottom) {
                     ScrollView(.vertical) {
                         VStack(spacing: 16) {
                             header()
                             searchBar()
                             if searchTerm.isEmpty {
-                                ForEach(categories, id: \.id) { category in
+                                ForEach(viewModel.categories, id: \.id) { category in
                                     VStack(alignment: .leading, spacing: 16) {
                                         Text(category.name ?? "Unknown")
                                             .font(.title2.weight(.bold))
@@ -36,7 +133,7 @@ struct OnboardingRecommendationsView: View {
                                             .padding(.horizontal, 20)
                                         DiscoverPodcastsGridView(
                                             category: category,
-                                            podcasts: categoryPodcasts[category.id ?? 0] ?? []
+                                            podcasts: viewModel.categoryPodcasts[category.id ?? 0] ?? []
                                         )
                                         .frame(minHeight: (DiscoverPodcastsGridView.Constants.itemHeight * 2) + DiscoverPodcastsGridView.Constants.gridSpacing + 4)
                                     }
@@ -78,23 +175,8 @@ struct OnboardingRecommendationsView: View {
                 ProgressView()
                     .progressViewStyle(CircularProgressViewStyle(tint: theme.primaryIcon01))
                     .task {
-                        let page = await DiscoverServerHandler.shared.discoverPage()
-                        guard let layout = page.0 else {
-                            return
-                        }
-
-                        let categoriesItem = layout.layout?.first { item in
-                            item.type == "categories"
-                        }
-                        guard let categoriesItem else {
-                            return
-                        }
-                        categories = await DiscoverServerHandler.shared.discoverCategories(source: categoriesItem.source ?? "", authenticated: categoriesItem.isAuthenticated)
-                        self.layout = layout
-
                         OnboardingFlow.shared.track(.recommendationsShown)
-
-                        await loadCategoryPodcasts(layout: layout)
+                        await viewModel.load()
                     }
             }
         }
@@ -143,30 +225,6 @@ struct OnboardingRecommendationsView: View {
             }
         }
     }
-
-    private func regionCode(for layout: DiscoverLayout) -> String {
-        let currentRegionCode = Settings.discoverRegion(discoverLayout: layout)
-        let serverRegion = layout.regions?[currentRegionCode]?.code ?? "us"
-        return serverRegion
-    }
-
-    private func loadCategoryPodcasts(layout: DiscoverLayout) async {
-        let regionCode = regionCode(for: layout)
-
-        await withTaskGroup(of: Void.self) { group in
-            for category in categories {
-                group.addTask {
-                    let source = category.source?.replacingOccurrences(of: layout.regionCodeToken, with: regionCode)
-                    let podcasts = await DiscoverServerHandler.shared.discoverCategoryDetails(source: source ?? "", authenticated: false)?.podcasts ?? []
-
-                    await MainActor.run {
-                        self.categoryPodcasts[category.id ?? 0] = podcasts
-                    }
-                }
-            }
-        }
-    }
-
 
     @ViewBuilder func header() -> some View {
         VStack(spacing: 16) {


### PR DESCRIPTION
| 📘 Part of: [Interests And Recommendations](https://linear.app/a8c/project/ios-new-onboarding-interests-and-recommendations-fce13508b1f5/issues) |  <!-- project issue number, if applicable -->
|:---:|

Fixes POC-150 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR integrates the selection mades in the Interests Screen with the Recommendations Screen.

https://github.com/user-attachments/assets/8ff6ad76-4d13-41d5-a9cf-72afa451fc56


## To test

1. Start the app
2. Go to Profile -> Settings -> Developer -> Show Onboarding Interests
3. Select at least 3 interests
4. Tap on Continue
5. Check if the Recommendations screen shows podcast for the interests you selected
6. Follow some of the podcasts
7. Swipe down to dismiss
8. Smoke test the general Recommendations by tapping on Show Onboarding Recommendations

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
