### PR TITLE
GRDB: default `Bool` to false

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBResultSet.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBResultSet.swift
@@ -61,7 +61,7 @@ class GRDBResultSet: PCDBResultSet {
     }
 
     func bool(forColumn: String) -> Bool {
-        row[forColumn]
+        row[forColumn] ?? false
     }
 
     func double(forColumn: String) -> Double {


### PR DESCRIPTION
| 📘 Part of: #2773 | 
|:---:|

We have a few crashes related to decoding booleans. In this PR I'm reintroducing FMDB behavior to default a `NULL` column to `false`. This shouldn't affect app behavior as it was like this before.

## To test

1. Code review

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
