### PR TITLE
[Playlists] Add new events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -359,6 +359,9 @@ enum AnalyticsEvent: String {
     case episodeRecentlyPlayedSortOptionTooltipShown
     case episodeRecentlyPlayedSortOptionTooltipDismissed
 
+    case episodeAddedToList
+    case episodeRemovedFromList
+
     case addToPlaylistsShown
     case addToPlaylistsEpisodeAddTapped
     case addToPlaylistsRemoveTapped

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -58,6 +58,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case suggestedFolderPopup = "popup"
     case userSatisfactionSurvey = "user_satisfaction_survey"
     case recommendations
+    case playlistEditor = "playlist_editor"
     case unknown
 
     var analyticsDescription: String { rawValue }

--- a/podcasts/New Detail/Custom Order/PlaylistDetailCustomOrderViewController.swift
+++ b/podcasts/New Detail/Custom Order/PlaylistDetailCustomOrderViewController.swift
@@ -122,7 +122,9 @@ extension PlaylistDetailCustomOrderViewController: UITableViewDataSource, UITabl
             tableView.deleteRows(at: [indexPath], with: .top)
             tableView.endUpdates()
 
-            track(.filterManualEpisodeDeleted)
+            if let viewModel {
+                track(episode: episode.episode, added: false, to: viewModel.playlist, source: "playlist_rearrange")
+            }
         }
     }
 

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -162,10 +162,12 @@ class ManualPlaylistsChooserViewController: PCViewController {
 
         manualPlaylists.forEach { playlist in
             if added.contains(playlist.uuid) {
+                track(episode: episode, added: true, to: playlist)
                 dataManager.add(episodes: [episode], to: playlist)
                 changedPlaylists.insert(playlist)
             }
             if removed.contains(playlist.uuid) {
+                track(episode: episode, added: false, to: playlist)
                 dataManager.deleteEpisodes([episode.uuid], from: playlist)
             }
         }
@@ -311,5 +313,11 @@ extension ManualPlaylistsChooserViewController: PCSearchBarDelegate {
 fileprivate extension UITableView {
     func reload(section: TableSection, with animation: UITableView.RowAnimation) {
         reloadSections(IndexSet(integer: section.rawValue), with: animation)
+    }
+}
+
+extension ManualPlaylistsChooserViewController: PlaylistTypeTrackerProvider {
+    var analyticsSourceType: String {
+        analyticsSource
     }
 }

--- a/podcasts/New Detail/PlaylistDetailViewController+Analytics.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+Analytics.swift
@@ -1,9 +1,11 @@
 import Foundation
 import PocketCastsUtils
+import PocketCastsDataModel
 
 protocol PlaylistTypeTrackerProvider {
     var analyticsSourceType: String { get }
     func track(_ event: AnalyticsEvent, properties: [AnyHashable: Any]?)
+    func track(episode: Episode, added: Bool, to playlist: EpisodeFilter, source: String?)
 }
 
 extension PlaylistTypeTrackerProvider {
@@ -13,6 +15,22 @@ extension PlaylistTypeTrackerProvider {
             playlistEventProperties["filter_type"] = analyticsSourceType
         }
         Analytics.track(event, properties: playlistEventProperties)
+    }
+
+    func track(episode: Episode, added: Bool, to playlist: EpisodeFilter, source: String? = nil) {
+        let properties = [
+            "source": source ?? analyticsSourceType,
+            "playlist_name": playlist.playlistName,
+            "playlist_uuid": playlist.uuid,
+            "episode_uuid": episode.uuid,
+            "podcast_uuid": episode.podcastUuid
+        ]
+
+        if added {
+            Analytics.track(.episodeAddedToList, properties: properties)
+        } else {
+            Analytics.track(.episodeRemovedFromList, properties: properties)
+        }
     }
 }
 

--- a/podcasts/New Detail/PlaylistDetailViewController+TableView.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+TableView.swift
@@ -230,6 +230,7 @@ extension PlaylistDetailViewController: UITableViewDelegate {
                 let view = ModalMessageViewController.episodeUnavailableAlert { [weak self] in
                     guard let self else { return }
                     self.track(.filterRemoveFromPlaylistTapped)
+                    self.track(episode: selectedEpisode, added: false, to: self.viewModel.playlist, source: "unavailable_episode")
                     self.viewModel.remove(episode: episodeUuid, at: indexPath.row)
                 }
                 BottomSheetSwiftUIWrapper.present(

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -443,7 +443,7 @@ class PlaylistDetailViewController: FakeNavViewController {
             return
         }
 
-        let searchAnalyticsHelper = SearchAnalyticsHelper(source: .unknown)
+        let searchAnalyticsHelper = SearchAnalyticsHelper(source: .playlistEditor)
         let searchResults = SearchResultsModel(analyticsHelper: searchAnalyticsHelper)
         let vc = PCHostingController(rootView: LocalSearchView(
             playlist: viewModel.playlist,

--- a/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
@@ -144,6 +144,19 @@ final class LocalSearchCoordinator {
             return
         }
 
+        // For now let's track the event directly here to avoid swift concurrency warning using the PlaylistTypeTrackerProvider
+        Analytics.track(
+            .episodeAddedToList,
+            properties:
+                [
+                    "source": "playlist_editor",
+                    "playlist_name": playlist.playlistName,
+                    "playlist_uuid": playlist.uuid,
+                    "episode_uuid": episode.uuid,
+                    "podcast_uuid": episode.podcastUuid
+                ]
+        )
+
         playlistEpisodeUUIDs.insert(searchResult.uuid)
         episodes.removeAll { $0.uuid == searchResult.uuid }
         addedEpisodeCount += 1

--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -222,7 +222,6 @@ private extension LocalSearchView {
                 searchText: viewModel.searchText,
                 selectedPodcastTitle: viewModel.selectedPodcast?.title,
                 onAddEpisode: { result in
-                    let isFull = false
                     if reduceMotion {
                         viewModel.handleAddEpisode(result)
                     } else {

--- a/podcasts/PlaylistCell.swift
+++ b/podcasts/PlaylistCell.swift
@@ -91,7 +91,7 @@ class PlaylistCell: ThemeableCell {
 
         separatorView.isHidden = isLastRow
         separatorView.backgroundColor = AppTheme.colorForStyle(.primaryUi05)
-        bringSubviewToFront(separatorView)        
+        bringSubviewToFront(separatorView)
     }
 
     func configureAddPlaylistCell() {


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-internal-testing-b4b2f66c6304/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=team&showCompletedIssues=all&showSubIssues=true&showTriageIssues=true)
|:---:|

Fixes PCIOS-310

This adds 2 new events when an episode is added or removed to/from a playlist.

## To test

- Run this branch and enable `Trackers`
- Go to Playlists
### Add events
- Open a manual playlist detail
- Tap on `Add episodes`
- Add an episode
- Confirm you see `🔵 Tracked: episode_added_to_list ["playlist_uuid": "14EF3D65-6012-4748-AAAC-D457B3D64D6A", "playlist_name": "Test Manual", "episode_uuid": "427a5402-81e5-44d7-a933-6aea5e2d93da", "podcast_uuid": "ba4bbcf0-b190-013d-1a78-0acc26574db2", "source": "playlist_editor"]` with `playlist_editor` as source
- Now add an episode from a Podcast detail (or any other source accessed by swipe gesture)
- When you save the episode added to one or more playlists you should see this event:
- `🔵 Tracked: episode_added_to_list ["podcast_uuid": "03da5ec0-31f4-013b-ef97-0acc26574db2", "playlist_name": "Test manual", "source": "swipe", "episode_uuid": "6e13318a-0626-4778-be47-5577c08aefc8", "playlist_uuid": "A7517746-FEEB-4E78-A17F-029BC9A16055"]` with source `swipe` for each playlist added to
- Play an episode and add it to a playlist from the Shelf
- Once added confirm you see this:
- `🔵 Tracked: episode_added_to_list ["episode_uuid": "9aee4db6-e151-467b-897b-9617e987b51e", "source": "shelf", "playlist_name": "Test manual", "podcast_uuid": "dc51d790-406b-0137-f266-1d245fc5f9cf", "playlist_uuid": "A7517746-FEEB-4E78-A17F-029BC9A16055"]` with source `shelf`

### Remove event
- Add the same episode as before from a Podcast detail (or any other source accessed by swipe gesture) in order to open the chooser with one or more playlists pre-selected
- Remove the episode from one or more playlists and save
- Confirm you see for each playlist removed this: `🔵 Tracked: episode_removed_from_list ["playlist_name": "Test manual", "podcast_uuid": "03da5ec0-31f4-013b-ef97-0acc26574db2", "episode_uuid": "6e13318a-0626-4778-be47-5577c08aefc8", "playlist_uuid": "A7517746-FEEB-4E78-A17F-029BC9A16055", "source": "swipe"]` with source `swipe`
- Now do the same test as above but from the player shelf. You should see the same event but with the source `shelf`
- Now go to a manual playlist detail
- Tap the `•••` top right menu
- Select Reorder Episodes
- Delete one episode
- Confirm you see `🔵 Tracked: episode_removed_from_list ["playlist_name": "Test Manual", "podcast_uuid": "96103ac0-528a-013a-d6e1-0acc26574db2", "episode_uuid": "0bcf8d54-9118-4838-9ee6-ad3a153156a8", "playlist_uuid": "14EF3D65-6012-4748-AAAC-D457B3D64D6A", "source": "playlist_rearrange"]` with the source `playlist_rearrange`
- Stop the app
- Open the file `PlaylistDetailViewController+TableView`
- In line `228` change `if selectedEpisode.wasDeleted {` in `if !selectedEpisode.wasDeleted {` to force the sheet to appear
- Run the app
- Open a manual playlist
- Tap on the episode to open the episode detail
- You should see the Unavailable sheet
- Tap on the button to remove it
- Confirm you see `🔵 Tracked: episode_removed_from_list ["playlist_name": "Test Manual", "source": "unavailable_episode", "episode_uuid": "b4415e8f-0d75-41b6-8e5a-16bdde681842", "playlist_uuid": "14EF3D65-6012-4748-AAAC-D457B3D64D6A", "podcast_uuid": "ede41160-9eeb-012f-3e7d-525400c11844"]` with the source `unavailable_episode`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
