### PR TITLE
[TF] Register new route to test IAP in TF builds

### DIFF
--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -393,6 +393,7 @@ extension AppDelegate {
         setupOnboardingRoutes()
         setupNewFeaturesRoutes()
         setupProfileRoutes()
+        setupTestFlightIAPRoutes()
     }
 
     func setupOnboardingRoutes() {
@@ -532,5 +533,31 @@ extension AppDelegate {
                 }
             }
         })
+    }
+
+    private func setupTestFlightIAPRoutes() {
+        if BuildEnvironment.current == .appStore {
+            return
+        }
+        JLRoutes.global().addRoute("/iap/:enabled") {[weak self] parameters -> Bool in
+            guard
+                self != nil,
+                let value = parameters["enabled"] as? String
+            else { return false }
+
+            let isEnabled = value.lowercased() == "true"
+            Settings.shouldEnableIAPInTestFlightBuilds = isEnabled
+
+            let title = isEnabled ? "✅ In-App Purchases Enabled" : "🚫 In-App Purchases Disabled"
+            let message = isEnabled ? "This beta build uses a test environment. Purchases made here are for testing only—please don’t use your production account." : "In-App Purchases are turned off on this device."
+
+            SJUIUtils.showAlert(
+                title: title,
+                message: message,
+                from: SceneHelper.rootViewController()
+            )
+
+            return true
+        }
     }
 }

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -536,7 +536,7 @@ extension AppDelegate {
     }
 
     private func setupTestFlightIAPRoutes() {
-        if BuildEnvironment.current == .appStore {
+        if BuildEnvironment.current != .testFlight {
             return
         }
         JLRoutes.global().addRoute("/iap/:enabled") {[weak self] parameters -> Bool in

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -24,7 +24,14 @@ class IAPHelper: NSObject {
     private var isRequestingProducts = false
 
     /// Whether purchasing is allowed in the current environment or not
-    private(set) var canMakePurchases = BuildEnvironment.current != .testFlight
+    var canMakePurchases: Bool {
+        switch BuildEnvironment.current {
+        case .debug, .appStore:
+            return true
+        case .testFlight:
+            return Settings.shouldEnableIAPInTestFlightBuilds
+        }
+    }
 
     private var settings: IAPHelperSettings
     private var networking: IAPHelperNetworking

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1516,6 +1516,10 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - New Filter Tip
+
+    static var shouldEnableIAPInTestFlightBuilds: Bool = false
+
     // MARK: - Informational Banner
 #if !os(watchOS) && !APPCLIP
     static func dismissBanner(for type: InformationalBannerType) {


### PR DESCRIPTION
Ref. C029BMLUGRX-Slack-p1756807600607279

This PR adds the testing option for IAP in TF builds using a deeplink.

## To test

### Setup
- Remove the SK scheme to be able to run on real device
- Run this branch on real device with a free user
- Add this url to your notes `pktc://iap/true`
- Add this url to your notes `pktc://iap/false`

### Debug
- Try to purchase something
- ✅ confirm you can purchase something
- ✅  Tap on `pktc://iap/true` and confirm nothing happens

### AppStore
- Modify `BuildEnvironment`, `determineCurrentEnvironment` (line 24) to return `appStore`
- Do the same above test
- ✅ confirm you can purchase something
- ✅  Tap on `pktc://iap/true` and confirm nothing happens

### Testflight
- Modify `BuildEnvironment`, `determineCurrentEnvironment` (line 24) to return `testFlight`
- Run this branch on real device with a free user
- Try to purchase something
- ✅ confirm you can not purchase something
- ✅  Tap on `pktc://iap/true` and confirm it opens the app
- ✅ Confirm you see the Alert saying the IAP are enabled
- Try to purchase something
- ✅ confirm you can purchase something
- ✅  Tap on `pktc://iap/false` and confirm it opens the app
- ✅ Confirm you see the Alert saying the IAP are disabled
- Try to purchase something
- ✅ confirm you can not purchase something

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
