### PR TITLE
Hotfix: Remove raw playlist type

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
@@ -100,7 +100,7 @@ class PlaylistDataManager {
     }
 
     func allSmartPlaylists(includeDeleted: Bool, dbQueue: PCDBQueue) -> [EpisodeFilter] {
-        let query = includeDeleted ? "SELECT * from \(DataManager.playlistsTableName) WHERE manual = 0 AND rawPlaylistType = 0 ORDER BY sortPosition ASC" : "SELECT * from \(DataManager.playlistsTableName) WHERE manual = 0 AND wasDeleted = 0 AND rawPlaylistType = 0 ORDER BY sortPosition ASC"
+        let query = includeDeleted ? "SELECT * from \(DataManager.playlistsTableName) WHERE manual = 0 ORDER BY sortPosition ASC" : "SELECT * from \(DataManager.playlistsTableName) WHERE manual = 0 AND wasDeleted = 0 ORDER BY sortPosition ASC"
         return allPlaylists(query: query, values: nil, dbQueue: dbQueue)
     }
 


### PR DESCRIPTION
Fixes [PCIOS-204](https://linear.app/a8c/issue/PCIOS-204/podcast-setting-filter-option-query-is-broken-in-799)

The `rawPlaylistType` column was added to differentiate different types of playlists.
It was removed in favor of a `manual` column.
The column still exists in some outdated queries.

## To test

* Open the Podcast page
* Navigate to Settings
* Tap the Filters settings option
* Ensure all filters are listed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
