### PR TITLE
[Playlists] Unavailable Episode handling

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -42,7 +42,8 @@ class EpisodeDataManager {
         "excludeFromEpisodeLimit",
         "starredModified",
         "deselectedChapters",
-        "deselectedChaptersModified"
+        "deselectedChaptersModified",
+        "wasDeleted"
     ]
 
     enum Constants {
@@ -193,7 +194,7 @@ class EpisodeDataManager {
     }
 
     func allEpisodesForPodcast(id: Int64, dbQueue: PCDBQueue) -> [Episode] {
-        loadMultiple(query: "SELECT * from \(DataManager.episodeTableName) WHERE podcast_id = ?", values: [id], dbQueue: dbQueue)
+        loadMultiple(query: "SELECT * from \(DataManager.episodeTableName) WHERE podcast_id = ? AND wasDeleted = 0", values: [id], dbQueue: dbQueue)
     }
 
     func episodesWithListenHistory(limit: Int, dbQueue: PCDBQueue) -> [Episode] {
@@ -201,11 +202,11 @@ class EpisodeDataManager {
     }
 
     func findLatestEpisode(podcast: Podcast, dbQueue: PCDBQueue) -> Episode? {
-        loadSingle(query: "SELECT * from \(DataManager.episodeTableName) WHERE podcast_id = ? ORDER BY publishedDate DESC, addedDate DESC LIMIT 1", values: [podcast.id], dbQueue: dbQueue)
+        loadSingle(query: "SELECT * from \(DataManager.episodeTableName) WHERE podcast_id = ? AND wasDeleted = 0 ORDER BY publishedDate DESC, addedDate DESC LIMIT 1", values: [podcast.id], dbQueue: dbQueue)
     }
 
     func findLatestEpisodes(podcast: Podcast, limit: Int, dbQueue: PCDBQueue) -> [Episode] {
-        loadMultiple(query: "SELECT * from \(DataManager.episodeTableName) WHERE podcast_id = ? ORDER BY publishedDate DESC, addedDate DESC LIMIT ?", values: [podcast.id, limit], dbQueue: dbQueue)
+        loadMultiple(query: "SELECT * from \(DataManager.episodeTableName) WHERE podcast_id = ? AND wasDeleted = 0 ORDER BY publishedDate DESC, addedDate DESC LIMIT ?", values: [podcast.id, limit], dbQueue: dbQueue)
     }
 
     func allUpNextEpisodes(dbQueue: PCDBQueue) -> [Episode] {
@@ -1093,6 +1094,7 @@ class EpisodeDataManager {
         values.append(episode.starredModified)
         values.append(DBUtils.nullIfNil(value: episode.deselectedChapters))
         values.append(episode.deselectedChaptersModified)
+        values.append(episode.wasDeleted)
 
         if includeIdForWhere {
             values.append(episode.id)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/BaseEpisode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/BaseEpisode.swift
@@ -22,6 +22,7 @@ import Foundation
 
     var archived: Bool { get set }
     var keepEpisode: Bool { get set }
+    var wasDeleted: Bool { get set }
 
     var episodeStatus: Int32 { get set }
     var playingStatus: Int32 { get set }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode+fromDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode+fromDatabase.swift
@@ -47,6 +47,7 @@ extension Episode {
         episode.starredModified = rs.longLongInt(forColumn: "starredModified")
         episode.deselectedChapters = rs.string(forColumn: "deselectedChapters")
         episode.deselectedChaptersModified = rs.longLongInt(forColumn: "deselectedChaptersModified")
+        episode.wasDeleted = rs.bool(forColumn: "wasDeleted")
         return episode
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -46,6 +46,7 @@ public class Episode: NSObject, BaseEpisode {
     @objc public var hasOnlyUuid = false
     @objc public var deselectedChapters: String?
     @objc public var deselectedChaptersModified = 0 as Int64
+    @objc public var wasDeleted = false
 
     public var hasBookmarks: Bool {
         // This wil cause a regression in which the bookmarks won't be displayed

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
@@ -38,6 +38,7 @@ public class UserEpisode: NSObject, BaseEpisode {
     // UserEpisode's are never archived or starred
     public var archived = false
     public var keepEpisode = false
+    public var wasDeleted = false
 
     public var hasBookmarks: Bool {
         DataManager.sharedManager.bookmarks.bookmarkCount(forEpisode: uuid) > 0

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -65,7 +65,6 @@ public class PlaylistQueryBuilder {
                   AND episode.rn = 1
                 LEFT JOIN \(DataManager.podcastTableName) podcast
                   ON episode.podcast_id = podcast.id
-                WHERE episode.archived = 0
                 """
 
             switch clause {
@@ -85,7 +84,7 @@ public class PlaylistQueryBuilder {
                     """
             case .podcast:
                 let select = manualSelect(clause: clause, for: playlist)
-                queryString = "\(select) WHERE episode.archived = 0"
+                queryString = "\(select) WHERE"
             }
         } else {
             let select = select(clause: clause)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/EpisodeSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/EpisodeSearchTask.swift
@@ -11,14 +11,31 @@ public struct EpisodeSearchResult: Codable, Hashable {
     public let duration: Double?
     public let podcastUuid: String
     public let podcastTitle: String
+    public let state: State
 
-    public init(uuid: String, title: String, publishedDate: Date, duration: Double? = nil, podcastUuid: String, podcastTitle: String) {
+    public init(uuid: String, title: String, publishedDate: Date, state: State, duration: Double? = nil, podcastUuid: String, podcastTitle: String) {
         self.uuid = uuid
         self.title = title
         self.publishedDate = publishedDate
+        self.state = state
         self.duration = duration
         self.podcastUuid = podcastUuid
         self.podcastTitle = podcastTitle
+    }
+
+    public enum State: Codable {
+        case normal
+        case archived
+        case unavailable
+
+        public var isNormal: Bool {
+            switch self {
+            case .normal:
+                true
+            default:
+                false
+            }
+        }
     }
 }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -362,7 +362,9 @@ extension SyncTask {
         }
 
         addedEpisodes.forEach { episode in
-            guard DataManager.sharedManager.findEpisode(uuid: episode.uuid) == nil else { return }
+            if DataManager.sharedManager.findEpisode(uuid: episode.uuid) == nil {
+                episode.wasDeleted = true
+            }
 
             if episode.addedDate == nil {
                 episode.addedDate = Date()

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskManualPlaylistTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskManualPlaylistTests.swift
@@ -87,6 +87,10 @@ final class SyncTaskManualPlaylistTests: XCTestCase {
     }
 
     func testProcessServerDataAddsMissingEpisodesFromPlaylist() {
+        FailingURLProtocol.requestCount = 0
+        URLProtocol.registerClass(FailingURLProtocol.self)
+        defer { URLProtocol.unregisterClass(FailingURLProtocol.self) }
+
         // One existing episode, one missing
         let existing = Episode()
         existing.uuid = "exist-1"
@@ -137,5 +141,31 @@ final class SyncTaskManualPlaylistTests: XCTestCase {
         XCTAssertEqual(added?.title, "Missing from DB")
         XCTAssertEqual(added?.downloadUrl, "http://example.com/missing.mp3")
         XCTAssertEqual(added?.addedDate?.timeIntervalSince1970, 456_000)
+        XCTAssertTrue(added?.wasDeleted ?? false)
+
+        let persistedExisting = dataManager.findEpisode(uuid: existing.uuid)
+        XCTAssertNotNil(persistedExisting)
+        XCTAssertFalse(persistedExisting?.wasDeleted ?? true)
+
+        XCTAssertGreaterThanOrEqual(FailingURLProtocol.requestCount, 1)
     }
+}
+
+private final class FailingURLProtocol: URLProtocol {
+    static var requestCount = 0
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        FailingURLProtocol.requestCount += 1
+        client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+    }
+
+    override func stopLoading() {}
 }

--- a/podcasts/EpisodeCell.swift
+++ b/podcasts/EpisodeCell.swift
@@ -202,7 +202,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             bookmarkIcon.tintColor = mainTintColor
             bookmarkIcon.isHidden = !showBookmarksIcon
 
-            let hideStatus = !episode.archived && !episode.downloaded(pathFinder: DownloadManager.shared) && !episode.downloadFailed() && !uploadFailed && !episode.playbackError()
+            let hideStatus = !episode.archived && !episode.wasDeleted && !episode.downloaded(pathFinder: DownloadManager.shared) && !episode.downloadFailed() && !uploadFailed && !episode.playbackError()
             if !hideStatus {
                 let statusImage: UIImage?
                 if episode.downloadFailed() || uploadFailed || episode.playbackError() {
@@ -215,8 +215,12 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
                     if showBookmarksIcon {
                         statusImage = UIImage(named: "bookmark-icon-episode")?.tintedImage(mainTintColor ?? ThemeColor.primaryIcon02())
                         bookmarkIcon.image = UIImage(named: "list_archived")?.tintedImage(ThemeColor.primaryIcon02())
-                    } else {
+                    } else if episode.wasDeleted {
+                        statusImage = UIImage(named: "option-cross-circle")?.tintedImage(ThemeColor.primaryIcon02())
+                    } else if episode.archived {
                         statusImage = UIImage(named: "list_archived")?.tintedImage(ThemeColor.primaryIcon02())
+                    } else {
+                        statusImage = nil
                     }
                 }
                 statusIndicator.image = statusImage
@@ -242,7 +246,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
                 }
             }
 
-            if episode.played() || episode.archived {
+            if episode.played() || episode.archived || episode.wasDeleted {
                 episodeImage.alpha = EpisodeCell.playedAlpha
                 contentStackView.alpha = EpisodeCell.playedAlpha
             } else {
@@ -255,7 +259,10 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
 
         EpisodeDateHelper.setDate(episode: episode, on: dayName, tintColor: mainTintColor)
 
-        if episode.archived {
+        if episode.wasDeleted {
+            informationLabel.text = L10n.podcastUnavailable + " • " + episode.displayableInfo(includeSize: false)
+        }
+        else if episode.archived {
             informationLabel.text = L10n.podcastArchived + " • " + episode.displayableInfo(includeSize: false)
         } else if let userEpisode = episode as? UserEpisode {
             informationLabel.text = userEpisode.displayableInfo(includeSize: Settings.primaryRowAction() == .download)

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -123,7 +123,7 @@ class EpisodesDataManager {
             sortStr = "ORDER BY CASE WHEN seasonNumber < 1 THEN 9999 ELSE seasonNumber END, CASE WHEN episodeNumber < 1 THEN 9999 ELSE episodeNumber END ASC, publishedDate ASC"
         }
 
-        var whereClauses = ["podcast_id = \(podcast.id)"]
+        var whereClauses = ["podcast_id = \(podcast.id)", "wasDeleted = 0"]
         if !podcast.shouldShowArchived {
             whereClauses.append("archived = 0")
         }

--- a/podcasts/New Creation/New Preview/Rules/Episode Preview/PlaylistEpisodePreviewRowView.swift
+++ b/podcasts/New Creation/New Preview/Rules/Episode Preview/PlaylistEpisodePreviewRowView.swift
@@ -36,13 +36,25 @@ struct PlaylistEpisodePreviewRowView: View {
                     Text(episode.title ?? "")
                         .font(size: 15.0, style: .body, weight: .medium)
                         .foregroundStyle(theme.primaryText01)
-                    Text(episode.displayableTimeLeft())
-                        .font(size: 12.0, style: .body, weight: .semibold)
-                        .foregroundStyle(theme.primaryText02)
+                    HStack(spacing: 4) {
+                        if episode.wasDeleted {
+                            Image("option-cross-circle")
+                            Text(L10n.podcastUnavailable)
+                            Text("•")
+                        } else if episode.archived {
+                            Image("list_archived")
+                            Text(L10n.podcastArchived)
+                            Text("•")
+                        }
+                        Text(episode.displayableTimeLeft())
+                    }
+                    .font(size: 12.0, style: .body, weight: .semibold)
+                    .foregroundStyle(theme.primaryText02)
                 }
                 Spacer()
             }
         }
+        .opacity(episode.played() || episode.archived || episode.wasDeleted ? 0.5 : 1.0)
     }
 }
 

--- a/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
@@ -391,8 +391,9 @@ extension EpisodeSearchResult {
         let publishedDate = episode.publishedDate ?? episode.addedDate ?? Date()
         let duration = episode.duration > 0 ? episode.duration : nil
         let podcastTitle = episode.parentPodcast(dataManager: dataManager)?.title ?? ""
+        let state: EpisodeSearchResult.State = episode.wasDeleted ? .unavailable : episode.archived ? .archived : .normal
 
-        self.init(uuid: episode.uuid, title: episode.displayableTitle(), publishedDate: publishedDate, duration: duration, podcastUuid: episode.podcastUuid, podcastTitle: podcastTitle)
+        self.init(uuid: episode.uuid, title: episode.displayableTitle(), publishedDate: publishedDate, state: state, duration: duration, podcastUuid: episode.podcastUuid, podcastTitle: podcastTitle)
     }
 
     init(listEpisode: ListEpisode, dataManager: DataManager = DataManager.sharedManager) {

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -57,10 +57,24 @@ struct SearchResultCell: View {
                                 .font(style: .subheadline, weight: .medium)
                                 .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
                                 .lineLimit(2)
-                            Text(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0)))
-                                .font(style: .caption, weight: .semibold)
-                                .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
-                                .lineLimit(1)
+                            HStack(spacing: 4) {
+                                switch episode.state {
+                                case .normal:
+                                    EmptyView()
+                                case .archived:
+                                    Image("list_archived")
+                                    Text(L10n.podcastArchived)
+                                    Text("•")
+                                case .unavailable:
+                                    Image(systemName: "option-cross-circle")
+                                    Text(L10n.podcastUnavailable)
+                                    Text("•")
+                                }
+                                Text(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0)))
+                            }
+                            .font(style: .caption, weight: .semibold)
+                            .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
+                            .lineLimit(1)
                         } else if let result = model.podcastFolder {
                             Text(result.titleToDisplay)
                                 .font(style: .subheadline, weight: .medium)
@@ -98,7 +112,7 @@ struct SearchResultCell: View {
                         SubscribeButtonView(podcastUuid: result.uuid, source: searchAnalyticsHelper.source)
                     }
                 }
-                .opacity(played ? 0.5 : 1.0)
+                .opacity(played || model.episode?.state.isNormal == false ? 0.5 : 1.0)
                 if showDivider {
                     ThemedDivider()
                 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2750,6 +2750,8 @@ internal enum L10n {
   internal static var podcastTomorrow: String { return L10n.tr("Localizable", "podcast_tomorrow", fallback: "Tomorrow") }
   /// Prompt to unarchive all of the selected items.
   internal static var podcastUnarchiveAll: String { return L10n.tr("Localizable", "podcast_unarchive_all", fallback: "Unarchive All") }
+  /// Indicates that the episode is unavailable server side.
+  internal static var podcastUnavailable: String { return L10n.tr("Localizable", "podcast_unavailable", fallback: "Unavailable") }
   /// Indicates that the updates to the podcast has ended on the specified date. '%1$@' is a placeholder for date that the updates ended.
   internal static func podcastUpdatesEnded(_ p1: Any) -> String {
     return L10n.tr("Localizable", "podcast_updates_ended", String(describing: p1), fallback: "Updates ended: %1$@")

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1821,6 +1821,9 @@
 /* Indicates that the episode has been archived. */
 "podcast_archived" = "Archived";
 
+/* Indicates that the episode is unavailable server side. */
+"podcast_unavailable" = "Unavailable";
+
 /* Label used to display the number or archived episodes in a podcast. '%1$@' is a placeholder for the archived episode number. */
 "podcast_archived_count_format" = "%1$@ archived";
 


### PR DESCRIPTION
Fixes [PCIOS-122](https://linear.app/a8c/issue/PCIOS-122/handle-unavailable-episodes-in-manual-playlist)

## To test

### Local episodes
* Add episodes to a manual playlist
* Manually edit the database to set `wasDeleted` on an episode added to a playlist to `1`.
* ✅ Ensure the episode remains visible in the playlist screen with "Unavailable" treatment

### Synced Unavailable


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
