### PR TITLE
[Search Improvements] Fix background colors for selection

### DIFF
--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -75,6 +75,7 @@ struct NewSearchResultsView: View {
                     }, footer: {
                         showFullResultsButton
                     })
+                    .listRowBackground(theme.primaryUi01)
                     .listSectionSeparator(.hidden, edges: .bottom)
                 }
                 .scrollDismissesKeyboard(.immediately)
@@ -111,6 +112,7 @@ struct NewSearchResultsView: View {
                 .font(style: .subheadline, weight: .medium)
                 .foregroundColor(AppTheme.color(for: .primaryInteractive01, theme: theme))
         })
+        .background(theme.primaryUi01)
     }
 
     @ViewBuilder var filterPicker: some View {
@@ -161,14 +163,14 @@ struct NewSearchResultsView: View {
         ForEach(filteredResults, id: \.self) { result in
             switch result {
                 case .podcast(let podcast):
-                    SearchResultCell(episode: nil, result: podcast, played: false, showDivider: false, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01))
+                    SearchResultCell(episode: nil, result: podcast, played: false, showDivider: false, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01, hightlightStyle: .primaryUi01))
                         .listRowBackground(theme.primaryUi01)
                         .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
                             return 0
                         }
                 case .episode(let episode):
                     let played = searchResults.playedEpisodesUUIDs.contains(episode.uuid)
-                    SearchResultCell(episode: episode, result: nil, played: played, showDivider: false, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01))
+                    SearchResultCell(episode: episode, result: nil, played: played, showDivider: false, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01, hightlightStyle: .primaryUi01))
                         .listRowBackground(theme.primaryUi01)
                         .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
                             return 0

--- a/podcasts/New Search/Views/Results/PredictiveList.swift
+++ b/podcasts/New Search/Views/Results/PredictiveList.swift
@@ -69,7 +69,7 @@ struct PredictiveList: View {
                 }
                 .background(theme.primaryUi01)
             case .podcast:
-                SearchResultCell(episode: nil, result: PodcastFolderSearchResult(from: predictiveSearch), played: false, showDivider: !FeatureFlag.searchImprovements.enabled, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01))
+                SearchResultCell(episode: nil, result: PodcastFolderSearchResult(from: predictiveSearch), played: false, showDivider: !FeatureFlag.searchImprovements.enabled, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01, hightlightStyle: .primaryUi01))
                     .listRowBackground(theme.primaryUi01)
                     .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
                         return 0


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-253 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR fixes the background color for the highlight selection state and makes it the same as the regular background . I tried the other way around but couldn't find an workaround using SwiftUI. I also fixed the background for the View All Results on other themes.

| 1 | 2 |
| - | - |
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2025-10-30 at 23 12 21" src="https://github.com/user-attachments/assets/8fb20e59-1566-4bc4-9297-42440b3b7dfd" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2025-10-30 at 23 12 33" src="https://github.com/user-attachments/assets/23cd2935-0e7a-46cc-817c-47fe5cda4212" /> | 

## To test

1. Start the app
2. Select a theme that is not the default light
3. Tap on search bar on Discovery
4. Type in some term without pressing Enter
5. Scroll to the end of the Predictive list and check if See All Result is correctly themed
6. Tap on one of the terms and see if no highlight is shown
7. On the full results
8. Tap on one of the search results and check if no highlight is show when selecting.
9. 
## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
