### PR TITLE
[Playlists] Add creation tooltip

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -55,6 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }
                 if FeatureFlag.playlistsRebranding.enabled {
                     Settings.shouldShowNewFilterTip = false
+                    Settings.shouldShowNewFilterTipInCreationView = false
                 }
             case .installed:
                 //Never show the podcast feed reload tooltip for fresh install

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -182,6 +182,7 @@ struct Constants {
         static let shouldShowRecentlyPlayedSortingTip = "ShouldShowRecentlyPlayedSortingTip"
 
         static let newFilterTip = "NewFilterTip"
+        static let newFilterTipCreationView = "NewFilterTipCreationView"
         static let playlistDragAndDropTip = "PlaylistDragAndDropTip"
         static let playlistsOnboarding = "NewPlaylistsOnboarding"
         static let firstTimePlaylistCreated = "FirstTimePlaylistCreated"

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -85,7 +85,7 @@ class NewPlaylistViewController: PCViewController {
         }
         setupContent()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftUI
 import PocketCastsDataModel
 
 class NewPlaylistViewController: PCViewController {
@@ -19,6 +20,8 @@ class NewPlaylistViewController: PCViewController {
     }
 
     private let creationType: CreationType
+    private var creationView: UIView?
+    private var smartPlaylistsTip: UIViewController? = nil
 
     weak var delegate: FilterCreatedDelegate?
 
@@ -82,6 +85,12 @@ class NewPlaylistViewController: PCViewController {
         }
         setupContent()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        showSmartPlaylistTooltip()
+    }
 
     private func setupNavBar() {
         let backgroundColor = AppTheme.viewBackgroundColor()
@@ -143,6 +152,8 @@ class NewPlaylistViewController: PCViewController {
             }.themedUIView
             creationView.translatesAutoresizingMaskIntoConstraints = false
             view.insertSubview(creationView, belowSubview: saveButton)
+
+            self.creationView = creationView
 
             constraints.append(contentsOf: [
                 creationView.topAnchor.constraint(equalTo: textFieldBorderView.bottomAnchor, constant: 16.0),
@@ -218,11 +229,82 @@ class NewPlaylistViewController: PCViewController {
     @objc private func textFieldDidChange() {
         playlistName = playlistNameTextField.text ?? ""
     }
+
+    private func showSmartPlaylistTooltip() {
+        if creationType != .default || !Settings.shouldShowNewFilterTipInCreationView {
+            return
+        }
+
+        guard
+            let source = creationView,
+            let vc = tip(
+                title: L10n.smartPlaylistsTipViewCreationTitle,
+                message: L10n.smartPlaylistsTipViewCreationDescription,
+                sourceView: source,
+                sourceRect: source.bounds
+            )
+        else {
+            return
+        }
+        smartPlaylistsTip = vc
+
+        present(vc, animated: true) {
+            Settings.shouldShowNewFilterTipInCreationView = false
+        }
+    }
+
+    private func dismissTipView() {
+        dismiss(animated: true) { [weak self] in
+            self?.smartPlaylistsTip = nil
+        }
+    }
+
+    private func tip(
+        idealSize: CGSize = CGSizeMake(290, 100),
+        title: String,
+        message: String,
+        sourceView: UIView?,
+        sourceRect: CGRect
+    ) -> UIHostingController<AnyView>? {
+        let vc = UIHostingController(rootView: AnyView (EmptyView()) )
+        let tipView = TipViewStatic(title: title,
+                                    message: message,
+                              onTap: { [weak self] in
+            self?.dismissTipView()
+        })
+            .frame(idealWidth: idealSize.width, minHeight: idealSize.height)
+            .setupDefaultEnvironment()
+        vc.rootView = AnyView(tipView)
+        vc.view.backgroundColor = .clear
+        vc.view.clipsToBounds = false
+        vc.modalPresentationStyle = .popover
+        vc.sizingOptions = [.preferredContentSize]
+        guard let popoverPresentationController = vc.popoverPresentationController else {
+            return nil
+        }
+        popoverPresentationController.delegate = self
+        popoverPresentationController.permittedArrowDirections = [.up]
+        popoverPresentationController.sourceView = sourceView
+        popoverPresentationController.sourceRect = sourceRect
+        popoverPresentationController.backgroundColor = ThemeColor.primaryUi01()
+        return vc
+    }
 }
 
 extension NewPlaylistViewController: UITextFieldDelegate {
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
         playlistName = ""
         return true
+    }
+}
+
+extension NewPlaylistViewController: UIPopoverPresentationControllerDelegate {
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        // Return no adaptive presentation style, use default presentation behaviour
+        return .none
+    }
+
+    func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
+        dismissTipView()
     }
 }

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1505,6 +1505,15 @@ class Settings: NSObject {
         }
     }
 
+    static var shouldShowNewFilterTipInCreationView: Bool {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.newFilterTipCreationView) as? Bool ?? true
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.newFilterTipCreationView)
+        }
+    }
+
     static var shouldShowDragAndDropTip: Bool {
         get {
             UserDefaults.standard.value(forKey: Constants.UserDefaults.playlistDragAndDropTip) as? Bool ?? false

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3812,6 +3812,10 @@ internal enum L10n {
   }
   /// A common string used throughout the app. Often refers to the Smart Playlist.
   internal static var smartPlaylist: String { return L10n.tr("Localizable", "smart_playlist", fallback: "Smart Playlist") }
+  /// The description shown in a Tip View when the user opens the new Playlist creation view for the first time
+  internal static var smartPlaylistsTipViewCreationDescription: String { return L10n.tr("Localizable", "smart_playlists_tip_view_creation_description", fallback: "Pick episodes yourself, or let Smart Playlist fill it automatically based on your Smart Rules.") }
+  /// The title shown in a Tip View when the user opens the new Playlist creation view for the first time
+  internal static var smartPlaylistsTipViewCreationTitle: String { return L10n.tr("Localizable", "smart_playlists_tip_view_creation_title", fallback: "Build your own playlist or let us help") }
   /// The description shown in a Tip View when the user hasn't yet added a smart playlist
   internal static var smartPlaylistsTipViewDescription: String { return L10n.tr("Localizable", "smart_playlists_tip_view_description", fallback: "We made these to help you get started. They auto-update based on your listening.") }
   /// The title shown in a Tip View when the user hasn't yet added a smart playlist

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5426,6 +5426,12 @@
 /* The description shown in a Tip View when the user hasn't yet added a smart playlist */
 "smart_playlists_tip_view_description" = "We made these to help you get started. They auto-update based on your listening.";
 
+/* The title shown in a Tip View when the user opens the new Playlist creation view for the first time */
+"smart_playlists_tip_view_creation_title" = "Build your own playlist or let us help";
+
+/* The description shown in a Tip View when the user opens the new Playlist creation view for the first time */
+"smart_playlists_tip_view_creation_description" = "Pick episodes yourself, or let Smart Playlist fill it automatically based on your Smart Rules.";
+
 /* The title shown in a Tip View when the user creates the first playlist */
 "playlists_tip_drag_and_drop_title" = "Reorder your playlists";
 


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-249

Adds the tooltip to be shown for new users only when showing the creation view for the first time

<img width="350"  alt="IMG_0417" src="https://github.com/user-attachments/assets/260f5c04-38a8-4b23-bd1f-ee8d92683d53" />

## To test

### New user
- Run this branch as fresh install
- Enable the playlists rebranding FF
- Restart the branch
- Go to Playlists
- Tap on the + (top tight)
- When the creation screen is presented you should see the tip
- Dismiss it and dismiss the view
- Reopen the view
- You shouldn't see the tip anymore

### Update user
- Check out trunk and run it as fresh install
- Sign in
- Enable the playlist rebranding FF
- Stop Xcode
- Checkout this branch
- Bump the version in order to force `appInstallState` to be `updated`
- Run the app
- Go to Playlists
- You should see the sheet which explains about Playlists
- Dismiss it
- Tap the + button to show the creation view
- You shouldn't see the tip

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
