### PR TITLE
[Crash] Fix crash with Localization helper

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -56,7 +56,11 @@ public enum ServerConstants {
     }
 
     private static func production() -> Bool {
-        ServerConfig.shared.syncDelegate?.production() ?? true
+        guard let delegate = ServerConfig.shared.syncDelegate else {
+            assertionFailure("ServerConfig.syncDelegate was nil at call time")
+            return true
+        }
+        return delegate.production()
     }
 
     public enum HttpConstants {

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -57,7 +57,6 @@ public enum ServerConstants {
 
     private static func production() -> Bool {
         guard let delegate = ServerConfig.shared.syncDelegate else {
-            assertionFailure("ServerConfig.syncDelegate was nil at call time")
             return true
         }
         return delegate.production()

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -104,10 +104,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             if FeatureFlag.downloadFixes.enabled {
                 DownloadManager.shared.startAllQueued()
             }
-        }
 
-        if FeatureFlag.enableLocalizationHeaders.enabled {
-            LocalizationHelper.provider = InternationalizationProvider(userRegion: Settings.userRegion())
+            if FeatureFlag.enableLocalizationHeaders.enabled {
+                LocalizationHelper.provider = InternationalizationProvider(userRegion: Settings.userRegion())
+            }
         }
 
         badgeHelper.setup()


### PR DESCRIPTION
Ref. Sentry-6952062503

The app was crashing on launch due to a call to ServerConstants.production() before ServerConfig.shared.syncDelegate was initialized, causing a EXC_BAD_ACCESS when invoking the protocol method.

Fix:
	•	Guarded the delegate access in production() to return a safe default if nil.
	•	Ensured the delegate is initialized earlier in AppDelegate to avoid race conditions.

This prevents early access and eliminates the launch crash.

## To test

- CI 🟢 
- Run the app and smoke test what was mentioned in #3553

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
