### PR TITLE
Fix notification sending when they are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.98
 -----
-
+- Fixed a bug where notification where still arriving even when disabled.[#3483](https://github.com/Automattic/pocket-casts-ios/pull/3483)
 
 7.97
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 7.98
 -----
-- Fixed a bug where notification where still arriving even when disabled.[#3483](https://github.com/Automattic/pocket-casts-ios/pull/3483)
+
 
 7.97
 -----
 - Enable Banner Ads in the Podcasts list and Player for free users [#3459](https://github.com/Automattic/pocket-casts-ios/pull/3459)
 - Fix the Podcast Chooser filter bottom margin [#3478](https://github.com/Automattic/pocket-casts-ios/pull/3478)
+- Fixed a bug where notification where still arriving even when disabled.[#3483](https://github.com/Automattic/pocket-casts-ios/pull/3483)
 
 7.96
 -----

--- a/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
+++ b/podcasts/Notifications/NotificationsCoordinator+AnalyticsAdapter.swift
@@ -9,6 +9,9 @@ extension NotificationsCoordinator: AnalyticsAdapter {
     }
 
     func updateDailyReminders(name: String, properties: [AnyHashable: Any]?) {
+        guard NotificationsGroup.dailyReminders.isEnabled else {
+            return
+        }
         for notification in NotificationsGroup.dailyReminders.notifications {
             if notification.checkCancelConditionsForEvent(name: name, properties: properties) {
                 markNotification(notification)
@@ -35,6 +38,9 @@ extension NotificationsCoordinator: AnalyticsAdapter {
     }
 
     func updateRecommendationNotifications(name: String, properties: [AnyHashable: Any]?) {
+        guard NotificationsGroup.recommendations.isEnabled else {
+            return
+        }
         var shouldUpdateNotifications = false
         for notification in NotificationsGroup.recommendations.notifications {
             if notification.checkCancelConditionsForEvent(name: name, properties: properties) {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-134 <!-- issue number, if applicable -->

Our code was updating and schedule notifications when certain analytics events were tracked but not checking if they were disabled.

## To test

1. Start the app
2. Enable all notification types in Profile -> Settings -> Notifications
3. Go to Profile -> Settings -> Developer and tap on Speed Up Notifications
4. Wait for them to start arriving
5. Disable all local notifications ( Trending & Recommendations, Daily Reminders, New Features And Tips, Pocket Casts offers  )
6. Check that notifications are do no shown again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
