### PR TITLE
[Hotfix] Remove banner when the view will appear if necessary

### DIFF
--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -177,6 +177,17 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
                     self.setupBannerAd(promotion: promotion, shouldAnimate: false)
                 }
             }
+        } else {
+            if bannerAdModel != nil {
+                bannerAdModel = nil
+                UIView.animate(withDuration: 0.25, delay: 0, options: [.curveEaseOut]) {
+                    self.isAnimatingBannerAd = false
+                } completion: { _ in
+                    self.podcastsCollectionView.performBatchUpdates({
+                        self.podcastsCollectionView.collectionViewLayout.invalidateLayout()
+                    })
+                }
+            }
         }
     }
 

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -161,8 +161,9 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
     }
 
     private func loadBannerAd() {
+        bannerTask?.cancel()
+
         if FeatureFlag.bannerAdPodcasts.enabled && !SubscriptionHelper.hasActiveSubscription() {
-            bannerTask?.cancel()
             DiscoverServerHandler.shared.blazePromotion(for: .podcastList) { [weak self] promotion, shouldAnimate in
                 guard let self = self else { return }
 


### PR DESCRIPTION
Fixes PCIOS-157

If the subscription status changes or the FF is off, when the view will appear, we want to remove the banner if present

## To test

- Run this branch from a fresh install
- Go to the podcasts list without login/signin
- Wait for the banner to be displayed
- Goto your profile and sign in with a plus user
- Go back to the podcasts list
- Confirm you see the banner being removed

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
