### PR TITLE
[Playback 2025] - Fix Share save image for Playback Longest Episode story

### DIFF
--- a/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
@@ -26,12 +26,8 @@ struct LongestEpisode2025Story: ShareableStory {
             Spacer()
                 .frame(height: 80)
             PodcastImage(uuid: podcast.uuid, size: .page, aspectRatio: nil, contentMode: .fill)
-                .frame(width: 196, height: 196)
-                .clipShape(RoundedRectangle(cornerRadius: 4))
-                .scaleEffect(renderForSharing ? 1 : imageScale)
-                .if(isAnimating) {
-                    $0.animation(scaleAnimation, value: imageScale)
-                }
+                .frame(width: 196 * imageScale, height: 196 * imageScale)
+                .cornerRadius(4)
             VStack {
                 Spacer()
                 footerView
@@ -51,12 +47,14 @@ struct LongestEpisode2025Story: ShareableStory {
         .background(backgroundColor)
         .foregroundStyle(foregroundColor)
         .onAppear {
-            self.isAnimating = true
-            self.imageScale = 1.0
+            withAnimation(scaleAnimation) {
+                self.imageScale = 1.0
+            }
         }
         .onDisappear {
-            self.isAnimating = false
-            self.imageScale = 1.1
+            withAnimation(scaleAnimation) {
+                self.imageScale = 1.1
+            }
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-331 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Simplify the animation to avoid an IF that was causing a flash and reload of the image
This avoid the image not being ready when saving for screenshot

| In app | Share |
|--------|--------|
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2025-11-14 at 14 25 42" src="https://github.com/user-attachments/assets/823ef25a-b06f-4f05-96a7-fb9065c9f115" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2025-11-14 at 14 25 54" src="https://github.com/user-attachments/assets/ddff1fee-c226-4916-a6c9-ccaf935ba16f" /> |

## To test

- Start the app
- Login with an user that has some stats for 2025
- Go to Profile -> Settings -> Beta features
- Enable the FF `End of Year 2025`
- Go to Developer Menu and tap on "End Of Year -> Reset modal/profile badge" and select 2025
- Restart the app
- Go to Profile 
- Check that you see a banner for the playback 2025
- Tap on it
- Check if Playback screen shows correctly
- Check if the loading and Intro screen show correctly
- Check if Longest Episode story shows correctly and the numbers animation and background animation are correct.
- Press on share and see if the image generated is correct.


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
