### PR TITLE
Add unit test for smart playlists query

### DIFF
--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistDataManagerTests.swift
@@ -1,0 +1,43 @@
+@testable import PocketCastsDataModel
+import GRDB
+import XCTest
+
+final class PlaylistDataManagerTests: XCTestCase {
+
+    func testAllSmartPlaylistsReturnsResultsWithoutRawPlaylistTypeFilter() throws {
+        guard let dbPool = try DatabasePool.newTestDatabase() else {
+            throw SQLiteValidator.SQLiteError.failedNewTestDatabase
+        }
+        let queue = GRDBQueue(dbPool: dbPool)
+        DatabaseHelper.setup(queue: queue)
+        let dataManager = DataManager(dbQueue: queue)
+
+        let activeSmart = EpisodeFilter()
+        activeSmart.uuid = "smart-active"
+        activeSmart.playlistName = "Smart Active"
+        activeSmart.manual = false
+        activeSmart.sortPosition = 1
+        dataManager.save(playlist: activeSmart)
+
+        let deletedSmart = EpisodeFilter()
+        deletedSmart.uuid = "smart-deleted"
+        deletedSmart.playlistName = "Smart Deleted"
+        deletedSmart.manual = false
+        deletedSmart.wasDeleted = true
+        deletedSmart.sortPosition = 2
+        dataManager.save(playlist: deletedSmart)
+
+        let manualPlaylist = EpisodeFilter()
+        manualPlaylist.uuid = "manual-playlist"
+        manualPlaylist.playlistName = "Manual Playlist"
+        manualPlaylist.manual = true
+        manualPlaylist.sortPosition = 3
+        dataManager.save(playlist: manualPlaylist)
+
+        let smartPlaylists = dataManager.allSmartPlaylists(includeDeleted: false)
+        XCTAssertEqual(smartPlaylists.map(\.uuid), ["smart-active"])
+
+        let smartPlaylistsWithDeleted = dataManager.allSmartPlaylists(includeDeleted: true)
+        XCTAssertEqual(smartPlaylistsWithDeleted.map(\.uuid), ["smart-active", "smart-deleted"])
+    }
+}


### PR DESCRIPTION
This test covers the 7.99.1 hotfix (312d8c9) where playlists weren't returned

## To test

* Run Unit Tests
* ✅ Ensure they pass
* Revert commit `312d8c9` locally
* Re-run the tests
* ✅ Ensure the unit test fails

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
