### PR TITLE
Re-arrange OR condition for Banner AD feature flag

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/SubscriptionHelper.swift
@@ -263,6 +263,10 @@ open class SubscriptionHelper: NSObject {
     }
 
     public class var shouldDisplayBannerAd: Bool {
-        FeatureFlag.bannerAdPodcasts.enabled && !(SubscriptionHelper.hasActiveSubscription() || SubscriptionHelper.shouldRemoveBannerAd)
+        FeatureFlag.bannerAdPodcasts.enabled && !(SubscriptionHelper.shouldRemoveBannerAd || SubscriptionHelper.hasActiveSubscription())
+    }
+
+    public class var shouldDisplayPlayerBannerAd: Bool {
+        FeatureFlag.bannerAdPlayer.enabled && !(SubscriptionHelper.shouldRemoveBannerAd || SubscriptionHelper.hasActiveSubscription())
     }
 }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -252,7 +252,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     private func loadBannerAd() {
 #if !APPCLIP
-        if SubscriptionHelper.shouldDisplayBannerAd {
+        if SubscriptionHelper.shouldDisplayPlayerBannerAd {
             DiscoverServerHandler.shared.blazePromotion(for: .player) { [weak self] promotion, shouldAnimate in
                 guard let self = self else { return }
 


### PR DESCRIPTION
Ref. p1759160164968449-Slack-C08U02AG7C5-thread_ts=1758964987.193159&cid=C08U02AG7C5

## To test

- Make sure both FF are on
- Make smoke tests banner are displayed / hidden (Use scenarios [here](https://github.com/Automattic/pocket-casts-ios/pull/3530))

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
