### PR TITLE
Update watch sync user agent to watchOS

### DIFF
--- a/Pocket Casts Watch App/WatchSyncManager+ServerSyncDelegate.swift
+++ b/Pocket Casts Watch App/WatchSyncManager+ServerSyncDelegate.swift
@@ -95,7 +95,7 @@ extension WatchSyncManager: ServerSyncDelegate {
     }
 
     func privateUserAgent() -> String {
-        "Pocket Casts/iOS/" + Settings.appVersion()
+        "Pocket Casts/watchOS/" + Settings.appVersion()
     }
 
     func autoDownloadLatestEpisodes(uuids: [String]) {}


### PR DESCRIPTION
Related to [PCIOS-199](https://linear.app/a8c/issue/POC-199/investigate-playback-issues-with-alexa-reported-by-user)

Sends a modified User Agent to differentiate our watchOS clients from iOS. We should be able to see these in the admin.

## To test

* Set a breakpoint in `ApiBaseTask.createRequest`
* Run the watchOS target
* Verify that the `User-Agent` header contains the watchOS string.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
