### PR TITLE
Keep downloads & Up Next queue on unsubscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 7.99
 -----
 - Bookmarks tab opens inline in the Podcast page [#3532](https://github.com/Automattic/pocket-casts-ios/pull/3532)
+- Keep Downloaded or Up Next episodes when unsubscribing from a podcast [#3538](https://github.com/Automattic/pocket-casts-ios/pull/3538)
 
 7.98
 -----

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
@@ -89,6 +89,23 @@ class PlaylistDataManager {
         return count
     }
 
+    func playlistContainsPodcast(podcastUuid: String, includeDeleted: Bool = false, dbQueue: PCDBQueue) -> Bool {
+        var exists = false
+        dbQueue.read { db in
+            do {
+                let query = PlaylistQueryBuilder.podcastExistsInPlaylistEpisodesQuery(includeDeleted: includeDeleted)
+                let resultSet = try db.executeQuery(query, values: [podcastUuid])
+                defer { resultSet.close() }
+
+                exists = resultSet.next()
+            } catch {
+                FileLog.shared.addMessage("PlaylistDataManager.playlistContainsPodcast error: \(error)")
+            }
+        }
+
+        return exists
+    }
+
     func allPlaylists(includeDeleted: Bool, dbQueue: PCDBQueue) -> [EpisodeFilter] {
         let query: String
         if FeatureFlag.playlistsRebranding.enabled {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -934,6 +934,10 @@ public class DataManager {
         return exists
     }
 
+    public func playlistContainsPodcast(podcastUuid: String, includeDeleted: Bool = false) -> Bool {
+        playlistManager.playlistContainsPodcast(podcastUuid: podcastUuid, includeDeleted: includeDeleted, dbQueue: dbQueue)
+    }
+
     public func findPlaylist(uuid: String) -> EpisodeFilter? {
         playlistManager.findBy(uuid: uuid, dbQueue: dbQueue)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -128,6 +128,11 @@ public class PlaylistQueryBuilder {
         return queryString
     }
 
+    public class func podcastExistsInPlaylistEpisodesQuery(includeDeleted: Bool = false) -> String {
+        let deletedClause = includeDeleted ? "" : " AND wasDeleted = 0"
+        return "SELECT 1 FROM \(DataManager.playlistEpisodeTableName) WHERE podcastUuid = ?\(deletedClause) LIMIT 1"
+    }
+
     private static func select(clause: SelectClause) -> String {
         switch clause {
         case .episode:

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistQueryBuilderTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistQueryBuilderTests.swift
@@ -36,4 +36,18 @@ final class PlaylistQueryBuilderTests: XCTestCase {
 
         XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
     }
+
+    func testPodcastExistsQueryExcludesDeletedByDefault() {
+        let query = PlaylistQueryBuilder.podcastExistsInPlaylistEpisodesQuery()
+
+        XCTAssertTrue(query.contains("wasDeleted = 0"))
+        XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
+    }
+
+    func testPodcastExistsQueryIncludesDeletedWhenRequested() {
+        let query = PlaylistQueryBuilder.podcastExistsInPlaylistEpisodesQuery(includeDeleted: true)
+
+        XCTAssertFalse(query.contains("wasDeleted = 0"))
+        XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
+    }
 }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistQueryBuilderTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistQueryBuilderTests.swift
@@ -41,13 +41,13 @@ final class PlaylistQueryBuilderTests: XCTestCase {
         let query = PlaylistQueryBuilder.podcastExistsInPlaylistEpisodesQuery()
 
         XCTAssertTrue(query.contains("wasDeleted = 0"))
-        XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
+        XCTAssertNoThrow(try SQLiteValidator.validate(sql: query, values: ["1234"]))
     }
 
     func testPodcastExistsQueryIncludesDeletedWhenRequested() {
         let query = PlaylistQueryBuilder.podcastExistsInPlaylistEpisodesQuery(includeDeleted: true)
 
         XCTAssertFalse(query.contains("wasDeleted = 0"))
-        XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
+        XCTAssertNoThrow(try SQLiteValidator.validate(sql: query, values: ["1234"]))
     }
 }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/SQLiteValidator.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/SQLiteValidator.swift
@@ -8,7 +8,7 @@ struct SQLiteValidator {
 
     /// Validates a SQL statement by preparing it against a test database
     /// that has been initialized using DatabaseHelper.setup(queue:).
-    static func validate(sql: String) throws {
+    static func validate(sql: String, values: [Any]? = nil) throws {
         // Create a fresh test database pool
         guard let dbPool = try DatabasePool.newTestDatabase() else {
             throw SQLiteError.failedNewTestDatabase
@@ -22,7 +22,7 @@ struct SQLiteValidator {
         var error: Error?
         queue.read { db in
             do {
-                _ = try db.executeQuery(sql, values: nil)
+                _ = try db.executeQuery(sql, values: values)
             } catch let inError {
                 error = inError
             }

--- a/podcasts/PodcastManager+Cleanup.swift
+++ b/podcasts/PodcastManager+Cleanup.swift
@@ -11,6 +11,9 @@ extension PodcastManager {
         // we don't delete podcasts added to the phone in the last week. This is to prevent stuff you just leave open in discover from being removed
         if let addedDate = podcast.addedDate, abs(addedDate.timeIntervalSinceNow) < 1.week { return }
 
+        // we don't delete podcasts which have any episodes in a playlist or Up Next
+        if dataManager.playlistContainsPodcast(podcastUuid: podcast.uuid) { return }
+
         let interactedEpisodes = dataManager.allEpisodesForPodcast(id: podcast.id).filter { $0.userHasInteractedWithEpisode() }
 
         // we can safely delete podcasts where the user hasn't interacted with any of the episodes

--- a/podcasts/PodcastManager+Delete.swift
+++ b/podcasts/PodcastManager+Delete.swift
@@ -10,13 +10,6 @@ extension PodcastManager {
         if SyncManager.isUserLoggedIn() {
             // if the user has signed in, there's a cleanup task that will run later to remove episodes they haven't interacted but we do some basic cleanup here
             // eg: remove downloaded/queued episodes and remove any that are in Up Next
-            let episodes = dataManager.allEpisodesForPodcast(id: podcast.id)
-            for episode in episodes {
-                PlaybackManager.shared.removeIfPlayingOrQueued(episode: episode, fireNotification: false)
-                downloadManager.removeFromQueue(episode: episode, fireNotification: false, userInitiated: false)
-                EpisodeManager.deleteDownloadedFiles(episode: episode)
-            }
-
             podcast.folderUuid = nil
             podcast.subscribed = 0
             podcast.autoArchiveEpisodeLimit = 0

--- a/podcasts/PodcastManager+Delete.swift
+++ b/podcasts/PodcastManager+Delete.swift
@@ -8,7 +8,7 @@ extension PodcastManager {
         let savedFolderUuid = podcast.folderUuid
 
         if SyncManager.isUserLoggedIn() {
-            // if the user has signed in, there's a cleanup task that will run later to remove episodes they haven't interacted but we do some basic cleanup here
+            // if the user has signed in, there's a cleanup task (PodcastManager.deletePodcastIfUnused) that will run later to remove episodes they haven't interacted but we do some basic cleanup here
             // eg: remove downloaded/queued episodes and remove any that are in Up Next
             podcast.folderUuid = nil
             podcast.subscribed = 0


### PR DESCRIPTION
Fixes [PCIOS-166](https://linear.app/a8c/issue/PCIOS-166/episodes-added-to-upnext-or-playlist-shouldnt-be-removed-when-unfollow)

- Adds a lightweight `playlistContainsPodcast` lookup to `PlaylistDataManager` and surface it through `DataManager`
- Extends `PlaylistQueryBuilder` with a dedicated existence query (and unit coverage) so we can toggle inclusion of deleted playlist items
- Stops the “unused podcast” cleanup from deleting unsubscribed shows that still have episodes living in any playlist

## To test

### Up Next queue
* Follow a podcast and add an episode to Up Next
* Unfollow the podcast
* ✅ Ensure the episode remains in Up Next
* ✅ Ensure it's playable
* ✅ Ensure the Details and other information are visible in the player
* Refresh from the Profile screen to trigger unused podcast cleanup
* ✅ Ensure the episode remains in Up Next
* ✅ Ensure it's playable
* ✅ Ensure the Details and other information are visible in the player


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
