### PR TITLE
[Fix] AsyncImageView with optional cacheKey

### DIFF
--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -119,10 +119,10 @@ struct BannerAdView: View {
     }
 
     @ViewBuilder func creative() -> some View {
-        AsyncImageView(url: model.imageURL!)
-        .cornerRadius(4)
-        .aspectRatio(1, contentMode: .fit)
-        .frame(width: 86, height: 86)
+        AsyncImageView(url: model.imageURL!, id: model.adID)
+            .cornerRadius(4)
+            .aspectRatio(1, contentMode: .fit)
+            .frame(width: 86, height: 86)
     }
 
     @ViewBuilder func text() -> some View {

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -119,7 +119,7 @@ struct BannerAdView: View {
     }
 
     @ViewBuilder func creative() -> some View {
-        AsyncImageView(url: model.imageURL!, id: model.adID)
+        AsyncImageView(url: model.imageURL!)
             .cornerRadius(4)
             .aspectRatio(1, contentMode: .fit)
             .frame(width: 86, height: 86)

--- a/podcasts/PlaylistArtworkView.swift
+++ b/podcasts/PlaylistArtworkView.swift
@@ -36,24 +36,24 @@ struct PlaylistArtworkView: View {
                     case 4:
                         VStack(spacing: 0) {
                             HStack(spacing: 0) {
-                                AsyncImageView(url: items[0].url, id: items[0].id, size: imageSize)
+                                AsyncImageView(url: items[0].url, cacheKey: items[0].id, size: imageSize)
                                     .frame(width: size.width / 2, height: size.height / 2)
                                     .clipped()
-                                AsyncImageView(url: items[1].url, id: items[1].id, size: imageSize)
+                                AsyncImageView(url: items[1].url, cacheKey: items[1].id, size: imageSize)
                                     .frame(width: size.width / 2, height: size.height / 2)
                                     .clipped()
                             }
                             HStack(spacing: 0) {
-                                AsyncImageView(url: items[2].url, id: items[2].id, size: imageSize)
+                                AsyncImageView(url: items[2].url, cacheKey: items[2].id, size: imageSize)
                                     .frame(width: size.width / 2, height: size.height / 2)
                                     .clipped()
-                                AsyncImageView(url: items[3].url, id: items[3].id, size: imageSize)
+                                AsyncImageView(url: items[3].url, cacheKey: items[3].id, size: imageSize)
                                     .frame(width: size.width / 2, height: size.height / 2)
                                     .clipped()
                             }
                         }
                     default:
-                        AsyncImageView(url: items[0].url, id: items[0].id, size: imageSize)
+                        AsyncImageView(url: items[0].url, cacheKey: items[0].id, size: imageSize)
                             .frame(width: size.width, height: size.height)
                             .clipped()
                     }

--- a/podcasts/SwiftUI/AsyncImageView.swift
+++ b/podcasts/SwiftUI/AsyncImageView.swift
@@ -3,7 +3,7 @@ import Kingfisher
 
 struct AsyncImageView: View {
     private let url: URL
-    private let id: String
+    private let cacheKey: String?
     private let size: Int
     private let cache: ImageCache
     private let placeholder: Image?
@@ -12,7 +12,7 @@ struct AsyncImageView: View {
 
     init(
         url: URL,
-        id: String,
+        cacheKey: String? = nil,
         size: Int = ImageManager.sharedManager.biggestPodcastImageSize,
         cache: ImageCache = ImageManager.sharedManager.subscribedPodcastsCache,
         placeholder: Image? = nil,
@@ -20,7 +20,7 @@ struct AsyncImageView: View {
         contentMode: SwiftUI.ContentMode = .fit
     ) {
         self.url = url
-        self.id = id
+        self.cacheKey = cacheKey
         self.size = size
         self.cache = cache
         self.placeholder = placeholder
@@ -30,7 +30,7 @@ struct AsyncImageView: View {
 
     var body: some View {
         let resizeProcessor = DownsamplingImageProcessor(size: .init(width: size, height: size))
-        let resource = KF.ImageResource(downloadURL: url, cacheKey: id)
+        let resource = KF.ImageResource(downloadURL: url, cacheKey: cacheKey)
 
         KFImage.resource(resource)
             .placeholder { _ in


### PR DESCRIPTION
Trunk doesn't build as the Banner uses an `AsyncImageView` with no id injected. This PR addresses this:
• `AsyncImageView` now has a `cacheKey` param, nil by default
• `KF.ImageResource` accepts an optional `cacheKey` has it uses an internal logic to extract the correct cache key if it's nil

## To test

• Review the code
• Run this branch with the banner and playlist rebranding FF on
• Make sure Banner ADS loads the image
• Make sure the playlists render the images

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
