### PR TITLE
[Playlists] Keyboard handling

### DIFF
--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import PocketCastsServer
 import PocketCastsDataModel
 import PocketCastsUtils
+import UIKit
 
 struct LocalSearchView: View {
     @EnvironmentObject var theme: Theme
@@ -56,6 +57,7 @@ struct LocalSearchView: View {
                 }
             })
             .onChange(of: navigationPath) { newValue in
+                UIApplication.shared.endEditing(true) // Dismiss the keyboard and end editing any time we navigate between sections.
                 handleNavigationPathChange(newValue, previousPath: previousNavigationPath)
                 previousNavigationPath = newValue
             }

--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -34,6 +34,7 @@ struct LocalSearchView: View {
                 previousNavigationPath = navigationPath
             }
             .onDisappear { viewModel.onDisappear() }
+            .scrollDismissesKeyboard(.immediately)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
                     if navigationPath.isEmpty {


### PR DESCRIPTION
Fixes [PCIOS-254](https://linear.app/a8c/issue/PCIOS-254/bug-when-searching-episodes-to-add-the-keyboard-hides-the-table)

Dismisses the keyboard:
* During any navigation change
* When scrolling

https://github.com/user-attachments/assets/c596bad9-8baf-44d2-b5d1-9cc67ac6f6cc

## To test

### Podcast to Episode

* Open a manual playlist
* Tap on add episodes
* Start searching for a podcast
* Tap on a podcast
* The keyboard will be dismissed
* Search something in episode
* Going back
* Keyboard should disappear

### Episode to Podcast
* Open a manual playlist
* Tap on add episodes
* Tap on a podcast
* Now search for an episode
* Navigate back
* Notice the keyboard will be dismissed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
