### PR TITLE
[New Onboarding] display the GB indication on the storage feature

### DIFF
--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5328,7 +5328,7 @@
 "feature_marketing_skip_chapters" = "Save time with Preselect Chapters";
 
 /* Cloud Storage feature marketing message. The %1$@ argument is the amount of cloud disk space available. Ex: 20 GB Cloud Storage for your files */
-"feature_marketing_cloud_storage" = "%1$@ Cloud Storage for your files";
+"feature_marketing_cloud_storage" = "%1$@ GB Cloud Storage for your files";
 
 /* Watch playback feature marketing message */
 "feature_marketing_watch_playback" = "Apps for Wear OS and Apple Watch";


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-143 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app using a a user without an active subscription
2. Tap on Profile -> Settings -> Pocket Casts Plus
3. Check that the Storage features shows: `20 Gb Cloud Storage for your files`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
