### PR TITLE
[New Onboarding] Layout fix notifications permissions view

### DIFF
--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -12,6 +12,7 @@ struct DeveloperMenu: View {
     @State var showingRecommendationsOnboardingSelected = false
     @State var showSurvey = false
     @State var showIntroCarousel = false
+    @State var showingNotificationsPermissions = false
 
     @StateObject var recommendationsViewModel = RecommendationsViewModel(configuration: .all)
 
@@ -311,6 +312,11 @@ struct DeveloperMenu: View {
             }
 
             Section {
+                Button("Notifications Permissions Screen") {
+                    showingNotificationsPermissions.toggle()
+                }.sheet(isPresented: $showingNotificationsPermissions) {
+                    NotificationsPermissionsView()
+                }
                 Button("Speed Up Notifications") {
                     NotificationsGroup.speedUpNotifications = true
                 }

--- a/podcasts/Notifications/NotificationsPermissionsView.swift
+++ b/podcasts/Notifications/NotificationsPermissionsView.swift
@@ -108,7 +108,7 @@ struct NotificationsPermissionsView: View {
     }
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             if FeatureFlag.newOnboardingAccountCreation.enabled {
                 Spacer()
                     .frame(maxHeight: 136)
@@ -135,6 +135,7 @@ struct NotificationsPermissionsView: View {
                 .textStyle(SecondaryText())
                 .font(.body)
                 .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
             Spacer()
             if FeatureFlag.newOnboardingAccountCreation.enabled {
                 VStack(alignment: .leading, spacing: 24) {
@@ -142,7 +143,8 @@ struct NotificationsPermissionsView: View {
                     optionRow(for: .notifications)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, 34)
+                .padding(.top, 8)
+                .padding(.bottom, 34)
             }
             Button(action: {
                 Analytics.track(.notificationsPermissionsAllowTapped)
@@ -158,6 +160,7 @@ struct NotificationsPermissionsView: View {
                 Text(FeatureFlag.newOnboardingAccountCreation.enabled ? L10n.notificationsPermissionsSavePreferences : L10n.notificationsPermissionsAction)
                 .textStyle(RoundedButton())
             }
+            Spacer()
         }
         .padding()
         .background(theme.primaryUi01)

--- a/podcasts/Notifications/NotificationsPermissionsView.swift
+++ b/podcasts/Notifications/NotificationsPermissionsView.swift
@@ -108,43 +108,48 @@ struct NotificationsPermissionsView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            if FeatureFlag.newOnboardingAccountCreation.enabled {
-                Spacer()
-                    .frame(maxHeight: 136)
-            } else {
-                Button(action: {
-                    Analytics.track(.notificationsPermissionsNotNowTapped)
-                    dismissAction()
-                }) {
-                    HStack {
+        ZStack(alignment: .bottom) {
+            ScrollView {
+                VStack(spacing: 0) {
+                    if FeatureFlag.newOnboardingAccountCreation.enabled {
                         Spacer()
-                        Text(L10n.eoyNotNow)
-                            .foregroundStyle(theme.primaryInteractive01)
-                            .font(.body.weight(.medium))
+                            .frame(maxHeight: 136)
+                    } else {
+                        Button(action: {
+                            Analytics.track(.notificationsPermissionsNotNowTapped)
+                            dismissAction()
+                        }) {
+                            HStack {
+                                Spacer()
+                                Text(L10n.eoyNotNow)
+                                    .foregroundStyle(theme.primaryInteractive01)
+                                    .font(.body.weight(.medium))
+                            }
+                        }
                     }
+                    Image("notifications_permissions_banner")
+                    Spacer().frame(height: 24)
+                    Text(L10n.notificationsPermissionsTitle)
+                        .textStyle(PrimaryText())
+                        .font(.largeTitle.bold())
+                    Spacer().frame(height: 20)
+                    Text(L10n.notificationsPermissionsBody)
+                        .textStyle(SecondaryText())
+                        .font(.body)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer()
+                    if FeatureFlag.newOnboardingAccountCreation.enabled {
+                        VStack(alignment: .leading, spacing: 24) {
+                            optionRow(for: .newsletter)
+                            optionRow(for: .notifications)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 8)
+                        .padding(.bottom, 34)
+                    }
+                    Spacer()
                 }
-            }
-            Image("notifications_permissions_banner")
-            Spacer().frame(height: 24)
-            Text(L10n.notificationsPermissionsTitle)
-                .textStyle(PrimaryText())
-                .font(.largeTitle.bold())
-            Spacer().frame(height: 20)
-            Text(L10n.notificationsPermissionsBody)
-                .textStyle(SecondaryText())
-                .font(.body)
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
-            Spacer()
-            if FeatureFlag.newOnboardingAccountCreation.enabled {
-                VStack(alignment: .leading, spacing: 24) {
-                    optionRow(for: .newsletter)
-                    optionRow(for: .notifications)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.top, 8)
-                .padding(.bottom, 34)
             }
             Button(action: {
                 Analytics.track(.notificationsPermissionsAllowTapped)
@@ -158,9 +163,8 @@ struct NotificationsPermissionsView: View {
                 }
             }) {
                 Text(FeatureFlag.newOnboardingAccountCreation.enabled ? L10n.notificationsPermissionsSavePreferences : L10n.notificationsPermissionsAction)
-                .textStyle(RoundedButton())
+                    .textStyle(RoundedButton())
             }
-            Spacer()
         }
         .padding()
         .background(theme.primaryUi01)

--- a/podcasts/Notifications/NotificationsPermissionsView.swift
+++ b/podcasts/Notifications/NotificationsPermissionsView.swift
@@ -145,28 +145,38 @@ struct NotificationsPermissionsView: View {
                             optionRow(for: .notifications)
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.top, 8)
-                        .padding(.bottom, 34)
+                        .padding(.vertical, 34)
+                        .padding(.horizontal, 4)
                     }
                     Spacer()
+                    Rectangle().fill(.clear).frame(height: 44)
                 }
+                .padding(.horizontal, 16)
             }
-            Button(action: {
-                Analytics.track(.notificationsPermissionsAllowTapped)
-                viewModel.saveNewsletterOptIn()
-                viewModel.trackNewsletterOptIn()
-                Task {
-                    if viewModel.notificationsOptIn {
-                        await viewModel.setupPermissions()
+            ZStack {
+                Button(action: {
+                    Analytics.track(.notificationsPermissionsAllowTapped)
+                    viewModel.saveNewsletterOptIn()
+                    viewModel.trackNewsletterOptIn()
+                    Task {
+                        if viewModel.notificationsOptIn {
+                            await viewModel.setupPermissions()
+                        }
+                        dismissAction()
                     }
-                    dismissAction()
+                }) {
+                    Text(FeatureFlag.newOnboardingAccountCreation.enabled ? L10n.notificationsPermissionsSavePreferences : L10n.notificationsPermissionsAction)
+                        .textStyle(RoundedButton())
                 }
-            }) {
-                Text(FeatureFlag.newOnboardingAccountCreation.enabled ? L10n.notificationsPermissionsSavePreferences : L10n.notificationsPermissionsAction)
-                    .textStyle(RoundedButton())
             }
+            .padding(16)
+            .background(
+                LinearGradient(gradient: Gradient(stops: [
+                    Gradient.Stop(color: theme.primaryUi01.opacity(0.0), location: 0.0),
+                    Gradient.Stop(color: theme.primaryUi01, location: 0.1),
+                ]), startPoint: .top, endPoint: .bottom)
+            )
         }
-        .padding()
         .background(theme.primaryUi01)
         .onAppear() {
             Analytics.track(.notificationsPermissionsShown)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR fix the layout for the notification permissions view on smaller screens. 
To ensure that all text is visible and with correct spacing

| Before | After |
| - | - |
|  <img width="372" height="749" alt="Screenshot 2025-09-18 at 15 32 25" src="https://github.com/user-attachments/assets/73667b55-16a4-46b6-85c0-2df847f6ba92" /> | <img width="389" height="735" alt="Screenshot 2025-09-18 at 15 27 21" src="https://github.com/user-attachments/assets/ad179d22-47a6-4e44-a85c-f520d9873fbd" /> |

## To test

- Start the app from scratch, and do not login on a smaller device. Ex: iPhone SE
- Skip the initial onboarding screens until you get to Notification Permissions screen
- Check that all the information is on screen and no string are trimmed.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
