### PR TITLE
[New Onboarding] Encourage account creation update for new onboarding

### DIFF
--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -291,6 +291,7 @@ struct DeveloperMenu: View {
             Section {
                 Button("Reset Informational Modal Visibility") {
                     Settings.shouldShowInitialOnboardingFlow = true
+                    Settings.hasShownInformationalViewModal = false
                 }
                 Button("Reset banners visibility") {
                     InformationalBannerType.allCases.forEach {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -189,6 +189,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         if FeatureFlag.encourageAccountCreation.enabled,
            !Settings.hasShownInformationalViewModal,
+           Settings.hasSeenInitialOnboardingBefore == true,
            (UIApplication.shared.delegate as? AppDelegate)?.appInstallState == .updated {
             NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.encourageAccountCreation])
         } else {

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -189,7 +189,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         if FeatureFlag.encourageAccountCreation.enabled,
            !Settings.hasShownInformationalViewModal,
-           Settings.hasSeenInitialOnboardingBefore == true,
+           Settings.hasSeenInitialOnboardingBefore,
            (UIApplication.shared.delegate as? AppDelegate)?.appInstallState == .updated {
             NavigationManager.sharedManager.navigateTo(NavigationManager.onboardingFlow, data: ["flow": OnboardingFlow.Flow.encourageAccountCreation])
         } else {

--- a/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalView.swift
+++ b/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsUtils
 
 struct InformationalModalView: View {
     @EnvironmentObject var theme: Theme
@@ -55,13 +56,13 @@ struct InformationalModalView: View {
     private var labels: some View {
         VStack(spacing: 0) {
             Text(L10n.eacInformationalViewModalTitle)
-                .font(size: 22.0, style: .body, weight: .bold)
+                .font(size: FeatureFlag.newOnboardingAccountCreation.enabled ? 28 : 22, style: FeatureFlag.newOnboardingAccountCreation.enabled ? .title : .body, weight: .bold)
                 .foregroundStyle(theme.primaryText01)
                 .multilineTextAlignment(.center)
                 .padding(.top, isiPad ? 0 : 20.0)
                 .padding(.bottom, 12.0)
             Text(L10n.eacInformationalViewModalDescription)
-                .font(size: 15.0, style: .body, weight: .medium)
+                .font(size: FeatureFlag.newOnboardingAccountCreation.enabled ? 17.0 : 15, style: .body, weight: FeatureFlag.newOnboardingAccountCreation.enabled ? .regular : .medium)
                 .foregroundStyle(theme.primaryText02)
                 .multilineTextAlignment(.center)
         }
@@ -70,7 +71,7 @@ struct InformationalModalView: View {
 
     private var buttons: some View {
         VStack(spacing: 0) {
-            Button(L10n.eacInformationalViewModalGetStartedButton) {
+            Button(FeatureFlag.newOnboardingAccountCreation.enabled ? L10n.createAccount : L10n.eacInformationalViewModalGetStartedButton) {
                 viewModel.getStarted()
             }
             .buttonStyle(RoundedButtonStyle(theme: theme))

--- a/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalView.swift
+++ b/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalView.swift
@@ -56,13 +56,13 @@ struct InformationalModalView: View {
     private var labels: some View {
         VStack(spacing: 0) {
             Text(L10n.eacInformationalViewModalTitle)
-                .font(size: FeatureFlag.newOnboardingAccountCreation.enabled ? 28 : 22, style: FeatureFlag.newOnboardingAccountCreation.enabled ? .title : .body, weight: .bold)
+                .font(size: 22, style: .body, weight: .bold)
                 .foregroundStyle(theme.primaryText01)
                 .multilineTextAlignment(.center)
                 .padding(.top, isiPad ? 0 : 20.0)
                 .padding(.bottom, 12.0)
             Text(L10n.eacInformationalViewModalDescription)
-                .font(size: FeatureFlag.newOnboardingAccountCreation.enabled ? 17.0 : 15, style: .body, weight: FeatureFlag.newOnboardingAccountCreation.enabled ? .regular : .medium)
+                .font(size: 15, style: .body, weight: .medium)
                 .foregroundStyle(theme.primaryText02)
                 .multilineTextAlignment(.center)
         }

--- a/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalViewModel.swift
+++ b/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import PocketCastsUtils
 
 class InformationalModalViewModel: NSObject, OnboardingModel {
     weak var navigationController: UINavigationController? = nil
@@ -39,7 +40,7 @@ class InformationalModalViewModel: NSObject, OnboardingModel {
     }
 
     private func pushOnboarding() {
-        let controller = OnboardingFlow.shared.begin(flow: .initialOnboarding, in: navigationController, source: .unknown)
+        let controller = OnboardingFlow.shared.begin(flow: FeatureFlag.newOnboardingAccountCreation ? .loggedOut : .initialOnboarding, in: navigationController, source: .unknown)
         navigationController?.pushViewController(controller, animated: true)
     }
 

--- a/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalViewModel.swift
+++ b/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalViewModel.swift
@@ -40,7 +40,7 @@ class InformationalModalViewModel: NSObject, OnboardingModel {
     }
 
     private func pushOnboarding() {
-        let controller = OnboardingFlow.shared.begin(flow: FeatureFlag.newOnboardingAccountCreation ? .loggedOut : .initialOnboarding, in: navigationController, source: .unknown)
+        let controller = OnboardingFlow.shared.begin(flow: FeatureFlag.newOnboardingAccountCreation.enabled ? .loggedOut : .initialOnboarding, in: navigationController, source: .unknown)
         navigationController?.pushViewController(controller, animated: true)
     }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1228,7 +1228,7 @@ internal enum L10n {
   internal static var featureMarketingBookmarks: String { return L10n.tr("Localizable", "feature_marketing_bookmarks", fallback: "Keep timestamps with Bookmarks") }
   /// Cloud Storage feature marketing message. The %1$@ argument is the amount of cloud disk space available. Ex: 20 GB Cloud Storage for your files
   internal static func featureMarketingCloudStorage(_ p1: Any) -> String {
-    return L10n.tr("Localizable", "feature_marketing_cloud_storage", String(describing: p1), fallback: "%1$@ Cloud Storage for your files")
+    return L10n.tr("Localizable", "feature_marketing_cloud_storage", String(describing: p1), fallback: "%1$@ GB Cloud Storage for your files")
   }
   /// Patron early access to new features marketing message
   internal static var featureMarketingEarlyAccess: String { return L10n.tr("Localizable", "feature_marketing_early_access", fallback: "Early access to new features") }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Updates the logic around new onboarding and encourage account creation to only show this screen when new onboarding was already show once and we are updating the app.
Also did some changes on the fonts to match the styling on new onboarding title and labels

<img width="392" height="749" alt="Screenshot 2025-09-19 at 16 23 16" src="https://github.com/user-attachments/assets/79d68b27-9231-4edc-9532-b44f6d1a389b" />

## To test

1. Start the app from a new install
2. Do the initial onboarding but do not create an account
3. Go to Profile -> Settings -> Developer 
4. Tap on Reset Informational Modal Visibility
5. Close the app
6. Comment out the line 193 on MainTabBarController.
7. Restart the app
8. Check if it shows the Encourage account creation screen
9. Tap on Create Account
10. Check the Create Account screen is shown
 
## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
