### PR TITLE
Playlists: ensure changed playlists are marked to sync

### DIFF
--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -172,7 +172,7 @@ class ManualPlaylistsChooserViewController: PCViewController {
 
         changedPlaylists.forEach { playlist in
             playlist.syncStatus = SyncStatus.notSynced.rawValue
-            DataManager.sharedManager.save(playlist: playlist)
+            dataManager.save(playlist: playlist)
         }
 
         dismiss(animated: true, completion: nil)

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -158,13 +158,22 @@ class ManualPlaylistsChooserViewController: PCViewController {
 
         FileLog.shared.console("Added \(added), removed \(removed)")
 
+        var changedPlaylists: Set<EpisodeFilter> = []
+
         manualPlaylists.forEach { playlist in
             if added.contains(playlist.uuid) {
                 dataManager.add(episodes: [episode], to: playlist)
+                changedPlaylists.insert(playlist)
             }
             if removed.contains(playlist.uuid) {
                 dataManager.deleteEpisodes([episode.uuid], from: playlist)
+                changedPlaylists.insert(playlist)
             }
+        }
+
+        changedPlaylists.forEach { playlist in
+            playlist.syncStatus = SyncStatus.notSynced.rawValue
+            DataManager.sharedManager.save(playlist: playlist)
         }
 
         dismiss(animated: true, completion: nil)

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -167,7 +167,6 @@ class ManualPlaylistsChooserViewController: PCViewController {
             }
             if removed.contains(playlist.uuid) {
                 dataManager.deleteEpisodes([episode.uuid], from: playlist)
-                changedPlaylists.insert(playlist)
             }
         }
 

--- a/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
@@ -131,6 +131,9 @@ final class LocalSearchCoordinator {
 
 
         let didAdd = dataManager.add(episodes: [episode], to: playlist)
+        playlist.syncStatus = SyncStatus.notSynced.rawValue
+        dataManager.save(playlist: playlist)
+
         let isFull = !didAdd
 
         Analytics.track(.filterAddEpisodesEpisodeTapped, properties: ["is_playlist_full": isFull])


### PR DESCRIPTION
Playlists are not syncing correctly when adding/removing episodes. This PR fixes it by marking a playlist as unsynced anytime an episode is added or removed.

## To test

1. Open the iOS app and the web player logged in into the **same account**
2. In the iOS app, create a manual playlist if there's none (or skip this step if there's any manual playlist)
3. Go to Profile > Refresh Now
4. Add one or more episodes to the playlist
5. Go to Profile > Refresh Now
6. Go to the web player, refresh the page
7. Check the playlist
8. ✅ The added episodes should be available there
9. Go back to the iOS app
10. Remove one or more episodes from this playlist
11. Go to Profile > Refresh Now
12. Go to the web player and refresh
13. ✅ The removed episodes should not be available there
14. Go to the iOS app
15. Open any playlist
16. Tap "Add Episodes"
17. Add one or more episodes
18. Go to the web player, refresh the page
7. Check the playlist
8. ✅ The added episodes should be available there

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
