### PR TITLE
Conditionally show toolbar top trailing item in bookmarks screen

### DIFF
--- a/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
@@ -36,23 +36,26 @@ struct BookmarksProfileListView: View {
                 .tint(style.theme.secondaryIcon01)
             }
         }
-        ToolbarItem(placement: .topBarTrailing) {
-            Button {
-                if viewModel.isMultiSelecting {
-                    viewModel.toggleMultiSelection()
-                } else {
-                    viewModel.showMoreOptions()
+
+        if viewModel.bookmarks.isEmpty == false {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    if viewModel.isMultiSelecting {
+                        viewModel.toggleMultiSelection()
+                    } else {
+                        viewModel.showMoreOptions()
+                    }
+                } label: {
+                    if viewModel.isMultiSelecting {
+                        Text(L10n.cancel)
+                    } else {
+                        Image("more")
+                    }
                 }
-            } label: {
-                if viewModel.isMultiSelecting {
-                    Text(L10n.cancel)
-                } else {
-                    Image("more")
-                }
+                .disabled(!viewModel.feature.isUnlocked)
+                .opacity(viewModel.feature.isUnlocked ? 1 : 0)
+                .tint(style.theme.secondaryIcon01)
             }
-            .disabled(!viewModel.feature.isUnlocked)
-            .opacity(viewModel.feature.isUnlocked ? 1 : 0)
-            .tint(style.theme.secondaryIcon01)
         }
     }
 


### PR DESCRIPTION
That is, only add the button if there are bookmarks on which it can act.

Before
<img width="300" height="1342" alt="image" src="https://github.com/user-attachments/assets/2298e7df-d20d-4c13-94b2-4a045d3f27bd" />

After
<img width="300" height="1156" alt="image" src="https://github.com/user-attachments/assets/5667a9c2-76af-445a-9514-8546eb830725" />

Fixes PCIOS-234

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
Run the app using a free account or an paid account that has no bookmarks. Notice how there is no empty button in the bookmarks screen.

When adding bookmarks, notice the button appears and still works:

<img width="419" height="453" alt="image" src="https://github.com/user-attachments/assets/fcf86eaf-2c4a-4d48-b92a-a7d95bf399c3" />

(_Also notice that the three dots are tinted blue/primary while the back button is white. Not sure how to fix that just yet._)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. — N.A.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
