### PR TITLE
[Banner ads] Accessibility fix

### DIFF
--- a/podcasts/Common SwiftUI/BannerAdView.swift
+++ b/podcasts/Common SwiftUI/BannerAdView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsServer
 import Kingfisher
+import PocketCastsUtils
 
 class BannerAdModel: ObservableObject {
     let adText: String
@@ -72,8 +73,10 @@ struct BannerAdView: View {
     @EnvironmentObject var theme: Theme
     @Environment(\.sizeCategory) private var sizeCategory
 
-    // We override this because we don't want the ad getting _too_ large. In the player, especially, we run out of space.
-    let maxSizeCategory: UIContentSizeCategory = .accessibilityMedium
+    // Keep banner text small only when Display Zoom is enabled.
+    var maxSizeCategory: UIContentSizeCategory {
+        A11y.isDisplayZoomed ? .small : .accessibilityMedium
+    }
 
     init(model: BannerAdModel, colors: Colors) {
         self.model = model

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -14,6 +14,12 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     private var bannerTask: Task<Void, Never>? = nil
 
+    // Detect Display Zoom (zoomed display makes UI elements appear larger).
+    // Scale controls down slightly when zoomed to avoid oversized buttons.
+    private var isZoomed: Bool {
+        A11y.isDisplayZoomed
+    }
+
     var videoViewController: VideoViewController?
 
     @IBOutlet var skipBackBtn: SkipButton! {
@@ -298,8 +304,16 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
         if playerControlsStackView.spacing != spacing { playerControlsStackView.spacing = spacing }
 
-        let height: CGFloat = displayTranscript ? 40 : view.bounds.height > 710 ? 100 : 80
-        if playPauseHeightConstraint.constant != height { playPauseHeightConstraint.constant = height }
+        // Base height for play/pause. If zoomed and not showing transcript, scale down a bit.
+        let baseHeight: CGFloat = displayTranscript ? 40 : (view.bounds.height > 710 ? 100 : 80)
+        let scaledHeight: CGFloat = (!displayTranscript && isZoomed) ? baseHeight * 0.9 : baseHeight
+        if playPauseHeightConstraint.constant != scaledHeight { playPauseHeightConstraint.constant = scaledHeight }
+
+        // Ensure skip buttons are not too large on zoomed displays.
+        // Use small size either when showing transcript or when display is zoomed.
+        let skipSize: SkipButton.Size = (displayTranscript || isZoomed) ? .small : .large
+        skipBackBtn.changeSize(to: skipSize)
+        skipFwdBtn.changeSize(to: skipSize)
 
         view.layoutIfNeeded()
     }
@@ -486,8 +500,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             // Display/hide the view that will fill the empty space
             fillView.isHidden = !isShowing
 
-            // Change skip back and forward size
-            let skipButtonSize: SkipButton.Size = isShowing ? .small : .large
+            // Change skip back and forward size (also keep small on zoomed displays)
+            let skipButtonSize: SkipButton.Size = (isShowing || isZoomed) ? .small : .large
             skipBackBtn.changeSize(to: skipButtonSize)
             skipFwdBtn.changeSize(to: skipButtonSize)
             skipBackBtn.layoutIfNeeded()


### PR DESCRIPTION
Fixes [PCIOS-156](https://linear.app/a8c/issue/PCIOS-156/play-button-disappears-with-large-accessibility-text-size-on-smaller)

| Before | After |
|--|--|
| <img width="750" height="1334" alt="simulator_screenshot_A860DC9B-028D-413B-9133-E8DEA49681D4" src="https://github.com/user-attachments/assets/aea04688-5276-418a-99bd-d68dc1114be9" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (3rd generation) - 2025-09-18 at 17 12 50" src="https://github.com/user-attachments/assets/1ffa2869-ac49-49ca-bf9c-7e1e06cd2bb8" /> |

## To test

* Use the iPhone SE simulator
* Enable the "Display Zoom" in Settings > Developer > Display Zoom > Larger
* Enable "Larger Accessibility" text sizes in Settings > Accessibility > Display & Text Size > Larger Text
* Increase the Text Size to one above the middle

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
