### PR TITLE
[Playlists] Add additional FeatureFlag protection

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -351,38 +351,43 @@ extension SyncTask {
             playlist.podcastUuids = ""
         }
 
-        let serverSet = Set(playlistItem.episodeOrder)
-        let matchedEpisodes = DataManager.sharedManager.playlistEpisodes(for: playlist).map { $0.uuid }
-        let missingEpisodes = serverSet.subtracting(matchedEpisodes)
+        if FeatureFlag.playlistsRebranding.enabled {
+            let serverSet = Set(playlistItem.episodeOrder)
+            let matchedEpisodes = DataManager.sharedManager.playlistEpisodes(for: playlist).map { $0.uuid }
+            let missingEpisodes = serverSet.subtracting(matchedEpisodes)
 
-        let addedEpisodes: [Episode] = missingEpisodes.compactMap { episode in
-            let playlistEpisode = playlistItem.episodes.first(where: { $0.episode == episode })
-            guard let playlistEpisode else { return nil }
-            return Episode(playlistEpisode)
-        }
-
-        addedEpisodes.forEach { episode in
-            guard DataManager.sharedManager.findEpisode(uuid: episode.uuid) == nil else { return }
-
-            if episode.addedDate == nil {
-                episode.addedDate = Date()
-            }
-            if episode.podcast_id == 0 {
-                episode.podcast_id = DataManager.sharedManager.findPodcast(uuid: episode.podcastUuid, includeUnsubscribed: true)?.id ?? 0
+            let addedEpisodes: [Episode] = missingEpisodes.compactMap { episode in
+                let playlistEpisode = playlistItem.episodes.first(where: { $0.episode == episode })
+                guard let playlistEpisode else { return nil }
+                return Episode(playlistEpisode)
             }
 
-            DataManager.sharedManager.save(episode: episode)
-        }
+            addedEpisodes.forEach { episode in
+                guard DataManager.sharedManager.findEpisode(uuid: episode.uuid) == nil else { return }
 
-        DataManager.sharedManager.add(episodes: addedEpisodes, to: playlist)
+                if episode.addedDate == nil {
+                    episode.addedDate = Date()
+                }
+                if episode.podcast_id == 0 {
+                    episode.podcast_id = DataManager.sharedManager.findPodcast(uuid: episode.podcastUuid, includeUnsubscribed: true)?.id ?? 0
+                }
 
-        updateEpisodePositionsIfNeeded(for: playlistItem, playlist: playlist)
+                DataManager.sharedManager.save(episode: episode)
+            }
 
-        playlist.syncStatus = SyncStatus.synced.rawValue
-        DataManager.sharedManager.save(playlist: playlist)
+            DataManager.sharedManager.add(episodes: addedEpisodes, to: playlist)
 
-        addedEpisodes.forEach { addedEpisode in
-            ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: addedEpisode.uuid, podcastUuid: addedEpisode.podcastUuid, shouldUpdateEpisode: true)
+            updateEpisodePositionsIfNeeded(for: playlistItem, playlist: playlist)
+
+            playlist.syncStatus = SyncStatus.synced.rawValue
+            DataManager.sharedManager.save(playlist: playlist)
+
+            addedEpisodes.forEach { addedEpisode in
+                ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: addedEpisode.uuid, podcastUuid: addedEpisode.podcastUuid, shouldUpdateEpisode: true)
+            }
+        } else {
+            playlist.syncStatus = SyncStatus.synced.rawValue
+            DataManager.sharedManager.save(playlist: playlist)
         }
     }
 

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskManualPlaylistTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskManualPlaylistTests.swift
@@ -1,5 +1,6 @@
 @testable import PocketCastsServer
 @testable import PocketCastsDataModel
+@testable import PocketCastsUtils
 import XCTest
 import GRDB
 import SwiftProtobuf
@@ -9,11 +10,17 @@ final class SyncTaskManualPlaylistTests: XCTestCase {
     private var syncTask: SyncTask!
 
     override func setUp() {
+        FeatureFlagMock().set(.playlistsRebranding, value: true)
+
         dataManager = DataManager(dbQueue: GRDBQueue(dbPool: try! DatabasePool(path: NSTemporaryDirectory().appending("\(UUID().uuidString).sqlite"))))
         syncTask = SyncTask(dataManager: dataManager)
 
         // Ensure any static usage reads from this DB
         DataManager.sharedManager = dataManager
+    }
+
+    override func tearDown() {
+        FeatureFlagMock().reset()
     }
 
     func testChangedFiltersIncludesManualEpisodesAndFlag() {


### PR DESCRIPTION
Add some additional feature flags around some of the import playlists code. This should avoid any edge case or problems as the main logic for dealing with new manual playlists is added to trunk.

## To test

- Make sure the playlist rebranding FF is off
- Smoke test filters
- Smoke test sync it's working correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
