### PR TITLE
Fix current event tracking in App Store review prompt

### DIFF
--- a/podcasts/UserSatisfactionSurveyManager.swift
+++ b/podcasts/UserSatisfactionSurveyManager.swift
@@ -111,6 +111,7 @@ public class UserSatisfactionSurveyManager: NSObject {
         }
 
         source.present(hostingController, animated: true)
+        currentEvent = event
         if !skipCheck {
             Settings.addSurveyPresented()
         }


### PR DESCRIPTION
Fixes an issue brought up in #3689 where the dismissal event is not properly tracking the current event. The current event was not being set when presenting the feedback survey.

## To test

* Go to the Debug Info panel for Ratings in the Developer Menu
* Tap "Present Survey"
* ✅ Ensure `user_satisfaction_survey_shown ` is tracked with the `trigger_event` set
```
🔵 Tracked: user_satisfaction_survey_shown ["user_type": "free", "trigger_event": "episode_starred"]
```
* Dismiss the survey prompt by tapping outside of it
* ✅ Ensure `user_satisfaction_survey_dismissed` is tracked with the `trigger_event` set
```
🔵 Tracked: user_satisfaction_survey_dismissed ["trigger_event": "unknown", "user_type": "free"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
