### PR TITLE
[Playlists] Add manual playlist episodes events

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
@@ -403,7 +403,7 @@ class PlaylistDataManager {
 
         // Check that the current episode count + new episodes wouldn't overflow, otherwise bail.
         // Callers should generally
-        let playlistCount = playlistEpisodeCount(clause: .episodeCount, playlist: playlist, episodeUuidToAdd: nil, shouldShowArchived: true, dbQueue: dbQueue)
+        let playlistCount = playlistEpisodeCount(clause: .allEpisodeCount, playlist: playlist, episodeUuidToAdd: nil, shouldShowArchived: true, dbQueue: dbQueue)
         let isFull = playlistCount + episodes.count > EpisodeDataManager.Constants.Limits.maxPlaylistItems
 
         guard episodes.count > 0 && !isFull else { return false }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
@@ -389,13 +389,24 @@ class PlaylistDataManager {
         return highestPosition + 1
     }
 
-    func add(episodes: [Episode], to playlist: EpisodeFilter, dbQueue: PCDBQueue) {
+    /// Returns a value indicating whether the episodes were added. If `false`, the playlist is full.
+    func add(episodes: [Episode], to playlist: EpisodeFilter, dbQueue: PCDBQueue) -> Bool {
+        // If the episodes are already larger than our max size, bail
+        guard episodes.count < EpisodeDataManager.Constants.Limits.maxPlaylistItems else {
+            return false
+        }
+
         // Ensure the filter exists and has a valid id before inserting playlist items
         if playlist.id == 0 {
             save(playlist: playlist, dbQueue: dbQueue)
         }
 
-        guard episodes.count > 0 else { return }
+        // Check that the current episode count + new episodes wouldn't overflow, otherwise bail.
+        // Callers should generally
+        let playlistCount = playlistEpisodeCount(clause: .episodeCount, playlist: playlist, episodeUuidToAdd: nil, shouldShowArchived: true, dbQueue: dbQueue)
+        let isFull = playlistCount + episodes.count > EpisodeDataManager.Constants.Limits.maxPlaylistItems
+
+        guard episodes.count > 0 && !isFull else { return false }
 
         dbQueue.write { db in
             do {
@@ -443,6 +454,8 @@ class PlaylistDataManager {
                 FileLog.shared.addMessage("EpisodeFilterDataManager.addEpisodes error: \(error)")
             }
         }
+
+        return true
     }
 
     // MARK: - Conversion

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -974,7 +974,7 @@ public class DataManager {
         playlistManager.save(playlist: playlist, dbQueue: dbQueue)
     }
 
-    public func add(episodes: [Episode], to playlist: EpisodeFilter) {
+    public func add(episodes: [Episode], to playlist: EpisodeFilter) -> Bool {
         playlistManager.add(episodes: episodes, to: playlist, dbQueue: dbQueue)
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -26,7 +26,11 @@ extension SyncTask {
 
             playlist.syncStatus = SyncStatus.synced.rawValue
             DataManager.sharedManager.save(playlist: playlist)
-            DataManager.sharedManager.add(episodes: addedEpisodes, to: playlist)
+            let didAdd = DataManager.sharedManager.add(episodes: addedEpisodes, to: playlist)
+            if !didAdd {
+                let playlistCount = DataManager.sharedManager.playlistEpisodeCount(for: playlist, episodeUuidToAdd: nil, shouldShowArchived: true)
+                FileLog.shared.addMessage("SyncTask: Tried to add too many episodes from server playlist \(playlist.playlistName) episodeCount: \(addedEpisodes) playlistCount: \(playlistCount)")
+            }
         }
     }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -377,7 +377,11 @@ extension SyncTask {
             DataManager.sharedManager.save(episode: episode)
         }
 
-        DataManager.sharedManager.add(episodes: addedEpisodes, to: playlist)
+        let didAdd = DataManager.sharedManager.add(episodes: addedEpisodes, to: playlist)
+        if !didAdd {
+            let playlistCount = DataManager.sharedManager.playlistEpisodeCount(for: playlist, episodeUuidToAdd: nil, shouldShowArchived: true)
+            FileLog.shared.addMessage("SyncTask: Tried to add too many episodes to imported playlist \(playlist.playlistName) episodeCount: \(addedEpisodes) playlistCount: \(playlistCount)")
+        }
 
         updateEpisodePositionsIfNeeded(for: playlistItem, playlist: playlist)
 

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskPlaylistOrderingTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskPlaylistOrderingTests.swift
@@ -111,7 +111,8 @@ private final class CapturingDataManager: DataManager {
         storedPlaylists[playlist.uuid] = playlist
     }
 
-    override func add(episodes: [Episode], to playlist: EpisodeFilter) {
+    override func add(episodes: [Episode], to playlist: EpisodeFilter) -> Bool {
         addedEpisodes[playlist.uuid] = episodes
+        return true
     }
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -310,6 +310,11 @@ enum AnalyticsEvent: String {
     case filterAutoDownloadUpdated
     case filterAutoDownloadLimitUpdated
 
+    case filterAddEpisodesShown
+    case filterAddEpisodesFolderTapped
+    case filterAddEpisodesPodcastTapped
+    case filterAddEpisodesEpisodeTapped
+
     case episodeRecentlyPlayedSortOptionTooltipShown
     case episodeRecentlyPlayedSortOptionTooltipDismissed
 

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -191,7 +191,8 @@ class NewPlaylistViewController: PCViewController {
         } else if case let .addEpisode(episode) = creationType {
             let didAdd = DataManager.sharedManager.add(episodes: [episode], to: playlist)
             guard didAdd else {
-                Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast)
+                let theme: any ToastTheme = ToastIconTheme(iconName: "option-alert", iconColor: Theme.sharedTheme.primaryIcon01)
+                Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast, theme: theme)
                 return
             }
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: playlist)

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -189,7 +189,11 @@ class NewPlaylistViewController: PCViewController {
             delegate?.filterCreated(newFilter: playlist)
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: playlist)
         } else if case let .addEpisode(episode) = creationType {
-            DataManager.sharedManager.add(episodes: [episode], to: playlist)
+            let didAdd = DataManager.sharedManager.add(episodes: [episode], to: playlist)
+            guard didAdd else {
+                Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast)
+                return
+            }
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: playlist)
             NavigationManager.sharedManager.navigateTo(NavigationManager.filterPageKey, data: [NavigationManager.filterUuidKey: playlist.uuid])
         }

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -154,7 +154,8 @@ class ManualPlaylistsChooserViewController: PCViewController {
             if added.contains(playlist.uuid) {
                 let didAdd = dataManager.add(episodes: [episode], to: playlist)
                 guard didAdd else {
-                    Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast)
+                    let theme: any ToastTheme = ToastIconTheme(iconName: "option-alert", iconColor: Theme.sharedTheme.primaryIcon01)
+                    Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast, theme: theme)
                     return
                 }
             }

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -152,7 +152,11 @@ class ManualPlaylistsChooserViewController: PCViewController {
 
         manualPlaylists.forEach { playlist in
             if added.contains(playlist.uuid) {
-                dataManager.add(episodes: [episode], to: playlist)
+                let didAdd = dataManager.add(episodes: [episode], to: playlist)
+                guard didAdd else {
+                    Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast)
+                    return
+                }
             }
             if removed.contains(playlist.uuid) {
                 dataManager.deleteEpisodes([episode.uuid], from: playlist)

--- a/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
@@ -163,7 +163,8 @@ final class LocalSearchCoordinator {
         Analytics.track(.filterAddEpisodesEpisodeTapped, properties: ["is_playlist_full": isFull])
 
         guard didAdd else {
-            Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast)
+            let theme: any ToastTheme = ToastIconTheme(iconName: "option-alert", iconColor: Theme.sharedTheme.primaryIcon01)
+            Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast, theme: theme)
             return
         }
 

--- a/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
@@ -156,7 +156,17 @@ final class LocalSearchCoordinator {
             return
         }
 
-        dataManager.add(episodes: [episode], to: playlist)
+
+        let didAdd = dataManager.add(episodes: [episode], to: playlist)
+        let isFull = !didAdd
+
+        Analytics.track(.filterAddEpisodesEpisodeTapped, properties: ["is_playlist_full": isFull])
+
+        guard didAdd else {
+            Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast)
+            return
+        }
+
         playlistEpisodeUUIDs.insert(searchResult.uuid)
         episodes.removeAll { $0.uuid == searchResult.uuid }
         addedEpisodeCount += 1

--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -219,7 +219,7 @@ private extension LocalSearchView {
                 searchText: viewModel.searchText,
                 selectedPodcastTitle: viewModel.selectedPodcast?.title,
                 onAddEpisode: { result in
-                    Analytics.track(.filterAddEpisodesEpisodeTapped)
+                    let isFull = false
                     if reduceMotion {
                         viewModel.handleAddEpisode(result)
                     } else {

--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -28,6 +28,7 @@ struct LocalSearchView: View {
                     .background(theme.secondaryUi01)
             }
             .onAppear {
+                Analytics.track(.filterAddEpisodesShown)
                 viewModel.onAppear(searchResultsModel: searchResults)
                 previousNavigationPath = navigationPath
             }
@@ -72,6 +73,7 @@ struct LocalSearchView: View {
     private func handleSelection(for result: PodcastFolderSearchResult) {
         switch result.kind {
         case .folder:
+            Analytics.track(.filterAddEpisodesFolderTapped)
             viewModel.selectFolder(result)
             let route = LocalSearchRoute.folder(result.uuid)
             if navigationPath.last != route {
@@ -80,6 +82,7 @@ struct LocalSearchView: View {
                 }
             }
         case .podcast:
+            Analytics.track(.filterAddEpisodesPodcastTapped)
             if navigationPath.last?.isPodcast == true {
                 withAnimation(navigationAnimation) {
                     navigationPath.removeLast()
@@ -216,6 +219,7 @@ private extension LocalSearchView {
                 searchText: viewModel.searchText,
                 selectedPodcastTitle: viewModel.selectedPodcast?.title,
                 onAddEpisode: { result in
+                    Analytics.track(.filterAddEpisodesEpisodeTapped)
                     if reduceMotion {
                         viewModel.handleAddEpisode(result)
                     } else {

--- a/podcasts/PlaylistCellView.swift
+++ b/podcasts/PlaylistCellView.swift
@@ -87,7 +87,8 @@ struct PlaylistCellView: View {
                         isSelected.toggle()
                         refreshToken = UUID()
                     } else {
-                        Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast)
+                        let theme: any ToastTheme = ToastIconTheme(iconName: "option-alert", iconColor: Theme.sharedTheme.primaryIcon01)
+                        Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast, theme: theme)
                     }
                 }
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2349,7 +2349,7 @@ internal enum L10n {
     return L10n.tr("Localizable", "playlist_episodes_count", String(describing: p1), fallback: "%1$@ episodes")
   }
   /// Toast message when the playlist is full
-  internal static var playlistManualAddEpisodeFullPlaylistToast: String { return L10n.tr("Localizable", "playlist_manual_add_episode_full_playlist_toast", fallback: "Playlist is full. Try creating a new one") }
+  internal static var playlistManualAddEpisodeFullPlaylistToast: String { return L10n.tr("Localizable", "playlist_manual_add_episode_full_playlist_toast", fallback: "This playlist is full. Remove a few episodes or start a new one.") }
   /// Manual Playlist: header button title to add new episodes to the playlist
   internal static var playlistManualAddEpisodes: String { return L10n.tr("Localizable", "playlist_manual_add_episodes", fallback: "Add Episodes") }
   /// Text of the placeholder used in the manual playlist detail screen when one episode is archived.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5556,7 +5556,7 @@
 "playlist_manual_episode_add_to_playlist" = "Add to playlist";
 
 /* Toast message when the playlist is full */
-"playlist_manual_add_episode_full_playlist_toast" = "Playlist is full. Try creating a new one";
+"playlist_manual_add_episode_full_playlist_toast" = "This playlist is full. Remove a few episodes or start a new one.";
 
 /* Text of the placeholder used in the manual playlist detail screen when one episode is archived. */
 "playlist_manual_archived_episode_placeholder" = "Your episode in this playlist has been archived";


### PR DESCRIPTION
Fixes [PCIOS-247](https://linear.app/a8c/issue/PCIOS-247/playlist-analytics-add-episodes-to-playlist)

Adds the following events:
* `filter_add_episodes_shown`
* `filter_add_episodes_folder_tapped`
* `filter_add_episodes_podcast_tapped`
* `filter_add_episdoes_episode_tapped`

Also the toast for the maximum playlist limit:
<img width="300" alt="CleanShot 2025-10-29 at 21 47 02@2x" src="https://github.com/user-attachments/assets/ee98b292-3b6a-46a5-90d1-e4ccdd9e67cc" />

## To test

- Enable `tracksLogging` and `playlistsRebranding` feature flags
- Create a new Manual Playlist
- Tap “Add Episodes”
- ✅ Make sure you see:

```
🔵 Tracked: filter_add_episodes_shown [:]
```

- Tap a Folder
- ✅ Make sure you see:

```
🔵 Tracked: filter_add_episodes_folder_tapped [:]
```

- Tap a Podcast from the list
- ✅ Make sure you see:

```
🔵 Tracked: filter_add_episodes_podcast_tapped [:]
```

- Tap the Add to Playlist Plus button on an episode
- ✅ Make sure you see:

```
🔵 Tracked: filter_add_episodes_episode_tapped ["is_playlist_full": false]
```

- Set `EpisodeDataManager.Constants.Limits.maxPlaylistItems` to `2`
- Add an episode to a manual playlist
- ✅ Verify you see a toast saying “Playlist is full. Try creating a new one” and the following logged:

```
🔵 Tracked: filter_add_episodes_episode_tapped ["is_playlist_full": true]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
