### PR TITLE
[Fix] Keyboard reappear after episode detail presented

### DIFF
--- a/podcasts/PodcastViewController+TableData.swift
+++ b/podcasts/PodcastViewController+TableData.swift
@@ -323,6 +323,10 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
                 if indexPath.section == PodcastViewController.allEpisodesSection {
                     guard let podcast = podcast, let episode = episodeAtIndexPath(indexPath) else { return }
 
+                    if searchController?.searchBarActive() == true {
+                        hideSearchKeyboard()
+                    }
+
                     let episodeController = EpisodeDetailViewController(episode: episode, podcast: podcast, source: .podcastScreen, playlist: .podcast(uuid: podcast.uuid))
                     episodeController.modalPresentationStyle = .formSheet
                     present(episodeController, animated: true, completion: nil)


### PR DESCRIPTION
Ref. p1761669027707849-Slack-C029BMLUGRX

Given a user searching in a Podcast detail, this PR dismissed the keyboard when tapping on an episode.

## To test

- Make sure you have few episodes in the UpNext queue
- Go to a podcast detail and start searching
- Tap on an episode
- The keyboard should disappear when the episode detail is presented
- Tap on the Up Next button
- Confirm you see the Option sheet
- Tap on one of those option
- Confirm that the keyboard doesn't show up again when the Option sheet disappear
- Navigating back and tapping on the searchbar it should still show the keyboard

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
