### PR TITLE
Move Up Next queue change to 7.100 release in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 7.100
 -----
-
+- Keep Downloaded or Up Next episodes when unsubscribing from a podcast [#3538](https://github.com/Automattic/pocket-casts-ios/pull/3538)
 
 7.99
 -----
 - Bookmarks tab opens inline in the Podcast page [#3532](https://github.com/Automattic/pocket-casts-ios/pull/3532)
-- Keep Downloaded or Up Next episodes when unsubscribing from a podcast [#3538](https://github.com/Automattic/pocket-casts-ios/pull/3538)
 
 7.98
 -----


### PR DESCRIPTION
I accidentally included this entry in the wrong release. It went in 7.100 not 7.99

## To test

🟢 CI

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
