### PR TITLE
[Playlists] Playlist detail: general fixes

### DIFF
--- a/podcasts/EpisodeFilter+Formatting.swift
+++ b/podcasts/EpisodeFilter+Formatting.swift
@@ -73,7 +73,7 @@ extension EpisodeFilter {
 
         let items = PlaylistCellViewModel.gridArtworkItems(from: episodes, limit: 4) { $0.podcastUuid }
 
-        return PlaylistArtworkView(items: items, imageSize: 168)
+        return PlaylistArtworkView(items: items)
             .frame(width: 56.0, height: 56.0)
             .environmentObject(Theme(previewTheme: carPlayPreviewTheme()))
             .snapshot()

--- a/podcasts/FilterEditOptionsViewController.swift
+++ b/podcasts/FilterEditOptionsViewController.swift
@@ -46,7 +46,7 @@ class FilterEditOptionsViewController: PCViewController, UITableViewDelegate, UI
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = L10n.filterOptions
+        title = Self.playlistRebrandingIsEnabled ? L10n.playlistOptions : L10n.filterOptions
 
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(backgroundTapped(_:)))
         tapRecognizer.cancelsTouchesInView = false

--- a/podcasts/New Detail/Playlist Header/PlaylistBlurHeaderView.swift
+++ b/podcasts/New Detail/Playlist Header/PlaylistBlurHeaderView.swift
@@ -8,7 +8,7 @@ struct PlaylistBlurHeaderView: View {
         GeometryReader { proxy in
             HStack {
                 Spacer()
-                PlaylistArtworkView(items: viewModel.images, imageSize: 168)
+                PlaylistArtworkView(items: viewModel.images)
                     .frame(width: proxy.size.width, height: proxy.size.height)
                 .blur(radius: 60)
                 Spacer()

--- a/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
+++ b/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
@@ -27,7 +27,7 @@ struct PlaylistHeaderView: View {
             VStack {
                 HStack {
                     Spacer()
-                    PlaylistArtworkView(items: viewModel.images, imageSize: 192)
+                    PlaylistArtworkView(items: viewModel.images, cornerRadius: 8)
                         .frame(width: 192.0, height: 192.0)
                         .padding(.top, 5.0)
                         .shadow(color: .black.opacity(0.2), radius: 30, x: 0, y: 2)

--- a/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
+++ b/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
@@ -43,7 +43,7 @@ struct PlaylistHeaderView: View {
                     Text(description)
                         .font(style: .footnote, weight: .regular)
                         .fixedSize(horizontal: false, vertical: true)
-                        .foregroundStyle(theme.secondaryText02)
+                        .foregroundStyle(theme.primaryText02)
                         .multilineTextAlignment(.center)
                 }
                 .padding(.top, 20.0)

--- a/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
@@ -266,8 +266,12 @@ extension PlaylistDetailViewController {
     }
 
     private func unarchiveAllPlaylistEpisodes() {
-        let episodes = viewModel.episodes.map { $0.episode }
-        EpisodeManager.bulkUnarchive(episodes: episodes)
+        DispatchQueue.global().async { [weak self] in
+            guard let self = self else { return }
+            let newData = viewModel.episodesDataManager.playlistEpisodes(for: viewModel.playlist, shouldShowArchived: true)
+            let episodes = newData.map { $0.episode }
+            EpisodeManager.bulkUnarchive(episodes: episodes)
+        }
     }
 
     // MARK: - Edit

--- a/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
@@ -266,9 +266,9 @@ extension PlaylistDetailViewController {
     }
 
     private func unarchiveAllPlaylistEpisodes() {
-        DispatchQueue.global().async { [weak self] in
+        Task { [weak self] in
             guard let self = self else { return }
-            let newData = viewModel.episodesDataManager.playlistEpisodes(for: viewModel.playlist, shouldShowArchived: true)
+            let newData = self.viewModel.episodesDataManager.playlistEpisodes(for: self.viewModel.playlist, shouldShowArchived: true)
             let episodes = newData.map { $0.episode }
             EpisodeManager.bulkUnarchive(episodes: episodes)
         }

--- a/podcasts/New Detail/PlaylistDetailViewController+TableView.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+TableView.swift
@@ -120,7 +120,7 @@ extension PlaylistDetailViewController: UITableViewDataSource {
         cell.playlist = .filter(uuid: viewModel.playlist.uuid)
         cell.delegate = self
         if let listEpisode = itemAtRow as? ListEpisode {
-            cell.populateFrom(episode: listEpisode.episode, tintColor: viewModel.playlist.playlistColor(), playlistUuid: viewModel.playlist.uuid)
+            cell.populateFrom(episode: listEpisode.episode, tintColor: nil, playlistUuid: viewModel.playlist.uuid)
             cell.shouldShowSelect = isMultiSelectEnabled
             if isMultiSelectEnabled {
                 cell.showTick = selectedEpisodesContains(uuid: listEpisode.episode.uuid)

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -406,6 +406,12 @@ class PlaylistDetailViewController: FakeNavViewController {
     }
 
     func addEpisodes() {
+        if viewModel.isPlaylistFull {
+            let theme: any ToastTheme = ToastIconTheme(iconName: "option-alert", iconColor: Theme.sharedTheme.primaryIcon01)
+            Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast, theme: theme)
+            return
+        }
+
         let searchAnalyticsHelper = SearchAnalyticsHelper(source: .unknown)
         let searchResults = SearchResultsModel(analyticsHelper: searchAnalyticsHelper)
         let vc = PCHostingController(rootView: LocalSearchView(

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -43,6 +43,14 @@ class PlaylistDetailViewModel: ObservableObject {
         isManualPlaylist ? 3 : 2
     }
 
+    var isPlaylistFull: Bool {
+#if DEBUG
+        playlistEpisodesCount >= Settings.debugPlaylistsLimit
+#else
+        playlistEpisodesCount >= Constants.Limits.maxFilterItems
+#endif
+    }
+
     @Published private(set) var dataSource: DataSourceValue = []
     @Published var images: [PlaylistArtworkView.ImageItem] = []
     @Published var playlistEpisodesCount: Int = 0

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -66,6 +66,7 @@ class PlaylistDetailViewModel: ObservableObject {
     private let imageManager: ImageManager
     private let onChange: (StagedChangeset<DataSourceValue>, Bool, Bool) -> Void
     private var tempEpisodes: [ListEpisode] = []
+    private let artworkImagesLimit = 4
 
     private lazy var operationQueue: OperationQueue = {
         let queue = OperationQueue()
@@ -105,7 +106,7 @@ class PlaylistDetailViewModel: ObservableObject {
                         self.isLoadingData = false
                     }
                 } else {
-                    let firstFourDistinct = self.firstDistinctPodcasts(from: self.episodes, limit: 4)
+                    let firstFourDistinct = self.firstDistinctPodcasts(from: self.episodes, limit: self.artworkImagesLimit)
                     let images = try await self.loadImagesURLs(episodes: firstFourDistinct)
                     await MainActor.run {
                         self.images = images
@@ -273,7 +274,7 @@ class PlaylistDetailViewModel: ObservableObject {
                        let url = URL(string: imageUrl) {
                         return PlaylistArtworkView.ImageItem(id: episode.episode.uuid, url: url)
                     }
-                    let url = self.imageManager.podcastUrl(imageSize: .grid, uuid: episode.episode.podcastUuid)
+                    let url = self.imageManager.podcastUrl(imageSize: .detail, uuid: episode.episode.podcastUuid)
                     return PlaylistArtworkView.ImageItem(id: episode.episode.podcastUuid, url: url)
                 }
             }
@@ -315,6 +316,10 @@ class PlaylistDetailViewModel: ObservableObject {
                     break
                 }
             }
+        }
+
+        if !list.isEmpty, list.count < limit {
+            return Array(list.prefix(1))
         }
         return list
     }

--- a/podcasts/PlaylistArtworkView.swift
+++ b/podcasts/PlaylistArtworkView.swift
@@ -10,14 +10,14 @@ struct PlaylistArtworkView: View {
     @EnvironmentObject var theme: Theme
     let items: [ImageItem]
 
-    private let imageSize: Int
+    private let cornerRadius: CGFloat
 
     init(
         items: [ImageItem],
-        imageSize: Int
+        cornerRadius: CGFloat = 4
     ) {
         self.items = items
-        self.imageSize = imageSize
+        self.cornerRadius = cornerRadius
     }
 
     var body: some View {
@@ -37,31 +37,30 @@ struct PlaylistArtworkView: View {
                     case 4:
                         VStack(spacing: 0) {
                             HStack(spacing: 0) {
-                                AsyncImageView(url: items[0].url, cacheKey: items[0].id, size: imageSize)
+                                AsyncImageView(url: items[0].url, cacheKey: items[0].id)
                                     .frame(width: size.width / 2, height: size.height / 2)
                                     .clipped()
-                                AsyncImageView(url: items[1].url, cacheKey: items[1].id, size: imageSize)
+                                AsyncImageView(url: items[1].url, cacheKey: items[1].id)
                                     .frame(width: size.width / 2, height: size.height / 2)
                                     .clipped()
                             }
                             HStack(spacing: 0) {
-                                AsyncImageView(url: items[2].url, cacheKey: items[2].id, size: imageSize)
+                                AsyncImageView(url: items[2].url, cacheKey: items[2].id)
                                     .frame(width: size.width / 2, height: size.height / 2)
                                     .clipped()
-                                AsyncImageView(url: items[3].url, cacheKey: items[3].id, size: imageSize)
+                                AsyncImageView(url: items[3].url, cacheKey: items[3].id)
                                     .frame(width: size.width / 2, height: size.height / 2)
                                     .clipped()
                             }
                         }
                     default:
-                        AsyncImageView(url: items[0].url, cacheKey: items[0].id, size: imageSize)
+                        AsyncImageView(url: items[0].url, cacheKey: items[0].id)
                             .frame(width: size.width, height: size.height)
                             .clipped()
                     }
                 }
             }
-            .cornerRadius(4)
-            .clipped()
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
         }
     }
 }

--- a/podcasts/PlaylistCellView.swift
+++ b/podcasts/PlaylistCellView.swift
@@ -66,7 +66,7 @@ struct PlaylistCellView: View {
                 .frame(width: 56.0, height: 56.0)
                 .padding(.leading, 16.0)
             } else {
-                PlaylistArtworkView(items: viewModel.images, imageSize: 168)
+                PlaylistArtworkView(items: viewModel.images)
                     .frame(width: 56.0, height: 56.0)
                     .padding(.leading, 16.0)
             }

--- a/podcasts/SwiftUI/AsyncImageView.swift
+++ b/podcasts/SwiftUI/AsyncImageView.swift
@@ -4,7 +4,6 @@ import Kingfisher
 struct AsyncImageView: View {
     private let url: URL
     private let cacheKey: String?
-    private let size: Int
     private let cache: ImageCache
     private let placeholder: Image?
     private let contentMode: SwiftUI.ContentMode
@@ -13,7 +12,6 @@ struct AsyncImageView: View {
     init(
         url: URL,
         cacheKey: String? = nil,
-        size: Int = ImageManager.sharedManager.biggestPodcastImageSize,
         cache: ImageCache = ImageManager.sharedManager.subscribedPodcastsCache,
         placeholder: Image? = nil,
         aspectRatio: CGFloat? = 1,
@@ -21,7 +19,6 @@ struct AsyncImageView: View {
     ) {
         self.url = url
         self.cacheKey = cacheKey
-        self.size = size
         self.cache = cache
         self.placeholder = placeholder
         self.contentMode = contentMode
@@ -29,7 +26,6 @@ struct AsyncImageView: View {
     }
 
     var body: some View {
-        let resizeProcessor = DownsamplingImageProcessor(size: .init(width: size, height: size))
         let resource = KF.ImageResource(downloadURL: url, cacheKey: cacheKey)
 
         KFImage.resource(resource)
@@ -40,7 +36,6 @@ struct AsyncImageView: View {
                 }
             }
             .resizable()
-            .setProcessor(resizeProcessor)
             .targetCache(cache)
             .fade(duration: 0.25)
             .aspectRatio(aspectRatio, contentMode: contentMode)


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-262
Fixes PCIOS-268
Fixes PCIOS-265
Fixes PCIOS-267

This PR fixes:
• Add the toast in manual playlist detail when tapping Add episodes if the playlist is already full
• Fix the logic to unarchive all
• Fix the title in the Filter Option vc
• Fixes the Playlist detail artwork low res (PCIOS-268)
• Fixes the Episode cells main tint color (PCIOS-265)
• Fixes the correct artwork radius in detail (PCIOS-267)

| 1 | 2 | 3 | 4 |
| :-------: | :-------: | :-------: | :-------: |
| <img width="1179" height="2556" alt="IMG_0437" src="https://github.com/user-attachments/assets/d04d0fc0-394c-437f-8dfc-31d4c8de9008" /> | <img width="1179" height="2556" alt="IMG_0438" src="https://github.com/user-attachments/assets/11bf049b-c7a6-43ac-b1af-5dd9674b2e0c" /> | <img width="1179" height="2556" alt="IMG_0439" src="https://github.com/user-attachments/assets/53afbbf4-84aa-494f-adf5-bfbb052c4af1" /> | <img width="1179" height="2556" alt="IMG_0440" src="https://github.com/user-attachments/assets/0e185262-01d4-46cb-9094-7e1c1011d210" /> |

## To test

- Run this branch
- Go to Profile -> Settings -> Beta features
- Enable the `playlistsRebranding` FF
- Restart the app

### Playlist detail fixes
- Go to `Playlists`
- Select one Playlist to open its detail
- Observe the main image has uniform corner radius of 8 (see screen 1 & 2)
- Observe the play button for each cell uses the primary color (see screen 1 & 2)
- Observe the header description (ex. 600 episodes • 100h 4m) color is more visible (see screen 1 & 2)
- Observe the main artwork image doesn't have low res (see screen 1 & 2)

### Options title
- From the playlist detail tap the `•••` top right button
- Select the last option `Playlist Options`
- Confirm the Playlist Options screen has `Playlist Options` title (see screen 3)

### Manual Playlist full toast
- Navigate back to the Playlist detail
- If you didn't select a manual playlist go back to the list and select one or create a new one
- Go the detail
- Add like 11 episodes (don't need to do that if you manual playlist has already more than 10 episodes)
- Tap on Profile in the tab bar, go to Settings (cog icon) -> Developer -> scroll down till the end and enable `Enable Debug Playlists limit`
- Go back to that manual playlist detail
- Tap on Add Episodes
- You should see the Toast message saying the playlist is full (see picture 4)

### Unarchive all
- From the same manual playlist detail tap the `•••` top right button
- Tap Archive all
- Make sure all archived episode are hidden and you see the empty state. If those are not hidden just tap on Hide Archived
- Tap again the `•••` and select Unarchive All
- All episodes should appear unarchived

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
