### PR TITLE
[Search Improvements] - Hide filter pills on single results and show all results link

### DIFF
--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -56,12 +56,21 @@ struct NewSearchResultsView: View {
                 .background(Theme.sharedTheme.primaryUi01)
             } else if searchResults.isShowingPredictiveSearch || (searchResults.isSearchingPredictive && !searchResults.predictive.isEmpty) {
                 List {
-                    Section {
+                    Section(content: {
                         PredictiveList()
                             .onAppear {
                                 self.searchAnalyticsHelper.trackPredictiveShown()
                             }
-                    }
+                    }, footer: {
+                        Button(action: {
+                            searchResults.search(term: searchResults.currentSearchTerm)
+                        }, label: {
+                            Text(L10n.searchResultsViewAll(searchResults.currentSearchTerm))
+                                .font(style: .subheadline, weight: .medium)
+                                .foregroundColor(AppTheme.color(for: .primaryInteractive01, theme: theme))
+                        })
+                    })
+                    .listSectionSeparator(.hidden, edges: .bottom)
                 }
                 .scrollDismissesKeyboard(.immediately)
                 .listStyle(.plain)

--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -36,24 +36,35 @@ struct NewSearchResultsView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .tint(AppTheme.loadingActivityColor().color)
             } else if searchResults.noResults {
-                HStack(alignment: .center) {
-                    EmptyStateView(title: L10n.searchResultsEmptyTitle,
-                                   message: L10n.searchResultsEmptyMessage,
-                                   icon: { Image("search") },
-                                   actions: [.init(title: L10n.searchResultsEmptyAction,
-                                                   style: SimpleTextButtonStyle(theme: .sharedTheme, textColor: .primaryInteractive01),
-                                                   action: {
-                        guard let source = SceneHelper.rootViewController() else {
-                            assertionFailure("WARNING: Root View Controller not found so survey was not presented")
-                            FileLog.shared.addMessage("UserSatisfactionSurveyManager: Root View Controller not found so survey was not presented")
-                            return
+                if searchResults.isShowingPredictiveSearch {
+                    VStack {
+                        HStack {
+                            showFullResultsButton
+                            Spacer()
                         }
-                        EmailHelper().presentSupportDialog(source, type: .satisfactionSurvey)
-                    })]
-                    )
+                        Spacer()
+                    }
+                    .padding(.horizontal, 16)
+                } else {
+                    HStack(alignment: .center) {
+                        EmptyStateView(title: L10n.searchResultsEmptyTitle,
+                                       message: L10n.searchResultsEmptyMessage,
+                                       icon: { Image("search") },
+                                       actions: [.init(title: L10n.searchResultsEmptyAction,
+                                                       style: SimpleTextButtonStyle(theme: .sharedTheme, textColor: .primaryInteractive01),
+                                                       action: {
+                            guard let source = SceneHelper.rootViewController() else {
+                                assertionFailure("WARNING: Root View Controller not found so survey was not presented")
+                                FileLog.shared.addMessage("UserSatisfactionSurveyManager: Root View Controller not found so survey was not presented")
+                                return
+                            }
+                            EmailHelper().presentSupportDialog(source, type: .satisfactionSurvey)
+                        })]
+                        )
+                    }
+                    .frame(maxHeight: .infinity)
+                    .background(Theme.sharedTheme.primaryUi01)
                 }
-                .frame(maxHeight: .infinity)
-                .background(Theme.sharedTheme.primaryUi01)
             } else if searchResults.isShowingPredictiveSearch || (searchResults.isSearchingPredictive && !searchResults.predictive.isEmpty) {
                 List {
                     Section(content: {
@@ -62,13 +73,7 @@ struct NewSearchResultsView: View {
                                 self.searchAnalyticsHelper.trackPredictiveShown()
                             }
                     }, footer: {
-                        Button(action: {
-                            searchResults.search(term: searchResults.currentSearchTerm)
-                        }, label: {
-                            Text(L10n.searchResultsViewAll(searchResults.currentSearchTerm))
-                                .font(style: .subheadline, weight: .medium)
-                                .foregroundColor(AppTheme.color(for: .primaryInteractive01, theme: theme))
-                        })
+                        showFullResultsButton
                     })
                     .listSectionSeparator(.hidden, edges: .bottom)
                 }
@@ -96,6 +101,16 @@ struct NewSearchResultsView: View {
             }
         }
         .background(theme.primaryUi01.ignoresSafeArea())
+    }
+
+    @ViewBuilder var showFullResultsButton: some View {
+        Button(action: {
+            searchResults.search(term: searchResults.currentSearchTerm)
+        }, label: {
+            Text(L10n.searchResultsViewAll(searchResults.currentSearchTerm))
+                .font(style: .subheadline, weight: .medium)
+                .foregroundColor(AppTheme.color(for: .primaryInteractive01, theme: theme))
+        })
     }
 
     @ViewBuilder var filterPicker: some View {

--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -69,7 +69,9 @@ struct NewSearchResultsView: View {
                 .scrollContentBackground(.hidden)
             } else {
                 VStack(spacing: 0) {
-                    filterPicker
+                    if searchResults.combinedResults.count > 1 {
+                        filterPicker
+                    }
                     List {
                         if displayMode != .episodes {
                             localResults

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3109,6 +3109,10 @@ internal enum L10n {
   internal static var searchResultsEmptyMessage: String { return L10n.tr("Localizable", "search_results_empty_message", fallback: "Try a new search, or by adding a podcast feed URL") }
   /// No Results
   internal static var searchResultsEmptyTitle: String { return L10n.tr("Localizable", "search_results_empty_title", fallback: "No Results") }
+  /// View all results for "%1$@"
+  internal static func searchResultsViewAll(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "search_results_view_all", String(describing: p1), fallback: "View all results for \"%1$@\"")
+  }
   /// A common string used throughout the app. Refers to the season a podcast episode is in.
   internal static var season: String { return L10n.tr("Localizable", "season", fallback: "Season") }
   /// Shorthand format used to show the Season and the Episode number of a podcast. 'S' is short for Season. '%1$@' is a placeholder for the season number. 'E' is short for Episode. '%2$@' is a placeholder for the episode number.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5621,3 +5621,6 @@
 /// Search results screen: action for sending feedback when no results found
 "search_results_empty_action" = "Send Us Feedback";
 
+/// Search results screen: action for doing full search on term. %1$@ argument is the term being searched. Ex: "View all results for "cautionary" "
+"search_results_view_all" = "View all results for \"%1$@\"";
+


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-250 <!-- issue number, if applicable -->
Fixes PCIOS-250

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

| Hide filter pill | Show all results |
| - | - |
|  <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2025-10-29 at 16 15 51" src="https://github.com/user-attachments/assets/290aa685-3f7f-4633-9898-bc6a209f9282" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2025-10-29 at 16 15 44" src="https://github.com/user-attachments/assets/c8e00f4c-b8eb-405a-bf22-35340748f2c7" /> |

## To test

1. Start the app
2. Open on Discovery 
3. Tap on Search
4. Tap a term like `news` but don't tap Search on keyboard
5. Scroll the predictive results to the bottom
6. Check if you see a See all results "news" button on the bottom
7. Tap on it
8. Check if the full results for news is shown
9. Now insert on search a podcast url like this: `https://omny.fm/shows/brand-new/playlists/podcast.rss`
10. Tap on Search
11. Check if a single result is shown and no pills are shown

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
