### PR TITLE
[Playlists] Analytics: Swipe action

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -55,6 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }
                 if FeatureFlag.playlistsRebranding.enabled {
                     Settings.shouldShowNewFilterTip = false
+                    Settings.shouldShowNewFilterTipInCreationView = false
                 }
             case .installed:
                 //Never show the podcast feed reload tooltip for fresh install

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -182,6 +182,7 @@ struct Constants {
         static let shouldShowRecentlyPlayedSortingTip = "ShouldShowRecentlyPlayedSortingTip"
 
         static let newFilterTip = "NewFilterTip"
+        static let newFilterTipCreationView = "NewFilterTipCreationView"
         static let playlistDragAndDropTip = "PlaylistDragAndDropTip"
         static let playlistsOnboarding = "NewPlaylistsOnboarding"
         static let firstTimePlaylistCreated = "FirstTimePlaylistCreated"

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import SwiftUI
 import PocketCastsDataModel
 
 class NewPlaylistViewController: PCViewController {
@@ -19,6 +20,8 @@ class NewPlaylistViewController: PCViewController {
     }
 
     private let creationType: CreationType
+    private var creationView: UIView?
+    private var smartPlaylistsTip: UIViewController? = nil
 
     weak var delegate: FilterCreatedDelegate?
 
@@ -82,6 +85,12 @@ class NewPlaylistViewController: PCViewController {
         }
         setupContent()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        showSmartPlaylistTooltip()
+    }
 
     private func setupNavBar() {
         let backgroundColor = AppTheme.viewBackgroundColor()
@@ -143,6 +152,8 @@ class NewPlaylistViewController: PCViewController {
             }.themedUIView
             creationView.translatesAutoresizingMaskIntoConstraints = false
             view.insertSubview(creationView, belowSubview: saveButton)
+
+            self.creationView = creationView
 
             constraints.append(contentsOf: [
                 creationView.topAnchor.constraint(equalTo: textFieldBorderView.bottomAnchor, constant: 16.0),
@@ -218,11 +229,82 @@ class NewPlaylistViewController: PCViewController {
     @objc private func textFieldDidChange() {
         playlistName = playlistNameTextField.text ?? ""
     }
+
+    private func showSmartPlaylistTooltip() {
+        if creationType != .default || !Settings.shouldShowNewFilterTipInCreationView {
+            return
+        }
+
+        guard
+            let source = creationView,
+            let vc = tip(
+                title: L10n.smartPlaylistsTipViewCreationTitle,
+                message: L10n.smartPlaylistsTipViewCreationDescription,
+                sourceView: source,
+                sourceRect: source.bounds
+            )
+        else {
+            return
+        }
+        smartPlaylistsTip = vc
+
+        present(vc, animated: true) {
+            Settings.shouldShowNewFilterTipInCreationView = false
+        }
+    }
+
+    private func dismissTipView() {
+        dismiss(animated: true) { [weak self] in
+            self?.smartPlaylistsTip = nil
+        }
+    }
+
+    private func tip(
+        idealSize: CGSize = CGSizeMake(290, 100),
+        title: String,
+        message: String,
+        sourceView: UIView?,
+        sourceRect: CGRect
+    ) -> UIHostingController<AnyView>? {
+        let vc = UIHostingController(rootView: AnyView (EmptyView()) )
+        let tipView = TipViewStatic(title: title,
+                                    message: message,
+                              onTap: { [weak self] in
+            self?.dismissTipView()
+        })
+            .frame(idealWidth: idealSize.width, minHeight: idealSize.height)
+            .setupDefaultEnvironment()
+        vc.rootView = AnyView(tipView)
+        vc.view.backgroundColor = .clear
+        vc.view.clipsToBounds = false
+        vc.modalPresentationStyle = .popover
+        vc.sizingOptions = [.preferredContentSize]
+        guard let popoverPresentationController = vc.popoverPresentationController else {
+            return nil
+        }
+        popoverPresentationController.delegate = self
+        popoverPresentationController.permittedArrowDirections = [.up]
+        popoverPresentationController.sourceView = sourceView
+        popoverPresentationController.sourceRect = sourceRect
+        popoverPresentationController.backgroundColor = ThemeColor.primaryUi01()
+        return vc
+    }
 }
 
 extension NewPlaylistViewController: UITextFieldDelegate {
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
         playlistName = ""
         return true
+    }
+}
+
+extension NewPlaylistViewController: UIPopoverPresentationControllerDelegate {
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        // Return no adaptive presentation style, use default presentation behaviour
+        return .none
+    }
+
+    func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
+        dismissTipView()
     }
 }

--- a/podcasts/New Detail/PlaylistDetailViewController+Swipe.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+Swipe.swift
@@ -33,7 +33,7 @@ extension PlaylistDetailViewController: SwipeTableViewCellDelegate, SwipeHandler
     // MARK: - SwipeActionsHandler
 
     var swipeSource: String {
-        "playlists"
+        "filters"
     }
 
     var swipeSourceType: SwipeSourceType {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1505,6 +1505,15 @@ class Settings: NSObject {
         }
     }
 
+    static var shouldShowNewFilterTipInCreationView: Bool {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.newFilterTipCreationView) as? Bool ?? true
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.newFilterTipCreationView)
+        }
+    }
+
     static var shouldShowDragAndDropTip: Bool {
         get {
             UserDefaults.standard.value(forKey: Constants.UserDefaults.playlistDragAndDropTip) as? Bool ?? false

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3812,6 +3812,10 @@ internal enum L10n {
   }
   /// A common string used throughout the app. Often refers to the Smart Playlist.
   internal static var smartPlaylist: String { return L10n.tr("Localizable", "smart_playlist", fallback: "Smart Playlist") }
+  /// The description shown in a Tip View when the user opens the new Playlist creation view for the first time
+  internal static var smartPlaylistsTipViewCreationDescription: String { return L10n.tr("Localizable", "smart_playlists_tip_view_creation_description", fallback: "Pick episodes yourself, or let Smart Playlist fill it automatically based on your Smart Rules.") }
+  /// The title shown in a Tip View when the user opens the new Playlist creation view for the first time
+  internal static var smartPlaylistsTipViewCreationTitle: String { return L10n.tr("Localizable", "smart_playlists_tip_view_creation_title", fallback: "Build your own playlist or let us help") }
   /// The description shown in a Tip View when the user hasn't yet added a smart playlist
   internal static var smartPlaylistsTipViewDescription: String { return L10n.tr("Localizable", "smart_playlists_tip_view_description", fallback: "We made these to help you get started. They auto-update based on your listening.") }
   /// The title shown in a Tip View when the user hasn't yet added a smart playlist

--- a/podcasts/SwipeActionsHelper.swift
+++ b/podcasts/SwipeActionsHelper.swift
@@ -195,9 +195,9 @@ enum SwipeActionsHelper {
             case .share:
                 return "share"
             case .addToManualPlaylist:
-                return "add_to_manual_playlist"
+                return "add_to_playlist"
             case .removeFromManualPlaylist:
-                return "remove_from_manual_playlist"
+                return "remove_from_playlist"
             }
         }
     }

--- a/podcasts/UpNextViewController+Swipe.swift
+++ b/podcasts/UpNextViewController+Swipe.swift
@@ -72,6 +72,13 @@ extension UpNextViewController: SwipeTableViewCellDelegate {
                let episode = DataManager.sharedManager.episodeInUpNextAt(index: indexPath.row + 1) as? Episode {
                 let shareAction = SwipeAction(style: .default, title: nil) { [weak self] _, indexPath in
                     guard let self else { return }
+                    Analytics.track(
+                        .episodeSwipeActionPerformed,
+                        properties: [
+                            "action": "add_to_playlist",
+                            "source": "up_next"
+                        ]
+                    )
                     let presentModal: () -> Void = { [weak self] in
                         NavigationManager.sharedManager.navigateTo(
                             NavigationManager.manualPlaylistsChooserKey,

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5426,6 +5426,12 @@
 /* The description shown in a Tip View when the user hasn't yet added a smart playlist */
 "smart_playlists_tip_view_description" = "We made these to help you get started. They auto-update based on your listening.";
 
+/* The title shown in a Tip View when the user opens the new Playlist creation view for the first time */
+"smart_playlists_tip_view_creation_title" = "Build your own playlist or let us help";
+
+/* The description shown in a Tip View when the user opens the new Playlist creation view for the first time */
+"smart_playlists_tip_view_creation_description" = "Pick episodes yourself, or let Smart Playlist fill it automatically based on your Smart Rules.";
+
 /* The title shown in a Tip View when the user creates the first playlist */
 "playlists_tip_drag_and_drop_title" = "Reorder your playlists";
 


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-242

Adds the new source and action when a user adds an episode to a manual playlist (or delete one) from the manual swipe gesture

## To test

- Make sure you have the rebranding Playlists FF enabled
- Make sure you have the Tracks flag enabled

### Remove
- Run this branch and enter a manual playlist with few episodes (make a new one if needed)
- Swipe left to show the right options
- Tap on the delete one
- When the episode is removed you should see tracked `🔵 Tracked: episode_swipe_action_performed ["action": "remove_from_playlist", "source": "filters"]`

### Add
#### Podcast detail
- Go to a podcast
- Swipe left an episode to show the right options
- Tap on the add button to show the add view
- Confirm you see `🔵 Tracked: episode_swipe_action_performed ["source": "podcast_details", "action": "add_to_playlist"]`

#### Smart Playlist
- Do the same test from Smart Playlist
- Confirm you see `🔵 Tracked: episode_swipe_action_performed ["source": "filters", "action": "add_to_playlist"]`

#### Up Next
- Do the same test from Up Next
- Confirm you see `🔵 Tracked: episode_swipe_action_performed ["source": "up_next", "action": "add_to_playlist"]`

#### Listening History
- Do the same test from Listening History
- Confirm you see `🔵 Tracked: episode_swipe_action_performed ["source": "listening_history", "action": "add_to_playlist"]`

#### Downloads
- Do the same test from Downloads
- Confirm you see `🔵 Tracked: episode_swipe_action_performed ["source": "downloads", "action": "add_to_playlist"]`

#### Starred
- Do the same test from Starred
- Confirm you see `🔵 Tracked: episode_swipe_action_performed ["source": "starred", "action": "add_to_playlist"]`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
