### PR TITLE
[Playlists] Fix onboarding settings behind FF

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -61,7 +61,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 Settings.shouldShowPodcastFeeReloadTip = false
                 Settings.shouldShowPodcastViewChangesTip = false
                 Settings.shouldShowRecentlyPlayedSortingTip = false
-                Settings.shouldShowPlaylistsOnboarding = false
+                if FeatureFlag.playlistsRebranding.enabled {
+                    Settings.shouldShowPlaylistsOnboarding = false
+                }
             case .sameVersion:
                 break
             }

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -182,7 +182,7 @@ struct Constants {
         static let shouldShowRecentlyPlayedSortingTip = "ShouldShowRecentlyPlayedSortingTip"
 
         static let newFilterTip = "NewFilterTip"
-        static let playlistsOnboarding = "PlaylistsOnboarding"
+        static let playlistsOnboarding = "NewPlaylistsOnboarding"
 
         enum headphones {
             static let previousAction = SettingValue("headphones.previousAction",

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -230,9 +230,11 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     }
 
     private func showOnboardingScreenIfNeeded() {
+        guard FeatureFlag.playlistsRebranding.enabled else { return }
+
         let userIsLoggedIn = SyncManager.isUserLoggedIn()
         let appInstallStateUpdated = (UIApplication.shared.delegate as? AppDelegate)?.appInstallState == .updated
-        let shouldDisplayOnboarding = appInstallStateUpdated && Settings.shouldShowPlaylistsOnboarding && FeatureFlag.playlistsRebranding.enabled && userIsLoggedIn
+        let shouldDisplayOnboarding = appInstallStateUpdated && Settings.shouldShowPlaylistsOnboarding && userIsLoggedIn
         guard shouldDisplayOnboarding else { return }
         let vc = ThemedHostingController(
             rootView: PlaylistsOnboardingView(


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-215

Based on #3362 this PR sets the onboarding settings flag behind FF

## To test

### Existent users
• Run this branch and enable the `playlistRebranding` FF (not from the code)
• Sing in with a user
• Stop Xcode and update line 46 in AppDelegate and with `appInstallState = .updated`
• Run this branch again
• Tap on `Playlists`
• Confirm the onboarding is showing and you can scroll between the 2 pages
• Dismiss it
• Change tab and go back to `Playlists`
• Confirm you don't see the onboarding screen

### New users
• Delete the app
• In Xcode force the `playlistRebranding` FF to be `true`
• Run this branch as new install
• Tap on `Playlists`
• Confirm you see the `Tip`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
