### PR TITLE
Playback Effects Voiceover crash fix

### DIFF
--- a/podcasts/CustomSegmentedControl.swift
+++ b/podcasts/CustomSegmentedControl.swift
@@ -62,12 +62,50 @@ class CustomSegmentedControl: UIControl {
         }
     }
 
-    private var actionViews = [UIView]()
+    override var isAccessibilityElement: Bool {
+        get { false }
+        set { }
+    }
+
+    private var actionViews = [SegmentView]()
     private var separatorViews = [UIView]()
     private var itemViews = [UIView]()
 
     private var actionCount = 0
     private var titleFont = UIFont.systemFont(ofSize: 15, weight: .bold)
+    private let selectionFeedbackGenerator = UISelectionFeedbackGenerator()
+
+    private final class SegmentView: UIView {
+        let index: Int
+        private let selectHandler: (Int) -> Void
+
+        init(index: Int, accessibilityLabel: String, selectHandler: @escaping (Int) -> Void) {
+            self.index = index
+            self.selectHandler = selectHandler
+            super.init(frame: .zero)
+            isAccessibilityElement = true
+            accessibilityTraits = [.button]
+            self.accessibilityLabel = accessibilityLabel
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func accessibilityActivate() -> Bool {
+            selectHandler(index)
+            return true
+        }
+
+        func updateSelectionState(isSelected: Bool) {
+            if isSelected {
+                accessibilityTraits.insert(.selected)
+            } else {
+                accessibilityTraits.remove(.selected)
+            }
+        }
+    }
 
     public func setActions(_ actions: [SegmentedAction]) {
         clearCurrentActions()
@@ -81,23 +119,20 @@ class CustomSegmentedControl: UIControl {
     }
 
     private func clearCurrentActions() {
-        actionViews.forEach { view in
-            view.removeFromSuperview()
-        }
+        actionViews.forEach { $0.removeFromSuperview() }
         actionViews.removeAll()
 
-        separatorViews.forEach { view in
-            view.removeFromSuperview()
-        }
+        separatorViews.forEach { $0.removeFromSuperview() }
         separatorViews.removeAll()
 
         itemViews.removeAll()
     }
 
     private func indexDidChange(previousValue: Int) {
-        // if we animate this in a future version, we should be able to do it here
         updateColors()
-        updateAccessibilityValue()
+        updateSegmentAccessibilityStates()
+        announceAccessibilitySelection()
+        provideSelectionFeedbackIfNeeded()
     }
 
     private func setup(actions: [SegmentedAction]) {
@@ -109,35 +144,35 @@ class CustomSegmentedControl: UIControl {
 
         var previousSeparator: UIView?
         for (index, action) in actions.enumerated() {
-            let actionView = UIView()
-            actionView.translatesAutoresizingMaskIntoConstraints = false
-            actionView.accessibilityLabel = action.accessibilityLabel
-            actionView.isAccessibilityElement = false // Disable individual segment accessibility
-            actionView.isUserInteractionEnabled = true
-            addSubview(actionView)
+            let segmentView = SegmentView(index: index, accessibilityLabel: action.accessibilityLabel, selectHandler: { [weak self] index in
+                self?.selectSegment(at: index)
+            })
+            segmentView.translatesAutoresizingMaskIntoConstraints = false
+            segmentView.isUserInteractionEnabled = true
+            addSubview(segmentView)
 
             let widthMultiplier = (1.0 / CGFloat(actionCount))
             let willHaveTrailingSeperator = (index < actions.count - 1)
             NSLayoutConstraint.activate([
-                actionView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, multiplier: widthMultiplier),
-                actionView.topAnchor.constraint(equalTo: topAnchor),
-                actionView.bottomAnchor.constraint(equalTo: bottomAnchor),
-                actionView.leadingAnchor.constraint(equalTo: previousSeparator?.trailingAnchor ?? leadingAnchor)
+                segmentView.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, multiplier: widthMultiplier),
+                segmentView.topAnchor.constraint(equalTo: topAnchor),
+                segmentView.bottomAnchor.constraint(equalTo: bottomAnchor),
+                segmentView.leadingAnchor.constraint(equalTo: previousSeparator?.trailingAnchor ?? leadingAnchor)
             ])
             if index == actions.count - 1 {
-                actionView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+                segmentView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
             }
 
             // set up touch handling
             let touchHandler = UITapGestureRecognizer(target: self, action: #selector(segmentTapped(_:)))
-            actionView.addGestureRecognizer(touchHandler)
+            segmentView.addGestureRecognizer(touchHandler)
 
             // add icon or text
             if let icon = action.icon {
                 let iconView = TintableImageView(image: icon)
                 iconView.contentMode = .center
-                actionView.addSubview(iconView)
-                iconView.anchorToAllSidesOf(view: actionView)
+                segmentView.addSubview(iconView)
+                iconView.anchorToAllSidesOf(view: segmentView)
 
                 itemViews.append(iconView)
             } else {
@@ -147,12 +182,12 @@ class CustomSegmentedControl: UIControl {
                 label.font = titleFont
                 label.adjustsFontSizeToFitWidth = true
                 label.minimumScaleFactor = 0.7
-                actionView.addSubview(label)
-                label.anchorToAllSidesOf(view: actionView, padding: 4)
+                segmentView.addSubview(label)
+                label.anchorToAllSidesOf(view: segmentView, padding: 4)
 
                 itemViews.append(label)
             }
-            actionViews.append(actionView)
+            actionViews.append(segmentView)
 
             // add seperator if required
             if willHaveTrailingSeperator {
@@ -164,7 +199,7 @@ class CustomSegmentedControl: UIControl {
                     separator.widthAnchor.constraint(equalToConstant: CustomSegmentedControl.separatorWidth),
                     separator.topAnchor.constraint(equalTo: topAnchor, constant: 2),
                     separator.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -2),
-                    separator.leadingAnchor.constraint(equalTo: actionView.trailingAnchor)
+                    separator.leadingAnchor.constraint(equalTo: segmentView.trailingAnchor)
                 ])
                 separatorViews.append(separator)
 
@@ -176,19 +211,23 @@ class CustomSegmentedControl: UIControl {
         setupAccessibility()
     }
 
-    private func setupAccessibility() {
-        // Make the entire control accessible as one element
-        isAccessibilityElement = true
-        accessibilityTraits = .adjustable
-        updateAccessibilityValue()
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window != nil {
+            selectionFeedbackGenerator.prepare()
+        }
+    }
 
-        // Ensure individual segments are not accessible
-        actionViews.forEach { $0.isAccessibilityElement = false }
+    private func setupAccessibility() {
+        isAccessibilityElement = false
+        accessibilityTraits = []
+        updateSegmentAccessibilityStates()
     }
 
     private func updateColors() {
         for (index, view) in actionViews.enumerated() {
-            view.backgroundColor = selectedIndex == index ? selectedBgColor : unselectedBgColor
+            let isSelected = selectedIndex == index
+            view.backgroundColor = isSelected ? selectedBgColor : unselectedBgColor
         }
 
         separatorViews.forEach { $0.backgroundColor = lineColor }
@@ -215,12 +254,41 @@ class CustomSegmentedControl: UIControl {
         layer.borderColor = lineColor.cgColor
     }
 
+    private func updateSegmentAccessibilityStates() {
+        for (index, segment) in actionViews.enumerated() {
+            segment.updateSelectionState(isSelected: index == selectedIndex)
+        }
+    }
+
+    private func announceAccessibilitySelection() {
+        guard UIAccessibility.isVoiceOverRunning,
+              window != nil,
+              !isHidden,
+              alpha > 0,
+              !accessibilityElementsHidden,
+              selectedIndex >= 0,
+              selectedIndex < actions.count else {
+            return
+        }
+
+        let label = actions[selectedIndex].accessibilityLabel
+        guard !label.isEmpty else { return }
+
+        DispatchQueue.main.async {
+            UIAccessibility.post(notification: .announcement, argument: label)
+        }
+    }
+
+    private func provideSelectionFeedbackIfNeeded() {
+        guard window != nil else { return }
+
+        selectionFeedbackGenerator.selectionChanged()
+        selectionFeedbackGenerator.prepare()
+    }
+
     @objc private func segmentTapped(_ recognizer: UITapGestureRecognizer) {
         let locationTapped = recognizer.location(in: self)
-        let segmentTapped = Int(locationTapped.x / (bounds.width / CGFloat(actionCount)))
-
-        selectedIndex = segmentTapped
-        sendActions(for: .valueChanged)
+        selectSegment(atLocation: locationTapped)
     }
 
     // MARK: - Accessibility Support
@@ -228,9 +296,7 @@ class CustomSegmentedControl: UIControl {
     private var actions: [SegmentedAction] = []
 
     func setActionsWithAccessibility(_ actions: [SegmentedAction]) {
-        self.actions = actions
         setActions(actions)
-        setupAccessibility()
     }
 
     private func clampSelectedIndexIfNeeded() {
@@ -248,41 +314,23 @@ class CustomSegmentedControl: UIControl {
         }
     }
 
-    private func updateAccessibilityValue() {
-        guard selectedIndex >= 0, selectedIndex < actions.count else {
-            accessibilityValue = nil
-            return
-        }
+    private func selectSegment(atLocation point: CGPoint) {
+        guard actionCount > 0, bounds.width > 0 else { return }
 
-        accessibilityValue = actions[selectedIndex].accessibilityLabel
+        let segmentWidth = bounds.width / CGFloat(actionCount)
+        guard segmentWidth > 0 else { return }
+
+        let rawIndex = Int(point.x / segmentWidth)
+        selectSegment(at: rawIndex)
     }
 
-    override func accessibilityIncrement() {
-        guard !actions.isEmpty else { return }
+    private func selectSegment(at index: Int) {
+        guard actionCount > 0 else { return }
 
-        let newIndex = min(selectedIndex + 1, actions.count - 1)
-        if newIndex != selectedIndex {
-            selectedIndex = newIndex
-            updateAccessibilityValue()
-            sendActions(for: .valueChanged)
-            UIAccessibility.post(notification: .announcement, argument: accessibilityValue)
-        }
-    }
+        let clampedIndex = max(0, min(actionCount - 1, index))
+        guard clampedIndex != selectedIndex else { return }
 
-    override func accessibilityDecrement() {
-        guard !actions.isEmpty else { return }
-
-        let newIndex = max(selectedIndex - 1, 0)
-        if newIndex != selectedIndex {
-            selectedIndex = newIndex
-            updateAccessibilityValue()
-            sendActions(for: .valueChanged)
-            UIAccessibility.post(notification: .announcement, argument: accessibilityValue)
-        }
-    }
-
-    private func indexDidChangeAccessibility(previousValue: Int) {
-        updateColors()
-        updateAccessibilityValue()
+        selectedIndex = clampedIndex
+        sendActions(for: .valueChanged)
     }
 }

--- a/podcasts/CustomSegmentedControl.swift
+++ b/podcasts/CustomSegmentedControl.swift
@@ -72,7 +72,9 @@ class CustomSegmentedControl: UIControl {
     public func setActions(_ actions: [SegmentedAction]) {
         clearCurrentActions()
 
+        self.actions = actions
         actionCount = actions.count
+        clampSelectedIndexIfNeeded()
         setup(actions: actions)
 
         layoutIfNeeded()
@@ -231,13 +233,33 @@ class CustomSegmentedControl: UIControl {
         setupAccessibility()
     }
 
-    private func updateAccessibilityValue() {
-        if selectedIndex < actions.count {
-            accessibilityValue = actions[selectedIndex].accessibilityLabel
+    private func clampSelectedIndexIfNeeded() {
+        if actions.isEmpty {
+            if selectedIndex != 0 {
+                selectedIndex = 0
+            }
+            return
+        }
+
+        let validRange = 0...(actions.count - 1)
+        let clampedValue = (selectedIndex...selectedIndex).clamped(to: validRange).lowerBound
+        if clampedValue != selectedIndex {
+            selectedIndex = clampedValue
         }
     }
 
+    private func updateAccessibilityValue() {
+        guard selectedIndex >= 0, selectedIndex < actions.count else {
+            accessibilityValue = nil
+            return
+        }
+
+        accessibilityValue = actions[selectedIndex].accessibilityLabel
+    }
+
     override func accessibilityIncrement() {
+        guard !actions.isEmpty else { return }
+
         let newIndex = min(selectedIndex + 1, actions.count - 1)
         if newIndex != selectedIndex {
             selectedIndex = newIndex
@@ -248,6 +270,8 @@ class CustomSegmentedControl: UIControl {
     }
 
     override func accessibilityDecrement() {
+        guard !actions.isEmpty else { return }
+
         let newIndex = max(selectedIndex - 1, 0)
         if newIndex != selectedIndex {
             selectedIndex = newIndex

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -387,6 +387,7 @@ class EffectsViewController: SimpleNotificationsViewController {
         let isEnabled = effects.trimSilence.isEnabled()
 
         trimSilenceSpeedsToLabelConstraint.isActive = isEnabled
+        let wasHidden = trimSilenceAmountControl.isHidden
         UIView.animate(withDuration: 0.3) {
             self.trimSilenceAmountControl.alpha = isEnabled ? 1 : 0
             self.view.layoutIfNeeded()
@@ -394,12 +395,16 @@ class EffectsViewController: SimpleNotificationsViewController {
 
         // Hide from accessibility when not enabled to prevent VoiceOver getting stuck
         trimSilenceAmountControl.isAccessibilityElement = isEnabled
+        trimSilenceAmountControl.accessibilityElementsHidden = !isEnabled
         trimSilenceAmountControl.isHidden = !isEnabled
 
         trimSilenceAmountControl.selectedIndex = trimSilenceAmountToIndex(effects.trimSilence)
 
         // Update accessibility order when trim silence state changes
-        setupAccessibilityOrder()
+        setupAccessibilityOrder(trimSilenceEnabled: isEnabled)
+        if isEnabled && wasHidden {
+            UIAccessibility.post(notification: .layoutChanged, argument: trimSilenceAmountControl)
+        }
 
         let timeSaved = StatsManager.shared.timeSavedDynamicSpeedInclusive()
         if timeSaved < 60 {
@@ -525,7 +530,8 @@ class EffectsViewController: SimpleNotificationsViewController {
         setupAccessibilityOrder()
     }
 
-    private func setupAccessibilityOrder() {
+    private func setupAccessibilityOrder(trimSilenceEnabled: Bool? = nil) {
+        let isTrimSilenceEnabled = trimSilenceEnabled ?? trimSilenceSwitch.isOn
         // Create explicit accessibility navigation order
         var accessibilityElements: [Any] = []
 
@@ -540,7 +546,7 @@ class EffectsViewController: SimpleNotificationsViewController {
         accessibilityElements.append(trimSilenceSwitch!)
 
         // Only include trim silence amount control when it's enabled and visible
-        if trimSilenceSwitch.isOn && !trimSilenceAmountControl.isHidden {
+        if isTrimSilenceEnabled && !trimSilenceAmountControl.isHidden {
             accessibilityElements.append(trimSilenceAmountControl!)
         }
 


### PR DESCRIPTION
Fixes a crash when using Voiceover to change the Trim Silence amount beyond its bounds.

Also fixes an issue where this segmented control wasn't added to the Voiceover list after enabling the Trim Silence switch.

## To test

* Open the fullscreen player and open Playback Effects
* Enable Voice Over using Siri
* Swipe through to ensure all controls are selectable
* Enable "Trim Silence"
* ✅ Ensure the Trim Silence values are selectable
* Try changing the values 
* ✅ Ensure values can be changed by swiping without crashing the app

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
