### PR TITLE
[Playback 25] Add text and logo animation

### DIFF
--- a/podcasts/End of Year/Stories/2025/EpilogueStory2025.swift
+++ b/podcasts/End of Year/Stories/2025/EpilogueStory2025.swift
@@ -6,19 +6,48 @@ struct EpilogueStory2025: StoryView {
 
     var identifier: String = "ending"
 
+    private var startDelay = 0.25
+    private var assetDelay = 0.07
+    private var opacityAnimation: Animation = .linear(duration: 0.34)
+    private var moveAnimation: Animation = .timingCurve(0.40, 0.00, 0.00, 1.00, duration: 1.2)
+
+    @State private var offset: CGFloat = 100
+    @State private var opacity: CGFloat = 0.0
+    @State private var isAnimating: Bool = true
+
     var body: some View {
         VStack {
             Spacer()
             VStack(spacing: 0) {
                 Image("eoy25_pc_logo")
                     .padding(.bottom, 24)
+                    .opacity(opacity)
+                    .offset(y: offset)
+                    .if(isAnimating) {
+                        $0.animation(moveAnimation, value: offset)
+                            .animation(opacityAnimation.delay(startDelay), value: opacity)
+                    }
+
                 Text(L10n.playback2025EndStoryTitle)
                     .font(.system(size: 25, weight: .semibold))
                     .multilineTextAlignment(.center)
                     .padding(.bottom, 16)
+                    .opacity(opacity)
+                    .offset(y: offset)
+                    .if(isAnimating) {
+                        $0.animation(moveAnimation.delay(assetDelay), value: offset)
+                            .animation(opacityAnimation.delay(startDelay + assetDelay), value: opacity)
+                    }
+
                 Text(L10n.playback2025EndStoryDescription)
                     .font(.system(size: 16, weight: .medium))
                     .multilineTextAlignment(.center)
+                    .opacity(opacity)
+                    .offset(y: offset)
+                    .if(isAnimating) {
+                        $0.animation(moveAnimation.delay(assetDelay + assetDelay), value: offset)
+                        .animation(opacityAnimation.delay(startDelay + assetDelay + assetDelay), value: opacity)
+                    }
             }
             .padding(.horizontal, 24)
             Spacer()
@@ -39,6 +68,16 @@ struct EpilogueStory2025: StoryView {
                 .allowsHitTesting(false)
         }
         .enableProportionalValueScaling()
+        .onAppear {
+            self.isAnimating = true
+            self.offset = 0
+            self.opacity = 1
+        }
+        .onDisappear {
+            self.isAnimating = false
+            self.offset = 100
+            self.opacity = 0
+        }
     }
 
     func onAppear() {


### PR DESCRIPTION
| 📘 Part of: [Playback 25](https://linear.app/a8c/project/ios-playback-2025-7fed05fea613/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-282

This PR adds the animation to the logo and text in the last story as followup of #3649

https://github.com/user-attachments/assets/43ca3220-e21c-4932-bfa4-a776795ef2ea

## To test

- Same test as #3649 to reach the last story
- Confirm you see the text and logo animations

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
