### PR TITLE
[Playlists] Analytics: update actions to track add to playlist

### DIFF
--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -179,7 +179,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
             button.isPointerInteractionEnabled = true
             button.imageView?.tintColor = ThemeColor.playerContrast02()
             button.setImage(UIImage(named: action.largeIconName(episode: playingEpisode)), for: .normal)
-            button.addTarget(self, action: #selector(presentManualPlaylistsChooser), for: .touchUpInside)
+            button.addTarget(self, action: #selector(presentManualPlaylistsChooser(_:)), for: .touchUpInside)
             button.accessibilityLabel = L10n.playlistManualEpisodeAddToPlaylist
 
             addToShelf(on: button)
@@ -422,6 +422,13 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     // MARK: - Manual Playlists
+
+    @objc func presentManualPlaylistsChooser(_ sender: UIButton) {
+#if !APPCLIP
+        shelfButtonTapped(.addToPlaylist)
+        presentManualPlaylistsChooser()
+#endif
+    }
 
     @objc func presentManualPlaylistsChooser() {
 #if !APPCLIP


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-243

This PR fixes a method to cover the full tracked property `add_to_playlist` when using the shelf

## To test

- Run this branch and make sure you have the playlist rebranding FF enabled and Tracks enabled
- Play an episode and open the player full screen
- If the `Add to playlist` + icon is not in your shelf, tap the `•••` to show the shelf button lists
- Tap on `Add to playlist`
- Confirm you see `🔵 Tracked: player_shelf_action_tapped ["action": "add_to_playlist", "from": "overflow_menu"]`
- Tap on edit and rearrange the + button to be in the shelf
- Confirm you see `🔵 Tracked: player_shelf_overflow_menu_rearrange_action_moved ["position": 1, "moved_to": "overflow_menu", "action": "add_to_playlist", "moved_from": "shelf"]`
- Save and dismiss it
- Tap the + button now present in the shelf
- Confirm you see `🔵 Tracked: player_shelf_action_tapped ["action": "add_to_playlist", "from": "shelf"]`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
