### PR TITLE
[Playlists] Adjust Pull down to reload

### DIFF
--- a/podcasts/CustomRefreshControl.swift
+++ b/podcasts/CustomRefreshControl.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class CustomRefreshControl: UIRefreshControl {
-    var perform: (() -> Void)?
+    var perform: ((CustomRefreshControl) -> Void)?
 
     private var refreshInnerImage = UIImageView()
     private var refreshOuterImage = UIImageView()
@@ -40,7 +40,7 @@ class CustomRefreshControl: UIRefreshControl {
         beginRefreshing()
         isAnimating = true
         startRefreshAnimation()
-        perform?()
+        perform?(self)
     }
 
     override func endRefreshing() {
@@ -51,6 +51,10 @@ class CustomRefreshControl: UIRefreshControl {
             self?.isAnimating = false
             self?.alpha = 0
         }
+    }
+
+    func set(text: String) {
+        refreshLabel.text = text
     }
 
     private func setupView() {

--- a/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
+++ b/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
@@ -29,7 +29,7 @@ struct PlaylistHeaderView: View {
                     Spacer()
                     PlaylistArtworkView(items: viewModel.images, cornerRadius: 8)
                         .frame(width: 192.0, height: 192.0)
-                        .padding(.top, 5.0)
+                        .padding(.top, 15.0)
                         .shadow(color: .black.opacity(0.2), radius: 30, x: 0, y: 2)
                     Spacer()
                 }

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -384,17 +384,29 @@ class PlaylistDetailViewController: FakeNavViewController {
 
         if animated, contentChanged {
             tableView.reload(using: data, with: .fade) { [weak self] newData in
-                self?.viewModel.update(data: newData)
+                self?.viewModel.update(data: newData) {
+                    self?.reloadRefreshControlColor()
+                }
             }
         } else {
             if let data = data.last?.data {
-                viewModel.update(data: data)
+                viewModel.update(data: data) { [weak self] in
+                    self?.reloadRefreshControlColor()
+                }
             }
             tableView.reloadData()
         }
         blurHeaderView.isHidden = viewModel.episodes.isEmpty
         reloadEmptyState()
         refreshMultiSelectEpisodes()
+    }
+
+    private func reloadRefreshControlColor() {
+        if let snapshot = blurHeaderView.sj_snapshotImage() {
+            refreshControl?.customTintColor =  snapshot.isDark ? .white : .black
+        } else {
+            refreshControl?.customTintColor = AppTheme.colorForStyle(.secondaryText02)
+        }
     }
 
     private func reloadNavTitle() {

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import PocketCastsDataModel
 import DifferenceKit
 import SwiftUI
+import PocketCastsServer
 
 class PlaylistDetailViewController: FakeNavViewController {
     private(set) var viewModel: PlaylistDetailViewModel!
@@ -354,10 +355,13 @@ class PlaylistDetailViewController: FakeNavViewController {
     }
 
     private func setupRefreshControl() {
+        if viewModel.isManualPlaylist { return }
+
         refreshControl = CustomRefreshControl()
         refreshControl?.customTintColor = AppTheme.colorForStyle(.secondaryText02)
-        refreshControl?.perform = { [weak self] in
-            self?.viewModel.reloadPlaylistAndEpisodes()
+        refreshControl?.perform = { refreshControl in
+            refreshControl.set(text: L10n.refreshControlFetchingEpisodes.uppercased())
+            RefreshManager.shared.refreshPodcasts()
         }
         tableView.refreshControl = refreshControl
     }
@@ -368,8 +372,15 @@ class PlaylistDetailViewController: FakeNavViewController {
     }
 
     private func reload(data: StagedChangeset<PlaylistDetailViewModel.DataSourceValue>, animated: Bool, contentChanged: Bool) {
-        refreshControl?.endRefreshing()
         loadingIndicator.stopAnimating()
+        refreshControl?.set(text: L10n.refreshControlRefreshComplete.uppercased())
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+            UIView.animate(withDuration: 0.2, animations: {
+                self?.refreshControl?.alpha = 0
+            }, completion: { _ in
+                self?.refreshControl?.endRefreshing()
+            })
+        }
 
         if animated, contentChanged {
             tableView.reload(using: data, with: .fade) { [weak self] newData in

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -90,7 +90,7 @@ class PlaylistDetailViewModel: ObservableObject {
         self.onButtonTapped = onButtonTapped
     }
 
-    func update(data: DataSourceValue) {
+    func update(data: DataSourceValue, then block: (() -> Void)? = nil) {
         self.dataSource = data
 
         if isLoadingData { return }
@@ -112,11 +112,13 @@ class PlaylistDetailViewModel: ObservableObject {
                         self.images = images
                         self.playlistEpisodesCount = count
                         self.isLoadingData = false
+                        block?()
                     }
                 }
             } catch {
                 await MainActor.run {
                     self.isLoadingData = false
+                    block?()
                 }
             }
         }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -1368,7 +1368,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         if shouldDisplayPodcastFeedReloadButton() {
             refreshControl = CustomRefreshControl()
             refreshControl?.customTintColor = contrastColorForPodcastImage
-            refreshControl?.perform = { [weak self] in
+            refreshControl?.perform = { [weak self] _ in
                 self?.reloadPodcastFeed(source: .refreshControl)
             }
             episodesTable.refreshControl = refreshControl


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-internal-testing-b4b2f66c6304/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=team&showCompletedIssues=all&showSubIssues=true&showTriageIssues=true)
|:---:|

Fixes PCIOS-291

This PR adds:
- Removes the pull to refresh on manual playlists
- Update the style of pull to refresh to match podcast detail

## To test

- Run this branch
- Go to Playlists
- Open a Smart Playlist
- Pull down to reload

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
