### PR TITLE
[Playlists] Analytics: informational banner source

### DIFF
--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -60,9 +60,8 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     private var firstTimeLoading = true
 
     lazy private var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
-        let bannerType: InformationalBannerType = FeatureFlag.playlistsRebranding.enabled ? .playlists : .filters
         let invertedColor: Bool? = FeatureFlag.playlistsRebranding.enabled ? true : nil
-        let viewModel = InformationalBannerViewModel(bannerType: bannerType, invertedColor: invertedColor)
+        let viewModel = InformationalBannerViewModel(bannerType: .filters, invertedColor: invertedColor)
         return InformationalBannerViewCoordinator(viewModel: viewModel)
     }()
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-244

This PR fixes the source for the informational banner events in the Playlists list view. We want to keep `filters` as source parameter. All other events listed in PCIOS-244 are already implemented.

## To test

- Start with a new installation
- Enable tracksLogging and playlistsRebranding feature flags
- Restart the app
- Go to Playlists
- Tap on the banner
- Confirm you see `🔵 Tracked: informational_banner_view_create_account_tap ["source": "filters"]`
- Tap on the `x` to dismiss it
- Confirm you see `🔵 Tracked: informational_banner_view_dismissed ["source": "filters"]`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
