### PR TITLE
[Banner Ads] Now Playing animation fixes

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
@@ -23,7 +23,7 @@ private struct BlazePromotions: Decodable {
 }
 
 extension DiscoverServerHandler {
-    public func blazePromotion(for location: BlazePromotion.Location) async -> (promotion: BlazePromotion, useCache: Bool)? {
+    func fetchBlazePromotion(for location: BlazePromotion.Location) async -> (promotion: BlazePromotion, useCache: Bool)? {
         let path = ServerConstants.Urls.discover() + "blaze/promotions.json"
         let fetchResult: (BlazePromotion, Bool)? = await withCheckedContinuation { continuation in
             discoverRequest(path: path, type: BlazePromotions.self, authenticated: false) { promotions, useCache in
@@ -39,7 +39,7 @@ extension DiscoverServerHandler {
         return fetchResult
     }
 
-    public func cachedBlazePromotion(for location: BlazePromotion.Location) -> BlazePromotion? {
+    func cachedBlazePromotion(for location: BlazePromotion.Location) -> BlazePromotion? {
         let path = ServerConstants.Urls.discover() + "blaze/promotions.json"
         guard let response = cachedResponse(for: path) else { return nil }
 
@@ -52,6 +52,21 @@ extension DiscoverServerHandler {
         } catch {
             FileLog.shared.addMessage("DiscoverServerHandler: Could not decode cached Blaze promotions: \(error)")
             return nil
+        }
+    }
+
+    public func blazePromotion(for location: BlazePromotion.Location, completion: @escaping (BlazePromotion, Bool) -> Void) {
+        if let cachedPromotion = cachedBlazePromotion(for: location) {
+            completion(cachedPromotion, false)
+            return
+        }
+
+        Task {
+            if let result = await fetchBlazePromotion(for: location) {
+                await MainActor.run {
+                    completion(result.promotion, !result.useCache)
+                }
+            }
         }
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsUtils
 
 public struct BlazePromotion: Decodable {
     public let id: String
@@ -22,20 +23,35 @@ private struct BlazePromotions: Decodable {
 }
 
 extension DiscoverServerHandler {
-    public func blazePromotions() async -> [BlazePromotion]? {
+    public func blazePromotion(for location: BlazePromotion.Location) async -> (promotion: BlazePromotion, useCache: Bool)? {
         let path = ServerConstants.Urls.discover() + "blaze/promotions.json"
-        let promotions = await withCheckedContinuation { continuation in
+        let fetchResult: (BlazePromotion, Bool)? = await withCheckedContinuation { continuation in
             discoverRequest(path: path, type: BlazePromotions.self, authenticated: false) { promotions, useCache in
-                if let promotions = promotions {
-                    continuation.resume(returning: promotions)
+                if let promotions = promotions,
+                   let promotion = promotions.promotions.first(where: { $0.location == location }) {
+                    continuation.resume(returning: (promotion, useCache))
+                } else {
+                    continuation.resume(returning: nil)
                 }
             }
         }
 
-        return promotions.promotions
+        return fetchResult
     }
 
-    public func blazePromotion(for location: BlazePromotion.Location) async -> BlazePromotion? {
-        await blazePromotions()?.first(where: { $0.location == location })
+    public func cachedBlazePromotion(for location: BlazePromotion.Location) -> BlazePromotion? {
+        let path = ServerConstants.Urls.discover() + "blaze/promotions.json"
+        guard let response = cachedResponse(for: path) else { return nil }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        do {
+            let decoded = try decoder.decode(BlazePromotions.self, from: response.data)
+            return decoded.promotions.first(where: { $0.location == location })
+        } catch {
+            FileLog.shared.addMessage("DiscoverServerHandler: Could not decode cached Blaze promotions: \(error)")
+            return nil
+        }
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -132,34 +132,45 @@ public class DiscoverServerHandler: DiscoverServerHandling {
         }
 
         return await withCheckedContinuation { continuation in
-            performDiscoverRequest(path: source, authenticated: item.isAuthenticated) { data, response, error in
+            performDiscoverRequest(path: source, authenticated: item.isAuthenticated) { data, response, error, _ in
                 let success = response?.extractStatusCode() == 200
                 continuation.resume(returning: success)
             }
         }
     }
 
+    public func cachedResponse(for path: String) -> CachedURLResponse? {
+        let url = ServerHelper.asUrl(path)
+        let request = URLRequest(url: url)
+        if let cachedResponse = discoveryCache.cachedResponse(for: request),
+           let expiryDate = cachedResponse.response.cacheExpiryDate(),
+           expiryDate.timeIntervalSinceNow > 0 {
+            return cachedResponse
+        }
+        return nil
+    }
+
     private func performDiscoverRequest(
         path: String,
         authenticated: Bool?,
-        completion: @escaping (Data?, URLResponse?, Error?) -> Void
+        completion: @escaping (Data?, URLResponse?, Error?, Bool) -> Void
     ) {
         let url = ServerHelper.asUrl(path)
         let request = URLRequest(url: url)
 
-        if let cachedResponse = discoveryCache.cachedResponse(for: request),
-           let expiryDate = cachedResponse.response.cacheExpiryDate(),
-           expiryDate.timeIntervalSinceNow > 0 {
-            completion(cachedResponse.data, cachedResponse.response, nil)
+        if let cachedResponse = cachedResponse(for: path) {
+            completion(cachedResponse.data, cachedResponse.response, nil, true)
             return
         }
 
         if FeatureFlag.recommendations.enabled && authenticated == true {
             tokenHelper.callSecureUrl(request: request) { response, data, error in
-                completion(data, response, error)
+                completion(data, response, error, false)
             }
         } else {
-            URLSession.shared.dataTask(with: request, completionHandler: completion).resume()
+            URLSession.shared.dataTask(with: request, completionHandler: { data, response, error in
+                completion(data, response, error, false)
+            }).resume()
         }
     }
 
@@ -197,7 +208,7 @@ public class DiscoverServerHandler: DiscoverServerHandling {
         let url = ServerHelper.asUrl(path)
         let request = URLRequest(url: url)
 
-        performDiscoverRequest(path: path, authenticated: authenticated) { [weak self] data, response, error in
+        performDiscoverRequest(path: path, authenticated: authenticated) { [weak self] data, response, error, useCache in
             guard
                 let self = self,
                 let data = data,
@@ -215,7 +226,7 @@ public class DiscoverServerHandler: DiscoverServerHandling {
                 useCache: true,
                 type: type
             )
-            completion(decoded, false)
+            completion(decoded, useCache)
         }
     }
 }

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PocketCastsServer
+import Kingfisher
 
 class BannerAdModel: ObservableObject {
     let adText: String
@@ -118,21 +119,8 @@ struct BannerAdView: View {
     }
 
     @ViewBuilder func creative() -> some View {
-        AsyncImage(url: model.imageURL) { phase in
-            switch phase {
-            case .empty, .failure:
-                ProgressView()
-            case .success(let image):
-                image
-                    .resizable()
-                    .cornerRadius(4)
-            @unknown default:
-                ProgressView()
-                    .onAppear {
-                        assertionFailure("Unexpected AsyncImage phase: \(phase)")
-                    }
-            }
-        }
+        AsyncImageView(url: model.imageURL!)
+        .cornerRadius(4)
         .aspectRatio(1, contentMode: .fit)
         .frame(width: 86, height: 86)
     }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -247,13 +247,19 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     private func loadBannerAd() {
 #if !APPCLIP
         if FeatureFlag.bannerAdPlayer.enabled && !SubscriptionHelper.hasActiveSubscription() {
-            removeBannerAd()
-            bannerTask = Task { [weak self] in
-                if let promotion = await DiscoverServerHandler.shared.blazePromotion(for: .player) {
-                    guard Task.isCancelled == false else { return }
-                    try? await Task.sleep(for: .seconds(2)) // Delay by 2 seconds so we don't immediately show
-                    await MainActor.run {
-                        self?.addAdBanner(promotion: promotion)
+            if let promotion = DiscoverServerHandler.shared.cachedBlazePromotion(for: .player) {
+                addAdBanner(promotion: promotion, animated: false)
+            } else {
+                bannerTask = Task { [weak self] in
+                    if let result = await DiscoverServerHandler.shared.blazePromotion(for: .player) {
+                        guard Task.isCancelled == false else { return }
+                        let shouldAnimate = !result.useCache
+                        if shouldAnimate {
+                            try? await Task.sleep(for: .seconds(2))
+                        }
+                        await MainActor.run {
+                            self?.addAdBanner(promotion: result.promotion, animated: shouldAnimate)
+                        }
                     }
                 }
             }
@@ -512,7 +518,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     // MARK: Banner Ad
 
-    func addAdBanner(promotion: BlazePromotion) {
+    func addAdBanner(promotion: BlazePromotion, animated: Bool = true) {
         guard let stackView = episodeImage.superview as? UIStackView else { return }
 
         let model = BannerAdModel(promotion: promotion, source: AnalyticsSource.player.rawValue) {
@@ -548,14 +554,19 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
         view.layoutIfNeeded()
 
-        // Animate move first
-        UIView.animate(withDuration: 0.25, delay: 0, options: [.curveEaseOut]) {
-            topConstraint.constant = 0
-            self.view.layoutIfNeeded()
-        }
+        if animated {
+            // Animate move first
+            UIView.animate(withDuration: 0.25, delay: 0, options: [.curveEaseOut]) {
+                topConstraint.constant = 0
+                self.view.layoutIfNeeded()
+            }
 
-        // Animate opacity second so it's more noticeable
-        UIView.animate(withDuration: 0.2, delay: 0.05) {
+            // Animate opacity second so it's more noticeable
+            UIView.animate(withDuration: 0.2, delay: 0.05) {
+                adUiView.alpha = 1
+            }
+        } else {
+            topConstraint.constant = 0
             adUiView.alpha = 1
         }
     }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -247,20 +247,18 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     private func loadBannerAd() {
 #if !APPCLIP
         if FeatureFlag.bannerAdPlayer.enabled && !SubscriptionHelper.hasActiveSubscription() {
-            if let promotion = DiscoverServerHandler.shared.cachedBlazePromotion(for: .player) {
-                addAdBanner(promotion: promotion, animated: false)
-            } else {
-                bannerTask = Task { [weak self] in
-                    if let result = await DiscoverServerHandler.shared.blazePromotion(for: .player) {
-                        guard Task.isCancelled == false else { return }
-                        let shouldAnimate = !result.useCache
-                        if shouldAnimate {
-                            try? await Task.sleep(for: .seconds(2))
-                        }
+            DiscoverServerHandler.shared.blazePromotion(for: .player) { [weak self] promotion, shouldAnimate in
+                guard let self = self else { return }
+
+                if shouldAnimate {
+                    self.bannerTask = Task { [weak self] in
+                        try? await Task.sleep(for: .seconds(2))
                         await MainActor.run {
-                            self?.addAdBanner(promotion: result.promotion, animated: shouldAnimate)
+                            self?.addAdBanner(promotion: promotion, animated: true)
                         }
                     }
+                } else {
+                    self.addAdBanner(promotion: promotion, animated: false)
                 }
             }
         }

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -163,20 +163,18 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     private func loadBannerAd() {
         if FeatureFlag.bannerAdPodcasts.enabled && !SubscriptionHelper.hasActiveSubscription() {
             bannerTask?.cancel()
-            if let promotion = DiscoverServerHandler.shared.cachedBlazePromotion(for: .podcastList) {
-                setupBannerAd(promotion: promotion, shouldAnimate: false)
-            } else {
-                bannerTask = Task { [weak self] in
-                    if let result = await DiscoverServerHandler.shared.blazePromotion(for: .podcastList) {
-                        guard Task.isCancelled == false else { return }
-                        let shouldAnimate = !result.useCache
-                        if shouldAnimate {
-                            try? await Task.sleep(for: .seconds(2))
-                        }
+            DiscoverServerHandler.shared.blazePromotion(for: .podcastList) { [weak self] promotion, shouldAnimate in
+                guard let self = self else { return }
+
+                if shouldAnimate {
+                    self.bannerTask = Task { [weak self] in
+                        try? await Task.sleep(for: .seconds(2))
                         await MainActor.run {
-                            self?.setupBannerAd(promotion: result.promotion, shouldAnimate: shouldAnimate)
+                            self?.setupBannerAd(promotion: promotion, shouldAnimate: true)
                         }
                     }
+                } else {
+                    self.setupBannerAd(promotion: promotion, shouldAnimate: false)
                 }
             }
         }

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -163,12 +163,19 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     private func loadBannerAd() {
         if FeatureFlag.bannerAdPodcasts.enabled && !SubscriptionHelper.hasActiveSubscription() {
             bannerTask?.cancel()
-            bannerTask = Task { [weak self] in
-                if let promotion = await DiscoverServerHandler.shared.blazePromotion(for: .podcastList) {
-                    guard Task.isCancelled == false else { return }
-                    try? await Task.sleep(for: .seconds(2)) // Delay by 2 seconds so we don't immediately show
-                    await MainActor.run {
-                        self?.setupBannerAd(promotion: promotion)
+            if let promotion = DiscoverServerHandler.shared.cachedBlazePromotion(for: .podcastList) {
+                setupBannerAd(promotion: promotion, shouldAnimate: false)
+            } else {
+                bannerTask = Task { [weak self] in
+                    if let result = await DiscoverServerHandler.shared.blazePromotion(for: .podcastList) {
+                        guard Task.isCancelled == false else { return }
+                        let shouldAnimate = !result.useCache
+                        if shouldAnimate {
+                            try? await Task.sleep(for: .seconds(2))
+                        }
+                        await MainActor.run {
+                            self?.setupBannerAd(promotion: result.promotion, shouldAnimate: shouldAnimate)
+                        }
                     }
                 }
             }
@@ -452,16 +459,23 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
         podcastsCollectionView.reloadData()
     }
 
-    private func setupBannerAd(promotion: BlazePromotion) {
+    private func setupBannerAd(promotion: BlazePromotion, shouldAnimate: Bool) {
         bannerAdModel = BannerAdModel(promotion: promotion, source: AnalyticsSource.podcastsList.rawValue) {
             UIApplication.shared.openSafariVCIfPossible(promotion.urlApple)
         }
-        isAnimatingBannerAd = true
+        isAnimatingBannerAd = shouldAnimate
 
-        UIView.animate(withDuration: 0.25, delay: 0, options: [.curveEaseOut]) {
-            self.isAnimatingBannerAd = false
-            self.podcastsCollectionView.performBatchUpdates({
-                self.podcastsCollectionView.collectionViewLayout.invalidateLayout()
+        if shouldAnimate {
+            UIView.animate(withDuration: 0.25, delay: 0, options: [.curveEaseOut]) {
+                self.isAnimatingBannerAd = false
+            } completion: { _ in
+                self.podcastsCollectionView.performBatchUpdates({
+                    self.podcastsCollectionView.collectionViewLayout.invalidateLayout()
+                })
+            }
+        } else {
+            podcastsCollectionView.performBatchUpdates({
+                podcastsCollectionView.collectionViewLayout.invalidateLayout()
             })
         }
     }


### PR DESCRIPTION
Fixes [PCIOS-128](https://linear.app/a8c/issue/PCIOS-128/only-animated-ad-on-the-now-playing-screen-when-its-initially-loading)

| Before | After |
|--|--|
| ![Before](https://github.com/user-attachments/assets/79a82db7-d826-4263-aa9a-19b3bac4487f) | ![After](https://github.com/user-attachments/assets/08425c65-05ce-429f-83b0-081492d4c28a) |

## To test


* Run the app
* Navigate to the player
* Ensure that the ad appears at the top. If this is a fresh install, you should see an animation.
* Go to Profile > Developer > Force Reload Discover
* Open the Player again
* The ad should animate
* Reopen the Player
* The ad should NOT animate

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
