### PR TITLE
Add tracking for episode complete

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -478,6 +478,8 @@ enum AnalyticsEvent: String {
 
     case playerPreviousChapterTapped
     case playerNextChapterTapped
+    case PlayerEpisodeCompleted
+
 
     // MARK: - Player: Sleep Timer
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -478,7 +478,7 @@ enum AnalyticsEvent: String {
 
     case playerPreviousChapterTapped
     case playerNextChapterTapped
-    case PlayerEpisodeCompleted
+    case playerEpisodeCompleted
 
 
     // MARK: - Player: Sleep Timer

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1064,6 +1064,10 @@ class PlaybackManager: ServerPlaybackDelegate {
             autoplayIfNeeded()
 
             FileLog.shared.addMessage("Finished playing \(episode.displayableTitle())")
+            Analytics.track(.PlayerEpisodeCompleted, properties: [
+                "podcast_uuid": episode.parentIdentifier(),
+                "episode_uuid": episode.uuid
+            ])
             episode.playingStatus = PlayingStatus.completed.rawValue
             episode.playedUpTo = episode.duration
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1064,7 +1064,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             autoplayIfNeeded()
 
             FileLog.shared.addMessage("Finished playing \(episode.displayableTitle())")
-            Analytics.track(.PlayerEpisodeCompleted, properties: [
+            Analytics.track(.playerEpisodeCompleted, properties: [
                 "podcast_uuid": episode.parentIdentifier(),
                 "episode_uuid": episode.uuid
             ])


### PR DESCRIPTION
<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds logging for when an episode is completed. 


## To test

1. Play an episode to the end.
2. Verify that the player_episode_completed event gets called and contains both podcast uuid and episode uuid properties.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
