### PR TITLE
Add Generated Transcripts to feature upgrade list

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -353,9 +353,9 @@ public enum FeatureFlag: String, CaseIterable {
         case .episodeDetailTranscript:
             true
         case .bannerAdPodcasts:
-            true
+            false
         case .bannerAdPlayer:
-            true
+            false
         case .streamingCustomSessionConfiguration:
             true
         case .guestListsNetworkHighlightsRedesign:

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountUpgradePrompt.swift
@@ -116,6 +116,7 @@ struct PlusAccountUpgradePrompt: View {
     private let productFeatures: [IAPProductID: [Feature]] = [
         .yearly: ([
             (FeatureFlag.bannerAdPodcasts.enabled || FeatureFlag.bannerAdPlayer.enabled) ? .init(iconName: "unsubscribe", title: L10n.plusMarketingNoBannerAds) : nil,
+            (FeatureFlag.generatedTranscripts.enabled) ? .init(iconName: "transcript", title: L10n.plusMarketingGeneratedTranscripts) : nil,
             .init(iconName: "plus-feature-folders", title: L10n.plusMarketingFoldersTitle),
             .init(iconName: "plus-feature-up-next-shuffle", title: L10n.plusMarketingUpNextShuffle),
             .init(iconName: "plus-feature-bookmarks", title: L10n.plusMarketingBookmarksTitle),

--- a/podcasts/Onboarding/Plus/UpgradeTier.swift
+++ b/podcasts/Onboarding/Plus/UpgradeTier.swift
@@ -42,6 +42,7 @@ extension UpgradeTier {
         if FeatureFlag.newOnboardingUpgrade.enabled {
             return [
                 bannerAdsFeature,
+                generatedTranscriptsFeature,
                 foldersFeature,
                 upNextShuffleFeature,
                 bookmarksFeature,
@@ -55,6 +56,7 @@ extension UpgradeTier {
         else {
             return [
                 bannerAdsFeature,
+                generatedTranscriptsFeature,
                 foldersFeature,
                 upNextShuffleFeature,
                 bookmarksFeature,
@@ -71,6 +73,7 @@ extension UpgradeTier {
         if FeatureFlag.newOnboardingUpgrade.enabled {
             return [
                 bannerAdsFeature,
+                generatedTranscriptsFeature,
                 foldersFeature,
                 upNextShuffleFeature,
                 bookmarksFeature,
@@ -85,6 +88,7 @@ extension UpgradeTier {
         else {
             return [
                 bannerAdsFeature,
+                generatedTranscriptsFeature,
                 foldersFeature,
                 upNextShuffleFeature,
                 bookmarksFeature,
@@ -112,6 +116,10 @@ extension UpgradeTier {
 
     static var bannerAdsFeature: UpgradeTier.TierFeature? {
         (FeatureFlag.bannerAdPodcasts.enabled || FeatureFlag.bannerAdPlayer.enabled) ? .init(iconName: "unsubscribe", title: L10n.plusMarketingNoBannerAds) : nil
+    }
+
+    static var generatedTranscriptsFeature: UpgradeTier.TierFeature? {
+        (FeatureFlag.generatedTranscripts.enabled) ? .init(iconName: "transcript", title: L10n.plusMarketingGeneratedTranscripts) : nil
     }
 
     static var foldersFeature: UpgradeTier.TierFeature {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2454,6 +2454,8 @@ internal enum L10n {
   internal static var plusMarketingFoldersDescription: String { return L10n.tr("Localizable", "plus_marketing_folders_description", fallback: "Create folders to organise your podcast collection.") }
   /// Pocket Casts Plus marketing page, title of the Folders feature
   internal static var plusMarketingFoldersTitle: String { return L10n.tr("Localizable", "plus_marketing_folders_title", fallback: "Folders") }
+  /// Pocket Casts Plus marketing page, description of generated transcriptsg
+  internal static var plusMarketingGeneratedTranscripts: String { return L10n.tr("Localizable", "plus_marketing_generated_transcripts", fallback: "Generated Transcripts") }
   /// Pocket Casts Plus marketing page, description of the hide ads feature
   internal static var plusMarketingHideAdsDescription: String { return L10n.tr("Localizable", "plus_marketing_hide_ads_description", fallback: "Ad-free experience which gives you more of what you love and less of what you don't") }
   /// Pocket Casts Plus marketing page, title of the hide ads feature

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1639,6 +1639,9 @@
 /* Message displayed when teh user tap "Pocket Casts Champion" button */
 "plus_champion_message" = "Thanks for being with Pocket Casts from the start. You're a real champion!";
 
+/* Pocket Casts Plus marketing page, description of generated transcriptsg */
+"plus_marketing_generated_transcripts" = "Generated Transcripts";
+
 /* Pocket Casts Plus marketing page, description of removing banner ads */
 "plus_marketing_no_banner_ads" = "No Banner Ads";
 


### PR DESCRIPTION
Fixes [PCIOS-198](https://linear.app/a8c/issue/PCIOS-198/add-generated-transcripts-to-upgrade-screen)

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-09 at 14 22 03" src="https://github.com/user-attachments/assets/9a861c4d-b49c-4c06-b6b5-0777ea222573" />

## To test

* Navigate to Profile > Settings > Pocket Casts Plus
* ✅ Verify that “Generated Transcripts” appears at the top.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
