### PR TITLE
Remove podcastHTMLDescription  FF

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -127,9 +127,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Uses the episode IDs from the server's response rather than our local database IDs
     case useSyncResponseEpisodeIDs
 
-    ///Use html description for podcast details
-    case usePodcastHTMLDescription
-
     /// Disables logout / keychain clearing when errors occur in the background
     case avoidLogoutInBackground
 
@@ -330,8 +327,6 @@ public enum FeatureFlag: String, CaseIterable {
 			true
         case .useSyncResponseEpisodeIDs:
             true
-        case .usePodcastHTMLDescription:
-            true
         case .avoidLogoutInBackground:
             true
         case .disablePrivateFeedSharing:
@@ -427,8 +422,6 @@ public enum FeatureFlag: String, CaseIterable {
             shouldEnableSyncedSettings ? "settings_sync" : nil
         case .defaultPlayerFilterCallbackFix:
             "default_player_filter_callback_fix"
-        case .usePodcastHTMLDescription:
-            "use_podcast_html_description"
         default:
             rawValue.lowerSnakeCased()
         }


### PR DESCRIPTION
| 📘 Part of: #2509  |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR simple removes the FF `podcastHTMLDescription` that is no longer used at all after the removal of the code associated with the FF `podcastViewChanges`

## To test

- CI green should be enough

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
