### PR TITLE
[Tooling] Reject builds waiting for review

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -624,10 +624,11 @@ platform :ios do
 
     upload_to_testflight(
       ipa: ipa_path,
+      reject_build_waiting_for_review: true,
       distribute_external: true,
       groups: EXTERNAL_BETA_TESTER_GROUPS,
-      changelog: changelog,
       notify_external_testers: true,
+      changelog: changelog,
       team_id: TEAM_ID_APP_STORE,
       api_key: app_store_connect_api_key
     )


### PR DESCRIPTION
## Why

When the Release Manager does a new beta less than 24h after the code freeze, or when Apple reviewers are slower to review TestFlight builds than usual, there's a chance that the previous TestFlight build would still be in "Waiting for Review" state.

In those cases, the `upload_to_testflight` action would fail with `[!] Another build is in review` error (like what happened [here](https://buildkite.com/automattic/pocket-casts-ios/builds/11846/steps/canvas?jid=019999d7-3376-47f9-85b3-9d78c9104722#019999d7-33b7-433e-b1b9-a680046515ad/503-549) — see also internal ref p1759223628042159-slack-C5ALGJYEP)

## What

Add `reject_build_waiting_for_review: true` parameter to the `upload_to_testflight` action call

## To test

Won't be able to test this until we encounter this case again while doing another beta.
