### PR TITLE
Playlists: handle episode deletion in incremental sync

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
@@ -288,6 +288,19 @@ class PlaylistDataManager {
         }
     }
 
+    /// Just delete episodes from a playlist and nothing more
+    func rawDeleteEpisodes(_ episodeUuids: [String], from playlist: EpisodeFilter, dbQueue: PCDBQueue) {
+        guard !episodeUuids.isEmpty else { return }
+        dbQueue.write { db in
+            do {
+                let inClause = DataHelper.convertArrayToInString(episodeUuids)
+                try db.executeUpdate("DELETE FROM \(DataManager.playlistEpisodeTableName) WHERE playlist_uuid = ? AND episodeUuid IN (\(inClause))", values: [playlist.uuid])
+            } catch {
+                FileLog.shared.addMessage("PlaylistDataManager.rawDeleteEpisodes error: \(error)")
+            }
+        }
+    }
+
     /// Delete all playlist-episode relationships for the given playlist
     func deleteAllEpisodes(in playlist: EpisodeFilter, dbQueue: PCDBQueue) {
         dbQueue.write { db in

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1020,6 +1020,10 @@ public class DataManager {
         playlistManager.deleteEpisodes(episodeUuids, from: playlist, dbQueue: dbQueue)
     }
 
+    public func rawDeleteEpisodes(_ episodeUuids: [String], from playlist: EpisodeFilter) {
+        playlistManager.rawDeleteEpisodes(episodeUuids, from: playlist, dbQueue: dbQueue)
+    }
+
     public func deleteAllEpisodes(in playlist: EpisodeFilter) {
         playlistManager.deleteAllEpisodes(in: playlist, dbQueue: dbQueue)
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -355,6 +355,7 @@ extension SyncTask {
             let serverSet = Set(playlistItem.episodeOrder)
             let matchedEpisodes = DataManager.sharedManager.playlistEpisodes(for: playlist).map { $0.uuid }
             let missingEpisodes = serverSet.subtracting(matchedEpisodes)
+            let episodesToDelete = Set(matchedEpisodes).subtracting(serverSet)
 
             let addedEpisodes: [Episode] = missingEpisodes.compactMap { episode -> Episode? in
                 let playlistEpisode = playlistItem.episodes.first(where: { $0.episode == episode })
@@ -377,6 +378,10 @@ extension SyncTask {
                 }
 
                 DataManager.sharedManager.save(episode: episode)
+            }
+
+            if episodesToDelete.count > 0 {
+                DataManager.sharedManager.rawDeleteEpisodes(Array(episodesToDelete), from: playlist)
             }
 
             let didAdd = DataManager.sharedManager.add(episodes: addedEpisodes, to: playlist)


### PR DESCRIPTION
Deleted episodes from another devices weren't removed from the app. This PR adds logic to handle this case.

## To test

1. Have the iOS app and the web player logged in into the same account
2. Make sure to have one or more playlists with a few episodes
3. In the web player, delete any episode from one of your playlists
4. In the iOS app, go to Profile > Refresh Now
5. Go to the playlist you deleted the episode
6. ✅ The episode shouldn't be there

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
