### PR TITLE
[Playback 2025] Refactor stories progress to fix view render

### DIFF
--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -4,7 +4,11 @@ import SwiftUI
 
 @MainActor
 class StoriesModel: ObservableObject {
-    @Published var progress: Double
+    private(set) var progress: Double = 0 {
+        didSet {
+            progressModel.progress = progress
+        }
+    }
 
     @Published var currentStoryIndex: Int = 0
 
@@ -19,6 +23,7 @@ class StoriesModel: ObservableObject {
     private let dataSource: StoriesDataSource
     private let publisher: Timer.TimerPublisher
     private let configuration: StoriesConfiguration
+    private let progressModel: StoriesProgressModel
 
     private var cancellables = Set<AnyCancellable>()
 
@@ -51,12 +56,22 @@ class StoriesModel: ObservableObject {
         configuration.indicatorSpacing
     }
 
-    init(dataSource: StoriesDataSource, configuration: StoriesConfiguration, activeTier: @autoclosure @escaping () -> SubscriptionTier = SubscriptionHelper.activeTier) {
+    var progressPublisher: StoriesProgressModel {
+        progressModel
+    }
+
+    init(
+        dataSource: StoriesDataSource,
+        configuration: StoriesConfiguration,
+        progressModel: StoriesProgressModel = .shared,
+        activeTier: @autoclosure @escaping () -> SubscriptionTier = SubscriptionHelper.activeTier
+    ) {
         self.dataSource = dataSource
         self.configuration = configuration
-        self.progress = 0
+        self.progressModel = progressModel
         self.publisher = Timer.publish(every: 0.01, on: .main, in: .default)
         self.activeTier = activeTier
+        self.progressModel.progress = progress
 
         Task.init {
             await isReady = dataSource.isReady()
@@ -104,7 +119,6 @@ class StoriesModel: ObservableObject {
             }
 
             self.progress = newProgress
-            StoriesProgressModel.shared.progress = newProgress
         })
 
         currentStory?.onResume()

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -143,7 +143,7 @@ struct StoriesView: View {
             VStack {
                 HStack(spacing: model.indicatorSpacing) {
                     ForEach(0 ..< model.numberOfStories, id: \.self) { x in
-                        StoryIndicator(index: x, style: model.indicatorStyle, progressModel: model)
+                        StoryIndicator(index: x, style: model.indicatorStyle, progressModel: model.progressPublisher)
                     }
                 }
                 .frame(height: model.indicatorHeight)

--- a/podcasts/End of Year/Views/StoryIndicator.swift
+++ b/podcasts/End of Year/Views/StoryIndicator.swift
@@ -28,9 +28,9 @@ struct StoryIndicatorStyle {
 struct StoryIndicator: View {
     let index: Int
     let style: StoryIndicatorStyle
-    @ObservedObject var progressModel: StoriesModel
+    @ObservedObject var progressModel: StoriesProgressModel
 
-    init(index: Int, style: StoryIndicatorStyle = StoryIndicatorStyle(), progressModel: StoriesModel) {
+    init(index: Int, style: StoryIndicatorStyle = StoryIndicatorStyle(), progressModel: StoriesProgressModel) {
         self.index = index
         self.style = style
         self.progressModel = progressModel


### PR DESCRIPTION
Fixes [PCIOS-302](https://linear.app/a8c/issue/PCIOS-302/onboarding-broke-the-stories-animation-theres-some-new-observable)

Moves the progress into a separatate observable instead of using `@Published` to avoid view re-renders.

## To test

### Playback

* Sign in with an account with listening history
* Enable `tracksLogging` and `endOfYear2025` feature flags
* These events should be logged, but only once:
```
🔵 Tracked: end_of_year_story_shown ["story": "cover", "year": "2025"]
🔵 Tracked: end_of_year_story_shown ["year": "2025", "story": "cover"]
```

### Onboarding
* Freshly install the app
* The onboaring screens should appear with the intro carousel
* Ensure that the progress indicators animate properly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
