### PR TITLE
[Playlists] CarPlay updates

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -947,8 +947,8 @@ public class DataManager {
         playlistManager.playlistEpisodeCount(clause: .allEpisodeCount, playlist: playlist, episodeUuidToAdd: episodeUuidToAdd, shouldShowArchived: true, dbQueue: dbQueue)
     }
 
-    public func playlistEpisodes(for playlist: EpisodeFilter) -> [Episode] {
-        let limit = EpisodeDataManager.Constants.Limits.maxPlaylistItems
+    public func playlistEpisodes(for playlist: EpisodeFilter, limit: Int? = nil) -> [Episode] {
+        let limit = limit ?? EpisodeDataManager.Constants.Limits.maxPlaylistItems
         let query = PlaylistQueryBuilder.query(
             clause: .episode,
             for: playlist,

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskPlaylistOrderingTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskPlaylistOrderingTests.swift
@@ -98,10 +98,6 @@ private final class CapturingDataManager: DataManager {
         addedEpisodes.removeValue(forKey: playlist.uuid)
     }
 
-    override func playlistEpisodes(for playlist: EpisodeFilter) -> [Episode] {
-        stubbedPlaylistEpisodes[playlist.uuid] ?? []
-    }
-
     override func save(playlist: EpisodeFilter) {
         storedPlaylists[playlist.uuid] = playlist
     }

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskPlaylistOrderingTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskPlaylistOrderingTests.swift
@@ -93,6 +93,15 @@ private final class CapturingDataManager: DataManager {
         storedPlaylists[uuid]
     }
 
+    public override func playlistEpisodes(for playlist: EpisodeFilter, limit: Int? = nil) -> [Episode] {
+        let episodes = stubbedPlaylistEpisodes[playlist.uuid] ?? []
+        if let limit {
+            return Array(episodes.prefix(limit))
+        } else {
+            return episodes
+        }
+    }
+
     override func delete(playlist: EpisodeFilter) {
         storedPlaylists.removeValue(forKey: playlist.uuid)
         addedEpisodes.removeValue(forKey: playlist.uuid)

--- a/podcasts/CarPlaySceneDelegate+Interaction.swift
+++ b/podcasts/CarPlaySceneDelegate+Interaction.swift
@@ -13,7 +13,7 @@ extension CarPlaySceneDelegate {
     func filterTapped(_ filter: EpisodeFilter) {
         pushEpisodeList(title: filter.playlistName, emptyTitle: L10n.episodeFilterNoEpisodesTitle, showArtwork: true, playlist: .filter(uuid: filter.uuid)) { () -> [BaseEpisode] in
             if FeatureFlag.playlistsRebranding.enabled {
-                return DataManager.sharedManager.playlistEpisodes(for: filter)
+                return DataManager.sharedManager.playlistEpisodes(for: filter, limit: Constants.Limits.maxCarplayItems)
             } else {
                 let query = PlaylistQueryBuilder.queryFor(filter: filter, episodeUuidToAdd: filter.episodeUuidToAddToQueries(), limit: Constants.Limits.maxCarplayItems)
                 return DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: nil)

--- a/podcasts/CarPlaySceneDelegate+Interaction.swift
+++ b/podcasts/CarPlaySceneDelegate+Interaction.swift
@@ -12,8 +12,12 @@ extension CarPlaySceneDelegate {
 
     func filterTapped(_ filter: EpisodeFilter) {
         pushEpisodeList(title: filter.playlistName, emptyTitle: L10n.episodeFilterNoEpisodesTitle, showArtwork: true, playlist: .filter(uuid: filter.uuid)) { () -> [BaseEpisode] in
-            let query = PlaylistQueryBuilder.queryFor(filter: filter, episodeUuidToAdd: filter.episodeUuidToAddToQueries(), limit: Constants.Limits.maxCarplayItems)
-            return DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: nil)
+            if FeatureFlag.playlistsRebranding.enabled {
+                return DataManager.sharedManager.playlistEpisodes(for: filter)
+            } else {
+                let query = PlaylistQueryBuilder.queryFor(filter: filter, episodeUuidToAdd: filter.episodeUuidToAddToQueries(), limit: Constants.Limits.maxCarplayItems)
+                return DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: nil)
+            }
         }
     }
 

--- a/podcasts/CarPlaySceneDelegate+Tabs.swift
+++ b/podcasts/CarPlaySceneDelegate+Tabs.swift
@@ -55,7 +55,13 @@ extension CarPlaySceneDelegate {
     private var filterTabSections: [CPListSection] {
         var filterItems = [CPListItem]()
         for filter in DataManager.sharedManager.allPlaylists(includeDeleted: false) {
-            let item = CPListItem(text: filter.playlistName, detailText: nil, image: UIImage(named: filter.iconImageNameCarPlay()))
+            var detail: String? = nil
+            if FeatureFlag.playlistsRebranding.enabled {
+                if filter.manual == false {
+                    detail = L10n.smartPlaylist
+                }
+            }
+            let item = CPListItem(text: filter.playlistName, detailText: detail, image: UIImage(named: filter.iconImageNameCarPlay()))
             item.accessoryType = .disclosureIndicator
             item.handler = { [weak self] _, completion in
                 self?.filterTapped(filter)

--- a/podcasts/CarPlaySceneDelegate+Tabs.swift
+++ b/podcasts/CarPlaySceneDelegate+Tabs.swift
@@ -61,7 +61,8 @@ extension CarPlaySceneDelegate {
                     detail = L10n.smartPlaylist
                 }
             }
-            let item = CPListItem(text: filter.playlistName, detailText: detail, image: UIImage(named: filter.iconImageNameCarPlay()))
+            let image = FeatureFlag.playlistsRebranding.enabled ? filter.grid() : UIImage(named: filter.iconImageNameCarPlay())
+            let item = CPListItem(text: filter.playlistName, detailText: detail, image: image)
             item.accessoryType = .disclosureIndicator
             item.handler = { [weak self] _, completion in
                 self?.filterTapped(filter)

--- a/podcasts/CarPlaySceneDelegate+Tabs.swift
+++ b/podcasts/CarPlaySceneDelegate+Tabs.swift
@@ -1,6 +1,7 @@
 import CarPlay
 import Foundation
 import PocketCastsDataModel
+import PocketCastsUtils
 
 // MARK: - Podcasts
 extension CarPlaySceneDelegate {
@@ -68,7 +69,8 @@ extension CarPlaySceneDelegate {
     }
 
     func createFiltersTab() -> CPListTemplate {
-        return CarPlayListData.template(title: L10n.filters, emptyTitle: L10n.watchNoFilters, image: UIImage(named: "car_tab_filters")) { [weak self] in
+        let title = FeatureFlag.playlistsRebranding.enabled ? L10n.playlists : L10n.filters
+        return CarPlayListData.template(title: title, emptyTitle: L10n.watchNoFilters, image: UIImage(named: "car_tab_filters")) { [weak self] in
             guard let self else { return nil }
             return self.filterTabSections
         }

--- a/podcasts/EpisodeFilter+Formatting.swift
+++ b/podcasts/EpisodeFilter+Formatting.swift
@@ -75,8 +75,23 @@ extension EpisodeFilter {
 
         return PlaylistArtworkView(items: items, imageSize: 168)
             .frame(width: 56.0, height: 56.0)
-            .environmentObject(Theme(previewTheme: .light)) //TODO: Change based on CarPlay theme
+            .environmentObject(Theme(previewTheme: carPlayPreviewTheme()))
             .snapshot()
+    }
+
+    private func carPlayPreviewTheme() -> Theme.ThemeType {
+        guard let interfaceStyle = CarPlayImageHelper.carTraitCollection?.userInterfaceStyle else {
+            return Theme.sharedTheme.activeTheme
+        }
+
+        switch interfaceStyle {
+        case .dark:
+            return .dark
+        case .light:
+            return .light
+        default:
+            return Theme.sharedTheme.activeTheme
+        }
     }
     #endif
 

--- a/podcasts/EpisodeFilter+Formatting.swift
+++ b/podcasts/EpisodeFilter+Formatting.swift
@@ -1,3 +1,6 @@
+#if canImport(UIKit)
+import UIKit
+#endif
 import Foundation
 import PocketCastsDataModel
 
@@ -62,6 +65,19 @@ extension EpisodeFilter {
 
             return name
         }
+    #endif
+
+    #if !os(watchOS) && !APPCLIP
+    @MainActor func grid() -> UIImage {
+        let episodes = DataManager.sharedManager.playlistEpisodes(for: self)
+
+        let items = PlaylistCellViewModel.gridArtworkItems(from: episodes, limit: 4) { $0.podcastUuid }
+
+        return PlaylistArtworkView(items: items, imageSize: 168)
+            .frame(width: 56.0, height: 56.0)
+            .environmentObject(Theme(previewTheme: .light)) //TODO: Change based on CarPlay theme
+            .snapshot()
+    }
     #endif
 
     class func imageForPlaylistIcon(icon: PlaylistIcon) -> UIImage? {

--- a/podcasts/PlaylistCellViewModel.swift
+++ b/podcasts/PlaylistCellViewModel.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 import PocketCastsDataModel
 
+#if canImport(UIKit)
+import UIKit
+#endif
+
 class PlaylistCellViewModel: ObservableObject {
     enum DisplayType {
         case count
@@ -19,6 +23,42 @@ class PlaylistCellViewModel: ObservableObject {
 #else
         episodesCount < Constants.Limits.maxFilterItems
 #endif
+    }
+
+    static func distinctPodcasts<T>(
+        from episodes: [T],
+        limit: Int,
+        podcastUuid: (T) -> String
+    ) -> [T] {
+        var seen = Set<String>()
+        var results: [T] = []
+
+        for episode in episodes {
+            if seen.insert(podcastUuid(episode)).inserted {
+                results.append(episode)
+
+                if results.count == limit {
+                    break
+                }
+            }
+        }
+
+        return results
+    }
+
+    static func gridArtworkItems<T>(
+        from episodes: [T],
+        limit: Int,
+        imageManager: ImageManager = .sharedManager,
+        podcastUuid: (T) -> String
+    ) -> [PlaylistArtworkView.ImageItem] {
+        let distinctEpisodes = distinctPodcasts(from: episodes, limit: limit, podcastUuid: podcastUuid)
+
+        return distinctEpisodes.map { episode in
+            let uuid = podcastUuid(episode)
+            let url = imageManager.podcastUrl(imageSize: .grid, uuid: uuid)
+            return PlaylistArtworkView.ImageItem(id: uuid, url: url)
+        }
     }
 
     private var playlist: EpisodeFilter
@@ -152,18 +192,6 @@ class PlaylistCellViewModel: ObservableObject {
     }
 
     private func firstDistinctPodcasts(from episodes: [ListEpisode], limit: Int) -> [ListEpisode] {
-        var seen = Set<String>()
-        var list: [ListEpisode] = []
-
-        for episode in episodes {
-            if seen.insert(episode.episode.podcastUuid).inserted {
-                list.append(episode)
-
-                if list.count == limit {
-                    break
-                }
-            }
-        }
-        return list
+        Self.distinctPodcasts(from: episodes, limit: limit) { $0.episode.podcastUuid }
     }
 }


### PR DESCRIPTION
Fixes [PCIOS-125](https://linear.app/a8c/issue/PCIOS-125/carplay-updates)

* Updates tab to "Playlists" from "Filters"
* Updates list image to the grid image
* Shows "Smart Playlists" subtitle in Playlists list

| | |
|--|--|
| <img width="800" height="480" alt="Main-VideoStream-2025-10-27-14-33-19" src="https://github.com/user-attachments/assets/22c61c63-bf59-4f3a-a45a-56f3022f46f6" /> | <img width="800" height="480" alt="Main-VideoStream-2025-10-27-14-33-31" src="https://github.com/user-attachments/assets/a82c14d5-e598-4826-ae34-e092320b0ca4" /> |


## To test

* Install the CarPlay simulator from the Additional Tools package from [Apple's Downloads](https://developer.apple.com/download/all/?q=additional%20tools)
* Build and run on a device
* Enable the `playlistsRebranding` feature flag
* Allow the device to connect to the CarPlay simulator
* Navigate to the Playlists tab
* ✅ Ensure playlists are shown with "Smart Playlists" shown as a subtitle and no subtitle shown for Manual playlists
* ✅ Ensure the Grid artwork is shown for playlists, the same as it is on the Playlists tab in the app
* Tap into a Manual playlist
* ✅ Ensure the episodes shown are correct
* Disable the `playlistsRebranding` feature flag
* ✅ Ensure the tab says "Filters"
* ✅ Ensure filters are listed with their icons showing and no subtitles

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
