### PR TITLE
Podcast Re-subscription fixes

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -1,7 +1,14 @@
 import Foundation
 import PocketCastsDataModel
 
-public class ServerPodcastManager: NSObject {
+protocol ServerPodcastManaging: AnyObject {
+    func addFromUuid(podcastUuid: String, subscribe: Bool, autoDownloads: Int, completion: ((Bool) -> Void)?)
+    func addMissingPodcast(episodeUuid: String, podcastUuid: String)
+    func addMissingEpisode(episodeUuid: String, podcastUuid: String) -> Episode?
+    func addMissingPodcastAndEpisode(episodeUuid: String, podcastUuid: String, shouldUpdateEpisode: Bool, completion: ((Episode?) -> Void)?)
+}
+
+public class ServerPodcastManager: NSObject, ServerPodcastManaging {
     private static let maxAutoDownloadSeperationTime = 12.hours
 
     public static let shared = ServerPodcastManager()

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -110,6 +110,15 @@ extension SyncTask {
 
         let existingPodcast = DataManager.sharedManager.findPodcast(uuid: podcastItem.uuid, includeUnsubscribed: true)
         let isDeleted = podcastItem.hasIsDeleted && podcastItem.isDeleted.value
+        let shouldSubscribe: Bool = {
+            if podcastItem.hasIsDeleted {
+                return !podcastItem.isDeleted.value
+            }
+            if podcastItem.hasSubscribed {
+                return podcastItem.subscribed.value
+            }
+            return true
+        }()
 
         if isDeleted {
             guard let podcast = existingPodcast else { return }
@@ -133,23 +142,24 @@ extension SyncTask {
             DataManager.sharedManager.save(podcast: podcast)
 
             ServerConfig.shared.syncDelegate?.podcastUpdated(podcastUuid: podcast.uuid)
-        } else {
-            let semaphore = DispatchSemaphore(value: 0)
-
-            serverPodcastManager.addFromUuid(podcastUuid: podcastItem.uuid, subscribe: true, autoDownloads: 0, completion: { success in
-                if success {
-                    if let podcast = DataManager.sharedManager.findPodcast(uuid: podcastItem.uuid, includeUnsubscribed: true) {
-                        podcast.syncStatus = SyncStatus.synced.rawValue
-                        self.importItem(podcastItem: podcastItem, into: podcast, checkIsDeleted: false)
-
-                        DataManager.sharedManager.save(podcast: podcast)
-                    }
-                }
-
-                semaphore.signal()
-            })
-            _ = semaphore.wait(timeout: .distantFuture)
+            return
         }
+
+        let semaphore = DispatchSemaphore(value: 0)
+
+        serverPodcastManager.addFromUuid(podcastUuid: podcastItem.uuid, subscribe: shouldSubscribe, autoDownloads: 0, completion: { success in
+            if success {
+                if let podcast = DataManager.sharedManager.findPodcast(uuid: podcastItem.uuid, includeUnsubscribed: true) {
+                    podcast.syncStatus = SyncStatus.synced.rawValue
+                    self.importItem(podcastItem: podcastItem, into: podcast, checkIsDeleted: false)
+
+                    DataManager.sharedManager.save(podcast: podcast)
+                }
+            }
+
+            semaphore.signal()
+        })
+        _ = semaphore.wait(timeout: .distantFuture)
 
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -125,7 +125,7 @@ extension SyncTask {
         } else {
             let semaphore = DispatchSemaphore(value: 0)
 
-            ServerPodcastManager.shared.addFromUuid(podcastUuid: podcastItem.uuid, subscribe: true, completion: { success in
+            serverPodcastManager.addFromUuid(podcastUuid: podcastItem.uuid, subscribe: true, autoDownloads: 0, completion: { success in
                 if success {
                     if let podcast = DataManager.sharedManager.findPodcast(uuid: podcastItem.uuid, includeUnsubscribed: true) {
                         podcast.syncStatus = SyncStatus.synced.rawValue
@@ -181,7 +181,7 @@ extension SyncTask {
         if existingEpisode == nil {
             // we don't have this episode so try and find it
             FileLog.shared.addMessage("Trying to find missing episode as part of a sync \(episodeItem.uuid)")
-            existingEpisode = ServerPodcastManager.shared.addMissingEpisode(episodeUuid: episodeItem.uuid, podcastUuid: episodeItem.podcastUuid)
+            existingEpisode = serverPodcastManager.addMissingEpisode(episodeUuid: episodeItem.uuid, podcastUuid: episodeItem.podcastUuid)
         }
 
         guard let episode = existingEpisode else { return }
@@ -382,7 +382,7 @@ extension SyncTask {
         DataManager.sharedManager.save(playlist: playlist)
 
         addedEpisodes.forEach { addedEpisode in
-            ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: addedEpisode.uuid, podcastUuid: addedEpisode.podcastUuid, shouldUpdateEpisode: true)
+            serverPodcastManager.addMissingPodcastAndEpisode(episodeUuid: addedEpisode.uuid, podcastUuid: addedEpisode.podcastUuid, shouldUpdateEpisode: true, completion: nil)
         }
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -102,6 +102,12 @@ extension SyncTask {
     }
 
     private func importPodcast(_ podcastItem: Api_SyncUserPodcast) {
+        defer {
+            NotificationCenter.default.post(name: ServerNotifications.syncProgressPodcastUpto, object: upToPodcast)
+            NotificationCenter.default.post(name: ServerNotifications.syncProgressPodcastCount, object: totalToImport)
+            upToPodcast += 1
+        }
+
         let existingPodcast = DataManager.sharedManager.findPodcast(uuid: podcastItem.uuid, includeUnsubscribed: true)
         if podcastItem.hasIsDeleted, podcastItem.isDeleted.value {
             if let podcast = existingPodcast {
@@ -140,9 +146,6 @@ extension SyncTask {
             _ = semaphore.wait(timeout: .distantFuture)
         }
 
-        NotificationCenter.default.post(name: ServerNotifications.syncProgressPodcastUpto, object: upToPodcast)
-        NotificationCenter.default.post(name: ServerNotifications.syncProgressPodcastCount, object: totalToImport)
-        upToPodcast += 1
     }
 
     private func importItem(podcastItem: Api_SyncUserPodcast, into podcast: Podcast, checkIsDeleted: Bool) {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -109,21 +109,26 @@ extension SyncTask {
         }
 
         let existingPodcast = DataManager.sharedManager.findPodcast(uuid: podcastItem.uuid, includeUnsubscribed: true)
-        if podcastItem.hasIsDeleted, podcastItem.isDeleted.value {
-            if let podcast = existingPodcast {
-                podcast.autoDownloadSetting = AutoDownloadSetting.off.rawValue
-                podcast.isPushEnabled = false
-                podcast.autoArchiveEpisodeLimit = 0
-                podcast.subscribed = 0
-                podcast.autoAddToUpNext = AutoAddToUpNextSetting.off.rawValue
-                podcast.settings = PodcastSettings.defaults
-                if FeatureFlag.settingsSync.enabled {
-                    podcast.processSettings(podcastItem.settings)
-                }
+        let isDeleted = podcastItem.hasIsDeleted && podcastItem.isDeleted.value
 
-                DataManager.sharedManager.save(podcast: podcast)
+        if isDeleted {
+            guard let podcast = existingPodcast else { return }
+
+            podcast.autoDownloadSetting = AutoDownloadSetting.off.rawValue
+            podcast.isPushEnabled = false
+            podcast.autoArchiveEpisodeLimit = 0
+            podcast.subscribed = 0
+            podcast.autoAddToUpNext = AutoAddToUpNextSetting.off.rawValue
+            podcast.settings = PodcastSettings.defaults
+            if FeatureFlag.settingsSync.enabled {
+                podcast.processSettings(podcastItem.settings)
             }
-        } else if let podcast = existingPodcast {
+
+            DataManager.sharedManager.save(podcast: podcast)
+            return
+        }
+
+        if let podcast = existingPodcast {
             importItem(podcastItem: podcastItem, into: podcast, checkIsDeleted: true)
             DataManager.sharedManager.save(podcast: podcast)
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -184,8 +184,12 @@ extension SyncTask {
             podcast.sortOrder = podcastItem.sortPosition.value
         }
 
-        if checkIsDeleted, podcastItem.hasIsDeleted {
-            podcast.subscribed = podcastItem.isDeleted.value ? 0 : 1
+        if checkIsDeleted {
+            if podcastItem.hasIsDeleted {
+                podcast.subscribed = podcastItem.isDeleted.value ? 0 : 1
+            } else if podcastItem.hasSubscribed {
+                podcast.subscribed = podcastItem.subscribed.value ? 1 : 0
+            }
         }
 
         if FeatureFlag.settingsSync.enabled {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -18,6 +18,15 @@ class SyncTask: ApiBaseTask {
 
     var status = UpdateStatus.notStarted
 
+    let serverPodcastManager: ServerPodcastManaging
+
+    init(dataManager: DataManager = .sharedManager,
+         serverPodcastManager: ServerPodcastManaging = ServerPodcastManager.shared,
+         urlConnection: URLConnection = URLConnection(handler: URLSession.shared)) {
+        self.serverPodcastManager = serverPodcastManager
+        super.init(dataManager: dataManager, urlConnection: urlConnection)
+    }
+
     private lazy var legacyLastModifiedFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withYear, .withMonth, .withDay, .withDashSeparatorInDate, .withColonSeparatorInTime, .withTime, .withFractionalSeconds]

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+PodcastImport.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+PodcastImport.swift
@@ -31,7 +31,7 @@ final class SyncTaskTests_PodcastImport: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testDoesNotReSubscribeMissingPodcastWhenServerMarksUnsubscribed() {
+    func testDoesNotReSubscribeMissingPodcastWhenServerMarksUnsubscribed() throws {
         let uuid = "pod-missing"
 
         var podcast = Api_SyncUserPodcast()
@@ -46,7 +46,10 @@ final class SyncTaskTests_PodcastImport: XCTestCase {
 
         syncTask.processServerData(response: response)
 
-        XCTAssertTrue(serverPodcastManager.addFromUuidCalls.isEmpty)
+        XCTAssertEqual(serverPodcastManager.addFromUuidCalls.count, 1)
+        let addCall = try XCTUnwrap(serverPodcastManager.addFromUuidCalls.first)
+        XCTAssertEqual(addCall.uuid, uuid)
+        XCTAssertFalse(addCall.subscribe)
         XCTAssertNil(DataManager.sharedManager.findPodcast(uuid: uuid, includeUnsubscribed: true))
     }
 }

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+PodcastImport.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+PodcastImport.swift
@@ -1,0 +1,105 @@
+@testable import PocketCastsServer
+@testable import PocketCastsDataModel
+import XCTest
+import GRDB
+import SwiftProtobuf
+
+final class SyncTaskTests_PodcastImport: XCTestCase {
+    private var originalDataManager: DataManager!
+    private var dataManager: PodcastCapturingDataManager!
+    private var serverPodcastManager: CapturingServerPodcastManager!
+    private var syncTask: SyncTask!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        originalDataManager = DataManager.sharedManager
+        dataManager = PodcastCapturingDataManager()
+        DataManager.sharedManager = dataManager
+
+        serverPodcastManager = CapturingServerPodcastManager()
+        syncTask = SyncTask(dataManager: dataManager, serverPodcastManager: serverPodcastManager)
+    }
+
+    override func tearDownWithError() throws {
+        DataManager.sharedManager = originalDataManager
+        syncTask = nil
+        serverPodcastManager = nil
+        dataManager = nil
+        originalDataManager = nil
+
+        try super.tearDownWithError()
+    }
+
+    func testDoesNotReSubscribeMissingPodcastWhenServerMarksUnsubscribed() {
+        let uuid = "pod-missing"
+
+        var podcast = Api_SyncUserPodcast()
+        podcast.uuid = uuid
+        podcast.subscribed = Self.boolValue(false)
+
+        var record = Api_Record()
+        record.podcast = podcast
+
+        var response = Api_SyncUpdateResponse()
+        response.records = [record]
+
+        syncTask.processServerData(response: response)
+
+        XCTAssertTrue(serverPodcastManager.addFromUuidCalls.isEmpty)
+        XCTAssertNil(DataManager.sharedManager.findPodcast(uuid: uuid, includeUnsubscribed: true))
+    }
+}
+
+private final class CapturingServerPodcastManager: ServerPodcastManaging {
+    private(set) var addFromUuidCalls: [(uuid: String, subscribe: Bool, autoDownloads: Int)] = []
+
+    func addFromUuid(podcastUuid: String, subscribe: Bool, autoDownloads: Int, completion: ((Bool) -> Void)?) {
+        addFromUuidCalls.append((podcastUuid, subscribe, autoDownloads))
+        completion?(false)
+    }
+
+    func addMissingPodcast(episodeUuid: String, podcastUuid: String) {}
+
+    func addMissingEpisode(episodeUuid: String, podcastUuid: String) -> Episode? {
+        nil
+    }
+
+    func addMissingPodcastAndEpisode(episodeUuid: String, podcastUuid: String, shouldUpdateEpisode: Bool, completion: ((Episode?) -> Void)?) {
+        completion?(nil)
+    }
+}
+
+private final class PodcastCapturingDataManager: DataManager {
+    private var storedPodcasts: [String: Podcast] = [:]
+
+    init() {
+        let dbPath = NSTemporaryDirectory().appending("\(UUID().uuidString).sqlite")
+        let pool = try! DatabasePool(path: dbPath)
+        super.init(dbQueue: GRDBQueue(dbPool: pool, logger: DataManager.logger))
+    }
+
+    override func findPodcast(uuid: String, includeUnsubscribed: Bool = false) -> Podcast? {
+        storedPodcasts[uuid]
+    }
+
+    override func save(podcast: Podcast) {
+        storedPodcasts[podcast.uuid] = podcast
+    }
+
+    func storedPodcastCount() -> Int {
+        storedPodcasts.count
+    }
+
+    override func markAllSynced(episodeIDs: [String]) {
+        // no-op for tests
+    }
+}
+
+private extension SyncTaskTests_PodcastImport {
+    static func boolValue(_ value: Bool) -> SwiftProtobuf.Google_Protobuf_BoolValue {
+        var bool = SwiftProtobuf.Google_Protobuf_BoolValue()
+        bool.value = value
+        return bool
+    }
+}


### PR DESCRIPTION
Fixes [PCIOS-175](https://linear.app/a8c/issue/PCIOS-175/ios-unsubscribed-podcasts-reappear-after-update)

There are two primary fix attempts here:

* Make sure we are fetching and passing `shouldSubscribe` when we call `serverPodcastManager.addFromUuid`. Otherwise, we could potentially subscribe to a Podcast which the server already told us is unsubscribed.
* When importing a podcast, we seemed to be setting `subscribed` based on the `isDeleted` value. It seems like we should also use `subscribed` if only it exists. I'm not 100% sure on why we ever use `isDeleted`, but I decided to keep that for now. It only happens in specific cases where `checkIsDeleted` is `true` but this might be something to look at in the future.

So both fixes really come down to using the server's `subscribed` value where we weren't before.

## To test

* Use two devices to test syncing
* Subscribe to a podcast on one device
* Refresh in the Profile tab to sync
* Unsubscribe on another device
* Refresh in the Profile tab to sync
* Verify that podcasts are properly synced and removed from lists


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.