### PR TITLE
[Playlists] Hide duration label when zero

### DIFF
--- a/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
+++ b/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
@@ -5,10 +5,21 @@ struct PlaylistHeaderView: View {
     @ObservedObject var viewModel: PlaylistDetailViewModel
 
     var description: String {
-        if viewModel.playlistEpisodesCount > 1 {
-            return L10n.playlistDetailDescription(viewModel.playlistEpisodesCount, viewModel.totalDuration())
+        let duration = viewModel.totalDuration()
+        switch viewModel.playlistEpisodesCount {
+        case let count where count > 1:
+            if let duration {
+                return L10n.playlistDetailDescription(count, duration)
+            }
+            return L10n.playlistEpisodesCount(count)
+        case 1:
+            if let duration {
+                return L10n.playlistDetailDescriptionOneEpisode(duration)
+            }
+            return L10n.podcastEpisodeCountSingular
+        default:
+            return L10n.playlistEpisodesCount(viewModel.playlistEpisodesCount)
         }
-        return L10n.playlistDetailDescriptionOneEpisode(viewModel.totalDuration())
     }
 
     var body: some View {

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -161,9 +161,13 @@ class PlaylistDetailViewModel: ObservableObject {
         operationQueue.addOperation(refreshOperation)
     }
 
-    func totalDuration() -> String {
+    func totalDuration() -> String? {
         let totalDuration = episodes.map { $0.episode.duration - $0.episode.playedUpTo }.reduce(0, +)
-        return TimeFormatter.shared.multipleUnitFormattedShortTime(time: totalDuration)
+        if totalDuration <= 0 {
+            return nil
+        }
+        let formattedDuration = TimeFormatter.shared.multipleUnitFormattedShortTime(time: totalDuration)
+        return formattedDuration.isEmpty ? nil : formattedDuration
     }
 
     func delete(episodes uuids: [String]) {


### PR DESCRIPTION
Fixes [PCIOS-238](https://linear.app/a8c/issue/PCIOS-238/hide-duration-when-zero)

Hides the duration label when the duration is zero.

https://github.com/user-attachments/assets/6018155a-1949-4e04-8d30-f1c5ab0532b6

## To test

* Create a manual playlist
* Add one episode
* Archive that episode
* ✅  Ensure the duration label is hidden when Archived episodes are hidden

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
