### PR TITLE
[Playlists] Attempt to fix crash on diffable when animating a reload

### DIFF
--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -372,21 +372,24 @@ class PlaylistDetailViewController: FakeNavViewController {
     }
 
     private func reload(data: StagedChangeset<PlaylistDetailViewModel.DataSourceValue>, animated: Bool, contentChanged: Bool) {
-        loadingIndicator.stopAnimating()
-        refreshControl?.set(text: L10n.refreshControlRefreshComplete.uppercased())
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
-            UIView.animate(withDuration: 0.2, animations: {
-                self?.refreshControl?.alpha = 0
-            }, completion: { _ in
-                self?.refreshControl?.endRefreshing()
-            })
-        }
-
+        removeLoadingIndicators()
+        
         if animated, contentChanged {
-            tableView.reload(using: data, with: .fade) { [weak self] newData in
-                self?.viewModel.update(data: newData) {
-                    self?.reloadRefreshControlColor()
+            do {
+                try SJCommonUtils.catchException { [weak self] in
+                    self?.tableView.reload(using: data, with: .fade) { [weak self] newData in
+                        self?.viewModel.update(data: newData) {
+                            self?.reloadRefreshControlColor()
+                        }
+                    }
                 }
+            } catch {
+                if let data = data.last?.data {
+                    viewModel.update(data: data) { [weak self] in
+                        self?.reloadRefreshControlColor()
+                    }
+                }
+                tableView.reloadData()
             }
         } else {
             if let data = data.last?.data {
@@ -399,6 +402,18 @@ class PlaylistDetailViewController: FakeNavViewController {
         blurHeaderView.isHidden = viewModel.episodes.isEmpty
         reloadEmptyState()
         refreshMultiSelectEpisodes()
+    }
+
+    private func removeLoadingIndicators() {
+        loadingIndicator.stopAnimating()
+        refreshControl?.set(text: L10n.refreshControlRefreshComplete.uppercased())
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+            UIView.animate(withDuration: 0.2, animations: {
+                self?.refreshControl?.alpha = 0
+            }, completion: { _ in
+                self?.refreshControl?.endRefreshing()
+            })
+        }
     }
 
     private func reloadRefreshControlColor() {

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -373,7 +373,7 @@ class PlaylistDetailViewController: FakeNavViewController {
 
     private func reload(data: StagedChangeset<PlaylistDetailViewModel.DataSourceValue>, animated: Bool, contentChanged: Bool) {
         removeLoadingIndicators()
-        
+
         if animated, contentChanged {
             do {
                 try SJCommonUtils.catchException { [weak self] in

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -129,6 +129,8 @@ class PlaylistDetailViewModel: ObservableObject {
     }
 
     func reloadPlaylistAndEpisodes() {
+        addSentryBreadcrumb(spot: "reloadPlaylistAndEpisodes", animated: false)
+
         if isSearching {
             searchEpisodes(for: searchTerm)
             return
@@ -147,6 +149,8 @@ class PlaylistDetailViewModel: ObservableObject {
     }
 
     func reloadEpisodeList(animated: Bool = true) {
+        addSentryBreadcrumb(spot: "reloadEpisodeList", animated: animated)
+
         if isSearching {
             searchEpisodes(for: searchTerm)
             return
@@ -220,51 +224,71 @@ class PlaylistDetailViewModel: ObservableObject {
         source: [ListEpisode],
         newData: [ListEpisode]
     ) -> (Bool, StagedChangeset<DataSourceValue>) {
-        let oldData = dataSource
-        var finalData: [ArraySection<Section, ListItem>] = []
-        let contentChanged = !source.isContentEqual(to: newData)
-        let changedData = contentChanged ? newData : episodes
-        finalData.append(ArraySection(
-            model: .header,
-            elements: [
-                PlaylistHeaderViewCellPlaceholder()
-            ])
+        let oldSections = dataSource
+        var newSections: [ArraySection<Section, ListItem>] = []
+
+        // Header section (always included)
+        newSections.append(
+            ArraySection(
+                model: .header,
+                elements: [PlaylistHeaderViewCellPlaceholder()]
+            )
         )
+
+        // Archive section (only for manual playlists)
         if isManualPlaylist {
-            finalData.append(ArraySection(
-                model: .archive,
-                elements: [
-                    PlaylistArchiveViewCellPlaceholder(
-                        archived: archivedEpisodesCount,
-                        showArchived: shouldShowArchived
-                    )
-                ])
+            newSections.append(
+                ArraySection(
+                    model: .archive,
+                    elements: [
+                        PlaylistArchiveViewCellPlaceholder(
+                            archived: archivedEpisodesCount,
+                            showArchived: shouldShowArchived
+                        )
+                    ]
+                )
             )
         }
-        if newData.isEmpty, isSearching {
-            finalData.append(ArraySection(
-                model: .episodes,
-                elements: [
-                    NoSearchResultsPlaceholder()
-                ])
-            )
-        } else if newData.isEmpty, !shouldShowArchived {
-            finalData.append(ArraySection(
-                model: .episodes,
-                elements: [
+
+        // Episodes section (always included: it shows placeholder in case of empty episodes)
+        let contentChanged = !source.isContentEqual(to: newData)
+        let effectiveEpisodes = contentChanged ? newData : episodes
+
+        let episodeElements: [ListItem]
+
+        if newData.isEmpty {
+            if isSearching {
+                episodeElements = [NoSearchResultsPlaceholder()]
+            } else if isManualPlaylist, !shouldShowArchived {
+                episodeElements = [
                     AllArchivedPlaceholder(
                         archived: archivedEpisodesCount,
-                        message: archivedEpisodesCount == 1 ? L10n.playlistManualArchivedEpisodePlaceholder : L10n.playlistManualArchivedEpisodesPlaceholder(archivedEpisodesCount)
+                        message: archivedEpisodesCount == 1
+                            ? L10n.playlistManualArchivedEpisodePlaceholder
+                            : L10n.playlistManualArchivedEpisodesPlaceholder(archivedEpisodesCount)
                     )
-                ])
-            )
+                ]
+            } else {
+                episodeElements = []
+            }
         } else {
-            finalData.append(ArraySection(
-                model: .episodes,
-                elements: changedData)
-            )
+            episodeElements = effectiveEpisodes
         }
-        return (contentChanged, StagedChangeset(source: oldData, target: finalData))
+
+        newSections.append(
+            ArraySection(
+                model: .episodes,
+                elements: episodeElements
+            )
+        )
+
+        let changeset = StagedChangeset(
+            source: oldSections,
+            target: newSections
+        )
+
+        let contentHasChanged = !newSections.isContentEqual(to: oldSections) || contentChanged
+        return (contentHasChanged, changeset)
     }
 
     private func loadImagesURLs(episodes: [ListEpisode], includingEpisodeArtwork: Bool = false) async throws -> [PlaylistArtworkView.ImageItem] {
@@ -366,8 +390,19 @@ extension PlaylistDetailViewModel {
         let escapedSearch = searchTerm.escapeLike(escapeChar: "\\")
         let newData = episodesDataManager.playlistEpisodes(for: playlist, limit: 0, shouldShowArchived: true, search: escapedSearch)
         let changeSetTuple = buildChangeSet(source: episodes, newData: newData)
+        addSentryBreadcrumb(spot: "searchEpisodes", animated: false)
         DispatchQueue.main.async { [weak self] in
             self?.onChange(changeSetTuple.1, true, changeSetTuple.0)
         }
+    }
+}
+
+extension PlaylistDetailViewModel {
+    func addSentryBreadcrumb(spot: String, animated: Bool) {
+        let crumb = Breadcrumb()
+        crumb.level = SentryLevel.info
+        crumb.category = "playlist"
+        crumb.message = "reload spot \(spot) - animated: \(animated)"
+        SentrySDK.addBreadcrumb(crumb)
     }
 }

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsUtils
 import DifferenceKit
+import Sentry
 
 class PlaylistDetailViewModel: ObservableObject {
     typealias DataSourceValue = [ArraySection<Section, ListItem>]
@@ -392,7 +393,8 @@ extension PlaylistDetailViewModel {
         let changeSetTuple = buildChangeSet(source: episodes, newData: newData)
         addSentryBreadcrumb(spot: "searchEpisodes", animated: false)
         DispatchQueue.main.async { [weak self] in
-            self?.onChange(changeSetTuple.1, true, changeSetTuple.0)
+            // Avoid animation as long we use the current diffable framework
+            self?.onChange(changeSetTuple.1, false, changeSetTuple.0)
         }
     }
 }


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-internal-testing-b4b2f66c6304/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=team&showCompletedIssues=all&showSubIssues=true&showTriageIssues=true)
|:---:|

Fixes PCIOS-323

An attempt to fix the Diffable crash when the update is animating.
This PR adds:
- Breadcrumbs for Sentry
- try/catch with fallback on table reload with no animation
- An extra edge case for sections
- Check if changes are made because the sections number changed

## To test

- Smoke tests manual and smart playlists, including search, empty states, archived, remove episodes by deleting, archiving, show/hide archived, unarchive all etc...

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
