### PR TITLE
[Tooling] Use ReleasesV2 version as the source of truth during Code Freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -293,15 +293,17 @@ platform :ios do
     computed_version = release_version_next
     new_version = version || computed_version
 
-    # Warn if provided version differs from computed version
+    # Fail if provided version differs from computed version
     if version && version != computed_version
-      warning_message = <<~WARNING
-        ⚠️ Version mismatch: The explicitly-provided version was '#{version}' while new computed version would have been '#{computed_version}'.
-        If this is unexpected, you might want to investigate the discrepency.
-        Continuing with the explicitly-provided verison '#{version}'.
-      WARNING
-      UI.important(warning_message)
-      buildkite_annotate(style: 'warning', context: 'code-freeze-version-mismatch', message: warning_message) if is_ci
+      error_message = <<~ERROR
+        ❌ Version mismatch detected!
+
+        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
+
+        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
+      ERROR
+      buildkite_annotate(style: 'error', context: 'code-freeze-version-mismatch', message: error_message) if is_ci
+      UI.user_error!(error_message)
     end
 
     message = <<-MESSAGE

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -289,43 +289,35 @@ platform :ios do
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # Use provided version from release tool, or fall back to computed version
-    computed_version = release_version_next
-    new_version = version || computed_version
-
-    # Fail if provided version differs from computed version
-    if version && version != computed_version
-      error_message = <<~ERROR
-        ❌ Version mismatch detected!
-
-        The explicitly-provided version from the release tool is '#{version}' but the computed version from the codebase is '#{computed_version}'.
-
-        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
-      ERROR
-      buildkite_annotate(style: 'error', context: 'code-freeze-version-mismatch', message: error_message) if is_ci
-      UI.user_error!(error_message)
-    end
+    # If a new version is passed, use it as source of truth from now on
+    new_version = version || release_version_next
+    release_branch_name = "release/#{new_version}"
+    new_build_code = build_code_code_freeze(version_short: new_version)
 
     message = <<-MESSAGE
 
       Code Freeze:
+      • New release/ branch from #{DEFAULT_BRANCH} will be: #{release_branch_name}
+
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New release version and build code: #{new_version} (#{build_code_code_freeze}).
-      • New release/ branch from #{DEFAULT_BRANCH} will be: release/#{new_version}
+      • New release version and build code: #{new_version} (#{new_build_code}).
+
     MESSAGE
     UI.important(message)
     UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Create the release branch
+    ensure_branch_does_not_exist!(release_branch_name)
+
     UI.message 'Creating release branch...'
-    Fastlane::Helper::GitHelper.create_branch("release/#{new_version}", from: DEFAULT_BRANCH)
+    Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: DEFAULT_BRANCH)
     UI.success "Done! New release branch is: #{git_branch}"
 
     # Bump the release version and build code and write it to the `xcconfig` file
     UI.message 'Bumping release version and build code...'
     VERSION_FILE.write(
-      version_short: release_version_next,
-      version_long: build_code_code_freeze
+      version_short: new_version,
+      version_long: new_build_code
     )
     commit_version_bump
     UI.success "Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}."
@@ -512,16 +504,18 @@ platform :ios do
     parsed_version = VERSION_FORMATTER.parse(version)
     previous_version = VERSION_FORMATTER.release_version(VERSION_CALCULATOR.previous_patch_version(version: parsed_version))
 
+    release_branch_name = "release/#{version}"
+
     # Check versions
     message = <<-MESSAGE
+
+      New hotfix branch from tag #{previous_version}: #{release_branch_name}
 
       Current release version: #{release_version_current}
       New hotfix version: #{version}
 
       Current build code: #{build_code_current}
       New build code: #{build_code_hotfix}
-
-      Branching from tag: #{previous_version}
 
     MESSAGE
 
@@ -534,7 +528,7 @@ platform :ios do
 
     # Create the hotfix branch
     UI.message 'Creating hotfix branch...'
-    Fastlane::Helper::GitHelper.create_branch("release/#{version}", from: previous_version)
+    Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: previous_version)
     UI.success "Done! New hotfix branch is: #{git_branch}"
 
     # Bump the hotfix version and build code and write it to the `xcconfig` file
@@ -1364,15 +1358,14 @@ platform :ios do
 
   # Returns the build code of the app for the code freeze. It is the release version name plus sets the build number to 0
   #
-  def build_code_code_freeze
+  def build_code_code_freeze(version_short: nil)
+    version_short ||= VERSION_FILE.read_release_version
     # Read the current build code from the .xcconfig file and parse it into an AppVersion object
     # The AppVersion is used because Pocket Casts iOS uses the four part (1.2.3.4) build code format, so the version
     # calculator can be used to calculate the next four-part version
-    release_version_current = VERSION_FORMATTER.parse(VERSION_FILE.read_release_version)
-    # Calculate the next release version, which will be used as the basis of the new build code
-    build_code_code_freeze = VERSION_CALCULATOR.next_release_version(version: release_version_current)
+    release_version_current = VERSION_FORMATTER.parse(version_short)
     # Return the formatted build code
-    BUILD_CODE_FORMATTER.build_code(version: build_code_code_freeze)
+    BUILD_CODE_FORMATTER.build_code(version: release_version_current)
   end
 
   # Returns the build code of the app for a hotfix. It is the hotfix version name plus sets the build number to 0
@@ -1428,5 +1421,16 @@ platform :ios do
     project.save
 
     UI.success('Dependency successfuly removed.')
+  end
+
+  def ensure_branch_does_not_exist!(branch_name)
+    return unless Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: branch_name)
+
+    error_message = "The branch `#{branch_name}` already exists. Please check first if there is an existing Pull Request that needs to be merged or closed first, " \
+                    'or delete the branch to then run again the release task.'
+
+    buildkite_annotate(style: 'error', context: 'error-checking-branch', message: error_message) if is_ci
+
+    UI.user_error!(error_message)
   end
 end


### PR DESCRIPTION
See AINFRA-1478

## Description

This PR enhances the version handling added in the previous iteration to assume the version received by the code freeze lane as the source of truth, ignoring potential mismatches between the ReleasesV2 version and the project's computed version.

## Testing

You can make sure the calculated release branch, current version and the next version are correctly shown in the "Continue" prompt. Just **remember to answer `N` when asked to continue**, to cancel the actual code freeze.

To avoid unexpected results, comment out the lines doing `ensure_git_status_clean` and `Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)` at the beginning of the lane.

You can run the `code_freeze` lane, with and without the version parameters:
- Run `bundle exec fastlane code_freeze` 
- Run `bundle exec fastlane code_freeze version:30.6`

This will be fully tested in the next release cycle during code freeze.