### PR TITLE
[Playlists] Swipe left to remove an episode from Manual Playlist

### DIFF
--- a/podcasts/DownloadsViewController+Swipe.swift
+++ b/podcasts/DownloadsViewController+Swipe.swift
@@ -70,4 +70,6 @@ extension DownloadsViewController: SwipeTableViewCellDelegate, SwipeHandler {
             ]
         )
     }
+
+    func removeFromManualPlaylist(episode: PocketCastsDataModel.Episode, at: IndexPath) { }
 }

--- a/podcasts/ListeningHistoryViewController+Swipe.swift
+++ b/podcasts/ListeningHistoryViewController+Swipe.swift
@@ -57,4 +57,6 @@ extension ListeningHistoryViewController: SwipeTableViewCellDelegate, SwipeHandl
             ]
         )
     }
+
+    func removeFromManualPlaylist(episode: PocketCastsDataModel.Episode, at: IndexPath) { }
 }

--- a/podcasts/New Detail/PlaylistDetailViewController+Swipe.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+Swipe.swift
@@ -64,4 +64,9 @@ extension PlaylistDetailViewController: SwipeTableViewCellDelegate, SwipeHandler
             ]
         )
     }
+
+    func removeFromManualPlaylist(episode: PocketCastsDataModel.Episode, at: IndexPath) {
+        viewModel.delete(episodes: [episode.uuid])
+        viewModel.reloadEpisodeList()
+    }
 }

--- a/podcasts/PlaylistViewController+Swipe.swift
+++ b/podcasts/PlaylistViewController+Swipe.swift
@@ -56,4 +56,6 @@ extension PlaylistViewController: SwipeTableViewCellDelegate, SwipeHandler {
     }
 
     func addToManualPlaylist(episode: PocketCastsDataModel.Episode, at: IndexPath) { } // we don't support this one
+
+    func removeFromManualPlaylist(episode: PocketCastsDataModel.Episode, at: IndexPath) { }  // we don't support this one
 }

--- a/podcasts/PodcastViewController+Swipe.swift
+++ b/podcasts/PodcastViewController+Swipe.swift
@@ -65,4 +65,6 @@ extension PodcastViewController: SwipeTableViewCellDelegate, SwipeHandler {
             ]
         )
     }
+
+    func removeFromManualPlaylist(episode: PocketCastsDataModel.Episode, at: IndexPath) { }
 }

--- a/podcasts/StarredViewController+Swipe.swift
+++ b/podcasts/StarredViewController+Swipe.swift
@@ -63,4 +63,6 @@ extension StarredViewController: SwipeTableViewCellDelegate, SwipeHandler {
             ]
         )
     }
+
+    func removeFromManualPlaylist(episode: PocketCastsDataModel.Episode, at: IndexPath) { }
 }

--- a/podcasts/SwipeActionsHelper.swift
+++ b/podcasts/SwipeActionsHelper.swift
@@ -12,12 +12,21 @@ enum SwipeSourceType {
     case listeningHistory
     case uploaded
 
-    var canAddToManualPlaylist: Bool {
+    var canAddEpisodeToManualPlaylist: Bool {
         switch self {
         case .filter, .uploaded, .manualPlaylistDetail:
             false
         default:
             true
+        }
+    }
+
+    var canRemoveEpisodeFromManualPlaylist: Bool {
+        switch self {
+        case .manualPlaylistDetail:
+            true
+        default:
+            false
         }
     }
 }
@@ -31,6 +40,7 @@ protocol SwipeHandler: AnyObject {
     func deleteRequested(uuid: String)
     func share(episode: Episode, at: IndexPath)
     func addToManualPlaylist(episode: Episode, at: IndexPath)
+    func removeFromManualPlaylist(episode: Episode, at: IndexPath)
 }
 
 enum SwipeActionsHelper {
@@ -122,13 +132,24 @@ enum SwipeActionsHelper {
             })
             tableSwipeActions.addAction(shareAction)
 
-            if FeatureFlag.playlistsRebranding.enabled, swipeHandler.swipeSourceType.canAddToManualPlaylist {
-                let shareAction = TableSwipeAction(indexPath: indexPath, title: L10n.playlistManualAddEpisodes, removesFromList: false, backgroundColor: ThemeColor.support02(), icon: UIImage(named: "playlist-add-episode"), tableView: tableView, handler: { indexPath -> Bool in
+            if FeatureFlag.playlistsRebranding.enabled {
+                if swipeHandler.swipeSourceType.canAddEpisodeToManualPlaylist {
+                    let shareAction = TableSwipeAction(indexPath: indexPath, title: L10n.playlistManualAddEpisodes, removesFromList: false, backgroundColor: ThemeColor.support02(), icon: UIImage(named: "playlist-add-episode"), tableView: tableView, handler: { indexPath -> Bool in
                         swipeHandler.addToManualPlaylist(episode: episode, at: indexPath)
                         Self.performAction(.addToManualPlaylist, handler: swipeHandler, willBeRemoved: false)
-                    return true
-                })
-                tableSwipeActions.addAction(shareAction)
+                        return true
+                    })
+                    tableSwipeActions.addAction(shareAction)
+                }
+
+                if swipeHandler.swipeSourceType.canRemoveEpisodeFromManualPlaylist {
+                    let removeAction = TableSwipeAction(indexPath: indexPath, title: L10n.delete, removesFromList: true, backgroundColor: ThemeColor.support05(), icon: UIImage(named: "delete"), tableView: tableView, handler: { _ -> Bool in
+                        swipeHandler.removeFromManualPlaylist(episode: episode, at: indexPath)
+                        Self.performAction(.removeFromManualPlaylist, handler: swipeHandler, willBeRemoved: false)
+                        return true
+                    })
+                    tableSwipeActions.addAction(removeAction, at: 0)
+                }
             }
         }
 
@@ -155,6 +176,7 @@ enum SwipeActionsHelper {
         case archive
         case share
         case addToManualPlaylist
+        case removeFromManualPlaylist
 
         var analyticsDescription: String {
             switch self {
@@ -174,6 +196,8 @@ enum SwipeActionsHelper {
                 return "share"
             case .addToManualPlaylist:
                 return "add_to_manual_playlist"
+            case .removeFromManualPlaylist:
+                return "remove_from_manual_playlist"
             }
         }
     }

--- a/podcasts/TableSwipeActions.swift
+++ b/podcasts/TableSwipeActions.swift
@@ -8,6 +8,10 @@ class TableSwipeActions {
         actions.append(action)
     }
 
+    func addAction(_ action: TableSwipeAction, at index: Int) {
+        actions.insert(action, at: index)
+    }
+
     func swipeActions() -> UISwipeActionsConfiguration? {
         var swipeActions = [UIContextualAction]()
         for tableAction in actions {

--- a/podcasts/UploadedViewController+Swipe.swift
+++ b/podcasts/UploadedViewController+Swipe.swift
@@ -52,4 +52,6 @@ extension UploadedViewController: SwipeTableViewCellDelegate, SwipeHandler {
     func share(episode: Episode, at: IndexPath) { }
 
     func addToManualPlaylist(episode: PocketCastsDataModel.Episode, at: IndexPath) { }
+
+    func removeFromManualPlaylist(episode: PocketCastsDataModel.Episode, at: IndexPath) { }
 }


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/view/ios-tasks-8039e91058ba?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-209

This PR adds the delete action by swiping left in manual playlists only.

| Smart Playlist | Manual Playlist |
| :-------: | :-------: |
| <img width="1179" height="2556" alt="simulator_screenshot_91B6C205-B9E5-48F8-AABA-6D460094110E" src="https://github.com/user-attachments/assets/edef7c35-7708-498f-af1f-6111ac22bb42" /> | <img width="1179" height="2556" alt="simulator_screenshot_4811D26C-3827-451D-9C8C-7DD2B9FD1EE7" src="https://github.com/user-attachments/assets/2097ec8b-409d-4641-a111-8345553196d3" /> |

## To test

- Run this branch and enable the rebranding playlist FF
- Make sure you have a manual playlist with episodes
- Swipe left to show the actions and confirm you see the delete button
- Tap on the delete button and confirm the episode is removed
- Confirm the number of episodes and time changes
- If the episode is an archived one, confirm the number of archived episodes changes
- Open a Smart Playlist
- Confirm you don't see the delete button

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
