### PR TITLE
[Playlists] Display Toast when adding an episode to playlists + hide row when tapping the + button

### DIFF
--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -177,7 +177,29 @@ class ManualPlaylistsChooserViewController: PCViewController {
             dataManager.save(playlist: playlist)
         }
 
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true) {
+            if added.isEmpty {
+                return
+            }
+
+            var actions: [Toast.Action]? = nil
+            var title = L10n.playlistEpisodesAddedToMultiplePlaylists
+            if changedPlaylists.count == 1 {
+                guard let playlist = (changedPlaylists.first { added.first == $0.uuid }) else { return }
+                title = L10n.playlistEpisodesAddedToSinglePlaylist(playlist.playlistName)
+                actions = [
+                    .init(title: L10n.bookmarkAddedButtonTitle) {
+                        NavigationManager.sharedManager.navigateTo(
+                            NavigationManager.filterPageKey,
+                            data: [
+                                NavigationManager.filterUuidKey: playlist.uuid
+                            ]
+                        )
+                    }
+                ]
+            }
+            Toast.show(title, actions: actions)
+        }
     }
 }
 

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -183,7 +183,7 @@ class ManualPlaylistsChooserViewController: PCViewController {
             }
 
             var actions: [Toast.Action]? = nil
-            var title = L10n.playlistEpisodesAddedToMultiplePlaylists
+            var title = L10n.playlistEpisodesAddedToMultiplePlaylists(changedPlaylists.count)
             if changedPlaylists.count == 1 {
                 guard let playlist = (changedPlaylists.first { added.first == $0.uuid }) else { return }
                 title = L10n.playlistEpisodesAddedToSinglePlaylist(playlist.playlistName)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2411,8 +2411,10 @@ internal enum L10n {
   internal static func playlistEpisodesAddedTitle(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "playlist_episodes_added_title", String(describing: p1), String(describing: p2), fallback: "%1$@ episodes added to \"%2$@\"")
   }
-  /// Toast message when an episode is added to multiple playlists from the playlists chooser
-  internal static var playlistEpisodesAddedToMultiplePlaylists: String { return L10n.tr("Localizable", "playlist_episodes_added_to_multiple_playlists", fallback: "Added to playlists") }
+  /// Toast message when an episode is added to multiple playlists from the playlists chooser. %1$@ is the number of playlists added to.
+  internal static func playlistEpisodesAddedToMultiplePlaylists(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "playlist_episodes_added_to_multiple_playlists", String(describing: p1), fallback: "Added to %1$@ playlists")
+  }
   /// Toast message when an episode is added to a single playlist from the playlists chooser. %1$@ is the playlist name.
   internal static func playlistEpisodesAddedToSinglePlaylist(_ p1: Any) -> String {
     return L10n.tr("Localizable", "playlist_episodes_added_to_single_playlist", String(describing: p1), fallback: "Added to %1$@")

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2412,7 +2412,7 @@ internal enum L10n {
     return L10n.tr("Localizable", "playlist_episodes_added_title", String(describing: p1), String(describing: p2), fallback: "%1$@ episodes added to \"%2$@\"")
   }
   /// Toast message when an episode is added to multiple playlists from the playlists chooser
-  internal static var playlistEpisodesAddedToMultiplePlaylists: String { return L10n.tr("Localizable", "playlist_episodes_added_to_multiple_playlists", fallback: "Added to multiple playlists") }
+  internal static var playlistEpisodesAddedToMultiplePlaylists: String { return L10n.tr("Localizable", "playlist_episodes_added_to_multiple_playlists", fallback: "Added to playlists") }
   /// Toast message when an episode is added to a single playlist from the playlists chooser. %1$@ is the playlist name.
   internal static func playlistEpisodesAddedToSinglePlaylist(_ p1: Any) -> String {
     return L10n.tr("Localizable", "playlist_episodes_added_to_single_playlist", String(describing: p1), fallback: "Added to %1$@")

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2411,6 +2411,12 @@ internal enum L10n {
   internal static func playlistEpisodesAddedTitle(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "playlist_episodes_added_title", String(describing: p1), String(describing: p2), fallback: "%1$@ episodes added to \"%2$@\"")
   }
+  /// Toast message when an episode is added to multiple playlists from the playlists chooser
+  internal static var playlistEpisodesAddedToMultiplePlaylists: String { return L10n.tr("Localizable", "playlist_episodes_added_to_multiple_playlists", fallback: "Added to multiple playlists") }
+  /// Toast message when an episode is added to a single playlist from the playlists chooser. %1$@ is the playlist name.
+  internal static func playlistEpisodesAddedToSinglePlaylist(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "playlist_episodes_added_to_single_playlist", String(describing: p1), fallback: "Added to %1$@")
+  }
   /// Playlist cell subtitle. It appears in the manual playlist add episode from podcast detail or player
   internal static func playlistEpisodesCount(_ p1: Any) -> String {
     return L10n.tr("Localizable", "playlist_episodes_count", String(describing: p1), fallback: "%1$@ episodes")

--- a/podcasts/SwipeActionsHelper.swift
+++ b/podcasts/SwipeActionsHelper.swift
@@ -142,7 +142,7 @@ enum SwipeActionsHelper {
 
             if FeatureFlag.playlistsRebranding.enabled {
                 if swipeHandler.swipeSourceType.canAddEpisodeToManualPlaylist {
-                    let shareAction = TableSwipeAction(indexPath: indexPath, title: L10n.playlistManualAddEpisodes, removesFromList: false, backgroundColor: ThemeColor.support02(), icon: UIImage(named: "playlist-add-episode"), tableView: tableView, handler: { indexPath -> Bool in
+                    let shareAction = TableSwipeAction(indexPath: indexPath, title: L10n.playlistManualAddEpisodes, removesFromList: false, backgroundColor: ThemeColor.support02(), icon: UIImage(named: "playlist-add-episode"), tableView: tableView, hidesWhenSelected: true, handler: { indexPath -> Bool in
                         swipeHandler.addToManualPlaylist(episode: episode, at: indexPath)
                         Self.performAction(.addToManualPlaylist, handler: swipeHandler, willBeRemoved: false)
                         return true

--- a/podcasts/TableSwipeActions.swift
+++ b/podcasts/TableSwipeActions.swift
@@ -44,6 +44,7 @@ class TableSwipeActions {
             if let image = tableAction.icon {
                 swipeAction.image = image
             }
+            swipeAction.hidesWhenSelected = tableAction.hidesWhenSelected
             swipeAction.accessibilityLabel = tableAction.title
             swipeActions.append(swipeAction)
         }
@@ -59,5 +60,26 @@ struct TableSwipeAction {
     let backgroundColor: UIColor
     let icon: UIImage?
     let tableView: UITableView
+    let hidesWhenSelected: Bool
     let handler: (IndexPath) -> Bool
+
+    init(
+        indexPath: IndexPath,
+        title: String?,
+        removesFromList: Bool,
+        backgroundColor: UIColor,
+        icon: UIImage?,
+        tableView: UITableView,
+        hidesWhenSelected: Bool = false,
+        handler: @escaping (IndexPath) -> Bool
+    ) {
+        self.indexPath = indexPath
+        self.title = title
+        self.removesFromList = removesFromList
+        self.backgroundColor = backgroundColor
+        self.icon = icon
+        self.tableView = tableView
+        self.hidesWhenSelected = hidesWhenSelected
+        self.handler = handler
+    }
 }

--- a/podcasts/UpNextViewController+Swipe.swift
+++ b/podcasts/UpNextViewController+Swipe.swift
@@ -94,6 +94,7 @@ extension UpNextViewController: SwipeTableViewCellDelegate {
                         presentModal()
                     }
                 }
+                shareAction.hidesWhenSelected = true
                 shareAction.backgroundColor = ThemeColor.support02()
                 shareAction.image = UIImage(named: "playlist-add-episode")
                 shareAction.accessibilityLabel = L10n.playlistManualAddEpisodes

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5546,8 +5546,8 @@
 /* Toast message when an episode is added to a single playlist from the playlists chooser. %1$@ is the playlist name. */
 "playlist_episodes_added_to_single_playlist" = "Added to %1$@";
 
-/* Toast message when an episode is added to multiple playlists from the playlists chooser */
-"playlist_episodes_added_to_multiple_playlists" = "Added to playlists";
+/* Toast message when an episode is added to multiple playlists from the playlists chooser. %1$@ is the number of playlists added to. */
+"playlist_episodes_added_to_multiple_playlists" = "Added to %1$@ playlists";
 
 /* Title displayed above the user's subscribed podcasts list when no podcast is selected. */
 "user_episodes_search_podcasts_title" = "Your Podcasts";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5543,6 +5543,12 @@
 /* Navigation title shown after adding multiple episodes to a playlist. %1$@ is the episode count. %2$@ is the playlist name. */
 "playlist_episodes_added_title" = "%1$@ episodes added to \"%2$@\"";
 
+/* Toast message when an episode is added to a single playlist from the playlists chooser. %1$@ is the playlist name. */
+"playlist_episodes_added_to_single_playlist" = "Added to %1$@";
+
+/* Toast message when an episode is added to multiple playlists from the playlists chooser */
+"playlist_episodes_added_to_multiple_playlists" = "Added to multiple playlists";
+
 /* Title displayed above the user's subscribed podcasts list when no podcast is selected. */
 "user_episodes_search_podcasts_title" = "Your Podcasts";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5547,7 +5547,7 @@
 "playlist_episodes_added_to_single_playlist" = "Added to %1$@";
 
 /* Toast message when an episode is added to multiple playlists from the playlists chooser */
-"playlist_episodes_added_to_multiple_playlists" = "Added to multiple playlists";
+"playlist_episodes_added_to_multiple_playlists" = "Added to playlists";
 
 /* Title displayed above the user's subscribed podcasts list when no podcast is selected. */
 "user_episodes_search_podcasts_title" = "Your Podcasts";


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-internal-testing-b4b2f66c6304/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=team&showCompletedIssues=all&showSubIssues=true&showTriageIssues=true)
|:---:|

Fixes PCIOS-298

This PR adds:
- When tapping the `+` button in a swipe left action to add an episode, the row will now close
- Adding an episode to one or more playlists and confirm the action, now shows a Toast

| Single Playlist | Multiple Playlists |
| :-------: | :-------: |
| <img width="1179" height="2556" alt="IMG_0475" src="https://github.com/user-attachments/assets/70fd2f77-8daf-46c7-b0d2-34bc3817bc87" /> | <img width="1179" height="2556" alt="IMG_0477" src="https://github.com/user-attachments/assets/66a90385-d133-468f-b408-5e62fbc472f8" /> |

## To test

- Run this branch
- Open the Playlists chooser by adding an episode from a Podcast detail, Smart Playlist detail, UpNext, Listening History and Fullscreen player shelf
- Select a single playlist
- Tap Done
- Confirm you see the Toast saying it's added to the playlist *you see the name)
- Tap on the Toast View and confirm you will be redirected to the Playlist detail
- Do the same test by adding to multiple playlists at the same time
- The Toast now says `Added to _N_ playlists`, where N is the playlists count you added to

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
