### PR TITLE
Fix SettingsTests when the FF is on/off

### DIFF
--- a/PocketCastsTests/Tests/Utilities/SettingsTests.swift
+++ b/PocketCastsTests/Tests/Utilities/SettingsTests.swift
@@ -9,18 +9,30 @@ final class SettingsTests: XCTestCase {
     private let userDefaultsSuiteName = "PocketCasts-SettingsTests"
 
     private var overriddenFlags = [FeatureFlag: Bool]()
-    private let defaultPlayerActions: [PlayerAction] = [.addBookmark,
-                                                        .markPlayed,
-                                                        .effects,
-                                                        .sleepTimer,
-                                                        .routePicker,
-                                                        .shareEpisode,
-                                                        .download,
-                                                        .transcript,
-                                                        .goToPodcast,
-                                                        .starEpisode,
-                                                        .chromecast,
-                                                        .archive]
+    private lazy var defaultPlayerActions: [PlayerAction] = {
+        var actions: [PlayerAction] = [
+            .addBookmark,
+            .markPlayed,
+            .effects,
+            .sleepTimer,
+            .routePicker,
+            .shareEpisode
+        ]
+        if FeatureFlag.playlistsRebranding.enabled {
+            actions.append(.addToPlaylist)
+        }
+        actions.append(
+            contentsOf: [
+                .download,
+                .transcript,
+                .goToPodcast,
+                .starEpisode,
+                .chromecast,
+                .archive
+            ]
+        )
+        return actions
+    }()
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
This PR fixes the `SettingsTests` when the `playlistsRebranding` is on/off

## To test

- As the FF is disabled by default, right now CI should be 🟢 

### Manual Test
- Open the `FeatureFlag` file and change the `playlistsRebranding` value to `true`
- Manually run `SettingsTests`
- Confirm tests are 🟢 
- Disable the `playlistsRebranding` value to `false`
- Manually run `SettingsTests`
- Confirm tests are 🟢 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
