### PR TITLE
Fix voiceover for playback effects

### DIFF
--- a/podcasts/CustomSegmentedControl.swift
+++ b/podcasts/CustomSegmentedControl.swift
@@ -95,7 +95,7 @@ class CustomSegmentedControl: UIControl {
     private func indexDidChange(previousValue: Int) {
         // if we animate this in a future version, we should be able to do it here
         updateColors()
-        updateAccessibilityTraits()
+        updateAccessibilityValue()
     }
 
     private func setup(actions: [SegmentedAction]) {
@@ -110,7 +110,7 @@ class CustomSegmentedControl: UIControl {
             let actionView = UIView()
             actionView.translatesAutoresizingMaskIntoConstraints = false
             actionView.accessibilityLabel = action.accessibilityLabel
-            actionView.isAccessibilityElement = true
+            actionView.isAccessibilityElement = false // Disable individual segment accessibility
             actionView.isUserInteractionEnabled = true
             addSubview(actionView)
 
@@ -171,17 +171,17 @@ class CustomSegmentedControl: UIControl {
         }
 
         updateColors()
-        updateAccessibilityTraits()
+        setupAccessibility()
     }
 
-    private func updateAccessibilityTraits() {
-        for (index, actionView) in actionViews.enumerated() {
-            if index == selectedIndex {
-                actionView.accessibilityTraits = [.button, .selected]
-            } else {
-                actionView.accessibilityTraits = [.button]
-            }
-        }
+    private func setupAccessibility() {
+        // Make the entire control accessible as one element
+        isAccessibilityElement = true
+        accessibilityTraits = .adjustable
+        updateAccessibilityValue()
+
+        // Ensure individual segments are not accessible
+        actionViews.forEach { $0.isAccessibilityElement = false }
     }
 
     private func updateColors() {
@@ -219,5 +219,46 @@ class CustomSegmentedControl: UIControl {
 
         selectedIndex = segmentTapped
         sendActions(for: .valueChanged)
+    }
+
+    // MARK: - Accessibility Support
+
+    private var actions: [SegmentedAction] = []
+
+    func setActionsWithAccessibility(_ actions: [SegmentedAction]) {
+        self.actions = actions
+        setActions(actions)
+        setupAccessibility()
+    }
+
+    private func updateAccessibilityValue() {
+        if selectedIndex < actions.count {
+            accessibilityValue = actions[selectedIndex].accessibilityLabel
+        }
+    }
+
+    override func accessibilityIncrement() {
+        let newIndex = min(selectedIndex + 1, actions.count - 1)
+        if newIndex != selectedIndex {
+            selectedIndex = newIndex
+            updateAccessibilityValue()
+            sendActions(for: .valueChanged)
+            UIAccessibility.post(notification: .announcement, argument: accessibilityValue)
+        }
+    }
+
+    override func accessibilityDecrement() {
+        let newIndex = max(selectedIndex - 1, 0)
+        if newIndex != selectedIndex {
+            selectedIndex = newIndex
+            updateAccessibilityValue()
+            sendActions(for: .valueChanged)
+            UIAccessibility.post(notification: .announcement, argument: accessibilityValue)
+        }
+    }
+
+    private func indexDidChangeAccessibility(previousValue: Int) {
+        updateColors()
+        updateAccessibilityValue()
     }
 }

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -195,6 +195,7 @@ class EffectsViewController: SimpleNotificationsViewController {
 
         updateColors()
         updateControls()
+        setupAccessibility()
 
         if isCustomPlaybackSettingsEnabled {
             playbackSettingsSegmentedControl.selectedSegmentIndex = PlaybackManager.shared.isCurrentEffectGlobal() ? 0 : 1
@@ -383,13 +384,22 @@ class EffectsViewController: SimpleNotificationsViewController {
         let effects = PlaybackManager.shared.effects()
         trimSilenceSwitch.isOn = effects.trimSilence.isEnabled()
 
-        trimSilenceSpeedsToLabelConstraint.isActive = effects.trimSilence.isEnabled()
+        let isEnabled = effects.trimSilence.isEnabled()
+
+        trimSilenceSpeedsToLabelConstraint.isActive = isEnabled
         UIView.animate(withDuration: 0.3) {
-            self.trimSilenceAmountControl.alpha = effects.trimSilence.isEnabled() ? 1 : 0
+            self.trimSilenceAmountControl.alpha = isEnabled ? 1 : 0
             self.view.layoutIfNeeded()
         }
 
+        // Hide from accessibility when not enabled to prevent VoiceOver getting stuck
+        trimSilenceAmountControl.isAccessibilityElement = isEnabled
+        trimSilenceAmountControl.isHidden = !isEnabled
+
         trimSilenceAmountControl.selectedIndex = trimSilenceAmountToIndex(effects.trimSilence)
+
+        // Update accessibility order when trim silence state changes
+        setupAccessibilityOrder()
 
         let timeSaved = StatsManager.shared.timeSavedDynamicSpeedInclusive()
         if timeSaved < 60 {
@@ -417,6 +427,9 @@ class EffectsViewController: SimpleNotificationsViewController {
         speedBtn.strokeColor = speedBtn.isOn ? ThemeColor.playerContrast01() : ThemeColor.playerContrast02()
         speedBtn.textColor = speedBtn.isOn ? PlayerColorHelper.playerBackgroundColor01() : ThemeColor.playerContrast01()
         speedBtn.accessibilityLabel = L10n.accessibilityPlayerEffectsPlaybackSpeed(effects.playbackSpeed.localized(.spellOut))
+
+        // Post accessibility notification for speed changes
+        UIAccessibility.post(notification: .announcement, argument: speedBtn.accessibilityLabel)
     }
 
     @objc private func updateColors() {
@@ -484,5 +497,55 @@ class EffectsViewController: SimpleNotificationsViewController {
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         .portrait
+    }
+
+    // MARK: - Accessibility
+
+    private func setupAccessibility() {
+        // Speed control buttons
+        minusBtn.accessibilityLabel = "Decrease Speed"//L10n.accessibilityPlayerEffectsDecreaseSpeed
+        plusBtn.accessibilityLabel = "Increase Speed"//L10n.accessibilityPlayerEffectsIncreaseSpeed
+
+        // Switches
+        trimSilenceSwitch.accessibilityLabel = L10n.trimSilence
+        volumeBoostSwitch.accessibilityLabel = L10n.volumeBoost
+
+        // Trim silence amount control accessibility is handled by the custom control itself
+        trimSilenceAmountControl.accessibilityLabel = L10n.trimSilence + " amount"
+        trimSilenceAmountControl.accessibilityHint = "Swipe up or down to change"
+
+        playbackSettingsSegmentedControl.accessibilityLabel = "Playback Effects Settings"
+
+        // Set accessibility hints
+        trimSilenceSwitch.accessibilityHint = L10n.playerEffectsTrimSilenceDetails
+        volumeBoostSwitch.accessibilityHint = L10n.volumeBoostDescription
+
+        // Configure view to allow VoiceOver navigation
+        view.accessibilityViewIsModal = true
+        setupAccessibilityOrder()
+    }
+
+    private func setupAccessibilityOrder() {
+        // Create explicit accessibility navigation order
+        var accessibilityElements: [Any] = []
+
+        // Always include these elements in order
+        if !playbackSettingsSegmentedControl.isHidden {
+            accessibilityElements.append(playbackSettingsSegmentedControl!)
+        }
+
+        accessibilityElements.append(speedBtn!)
+        accessibilityElements.append(minusBtn!)
+        accessibilityElements.append(plusBtn!)
+        accessibilityElements.append(trimSilenceSwitch!)
+
+        // Only include trim silence amount control when it's enabled and visible
+        if trimSilenceSwitch.isOn && !trimSilenceAmountControl.isHidden {
+            accessibilityElements.append(trimSilenceAmountControl!)
+        }
+
+        accessibilityElements.append(volumeBoostSwitch!)
+
+        view.accessibilityElements = accessibilityElements
     }
 }


### PR DESCRIPTION
Fixes [PCIOS-129](https://linear.app/a8c/issue/PCIOS-129/unable-to-navigate-playback-effects-using-voiceover)

Fixes Voice Over when navigating through the Playback Effects screen in the player.

## To test

* Open the Fullscreen player view
* Enable voice over
* Navigate through the player to open the Playback Effects modal
* Swipe through and ensure you can access the controls beneath the "All Podcasts" and "This Podcast" segmented control

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
