### PR TITLE
[Search Improvements] Enable predictive search FF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 7.100
 -----
 - Keep Downloaded or Up Next episodes when unsubscribing from a podcast [#3538](https://github.com/Automattic/pocket-casts-ios/pull/3538)
+- Enable improved type-ahead search predictions.[#3568](https://github.com/Automattic/pocket-casts-ios/pull/3568)
 
 7.99
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -400,7 +400,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .searchImprovements:
             false
         case .searchPredictive:
-            false
+            true
         case .podcastBookmarksInline:
             true
         case .earlyReloadSubscriptionStatus:


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This  PR enables predictive search as you type on the Podcasts search

## To test

- Start the app
- Tap on the search bar on the Discovery tab
- Tap at least three characters
- Without pressing Enter see if search results appear

## Checklist

- [X] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [X] I have considered adding unit tests for my changes.
- [X] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
