### PR TITLE
[Banner ads] Change promotion location to `podcast_list`

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
@@ -12,7 +12,7 @@ public struct BlazePromotion: Decodable {
     public let location: Location
 
     public enum Location: String, Decodable {
-        case podcastList
+        case podcastList = "podcast_list"
         case player
         case unknown
 

--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -28,7 +28,7 @@ class BannerAdModel: ObservableObject {
         self.titleLabel = promotion.urlTitle
         self.onLinkTap = onLinkTap
         self.adID = promotion.id
-        self.location = promotion.location.rawValue.toSnakeCaseFromCamelCase()
+        self.location = promotion.location.rawValue
     }
 }
 


### PR DESCRIPTION
Updates the promotion location from `podcastList` to `podcast_list`

## To test

* Open the app
* Enable the `tracksLogging` feature flag
* Use Developer > Force Reload Discover
* Go to the Podcast list
* ✅ Ensure Ad Banner is shown
* ✅ Verify `banner_ad_impression` event is logged with `location: "podcast_list"`:
```
🔵 Tracked: banner_ad_impression ["id": "4bd49950-6c29-013e-860b-3697f02c49bd", "location": "podcast_list"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
