### PR TITLE
[Playlists] Ensure Up Next fetch queries are constrained

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -224,7 +224,18 @@ class EpisodeDataManager {
         let upNextTableName = DataManager.playlistEpisodeTableName
         let episodeTableName = DataManager.episodeTableName
 
-        return loadMultiple(query: "SELECT \(episodeTableName).* FROM \(upNextTableName) JOIN \(episodeTableName) ON \(episodeTableName).uuid = \(upNextTableName).episodeUuid ORDER BY \(upNextTableName).episodePosition ASC", values: nil, dbQueue: dbQueue)
+        return loadMultiple(
+            query: """
+            SELECT \(episodeTableName).*
+            FROM \(upNextTableName)
+            JOIN \(episodeTableName)
+            ON \(episodeTableName).uuid = \(upNextTableName).episodeUuid
+            WHERE \(upNextTableName).playlist_id = ?
+            ORDER BY \(upNextTableName).episodePosition ASC
+            """,
+            values: [UpNextDataManager.upNextPlaylistId],
+            dbQueue: dbQueue
+        )
     }
 
     func allUpNextEpisodes(from uuids: [String], dbQueue: PCDBQueue) -> [Episode] {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
@@ -117,7 +117,18 @@ class UserEpisodeDataManager {
     func allUpNextEpisodes(dbQueue: PCDBQueue) -> [UserEpisode] {
         let upNextTableName = DataManager.playlistEpisodeTableName
         let userEpisodeTableName = DataManager.userEpisodeTableName
-        return loadMultiple(query: "SELECT \(userEpisodeTableName).* FROM \(upNextTableName) JOIN \(userEpisodeTableName) ON \(userEpisodeTableName).uuid = \(upNextTableName).episodeUuid ORDER BY \(upNextTableName).episodePosition ASC", values: nil, dbQueue: dbQueue)
+        return loadMultiple(
+            query: """
+            SELECT \(userEpisodeTableName).*
+            FROM \(upNextTableName)
+            JOIN \(userEpisodeTableName)
+            ON \(userEpisodeTableName).uuid = \(upNextTableName).episodeUuid
+            WHERE \(upNextTableName).playlist_id = ?
+            ORDER BY \(upNextTableName).episodePosition ASC
+            """,
+            values: [UpNextDataManager.upNextPlaylistId],
+            dbQueue: dbQueue
+        )
     }
 
     private func loadSingle(query: String, values: [Any]?, dbQueue: PCDBQueue) -> UserEpisode? {

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/UpNextEpisodeFetchTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/UpNextEpisodeFetchTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+import GRDB
+@testable import PocketCastsDataModel
+
+final class UpNextEpisodeFetchTests: XCTestCase {
+
+    enum TestSetupError: Error {
+        case failedToCreateDatabase
+    }
+
+    func testEpisodeDataManagerFiltersNonUpNextPlaylists() throws {
+        let queue = try makeQueue()
+        let episodeManager = EpisodeDataManager()
+        let upNextManager = UpNextDataManager()
+        upNextManager.setup(dbQueue: queue)
+
+        let upNextEpisode = Episode()
+        upNextEpisode.uuid = "ep-upnext"
+        upNextEpisode.title = "Up Next Episode"
+        upNextEpisode.podcastUuid = "pod-upnext"
+        upNextEpisode.addedDate = Date()
+        episodeManager.save(episode: upNextEpisode, dbQueue: queue)
+
+        let otherEpisode = Episode()
+        otherEpisode.uuid = "ep-other"
+        otherEpisode.title = "Other Playlist Episode"
+        otherEpisode.podcastUuid = "pod-other"
+        otherEpisode.addedDate = Date()
+        episodeManager.save(episode: otherEpisode, dbQueue: queue)
+
+        addUpNextEntry(upNextManager: upNextManager, queue: queue, episodeUuid: upNextEpisode.uuid, title: upNextEpisode.title ?? "", podcastUuid: upNextEpisode.podcastUuid, position: 0)
+        addPlaylistEntry(queue: queue, episodeUuid: otherEpisode.uuid, playlistId: 999, position: 1, title: otherEpisode.title ?? "", podcastUuid: otherEpisode.podcastUuid)
+
+        let results = episodeManager.allUpNextEpisodes(dbQueue: queue)
+        XCTAssertEqual(results.map(\.uuid), [upNextEpisode.uuid])
+    }
+
+    func testUserEpisodeDataManagerFiltersNonUpNextPlaylists() throws {
+        let queue = try makeQueue()
+        let userEpisodeManager = UserEpisodeDataManager()
+        let upNextManager = UpNextDataManager()
+        upNextManager.setup(dbQueue: queue)
+
+        let upNextUserEpisode = UserEpisode()
+        upNextUserEpisode.uuid = "user-ep-upnext"
+        upNextUserEpisode.title = "Up Next User Episode"
+        upNextUserEpisode.addedDate = Date()
+        userEpisodeManager.save(episode: upNextUserEpisode, dbQueue: queue)
+
+        let otherUserEpisode = UserEpisode()
+        otherUserEpisode.uuid = "user-ep-other"
+        otherUserEpisode.title = "Other Playlist User Episode"
+        otherUserEpisode.addedDate = Date()
+        userEpisodeManager.save(episode: otherUserEpisode, dbQueue: queue)
+
+        addUpNextEntry(upNextManager: upNextManager, queue: queue, episodeUuid: upNextUserEpisode.uuid, title: upNextUserEpisode.title ?? "", podcastUuid: DataConstants.userEpisodeFakePodcastId, position: 0)
+        addPlaylistEntry(queue: queue, episodeUuid: otherUserEpisode.uuid, playlistId: 999, position: 1, title: otherUserEpisode.title ?? "", podcastUuid: DataConstants.userEpisodeFakePodcastId)
+
+        let results = userEpisodeManager.allUpNextEpisodes(dbQueue: queue)
+        XCTAssertEqual(results.map(\.uuid), [upNextUserEpisode.uuid])
+    }
+
+    // MARK: - Helpers
+
+    private func makeQueue() throws -> PCDBQueue {
+        guard let dbPool = try DatabasePool.newTestDatabase() else {
+            throw TestSetupError.failedToCreateDatabase
+        }
+        let queue = GRDBQueue(dbPool: dbPool)
+        DatabaseHelper.setup(queue: queue)
+        return queue
+    }
+
+    private func addUpNextEntry(upNextManager: UpNextDataManager, queue: PCDBQueue, episodeUuid: String, title: String, podcastUuid: String, position: Int32) {
+        let playlistEpisode = PlaylistEpisode()
+        playlistEpisode.episodeUuid = episodeUuid
+        playlistEpisode.title = title
+        playlistEpisode.podcastUuid = podcastUuid
+        playlistEpisode.episodePosition = position
+        upNextManager.save(playlistEpisode: playlistEpisode, dbQueue: queue)
+    }
+
+    private func addPlaylistEntry(queue: PCDBQueue, episodeUuid: String, playlistId: Int, position: Int, title: String, podcastUuid: String) {
+        queue.write { db in
+            do {
+                try db.executeUpdate(
+                    """
+                    INSERT INTO \(DataManager.playlistEpisodeTableName)
+                    (episodePosition, episodeUuid, playlist_id, upcoming, wasDeleted, title, podcastUuid)
+                    VALUES (?, ?, ?, 0, 0, ?, ?)
+                    """,
+                    values: [
+                        position,
+                        episodeUuid,
+                        playlistId,
+                        title,
+                        podcastUuid
+                    ]
+                )
+            } catch {
+                XCTFail("Failed to insert playlist entry: \(error)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes [PCIOS-322](https://linear.app/a8c/issue/PCIOS-322/up-next-includes-other-playlist-episodes)

| Before | After |
|--|--|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-12 at 19 53 09" src="https://github.com/user-attachments/assets/cd8b42fd-7a86-4a10-9221-eb1e5a3f3750" /> |  <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-12 at 19 54 17" src="https://github.com/user-attachments/assets/d5e4c518-bacf-4637-b99d-66272cc9a42b" /> |

| Before | After |
|--|--|
| <img width="1414" height="912" alt="CleanShot 2025-11-12 at 20 11 10@2x" src="https://github.com/user-attachments/assets/063097df-f585-4880-b4e3-7a4d70cf2a86" /> | <img width="1414" height="912" alt="CleanShot 2025-11-12 at 20 07 04@2x" src="https://github.com/user-attachments/assets/718cc434-97dc-4d8b-ad6b-be3801091bad" /> |

## To test

### Up Next Duration

- Log in with a user without User Episodes (required for a specific code path)
- Create a manual playlist with 5 or 10 episodes to make the duration relatively large
- Add one or two episodes to Up Next
- ✅ Verify that the duration label is correct

### CarPlay

- Log in with a user without User Episodes (required for a specific code path)
- Create a manual playlist with 5 or 10 episodes to make the duration relatively large
- Add one or two episodes to Up Next
- Run the app with the CarPlay simulator attached
- Navigate to the Up Next queue
- ✅ Verify only the Up Next episodes are shown and not other playlists

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
