### PR TITLE
[Playlists] Apply icon and height of PCSearchBarController to SwiftUI version for local search

### DIFF
--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -152,6 +152,7 @@ private extension LocalSearchView {
         SearchField(
             theme: LocalSearchFieldTheme(),
             text: $viewModel.searchText,
+            iconImageName: "search",
             showsCancelButton: false,
             placeholder: searchPromptString
         )
@@ -161,7 +162,7 @@ private extension LocalSearchView {
         .onSubmit {
             viewModel.triggerImmediateSearch()
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, idealHeight: 32)
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
     }

--- a/podcasts/SwiftUI/SearchField.swift
+++ b/podcasts/SwiftUI/SearchField.swift
@@ -28,6 +28,8 @@ struct SearchField: View {
     /// The search text binding
     @Binding var text: String
 
+    var iconImageName = "custom_search"
+
     var showsCancelButton: Bool = true
 
     /// The placeholder text to display when the field is empty
@@ -49,7 +51,7 @@ struct SearchField: View {
         // We use 2 stacks here to have the cancel button appear outside the background
         HStack {
             HStack(spacing: SearchFieldConstants.horizontalPadding) {
-                Image("custom_search")
+                Image(iconImageName)
                     .renderingMode(.template)
                     .resizable()
                     .aspectRatio(contentMode: .fit)


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-internal-testing-b4b2f66c6304/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=team&showCompletedIssues=all&showSubIssues=true&showTriageIssues=true)
|:---:|

Fixes PCIOS-295

Update icon and height of the local search to match the `PCSearchBarController`

| 1 | 2 |
| :-------: | :-------: |
| <img width="1179" height="2556" alt="IMG_0473" src="https://github.com/user-attachments/assets/57c9c9ec-2ac5-4994-ba8d-0b030cacf382" /> | <img width="1179" height="2556" alt="IMG_0474" src="https://github.com/user-attachments/assets/32bc0394-7ec0-438c-8702-b0478da5c40d" /> |

## To test

- Run this branch
- Open a manual playlist
- Look at the search
- Tap on Add Episodes
- Look at the search
- Both search textfields should have the same icon and same height

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
