### PR TITLE
Fixes the You Might Like tab reloading when popping back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.98
 -----
 - New onboarding screens with User Stories, Interests and Recommendations Screens [#3469](https://github.com/Automattic/pocket-casts-ios/pull/3469)
+- Fix You Might Like tab reloading when navigating back to the Podcast page [#3480](https://github.com/Automattic/pocket-casts-ios/pull/3480)
 
 7.97
 -----

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -486,7 +486,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         showViewChangesTipIfNeeded()
 
         // Load recommendations when view appears
-        if FeatureFlag.recommendations.enabled {
+        if FeatureFlag.recommendations.enabled && recommendations == nil {
             Task {
                 await loadRecommendations()
             }


### PR DESCRIPTION
Fixes [PCIOS-135](https://linear.app/a8c/issue/PCIOS-135/ios-you-might-like-section-reloads-when-tapping-back-button)
Fixes #3402

| Before | After |
|--|--|
| ![Simulator Screen Recording - iPhone 16 Plus - 2025-09-09 at 22 53 24](https://github.com/user-attachments/assets/2ca3f9d9-0656-4ce2-b6f7-ec3e79efb9c0) | ![Simulator Screen Recording - iPhone 16 Plus - 2025-09-09 at 22 58 52](https://github.com/user-attachments/assets/795e1152-abc7-4ec7-adca-b43147ba5635) |

## To test

* Open a Podcast page
* Tap the "You Might Like" tab
* Scroll down and tap on a recommended Podcast
* Go back
* ✅ Ensure the tab isn't reloaded

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
