### PR TITLE
Ensure table is not dealocated before all work is done.

### DIFF
--- a/podcasts/ThreadSafeDictionary.swift
+++ b/podcasts/ThreadSafeDictionary.swift
@@ -9,9 +9,9 @@ class ThreadSafeDictionary<Key: Hashable, Value> {
 
     deinit {
         //ensure that all work is done before releasing the table
-        queue.sync(flags: .barrier) { [weak self] in
+        queue.async(flags: .barrier) { [table] in
             //Last work item
-            self?.table.removeAll()
+            print("Dealocating table with \(table.count) elements")
         }
     }
 

--- a/podcasts/ThreadSafeDictionary.swift
+++ b/podcasts/ThreadSafeDictionary.swift
@@ -11,7 +11,7 @@ class ThreadSafeDictionary<Key: Hashable, Value> {
         //ensure that all work is done before releasing the table
         queue.async(flags: .barrier) { [table] in
             //Last work item
-            print("Dealocating table with \(table.count) elements")
+            FileLog.shared.console("Dealocating table with \(table.count) elements")
         }
     }
 

--- a/podcasts/ThreadSafeDictionary.swift
+++ b/podcasts/ThreadSafeDictionary.swift
@@ -1,3 +1,5 @@
+import PocketCastsUtils
+
 class ThreadSafeDictionary<Key: Hashable, Value> {
 
     private let queue: DispatchQueue


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This updates the deinit in Thread dictionary to be async but ensuring that the table is retained until the dealocation is complete.

## To test

- CI green should be enough

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
