### PR TITLE
Fix download arrow alignment in SearchResultCell

### DIFF
--- a/podcasts/MainEpisodeActionView.swift
+++ b/podcasts/MainEpisodeActionView.swift
@@ -384,8 +384,11 @@ extension MainEpisodeActionView {
         context.setLineWidth(2)
         context.setStrokeColor(color.cgColor)
 
-        let x = 15.64 - rightPadding
-        let y = 12 + (bottomPadding / 2.0)
+        // Center the arrow relative to circleCenter like other drawing methods
+        let arrowWidth: CGFloat = 12.72
+        let arrowHeight: CGFloat = 16.07
+        let x = circleCenter.x - (arrowWidth / 2.0)
+        let y = circleCenter.y - (arrowHeight / 2.0)
         // arrow, taken from Paint Code
         let bezier2Path = UIBezierPath()
         bezier2Path.move(to: CGPoint(x: x + 12.72, y: y + 9.71))


### PR DESCRIPTION
Center the download arrow relative to circleCenter instead of using hardcoded positioning. This ensures the arrow is properly aligned within the button, matching the centering approach used by other UI elements like the play triangle.

Fixes [PCIOS-257](https://linear.app/a8c/issue/PCIOS-257/download-arrow-is-misaligned-in-episode-search-cells)

| Before | After |
|--|--|
| <img width="300" alt="IMG_3461" src="https://github.com/user-attachments/assets/47b4077d-4887-4f08-ac4c-460e65ef662b" /> | <img width="300" alt="Simulator Screenshot - iPhone 16 Plus - 2025-11-01 at 10 22 16" src="https://github.com/user-attachments/assets/0952a365-446b-4f14-a95d-2dac4f4ad40d" /> |

## To test

* Profile > Settings > General > Set Row Action to Download
* Search in Podcasts tab
* Hit the Search button to do a full search and bring up pills
* Switch to the Episodes pill
* Check download buttons

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
