### PR TITLE
[Search Improvements] Remove send us feedback

### DIFF
--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -50,16 +50,7 @@ struct NewSearchResultsView: View {
                         EmptyStateView(title: L10n.searchResultsEmptyTitle,
                                        message: L10n.searchResultsEmptyMessage,
                                        icon: { Image("search") },
-                                       actions: [.init(title: L10n.searchResultsEmptyAction,
-                                                       style: SimpleTextButtonStyle(theme: .sharedTheme, textColor: .primaryInteractive01),
-                                                       action: {
-                            guard let source = SceneHelper.rootViewController() else {
-                                assertionFailure("WARNING: Root View Controller not found so survey was not presented")
-                                FileLog.shared.addMessage("UserSatisfactionSurveyManager: Root View Controller not found so survey was not presented")
-                                return
-                            }
-                            EmailHelper().presentSupportDialog(source, type: .satisfactionSurvey)
-                        })]
+                                       actions: []
                         )
                     }
                     .frame(maxHeight: .infinity)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-256 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR removes the Send Us Feedback link on empty search results.

<img width="320"  alt="simulator_screenshot_1BA14FFA-299A-432E-8186-0370004B9269" src="https://github.com/user-attachments/assets/98ca7503-30df-4cdd-af82-040aa65c727c" />


## To test

1. Start the app
2. Tap on the Search Bar
3. Search for a non existing search term: Ex:
4. Tap Enter/Search
5. Check that the no results view does not have the Send Us Feedback button

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
