### PR TITLE
[Playback 25] Completion Story: adjust offset for small devices

### DIFF
--- a/podcasts/End of Year/Stories/2025/CompletionRate2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/CompletionRate2025Story.swift
@@ -44,6 +44,7 @@ struct CompletionRate2025Story: ShareableStory {
                 .playbackMode(.playing(.fromProgress(0, toProgress: 1, loopMode: .playOnce)))
                 .scaledToFill()
                 .ignoresSafeArea()
+                .offset(y: UIScreen.isSmallScreen ? 60 : 0)
         }
         .ignoresSafeArea()
         .background(backgroundColor)

--- a/podcasts/End of Year/Stories/2025/StoryHeader2025.swift
+++ b/podcasts/End of Year/Stories/2025/StoryHeader2025.swift
@@ -33,7 +33,7 @@ struct StoryHeader2025: View {
             }
         }
         .padding(.horizontal, 24)
-        .padding(.top, topPadding ?? (UIScreen.isSmallScreen ? 80 : 110))
+        .padding(.top, topPadding ?? (UIScreen.isSmallScreen ? 70 : 110))
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: [Playback](https://linear.app/a8c/project/ios-playback-2025-7fed05fea613/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-303

Adjust the offset for the bg animation in the completion story and header title for small devices

| Big | Small |
| :-------: | :-------: |
| <img width="500" height="910" alt="Screenshot 2025-11-12 at 11 29 10" src="https://github.com/user-attachments/assets/6b273710-d9a5-4a8e-8b67-eccc13e367eb" /> | <img width="494" height="921" alt="Screenshot 2025-11-12 at 11 27 50" src="https://github.com/user-attachments/assets/415f64cd-bf27-4004-bc8c-f861bcb368c8" /> |


## To test

- Test on both large and small devices
- Enable the all playback FFs needed
- Give yourself a paid plus
- Go to Profile and tap the Playback banner
- Navigate till you reach the completion story
- Confirm the text doesn't overlap with the animation

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
