### PR TITLE
Fix Swift 6.2 compilation

### DIFF
--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -322,12 +322,21 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
                 process: tapProcess
             )
 
+#if compiler(>=6.2)
+            var audioProcessingTap: MTAudioProcessingTap?
+            if noErr == MTAudioProcessingTapCreate(kCFAllocatorDefault, &callbacks, kMTAudioProcessingTapCreationFlag_PreEffects, &audioProcessingTap) {
+                audioMixInputParameters.audioTapProcessor = audioProcessingTap
+                mutableMix.inputParameters = [audioMixInputParameters]
+                audioMix = mutableMix
+            }
+#else
             var audioProcessingTap: Unmanaged<MTAudioProcessingTap>?
             if noErr == MTAudioProcessingTapCreate(kCFAllocatorDefault, &callbacks, kMTAudioProcessingTapCreationFlag_PreEffects, &audioProcessingTap) {
                 audioMixInputParameters.audioTapProcessor = audioProcessingTap?.takeRetainedValue()
                 mutableMix.inputParameters = [audioMixInputParameters]
                 audioMix = mutableMix
             }
+#endif
         }
 
         // MARK: - Tap Callbacks


### PR DESCRIPTION
Fixes [PCIOS-177](https://linear.app/a8c/issue/PCIOS-177/fix-compilation-error-in-swift-62)

This ifdefs out the change to fix the `MTAudioProcessingTap` for the Xcode 26 compiler.

We can't use `swift(>=6.2)` here because our language version is set to 5 so it will not be updated automatically. However, the compiler _does_ change.

## To test

* Build with Xcode 16.4
* 🟢Build succeeds
* Build with Xcode 26.0
* 🟢Build succeeds

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
