### PR TITLE
[Playlists] Manual episodes cleanup

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -17,6 +17,7 @@ class DatabaseHelper {
                     try db.executeUpdate("PRAGMA user_version = \(newSchemaVersion)", values: nil)
                 }
             } catch {
+                assertionFailure("Failed to setup database \(db.lastErrorCode()): \(db.lastErrorMessage()) actual error: \(error)")
                 FileLog.shared.addMessage("Failed to setup database \(db.lastErrorCode()): \(db.lastErrorMessage()) actual error: \(error)")
             }
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/EpisodeSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/EpisodeSearchTask.swift
@@ -11,9 +11,9 @@ public struct EpisodeSearchResult: Codable, Hashable {
     public let duration: Double?
     public let podcastUuid: String
     public let podcastTitle: String
-    public let state: State
+    public let state: State?
 
-    public init(uuid: String, title: String, publishedDate: Date, state: State, duration: Double? = nil, podcastUuid: String, podcastTitle: String) {
+    public init(uuid: String, title: String, publishedDate: Date, state: State? = nil, duration: Double? = nil, podcastUuid: String, podcastTitle: String) {
         self.uuid = uuid
         self.title = title
         self.publishedDate = publishedDate

--- a/PocketCastsTests/UnitTests.xctestplan
+++ b/PocketCastsTests/UnitTests.xctestplan
@@ -13,7 +13,6 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
     "environmentVariableEntries" : [
       {
         "key" : "BUILDKITE_ANALYTICS_TOKEN",

--- a/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
@@ -42,7 +42,7 @@ struct LocalSearchEpisodeResultsView: View {
                 }
                 .listRowInsets(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8))
                 .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
+                .listRowBackground(theme.primaryUi01)
             }
         }
         .listStyle(.plain)

--- a/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
@@ -15,9 +15,9 @@ struct LocalSearchEpisodeResultsView: View {
 
     var body: some View {
         ZStack {
-            resultsList
-                .opacity(episodes.isEmpty ? 0 : 1)
-                .allowsHitTesting(!episodes.isEmpty)
+            if !episodes.isEmpty {
+                resultsList
+            }
 
             if isLoading {
                 loadingOverlay

--- a/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
@@ -29,21 +29,25 @@ struct LocalSearchEpisodeResultsView: View {
 
     private var resultsList: some View {
         List {
-            ForEach(episodes, id: \.uuid) { searchResult in
-                SearchResultCell(
-                    episode: searchResult,
-                    result: nil,
-                    played: false,
-                    showDivider: searchResult.uuid != episodes.last?.uuid,
-                    showEpisodeAddButton: true,
-                    episodeAddAction: {
-                        onAddEpisode(searchResult)
-                    },
-                    isSelectionEnabled: false,
-                    cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01)
-                )
-                .listRowSeparator(.hidden)
-                .listRowBackground(theme.primaryUi01)
+            Section {
+                ForEach(episodes, id: \.uuid) { searchResult in
+                    SearchResultCell(
+                        episode: searchResult,
+                        result: nil,
+                        played: false,
+                        showDivider: false,
+                        showEpisodeAddButton: true,
+                        episodeAddAction: {
+                            onAddEpisode(searchResult)
+                        },
+                        isSelectionEnabled: false,
+                        cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01)
+                    )
+                    .listRowBackground(theme.primaryUi01)
+                    .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                        return 0
+                    }
+                }
             }
         }
         .listStyle(.plain)

--- a/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
@@ -42,7 +42,6 @@ struct LocalSearchEpisodeResultsView: View {
                     isSelectionEnabled: false,
                     cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01)
                 )
-                .listRowInsets(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8))
                 .listRowSeparator(.hidden)
                 .listRowBackground(theme.primaryUi01)
             }

--- a/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
@@ -36,10 +36,12 @@ struct LocalSearchEpisodeResultsView: View {
                     played: false,
                     showDivider: searchResult.uuid != episodes.last?.uuid,
                     showEpisodeAddButton: true,
+                    episodeAddAction: {
+                        onAddEpisode(searchResult)
+                    },
+                    isSelectionEnabled: false,
                     cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01)
-                ) {
-                    onAddEpisode(searchResult)
-                }
+                )
                 .listRowInsets(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8))
                 .listRowSeparator(.hidden)
                 .listRowBackground(theme.primaryUi01)

--- a/podcasts/New Search/Views/Results/LocalSearchPodcastResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchPodcastResultsView.swift
@@ -31,19 +31,23 @@ struct LocalSearchPodcastResultsView: View {
     private var resultsList: some View {
         List {
             listHeader
-            ForEach(Array(currentResults.enumerated()), id: \.element.id) { index, result in
-                SearchResultCell(
-                    episode: nil,
-                    result: result,
-                    played: false,
-                    showDivider: index < currentResults.count - 1,
-                    showPodcastSubscribeButton: false,
-                    cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01),
-                    action: {
-                    onSelectResult(result)
-                })
-                .listRowSeparator(.hidden)
-                .listRowBackground(theme.primaryUi01)
+            Section {
+                ForEach(Array(currentResults.enumerated()), id: \.element.id) { index, result in
+                    SearchResultCell(
+                        episode: nil,
+                        result: result,
+                        played: false,
+                        showDivider: false,
+                        showPodcastSubscribeButton: false,
+                        cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01),
+                        action: {
+                        onSelectResult(result)
+                    })
+                    .listRowBackground(theme.primaryUi01)
+                    .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                        return 0
+                    }
+                }
             }
         }
         .listStyle(.plain)

--- a/podcasts/New Search/Views/Results/LocalSearchPodcastResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchPodcastResultsView.swift
@@ -44,7 +44,7 @@ struct LocalSearchPodcastResultsView: View {
                 })
                 .listRowInsets(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8))
                 .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
+                .listRowBackground(theme.primaryUi01)
             }
         }
         .listStyle(.plain)
@@ -59,7 +59,7 @@ struct LocalSearchPodcastResultsView: View {
                 .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
                 .listRowInsets(EdgeInsets(top: 16, leading: 16, bottom: 8, trailing: 16))
                 .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
+                .listRowBackground(theme.primaryUi01)
         }
     }
 

--- a/podcasts/New Search/Views/Results/LocalSearchPodcastResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchPodcastResultsView.swift
@@ -42,7 +42,6 @@ struct LocalSearchPodcastResultsView: View {
                     action: {
                     onSelectResult(result)
                 })
-                .listRowInsets(EdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8))
                 .listRowSeparator(.hidden)
                 .listRowBackground(theme.primaryUi01)
             }

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -14,14 +14,18 @@ struct SearchResultCell: View {
     let showDivider: Bool
     let showPodcastSubscribeButton: Bool
     let showEpisodeAddButton: Bool
+    let isSelectionEnabled: Bool
+    let episodeAddAction: (() -> Void)?
     let cellStyle: ListCellButtonStyle
     let action: (() -> Void)?
 
-    init(episode: EpisodeSearchResult?, result: PodcastFolderSearchResult?, played: Bool = false, showDivider: Bool = true, showPodcastSubscribeButton: Bool = true, showEpisodeAddButton: Bool = false, cellStyle: ListCellButtonStyle = .init(), action: (() -> Void)? = nil) {
+    init(episode: EpisodeSearchResult?, result: PodcastFolderSearchResult?, played: Bool = false, showDivider: Bool = true, showPodcastSubscribeButton: Bool = true, showEpisodeAddButton: Bool = false, episodeAddAction: (() -> Void)? = nil, isSelectionEnabled: Bool = true, cellStyle: ListCellButtonStyle = .init(), action: (() -> Void)? = nil) {
         self.played = episode != nil && played
         self.showDivider = showDivider
         self.showPodcastSubscribeButton = showPodcastSubscribeButton
         self.showEpisodeAddButton = showEpisodeAddButton
+        self.isSelectionEnabled = isSelectionEnabled
+        self.episodeAddAction = episodeAddAction
         self.cellStyle = cellStyle
         self._model = StateObject<SearchResultCellModel>(wrappedValue: SearchResultCellModel(episode: episode, podcastFolder: result))
         self.action = action
@@ -52,94 +56,16 @@ struct SearchResultCell: View {
     }
 
     var body: some View {
-        ZStack {
-            Button(action: {
-                if let action {
-                    action()
-                } else {
-                    performDefaultAction()
+        Group {
+            if isSelectionEnabled {
+                Button(action: triggerSelectionAction) {
+                    cellContent
                 }
-            }) {
-                Rectangle()
-                    .foregroundColor(.clear)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .buttonStyle(cellStyle)
+            } else {
+                cellContent
+                    .background(disabledBackgroundColor)
             }
-            .buttonStyle(cellStyle)
-
-            VStack(alignment: .leading, spacing: 12) {
-                HStack(spacing: 12) {
-                    (model.episode?.podcastUuid ?? model.podcastFolder?.uuid).map {
-                        SearchEntryImage(uuid: $0, kind: model.podcastFolder?.kind)
-                    }
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        if let episode = model.episode {
-                            Text(DateFormatHelper.sharedHelper.tinyLocalizedFormat(episode.publishedDate).localizedUppercase)
-                                .font(style: .footnote, weight: .bold)
-                                .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
-                            Text(episode.title)
-                                .font(style: .subheadline, weight: .medium)
-                                .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
-                                .lineLimit(2)
-                            HStack(spacing: 4) {
-                                if let icon = episodeStateIcon {
-                                    Image(icon)
-                                        .renderingMode(.template)
-                                }
-                                if let stateText = episodeStateText {
-                                    Text(stateText)
-                                    Text("•")
-                                }
-                                Text(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0)))
-                            }
-                            .font(style: .caption, weight: .semibold)
-                            .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
-                            .lineLimit(1)
-                        } else if let result = model.podcastFolder {
-                            Text(result.titleToDisplay)
-                                .font(style: .subheadline, weight: .medium)
-                                .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
-                                .lineLimit(2)
-                            Text(subtitle(for: result))
-                                .font(style: .caption, weight: .semibold)
-                                .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
-                                .lineLimit(1)
-                        }
-                    }
-                    .allowsHitTesting(false)
-                    Spacer()
-                    if model.episode != nil && model.episode?.state != .unavailable {
-                        if played {
-                            Image("list_played", bundle: nil)
-                                .resizable()
-                                .renderingMode(.template)
-                                .foregroundStyle(AppTheme.episodeCellPlayedIndicatorColor().color)
-                                .frame(width: 48, height: 48)
-                        } else if FeatureFlag.searchImprovements.enabled && !showEpisodeAddButton {
-                            EpisodeActionButton(model: self.model)
-                                .frame(width: 48, height: 48)
-                        }
-                        if showEpisodeAddButton {
-                            Button(action: {
-                                action?()
-                            }) {
-                                Image("plus-circle")
-                                    .resizable()
-                                    .renderingMode(.template)
-                            }
-                            .frame(width: 32, height: 32)
-                            .foregroundColor(theme.primaryInteractive01)
-                        }
-                    } else if showPodcastSubscribeButton, let result = model.podcastFolder, result.kind == .podcast {
-                        SubscribeButtonView(podcastUuid: result.uuid, source: searchAnalyticsHelper.source)
-                    }
-                }
-                .opacity(played || model.episode?.state.isNormal == false ? 0.5 : 1.0)
-                if showDivider {
-                    ThemedDivider()
-                }
-            }
-            .padding(FeatureFlag.searchImprovements.enabled ? EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0) : EdgeInsets(top: 12, leading: 8, bottom: 0, trailing: 8))
         }
     }
 
@@ -157,6 +83,96 @@ struct SearchResultCell: View {
 }
 
 private extension SearchResultCell {
+    var cellContent: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                (model.episode?.podcastUuid ?? model.podcastFolder?.uuid).map {
+                    SearchEntryImage(uuid: $0, kind: model.podcastFolder?.kind)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    if let episode = model.episode {
+                        Text(DateFormatHelper.sharedHelper.tinyLocalizedFormat(episode.publishedDate).localizedUppercase)
+                            .font(style: .footnote, weight: .bold)
+                            .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
+                        Text(episode.title)
+                            .font(style: .subheadline, weight: .medium)
+                            .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
+                            .lineLimit(2)
+                        HStack(spacing: 4) {
+                            if let icon = episodeStateIcon {
+                                Image(icon)
+                                    .renderingMode(.template)
+                            }
+                            if let stateText = episodeStateText {
+                                Text(stateText)
+                                Text("•")
+                            }
+                            Text(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0)))
+                        }
+                        .font(style: .caption, weight: .semibold)
+                        .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
+                        .lineLimit(1)
+                    } else if let result = model.podcastFolder {
+                        Text(result.titleToDisplay)
+                            .font(style: .subheadline, weight: .medium)
+                            .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
+                            .lineLimit(2)
+                        Text(subtitle(for: result))
+                            .font(style: .caption, weight: .semibold)
+                            .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
+                            .lineLimit(1)
+                    }
+                }
+                .allowsHitTesting(false)
+                Spacer()
+                if model.episode != nil && model.episode?.state != .unavailable {
+                    if played {
+                        Image("list_played", bundle: nil)
+                            .resizable()
+                            .renderingMode(.template)
+                            .foregroundStyle(AppTheme.episodeCellPlayedIndicatorColor().color)
+                            .frame(width: 48, height: 48)
+                    } else if FeatureFlag.searchImprovements.enabled && !showEpisodeAddButton {
+                        EpisodeActionButton(model: self.model)
+                            .frame(width: 48, height: 48)
+                    }
+                    if showEpisodeAddButton {
+                        Button(action: {
+                            (episodeAddAction ?? action)?()
+                        }) {
+                            Image("plus-circle")
+                                .resizable()
+                                .renderingMode(.template)
+                        }
+                        .buttonStyle(.plain)
+                        .frame(width: 32, height: 32)
+                        .foregroundColor(theme.primaryInteractive01)
+                    }
+                } else if showPodcastSubscribeButton, let result = model.podcastFolder, result.kind == .podcast {
+                    SubscribeButtonView(podcastUuid: result.uuid, source: searchAnalyticsHelper.source)
+                }
+            }
+            .opacity(played || model.episode?.state.isNormal == false ? 0.5 : 1.0)
+            if showDivider {
+                ThemedDivider()
+            }
+        }
+        .padding(FeatureFlag.searchImprovements.enabled ? EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0) : EdgeInsets(top: 12, leading: 8, bottom: 0, trailing: 8))
+    }
+
+    func triggerSelectionAction() {
+        if let action {
+            action()
+        } else {
+            performDefaultAction()
+        }
+    }
+
+    var disabledBackgroundColor: Color {
+        AppTheme.colorForStyle(cellStyle.backgroundStyle, themeOverride: theme.activeTheme).color
+    }
+
     func subtitle(for result: PodcastFolderSearchResult) -> String {
         if result.kind == .folder {
             guard let folder = DataManager.sharedManager.findFolder(uuid: result.uuid) else {

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -32,8 +32,8 @@ struct SearchResultCell: View {
     }
 
     var episodeStateIcon: String? {
-        guard let episode = model.episode else { return nil }
-        switch episode.state {
+        guard let episode = model.episode, let state = episode.state else { return nil }
+        switch state {
         case .normal:
             return nil
         case .archived:
@@ -44,8 +44,8 @@ struct SearchResultCell: View {
     }
 
     var episodeStateText: String? {
-        guard let episode = model.episode else { return nil }
-        switch episode.state {
+        guard let episode = model.episode, let state = episode.state else { return nil }
+        switch state {
         case .normal:
             return nil
         case .archived:
@@ -212,7 +212,7 @@ private extension SearchResultCell {
                 SubscribeButtonView(podcastUuid: result.uuid, source: searchAnalyticsHelper.source)
             }
         }
-        .opacity(played || model.episode?.state.isNormal == false ? 0.5 : 1.0)
+        .opacity(played || model.episode?.state?.isNormal == false ? 0.5 : 1.0)
         .padding(.top, contentPadding.top)
         .padding(.leading, contentPadding.leading)
         .padding(.trailing, contentPadding.trailing)

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -56,16 +56,9 @@ struct SearchResultCell: View {
     }
 
     var body: some View {
-        Group {
-            if isSelectionEnabled {
-                Button(action: triggerSelectionAction) {
-                    cellContent
-                }
-                .buttonStyle(cellStyle)
-            } else {
-                cellContent
-                    .background(disabledBackgroundColor)
-            }
+        VStack(spacing: 0) {
+            tappableContent
+            dividerContent
         }
     }
 
@@ -83,84 +76,6 @@ struct SearchResultCell: View {
 }
 
 private extension SearchResultCell {
-    var cellContent: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 12) {
-                (model.episode?.podcastUuid ?? model.podcastFolder?.uuid).map {
-                    SearchEntryImage(uuid: $0, kind: model.podcastFolder?.kind)
-                }
-
-                VStack(alignment: .leading, spacing: 2) {
-                    if let episode = model.episode {
-                        Text(DateFormatHelper.sharedHelper.tinyLocalizedFormat(episode.publishedDate).localizedUppercase)
-                            .font(style: .footnote, weight: .bold)
-                            .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
-                        Text(episode.title)
-                            .font(style: .subheadline, weight: .medium)
-                            .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
-                            .lineLimit(2)
-                        HStack(spacing: 4) {
-                            if let icon = episodeStateIcon {
-                                Image(icon)
-                                    .renderingMode(.template)
-                            }
-                            if let stateText = episodeStateText {
-                                Text(stateText)
-                                Text("•")
-                            }
-                            Text(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0)))
-                        }
-                        .font(style: .caption, weight: .semibold)
-                        .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
-                        .lineLimit(1)
-                    } else if let result = model.podcastFolder {
-                        Text(result.titleToDisplay)
-                            .font(style: .subheadline, weight: .medium)
-                            .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
-                            .lineLimit(2)
-                        Text(subtitle(for: result))
-                            .font(style: .caption, weight: .semibold)
-                            .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
-                            .lineLimit(1)
-                    }
-                }
-                .allowsHitTesting(false)
-                Spacer()
-                if model.episode != nil && model.episode?.state != .unavailable {
-                    if played {
-                        Image("list_played", bundle: nil)
-                            .resizable()
-                            .renderingMode(.template)
-                            .foregroundStyle(AppTheme.episodeCellPlayedIndicatorColor().color)
-                            .frame(width: 48, height: 48)
-                    } else if FeatureFlag.searchImprovements.enabled && !showEpisodeAddButton {
-                        EpisodeActionButton(model: self.model)
-                            .frame(width: 48, height: 48)
-                    }
-                    if showEpisodeAddButton {
-                        Button(action: {
-                            (episodeAddAction ?? action)?()
-                        }) {
-                            Image("plus-circle")
-                                .resizable()
-                                .renderingMode(.template)
-                        }
-                        .buttonStyle(.plain)
-                        .frame(width: 32, height: 32)
-                        .foregroundColor(theme.primaryInteractive01)
-                    }
-                } else if showPodcastSubscribeButton, let result = model.podcastFolder, result.kind == .podcast {
-                    SubscribeButtonView(podcastUuid: result.uuid, source: searchAnalyticsHelper.source)
-                }
-            }
-            .opacity(played || model.episode?.state.isNormal == false ? 0.5 : 1.0)
-            if showDivider {
-                ThemedDivider()
-            }
-        }
-        .padding(FeatureFlag.searchImprovements.enabled ? EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0) : EdgeInsets(top: 12, leading: 8, bottom: 0, trailing: 8))
-    }
-
     func triggerSelectionAction() {
         if let action {
             action()
@@ -183,6 +98,125 @@ private extension SearchResultCell {
         }
 
         return result.authorToDisplay
+    }
+
+    var baseContentPadding: EdgeInsets {
+        if FeatureFlag.searchImprovements.enabled {
+            return EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+        }
+        return EdgeInsets(top: 12, leading: 8, bottom: 0, trailing: 8)
+    }
+
+    var contentPadding: EdgeInsets {
+        let base = baseContentPadding
+        return EdgeInsets(top: base.top, leading: base.leading, bottom: showDivider ? 0 : base.bottom, trailing: base.trailing)
+    }
+
+    var dividerPadding: EdgeInsets {
+        let base = baseContentPadding
+        return EdgeInsets(top: 0, leading: base.leading, bottom: 0, trailing: base.trailing)
+    }
+
+    var dividerSpacing: CGFloat {
+        12
+    }
+
+    @ViewBuilder
+    var tappableContent: some View {
+        if isSelectionEnabled {
+            Button(action: triggerSelectionAction) {
+                rowContent
+            }
+            .buttonStyle(cellStyle)
+        } else {
+            rowContent
+                .background(disabledBackgroundColor)
+        }
+    }
+
+    @ViewBuilder
+    var dividerContent: some View {
+        if showDivider {
+            ThemedDivider()
+                .padding(.leading, dividerPadding.leading)
+                .padding(.trailing, dividerPadding.trailing)
+        }
+    }
+
+    var rowContent: some View {
+        HStack(spacing: 12) {
+            (model.episode?.podcastUuid ?? model.podcastFolder?.uuid).map {
+                SearchEntryImage(uuid: $0, kind: model.podcastFolder?.kind)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                if let episode = model.episode {
+                    Text(DateFormatHelper.sharedHelper.tinyLocalizedFormat(episode.publishedDate).localizedUppercase)
+                        .font(style: .footnote, weight: .bold)
+                        .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
+                    Text(episode.title)
+                        .font(style: .subheadline, weight: .medium)
+                        .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
+                        .lineLimit(2)
+                    HStack(spacing: 4) {
+                        if let icon = episodeStateIcon {
+                            Image(icon)
+                                .renderingMode(.template)
+                        }
+                        if let stateText = episodeStateText {
+                            Text(stateText)
+                            Text("•")
+                        }
+                        Text(TimeFormatter.shared.multipleUnitFormattedShortTime(time: TimeInterval(episode.duration ?? 0)))
+                    }
+                    .font(style: .caption, weight: .semibold)
+                    .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
+                    .lineLimit(1)
+                } else if let result = model.podcastFolder {
+                    Text(result.titleToDisplay)
+                        .font(style: .subheadline, weight: .medium)
+                        .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
+                        .lineLimit(2)
+                    Text(subtitle(for: result))
+                        .font(style: .caption, weight: .semibold)
+                        .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
+                        .lineLimit(1)
+                }
+            }
+            .allowsHitTesting(false)
+            Spacer()
+            if model.episode != nil && model.episode?.state != .unavailable {
+                if played {
+                    Image("list_played", bundle: nil)
+                        .resizable()
+                        .renderingMode(.template)
+                        .foregroundStyle(AppTheme.episodeCellPlayedIndicatorColor().color)
+                        .frame(width: 48, height: 48)
+                } else if FeatureFlag.searchImprovements.enabled && !showEpisodeAddButton {
+                    EpisodeActionButton(model: self.model)
+                        .frame(width: 48, height: 48)
+                }
+                if showEpisodeAddButton {
+                    Button(action: {
+                        (episodeAddAction ?? action)?()
+                    }) {
+                        Image("plus-circle")
+                            .resizable()
+                            .renderingMode(.template)
+                    }
+                    .buttonStyle(.plain)
+                    .frame(width: 32, height: 32)
+                    .foregroundColor(theme.primaryInteractive01)
+                }
+            } else if showPodcastSubscribeButton, let result = model.podcastFolder, result.kind == .podcast {
+                SubscribeButtonView(podcastUuid: result.uuid, source: searchAnalyticsHelper.source)
+            }
+        }
+        .opacity(played || model.episode?.state.isNormal == false ? 0.5 : 1.0)
+        .padding(.top, contentPadding.top)
+        .padding(.leading, contentPadding.leading)
+        .padding(.trailing, contentPadding.trailing)
+        .padding(.bottom, showDivider ? dividerSpacing : contentPadding.bottom)
     }
 }
 

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -102,7 +102,7 @@ private extension SearchResultCell {
 
     var baseContentPadding: EdgeInsets {
         if FeatureFlag.searchImprovements.enabled {
-            return EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+            return EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
         }
         return EdgeInsets(top: 12, leading: 8, bottom: 0, trailing: 8)
     }

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -125,8 +125,10 @@ struct SearchResultCell: View {
                             }) {
                                 Image("plus-circle")
                                     .resizable()
+                                    .renderingMode(.template)
                             }
                             .frame(width: 32, height: 32)
+                            .foregroundColor(theme.primaryInteractive01)
                         }
                     } else if showPodcastSubscribeButton, let result = model.podcastFolder, result.kind == .podcast {
                         SubscribeButtonView(podcastUuid: result.uuid, source: searchAnalyticsHelper.source)

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -101,7 +101,7 @@ private extension SearchResultCell {
     }
 
     var baseContentPadding: EdgeInsets {
-        if FeatureFlag.searchImprovements.enabled {
+        if !showDivider {
             return EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
         }
         return EdgeInsets(top: 12, leading: 8, bottom: 0, trailing: 8)


### PR DESCRIPTION
Improves the styling of Podcast and Episode cells as some things were changed as part of the search improvements project.

This also disables selection of the entire cell so you have to press the plus button to add to a playlist.

| | | |
|--|--|--|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-30 at 07 56 21" src="https://github.com/user-attachments/assets/d4ba3715-ea5c-488f-9c4e-1e7f4ee2c627" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-30 at 07 56 24" src="https://github.com/user-attachments/assets/c8a40937-61d5-4955-8cf6-58f76916c95f" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-30 at 09 14 59" src="https://github.com/user-attachments/assets/46a6286d-8268-47a1-8412-a4ae7a494fda" /> |

## To test

### Playlists
* With `playlistsRebranding` and `searchImprovements` flags enabled
* Visit or create a Manual playlist
* Tap "Add Episodes"
* ✅ Make sure all cells look correct
* ✅ Make sure tapping the episode cells doesn't add them but tapping the plus button does

### Search
* With `playlistsRebranding` and `searchImprovements` flags enabled
* Search on the Podcasts tab
* ✅ Ensure cells look correct
* ✅ Ensure tapping the cell opens the correct detail page

### Search
* Disable `playlistsRebranding` and `searchImprovements` flags
* Restart the app
* Search on the Podcasts tab
* ✅ Ensure cells look correct
* ✅ Ensure tapping the cell opens the correct detail page

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
