### PR TITLE
Fix analytics on discovery

### DIFF
--- a/podcasts/HorizontaCollectionModel.swift
+++ b/podcasts/HorizontaCollectionModel.swift
@@ -11,6 +11,8 @@ extension DiscoverPodcast: @retroactive Identifiable {
 
 class HorizontalCollectionModel: ObservableObject {
 
+    var category: DiscoverCategory?
+
     @Published var item: DiscoverItem?
 
     @Published var podcastCollection: PodcastCollection?
@@ -46,6 +48,7 @@ class HorizontalCollectionModel: ObservableObject {
         guard let source = item.source else { return }
 
         self.item = item
+        self.category = category
         DiscoverServerHandler.shared.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastCollection in
             guard podcastCollection?.podcasts != nil || podcastCollection?.episodes != nil else { return }
 

--- a/podcasts/HorizontalCollectionListViewController.swift
+++ b/podcasts/HorizontalCollectionListViewController.swift
@@ -22,4 +22,13 @@ class HorizontalCollectionListViewController: ThemedHostingController<Horizontal
         model.populateFrom(item: item, region: region, category: category)
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if let listId = model.item?.uuid {
+            let categoryId = model.category?.id.map(String.init)
+            AnalyticsHelper.listImpression(listId: listId, category: categoryId)
+        }
+    }
+
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Add missing analytics event on network discovery

## To test

1. Start the app
2. Enable analytics tracking on FF
3. Open Discovery
4. Scroll until you see the BBC network highlight
5. Check if you see the following in the console: `Tracked: discover_list_impression ["list_id": "bbc-2025"]`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
