### PR TITLE
[Playlists] Fix correct source when searching

### DIFF
--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -226,7 +226,8 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
     }
 
     @objc private func saveTapped(sender: Any) {
-        if selectedUuids.count == allPodcasts.count || selectedUuids.count == 0 {
+        let podcasts = currentPodcastsSource()
+        if selectedUuids.count == podcasts.count || selectedUuids.count == 0 {
             filterToEdit.podcastUuids = ""
             filterToEdit.filterAllPodcasts = true
         } else {


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-internal-testing-b4b2f66c6304/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=team&showCompletedIssues=all&showSubIssues=true&showTriageIssues=true)
|:---:|

Fixes PCIOS-290

This PR fixes the correct datasource when creating a smart rule for podcasts and still searching

## To test

- Run this branch
- Go to playlist
- Tap on `+` to add a new playlist
- Select `Make into Smart Playlist`
- Tap on `Podcasts`
- Deselect `All Followed Podcasts`
- Search for a podcast and select it
- Tap the keyboard button `Search` to dismiss it
- Tap `Save Smart Rule`
- Confirm you see just one Podcast as selected in the preview
- Go back to add more change podcast and add one or more while searching or not
- Confirm after saving you will see the correct podcasts selection
- Do a smoke test with the FF off that everything works on filter

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
