### PR TITLE
Up Next clearing 

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -547,6 +547,12 @@ class PlaybackManager: ServerPlaybackDelegate {
             AnalyticsEpisodeHelper.shared.episodeAddedToUpNext(episode: episode, toTop: toTop)
         }
 
+        // If we don't have a current episode, reload the persisted queue to updated our cache just in case
+        // We're getting reports from users about Up Next being cleared where this line is indicated by the logs
+        if currentEpisode() == nil {
+            queue.loadPersistedQueue()
+        }
+
         guard let playingEpisode = currentEpisode() else {
             // if there's nothing playing, just play this
             load(episode: episode, autoPlay: false, overrideUpNext: true)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -550,6 +550,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         // If we don't have a current episode, reload the persisted queue to updated our cache just in case
         // We're getting reports from users about Up Next being cleared where this line is indicated by the logs
         if currentEpisode() == nil {
+            FileLog.shared.addMessage("PlaybackManager: Missing current episode, reloading queue")
             queue.loadPersistedQueue()
         }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -578,19 +578,6 @@ class PlaybackManager: ServerPlaybackDelegate {
         queue.add(episode: episode, fireNotification: true, partOfBulkAdd: false, toTop: toTop)
     }
 
-    func insertIntoUpNext(episode: Episode, position: Int) {
-        guard let playingEpisode = currentEpisode() else {
-            // if there's nothing playing, just play this
-            load(episode: episode, autoPlay: false, overrideUpNext: true)
-
-            return
-        }
-
-        if playingEpisode.uuid == episode.uuid { return }
-
-        queue.insert(episode: episode, position: position)
-    }
-
     func removeIfPlayingOrQueued(episode: BaseEpisode?, fireNotification: Bool, saveCurrentEpisode: Bool = true, userInitiated: Bool = false) {
         if userInitiated, let episode {
             AnalyticsEpisodeHelper.shared.episodeRemovedFromUpNext(episode: episode)

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -389,7 +389,7 @@ class PlaybackQueue: NSObject {
             }
         }
 
-        FileLog.shared.addMessage("PlaybackQueue: Saving replace of \(episodeUuids.count) episodes")
+        FileLog.shared.addMessage("PlaybackQueue: Saving replace of \(upNextCount()) with \(episodeUuids.count) episodes")
 
         DataManager.sharedManager.saveReplace(episodeList: episodeUuids)
 


### PR DESCRIPTION
Fixes [PCIOS-37](https://linear.app/a8c/issue/PCIOS-37/investigate-upnext-playlist-issue-on-iphone-and-ipad)

* Logs the current up next count on `PlaybackQueue: Saving replace`
* Removes `PlaybackQueue.insertIntoUpNext` which is now unused. This was confusing my log analysis so removing it makes this clear.
* Reloads the cached `PlaybackQueue.episode` if it is `nil` just to be _sure_ since a `nil` `currentEpisode` will result in the Up Next queue being overwritten.

This is a shot in the dark based on this user's logs. There was at least one instance where the code path chaged in be6b83ba replaced the queue with a new episode. Unsure whether this was the case where the Up Next queue was cleared for them but it seems possible the cache could get out of date in some situations.

## To test

* Test that adding episode to the Up Next queue works
* Empty the playback queue
* Play an episode
* Make sure the episode plays and is shown in the mini player and Up Next queue screens

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
