### PR TITLE
[Playlists] Sort order sync

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -963,13 +963,14 @@ public class DataManager {
         playlistManager.playlistEpisodeCount(clause: .allEpisodeCount, playlist: playlist, episodeUuidToAdd: episodeUuidToAdd, shouldShowArchived: includingArchivedEpisodes, dbQueue: dbQueue)
     }
 
-    public func playlistEpisodes(for playlist: EpisodeFilter, limit: Int? = nil) -> [Episode] {
+    public func playlistEpisodes(for playlist: EpisodeFilter, limit: Int? = nil, sortType: PlaylistSort? = nil) -> [Episode] {
         let limit = limit ?? EpisodeDataManager.Constants.Limits.maxPlaylistItems
         let query = PlaylistQueryBuilder.query(
             clause: .episode,
             for: playlist,
             episodeUuidToAdd: nil,
-            limit: limit
+            limit: limit,
+            sortType: sortType
         )
         return episodeManager.findPlaylistEpisodesWhere(query: query, arguments: nil, dbQueue: dbQueue)
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -33,7 +33,8 @@ public class PlaylistQueryBuilder {
         episodeUuidToAdd: String? = nil,
         searchTerm: String? = nil,
         limit: Int = 0,
-        shouldShowArchived: Bool = false
+        shouldShowArchived: Bool = false,
+        sortType: PlaylistSort? = nil
     ) -> String {
 
         var queryString: String = ""
@@ -131,7 +132,7 @@ public class PlaylistQueryBuilder {
             queryString += " \(searchClause) (UPPER(episode.title) LIKE '%\(searchTerm.uppercased())%' ESCAPE '\\'"
             queryString += " OR UPPER(podcast.title) LIKE '%\(searchTerm.uppercased())%'  ESCAPE '\\')"
         }
-        if let sort = add(sortFor: playlist.sortType), clause != .episodeCount, clause != .allEpisodeCount {
+        if let sort = add(sortFor: sortType?.rawValue ?? playlist.sortType), clause != .episodeCount, clause != .allEpisodeCount {
             queryString += " \(sort) "
         }
         if limit > 0 { queryString += " LIMIT \(limit)" }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -154,7 +154,7 @@ extension SyncTask {
         playlistRecord.manual.value = filter.manual
 
         if filter.manual {
-            let episodes = DataManager.sharedManager.playlistEpisodes(for: filter)
+            let episodes = DataManager.sharedManager.playlistEpisodes(for: filter, sortType: .dragAndDrop)
             playlistRecord.episodes = episodes.map { episode in
                 createSyncEpisode(from: episode)
             }

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskManualPlaylistTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskManualPlaylistTests.swift
@@ -75,6 +75,49 @@ final class SyncTaskManualPlaylistTests: XCTestCase {
         XCTAssertTrue(playlist.manual.value)
     }
 
+    func testManualPlaylistSyncOverridesSortTypeToDragAndDrop() {
+        // Seed episodes that would be sorted differently if playlist.sortType was honored
+        let older = Episode()
+        older.uuid = "manual-old"
+        older.podcastUuid = "pod-old"
+        older.podcast_id = 1
+        older.title = "Old Episode"
+        older.downloadUrl = "http://example.com/old.mp3"
+        older.addedDate = Date(timeIntervalSince1970: 1)
+        older.publishedDate = Date(timeIntervalSince1970: 1)
+        dataManager.save(episode: older)
+
+        let newer = Episode()
+        newer.uuid = "manual-new"
+        newer.podcastUuid = "pod-new"
+        newer.podcast_id = 2
+        newer.title = "New Episode"
+        newer.downloadUrl = "http://example.com/new.mp3"
+        newer.addedDate = Date(timeIntervalSince1970: 2)
+        newer.publishedDate = Date(timeIntervalSince1970: 2)
+        dataManager.save(episode: newer)
+
+        let playlist = EpisodeFilter()
+        playlist.uuid = "manual-sort-override"
+        playlist.playlistName = "Manual Needs Override"
+        playlist.manual = true
+        playlist.sortType = PlaylistSort.newestToOldest.rawValue
+        playlist.syncStatus = SyncStatus.notSynced.rawValue
+        dataManager.save(playlist: playlist)
+        dataManager.add(episodes: [older, newer], to: playlist)
+
+        let records = syncTask.changedPlaylists()
+        let playlistRecords = records?.compactMap { $0.record }.compactMap { record -> Api_SyncUserPlaylist? in
+            if case let .playlist(p) = record { return p }
+            return nil
+        }
+
+        let syncedPlaylist = try! XCTUnwrap(playlistRecords?.first)
+        XCTAssertEqual(syncedPlaylist.sortType.value, PlaylistSort.newestToOldest.rawValue)
+        XCTAssertEqual(syncedPlaylist.episodeOrder, [older.uuid, newer.uuid])
+        XCTAssertEqual(syncedPlaylist.episodes.map(\.episode), [older.uuid, newer.uuid])
+    }
+
     func testEpisodeFromServerPlaylistEpisodeCreatesEpisode() {
         // Prepare a proto playlist episode
         var proto = Api_SyncPlaylistEpisode()

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskPlaylistOrderingTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskPlaylistOrderingTests.swift
@@ -93,7 +93,7 @@ private final class CapturingDataManager: DataManager {
         storedPlaylists[uuid]
     }
 
-    public override func playlistEpisodes(for playlist: EpisodeFilter, limit: Int? = nil) -> [Episode] {
+    public override func playlistEpisodes(for playlist: EpisodeFilter, limit: Int? = nil, sortType: PlaylistSort? = nil) -> [Episode] {
         let episodes = stubbedPlaylistEpisodes[playlist.uuid] ?? []
         if let limit {
             return Array(episodes.prefix(limit))


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-internal-testing-b4b2f66c6304/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=team&showCompletedIssues=all&showSubIssues=true&showTriageIssues=true)
|:---:|

Fixes [PCIOS-328](https://linear.app/a8c/issue/PCIOS-328/manual-playlist-custom-order-not-applied-after-changing-it-and-sync)

When setting `episodeOrder` for a manual playlist, drag and drop ordering should always be used so we don't reset custom ordering. The UI will always use the saved `sortType` on the playlist and isn't affected.

## To test

### Saved ordering
* Open a manual playlist
* Change order from custom to any other (like Newest to Oldest)
* Sync playlist
* Close the app
* Reopen it
* ✅ Verify episodes are sorted "Newest to Oldest" and Sort Type is correct
* Change order back to Custom
* ✅ Verify custom episode ordering is preserved from before

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
