### PR TITLE
fullScreenLogin FF Removal

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -152,9 +152,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable Newform AppsFlyer SDK
     case podcastNewformAppsFlyer
 
-    /// Force full screen login on iPhone
-    case fullScreenLogin
-
     /// Encourage Account Creation
     case encourageAccountCreation
 
@@ -345,8 +342,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .generatedTranscripts:
             true
         case .podcastNewformAppsFlyer:
-            true
-        case .fullScreenLogin:
             true
         case .libroFm:
             false

--- a/podcasts/Onboarding/Login/LoginLandingHostingController.swift
+++ b/podcasts/Onboarding/Login/LoginLandingHostingController.swift
@@ -18,14 +18,8 @@ class LoginLandingHostingController<Content>: OnboardingHostingViewController<Co
 
         if navigationController?.viewControllers.first == self {
             let dismissItem: UIBarButtonItem
-            if FeatureFlag.fullScreenLogin.enabled {
-                dismissItem = UIBarButtonItem(image: UIImage(named: "close"), style: .plain, target: viewModel, action: #selector(viewModel.dismissTapped))
-                dismissItem.tintColor = ThemeColor.primaryText01()
-            } else {
-                dismissItem = UIBarButtonItem(title: L10n.eoyNotNow, style: .plain, target: viewModel, action: #selector(viewModel.dismissTapped))
-                dismissItem.setTitleTextAttributes([NSAttributedString.Key.font: UIFont.font(with: .body, weight: .medium),
-                                                    NSAttributedString.Key.foregroundColor: iconTintColor], for: .normal)
-            }
+            dismissItem = UIBarButtonItem(image: UIImage(named: "close"), style: .plain, target: viewModel, action: #selector(viewModel.dismissTapped))
+            dismissItem.tintColor = ThemeColor.primaryText01()
             navigationItem.rightBarButtonItem = dismissItem
         }
 

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -108,7 +108,7 @@ class LoginCoordinator: NSObject, OnboardingModel {
     func recommendationsContinueTapped() {
         socialAuthProvider = nil
         OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "recommendations_continue"])
-        let view = LoginLandingView(coordinator: self, fullScreenMode: FeatureFlag.fullScreenLogin.enabled)
+        let view = LoginLandingView(coordinator: self, fullScreenMode: true)
         let hostingController = LoginLandingHostingController(rootView: view.setupDefaultEnvironment())
         hostingController.viewModel = self
         navigationController?.pushViewController(hostingController, animated: true)
@@ -291,16 +291,14 @@ extension LoginCoordinator {
             let hostingController = IntroCarouselHostingController(rootView: view)
             controller = hostingController
         } else {
-            let view = LoginLandingView(coordinator: coordinator, fullScreenMode: FeatureFlag.fullScreenLogin.enabled)
+            let view = LoginLandingView(coordinator: coordinator, fullScreenMode: true)
             let hostingController = LoginLandingHostingController(rootView: view.setupDefaultEnvironment())
             hostingController.viewModel = coordinator
             controller = hostingController
         }
 
         let navController = navigationController ?? UINavigationController(rootViewController: controller)
-        if FeatureFlag.fullScreenLogin.enabled {
-            navController.modalPresentationStyle = UIDevice.current.isiPad() ? .formSheet : .fullScreen
-        }
+        navController.modalPresentationStyle = UIDevice.current.isiPad() ? .formSheet : .fullScreen
         coordinator.navigationController = navController
 
         return (navigationController == nil) ? navController : controller


### PR DESCRIPTION
This PR removes `fullScreenLogin` FF
## To test

- Test the login and new onboarding flow
- Tapping from the profile should always present the signing fullscreen
- Do a smoke test with the new onboarding FFs off: Sign in should always be fullscreen

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
