### PR TITLE
[Fix] Fix constraint for podcast chooser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 7.97
 -----
 - Enable Banner Ads in the Podcasts list and Player for free users [#3459](https://github.com/Automattic/pocket-casts-ios/pull/3459)
+- Fix the Podcast Chooser filter bottom margin [#3478](https://github.com/Automattic/pocket-casts-ios/pull/3478)
 
 7.96
 -----

--- a/podcasts/PodcastChooserViewController.swift
+++ b/podcasts/PodcastChooserViewController.swift
@@ -25,6 +25,7 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
             podcastTable.register(UINib(nibName: "PodcastChooserCell", bundle: nil), forCellReuseIdentifier: cellId)
         }
     }
+    @IBOutlet weak var podcastTableBottomConstraint: NSLayoutConstraint!
 
     var allPodcasts = [Podcast]()
     var selectBtn: UIBarButtonItem!

--- a/podcasts/PodcastChooserViewController.xib
+++ b/podcasts/PodcastChooserViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,6 +11,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PodcastChooserViewController" customModule="podcasts" customModuleProvider="target">
             <connections>
                 <outlet property="podcastTable" destination="CHn-Ju-JZ5" id="tgx-zK-npN"/>
+                <outlet property="podcastTableBottomConstraint" destination="85m-Dn-aAK" id="g9Y-Jd-Cls"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -27,6 +27,10 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
         if FeatureFlag.playlistsRebranding.enabled {
             largeTitleFont = UIFont.systemFont(ofSize: 22, weight: .bold)
         }
+
+        insetAdjuster = InsetAdjuster(ignoreMiniPlayer: true)
+        insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: podcastTable)
+
         delegate = self
         podcastTable.delegate = self
         podcastTable.dataSource = self
@@ -144,13 +148,17 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
             saveButton.topAnchor.constraint(equalTo: footerView.topAnchor, constant: 16)
         ])
 
+        podcastTableBottomConstraint.isActive = false
+
         view.addSubview(footerView)
         view.bringSubviewToFront(footerView)
         NSLayoutConstraint.activate([
             footerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),
             footerView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
             footerView.heightAnchor.constraint(equalToConstant: 110),
-            footerView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0)
+            footerView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0),
+
+            podcastTable.bottomAnchor.constraint(equalTo: footerView.topAnchor)
         ])
 
         view.layoutSubviews()


### PR DESCRIPTION
Fixes PCIOS-136

We have a report that the Filter Podcasts chooser tableview is partially hidden on the last cell when scrolling down. I believe the problem is when the miniplayer is not present as the `PodcastFilterOverlayController` inherits from `PodcastChooserViewController` which uses an `InsetAdjuster` to adjust the table inset when the miniplayer is present or not.

This PR overrides the inset adjuster without considering the miniplayer, reset the correct inset and set a constraint to attach to the footer top.

## To test

• Make sure the rebranding playlist FF is off
• Restart the app with the FF off
• Tap Filters and select a filter
• Tap the filter's name to bring up its settings
• Tap Podcasts to bring up the Choose Podcasts screen
• Test it with All Podcasts toggled off and on
• Scroll the podcast list all the way down
• Confirm the last row is not hidden behind the footer
• Do the same test with the miniplayer on and off screen

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
