### PR TITLE
[Playlists] Play All order fix with custom order Manual playlists

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UpNextDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UpNextDataManager.swift
@@ -81,7 +81,17 @@ class UpNextDataManager {
         dbQueue.write { db in
             do {
                 // move every episode after this one down one, if there are any
-                try db.executeUpdate("UPDATE \(DataManager.playlistEpisodeTableName) SET episodePosition = episodePosition + 1 WHERE episodePosition >= ? AND episodeUuid != ? AND wasDeleted = 0", values: [playlistEpisode.episodePosition, playlistEpisode.episodeUuid])
+                try db.executeUpdate(
+                    """
+                    UPDATE \(DataManager.playlistEpisodeTableName)
+                    SET episodePosition = episodePosition + 1
+                    WHERE episodePosition >= ?
+                      AND episodeUuid != ?
+                      AND wasDeleted = 0
+                      AND playlist_id = ?
+                    """,
+                    values: [playlistEpisode.episodePosition, playlistEpisode.episodeUuid, UpNextDataManager.upNextPlaylistId]
+                )
 
                 if playlistEpisode.id == 0 {
                     playlistEpisode.id = DBUtils.generateUniqueId()
@@ -106,7 +116,17 @@ class UpNextDataManager {
                 // move every episode after this one down , if there are any
                 db.beginTransaction()
 
-                try db.executeUpdate("UPDATE \(DataManager.playlistEpisodeTableName) SET episodePosition = episodePosition + ? WHERE episodePosition >= ? AND wasDeleted = 0 AND episodeUuid NOT IN (\(DataHelper.convertArrayToInString(uuids)))", values: [playlistEpisodes.count, topPosition])
+                try db.executeUpdate(
+                    """
+                    UPDATE \(DataManager.playlistEpisodeTableName)
+                    SET episodePosition = episodePosition + ?
+                    WHERE episodePosition >= ?
+                      AND wasDeleted = 0
+                      AND playlist_id = ?
+                      AND episodeUuid NOT IN (\(DataHelper.convertArrayToInString(uuids)))
+                    """,
+                    values: [playlistEpisodes.count, topPosition, UpNextDataManager.upNextPlaylistId]
+                )
 
                 for playlistEpisode in playlistEpisodes {
                     if playlistEpisode.id == 0 {
@@ -167,7 +187,10 @@ class UpNextDataManager {
         dbQueue.write { db in
             do {
                 if uuids.count == 0 {
-                    try db.executeUpdate("DELETE FROM \(DataManager.playlistEpisodeTableName)", values: nil)
+                    try db.executeUpdate(
+                        "DELETE FROM \(DataManager.playlistEpisodeTableName) WHERE playlist_id = ?",
+                        values: [UpNextDataManager.upNextPlaylistId]
+                    )
                 } else {
                     try db.executeUpdate("DELETE FROM \(DataManager.playlistEpisodeTableName) WHERE episodeUuid NOT IN (\(DataHelper.convertArrayToInString(uuids))) AND playlist_id = ?", values: [UpNextDataManager.upNextPlaylistId])
                 }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/UpNextEpisodeFetchTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/UpNextEpisodeFetchTests.swift
@@ -60,6 +60,108 @@ final class UpNextEpisodeFetchTests: XCTestCase {
         XCTAssertEqual(results.map(\.uuid), [upNextUserEpisode.uuid])
     }
 
+    func testSavingUpNextEpisodeDoesNotShiftManualPlaylistOrdering() throws {
+        let queue = try makeQueue()
+        let upNextManager = UpNextDataManager()
+        upNextManager.setup(dbQueue: queue)
+
+        let manualPlaylistUuid = "manual-playlist"
+        addManualPlaylistEntry(
+            queue: queue,
+            episodeUuid: "manual-episode-1",
+            playlistId: 42,
+            playlistUuid: manualPlaylistUuid,
+            position: 0,
+            title: "Manual Episode 1",
+            podcastUuid: "manual-podcast"
+        )
+        addManualPlaylistEntry(
+            queue: queue,
+            episodeUuid: "manual-episode-2",
+            playlistId: 42,
+            playlistUuid: manualPlaylistUuid,
+            position: 1,
+            title: "Manual Episode 2",
+            podcastUuid: "manual-podcast"
+        )
+
+        let playlistEpisode = PlaylistEpisode()
+        playlistEpisode.episodeUuid = "upnext-1"
+        playlistEpisode.title = "Up Next Episode"
+        playlistEpisode.podcastUuid = "upnext-podcast"
+        playlistEpisode.episodePosition = 0
+        upNextManager.save(playlistEpisode: playlistEpisode, dbQueue: queue)
+
+        XCTAssertEqual(fetchManualPlaylistOrder(queue: queue, playlistUuid: manualPlaylistUuid), ["manual-episode-1", "manual-episode-2"])
+    }
+
+    func testBulkSavingUpNextEpisodesDoesNotShiftManualPlaylistOrdering() throws {
+        let queue = try makeQueue()
+        let upNextManager = UpNextDataManager()
+        upNextManager.setup(dbQueue: queue)
+
+        let manualPlaylistUuid = "manual-playlist"
+        addManualPlaylistEntry(
+            queue: queue,
+            episodeUuid: "manual-episode-1",
+            playlistId: 42,
+            playlistUuid: manualPlaylistUuid,
+            position: 0,
+            title: "Manual Episode 1",
+            podcastUuid: "manual-podcast"
+        )
+        addManualPlaylistEntry(
+            queue: queue,
+            episodeUuid: "manual-episode-2",
+            playlistId: 42,
+            playlistUuid: manualPlaylistUuid,
+            position: 1,
+            title: "Manual Episode 2",
+            podcastUuid: "manual-podcast"
+        )
+
+        let bulkEpisodes = (0..<3).map { index -> PlaylistEpisode in
+            let episode = PlaylistEpisode()
+            episode.episodeUuid = "upnext-bulk-\(index)"
+            episode.title = "Up Next Bulk \(index)"
+            episode.podcastUuid = "upnext-podcast"
+            episode.episodePosition = Int32(index)
+            return episode
+        }
+        upNextManager.save(playlistEpisodes: bulkEpisodes, dbQueue: queue)
+
+        XCTAssertEqual(fetchManualPlaylistOrder(queue: queue, playlistUuid: manualPlaylistUuid), ["manual-episode-1", "manual-episode-2"])
+    }
+
+    func testDeletingUpNextEpisodesWithEmptyListDoesNotAffectManualPlaylist() throws {
+        let queue = try makeQueue()
+        let upNextManager = UpNextDataManager()
+        upNextManager.setup(dbQueue: queue)
+
+        let manualPlaylistUuid = "manual-playlist"
+        addManualPlaylistEntry(
+            queue: queue,
+            episodeUuid: "manual-episode-1",
+            playlistId: 42,
+            playlistUuid: manualPlaylistUuid,
+            position: 0,
+            title: "Manual Episode 1",
+            podcastUuid: "manual-podcast"
+        )
+
+        let upNextEpisode = PlaylistEpisode()
+        upNextEpisode.episodeUuid = "upnext-episode"
+        upNextEpisode.title = "Up Next Episode"
+        upNextEpisode.podcastUuid = "upnext-podcast"
+        upNextEpisode.episodePosition = 0
+        upNextManager.save(playlistEpisode: upNextEpisode, dbQueue: queue)
+
+        upNextManager.deleteAllUpNextEpisodesNotIn(uuids: [], dbQueue: queue)
+
+        XCTAssertEqual(fetchManualPlaylistOrder(queue: queue, playlistUuid: manualPlaylistUuid), ["manual-episode-1"])
+        XCTAssertTrue(upNextManager.allUpNextPlaylistEpisodes(dbQueue: queue).isEmpty)
+    }
+
     // MARK: - Helpers
 
     private func makeQueue() throws -> PCDBQueue {
@@ -101,5 +203,56 @@ final class UpNextEpisodeFetchTests: XCTestCase {
                 XCTFail("Failed to insert playlist entry: \(error)")
             }
         }
+    }
+
+    private func addManualPlaylistEntry(
+        queue: PCDBQueue,
+        episodeUuid: String,
+        playlistId: Int,
+        playlistUuid: String,
+        position: Int,
+        title: String,
+        podcastUuid: String
+    ) {
+        queue.write { db in
+            do {
+                try db.executeUpdate(
+                    """
+                    INSERT INTO \(DataManager.playlistEpisodeTableName)
+                    (episodePosition, episodeUuid, playlist_id, upcoming, wasDeleted, title, podcastUuid, playlist_uuid)
+                    VALUES (?, ?, ?, 0, 0, ?, ?, ?)
+                    """,
+                    values: [
+                        position,
+                        episodeUuid,
+                        playlistId,
+                        title,
+                        podcastUuid,
+                        playlistUuid
+                    ]
+                )
+            } catch {
+                XCTFail("Failed to insert manual playlist entry: \(error)")
+            }
+        }
+    }
+
+    private func fetchManualPlaylistOrder(queue: PCDBQueue, playlistUuid: String) -> [String] {
+        var order = [String]()
+        queue.read { db in
+            do {
+                let rs = try db.executeQuery(
+                    "SELECT episodeUuid FROM \(DataManager.playlistEpisodeTableName) WHERE playlist_uuid = ? ORDER BY episodePosition ASC",
+                    values: [playlistUuid]
+                )
+                defer { rs.close() }
+                while rs.next() {
+                    order.append(DBUtils.nonNilStringFromColumn(resultSet: rs, columnName: "episodeUuid"))
+                }
+            } catch {
+                XCTFail("Failed to fetch manual playlist order: \(error)")
+            }
+        }
+        return order
     }
 }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/UpNextEpisodeFetchTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/UpNextEpisodeFetchTests.swift
@@ -60,6 +60,65 @@ final class UpNextEpisodeFetchTests: XCTestCase {
         XCTAssertEqual(results.map(\.uuid), [upNextUserEpisode.uuid])
     }
 
+    func testSavingUpNextEpisodeShiftsExistingUpNextEntries() throws {
+        let queue = try makeQueue()
+        let upNextManager = UpNextDataManager()
+        upNextManager.setup(dbQueue: queue)
+
+        addUpNextEntry(upNextManager: upNextManager, queue: queue, episodeUuid: "existing-0", title: "Existing 0", podcastUuid: "pod", position: 0)
+        addUpNextEntry(upNextManager: upNextManager, queue: queue, episodeUuid: "existing-1", title: "Existing 1", podcastUuid: "pod", position: 1)
+
+        let newEpisode = PlaylistEpisode()
+        newEpisode.episodeUuid = "incoming-episode"
+        newEpisode.title = "Incoming Episode"
+        newEpisode.podcastUuid = "pod"
+        newEpisode.episodePosition = Int32(0)
+        upNextManager.save(playlistEpisode: newEpisode, dbQueue: queue)
+
+        let episodes = upNextManager.allUpNextPlaylistEpisodes(dbQueue: queue)
+        XCTAssertEqual(episodes.map(\.episodeUuid), ["incoming-episode", "existing-0", "existing-1"])
+        XCTAssertEqual(episodes.map { Int($0.episodePosition) }, [0, 1, 2])
+    }
+
+    func testBulkSavingUpNextEpisodesShiftsExistingEntries() throws {
+        let queue = try makeQueue()
+        let upNextManager = UpNextDataManager()
+        upNextManager.setup(dbQueue: queue)
+
+        addUpNextEntry(upNextManager: upNextManager, queue: queue, episodeUuid: "existing-0", title: "Existing 0", podcastUuid: "pod", position: 0)
+        addUpNextEntry(upNextManager: upNextManager, queue: queue, episodeUuid: "existing-1", title: "Existing 1", podcastUuid: "pod", position: 1)
+
+        let incomingEpisodes = (0..<2).map { index -> PlaylistEpisode in
+            let episode = PlaylistEpisode()
+            episode.episodeUuid = "incoming-\(index)"
+            episode.title = "Incoming \(index)"
+            episode.podcastUuid = "pod"
+            episode.episodePosition = Int32(index)
+            return episode
+        }
+        upNextManager.save(playlistEpisodes: incomingEpisodes, dbQueue: queue)
+
+        let episodes = upNextManager.allUpNextPlaylistEpisodes(dbQueue: queue)
+        XCTAssertEqual(episodes.map(\.episodeUuid), ["incoming-0", "incoming-1", "existing-0", "existing-1"])
+        XCTAssertEqual(episodes.map { Int($0.episodePosition) }, [0, 1, 2, 3])
+    }
+
+    func testDeleteAllUpNextEpisodesNotInKeepsSpecifiedUpNextEpisodes() throws {
+        let queue = try makeQueue()
+        let upNextManager = UpNextDataManager()
+        upNextManager.setup(dbQueue: queue)
+
+        addUpNextEntry(upNextManager: upNextManager, queue: queue, episodeUuid: "to-keep", title: "Keep", podcastUuid: "pod", position: 0)
+        addUpNextEntry(upNextManager: upNextManager, queue: queue, episodeUuid: "to-remove-1", title: "Remove 1", podcastUuid: "pod", position: 1)
+        addUpNextEntry(upNextManager: upNextManager, queue: queue, episodeUuid: "to-remove-2", title: "Remove 2", podcastUuid: "pod", position: 2)
+
+        upNextManager.deleteAllUpNextEpisodesNotIn(uuids: ["to-keep"], dbQueue: queue)
+
+        let episodes = upNextManager.allUpNextPlaylistEpisodes(dbQueue: queue)
+        XCTAssertEqual(episodes.map(\.episodeUuid), ["to-keep"])
+        XCTAssertEqual(episodes.map { Int($0.episodePosition) }, [0])
+    }
+
     func testSavingUpNextEpisodeDoesNotShiftManualPlaylistOrdering() throws {
         let queue = try makeQueue()
         let upNextManager = UpNextDataManager()

--- a/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
@@ -84,9 +84,26 @@ extension PlaylistDetailViewController {
     }
 
     private func checkDifferencesWithUpNext() async -> Bool {
-        let episodesToPlay = viewModel.episodes.map { $0.episode.uuid }
-        let uuids = viewModel.dataManager.allUpNextEpisodeUuids().compactMap(\.uuid)
-        return Set(episodesToPlay) != Set(uuids)
+        let playlistEpisodeUuids = viewModel.episodes.map { $0.episode.uuid }
+        let upNextEpisodeUuids = viewModel.dataManager.allUpNextEpisodeUuids().compactMap(\.uuid)
+
+        if playlistEpisodeUuids.count != upNextEpisodeUuids.count {
+            return true
+        }
+
+        if playlistEpisodeUuids != upNextEpisodeUuids {
+            return true
+        }
+
+        guard let firstPlaylistUuid = playlistEpisodeUuids.first else {
+            return false
+        }
+
+        guard let currentUuid = PlaybackManager.shared.currentEpisode()?.uuid else {
+            return true
+        }
+
+        return currentUuid != firstPlaylistUuid
     }
 
     // MARK: - Multiselect


### PR DESCRIPTION
Fixes [PCIOS-333](https://linear.app/a8c/issue/PCIOS-333/when-creating-a-manual-playlist-from-upnext-queue-the-first-played)

* The `UpNextDataManager` queries need to be scoped to the Up Next `playlist_id`
* I also ensured `checkDifferencesWithUpNext` considers episode ordering

## To test

* Set up a Manual playlist with custom order
* Add another playlist to switch betweeen
* Press "Play All" on the Manual playlist and replace Up Next
* ✅ Verify that all episodes remain in order in the Manual playlist and maintain order in Up Next

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
