### PR TITLE
[Search Improvements] Avoid displaying the View All button if the predictive search result is empty

### DIFF
--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -228,7 +228,7 @@ class SearchResultsModel: ObservableObject {
     }
 
     private func show(predictiveResults: [PredictiveSearchResult]) {
-        isShowingPredictiveSearch = true
+        isShowingPredictiveSearch = !predictiveResults.isEmpty
         predictive = predictiveResults
     }
 


### PR DESCRIPTION
| 📘 Part of: [Search Improvements](https://linear.app/a8c/project/ios-improving-search-338274580cba/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-273

It should avoid showing the View all button when typing some value that returns 0 results in the predictive search

| Before | After |
| :-------: | :-------: |
| <img width="1179" height="2556" alt="IMG_0442" src="https://github.com/user-attachments/assets/a6471036-6fba-49be-a2ad-0571b46383f6" /> | <img width="1179" height="2556" alt="IMG_0441" src="https://github.com/user-attachments/assets/25da51ab-04a6-40d7-b269-2a6bb36d5cef" /> |


## To test

- Run this branch
- Go to discover or podcasts
- Type something like `asdfghjklqwertyuiop`
- Confirm you see the empty state
- Smoke test everything still work as mentioned in the Beta test P2

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
