### PR TITLE
Don't show gradient when presenting the new flow with title above

### DIFF
--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -81,22 +81,29 @@ private struct LoginLandingContent: View {
                         .clipped()
                 }
 
-                VStack {
+                VStack(spacing: 0) {
                     if !FeatureFlag.newOnboardingAccountCreation.enabled {
                         // Title and Subtitle
                         VStack(spacing: 8) {
                             LoginLabel(title, for: .title)
                             LoginLabel(subtitle, for: .subtitle)
                         }
-
-                        Spacer()
                     }
-
+                    Spacer()
+                    Rectangle().frame(height: 10)
+                        .foregroundStyle(Color.clear)
+                        .background {
+                        LinearGradient(gradient: Gradient(stops: [
+                            Gradient.Stop(color: backgroundColor.opacity(0.0), location: 0.0),
+                            Gradient.Stop(color: backgroundColor, location: 0.9),
+                        ]), startPoint: .top, endPoint: .bottom)
+                        }
                     HStack(spacing: 0) {
                         Spacer()
                         LoginButtons(coordinator: coordinator, shouldShowLogin: !coordinator.isOnboarding)
                         Spacer()
                     }
+                    .background(backgroundColor)
                 }
                 .padding(.horizontal, Config.padding)
                 .padding(.top, headerHeight)
@@ -344,8 +351,6 @@ private struct LoginButtons: View {
 
     var body: some View {
         VStack(spacing: 16) {
-            Spacer()
-
             SocialLoginButtons(coordinator: coordinator)
 
             Button(FeatureFlag.newOnboardingAccountCreation.enabled ? "Sign up with email" : "Sign Up") {

--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -88,6 +88,7 @@ private struct LoginLandingContent: View {
                             LoginLabel(title, for: .title)
                             LoginLabel(subtitle, for: .subtitle)
                         }
+                        .padding(.horizontal, Config.padding)
                     }
                     Spacer()
                     Rectangle().frame(height: 10)
@@ -103,9 +104,9 @@ private struct LoginLandingContent: View {
                         LoginButtons(coordinator: coordinator, shouldShowLogin: !coordinator.isOnboarding)
                         Spacer()
                     }
+                    .padding(.horizontal, Config.padding)
                     .background(backgroundColor)
                 }
-                .padding(.horizontal, Config.padding)
                 .padding(.top, headerHeight)
                 .if(coordinator.isOnboarding) {
                     $0.padding(.bottom)

--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -121,7 +121,7 @@ private struct LoginLandingContent: View {
                             }
                         }
 
-                        if showGradient == true {
+                        if showGradient == true, !FeatureFlag.newOnboardingAccountCreation.enabled {
                             // Determine how much of the login header takes up of the height
                             // Then make sure the gradient stops there so the content is covered in a solid background
                             let headerPercentage = headerHeight / viewHeight


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the login landing view so that the gradient view does not overlaps the podcasts images.

| Before | After |
| - | - |
| <img width="1179" height="2556" alt="IMG_0363" src="https://github.com/user-attachments/assets/5e78515f-b013-420f-a9b4-1050778d38b8" /> | <img width="1170" height="2532" alt="simulator_screenshot_99AF4F88-7082-4439-AAB5-6970A7A9DB60" src="https://github.com/user-attachments/assets/002f34c7-146e-4b9c-9b42-c8fc959719ed" /> |

## To test

1. Start the app on a real device 
2. Ensure that are you not logged in
3. Go to Profile -> Account
4. Check that the podcast images show correctly
5. Check the same with the onboardingAccountCreation FF disabled

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
