### PR TITLE
[Search improvements] Allow offline search when searching in podcasts

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -700,6 +700,7 @@ enum AnalyticsEvent: String {
     case searchDismissed
     case searchPerformed
     case searchFailed
+    case searchEmptyResults
     case searchPredictiveFailed
     case searchResultTapped
     case searchListShown

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -26,6 +26,10 @@ class SearchAnalyticsHelper: ObservableObject {
         Analytics.track(.searchFailed, properties: ["source": source, "error_code": (error as NSError).code])
     }
 
+    func trackEmptyResults(for term: String) {
+        Analytics.track(.searchEmptyResults, properties: ["source": source, "term": term])
+    }
+
     func trackPredictiveShown() {
         Analytics.track(.searchPredictiveShown, properties: ["source": source])
     }

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -77,6 +77,8 @@ class SearchResultsModel: ObservableObject {
                 currentPredictiveSearchTerm = term
             } catch {
                 predictiveSearchError = error
+                isShowingPredictiveSearch = true
+                predictive = []
                 analyticsHelper.trackPredictiveFailed(error)
             }
             isSearchingPredictive = false

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -156,6 +156,9 @@ class SearchResultsModel: ObservableObject {
             isSearchingForPodcasts = true
             do {
                 let results = try await combinedSearch.search(term: term)
+                if results.isEmpty {
+                    analyticsHelper.trackEmptyResults(for: term)
+                }
                 showCombinedResults(results)
             } catch {
                 isShowingPredictiveSearch = false

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -59,11 +59,16 @@ class SearchResultsModel: ObservableObject {
         currentSearchTerm = ""
     }
 
+    func clearErrors() {
+        episodeSearchError = nil
+        podcastSearchError = nil
+        predictiveSearchError = nil
+    }
+
     @MainActor
     func predictiveSearch(term: String) {
         currentSearchTerm = term
-        episodeSearchError = nil
-        podcastSearchError = nil
+        clearErrors()
 
         guard term.count > 1, !isTermAnURL(term) else {
             return
@@ -97,8 +102,7 @@ class SearchResultsModel: ObservableObject {
         }
 
         currentSearchTerm = term
-        episodeSearchError = nil
-        podcastSearchError = nil
+        clearErrors()
 
         if !isShowingLocalResultsOnly {
             clearSearch()
@@ -142,8 +146,7 @@ class SearchResultsModel: ObservableObject {
     @MainActor
     func combinedSearch(term: String) {
         currentSearchTerm = term
-        episodeSearchError = nil
-        podcastSearchError = nil
+        clearErrors()
 
         if !isShowingLocalResultsOnly {
             clearSearch()
@@ -155,6 +158,7 @@ class SearchResultsModel: ObservableObject {
                 let results = try await combinedSearch.search(term: term)
                 showCombinedResults(results)
             } catch {
+                isShowingPredictiveSearch = false
                 podcastSearchError = error
                 analyticsHelper.trackFailed(error)
             }

--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -16,7 +16,7 @@ struct NewSearchResultsView: View {
 
     var body: some View {
         Group {
-            if searchResults.episodeSearchError != nil && searchResults.podcastSearchError != nil {
+            if searchResults.podcastSearchError != nil || searchResults.predictiveSearchError != nil {
                 HStack(alignment: .center) {
                     EmptyStateView(
                         title: L10n.discoverSearchFailed,

--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -16,7 +16,7 @@ struct NewSearchResultsView: View {
 
     var body: some View {
         Group {
-            if searchResults.podcastSearchError != nil || searchResults.predictiveSearchError != nil {
+            if (searchResults.podcastSearchError != nil || searchResults.predictiveSearchError != nil) && !searchResults.resultsContainLocalPodcasts {
                 HStack(alignment: .center) {
                     EmptyStateView(
                         title: L10n.discoverSearchFailed,


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-241 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR reinstates the possibility of doing offline local only search when accessing Search on Podcasts and the device is offline.

## To test

1. Start the app
2. Open podcasts
4. Put the device offline
5. Tap on the search bar
6. Check if while typing local results are show
7. Check that if you tap search, local results ares shown
8. Check that you can open podcasts that are locally

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
