### PR TITLE
[Playlists] Avoid pushing again the detail if viewDidLoad wasn't called before

### DIFF
--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -33,6 +33,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
     var sourceIndexPath: IndexPath?
     var snapshot: UIView?
+    var previouslyDisplayedDetail = false
 
     @IBOutlet var footerView: ThemeableView! {
         didSet {
@@ -77,6 +78,23 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
         title = FeatureFlag.playlistsRebranding.enabled ? L10n.playlists : L10n.filters
 
+        if FeatureFlag.playlistsRebranding.enabled {
+            if !previouslyDisplayedDetail {
+                autoPushPlaylist()
+            }
+        } else {
+            autoPushPlaylist()
+        }
+
+        loadingIndicator = ThemeLoadingIndicator()
+        insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: filtersTable)
+        if !FeatureFlag.playlistsRebranding.enabled {
+            setupNewFilterButton()
+        }
+        handleThemeChanged()
+    }
+
+    func autoPushPlaylist() {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
 
@@ -86,13 +104,6 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
                 }
             }
         }
-
-        loadingIndicator = ThemeLoadingIndicator()
-        insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: filtersTable)
-        if !FeatureFlag.playlistsRebranding.enabled {
-            setupNewFilterButton()
-        }
-        handleThemeChanged()
     }
 
     func setupNewFilterButton() {
@@ -183,6 +194,8 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     }
 
     func showFilter(_ filter: EpisodeFilter, isNew: Bool? = false) {
+        previouslyDisplayedDetail = true
+
         let viewController: UIViewController
         if FeatureFlag.playlistsRebranding.enabled {
             viewController = PlaylistDetailViewController(playlist: filter)


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-252

This PR fixes the playlist detail pushed again after navigating back if the list wasn't showed before.

## To test

- Make sure the playlist rebranding FF is on
- Run the app starting from a section that is not Playlists
- Open a podcast detail
- Swipe to add that episode
- From that panel create a new playlist
- The app should push the new playlist detail with that episode added
- Now tap on the Playlist tab to navigate back
- The details shouldn't push again the detail
- Disable the FF and restart the app
- Smoke test Filters works as before

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
