### PR TITLE
[Playlists] Analytics: add event for episode added to manual playlists

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -313,6 +313,12 @@ enum AnalyticsEvent: String {
     case episodeRecentlyPlayedSortOptionTooltipShown
     case episodeRecentlyPlayedSortOptionTooltipDismissed
 
+    case addToPlaylistsShown
+    case addToPlaylistsEpisodeAddTapped
+    case addToPlaylistsRemoveTapped
+    case addToPlaylistsNewPlaylistTapped
+    case addToPlaylistsCreateNewPlaylistTapped
+
     // MARK: - Podcast screen
 
     case podcastScreenShown

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -426,11 +426,11 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         switchToTab(.filter)
     }
 
-    func presentManualPlaylistsChooser(for episode: Episode, rootViewController: UIViewController?) {
+    func presentManualPlaylistsChooser(for episode: Episode, rootViewController: UIViewController?, source: String) {
         guard let navController = selectedViewController as? UINavigationController else {
             return
         }
-        let manualPlaylistsChooser = ManualPlaylistsChooserViewController(episode: episode)
+        let manualPlaylistsChooser = ManualPlaylistsChooserViewController(episode: episode, analyticsSource: source)
         let navVC = SJUIUtils.navController(for: manualPlaylistsChooser)
         if presentedViewController is PlayerContainerViewController {
             presentedViewController?.present(navVC, animated: true, completion: nil)

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -82,6 +82,7 @@ class NavigationManager {
     static let manualPlaylistsChooserKey = "manualPlaylistsChooserKey"
     static let manualPlaylistsChooserEpisodeKey = "manualPlaylistsChooserEpisodeKey"
     static let manualPlaylistsChooserRootKey = "manualPlaylistsChooserRootKey"
+    static let manualPlaylistsChooserSourceKey = "manualPlaylistsChooserSourceKey"
 
     static let sharedManager = NavigationManager()
 
@@ -252,7 +253,8 @@ class NavigationManager {
         } else if place == NavigationManager.manualPlaylistsChooserKey {
             if let episode = data?[NavigationManager.manualPlaylistsChooserEpisodeKey] as? Episode {
                 let root = data?[NavigationManager.manualPlaylistsChooserRootKey] as? UIViewController
-                mainController?.presentManualPlaylistsChooser(for: episode, rootViewController: root)
+                let source = data?[NavigationManager.manualPlaylistsChooserSourceKey] as? String ?? "swipe"
+                mainController?.presentManualPlaylistsChooser(for: episode, rootViewController: root, source: source)
             }
         }
     }

--- a/podcasts/NavigationProtocol.swift
+++ b/podcasts/NavigationProtocol.swift
@@ -23,7 +23,7 @@ protocol NavigationProtocol: AnyObject {
     func navigateToFilter(_ filter: EpisodeFilter?, animated: Bool)
     func navigateToEditFilter(_ filter: EpisodeFilter)
     func navigateToAddFilter()
-    func presentManualPlaylistsChooser(for episode: Episode, rootViewController: UIViewController?)
+    func presentManualPlaylistsChooser(for episode: Episode, rootViewController: UIViewController?, source: String)
 
     func navigateToUpNext(_ animated: Bool)
 

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -19,6 +19,7 @@ class NewPlaylistViewController: PCViewController {
     }
 
     private let creationType: CreationType
+    private let analyticsSource: String?
 
     weak var delegate: FilterCreatedDelegate?
 
@@ -64,8 +65,9 @@ class NewPlaylistViewController: PCViewController {
         }
     }
 
-    init(creationType: CreationType = .default) {
+    init(creationType: CreationType = .default, analyticsSource: String? = nil) {
         self.creationType = creationType
+        self.analyticsSource = analyticsSource
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -190,6 +192,7 @@ class NewPlaylistViewController: PCViewController {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: playlist)
         } else if case let .addEpisode(episode) = creationType {
             DataManager.sharedManager.add(episodes: [episode], to: playlist)
+            Analytics.track(.addToPlaylistsCreateNewPlaylistTapped, properties: ["source": analyticsSource ?? "unknown"])
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: playlist)
             NavigationManager.sharedManager.navigateTo(NavigationManager.filterPageKey, data: [NavigationManager.filterUuidKey: playlist.uuid])
         }

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -15,6 +15,7 @@ class ManualPlaylistsChooserViewController: PCViewController {
     private var newSelectedPlaylists: Set<String> = []
     private var searchController: PCSearchBarController?
     private let episode: Episode
+    private let analyticsSource: String
     private let dataManager = DataManager.sharedManager
 
     private var tableView: ThemeableTable! {
@@ -49,8 +50,9 @@ class ManualPlaylistsChooserViewController: PCViewController {
         }
     }
 
-    init(episode: Episode) {
+    init(episode: Episode, analyticsSource: String) {
         self.episode = episode
+        self.analyticsSource = analyticsSource
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -64,6 +66,12 @@ class ManualPlaylistsChooserViewController: PCViewController {
         setupNavBar()
         addCloseButton()
         setupContent()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        Analytics.track(.addToPlaylistsShown, properties: ["source": analyticsSource])
     }
 
     private func setupNavBar() {
@@ -208,7 +216,8 @@ extension ManualPlaylistsChooserViewController: UITableViewDelegate, UITableView
                 playlist: playlist,
                 isLastRow: indexPath.row == manualPlaylists.count - 1,
                 isSelected: isSelected,
-                canBeDisabled: !episodeIsInPlaylist
+                canBeDisabled: !episodeIsInPlaylist,
+                analyticsSource: analyticsSource
             )
         }
         return cell
@@ -223,7 +232,9 @@ extension ManualPlaylistsChooserViewController: UITableViewDelegate, UITableView
 
         tableView.deselectRow(at: indexPath, animated: true)
 
-        let createPlaylistViewController = NewPlaylistViewController(creationType: .addEpisode(episode: episode))
+        Analytics.track(.addToPlaylistsNewPlaylistTapped, properties: ["source": analyticsSource])
+
+        let createPlaylistViewController = NewPlaylistViewController(creationType: .addEpisode(episode: episode), analyticsSource: analyticsSource)
         navigationController?.pushViewController(createPlaylistViewController, animated: true)
     }
 }

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -67,7 +67,7 @@ class ManualPlaylistsChooserViewController: PCViewController {
         addCloseButton()
         setupContent()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -430,7 +430,8 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
         NavigationManager.sharedManager.navigateTo(
             NavigationManager.manualPlaylistsChooserKey,
             data: [
-                NavigationManager.manualPlaylistsChooserEpisodeKey: episode
+                NavigationManager.manualPlaylistsChooserEpisodeKey: episode,
+                NavigationManager.manualPlaylistsChooserSourceKey: "shelf"
             ]
         )
 #endif

--- a/podcasts/PlaylistCell.swift
+++ b/podcasts/PlaylistCell.swift
@@ -63,7 +63,8 @@ class PlaylistCell: ThemeableCell {
         playlist: EpisodeFilter,
         isLastRow: Bool,
         isSelected: Binding<Bool> = .constant(false),
-        canBeDisabled: Bool = false
+        canBeDisabled: Bool = false,
+        analyticsSource: String? = nil
     ) {
         switch cellType {
         case .count, .plain:
@@ -79,7 +80,8 @@ class PlaylistCell: ThemeableCell {
                     displayType: cellType
                 ),
                 isSelected: isSelected,
-                canBeDisabled: canBeDisabled
+                canBeDisabled: canBeDisabled,
+                analyticsSource: analyticsSource
             )
             .environmentObject(Theme.sharedTheme)
             .frame(maxWidth: .infinity, minHeight: Self.cellHeight, alignment: .leading)

--- a/podcasts/PlaylistCellView.swift
+++ b/podcasts/PlaylistCellView.swift
@@ -8,6 +8,7 @@ struct PlaylistCellView: View {
     @Binding private var isSelected: Bool
     @State private var refreshToken = UUID()
     private let canBeDisabled: Bool
+    private let analyticsSource: String?
 
     private var title: String {
         switch viewModel.displayType {
@@ -41,11 +42,13 @@ struct PlaylistCellView: View {
     init(
         viewModel: PlaylistCellViewModel,
         isSelected: Binding<Bool> = .constant(false),
-        canBeDisabled: Bool = false
+        canBeDisabled: Bool = false,
+        analyticsSource: String? = nil
     ) {
         self.viewModel = viewModel
         self._isSelected = isSelected
         self.canBeDisabled = canBeDisabled
+        self.analyticsSource = analyticsSource
     }
 
     var body: some View {
@@ -83,6 +86,8 @@ struct PlaylistCellView: View {
             view
                 .contentShape(Rectangle())
                 .onTapGesture {
+                    trackTapEvent()
+
                     if !shouldDisableRow {
                         isSelected.toggle()
                         refreshToken = UUID()
@@ -135,6 +140,15 @@ struct PlaylistCellView: View {
         case .addNew, .plain:
             EmptyView()
         }
+    }
+
+    private func trackTapEvent() {
+        let event: AnalyticsEvent = !isSelected ? .addToPlaylistsEpisodeAddTapped : .addToPlaylistsRemoveTapped
+        var properties = ["source": self.analyticsSource ?? "unknown"]
+        if !isSelected {
+            properties["is_playlist_full"] = shouldDisableRow ? "true" : "false"
+        }
+        Analytics.track(event, properties: properties)
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/initiative/playback-2025-f8cbf7b0c80d/overview)
|:---:|

Fixes PCIOS-248

Add the analytics events when an episode is added to one or more manual playlists from the swipe option or shelf

## To test
### Source Swipe

1. Make sure you run this branch, enable the rebranding FF and Tracks event
2. Go to a podcast detail
3. Swipe left an episode and tap add
4. Confirm you see the Playlist chooser and the event `🔵 Tracked: add_to_playlists_shown ["source": "swipe"]` tracked
5. Tap on one or more playlists to add/remove the episode. You should see these 2 events:
6. `🔵 Tracked: add_to_playlists_episode_add_tapped ["source": "swipe", "is_playlist_full": "false"]`
7. `🔵 Tracked: add_to_playlists_remove_tapped ["source": "swipe"]`
8. If you tap on a disabled playlist (which is full) you should see `🔵 Tracked: add_to_playlists_episode_add_tapped ["is_playlist_full": "true", "source": "swipe"]`  (you can enable from the dev menu a limit for that)
9. Now in the same screen tap on `New Playlist`
10. You should see `🔵 Tracked: add_to_playlists_new_playlist_tapped ["source": "swipe"]`
11. Add a name and tap Create
12. You should see `🔵 Tracked: add_to_playlists_create_new_playlist_tapped ["source": "swipe"]`
13. Do the same test from Smart Playlist, UpNext, Listening History, Downloads and Starred.

### Shelf
- Play an episode and open the player full screen
- Tap on the `•••` shelf button and tap on `+ Add to playlist` shelf option
- Starts doing the same test from point 4, but now the source is `shelf` and not `swipe`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
