### PR TITLE
[Search Improvements] Fix Search result cell padding for selection state

### DIFF
--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -75,6 +75,7 @@ struct NewSearchResultsView: View {
                     }, footer: {
                         showFullResultsButton
                     })
+                    .listRowBackground(theme.primaryUi01)
                     .listSectionSeparator(.hidden, edges: .bottom)
                 }
                 .scrollDismissesKeyboard(.immediately)
@@ -111,6 +112,7 @@ struct NewSearchResultsView: View {
                 .font(style: .subheadline, weight: .medium)
                 .foregroundColor(AppTheme.color(for: .primaryInteractive01, theme: theme))
         })
+        .background(theme.primaryUi01)
     }
 
     @ViewBuilder var filterPicker: some View {

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -105,6 +105,7 @@ struct SearchResultCell: View {
             }
             .padding(FeatureFlag.searchImprovements.enabled ? EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0) : EdgeInsets(top: 12, leading: 8, bottom: 0, trailing: 8))
         }
+        .listRowInsets(showDivider ? nil : EdgeInsets()) // Clears out edge insets when dividers are not shown. Otherwise selection state is too small
     }
 
     private func performDefaultAction() {

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -103,7 +103,7 @@ struct SearchResultCell: View {
                     ThemedDivider()
                 }
             }
-            .padding(FeatureFlag.searchImprovements.enabled ? EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0) : EdgeInsets(top: 12, leading: 8, bottom: 0, trailing: 8))
+            .padding(FeatureFlag.searchImprovements.enabled ? EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16) : EdgeInsets(top: 12, leading: 8, bottom: 0, trailing: 8)) // We need to re-add padding, especially in the case where showDivider is false since EdgeInsets are cleared.
         }
         .listRowInsets(showDivider ? nil : EdgeInsets()) // Clears out edge insets when dividers are not shown. Otherwise selection state is too small
     }


### PR DESCRIPTION
Fixes [PCIOS-253](https://linear.app/a8c/issue/PCIOS-253/fix-selection-background-on-predictive-and-main-search-results)

| Before | After |
|--|--|
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-10-31 at 10 08 10](https://github.com/user-attachments/assets/cb4b1d8e-9182-4505-aaa4-5b5f9b35247e) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-10-31 at 10 05 43](https://github.com/user-attachments/assets/5eda6e13-d804-4a25-8831-98065d5d9436) |

## To test

- Start the app
- Select a theme that is not the default light
- Tap on search bar on Discovery
- Type in some term without pressing Enter
- Scroll to the end of the Predictive list and check if See All Result is correctly themed
- Tap on one of the terms and see if no highlight is shown
- On the full results
- Tap on one of the search results and check that the highlight state takes the full width and height of the cell

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
