### PR TITLE
[Hotfix] Early reload Subscription status and fix condition to display AD

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
@@ -263,6 +263,6 @@ open class SubscriptionHelper: NSObject {
     }
 
     public class var shouldDisplayBannerAd: Bool {
-        FeatureFlag.bannerAdPodcasts.enabled && !SubscriptionHelper.shouldRemoveBannerAd
+        FeatureFlag.bannerAdPodcasts.enabled && (!SubscriptionHelper.hasActiveSubscription() || !SubscriptionHelper.shouldRemoveBannerAd)
     }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
@@ -263,6 +263,6 @@ open class SubscriptionHelper: NSObject {
     }
 
     public class var shouldDisplayBannerAd: Bool {
-        FeatureFlag.bannerAdPodcasts.enabled && (!SubscriptionHelper.hasActiveSubscription() || !SubscriptionHelper.shouldRemoveBannerAd)
+        FeatureFlag.bannerAdPodcasts.enabled && !(SubscriptionHelper.hasActiveSubscription() || SubscriptionHelper.shouldRemoveBannerAd)
     }
 }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -245,6 +245,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Use the new interests and recommendations flow
     case newOnboardingRecommendationChanges
 
+    /// Enable reloading the subscription status in App Delegate
+    case earlyReloadSubscriptionStatus
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -412,6 +415,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .newOnboardingUpgradeTrialTimeline:
             false
         case .newOnboardingRecommendationChanges:
+            true
+        case .earlyReloadSubscriptionStatus:
             true
         }
     }

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -126,6 +126,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
         }
 
+        if FeatureFlag.earlyReloadSubscriptionStatus.enabled,
+           SyncManager.isUserLoggedIn(),
+           appInstallState == .updated {
+            ApiServerHandler.shared.retrieveSubscriptionStatus()
+        }
+
         return true
     }
 

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -130,6 +130,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
            SyncManager.isUserLoggedIn(),
            appInstallState == .updated {
             ApiServerHandler.shared.retrieveSubscriptionStatus()
+            FileLog.shared.addMessage("Reload subscription status early as the app updated")
         }
 
         return true


### PR DESCRIPTION
**Note**: Rebase this branch against the hotfix `7.98.1` as soon it's available

Ref: p1758964932663029-Slack-C08U02AG7C5

This PR fixes the condition to display the AD banner and early loads the subscription status when the application updates

## To test

### App Update Scenario with old User

1. **You need to use Staging
2. Old user available here p1758782139774569-Slack-C08U02AG7C5
3. Enable the our tracking by code so it will available by default**
4. Checkout the prod version from our tags and use `7.97.1`
5. Run the app and login with the user above
6. Navigate to podcasts view and you should see the AD banner
7. Stop and checkout this branch
8. Run the app
9. Once the app is open the banner should have disappeared
10. Check the console log by filter for `Reload subscription status early as the app updated` to confirm the early reload happened
11. Check the console log by filter for `Received subscription` to see the subscription status update

### App Update Scenario with Plus User

1. **You need to use Staging
3. Enable the our tracking by code so it will available by default**
4. Checkout the prod version from our tags and use `7.97.1`
5. Run the app and login with the a plus user
6. Navigate to podcasts view and you should NOT see the AD banner
7. Stop and checkout this branch
8. Run the app
9. Once the app is open the banner should still be removed
10. Check the console log by filter for `Reload subscription status early as the app updated` to confirm the early reload happened
11. Check the console log by filter for `Received subscription` to see the subscription status update

### App Update Scenario with a Free User

1. **You need to use Staging
3. Enable the our tracking by code so it will available by default**
4. Checkout the prod version from our tags and use `7.97.1`
5. Run the app and login with the a free user
6. Navigate to podcasts view and you should see the AD banner
7. Stop and checkout this branch
8. Run the app
9. Once the app is open the banner should still be visible
10. Check the console log by filter for `Reload subscription status early as the app updated` to confirm the early reload happened
11. Check the console log by filter for `Received subscription` to see the subscription status update

### New Install Old User

**1. You need to use Staging
2. Old user available here p1758782139774569-Slack-C08U02AG7C5**
3. Run the branch as new install
4. You should see the banner AD
5. Login with the user above
6. Banner should disappear

### New Install Plus User

1. **You need to use Staging**
2. Use a Plus User
3. Run the branch as new install
4. You should see the banner AD
5. Login with the a plus user
6. Banner should disappear

### New Install Free User

1. **You need to use Staging**
2. Use a Free User
3. Run the branch as new install
4. You should see the banner AD
5. Login with the a free user
6. Banner should still be there

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
