### PR TITLE
[Playlists] Fix Manual Playlists episode search

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -185,6 +185,17 @@ class EpisodeDataManager {
         loadMultiple(query: "SELECT * from \(DataManager.episodeTableName) WHERE \(customWhere)", values: arguments, dbQueue: dbQueue)
     }
 
+    func findEpisodes(with term: String, podcastUUID: String, dbQueue: PCDBQueue) -> [Episode] {
+        let escapedSearch = term.escapeLike(escapeChar: "\\")
+        let query = """
+        (UPPER(title) LIKE '%' || UPPER(?) || '%'  ESCAPE '\\' AND
+        podcastUuid = ? AND wasDeleted = 0)
+        ORDER BY publishedDate DESC, addedDate DESC
+        """
+
+        return findEpisodesWhere(customWhere: query, arguments: [escapedSearch, podcastUUID], dbQueue: dbQueue)
+    }
+
     func findPlaylistEpisodesWhere(query: String, arguments: [Any]?, dbQueue: PCDBQueue) -> [Episode] {
         loadMultiple(query: query, values: arguments, dbQueue: dbQueue)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -503,6 +503,10 @@ public class DataManager {
         episodeManager.findEpisodesWhere(customWhere: customWhere, arguments: arguments, dbQueue: dbQueue)
     }
 
+    public func findEpisodes(with term: String, podcastUUID: String) -> [Episode] {
+        episodeManager.findEpisodes(with: term, podcastUUID: podcastUUID, dbQueue: dbQueue)
+    }
+
     public func findPlaylistEpisodesWhere(query: String, arguments: [Any]?) -> [Episode] {
         episodeManager.findPlaylistEpisodesWhere(query: query, arguments: arguments, dbQueue: dbQueue)
     }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/FindEpisodesTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/FindEpisodesTests.swift
@@ -1,0 +1,138 @@
+@testable import PocketCastsDataModel
+import XCTest
+
+final class FindEpisodesTests: XCTestCase {
+    func testFindEpisodesFiltersByPodcastAndDeletionAndOrdersByDates() {
+        let dataManager = DataManager.newTestDataManager()
+        let podcastUuid = "pod-filter"
+
+        let newest = makeEpisode(
+            uuid: "ep-newest",
+            podcastUuid: podcastUuid,
+            title: "Latest Daily Breakdown",
+            published: 4_000,
+            added: 4_000
+        )
+
+        let samePublishedNewerAdded = makeEpisode(
+            uuid: "ep-same-pub-newer-added",
+            podcastUuid: podcastUuid,
+            title: "Daily Insights",
+            published: 3_000,
+            added: 3_500
+        )
+
+        let samePublishedOlderAdded = makeEpisode(
+            uuid: "ep-same-pub-older-added",
+            podcastUuid: podcastUuid,
+            title: "Daily Recap",
+            published: 3_000,
+            added: 3_000
+        )
+
+        let otherPodcast = makeEpisode(
+            uuid: "ep-other-podcast",
+            podcastUuid: "pod-other",
+            title: "Daily News Elsewhere",
+            published: 5_000,
+            added: 5_000,
+            podcastId: 2
+        )
+
+        let deleted = makeEpisode(
+            uuid: "ep-deleted",
+            podcastUuid: podcastUuid,
+            title: "Daily Deleted",
+            published: 2_000,
+            added: 2_000
+        )
+        deleted.wasDeleted = true
+
+        let nonMatching = makeEpisode(
+            uuid: "ep-non-matching",
+            podcastUuid: podcastUuid,
+            title: "Weekly Summary",
+            published: 1_000,
+            added: 1_000
+        )
+
+        [newest,
+         samePublishedNewerAdded,
+         samePublishedOlderAdded,
+         otherPodcast,
+         deleted,
+         nonMatching].forEach { episode in
+            dataManager.save(episode: episode)
+        }
+
+        let results = dataManager.findEpisodes(with: "daily", podcastUUID: podcastUuid)
+        let resultIds = results.map(\.uuid)
+
+        XCTAssertEqual(resultIds, [
+            "ep-newest",
+            "ep-same-pub-newer-added",
+            "ep-same-pub-older-added"
+        ])
+    }
+
+    func testFindEpisodesEscapesLikeWildcards() {
+        let dataManager = DataManager.newTestDataManager()
+        let podcastUuid = "pod-wildcard"
+
+        let percentEpisode = makeEpisode(
+            uuid: "ep-percent",
+            podcastUuid: podcastUuid,
+            title: "Growth up 50% this quarter",
+            published: 4_000,
+            added: 4_000
+        )
+
+        let underscoreEpisode = makeEpisode(
+            uuid: "ep-underscore",
+            podcastUuid: podcastUuid,
+            title: "Release_v2.0 recap",
+            published: 3_000,
+            added: 3_000
+        )
+
+        let plainEpisode = makeEpisode(
+            uuid: "ep-plain",
+            podcastUuid: podcastUuid,
+            title: "Plain title without symbols",
+            published: 2_000,
+            added: 2_000
+        )
+
+        [percentEpisode, underscoreEpisode, plainEpisode].forEach { episode in
+            dataManager.save(episode: episode)
+        }
+
+        let percentResults = dataManager.findEpisodes(with: "%", podcastUUID: podcastUuid)
+        XCTAssertEqual(percentResults.map(\.uuid), ["ep-percent"])
+
+        let underscoreResults = dataManager.findEpisodes(with: "_", podcastUUID: podcastUuid)
+        XCTAssertEqual(underscoreResults.map(\.uuid), ["ep-underscore"])
+    }
+
+    // MARK: - Helpers
+
+    private func makeEpisode(
+        uuid: String,
+        podcastUuid: String,
+        title: String,
+        published: TimeInterval,
+        added: TimeInterval,
+        podcastId: Int64 = 1
+    ) -> Episode {
+        let episode = Episode()
+        episode.uuid = uuid
+        episode.podcastUuid = podcastUuid
+        episode.podcast_id = podcastId
+        episode.title = title
+        episode.addedDate = Date(timeIntervalSince1970: added)
+        episode.publishedDate = Date(timeIntervalSince1970: published)
+        episode.episodeStatus = DownloadStatus.downloaded.rawValue
+        episode.playingStatus = PlayingStatus.notPlayed.rawValue
+        return episode
+    }
+}

--- a/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
@@ -11,7 +11,6 @@ final class LocalSearchCoordinator {
     @Published private(set) var addedEpisodeCount = 0
 
     private let playlist: EpisodeFilter
-    private let searchResultsModel: SearchResultsModel
     private let dataManager: DataManager
 
     private var playlistEpisodeUUIDs = Set<String>()
@@ -22,11 +21,9 @@ final class LocalSearchCoordinator {
 
     init(
         playlist: EpisodeFilter,
-        searchResultsModel: SearchResultsModel,
         dataManager: DataManager = DataManager.sharedManager
     ) {
         self.playlist = playlist
-        self.searchResultsModel = searchResultsModel
         self.dataManager = dataManager
     }
 
@@ -126,30 +123,6 @@ final class LocalSearchCoordinator {
         preloadTask = nil
     }
 
-    func updateEpisodesFromSearchResults(
-        _ results: [EpisodeSearchResult],
-        selectedPodcastUUID: String?,
-        trimmedSearchText: String
-    ) {
-        guard shouldApplySearchResults(selectedPodcastUUID: selectedPodcastUUID, trimmedSearchText: trimmedSearchText),
-              let selectedPodcastUUID else {
-            return
-        }
-
-        let filtered = results.filter { $0.podcastUuid == selectedPodcastUUID }
-        let available = filtered.filter { !playlistEpisodeUUIDs.contains($0.uuid) }
-        episodes = available
-        isSearchInFlight = false
-    }
-
-    func handleSearchError(_ error: Error?, selectedPodcastUUID: String?, trimmedSearchText: String) {
-        guard error != nil,
-              shouldApplySearchResults(selectedPodcastUUID: selectedPodcastUUID, trimmedSearchText: trimmedSearchText) else {
-            return
-        }
-        isSearchInFlight = false
-    }
-
     func handleAddEpisode(_ searchResult: EpisodeSearchResult) {
         guard let episode = dataManager.findEpisode(uuid: searchResult.uuid) else {
             assertionFailure("Episode should exist")
@@ -162,24 +135,25 @@ final class LocalSearchCoordinator {
         addedEpisodeCount += 1
     }
 
-    private func shouldApplySearchResults(selectedPodcastUUID: String?, trimmedSearchText: String) -> Bool {
-        guard let selectedPodcastUUID,
-              let currentSearchPodcastUUID,
-              currentSearchPodcastUUID == selectedPodcastUUID else {
-            return false
-        }
-
-        guard trimmedSearchText.count >= 2 else {
-            return false
-        }
-
-        return trimmedSearchText == currentEpisodeSearchTerm
-    }
-
     private func performSearch(term: String, podcastUuid: String) async {
         currentEpisodeSearchTerm = term
         currentSearchPodcastUUID = podcastUuid
         episodes = []
-        searchResultsModel.search(term: term)
+        let matchedEpisodes = DataManager.sharedManager.findEpisodes(with: term, podcastUUID: podcastUuid)
+
+        guard !Task.isCancelled else {
+            if currentEpisodeSearchTerm == term, currentSearchPodcastUUID == podcastUuid {
+                isSearchInFlight = false
+            }
+            return
+        }
+
+        guard currentEpisodeSearchTerm == term,
+              currentSearchPodcastUUID == podcastUuid else {
+            return
+        }
+
+        episodes = matchedEpisodes.map { EpisodeSearchResult(episode: $0) }
+        isSearchInFlight = false
     }
 }

--- a/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
@@ -235,7 +235,7 @@ final class LocalSearchViewModel: ObservableObject {
     private func configureSearchResultsIfNeeded(_ searchResultsModel: SearchResultsModel) {
         guard self.searchResultsModel !== searchResultsModel else { return }
         self.searchResultsModel = searchResultsModel
-        configureEpisodeCoordinatorIfNeeded(using: searchResultsModel)
+        configureEpisodeCoordinatorIfNeeded()
 
         searchResultsModel.$podcasts
             .receive(on: DispatchQueue.main)
@@ -246,28 +246,13 @@ final class LocalSearchViewModel: ObservableObject {
                 }
             }
             .store(in: &cancellables)
-
-        searchResultsModel.$episodes
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] results in
-                self?.updateEpisodesFromSearchResults(results)
-            }
-            .store(in: &cancellables)
-
-        searchResultsModel.$episodeSearchError
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] error in
-                self?.handleEpisodeSearchError(error)
-            }
-            .store(in: &cancellables)
     }
 
-    private func configureEpisodeCoordinatorIfNeeded(using searchResultsModel: SearchResultsModel) {
+    private func configureEpisodeCoordinatorIfNeeded() {
         guard episodeCoordinator == nil else { return }
 
         let coordinator = LocalSearchCoordinator(
-            playlist: playlist,
-            searchResultsModel: searchResultsModel
+            playlist: playlist
         )
 
         coordinator.$episodes
@@ -367,22 +352,6 @@ final class LocalSearchViewModel: ObservableObject {
         }
 
         coordinator.scheduleSearch(for: trimmed, podcastUuid: podcastUuid)
-    }
-
-    private func updateEpisodesFromSearchResults(_ results: [EpisodeSearchResult]) {
-        episodeCoordinator?.updateEpisodesFromSearchResults(
-            results,
-            selectedPodcastUUID: selectedPodcast?.uuid,
-            trimmedSearchText: trimmedSearchText
-        )
-    }
-
-    private func handleEpisodeSearchError(_ error: Error?) {
-        episodeCoordinator?.handleSearchError(
-            error,
-            selectedPodcastUUID: selectedPodcast?.uuid,
-            trimmedSearchText: trimmedSearchText
-        )
     }
 }
 


### PR DESCRIPTION
Use local search for manual playlist episodes.

https://github.com/user-attachments/assets/7e7f8e63-fc1a-48e6-8a6f-49ec23240518

## To test

* Open a manual playlist
* Tap Add Episodes
* ✅ Make sure podcasts and folders load
* Navigate into a podcast
* ✅ Make sure episodes for that podcast are listed
* Search episodes
* ✅ Ensure episodes are filtered by your search term

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
