### PR TITLE
[Bug] Fix About Form background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - New onboarding screens with User Stories, Interests and Recommendations Screens [#3469](https://github.com/Automattic/pocket-casts-ios/pull/3469)
 - Disable multiple windows on iPad [#3484](https://github.com/Automattic/pocket-casts-ios/pull/3484)
 - Fix You Might Like tab reloading when navigating back to the Podcast page [#3480](https://github.com/Automattic/pocket-casts-ios/pull/3480)
+- Fix About background color [#3504](https://github.com/Automattic/pocket-casts-ios/pull/3504)
 
 7.97
 -----

--- a/podcasts/AboutView.swift
+++ b/podcasts/AboutView.swift
@@ -120,6 +120,8 @@ struct AboutView: View {
                         .listRowBackground(Color.clear)
                     }
                     .colorScheme(theme.activeTheme.isDark ? .dark : .light)
+                    .scrollContentBackground(.hidden)
+                    .background(theme.primaryUi04)
                 }
                 NavigationLink(destination: LegalAndMore(), isActive: $showLegalAndMore) {}
             }


### PR DESCRIPTION
Fixes PCIOS-144

Fix the About Form background color

| Before | After |
| :-------: | :-------: |
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2025-09-18 at 11 43 40" src="https://github.com/user-attachments/assets/e446ddc5-820a-4380-92d8-16f7c3c8efeb" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2025-09-18 at 11 42 47" src="https://github.com/user-attachments/assets/19f6e593-1cc3-4cb7-9828-3d7c96c008a1" /> |


## To test

- Run this branch
- Enable the Rose theme
- Open the About
- Check the background color
- Test some other theme color

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
