### PR TITLE
[Banner ads] Rendering fix

### DIFF
--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -517,6 +517,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     // MARK: Banner Ad
 
     func addAdBanner(promotion: BlazePromotion, animated: Bool = true) {
+        removeBannerAd()
+
         guard let stackView = episodeImage.superview as? UIStackView else { return }
 
         let model = BannerAdModel(promotion: promotion) {


### PR DESCRIPTION
Fixes [PCIOS-151](https://linear.app/a8c/issue/PCIOS-151/fix-rendering-issue-with-banner-ads-when-returning)

| Before | After |
|--|--|
| <img width="1032" height="608" alt="CleanShot 2025-09-11 at 12 25 06@2x" src="https://github.com/user-attachments/assets/9eb24a46-9be3-4025-807a-7311dd670141" /> | <img width="1032" height="608" alt="CleanShot 2025-09-11 at 12 25 34@2x" src="https://github.com/user-attachments/assets/4ea52eb9-4880-4132-ab25-d9e85cf85c6d" /> |

### The Issue
<img width=300 src="https://github.com/user-attachments/assets/0351110c-9d66-48a8-9e5f-0757c01d5a2c">


## To test

* Open the Player with a non-plus account
* Tap the banner ad
* ✅ Make sure that going back doesn't show a second banner ad over the other one.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
