### PR TITLE
[Playlists] Add default text for duration and starred

### DIFF
--- a/podcasts/New Creation/New Preview/PlaylistPreviewViewModel.swift
+++ b/podcasts/New Creation/New Preview/PlaylistPreviewViewModel.swift
@@ -105,14 +105,14 @@ class PlaylistPreviewViewModel: ObservableObject {
         case .releaseDate:
             return ReleaseDateFilterOption(rawValue: newPlaylist.filterHours)?.description
         case .starred:
-            return newPlaylist.filterStarred ? "\(episodes.count)" : nil
+            return newPlaylist.filterStarred ? "\(episodes.count)" : L10n.off
         case .duration:
             if newPlaylist.filterDuration {
                 let shortTime = TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(newPlaylist.shorterThan * 60))
                 let longTime = TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(newPlaylist.longerThan * 60))
                 return "\(longTime) - \(shortTime)"
             }
-            return nil
+            return L10n.off
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-219

Add default label to Duration and Starred smart rules

| Before | After |
| :-------: | :-------: |
| <img width="1179" height="2556" alt="simulator_screenshot_39F84059-7479-4945-8F20-41D521E65179" src="https://github.com/user-attachments/assets/0c88f37a-843d-4717-bb63-e81d1914a1ee" /> | <img width="1179" height="2556" alt="simulator_screenshot_84041721-FAD4-41AB-AC79-05C04FC16064" src="https://github.com/user-attachments/assets/40e12d8c-e7cf-4aa4-8d27-a5101f9e0842" /> |


## To test

- Run this branch with the rebranding FF on
- Open a Smart Playlist and edit the rules
- Check the duration and starred have the default text to "Off"
- Change the value and confirm it still changes 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
