### PR TITLE
[Playlists] Add episode search

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -162,13 +162,18 @@ class EpisodeDataManager {
         loadMultiple(query: "SELECT * from \(DataManager.episodeTableName) WHERE \(columnName) IS NOT NULL", values: nil, dbQueue: dbQueue)
     }
 
-    func findEpisodesAndPodcastsWhere(customWhere: String, dbQueue: PCDBQueue) -> [Episode] {
+    func findEpisodesAndPodcastsWhere(customWhere: String, listenedTo: Bool, dbQueue: PCDBQueue) -> [Episode] {
+        let listenedToQuery: String = """
+        lastPlaybackInteractionDate IS NOT NULL
+        AND lastPlaybackInteractionDate > 0
+        AND
+        """
         let query = """
         SELECT episode.* FROM \(DataManager.episodeTableName) episode
         LEFT JOIN \(DataManager.podcastTableName) podcast ON episode.podcast_id = podcast.id
-        WHERE lastPlaybackInteractionDate IS NOT NULL
-        AND lastPlaybackInteractionDate > 0
-        AND (UPPER(episode.title) LIKE '%' || UPPER(?) || '%'  ESCAPE '\\'
+        WHERE
+        \(listenedTo ? listenedToQuery : "")
+        (UPPER(episode.title) LIKE '%' || UPPER(?) || '%'  ESCAPE '\\'
          OR UPPER(podcast.title) LIKE '%' || UPPER(?) || '%'  ESCAPE '\\')
         ORDER BY lastPlaybackInteractionDate DESC LIMIT 1000
         """

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -1,6 +1,16 @@
 import PocketCastsUtils
 import Foundation
 
+extension Podcast: Sortable {
+    public var itemUUID: String {
+        uuid
+    }
+
+    public var itemTitle: String? {
+        title
+    }
+}
+
 class PodcastDataManager {
     private var cachedPodcasts = [String: Podcast]()
     private lazy var cachedPodcastsQueue: DispatchQueue = {
@@ -308,6 +318,34 @@ class PodcastDataManager {
 
             return podcast
         }
+    }
+
+    func searchPodcasts(term: String, dbQueue: PCDBQueue) -> [Podcast] {
+        let trimmedTerm = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTerm.isEmpty else { return [] }
+
+        let locale = Locale.current
+        let options: String.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
+
+        var matchingPodcasts = [Podcast]()
+        cachedPodcastsQueue.sync {
+            for podcast in cachedPodcasts.values {
+                guard podcast.isSubscribed() else { continue }
+
+                if podcast.title?.range(of: trimmedTerm, options: options, range: nil, locale: locale) != nil {
+                    matchingPodcasts.append(podcast)
+                    continue
+                }
+
+                if podcast.author?.range(of: trimmedTerm, options: options, range: nil, locale: locale) != nil {
+                    matchingPodcasts.append(podcast)
+                }
+            }
+        }
+
+        return matchingPodcasts.sorted(by: { lhs, rhs in
+            PodcastSorter.sortByNameAndUUID(item1: lhs, item2: rhs)
+        })
     }
 
     func count(dbQueue: PCDBQueue) -> Int {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -302,6 +302,10 @@ public class DataManager {
         podcastManager.allPodcasts(includeUnsubscribed: includeUnsubscribed, reloadFromDatabase: reloadFromDatabase, dbQueue: dbQueue)
     }
 
+    public func searchPodcasts(term: String) -> [Podcast] {
+        podcastManager.searchPodcasts(term: term, dbQueue: dbQueue)
+    }
+
     public func allPodcastsOrderedByTitle(reloadFromDatabase: Bool = false) -> [Podcast] {
         podcastManager.allPodcastsOrderedByTitle(reloadFromDatabase: reloadFromDatabase, dbQueue: dbQueue)
     }
@@ -503,8 +507,8 @@ public class DataManager {
         episodeManager.findPlaylistEpisodesWhere(query: query, arguments: arguments, dbQueue: dbQueue)
     }
 
-    public func findEpisodesAndPodcastsWhere(customWhere: String) -> [Episode] {
-        episodeManager.findEpisodesAndPodcastsWhere(customWhere: customWhere, dbQueue: dbQueue)
+    public func findEpisodesAndPodcastsWhere(customWhere: String, listenedTo: Bool) -> [Episode] {
+        episodeManager.findEpisodesAndPodcastsWhere(customWhere: customWhere, listenedTo: listenedTo, dbQueue: dbQueue)
     }
 
     public func findLatestEpisode(podcast: Podcast) -> Episode? {

--- a/podcasts/EpisodeTableHelper.swift
+++ b/podcasts/EpisodeTableHelper.swift
@@ -68,9 +68,9 @@ struct EpisodeTableHelper {
         return [newData]
     }
 
-    static func searchSectionedEpisodes(for search: String, tintColor: UIColor = AppTheme.appTintColor(), episodeShortKey: (Episode) -> String) -> [ArraySection<String, ListEpisode>] {
+    static func searchSectionedEpisodes(for search: String, listenedTo: Bool, tintColor: UIColor = AppTheme.appTintColor(), episodeShortKey: (Episode) -> String) -> [ArraySection<String, ListEpisode>] {
         let escapedSearch = search.escapeLike(escapeChar: "\\")
-        let loadedEpisodes = DataManager.sharedManager.findEpisodesAndPodcastsWhere(customWhere: escapedSearch)
+        let loadedEpisodes = DataManager.sharedManager.findEpisodesAndPodcastsWhere(customWhere: escapedSearch, listenedTo: listenedTo)
 
         var previousSectionName = ""
         var currSectionIndex = -1

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -175,8 +175,8 @@ class EpisodesDataManager {
         })
     }
 
-    func searchEpisodes(for search: String) -> [ArraySection<String, ListEpisode>] {
-        return EpisodeTableHelper.searchSectionedEpisodes(for: search, episodeShortKey: { episode -> String in
+    func searchEpisodes(for search: String, listenedTo: Bool = true) -> [ArraySection<String, ListEpisode>] {
+        return EpisodeTableHelper.searchSectionedEpisodes(for: search, listenedTo: listenedTo, episodeShortKey: { episode -> String in
             episode.shortLastPlaybackInteractionDate()
         })
     }

--- a/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
@@ -11,23 +11,27 @@ final class LocalSearchCoordinator {
     @Published private(set) var addedEpisodeCount = 0
 
     private let playlist: EpisodeFilter
+    private let searchResultsModel: SearchResultsModel
     private let dataManager: DataManager
 
     private var playlistEpisodeUUIDs = Set<String>()
+    private var currentEpisodeSearchTerm = ""
+    private var currentSearchPodcastUUID: String?
+    private var searchTask: Task<Void, Never>?
     private var preloadTask: Task<Void, Never>?
 
     init(
         playlist: EpisodeFilter,
+        searchResultsModel: SearchResultsModel,
         dataManager: DataManager = DataManager.sharedManager
     ) {
         self.playlist = playlist
+        self.searchResultsModel = searchResultsModel
         self.dataManager = dataManager
     }
 
     deinit {
-        DispatchQueue.main.async { [weak self] in
-            self?.cancelPreloadTask()
-        }
+        searchTask?.cancel()
     }
 
     func refreshPlaylistEpisodes() {
@@ -35,10 +39,55 @@ final class LocalSearchCoordinator {
         playlistEpisodeUUIDs = Set(playlistEpisodes.map { $0.uuid })
     }
 
+    func scheduleSearch(for trimmedTerm: String, podcastUuid: String?) {
+        cancelPendingSearch()
+
+        guard trimmedTerm.count >= 2, let podcastUuid else {
+            clearPendingSearchState()
+            return
+        }
+
+        scheduleSearchTask(delay: .milliseconds(3), term: trimmedTerm, podcastUuid: podcastUuid)
+    }
+
+    func triggerImmediateSearch(for trimmedTerm: String, podcastUuid: String?) {
+        cancelPendingSearch()
+
+        guard trimmedTerm.count >= 2, let podcastUuid else {
+            clearPendingSearchState()
+            return
+        }
+
+        scheduleSearchTask(delay: .zero, term: trimmedTerm, podcastUuid: podcastUuid)
+    }
+
+    func cancelPendingSearch() {
+        searchTask?.cancel()
+        searchTask = nil
+    }
+
     func clearResults() {
+        cancelPendingSearch()
+        clearPendingSearchState()
         cancelPreloadTask()
+    }
+
+    private func clearPendingSearchState() {
         isSearchInFlight = false
         episodes = []
+        currentEpisodeSearchTerm = ""
+        currentSearchPodcastUUID = nil
+    }
+
+    private func scheduleSearchTask(delay: Duration, term: String, podcastUuid: String) {
+        isSearchInFlight = true
+        searchTask = Task { [weak self] in
+            if delay > .zero {
+                try? await Task.sleep(for: delay)
+            }
+            guard !Task.isCancelled else { return }
+            await self?.performSearch(term: term, podcastUuid: podcastUuid)
+        }
     }
 
     func preloadEpisodes(for podcast: Podcast?) {
@@ -77,6 +126,30 @@ final class LocalSearchCoordinator {
         preloadTask = nil
     }
 
+    func updateEpisodesFromSearchResults(
+        _ results: [EpisodeSearchResult],
+        selectedPodcastUUID: String?,
+        trimmedSearchText: String
+    ) {
+        guard shouldApplySearchResults(selectedPodcastUUID: selectedPodcastUUID, trimmedSearchText: trimmedSearchText),
+              let selectedPodcastUUID else {
+            return
+        }
+
+        let filtered = results.filter { $0.podcastUuid == selectedPodcastUUID }
+        let available = filtered.filter { !playlistEpisodeUUIDs.contains($0.uuid) }
+        episodes = available
+        isSearchInFlight = false
+    }
+
+    func handleSearchError(_ error: Error?, selectedPodcastUUID: String?, trimmedSearchText: String) {
+        guard error != nil,
+              shouldApplySearchResults(selectedPodcastUUID: selectedPodcastUUID, trimmedSearchText: trimmedSearchText) else {
+            return
+        }
+        isSearchInFlight = false
+    }
+
     func handleAddEpisode(_ searchResult: EpisodeSearchResult) {
         guard let episode = dataManager.findEpisode(uuid: searchResult.uuid) else {
             assertionFailure("Episode should exist")
@@ -88,15 +161,25 @@ final class LocalSearchCoordinator {
         episodes.removeAll { $0.uuid == searchResult.uuid }
         addedEpisodeCount += 1
     }
-}
 
+    private func shouldApplySearchResults(selectedPodcastUUID: String?, trimmedSearchText: String) -> Bool {
+        guard let selectedPodcastUUID,
+              let currentSearchPodcastUUID,
+              currentSearchPodcastUUID == selectedPodcastUUID else {
+            return false
+        }
 
-extension EpisodeSearchResult {
-    init(episode: Episode, dataManager: DataManager = DataManager.sharedManager) {
-        let publishedDate = episode.publishedDate ?? episode.addedDate ?? Date()
-        let duration = episode.duration > 0 ? episode.duration : nil
-        let podcastTitle = episode.parentPodcast(dataManager: dataManager)?.title ?? ""
+        guard trimmedSearchText.count >= 2 else {
+            return false
+        }
 
-        self.init(uuid: episode.uuid, title: episode.displayableTitle(), publishedDate: publishedDate, duration: duration, podcastUuid: episode.podcastUuid, podcastTitle: podcastTitle)
+        return trimmedSearchText == currentEpisodeSearchTerm
+    }
+
+    private func performSearch(term: String, podcastUuid: String) async {
+        currentEpisodeSearchTerm = term
+        currentSearchPodcastUUID = podcastUuid
+        episodes = []
+        searchResultsModel.search(term: term)
     }
 }

--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -25,7 +25,7 @@ struct LocalSearchView: View {
             .background(backgroundColor.ignoresSafeArea())
             .safeAreaInset(edge: .top) {
                 searchBar
-                    .background(backgroundColor)
+                    .background(theme.secondaryUi01)
             }
             .onAppear {
                 viewModel.onAppear(searchResultsModel: searchResults)
@@ -46,9 +46,6 @@ struct LocalSearchView: View {
             }
             .navigationTitle(viewModel.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
-            .modify({ view in
-                view.toolbarBackground(.hidden, for: .navigationBar)
-            })
             .modify({ view in
                 if #available(iOS 17.1, *) {
                     view

--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -24,11 +24,8 @@ struct LocalSearchView: View {
         navigationContent
             .background(backgroundColor.ignoresSafeArea())
             .safeAreaInset(edge: .top) {
-                SearchField(text: .constant(""), placeholder: L10n.searchPodcasts)
+                searchBar
                     .background(backgroundColor)
-                    .frame(maxWidth: .infinity)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 8)
             }
             .onAppear {
                 viewModel.onAppear(searchResultsModel: searchResults)
@@ -125,7 +122,7 @@ private extension LocalSearchView {
     private var podcastsView: some View {
         LocalSearchPodcastResultsView(
             listMode: viewModel.rootListMode,
-            selectedFolder: viewModel.selectedFolder,
+            selectedFolder: nil,
             searchText: viewModel.searchText,
             defaultLibraryItems: viewModel.defaultLibraryItems,
             folderResults: viewModel.filteredFolderPodcastResults,
@@ -137,6 +134,33 @@ private extension LocalSearchView {
         .background(backgroundColor.ignoresSafeArea())
         .navigationTitle(viewModel.navigationTitle)
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var searchPromptString: String {
+        switch viewModel.searchMode {
+        case .podcasts:
+            return L10n.searchPodcasts
+        case .episodes:
+            return L10n.localizedFormat("user_episodes_search_episodes_prompt", "Localizable", "Search Episodes")
+        }
+    }
+
+    private var searchBar: some View {
+        SearchField(
+            theme: LocalSearchFieldTheme(),
+            text: $viewModel.searchText,
+            showsCancelButton: false,
+            placeholder: searchPromptString
+        )
+        .submitLabel(.search)
+        .textInputAutocapitalization(.never)
+        .autocorrectionDisabled(true)
+        .onSubmit {
+            viewModel.triggerImmediateSearch()
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
     }
 
     private var closeButton: some View {
@@ -253,6 +277,14 @@ private enum LocalSearchRoute: Hashable {
         if case .podcast = self { return true }
         return false
     }
+}
+
+private final class LocalSearchFieldTheme: SearchField.SearchTheme {
+    override var background: Color { theme.primaryField01 }
+    override var placeholder: Color { theme.primaryText02 }
+    override var text: Color { theme.primaryText02 }
+    override var cancel: Color { theme.primaryText01 }
+    override var icon: Color { theme.primaryIcon02 }
 }
 
 struct LocalSearchView_Previews: PreviewProvider {

--- a/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
@@ -14,15 +14,34 @@ final class LocalSearchViewModel: ObservableObject {
     @Published private(set) var filteredFolderPodcasts: [Podcast] = []
     @Published private(set) var isEpisodeSearchInFlight = false
     @Published private(set) var addedEpisodeCount = 0
+    @Published private(set) var searchResultsPodcasts: [PodcastFolderSearchResult] = []
+    @Published private(set) var disableLibraryAnimation = false
 
     let playlist: EpisodeFilter
 
-    private var episodeCoordinator: LocalSearchCoordinator?
     private var cancellables = Set<AnyCancellable>()
+    private var searchResultsModel: SearchResultsModel?
+    private var episodeCoordinator: LocalSearchCoordinator?
     private var hasAppeared = false
+
+    private struct PodcastSearchState {
+        let term: String
+        let results: [PodcastFolderSearchResult]
+    }
+
+    private var previouslySelectedFolder: Folder?
+    private var previousPodcastSearchState: PodcastSearchState?
+    private var folderSearchStateStack: [PodcastSearchState] = []
 
     init(playlist: EpisodeFilter) {
         self.playlist = playlist
+
+        $searchText
+            .removeDuplicates()
+            .sink { [weak self] newValue in
+                self?.handleSearchTextChange(newValue)
+            }
+            .store(in: &cancellables)
     }
 
     var searchMode: SearchMode {
@@ -30,11 +49,20 @@ final class LocalSearchViewModel: ObservableObject {
     }
 
     var podcastListMode: PodcastListMode {
-        selectedFolder == nil ? .library : .folder
+        if selectedFolder != nil {
+            return .folder
+        }
+        if !trimmedSearchText.isEmpty || previousPodcastSearchState != nil || !folderSearchStateStack.isEmpty {
+            return .search
+        }
+        return .library
     }
 
     var rootListMode: PodcastListMode {
-        selectedFolder == nil ? .library : .folder
+        if !trimmedSearchText.isEmpty || previousPodcastSearchState != nil || !folderSearchStateStack.isEmpty {
+            return .search
+        }
+        return .library
     }
 
     var defaultLibraryItems: [PodcastFolderSearchResult] {
@@ -59,14 +87,6 @@ final class LocalSearchViewModel: ObservableObject {
         !folderPodcasts.isEmpty
     }
 
-    var searchResultsPodcasts: [PodcastFolderSearchResult] {
-        []
-    }
-
-    var disableLibraryAnimation: Bool {
-        false
-    }
-
     var navigationTitle: String {
         let name = playlist.playlistName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard addedEpisodeCount > 0 else {
@@ -83,14 +103,15 @@ final class LocalSearchViewModel: ObservableObject {
     }
 
     func onAppear(searchResultsModel: SearchResultsModel) {
-        configureEpisodeCoordinatorIfNeeded()
+        configureSearchResultsIfNeeded(searchResultsModel)
         guard !hasAppeared else { return }
         hasAppeared = true
+        loadPodcastsIfNeeded()
         refreshPlaylistEpisodes()
     }
 
     func onDisappear() {
-        episodeCoordinator?.clearResults()
+        episodeCoordinator?.cancelPendingSearch()
     }
 
     func podcast(from result: PodcastFolderSearchResult) -> Podcast? {
@@ -102,8 +123,11 @@ final class LocalSearchViewModel: ObservableObject {
     }
 
     func beginEpisodeMode(with podcast: Podcast) {
+        previousPodcastSearchState = currentSearchState()
+        previouslySelectedFolder = selectedFolder
         selectedPodcast = podcast
         searchText = ""
+
         episodeCoordinator?.clearResults()
         episodeCoordinator?.refreshPlaylistEpisodes()
         episodeCoordinator?.preloadEpisodes(for: selectedPodcast)
@@ -119,38 +143,131 @@ final class LocalSearchViewModel: ObservableObject {
               let folder = DataManager.sharedManager.findFolder(uuid: folderResult.uuid) else {
             return
         }
+
+        if let searchState = currentSearchState() {
+            folderSearchStateStack.append(searchState)
+        }
+
         selectedFolder = folder
+        previouslySelectedFolder = folder
         selectedPodcast = nil
-        loadPodcastsForSelectedFolder(folder)
         episodeCoordinator?.clearResults()
+        loadPodcastsForSelectedFolder(folder)
+        if !trimmedSearchText.isEmpty {
+            searchText = ""
+        } else {
+            filterPodcasts(using: searchText)
+        }
     }
 
     func clearSelectedPodcast() {
+        let searchState = previousPodcastSearchState
         selectedPodcast = nil
-        episodeCoordinator?.clearResults()
-        episodeCoordinator?.preloadEpisodes(for: nil)
+        if let folder = previouslySelectedFolder {
+            selectedFolder = folder
+            loadPodcastsForSelectedFolder(folder)
+            let restoreTerm = searchState?.term ?? ""
+            if searchText != restoreTerm {
+                searchText = restoreTerm
+            } else {
+                filterPodcasts(using: restoreTerm)
+            }
+        } else if let searchState, !searchState.term.isEmpty {
+            selectedFolder = nil
+            searchResultsPodcasts = searchState.results
+            if searchText != searchState.term {
+                searchText = searchState.term
+            } else {
+                filterPodcasts(using: searchState.term)
+            }
+        } else {
+            selectedFolder = nil
+            if !searchText.isEmpty {
+                searchText = ""
+            }
+            filterPodcasts(using: "")
+        }
+        DispatchQueue.main.async { [weak self] in
+            self?.episodeCoordinator?.clearResults()
+        }
+        previousPodcastSearchState = nil
     }
 
     func clearSelectedFolder() {
         selectedFolder = nil
         folderPodcasts = []
         filteredFolderPodcasts = []
+        if let previousState = folderSearchStateStack.popLast() {
+            searchResultsPodcasts = previousState.results
+            if searchText != previousState.term {
+                searchText = previousState.term
+            } else {
+                filterPodcasts(using: previousState.term)
+            }
+        } else {
+            searchText = ""
+            filterPodcasts(using: searchText, disableAnimationsWhenClearing: false)
+        }
+        DispatchQueue.main.async { [weak self] in
+            self?.episodeCoordinator?.clearResults()
+        }
+        previouslySelectedFolder = nil
     }
 
     func triggerImmediateSearch() {
-        episodeCoordinator?.preloadEpisodes(for: selectedPodcast)
+        guard searchMode == .episodes,
+              let coordinator = episodeCoordinator else { return }
+
+        let trimmed = trimmedSearchText
+        guard let podcastUuid = selectedPodcast?.uuid, trimmed.count >= 2 else {
+            coordinator.clearResults()
+            coordinator.preloadEpisodes(for: selectedPodcast)
+            return
+        }
+
+        coordinator.triggerImmediateSearch(for: trimmed, podcastUuid: podcastUuid)
     }
 
     func handleAddEpisode(_ searchResult: EpisodeSearchResult) {
         episodeCoordinator?.handleAddEpisode(searchResult)
-        addedEpisodeCount = episodeCoordinator?.addedEpisodeCount ?? 0
     }
 
-    private func configureEpisodeCoordinatorIfNeeded() {
+    private func configureSearchResultsIfNeeded(_ searchResultsModel: SearchResultsModel) {
+        guard self.searchResultsModel !== searchResultsModel else { return }
+        self.searchResultsModel = searchResultsModel
+        configureEpisodeCoordinatorIfNeeded(using: searchResultsModel)
+
+        searchResultsModel.$podcasts
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] results in
+                guard let self else { return }
+                self.searchResultsPodcasts = results.filter { result in
+                    (result.kind == .podcast || result.kind == .folder) && (result.isLocal ?? true)
+                }
+            }
+            .store(in: &cancellables)
+
+        searchResultsModel.$episodes
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] results in
+                self?.updateEpisodesFromSearchResults(results)
+            }
+            .store(in: &cancellables)
+
+        searchResultsModel.$episodeSearchError
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] error in
+                self?.handleEpisodeSearchError(error)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func configureEpisodeCoordinatorIfNeeded(using searchResultsModel: SearchResultsModel) {
         guard episodeCoordinator == nil else { return }
 
         let coordinator = LocalSearchCoordinator(
-            playlist: playlist
+            playlist: playlist,
+            searchResultsModel: searchResultsModel
         )
 
         coordinator.$episodes
@@ -173,8 +290,12 @@ final class LocalSearchViewModel: ObservableObject {
         episodeCoordinator?.preloadEpisodes(for: selectedPodcast)
     }
 
-    private func refreshPlaylistEpisodes() {
-        episodeCoordinator?.refreshPlaylistEpisodes()
+    private var trimmedSearchText: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func loadPodcastsIfNeeded() {
+        filterPodcasts(using: searchText)
     }
 
     private func loadPodcastsForSelectedFolder(_ folder: Folder) {
@@ -189,11 +310,105 @@ final class LocalSearchViewModel: ObservableObject {
         filteredFolderPodcasts = sorted
     }
 
+    private func refreshPlaylistEpisodes() {
+        episodeCoordinator?.refreshPlaylistEpisodes()
+    }
+
+    private func handleSearchTextChange(_ newValue: String) {
+        switch searchMode {
+        case .podcasts:
+            filterPodcasts(using: newValue)
+        case .episodes:
+            scheduleEpisodeSearch(with: newValue)
+        }
+    }
+
+    private func filterPodcasts(using term: String, disableAnimationsWhenClearing: Bool = true) {
+        let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if selectedFolder != nil {
+            if trimmed.isEmpty {
+                filteredFolderPodcasts = folderPodcasts
+            } else {
+                filteredFolderPodcasts = folderPodcasts.filter { podcast in
+                    guard let title = podcast.title else { return false }
+                    return title.localizedCaseInsensitiveContains(trimmed)
+                }
+            }
+        } else {
+            guard let searchResultsModel else { return }
+            if trimmed.isEmpty {
+                if disableAnimationsWhenClearing {
+                    disableLibraryAnimation = true
+                }
+                let transaction = disableAnimationsWhenClearing ? Transaction(animation: nil) : Transaction()
+                withTransaction(transaction) {
+                    searchResultsModel.clearSearch()
+                }
+                if disableAnimationsWhenClearing {
+                    DispatchQueue.main.async { [weak self] in
+                        self?.disableLibraryAnimation = false
+                    }
+                }
+            } else {
+                searchResultsModel.searchLocally(term: trimmed)
+            }
+        }
+    }
+
+    private func scheduleEpisodeSearch(with term: String) {
+        guard let coordinator = episodeCoordinator else { return }
+
+        let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let podcastUuid = selectedPodcast?.uuid, trimmed.count >= 2 else {
+            coordinator.clearResults()
+            coordinator.preloadEpisodes(for: selectedPodcast)
+            return
+        }
+
+        coordinator.scheduleSearch(for: trimmed, podcastUuid: podcastUuid)
+    }
+
+    private func updateEpisodesFromSearchResults(_ results: [EpisodeSearchResult]) {
+        episodeCoordinator?.updateEpisodesFromSearchResults(
+            results,
+            selectedPodcastUUID: selectedPodcast?.uuid,
+            trimmedSearchText: trimmedSearchText
+        )
+    }
+
+    private func handleEpisodeSearchError(_ error: Error?) {
+        episodeCoordinator?.handleSearchError(
+            error,
+            selectedPodcastUUID: selectedPodcast?.uuid,
+            trimmedSearchText: trimmedSearchText
+        )
+    }
+}
+
+extension EpisodeSearchResult {
+    init(episode: Episode, dataManager: DataManager = DataManager.sharedManager) {
+        let publishedDate = episode.publishedDate ?? episode.addedDate ?? Date()
+        let duration = episode.duration > 0 ? episode.duration : nil
+        let podcastTitle = episode.parentPodcast(dataManager: dataManager)?.title ?? ""
+
+        self.init(uuid: episode.uuid, title: episode.displayableTitle(), publishedDate: publishedDate, duration: duration, podcastUuid: episode.podcastUuid, podcastTitle: podcastTitle)
+    }
+
+    init(listEpisode: ListEpisode, dataManager: DataManager = DataManager.sharedManager) {
+        self.init(episode: listEpisode.episode, dataManager: dataManager)
+    }
 }
 
 extension LocalSearchViewModel {
     enum SearchMode {
         case podcasts
         case episodes
+    }
+
+    private func currentSearchState() -> PodcastSearchState? {
+        let trimmed = trimmedSearchText
+        guard !trimmed.isEmpty else { return nil }
+        return PodcastSearchState(term: trimmed, results: searchResultsPodcasts)
     }
 }


### PR DESCRIPTION
Completes [PCIOS-123](https://linear.app/a8c/issue/PCIOS-123/handle-search-episodes-when-adding-a-new-one-in-manual-playlist)

https://github.com/user-attachments/assets/aa872f66-8dd2-493d-bb53-c7a9bbc7011c

## To test

* Enable the `playlistsRebranding` feature flag
* Go to the Playlists tab
* Create a Manual playlist
* Tap "Add Episodes"
* Search for a Podcast
* ✅ Ensure it shows up regardless of whether it's in a folder
* Tap the podcast
* ✅ Ensure it's episodes show up
* Search the episodes
* ✅ Ensure episodes are filtered based on your search term
* Tap an episode cell - Note: This will change in a follow up to be just the Plus button
* ✅ Verify the episode is removed from the search and the title updates to "Added 1 episode to "Playlist""
* Back out to the top level
* Search for a Folder name
* ✅ Verify folders are shown
* Tap a folder
* ✅ Verify its podcasts are shown
* Tap a podcast
* ✅ Verify its episodes are shown
* Back out
* ✅ Verify the selected folder's podcasts are shown again

Generally test this and let me know if it reacts in any unexpected way.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
