### PR TITLE
Add NSUserTrackingUsageDescription

### DIFF
--- a/podcasts/podcasts-Info.plist
+++ b/podcasts/podcasts-Info.plist
@@ -1039,6 +1039,8 @@
 		<string>SJOpenFilterIntent</string>
 		<string>SJSleepTimerIntent</string>
 	</array>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>We use analytics to make the app better and to measure if our ad campaigns are successful.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>DMSans.ttf</string>


### PR DESCRIPTION
It seems like this key is needed even if we may not be using the API:

> While your app might not use these APIs, a purpose string is still required.

## To test

* 🟢 CI builds work
* We'll submit this and see if we don't get a warning message from App Store Connect

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
