### PR TITLE
Enable the inline bookmarks tab feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 7.99
 -----
+- Bookmarks tab opens inline in the Podcast page[#3532](https://github.com/Automattic/pocket-casts-ios/pull/3532)
 
 7.98
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 7.99
 -----
-- Bookmarks tab opens inline in the Podcast page[#3532](https://github.com/Automattic/pocket-casts-ios/pull/3532)
+- Bookmarks tab opens inline in the Podcast page [#3532](https://github.com/Automattic/pocket-casts-ios/pull/3532)
 
 7.98
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -391,7 +391,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .searchImprovements:
             false
         case .podcastBookmarksInline:
-            false
+            true
         case .earlyReloadSubscriptionStatus:
             true
         }


### PR DESCRIPTION
Enables the inline bookmarks tab from #3479

## To test

* Run the app
* Ensure tapping "Bookmarks" opens bookmarks on the Podcast detail page

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
