### PR TITLE
Sync queue and remove all table entries before deinit completes

### DIFF
--- a/podcasts/ThreadSafeDictionary.swift
+++ b/podcasts/ThreadSafeDictionary.swift
@@ -7,6 +7,15 @@ class ThreadSafeDictionary<Key: Hashable, Value> {
         queue = DispatchQueue(label: label, attributes: .concurrent)
     }
 
+    deinit {
+        //ensure that all work is done before releasing the table
+        queue.sync(flags: .barrier) { [weak self] in
+            //Last work item
+            print("Remove all before dealocating")
+            self?.table.removeAll()
+        }
+    }
+
     func value(forKey key: Key) -> Value? {
         var value: Value?
         queue.sync { [weak self] in


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-12 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This is an attempt  to fix the crashes being reported during denit of our ThreadSafeDictionary.
My rationale is that the global queues keep some work to be executed even after the dictionary is deallocated and makes it crash. This way we ensure all work is completed before we deinit the supporting tables.

## To test

1. Start the app
2. Ensure that a lot of downloads are started
3. Switch out of the app

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
