### PR TITLE
[Playlists] Adjust multiselection Header and Footer

### DIFF
--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -132,6 +132,7 @@ class PlaylistDetailViewController: FakeNavViewController {
     var multiSelectAllBtn: UIButton! {
         didSet {
             multiSelectAllBtn.translatesAutoresizingMaskIntoConstraints = false
+            multiSelectAllBtn.titleLabel?.font = UIFont.systemFont(ofSize: 17.0, weight: .medium)
             multiSelectAllBtn.addTarget(self, action: #selector(selectAllTapped), for: .touchUpInside)
         }
     }
@@ -139,6 +140,7 @@ class PlaylistDetailViewController: FakeNavViewController {
     var multiSelectCancelBtn: UIButton! {
         didSet {
             multiSelectCancelBtn.translatesAutoresizingMaskIntoConstraints = false
+            multiSelectCancelBtn.titleLabel?.font = UIFont.systemFont(ofSize: 17.0, weight: .medium)
             multiSelectCancelBtn.setTitle(L10n.cancel, for: .normal)
             multiSelectCancelBtn.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
         }
@@ -330,8 +332,8 @@ class PlaylistDetailViewController: FakeNavViewController {
             multiSelectCancelBtn.bottomAnchor.constraint(equalTo: multiSelectHeaderView.bottomAnchor),
             multiSelectCancelBtn.heightAnchor.constraint(equalToConstant: 44),
 
-            multiSelectFooter.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16.0),
-            multiSelectFooter.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16.0),
+            multiSelectFooter.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 8.0),
+            multiSelectFooter.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -8.0),
             multiSelectFooterBottomConstraint,
             multiSelectFooter.heightAnchor.constraint(equalToConstant: 64)
         ])


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-330

Applies the xib values into the multi select header and footer

| Podcast | Playlist |
| :-------: | :-------: |
| <img width="1179" height="2556" alt="IMG_0479" src="https://github.com/user-attachments/assets/9f1bc28f-6064-4375-8b39-9216fd960d55" /> | <img width="1179" height="2556" alt="IMG_0480" src="https://github.com/user-attachments/assets/06563a0b-94a6-4abe-98c5-c1054367e5e1" /> |

## To test

- Run this branch
- Open a Podcast detail from Podcasts 
- Long press on an episode to activate the multi select tool and observe the footer padding and header font size
- Now do the same on a Playlist detail
- Switch between Podcasts and Playlists tab
- You should no t see any differences

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
