### PR TITLE
[Crash] Revert code in ThreadSafeDictionary

### DIFF
--- a/podcasts/ThreadSafeDictionary.swift
+++ b/podcasts/ThreadSafeDictionary.swift
@@ -1,5 +1,3 @@
-import PocketCastsUtils
-
 class ThreadSafeDictionary<Key: Hashable, Value> {
 
     private let queue: DispatchQueue
@@ -7,14 +5,6 @@ class ThreadSafeDictionary<Key: Hashable, Value> {
 
     init(label: String = "au.com.shiftyjelly.podcasts.SyncHashTable") {
         queue = DispatchQueue(label: label, attributes: .concurrent)
-    }
-
-    deinit {
-        //ensure that all work is done before releasing the table
-        queue.async(flags: .barrier) { [table] in
-            //Last work item
-            FileLog.shared.console("Dealocating table with \(table.count) elements")
-        }
     }
 
     func value(forKey key: Key) -> Value? {


### PR DESCRIPTION
Ref. #3496
Ref. #3528

Revert `deinit` which doesn't fix the main issue and raise more exceptions.

## To test

- Start the app
- Ensure that a lot of downloads are started
- Switch out of the app

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
