### PR TITLE
[Fix] Fix opt in/out tracking

### DIFF
--- a/podcasts/Analytics/Analytics.swift
+++ b/podcasts/Analytics/Analytics.swift
@@ -13,8 +13,7 @@ class Analytics {
 
     static func register(adapters: [AnalyticsAdapter]) {
         Self.shared.adapters = adapters
-        shared.adaptersRegistered = true
-        logCurrentAdapters()
+        Self.shared.setAdaptersRegisteredStatus(true)
     }
 
     /// Unregisters all the registered adapters, disabling analytics
@@ -26,8 +25,7 @@ class Analytics {
         } else {
             Self.shared.adapters = nil
         }
-        shared.adaptersRegistered = false
-        logCurrentAdapters()
+        Self.shared.setAdaptersRegisteredStatus(false)
     }
 #if !os(watchOS) && !APPCLIP
     static func add(analyticsAppThemeProvider: AnalyticsAppThemeProviding) {
@@ -59,6 +57,11 @@ class Analytics {
         FileLog.shared.console("Analytics adapters: \(Self.shared.adapters ?? [])")
 #endif
     }
+
+    fileprivate func setAdaptersRegisteredStatus(_ value: Bool) {
+        adaptersRegistered = value
+        Self.logCurrentAdapters()
+    }
 }
 
 // MARK: - Analytics + Source
@@ -84,6 +87,7 @@ extension Analytics {
     func optInOfAnalytics() {
 #if !os(watchOS) && !APPCLIP
         Settings.setAnalytics(optOut: false)
+        setAdaptersRegisteredStatus(false)
         (UIApplication.shared.delegate as? AppDelegate)?.setupAnalytics()
         Analytics.track(.analyticsOptIn)
 #endif


### PR DESCRIPTION
This PR should fix the Opt In/Out analytics logic to rebuild the trackers after optioning in again

## To test

- Make sure the trackers logger is on
- Go to Privacy
- Opt Out the First party analytics
- Make sure `🔵 Tracked: analytics_opt_out` is tracked and the list of trackers is printed
- Make sure we don't track anything (except for 3rd party if enabled)
- Opti in again
- Make sure `🔵 Tracked: analytics_opt_in` is tracked and the list of trackers is printed
- Make sure everything tracks as usual

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
