### PR TITLE
Add a button to the Debug Menu to reset overridden feature flags

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlagOverrideStore.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlagOverrideStore.swift
@@ -12,13 +12,14 @@ public protocol OverrideableFlag: CustomStringConvertible {
 ///
 public struct FeatureFlagOverrideStore {
     private let store: UserDefaults
+    private let overrideKeyPrefix = "ff-override-"
 
     public init(store: UserDefaults = UserDefaults.standard) {
         self.store = store
     }
 
     private func key(for flag: OverrideableFlag) -> String {
-        return "ff-override-\(String(describing: flag))"
+        return "\(overrideKeyPrefix)\(String(describing: flag))"
     }
 
     /// - returns: True if the specified feature flag is overridden
@@ -54,6 +55,13 @@ public struct FeatureFlagOverrideStore {
         }
 
         return value
+    }
+
+    /// Clears all stored overrides for feature flags.
+    public func resetOverrides() {
+        for key in store.dictionaryRepresentation().keys where key.hasPrefix(overrideKeyPrefix) {
+            store.removeObject(forKey: key)
+        }
     }
 }
 

--- a/podcasts/Beta/BetaMenu.swift
+++ b/podcasts/Beta/BetaMenu.swift
@@ -3,6 +3,7 @@ import PocketCastsUtils
 
 struct BetaMenu: View {
     @State private var searchText = ""
+    @State private var resetTrigger = false
 
     var body: some View {
         List {
@@ -27,9 +28,17 @@ struct BetaMenu: View {
                 }
             }
         }
+        .id(resetTrigger)
         .listStyle(.plain)
         .searchable(text: $searchText, prompt: L10n.search)
         .miniPlayerSafeAreaInset()
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Reset") {
+                    resetOverrides()
+                }
+            }
+        }
     }
 
     private var filteredFeatures: [FeatureFlag] {
@@ -40,6 +49,12 @@ struct BetaMenu: View {
                 String(describing: feature).localizedCaseInsensitiveContains(searchText)
             }
         }
+    }
+
+    private func resetOverrides() {
+        FeatureFlagOverrideStore().resetOverrides()
+        resetTrigger.toggle()
+        Toast.show("Feature flag overrides reset")
     }
 }
 


### PR DESCRIPTION
This adds a new "Reset" button to the Beta Features list that resets all overridden feature flags.

https://github.com/user-attachments/assets/62581aa4-9a96-4084-9dc3-6ea4de2571da


## To test

* Open Profile > Settings > Beta Features
* Change some flags from their defaults
* Hit the Reset button
* ✅ Verify that the flags are reset

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
