### PR TITLE
[Playlists] Address testing feedback part 2

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -951,12 +951,16 @@ public class DataManager {
         }
     }
 
-    public func playlistEpisodeCount(for playlist: EpisodeFilter, episodeUuidToAdd: String?, shouldShowArchived: Bool = false) -> Int {
-        playlistManager.playlistEpisodeCount(clause: .episodeCount, playlist: playlist, episodeUuidToAdd: episodeUuidToAdd, shouldShowArchived: shouldShowArchived, dbQueue: dbQueue)
+    public func playlistEpisodeCount(for playlist: EpisodeFilter, episodeUuidToAdd: String?) -> Int {
+        playlistManager.playlistEpisodeCount(clause: .episodeCount, playlist: playlist, episodeUuidToAdd: episodeUuidToAdd, shouldShowArchived: false, dbQueue: dbQueue)
     }
 
-    public func allPlaylistEpisodeCount(for playlist: EpisodeFilter, episodeUuidToAdd: String?) -> Int {
-        playlistManager.playlistEpisodeCount(clause: .allEpisodeCount, playlist: playlist, episodeUuidToAdd: episodeUuidToAdd, shouldShowArchived: true, dbQueue: dbQueue)
+    public func playlistArchivedEpisodeCount(for playlist: EpisodeFilter, episodeUuidToAdd: String?) -> Int {
+        playlistManager.playlistEpisodeCount(clause: .episodeCount, playlist: playlist, episodeUuidToAdd: episodeUuidToAdd, shouldShowArchived: true, dbQueue: dbQueue)
+    }
+
+    public func allPlaylistEpisodeCount(for playlist: EpisodeFilter, episodeUuidToAdd: String?, includingArchivedEpisodes: Bool = false) -> Int {
+        playlistManager.playlistEpisodeCount(clause: .allEpisodeCount, playlist: playlist, episodeUuidToAdd: episodeUuidToAdd, shouldShowArchived: includingArchivedEpisodes, dbQueue: dbQueue)
     }
 
     public func playlistEpisodes(for playlist: EpisodeFilter, limit: Int? = nil) -> [Episode] {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -92,6 +92,7 @@ public class PlaylistQueryBuilder {
                     \(manualCTE)
                     SELECT COUNT(*)
                     \(manualJoin)
+                    \(shouldShowArchived ? "" : "WHERE episode.archived = 0")
                     """
             case .podcast:
                 let select = manualSelect(clause: clause, for: playlist)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -28,7 +28,7 @@ extension SyncTask {
             DataManager.sharedManager.save(playlist: playlist)
             let didAdd = DataManager.sharedManager.add(episodes: addedEpisodes, to: playlist)
             if !didAdd {
-                let playlistCount = DataManager.sharedManager.playlistEpisodeCount(for: playlist, episodeUuidToAdd: nil, shouldShowArchived: true)
+                let playlistCount = DataManager.sharedManager.allPlaylistEpisodeCount(for: playlist, episodeUuidToAdd: nil, includingArchivedEpisodes: true)
                 FileLog.shared.addMessage("SyncTask: Tried to add too many episodes from server playlist \(playlist.playlistName) episodeCount: \(addedEpisodes) playlistCount: \(playlistCount)")
             }
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -386,7 +386,7 @@ extension SyncTask {
 
             let didAdd = DataManager.sharedManager.add(episodes: addedEpisodes, to: playlist)
             if !didAdd {
-                let playlistCount = DataManager.sharedManager.playlistEpisodeCount(for: playlist, episodeUuidToAdd: nil, shouldShowArchived: true)
+                let playlistCount = DataManager.sharedManager.allPlaylistEpisodeCount(for: playlist, episodeUuidToAdd: nil, includingArchivedEpisodes: true)
                 FileLog.shared.addMessage("SyncTask: Tried to add too many episodes to imported playlist \(playlist.playlistName) episodeCount: \(addedEpisodes) playlistCount: \(playlistCount)")
             }
 

--- a/podcasts/FilterEditOptionsViewController.swift
+++ b/podcasts/FilterEditOptionsViewController.swift
@@ -204,7 +204,11 @@ class FilterEditOptionsViewController: PCViewController, UITableViewDelegate, UI
             navigationController?.pushViewController(singleFilterVC, animated: true)
             tableView.deselectRow(at: indexPath, animated: false)
         case .deletePlaylist:
-            showAlert()
+            if Self.playlistRebrandingIsEnabled {
+                showDeleteOptionPicker(for: filterToEdit)
+            } else {
+                showAlert()
+            }
 
             tableView.deselectRow(at: indexPath, animated: true)
         default:
@@ -332,5 +336,46 @@ class FilterEditOptionsViewController: PCViewController, UITableViewDelegate, UI
 extension FilterEditOptionsViewController: PlaylistTypeTrackerProvider {
     var analyticsSourceType: String {
         filterToEdit.manual ? "manual" : "smart"
+    }
+}
+
+// MARK: - Delete
+
+extension FilterEditOptionsViewController {
+    fileprivate func showDeleteOptionPicker(for playlist: EpisodeFilter) {
+        let playlistType = playlist.manual ? "manual" : "smart"
+        let analyticsProperties = ["filter_type": playlistType]
+        Analytics.track(.filterDeleteTriggered, properties: analyticsProperties)
+        let delete = OptionAction(
+            label: L10n.delete,
+            icon: nil,
+            action: { [weak self] in
+                self?.delete(playlist: playlist)
+            }
+        )
+        delete.destructive = true
+
+        let picker = OptionsPicker(title: "")
+        picker.addDescriptiveActions(
+            title: L10n.playlistsDeleteAlertTitle,
+            message: L10n.playlistsDeleteAlertMessage,
+            icon: "option-alert",
+            actions: [
+                delete
+            ]
+        )
+        picker.setNoActionCallback {
+            Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
+        }
+        picker.show(statusBarStyle: .default)
+    }
+
+    fileprivate func delete(playlist: EpisodeFilter) {
+        PlaylistManager.delete(playlist: playlist, fireEvent: true)
+
+        var properties: [AnyHashable: Any]? = [:]
+        properties?["filter_type"] = playlist.manual ? "manual" : "smart"
+        Analytics.track(.filterDeleted, properties: properties)
+        navigationController?.popToRootViewController(animated: true)
     }
 }

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -32,10 +32,11 @@ class NewPlaylistViewController: PCViewController {
         didSet {
             playlistNameTextField.translatesAutoresizingMaskIntoConstraints = false
             playlistNameTextField.placeholder = L10n.playlistsDefaultNewPlaylist
+            playlistNameTextField.text = L10n.playlistsDefaultNewPlaylist
             playlistNameTextField.placeholderStyle = .primaryText01
             playlistNameTextField.delegate = self
             playlistNameTextField.addTarget(self, action: #selector(textFieldDidChange), for: UIControl.Event.editingChanged)
-            playlistNameTextField.clearsOnBeginEditing = true
+            playlistNameTextField.clearsOnBeginEditing = false
             playlistNameTextField.clearButtonMode = .whileEditing
             playlistNameTextField.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 8)
             playlistNameTextField.font = .systemFont(ofSize: 15, weight: .medium)
@@ -95,6 +96,9 @@ class NewPlaylistViewController: PCViewController {
         Analytics.track(.filterCreateShown)
 
         showSmartPlaylistTooltip()
+
+        playlistNameTextField.becomeFirstResponder()
+        playlistNameTextField.selectAll(nil)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/podcasts/New Creation/New Playlist/SmartPlaylistCreationView.swift
+++ b/podcasts/New Creation/New Playlist/SmartPlaylistCreationView.swift
@@ -25,9 +25,9 @@ struct SmartPlaylistCreationView: View {
                         .font(size: 13.0, style: .body, weight: .regular)
                         .foregroundStyle(theme.primaryText02)
                         .multilineTextAlignment(.leading)
-                        .lineLimit(1)
                         .minimumScaleFactor(0.8)
                 }
+                .padding(.vertical, 2.0)
                 Spacer()
                 Image("cs-chevron")
                     .renderingMode(.template)

--- a/podcasts/New Detail/Operation/PlaylistDetailFetchOperation.swift
+++ b/podcasts/New Detail/Operation/PlaylistDetailFetchOperation.swift
@@ -32,10 +32,9 @@ class PlaylistDetailFetchOperation: Operation {
 
             let newData = episodesDataManager.playlistEpisodes(for: playlist, shouldShowArchived: shouldShowArchived)
 
-            let archivedEpisodesCount = dataManager.playlistEpisodeCount(
+            let archivedEpisodesCount = dataManager.playlistArchivedEpisodeCount(
                 for: playlist,
-                episodeUuidToAdd: playlist.episodeUuidToAddToQueries(),
-                shouldShowArchived: true
+                episodeUuidToAdd: playlist.episodeUuidToAddToQueries()
             )
 
             DispatchQueue.main.sync { [weak self] in

--- a/podcasts/New Detail/PlaylistDetailViewController+Analytics.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+Analytics.swift
@@ -19,7 +19,7 @@ extension PlaylistTypeTrackerProvider {
 
     func track(episode: Episode, added: Bool, to playlist: EpisodeFilter, source: String? = nil) {
         let properties = [
-            "source": source ?? analyticsSourceType,
+            "source": finalSourceType(from: source, added: added),
             "playlist_name": playlist.playlistName,
             "playlist_uuid": playlist.uuid,
             "episode_uuid": episode.uuid,
@@ -31,6 +31,14 @@ extension PlaylistTypeTrackerProvider {
         } else {
             Analytics.track(.episodeRemovedFromList, properties: properties)
         }
+    }
+
+    private func finalSourceType(from source: String?, added: Bool) -> String {
+        let finalSource = source ?? analyticsSourceType
+        if finalSource == "swipe" {
+            return added ? "swipe_edit" : "swipe_remove"
+        }
+        return finalSource
     }
 }
 

--- a/podcasts/New Detail/PlaylistDetailViewController+Swipe.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+Swipe.swift
@@ -66,6 +66,8 @@ extension PlaylistDetailViewController: SwipeTableViewCellDelegate, SwipeHandler
     }
 
     func removeFromManualPlaylist(episode: PocketCastsDataModel.Episode, at: IndexPath) {
+        track(episode: episode, added: false, to: viewModel.playlist, source: "swipe_remove")
+
         viewModel.delete(episodes: [episode.uuid])
         viewModel.reloadEpisodeList()
     }

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel+Archive.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel+Archive.swift
@@ -14,8 +14,7 @@ extension PlaylistDetailViewModel {
     func unarchivedEpisodesCount() -> Int {
         dataManager.playlistEpisodeCount(
             for: playlist,
-            episodeUuidToAdd: playlist.episodeUuidToAddToQueries(),
-            shouldShowArchived: false
+            episodeUuidToAdd: playlist.episodeUuidToAddToQueries()
         )
     }
 

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -302,7 +302,8 @@ class PlaylistDetailViewModel: ObservableObject {
         return await Task.detached(priority: .userInitiated) {
             dataManager.allPlaylistEpisodeCount(
                 for: playlist,
-                episodeUuidToAdd: playlist.episodeUuidToAddToQueries()
+                episodeUuidToAdd: playlist.episodeUuidToAddToQueries(),
+                includingArchivedEpisodes: playlist.manual
             )
         }.value
     }

--- a/podcasts/PlaylistCellViewModel.swift
+++ b/podcasts/PlaylistCellViewModel.swift
@@ -186,7 +186,8 @@ class PlaylistCellViewModel: ObservableObject {
         return await Task.detached(priority: .userInitiated) {
             dataManager.allPlaylistEpisodeCount(
                 for: playlist,
-                episodeUuidToAdd: playlist.episodeUuidToAddToQueries()
+                episodeUuidToAdd: playlist.episodeUuidToAddToQueries(),
+                includingArchivedEpisodes: playlist.manual
             )
         }.value
     }

--- a/podcasts/PlaylistManager.swift
+++ b/podcasts/PlaylistManager.swift
@@ -4,11 +4,16 @@ import PocketCastsUtils
 import UIKit
 
 class PlaylistManager {
+    enum DefaultUUIDs {
+        static let newReleases = "2797DCF8-1C93-4999-B52A-D1849736FA2C"
+        static let inProgress = "D89A925C-5CE1-41A4-A879-2751838CE5CE"
+    }
+
     // MARK: - Default Playlists
 
     class func createDefaultPlaylists() {
         // new releases
-        var existingUuid = "2797DCF8-1C93-4999-B52A-D1849736FA2C"
+        var existingUuid = DefaultUUIDs.newReleases
         var existingFilter = DataManager.sharedManager.findPlaylist(uuid: existingUuid)
         if existingFilter == nil {
             let newReleases = EpisodeFilter()
@@ -36,7 +41,7 @@ class PlaylistManager {
         }
 
         // in progress
-        existingUuid = "D89A925C-5CE1-41A4-A879-2751838CE5CE"
+        existingUuid = DefaultUUIDs.inProgress
         existingFilter = DataManager.sharedManager.findPlaylist(uuid: existingUuid)
         if existingFilter == nil {
             let inProgress = EpisodeFilter()

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -1,4 +1,5 @@
 import PocketCastsDataModel
+import PocketCastsServer
 import PocketCastsUtils
 import UIKit
 import SwiftUI
@@ -207,19 +208,40 @@ extension PlaylistsViewController {
     }
 
     func showPlaylistsTipIfNeeded() {
-        if Settings.shouldShowNewFilterTip, newFilterTip == nil {
+        if !FeatureFlag.playlistsRebranding.enabled {
             showNewFilterTip()
             return
         }
 
-        if FeatureFlag.playlistsRebranding.enabled,
-           Settings.firstTimePlaylistCreated,
+        guard SyncManager.isUserLoggedIn() else { return }
+
+        if Settings.shouldShowNewFilterTip,
+           !hasPremadePlaylists(),
+           newFilterTip == nil {
+            showNewFilterTip()
+            return
+        }
+
+        if Settings.firstTimePlaylistCreated,
            Settings.shouldShowDragAndDropTip,
            !presentingPlaylistDetail,
            newFilterTip == nil {
             presentPlaylistsDragAndDropTip()
             return
         }
+    }
+
+    private func hasPremadePlaylists() -> Bool {
+        let premadePlaylistUuids: Set<String> = [
+            PlaylistManager.DefaultUUIDs.newReleases,
+            PlaylistManager.DefaultUUIDs.inProgress
+        ]
+        let playlistsUUID = playlists.map { $0.uuid }
+        let playlistsUUIDSet: Set<String> = Set(playlistsUUID)
+        if playlistsUUIDSet.count > premadePlaylistUuids.count || premadePlaylistUuids != playlistsUUIDSet {
+            return true
+        }
+        return false
     }
 
     private func filtersTip() -> UIHostingController<AnyView>? {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2920,7 +2920,7 @@ internal enum L10n {
   /// Title for the options to configure badge display options.
   internal static var podcastsBadges: String { return L10n.tr("Localizable", "podcasts_badges", fallback: "Badges") }
   /// Episodes will be displayed in custom order by drag and drop
-  internal static var podcastsEpisodeSortDragAndDrop: String { return L10n.tr("Localizable", "podcasts_episode_sort_drag_and_drop", fallback: "Drag and Drop") }
+  internal static var podcastsEpisodeSortDragAndDrop: String { return L10n.tr("Localizable", "podcasts_episode_sort_drag_and_drop", fallback: "Custom order") }
   /// Episodes will be displayed in order from the longest to the shortest.
   internal static var podcastsEpisodeSortLongestToShortest: String { return L10n.tr("Localizable", "podcasts_episode_sort_longest_to_shortest", fallback: "Longest to Shortest") }
   /// Episodes will be displayed in order from the most resent to the oldest.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2047,7 +2047,7 @@
 "podcasts_episode_sort_shortest_to_longest" = "Shortest to Longest";
 
 /* Episodes will be displayed in custom order by drag and drop */
-"podcasts_episode_sort_drag_and_drop" = "Drag and Drop";
+"podcasts_episode_sort_drag_and_drop" = "Custom order";
 
 /* Presents the podcasts with large podcast artwork tiles. */
 "podcasts_large_grid" = "Large Grid";


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-internal-testing-b4b2f66c6304/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=team&showCompletedIssues=all&showSubIssues=true&showTriageIssues=true)
|:---:|

Fixes PCIOS-307
Fixes PCIOS-311
Fixes PCIOS-318
Fixes PCIOS-315
Fixes PCIOS-313

This PR fixes:
• Adds the option sheet when deleting a playlist from the Playlist options
• When creating a new playlist and the New Playlist screen appears, the keyboard will show automatically and select the whole predefined playlist name
• The Smart Playlist tooltip is now showed correctly considering if the user is logged in and if the user had playlist created before
• For manual playlist, it renames Drag and drop to Custom order as order type
• Episodes number for Smart playlist now don't take in consideration archived episodes
• Small update to Analytics

| Tip | Custom order | Delete sheet | New playlist |
| :-------: | :-------: | :-------: | :-------: |
| <img width="1179" height="2556" alt="IMG_0465" src="https://github.com/user-attachments/assets/66d3bf06-d4d7-4770-9f17-5890870e8f43" /> | <img width="1179" height="2556" alt="IMG_0466" src="https://github.com/user-attachments/assets/a21577cd-f46e-4c92-8e26-8fe9e71956c5" /> | <img width="1179" height="2556" alt="IMG_0467" src="https://github.com/user-attachments/assets/c1f9bffe-a0cf-415b-ab30-9bcb771278f4" /> | <img width="1179" height="2556" alt="IMG_0468" src="https://github.com/user-attachments/assets/bb8812e2-42f2-490a-be26-cd1807fbda59" /> |

## To test

### Rename drag & drop
- Run this branch
- Go to Playlists and open a manual playlist
- Tap the top right `•••` button
- And see the options
- If you didn't change the order you should see preselected `Custom order`
- If you did change it, tap on `Sort by` and confirm you see `Custom order`
- Confirm selecting it, still works

### Delete Alert sheet
- From the same playlist detail tap again the top right `•••` button
- Tap on `playlist Option`
- Tap on Delete Playlist
- Observe the Delete Sheet is presented
- Tap on `Delete`
- Confirm you are going back to the playlists list

### Smart playlist episode count
- Go to playlist
- Open a smart playlist
- Archive an episode
- Check that the number of episodes changed
- Do the same test with a manual one
- Observe the total episode count for a manual never change when archiving an episode

### Create a new playlist pre-selection
- Go to playlists
- Tap on `+`
- When the New Playlist screen appears observe the keyboard is shown and the text `New Playlist` is selected
- Test adding a new playlist with or without changing the name still works

### Test Smart Playlist tip
- Start this branch from a fresh install
- Don't sign in
- Go to Playlists
- Observe no tip is shown
- Sign in with a user that has already playlists created
- Go to Playlists
- Unless the user has only the 2 pre-defined playlists, the tip should not appear
- Delete the app
- Install again and create a new user
- Go to playlists
- You should see the tip

### Analytics
- Same test as #3683 but when the source should be `swipe` you should now see `swipe_edit` (when adding) and `swipe_remove` (when removing)
- I also track the `episode_removed_from_list` when in a Manual playlist you swipe and delete an episode: you should see  `🔵 Tracked: episode_removed_from_list ["source": "swipe_remove", "episode_uuid": "a762fe21-a14a-4e20-b6e5-9e43c9fdca74", "playlist_name": "Up Next - October 28", "playlist_uuid": "6535CC90-D305-4FE1-A704-7EFE85894543", "podcast_uuid": "677a8990-72d2-0138-edcf-0acc26574db2"]` with `swipe_remove` as source

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
