### PR TITLE
[Playlists] Smart Playlist: add preview if edit mode is on and playlist changed

### DIFF
--- a/podcasts/New Creation/New Preview/PlaylistPreviewViewModel.swift
+++ b/podcasts/New Creation/New Preview/PlaylistPreviewViewModel.swift
@@ -124,30 +124,37 @@ class PlaylistPreviewViewModel: ObservableObject {
         }
         newPlaylist = playlist
 
-        if playlistMode == .edit {
+        switch playlistMode {
+        case .creation:
+            newPlaylist.isNew = true
+            isInPreview = true
+
+            enabledRules.removeAll()
+            availableRules.removeAll()
+
+            for rule in SmartPlaylistRule.allCases {
+                if smartRuleIsApplied(for: rule) {
+                    let ruleText = ruleText(for: rule)
+                    enabledRules.append(SmartPlaylistRuleInfo(type: rule, description: ruleText))
+                } else {
+                    availableRules.append(SmartPlaylistRuleInfo(type: rule))
+                }
+            }
+        case .edit:
             availableRules = SmartPlaylistRule.allCases.map {
                 let ruleText = ruleText(for: $0)
                 return SmartPlaylistRuleInfo(type: $0, description: ruleText)
             }
-            newPlaylistHasChanged = true
-            return
         }
 
-        newPlaylist.isNew = true
-        isInPreview = true
+        startOperation()
+    }
 
-        enabledRules.removeAll()
-        availableRules.removeAll()
+    func removeObserver() {
+        NotificationCenter.default.removeObserver(self)
+    }
 
-        for rule in SmartPlaylistRule.allCases {
-            if smartRuleIsApplied(for: rule) {
-                let ruleText = ruleText(for: rule)
-                enabledRules.append(SmartPlaylistRuleInfo(type: rule, description: ruleText))
-            } else {
-                availableRules.append(SmartPlaylistRuleInfo(type: rule))
-            }
-        }
-
+    private func startOperation() {
         if operationQueue.operationCount > 0 {
             operationQueue.cancelAllOperations()
             episodes.removeAll()
@@ -159,9 +166,5 @@ class PlaylistPreviewViewModel: ObservableObject {
             }
         }
         operationQueue.addOperation(refreshOperation)
-    }
-
-    func removeObserver() {
-        NotificationCenter.default.removeObserver(self)
     }
 }

--- a/podcasts/New Creation/New Preview/Rules/SmartPlaylistRulesView.swift
+++ b/podcasts/New Creation/New Preview/Rules/SmartPlaylistRulesView.swift
@@ -37,6 +37,13 @@ struct SmartPlaylistRulesView: View {
                     availableRules: viewModel.availableRules,
                     action: viewModel.action
                 )
+
+                if viewModel.newPlaylistHasChanged {
+                    SmartPlaylistRulesEpisodesSection(
+                        episodes: viewModel.episodes,
+                        playlistName: viewModel.newPlaylist.playlistName
+                    )
+                }
             }
         }
         .listStyle(.plain)
@@ -73,6 +80,7 @@ fileprivate struct SmartPlaylistRulesDefaultSection: View {
                 action: action
             )
             .padding(.top, 24.0)
+            .padding(.bottom, 16.0)
             .listRowClearStyle()
         }
         .padding(.horizontal, 16.0)


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-213

| Edit Smart Rules | Edit Smart Rules Preview  |
| :-------: | :-------: |
| <img width="1179" height="2556" alt="simulator_screenshot_8C04F2A4-B140-4222-86B1-774D2A6D338D" src="https://github.com/user-attachments/assets/e18e9a4b-cd1e-4380-9262-b2308747e3b0" /> | <img width="1179" height="2556" alt="simulator_screenshot_CA37DC67-F0E4-4F37-9563-C3F0112E7424" src="https://github.com/user-attachments/assets/2e45f1f0-6264-42e5-98ec-83a63fb0b001" /> |


## To test

- Run this branch and make sure the rebranding FF is on
- Create or Open a Smart Playlist
- Open it and tap on Smart Rules
- You should see the list of rules with no preview
- Change one rule and save
- You should see the list of rules and the Preview (with episodes or empty state)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
