### PR TITLE
Podcast Bookmarks tab fixes

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1750,6 +1750,7 @@
 		F536B45B2DEA02830051A929 /* PCHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6B432B27561EA8005E4017 /* PCHostingController.swift */; };
 		F53C3E832CC73549004F3581 /* TopSpotStory2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53C3E822CC73538004F3581 /* TopSpotStory2024.swift */; };
 		F53DDB682DD508CA00A1E890 /* HostingConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53DDB672DD508CA00A1E890 /* HostingConfiguration.swift */; };
+		F53E13622E97018700B11BB0 /* HairlineSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53E13612E97018700B11BB0 /* HairlineSeparator.swift */; };
 		F53EFEE82CD405DA00F4561B /* YearOverYearCompareTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53EFEE72CD405DA00F4561B /* YearOverYearCompareTests.swift */; };
 		F53EFEEA2CD42AE400F4561B /* Ratings2024Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53EFEE92CD42ADF00F4561B /* Ratings2024Story.swift */; };
 		F543F6A42C0804FA00FEC8B6 /* AnyPublisher+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */; };
@@ -4036,6 +4037,7 @@
 		F53481C52E21C07B00E80253 /* UserSatisfactionSurveyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSatisfactionSurveyManager.swift; sourceTree = "<group>"; };
 		F53C3E822CC73538004F3581 /* TopSpotStory2024.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopSpotStory2024.swift; sourceTree = "<group>"; };
 		F53DDB672DD508CA00A1E890 /* HostingConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostingConfiguration.swift; sourceTree = "<group>"; };
+		F53E13612E97018700B11BB0 /* HairlineSeparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HairlineSeparator.swift; sourceTree = "<group>"; };
 		F53EFEE72CD405DA00F4561B /* YearOverYearCompareTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YearOverYearCompareTests.swift; sourceTree = "<group>"; };
 		F53EFEE92CD42ADF00F4561B /* Ratings2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ratings2024Story.swift; sourceTree = "<group>"; };
 		F543F6A32C0804FA00FEC8B6 /* AnyPublisher+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnyPublisher+Async.swift"; sourceTree = "<group>"; };
@@ -8479,6 +8481,7 @@
 		C7E99F022A5E0F9600E7CBAF /* Common SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				F53E13612E97018700B11BB0 /* HairlineSeparator.swift */,
 				F5E63CAD2DEA0660000B9EBD /* NonEditableTextView.swift */,
 				F5A292152DE95F8C00C49AC4 /* BannerAdView.swift */,
 				F59F08122DF289C400668EA7 /* BannerAdReporter.swift */,
@@ -10990,6 +10993,7 @@
 				BD60A0781FBEA53900008ACA /* MainEpisodeActionView.swift in Sources */,
 				BDF63D2522BCB1370037AA4A /* MainTabBarController+shortcuts.swift in Sources */,
 				BD8139D21FB95C3900DBF0EC /* ProfileViewController.swift in Sources */,
+				F53E13622E97018700B11BB0 /* HairlineSeparator.swift in Sources */,
 				BD7114BF20E224BF003DF634 /* AutoArchiveViewController.swift in Sources */,
 				C7D6551428E5153200AD7174 /* Debounce.swift in Sources */,
 				FFBDF6FC2E5679E900A969B3 /* InterestButton.swift in Sources */,

--- a/podcasts/Bookmarks/List/BookmarkRow.swift
+++ b/podcasts/Bookmarks/List/BookmarkRow.swift
@@ -22,7 +22,7 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
     var body: some View {
         let selected = viewModel.isSelected(bookmark)
         MultiSelectRow(showSelectButton: viewModel.isMultiSelecting, selected: selected) {
-            HStack(spacing: RowConstants.padding) {
+            HStack(spacing: RowConstants.spacing) {
                 imageView
                 detailsView
                 playButtonView
@@ -33,7 +33,8 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
             }
         }
         .selectButtonStyle(tintColor: style.selectButton, checkColor: style.selectCheck, strokeColor: style.selectButtonStroke)
-        .padding(RowConstants.padding)
+        .padding(.horizontal, RowConstants.horizontalPadding)
+        .padding(.vertical, RowConstants.verticalPadding)
         .animation(.default, value: viewModel.isMultiSelecting)
 
         // Display a highlight when tapped, or the row is selected
@@ -118,7 +119,7 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
                     .renderingMode(.template)
             }
             .foregroundStyle(style.playButtonText)
-            .padding(.horizontal, RowConstants.padding)
+            .padding(.horizontal, RowConstants.horizontalPadding)
             .padding(.vertical, RowConstants.playButtonVerticalPadding)
             .background(style.playButtonBackground)
             .cornerRadius(.infinity) // Always rounded
@@ -134,6 +135,8 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
 }
 
 private enum RowConstants {
-    static let padding = 16.0
+    static let horizontalPadding = 16.0
+    static let spacing = 12.0
+    static let verticalPadding = 12.0
     static let playButtonVerticalPadding = 8.0
 }

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -68,12 +68,25 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            let searchTheme = PodcastSearchTheme()
             // Optional search bar shown when flagged and either searching or there are items
             if showSearchField, viewModel.isSearching || viewModel.numberOfItems > 0 {
-                SearchField(theme: PodcastSearchTheme(), text: $viewModel.searchText)
-                    .disabled(viewModel.isMultiSelecting)
-                    .padding(.horizontal, BookmarkListConstants.padding)
-                    .padding(.bottom, BookmarkListConstants.headerPadding)
+                HStack(spacing: BookmarkListConstants.padding) {
+                    SearchField(theme: searchTheme,
+                                text: $viewModel.searchText,
+                                showsCancelButton: false,
+                                placeholder: L10n.searchBookmarks)
+                        .disabled(viewModel.isMultiSelecting)
+                    Button(action: {
+                        viewModel.showMoreOptions()
+                    }) {
+                        Image("podcast-more-options")
+                            .padding(.trailing, 1) // Needed to nudge this over to match exactly. Not sure why.
+                    }
+                    .foregroundStyle(searchTheme.icon)
+                }
+                .padding(.horizontal, BookmarkListConstants.padding)
+                .padding(.bottom, BookmarkListConstants.searchFieldBottomPadding)
             }
 
             if !feature.isUnlocked || viewModel.bookmarks.isEmpty {
@@ -115,6 +128,10 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
     @ViewBuilder
     private var listView: some View {
         if showHeader {
+            if showSearchField {
+                divider
+                    .padding(.bottom, BookmarkListConstants.headerPadding)
+            }
             headerView
             divider
         }
@@ -144,7 +161,7 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
 
                 Spacer()
 
-                if showMoreInHeader {
+                if showMoreInHeader && !showSearchField {
                     Image("more").foregroundStyle(style.primaryText).buttonize {
                         viewModel.showMoreOptions()
                     }
@@ -248,7 +265,7 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
     /// Styled divider view
     @ViewBuilder
     private var divider: some View {
-        Divider().background(style.divider)
+        HairlineSeparator(color: style.divider)
     }
 }
 
@@ -281,9 +298,10 @@ struct BookmarkListMultiSelectHeaderView<HeaderStyle: BookmarksStyle>: View {
 enum BookmarkListConstants {
     static let shadowHeight = 20.0
     static let padding = 16.0
-    static let headerPadding = 12.0
+    static let headerPadding = 18.0
     static let headerTransitionOffset = 10.0
     static let multiSelectionBottomPadding = 70.0
+    static let searchFieldBottomPadding = 10.0
 }
 
 // Represents the current desired state for an externally presented action bar

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -89,6 +89,7 @@ struct CategoriesPillsView: View {
 
     fileprivate enum Constants {
         static let buttonInsets: EdgeInsets = EdgeInsets(top: 2, leading: 16, bottom: 16, trailing: 16)
+        static let selectedButtonInsets: EdgeInsets = EdgeInsets(top: 2, leading: 16, bottom: 0, trailing: 16)
     }
 
     var body: some View {
@@ -99,7 +100,7 @@ struct CategoriesPillsView: View {
                 CategoryButton(category: selectedCategory, selectedCategory: $selectedCategory, model: .init(region: region, index: 0, isSponsored: selectedCategoryItem?.isSponsored ?? false, visits: selectedCategoryItem?.visits ?? 0))
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(Constants.buttonInsets)
+            .padding(Constants.selectedButtonInsets)
         } else {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {

--- a/podcasts/Common SwiftUI/HairlineSeparator.swift
+++ b/podcasts/Common SwiftUI/HairlineSeparator.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+/// A separator which is drawn as 1 physical pixel. This mirrors the separator used in UITableView
+struct HairlineSeparator: View {
+    var color: Color = Color(UIColor.separator)
+
+    @Environment(\.displayScale) private var scale
+
+    var body: some View {
+        Rectangle()
+            .fill(color)
+            .frame(height: 1 / scale)          // 1 physical pixel
+            .allowsHitTesting(false)
+    }
+}

--- a/podcasts/EpisodeListSearchController.swift
+++ b/podcasts/EpisodeListSearchController.swift
@@ -87,7 +87,7 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
         searchTextField.backgroundColor = UIColor.clear
         searchTextField.textColor = ThemeColor.primaryText02()
-        searchTextField.attributedPlaceholder = NSAttributedString(string: L10n.search, attributes: [NSAttributedString.Key.foregroundColor: ThemeColor.primaryText02()])
+        searchTextField.attributedPlaceholder = NSAttributedString(string: L10n.searchEpisodes, attributes: [NSAttributedString.Key.foregroundColor: ThemeColor.primaryText02()])
         searchTextField.keyboardAppearance = AppTheme.keyboardAppearance()
         roundedBackgroundView.backgroundColor = ThemeColor.primaryField01()
         searchIcon.tintColor = ThemeColor.primaryIcon02()

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -344,6 +344,10 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         super.scrollViewDidScroll(scrollView)
+
+        if scrollView.isDragging || scrollView.isDecelerating {
+            dismissKeyboardForScrollIfNeeded()
+        }
         if FeatureFlag.podcastFeedUpdate.enabled {
             refreshControl?.scrollViewDidScroll(scrollView)
         }
@@ -529,7 +533,12 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        dismissKeyboardForScrollIfNeeded()
+    }
+
+    private func dismissKeyboardForScrollIfNeeded() {
         searchController?.hideKeyboard()
+        view.endEditing(true)
     }
 
     @objc private func searchRequested() {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3030,6 +3030,10 @@ internal enum L10n {
   internal static var saveBookmark: String { return L10n.tr("Localizable", "save_bookmark", fallback: "Save Bookmark") }
   /// A common string used throughout the app. Placeholder text used in search boxes.
   internal static var search: String { return L10n.tr("Localizable", "search", fallback: "Search") }
+  /// A placeholder used when searching bookmarks.
+  internal static var searchBookmarks: String { return L10n.tr("Localizable", "search_bookmarks", fallback: "Search bookmarks") }
+  /// A placeholder used when searchng episodes.
+  internal static var searchEpisodes: String { return L10n.tr("Localizable", "search_episodes", fallback: "Search episodes") }
   /// The label of the search button in Discover. Explaining the user can search or directly add a RSS URL.
   internal static var searchLabel: String { return L10n.tr("Localizable", "search_label", fallback: "Search podcasts or add RSS URL") }
   /// A common string used throughout the app when searching podcasts. Placeholder text used in search boxes.

--- a/podcasts/SwiftUI/SearchField.swift
+++ b/podcasts/SwiftUI/SearchField.swift
@@ -48,8 +48,8 @@ struct SearchField: View {
     var body: some View {
         // We use 2 stacks here to have the cancel button appear outside the background
         HStack {
-            HStack(spacing: SearchFieldConstants.padding) {
-                Image("search")
+            HStack(spacing: SearchFieldConstants.horizontalPadding) {
+                Image("custom_search")
                     .renderingMode(.template)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
@@ -61,7 +61,7 @@ struct SearchField: View {
                 TextField(placeholder, text: $text, prompt: prompt)
                     .foregroundColor(theme.text)
                     .focused($isFocused)
-                    .padding(.vertical, SearchFieldConstants.padding)
+                    .padding(.vertical, SearchFieldConstants.verticalPadding)
 
                 if !text.isEmpty {
                     Image("search_cancel")
@@ -71,9 +71,9 @@ struct SearchField: View {
                         }
                 }
             }
-            .padding(.horizontal, SearchFieldConstants.padding)
+            .padding(.horizontal, SearchFieldConstants.horizontalPadding)
             .background(theme.background)
-            .cornerRadius(SearchFieldConstants.cornerRadius)
+            .clipShape(RoundedRectangle(cornerSize: CGSize(width: SearchFieldConstants.cornerRadius, height: SearchFieldConstants.cornerRadius), style: .continuous))
             .font(size: 15, style: .body)
 
             // Show the cancel button
@@ -134,7 +134,8 @@ struct SearchField: View {
 }
 
 private enum SearchFieldConstants {
-    static let padding = 8.0
+    static let horizontalPadding = 10.0
+    static let verticalPadding = 8.0
     static let cornerRadius = 8.0
 }
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2185,6 +2185,12 @@
 /* A common string used throughout the app when searching podcasts. Placeholder text used in search boxes. */
 "search_podcasts" = "Search Podcasts";
 
+/* A placeholder used when searchng episodes. */
+"search_episodes" = "Search episodes";
+
+/* A placeholder used when searching bookmarks. */
+"search_bookmarks" = "Search bookmarks";
+
 /* A common string used throughout the app. Refers to the season a podcast episode is in. */
 "season" = "Season";
 


### PR DESCRIPTION
Fixes [PCIOS-195](https://linear.app/a8c/issue/PCIOS-195/more-closely-match-the-episodes-and-bookmarks-tab-on-the-podcast)

* Search text fields padding and icon
* Placeholder match Android with "Search episodes" and "Search bookmarks" placeholders
* The "More" button matches the position of the Episodes tab
* Dividers match up in the header view
* Dismisses the keyboard when scrolling

![Simulator Screen Recording - iPhone 16 Pro - 2025-10-08 at 14 48 29](https://github.com/user-attachments/assets/de7e370a-3ca6-41f6-beb3-e4188fda310d)

## To test

* Visit a Podcast with Bookmarks
* Toggle between the Episodes and Bookmarks tabs
* ✅ Verify that the styling of the search bar and dividers match between the two tabs
* ✅ Verify that tapping the More button next to the search bar opens the bottom picker
* ✅ Verify that the bottom picker actions work as expected
* Search the Bookmarks
* Scroll the bookmarks list while editing the search field
* ✅ Verify the keyboard is dismissed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
