### PR TITLE
Enable Search Predictive for test flight builds only

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -400,7 +400,11 @@ public enum FeatureFlag: String, CaseIterable {
         case .searchImprovements:
             false
         case .searchPredictive:
-            true
+            #if DEBUG
+                true
+            #else
+                BuildEnvironment.current == .testFlight
+            #endif
         case .podcastBookmarksInline:
             true
         case .earlyReloadSubscriptionStatus:
@@ -440,7 +444,12 @@ extension FeatureFlag: OverrideableFlag {
     }
 
     public var canOverride: Bool {
-        true
+        switch self {
+            case .searchPredictive:
+                !Self.isTestFlight
+            default:
+                true
+        }
     }
 
     private static let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This ensure that predicitive search is enabled for TF builds and debug builds only.
AppStore build should have this active

## To test

- Check that if in a debug build the FF is active by default
- In order for us to test this we will need to deploy a TF build after to test if it work correctly


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
