### PR TITLE
Fix animation sizing to work correctly when using larger fonts or on smaller devices.

### DIFF
--- a/podcasts/Onboarding/Plus/NewUpgrade/Animations/FoldersAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/Animations/FoldersAnimationView.swift
@@ -135,10 +135,11 @@ struct FoldersAnimationView: View {
                         Spacer().frame(width: (animationProgress * 20) + 10)
                     }
                 }
-                .frame(width: geometry.size.width)
                 Spacer()
             }
+            .frame(maxWidth: geometry.size.width)
         }
+        .frame(minHeight: 210)
         .onAppear() {
             animate()
         }

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountView.swift
@@ -142,7 +142,7 @@ struct UpgradeAccountView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 0) {
                         pageOne(proxy: proxy)
-                            .frame(height: model.style == .generic ? nil : sizeProxy.size.height - (Constants.gradientHeight * 2))
+                            .frame(minHeight: model.style == .generic ? nil : sizeProxy.size.height - (Constants.gradientHeight * 2))
                         if expand, model.isFreeTrialAvailable || model.style == .contextual {
                             VStack {
                                 Spacer().frame(height: 16)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR fixes sizing issues with the contextual animations that were overlapping the text  of the features.

# Before
https://github.com/user-attachments/assets/5c26f50e-9c4c-454d-91a2-108a901445ba 
# After
https://github.com/user-attachments/assets/c9644b73-1117-434a-990f-ca2666fa29e5

## To test

- Start the app on a smaller device ( iPhone SE) and login with an user without a subscription
- Check the upgrade screen in the following locations
- Folders
- Bookmarks
- UpNext Shuffle
- Pre Select Chapter ( you need to play an episode)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
