### PR TITLE
[Tooling] Use Release Version from ReleasesV2 in Code Freeze

### DIFF
--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -19,7 +19,7 @@ steps:
       bundle exec fastlane run configure_apply
 
       echo '--- ❄️ Code Freeze'
-      bundle exec fastlane code_freeze skip_confirm:true
+      bundle exec fastlane code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     plugins: [$CI_TOOLKIT]
     agents:
       queue: "mac"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -287,26 +287,30 @@ platform :ios do
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # Validate provided version matches the calculated version
-    expected_version = release_version_next
-    if version && version != expected_version
-      UI.user_error!("Version mismatch: Provided version '#{version}' does not match calculated version '#{expected_version}'. Please check the release scenario version matches the project version.")
+    # Use provided version from release tool, or fall back to calculated version
+    calculated_version = release_version_next
+    release_version = version || calculated_version
+
+    # Warn if provided version differs from calculated version
+    if version && version != calculated_version
+      warning_message = "⚠️ Version mismatch: Release tool version is '#{version}' but calculated version is '#{calculated_version}'. Using '#{version}' from release tool."
+      UI.important(warning_message)
+      buildkite_annotate(style: 'warning', context: 'code-freeze-version-mismatch', message: warning_message) if is_ci
     end
-    UI.success("✓ Version validation passed: Version (#{version || expected_version}) matches calculated version") if version
 
     message = <<-MESSAGE
 
       Code Freeze:
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New release version and build code: #{expected_version} (#{build_code_code_freeze}).
-      • New release/ branch from #{DEFAULT_BRANCH} will be: release/#{expected_version}
+      • New release version and build code: #{release_version} (#{build_code_code_freeze}).
+      • New release/ branch from #{DEFAULT_BRANCH} will be: release/#{release_version}
     MESSAGE
     UI.important(message)
     UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Create the release branch
     UI.message 'Creating release branch...'
-    Fastlane::Helper::GitHelper.create_branch("release/#{release_version_next}", from: DEFAULT_BRANCH)
+    Fastlane::Helper::GitHelper.create_branch("release/#{release_version}", from: DEFAULT_BRANCH)
     UI.success "Done! New release branch is: #{git_branch}"
 
     # Bump the release version and build code and write it to the `xcconfig` file

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -279,7 +279,7 @@ platform :ios do
   #
   # @param skip_confirm [Boolean] If true, avoids any interactive prompt (default: false)
   #
-  lane :code_freeze do |skip_confirm: false|
+  lane :code_freeze do |version: nil, skip_confirm: false|
     require_env_vars!('GITHUB_TOKEN')
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean
@@ -287,12 +287,19 @@ platform :ios do
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
+    # Validate provided version matches the calculated version
+    expected_version = release_version_next
+    if version && version != expected_version
+      UI.user_error!("Version mismatch: Provided version '#{version}' does not match calculated version '#{expected_version}'. Please check the release scenario version matches the project version.")
+    end
+    UI.success("✓ Version validation passed: Version (#{version || expected_version}) matches calculated version") if version
+
     message = <<-MESSAGE
 
       Code Freeze:
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New release version and build code: #{release_version_next} (#{build_code_code_freeze}).
-      • New release/ branch from #{DEFAULT_BRANCH} will be: release/#{release_version_next}
+      • New release version and build code: #{expected_version} (#{build_code_code_freeze}).
+      • New release/ branch from #{DEFAULT_BRANCH} will be: release/#{expected_version}
     MESSAGE
     UI.important(message)
     UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -277,7 +277,8 @@ platform :ios do
   # - Enables the GitHub branch protection for the new branch
   # - Move all still-opened PRs targeting current milestone to the next one and Freezes the GitHub milestone
   #
-  # @param skip_confirm [Boolean] If true, avoids any interactive prompt (default: false)
+  # @param [String] version (optional) The version number for the release from the release tool. If not provided, uses the calculated version.
+  # @param [Boolean] skip_confirm If true, avoids any interactive prompt (default: false)
   #
   lane :code_freeze do |version: nil, skip_confirm: false|
     require_env_vars!('GITHUB_TOKEN')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -277,7 +277,8 @@ platform :ios do
   # - Enables the GitHub branch protection for the new branch
   # - Move all still-opened PRs targeting current milestone to the next one and Freezes the GitHub milestone
   #
-  # @param [String] version (optional) The version number for the release from the release tool. If not provided, uses the calculated version.
+  # @param [String] version (optional) The version to use for the new release version to code freeze for.
+  #                 Typically auto-provided by ReleasesV2. If nil, computes the new version based on current one.
   # @param [Boolean] skip_confirm If true, avoids any interactive prompt (default: false)
   #
   lane :code_freeze do |version: nil, skip_confirm: false|
@@ -288,13 +289,17 @@ platform :ios do
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # Use provided version from release tool, or fall back to calculated version
-    calculated_version = release_version_next
-    release_version = version || calculated_version
+    # Use provided version from release tool, or fall back to computed version
+    computed_version = release_version_next
+    new_version = version || computed_version
 
-    # Warn if provided version differs from calculated version
-    if version && version != calculated_version
-      warning_message = "⚠️ Version mismatch: Release tool version is '#{version}' but calculated version is '#{calculated_version}'. Using '#{version}' from release tool."
+    # Warn if provided version differs from computed version
+    if version && version != computed_version
+      warning_message = <<~WARNING
+        ⚠️ Version mismatch: The explicitly-provided version was '#{version}' while new computed version would have been '#{computed_version}'.
+        If this is unexpected, you might want to investigate the discrepency.
+        Continuing with the explicitly-provided verison '#{version}'.
+      WARNING
       UI.important(warning_message)
       buildkite_annotate(style: 'warning', context: 'code-freeze-version-mismatch', message: warning_message) if is_ci
     end
@@ -303,15 +308,15 @@ platform :ios do
 
       Code Freeze:
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New release version and build code: #{release_version} (#{build_code_code_freeze}).
-      • New release/ branch from #{DEFAULT_BRANCH} will be: release/#{release_version}
+      • New release version and build code: #{new_version} (#{build_code_code_freeze}).
+      • New release/ branch from #{DEFAULT_BRANCH} will be: release/#{new_version}
     MESSAGE
     UI.important(message)
     UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Create the release branch
     UI.message 'Creating release branch...'
-    Fastlane::Helper::GitHelper.create_branch("release/#{release_version}", from: DEFAULT_BRANCH)
+    Fastlane::Helper::GitHelper.create_branch("release/#{new_version}", from: DEFAULT_BRANCH)
     UI.success "Done! New release branch is: #{git_branch}"
 
     # Bump the release version and build code and write it to the `xcconfig` file


### PR DESCRIPTION
Closes [AINFRA-1374: PCiOS: Validate that release version sent by ReleasesV2 matches the project](https://linear.app/a8c/issue/AINFRA-1374/pcios-validate-that-release-version-sent-by-releasesv2-matches-the)

## Description

This PR updates the code freeze process to use the release version provided by ReleasesV2 as the source of truth.

The code freeze Buildkite pipeline now passes the `RELEASE_VERSION` environment variable to the `code_freeze` Fastlane lane.
If there's a mismatch between the passed version and the project calculated version, a warning is displayed to help identify configuration discrepancies, but the ReleasesV2 version is always used.

## Testing

The code freeze lane has several side effects like potentially changing the version in the main branch, creating a release branch, updating release notes, etc, making it hard to easily test it. We can run a couple of tests locally commenting out parts of the lane, but they'll only test a minor part of the lane.
The changes will then be fully tested in the next release cycle during code freeze.