### PR TITLE
[Search Improvements] Enable FF by default

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -398,17 +398,9 @@ public enum FeatureFlag: String, CaseIterable {
         case .newOnboardingRecommendationChanges:
             true
         case .searchImprovements:
-            #if DEBUG
-                true
-            #else
-                BuildEnvironment.current == .testFlight
-            #endif
+            true
         case .searchPredictive:
-            #if DEBUG
-                true
-            #else
-                BuildEnvironment.current == .testFlight
-            #endif
+            true
         case .podcastBookmarksInline:
             true
         case .earlyReloadSubscriptionStatus:
@@ -448,12 +440,7 @@ extension FeatureFlag: OverrideableFlag {
     }
 
     public var canOverride: Bool {
-        switch self {
-            case .searchPredictive, .searchImprovements:
-                !Self.isTestFlight
-            default:
-                true
-        }
+        true
     }
 
     private static let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"


### PR DESCRIPTION
| 📘 Part of:[Search Improvements](https://linear.app/a8c/project/ios-improving-search-338274580cba/overview)
|:---:|

This PR just enable the FF for search improvements by default

## To test

- Run this branch
- Make sure the `searchImprovements` and `searchPredictive` are enabled

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
