### PR TITLE
[Playback 2025] Handle App Store Review prompt after sharing playback

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -793,6 +793,7 @@ enum AnalyticsEvent: String {
     case endOfYearStoryShown
     case endOfYearStoryShare
     case endOfYearStoryShared
+    case playbackShared
     case endOfYearProfileCardTapped
     case endOfYearUpsellShown
     case endOfYearLearnRatingsShown

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -195,8 +195,12 @@ struct EndOfYear {
             }
 
             if let activity, success {
-                Analytics.track(.endOfYearStoryShared, properties: ["activity": activity.rawValue, "story": storyIdentifier])
-                fakeViewController.dismiss(animated: false)
+                let properties = ["activity": activity.rawValue, "story": storyIdentifier]
+                Analytics.track(.endOfYearStoryShared, properties: properties)
+                DispatchQueue.main.async {
+                    model.recordPlaybackShare(properties: properties.merging(["source": "end_of_year"]) { $1 })
+                    fakeViewController.dismiss(animated: false)
+                }
             }
         }
 

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -35,6 +35,8 @@ class StoriesModel: ObservableObject {
 
     private var currentStory: Story?
 
+    private var pendingPlaybackShareEvents: [[String: String]] = []
+
     var numberOfStories: Int {
         dataSource.numberOfStories
     }
@@ -236,6 +238,7 @@ class StoriesModel: ObservableObject {
 
     func stopAndDismiss() {
         pause()
+        trackPendingPlaybackSharesIfNeeded()
         NavigationManager.sharedManager.dismissPresentedViewController()
     }
 
@@ -273,6 +276,10 @@ class StoriesModel: ObservableObject {
 
     func shouldShowDismissButton() -> Bool {
         configuration.shouldShowDismissButton
+    }
+
+    func recordPlaybackShare(properties: [String: String]) {
+        pendingPlaybackShareEvents.append(properties)
     }
 }
 
@@ -322,5 +329,15 @@ private extension StoriesModel {
     /// Whether some Plus stories should be skipped or not
     func shouldSkipPlusStories() -> Bool {
         !isPaidUser() && !manuallyChanged && currentStoryIsPlus && nextStoryIsPlus()
+    }
+
+    func trackPendingPlaybackSharesIfNeeded() {
+        guard !pendingPlaybackShareEvents.isEmpty else { return }
+
+        pendingPlaybackShareEvents.forEach {
+            Analytics.track(.playbackShared, properties: $0)
+        }
+
+        pendingPlaybackShareEvents.removeAll()
     }
 }

--- a/podcasts/UserSatisfactionSurveyManager.swift
+++ b/podcasts/UserSatisfactionSurveyManager.swift
@@ -53,6 +53,8 @@ public class UserSatisfactionSurveyManager: NSObject {
             return !isPlus ? .canShow : .wrongUserType // Free user events
         case .plusUpgraded, .folderCreated, .bookmarkCreated, .customThemeSet, .referralShared:
             return isPlus ? .canShow : .wrongUserType // Plus user events
+        case .playbackShared:
+            return .canShow
         }
     }
 
@@ -190,6 +192,8 @@ extension UserSatisfactionSurveyManager: AnalyticsAdapter {
             return handlePlusUpgrade()
         case AnalyticsEvent.applicationOpened.eventName:
             return handleAppOpened()
+        case AnalyticsEvent.playbackShared.eventName:
+            return .playbackShared
         default:
             return nil
         }
@@ -275,4 +279,7 @@ enum SurveyTriggerEvent: String, CaseIterable {
     case bookmarkCreated = "bookmark_created"
     case customThemeSet = "custom_theme_set"
     case referralShared = "referral_shared"
+
+    // Shared events
+    case playbackShared = "playback_shared"
 }


### PR DESCRIPTION
Fixes [PCIOS-305](https://linear.app/a8c/issue/PCIOS-305/prompt-the-user-to-review-the-app-after-sharing-playback-story)

We keep track of shares from the playback / end of year screens and trigger the review prompt event only on dismissal.

## To test

### No Prompt

- Log in with an account with listening history
- Go to Developer Tools > Ratings Debug Info > Reset Survey & Reviews
- Open Playback 2025 from Profile
- Close playback
- ✅ Verify NO survey prompt is shown

### Prompt
- Log in with an account with listening history
- Go to Developer Tools > Ratings Debug Info > Reset Survey & Reviews
- Open Playback 2025 from Profile
- Share a story from Playback 2025 (you must complete the share)
- Close playback
- ✅ Verify the survey prompt is shown
- ✅ Verify `user_satisfaction_survey_shown` includes `"trigger_event": "playback_shared"`

```
🔵 Tracked: user_satisfaction_survey_shown ["user_type": "free", "trigger_event": "playback_shared"]
```

- Dismiss the prompt
- ✅ Verify `user_satisfaction_survey_dismissed` includes `"trigger_event": "playback_shared"`

```
🔵 Tracked: user_satisfaction_survey_dismissed ["user_type": "free", "trigger_event": "playback_shared"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
