### PR TITLE
[Playlists] Show Toast when the list is empty and Play all is tapped

### DIFF
--- a/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
@@ -10,6 +10,11 @@ extension PlaylistDetailViewController {
     }
 
     func playAll() {
+        if viewModel.episodes.isEmpty {
+            Toast.show(L10n.playlistManualPlayAllEmptyList)
+            return
+        }
+
         Analytics.track(.filterOptionsModalOptionTapped, properties: ["option": "play_all"])
         let playableEpisodeCount = min(ServerSettings.autoAddToUpNextLimit(), viewModel.episodes.count)
         OptionsPickerHelper.playAllWarning(episodeCount: playableEpisodeCount, confirmAction: { [weak self] in

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2348,6 +2348,8 @@ internal enum L10n {
   internal static var playlistManualEpisodeAddToPlaylist: String { return L10n.tr("Localizable", "playlist_manual_episode_add_to_playlist", fallback: "Add to playlist") }
   /// Manual Playlist: manual episodes order option that appears when showing the options sheet
   internal static var playlistManualEpisodesOrderOption: String { return L10n.tr("Localizable", "playlist_manual_episodes_order_option", fallback: "Reorder Episodes") }
+  /// Toast message displayed when a user tries to play all archived episodes in a manual playlist
+  internal static var playlistManualPlayAllEmptyList: String { return L10n.tr("Localizable", "playlist_manual_play_all_empty_list", fallback: "All episodes archived. Add or unarchive to play.") }
   /// Menu prompt to open the Playlist options. Also used for the title of the playlist options screen.
   internal static var playlistOptions: String { return L10n.tr("Localizable", "playlist_options", fallback: "Playlist Options") }
   /// Button title used to create a new smart playlist

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5507,6 +5507,9 @@
 /* Text of the placeholder used in the manual playlist detail screen when one episode is archived. */
 "playlist_manual_archived_episode_placeholder" = "Your episode in this playlist has been archived";
 
+/* Toast message displayed when a user tries to play all archived episodes in a manual playlist */
+"playlist_manual_play_all_empty_list" = "All episodes archived. Add or unarchive to play.";
+
 /* Text of the placeholder used in the manual playlist detail screen when all episodes are archived. '%1$@' represents the number of archived episodes */
 "playlist_manual_archived_episodes_placeholder" = "All %1$@ episodes of this playlist have been archived";
 


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/view/ios-tasks-8039e91058ba?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-205

| Hidden | Showed |
| :-------: | :-------: |
| <img width="1179" height="2556" alt="simulator_screenshot_B7DA5D6E-9AEC-4FDA-942B-373C541391A6" src="https://github.com/user-attachments/assets/df4e4a9c-b2ac-4d6e-9c21-ef05f67c70b9" /> | <img width="1179" height="2556" alt="simulator_screenshot_524ECE32-6C4A-4A41-9003-DB1864D4441F" src="https://github.com/user-attachments/assets/bc9765b7-1ee8-4124-8c05-c5e64105ba64" /> |

## To test

- Run this branch
- Open a manual playlist
- Archive all episode and keep them hidden
- Tap Play All
- Confirm you see the Toast menu
- Show all archived episode
- Tap Play all
- Confirm you see the sheet about playing all episodes

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
