### PR TITLE
[Playlists] Update Buttons copy

### DIFF
--- a/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
+++ b/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
@@ -46,7 +46,7 @@ struct PlaylistHeaderView: View {
                         type: .playAll,
                         color: theme.primaryUi02,
                         image: Image("filter_play"),
-                        title: L10n.playAll,
+                        title: L10n.playlistsPlayAll,
                         background: theme.primaryText01) { type in
                             viewModel.onButtonTapped(type)
                     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2342,7 +2342,7 @@ internal enum L10n {
   /// Manual Playlist: header button title to add new episodes to the playlist
   internal static var playlistManualAddEpisodes: String { return L10n.tr("Localizable", "playlist_manual_add_episodes", fallback: "Add Episodes") }
   /// Manual Playlist: title when no episodes are added and there are nosubscribed podcasts
-  internal static var playlistManualBrowseShowsTitle: String { return L10n.tr("Localizable", "playlist_manual_browse_shows_title", fallback: "Browse Shows") }
+  internal static var playlistManualBrowseShowsTitle: String { return L10n.tr("Localizable", "playlist_manual_browse_shows_title", fallback: "Browse podcasts") }
   /// Manual Playlist: empty state subtitle when no episodes are added and there are nosubscribed podcasts
   internal static var playlistManualEmptyStateSubtitleNoPodcasts: String { return L10n.tr("Localizable", "playlist_manual_empty_state_subtitle_no_podcasts", fallback: "Swipe left on an episode to add it your playlist.") }
   /// Manual Playlist: empty state title when no episodes are added
@@ -2403,6 +2403,8 @@ internal enum L10n {
   internal static var playlistsOnboardingSmartDescription: String { return L10n.tr("Localizable", "playlists_onboarding_smart_description", fallback: "They still work exactly the same, using rules to auto-add your episodes. All your existing Filters are right here, nothing’s changed but the name.") }
   /// Playlists Onboarding screen: title for the smart playlist card
   internal static var playlistsOnboardingSmartTitle: String { return L10n.tr("Localizable", "playlists_onboarding_smart_title", fallback: "Filters are now Smart Playlists") }
+  /// Playlist Play all button
+  internal static var playlistsPlayAll: String { return L10n.tr("Localizable", "playlists_play_all", fallback: "Play all") }
   /// A common string used throughout the app. Catch all prompt to suggest to the user to try the task again.
   internal static var pleaseTryAgain: String { return L10n.tr("Localizable", "please_try_again", fallback: "Please try again") }
   /// A common string used throughout the app. Catch all prompt to suggest to the user to try the task again later.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5393,6 +5393,9 @@
 /* A common string used throughout the app. Often refers to the Playlists screen. */
 "playlists" = "Playlists";
 
+/* Playlist Play all button */
+"playlists_play_all" = "Play all";
+
 /* A common string used throughout the app. Often refers to the Smart Playlist. */
 "smart_playlist" = "Smart Playlist";
 
@@ -5502,7 +5505,7 @@
 "playlist_manual_empty_state_subtitle_no_podcasts" = "Swipe left on an episode to add it your playlist.";
 
 /* Manual Playlist: title when no episodes are added and there are nosubscribed podcasts */
-"playlist_manual_browse_shows_title" = "Browse Shows";
+"playlist_manual_browse_shows_title" = "Browse podcasts";
 
 /* Manual Playlist: manual episodes order option that appears when showing the options sheet */
 "playlist_manual_episodes_order_option" = "Reorder Episodes";


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/initiative/playlists-f7f3c1cddf7c/overview)
|:---:|

Fixes PCIOS-225

Change the copy for the manual playlist empty state when no podcasts are followed. Also changes the copy for Play all in detail

| Empty State | Detail |
| :-------: | :-------: |
| <img width="1179" height="2556" alt="IMG_0400" src="https://github.com/user-attachments/assets/937e6fd2-151a-44f4-9815-5f640b1cdef2" /> | <img width="1179" height="2556" alt="IMG_0401" src="https://github.com/user-attachments/assets/8ca161c8-ca48-40c5-92f0-f1d00e6481e5" /> |


## To test

- Start with a new install
- Run the app and enable the rebranding FF
- Don't login
- Create a new manual playlist
- Confirm the empty state as `Browse podcasts` as button
- Login
- Go into one of your playlists
- Confirm the Play all says `Play all`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
