### PR TITLE
Add option picker to warn when swipe to delete

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -291,7 +291,8 @@ enum AnalyticsEvent: String {
     case filterCreateAsManualPlaylistTapped
     case filterCreateAsSmartPlaylistTapped
     case filterCreateCancelled
-    case filterDeleteTapped
+    case filterDeleteTriggered
+    case filterDeleteDismissed
 
     case filterShown
     case filterTooltipShown

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -291,6 +291,7 @@ enum AnalyticsEvent: String {
     case filterCreateAsManualPlaylistTapped
     case filterCreateAsSmartPlaylistTapped
     case filterCreateCancelled
+    case filterDeleteTapped
 
     case filterShown
     case filterTooltipShown

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -139,6 +139,9 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
 
 extension PlaylistsViewController {
     fileprivate func showDeleteOptionPicker(for playlist: EpisodeFilter, at indexPath: IndexPath, in tableView: UITableView) {
+        let playlistType = playlist.manual ? "manual" : "smart"
+        let analyticsProperties = ["filter_type": playlistType]
+        Analytics.track(.filterDeleteTriggered, properties: analyticsProperties)
         let delete = OptionAction(
             label: L10n.delete,
             icon: nil,
@@ -157,9 +160,10 @@ extension PlaylistsViewController {
                 delete
             ]
         )
+        picker.setNoActionCallback {
+            Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
+        }
         picker.show(statusBarStyle: .default)
-
-        Analytics.track(.filterDeleteTapped)
     }
 
     fileprivate func delete(playlist: EpisodeFilter, at indexPath: IndexPath, in tableView: UITableView) {
@@ -169,7 +173,13 @@ extension PlaylistsViewController {
         tableView.deleteRows(at: [indexPath], with: .top)
         tableView.endUpdates()
 
-        Analytics.track(.filterDeleted)
+        var properties: [AnyHashable: Any]? = [:]
+
+        if FeatureFlag.playlistsRebranding.enabled {
+            properties?["filter_type"] = playlist.manual ? "manual" : "smart"
+        }
+
+        Analytics.track(.filterDeleted, properties: properties)
     }
 }
 

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -107,13 +107,11 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete, let playlist = playlists[safe: indexPath.row] {
-            PlaylistManager.delete(playlist: playlist, fireEvent: false)
-            playlists.remove(at: indexPath.row)
-            tableView.beginUpdates()
-            tableView.deleteRows(at: [indexPath], with: .top)
-            tableView.endUpdates()
-
-            Analytics.track(.filterDeleted)
+            if FeatureFlag.playlistsRebranding.enabled {
+                showDeleteOptionPicker(for: playlist, at: indexPath, in: tableView)
+            } else {
+                delete(playlist: playlist, at: indexPath, in: tableView)
+            }
         }
     }
 
@@ -136,6 +134,46 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
         Analytics.track(.filterListReordered)
     }
 }
+
+// MARK: - Delete
+
+extension PlaylistsViewController {
+    fileprivate func showDeleteOptionPicker(for playlist: EpisodeFilter, at indexPath: IndexPath, in tableView: UITableView) {
+        let delete = OptionAction(
+            label: L10n.delete,
+            icon: nil,
+            action: { [weak self] in
+                self?.delete(playlist: playlist, at: indexPath, in: tableView)
+            }
+        )
+        delete.destructive = true
+
+        let picker = OptionsPicker(title: "")
+        picker.addDescriptiveActions(
+            title: L10n.playlistsDeleteAlertTitle,
+            message: L10n.playlistsDeleteAlertMessage,
+            icon: "option-alert",
+            actions: [
+                delete
+            ]
+        )
+        picker.show(statusBarStyle: .default)
+
+        Analytics.track(.filterDeleteTapped)
+    }
+
+    fileprivate func delete(playlist: EpisodeFilter, at indexPath: IndexPath, in tableView: UITableView) {
+        PlaylistManager.delete(playlist: playlist, fireEvent: false)
+        playlists.remove(at: indexPath.row)
+        tableView.beginUpdates()
+        tableView.deleteRows(at: [indexPath], with: .top)
+        tableView.endUpdates()
+
+        Analytics.track(.filterDeleted)
+    }
+}
+
+// MARK: - Tip
 
 extension PlaylistsViewController {
     func showNewFilterTip() {


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-260

<img width="400" alt="IMG_0428" src="https://github.com/user-attachments/assets/f960ad38-3390-4161-ad87-d6e302ee3c8a" />

This PR adds our Option Picker as warning when a user tries to swipe left to delete a Playlist from the Playlists list screen.
This also adds 2 new Analytics event and modify an existent one.

## To test

### Test Playlists
- Run this branch
- Go to Profile -> Settings -> Beta Features
- Enable `playlistsRebranding` and `tracksLogging`
- Restart the app
- Go to Playlist
- Create a playlist (smart or manual)
- Navigate back to the Playlists screen
- Swipe left to show the right option delete
- Tapping it or force sliding left will show the picker
- Confirm you see in the console the event: `🔵 Tracked: filter_delete_triggered ["filter_type": "manual"]`
- If the playlist is manual, the `filter_type` will be tracked as `manual`. If it's a smart playlist, it will be `smart`
- Tap outside the picker to dismiss it and you should see tracked: `🔵 Tracked: filter_delete_dismissed ["filter_type": "manual"]`
- Do it again and this time tap the red button to confirm the delete
- You should see the event tracked: `🔵 Tracked: filter_deleted ["filter_type": "manual"]`

### Test Filters
- Run this branch
- Go to Profile -> Settings -> Beta Features
- Disable `playlistsRebranding` (keep the `tracksLogging` flag on to see the events)
- Restart the app
- Go to Filters
- Swipe to delete
- Confirm you don't see any Picker showing
- Delete the filter
- Confirm you see this event tracked `🔵 Tracked: filter_deleted` with no property

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
