### PR TITLE
Set the tableview to separator style none

### DIFF
--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -133,6 +133,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             episodesTable.estimatedRowHeight = 80.0
             episodesTable.allowsMultipleSelectionDuringEditing = true
             episodesTable.sectionHeaderTopPadding = 0
+            episodesTable.separatorStyle = .none
         }
     }
 


### PR DESCRIPTION
Fixes PCIOS-194

Fixes #3561


Removing the separator style should fix the separator appeared in beta iOS 26.1.

| Before | Before | After | After|
| :-------: | :-------: | :-------: | :-------: |
| <img width="585" height="1266" alt="IMG_0009" src="https://github.com/user-attachments/assets/ca5c3dc5-e03f-4620-89e2-a2ce5daa831c" /> | <img width="585" height="1266" alt="IMG_0010" src="https://github.com/user-attachments/assets/b3f6991c-0a2a-42e0-aac5-3041e00bc734" /> | <img width="585" height="1266" alt="IMG_0008" src="https://github.com/user-attachments/assets/c8af99b8-6e93-4d23-bb5b-9caa137905c1" /> | <img width="585" height="1266" alt="IMG_0011" src="https://github.com/user-attachments/assets/70123cf1-e265-4d44-812e-e72053e77668" /> |

## To test

### iOS 26 beta
• Run the test on a device with beta iOS 26.1
• Make sure the OS appearance has Dark mode off
• Run trunk
• Go to discover and visit a podcast like https://pca.st/podcast/9f13dd00-4e97-013e-a243-025eceac941b
• You should see both top and tabs separators
• Run this branch over and navigate to the same podcast
• Confirm the separators disappeared
• Confirm all other cell separators are still there and visible

### iOS 26 prod and lower versions
• Run this branch on a device with iOS 26  prod and previous version
• Confirm those separators are not visible
• Confirm all other cell separators are still there and visible

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
