### PR TITLE
[Playback2025] Always show plus story

### DIFF
--- a/PocketCastsTests/Tests/End of Year/StoriesModelTests.swift
+++ b/PocketCastsTests/Tests/End of Year/StoriesModelTests.swift
@@ -151,7 +151,10 @@ class StoriesModelTests: XCTestCase {
 }
 
 class MockStoriesDataSource: StoriesDataSource {
-    var indicatorColor: Color = .white
+
+    func indicatorColor(for storyIndex: Int) -> Color {
+        return .white
+    }
 
     var primaryBackgroundColor: Color = .black
 
@@ -200,7 +203,10 @@ class MockStoriesDataSource: StoriesDataSource {
 }
 
 class MockStoriesWithPlusDataSource: StoriesDataSource {
-    var indicatorColor: Color = .white
+
+    func indicatorColor(for storyIndex: Int) -> Color {
+        return .white
+    }
 
     var primaryBackgroundColor: Color = .black
 

--- a/podcasts/End of Year/End of Year 2023/EndOfYear2023StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2023/EndOfYear2023StoriesModel.swift
@@ -7,7 +7,7 @@ class EndOfYear2023StoriesModel: StoryModel {
     var stories = [EndOfYear2023Story]()
     var data = EndOfYear2023StoriesData()
 
-    var indicatorColor: Color {
+    func indicatorColor(for storyNumber: Int) -> Color {
         .white
     }
 

--- a/podcasts/End of Year/End of Year 2024/EndOfYear2024StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2024/EndOfYear2024StoriesModel.swift
@@ -7,7 +7,7 @@ class EndOfYear2024StoriesModel: StoryModel {
     var stories = [EndOfYear2024Story]()
     var data = EndOfYear2024StoriesData()
 
-    var indicatorColor: Color {
+    func indicatorColor(for storyNumber: Int) -> Color {
         .black
     }
 

--- a/podcasts/End of Year/End of Year 2025/EndOfYear2025StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2025/EndOfYear2025StoriesModel.swift
@@ -59,6 +59,8 @@ class EndOfYear2025StoriesModel: StoryModel {
             }
         }
 
+        stories.append(.plus)
+
         // Year over year listening time
         let yearOverYearListeningTime = dataManager.yearOverYearListeningTime(in: Self.year)
         if yearOverYearListeningTime.totalPlayedTimeThisYear != 0 ||
@@ -96,15 +98,15 @@ class EndOfYear2025StoriesModel: StoryModel {
                 return CompletionRate2025Story(subscriptionTier: SubscriptionHelper.activeTier, startedAndCompleted: data.episodesStartedAndCompleted)
             case .epilogue:
                 return EpilogueStory2025()
+            case .plus:
+                return PaidStoryWallView2025(subscriptionTier: SubscriptionHelper.activeTier)
         }
     }
 
     func isInteractiveView(for storyNumber: Int) -> Bool {
         switch stories[storyNumber] {
-            case .epilogue:
-                return true
-            case .top5Podcasts:
-                return true
+            case .epilogue, .plus, .top5Podcasts:
+                return true         
             case .ratings:
                 return data.ratings.isEmpty
             default:

--- a/podcasts/End of Year/End of Year 2025/EndOfYear2025StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2025/EndOfYear2025StoriesModel.swift
@@ -7,8 +7,16 @@ class EndOfYear2025StoriesModel: StoryModel {
     var stories = [EndOfYear2025Story]()
     var data = EndOfYear2025StoriesData()
 
-    var indicatorColor: Color {
-        .white
+    func indicatorColor(for storyNumber: Int) -> Color {
+        if stories.isEmpty || storyNumber >= stories.count || storyNumber < 0 {
+            return .white
+        }
+        switch stories[storyNumber] {
+        case .plus, .top5Podcasts:
+            return .black
+        default:
+            return .white
+        }
     }
 
     var primaryBackgroundColor: Color {
@@ -106,7 +114,7 @@ class EndOfYear2025StoriesModel: StoryModel {
     func isInteractiveView(for storyNumber: Int) -> Bool {
         switch stories[storyNumber] {
             case .epilogue, .plus, .top5Podcasts:
-                return true         
+                return true
             case .ratings:
                 return data.ratings.isEmpty
             default:

--- a/podcasts/End of Year/End of Year 2025/EndOfYear2025Story.swift
+++ b/podcasts/End of Year/End of Year 2025/EndOfYear2025Story.swift
@@ -6,6 +6,7 @@ enum EndOfYear2025Story: CaseIterable {
     case ratings
     case listeningTime
     case longestEpisode
+    case plus
     case yearOverYearListeningTime
     case completionRate
     case epilogue

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -62,7 +62,7 @@ protocol StoryModel {
     func overlaidShareView() -> AnyView?
     /// Shown at the bottom of the story as an additional safe area
     func footerShareView() -> AnyView?
-    var indicatorColor: Color { get }
+    func indicatorColor(for storyNumber: Int) -> Color
     var primaryBackgroundColor: Color { get }
     func sharingSnapshotModifier(_ view: AnyView) -> AnyView
 }

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -44,8 +44,8 @@ struct PaidStoryWallView2025: StoryView {
                     }
                     .padding(.top, UIScreen.isSmallScreen ? 80 : 110)
                     .allowsHitTesting(false)
-                StoryHeader2025(title: subscriptionTier == .none ?  L10n.playback2025PlusUpsellTitle : "Thanks for supporting Pocket Casts!",
-                                description: subscriptionTier == .none ?  L10n.playback2025PlusUpsellDescription : "Your Plus perks unlock extra stats and power features",
+                StoryHeader2025(title: subscriptionTier == .none ?  L10n.playback2025PlusUpsellTitle : L10n.playback2025PlusThanksTitle,
+                                description: subscriptionTier == .none ?  L10n.playback2025PlusUpsellDescription : L10n.playback2025PlusThanksDescription,
                                 subscriptionTier: subscriptionTier == .none ? .plus : subscriptionTier,
                                 topPadding: 0)
                 Button(subscriptionTier == .none ?  L10n.playback2025PlusUpsellButtonTitle : L10n.continue) {

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -16,6 +16,8 @@ struct PaidStoryWallView2025: StoryView {
 
     private let videoAspectRatio = CGFloat(1.37)
 
+    let plusOnly = true
+
     init(subscriptionTier: SubscriptionTier) {
         self.subscriptionTier = subscriptionTier
     }

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -6,6 +6,9 @@ import PocketCastsUtils
 struct PaidStoryWallView2025: StoryView {
     let identifier = "plus_interstitial"
 
+    @Environment(\.pauseState) var pauseState: PauseState
+    @EnvironmentObject var storyModel: StoriesModel
+
     @StateObject private var model = PlusPricingInfoModel()
 
     let subscriptionTier: SubscriptionTier
@@ -53,7 +56,8 @@ struct PaidStoryWallView2025: StoryView {
 
                         NavigationManager.sharedManager.showUpsellView(from: storiesViewController, source: .endOfYear, flow: SyncManager.isUserLoggedIn() ? .endOfYearUpsell : .endOfYear)
                     } else {
-                        
+                        pauseState.togglePause()
+                        storyModel.next()
                     }
                 }
                 .buttonStyle(BasicButtonStyle(textColor: .white, backgroundColor: .black, borderColor: .black))
@@ -72,6 +76,7 @@ struct PaidStoryWallView2025: StoryView {
         .onAppear {
             Analytics.track(.endOfYearUpsellShown, properties: ["year": "2025"])
             Analytics.track(.endOfYearStoryShown, story: identifier)
+            pauseState.togglePause()
         }
     }
 }

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -45,7 +45,7 @@ struct PaidStoryWallView2025: StoryView {
                     .padding(.top, UIScreen.isSmallScreen ? 80 : 110)
                     .allowsHitTesting(false)
                 StoryHeader2025(title: subscriptionTier == .none ?  L10n.playback2025PlusUpsellTitle : L10n.playback2025PlusThanksTitle,
-                                description: subscriptionTier == .none ?  L10n.playback2025PlusUpsellDescription : L10n.playback2025PlusThanksDescription,
+                                description: subscriptionTier == .none ?  L10n.playback2025PlusUpsellDescription : L10n.playback2025PlusThanksDescription(subscriptionTier.displayName),
                                 subscriptionTier: subscriptionTier == .none ? .plus : subscriptionTier,
                                 topPadding: 0)
                 Button(subscriptionTier == .none ?  L10n.playback2025PlusUpsellButtonTitle : L10n.continue) {

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -3,7 +3,7 @@ import AVKit
 import PocketCastsServer
 import PocketCastsUtils
 
-struct PaidStoryWallView2025: View {
+struct PaidStoryWallView2025: StoryView {
     let identifier = "plus_interstitial"
 
     @StateObject private var model = PlusPricingInfoModel()
@@ -39,15 +39,22 @@ struct PaidStoryWallView2025: View {
                     }
                     .padding(.top, UIScreen.isSmallScreen ? 80 : 110)
                     .allowsHitTesting(false)
-                StoryHeader2025(title: L10n.playback2025PlusUpsellTitle, description: L10n.playback2025PlusUpsellDescription, subscriptionTier: .plus, topPadding: 0)
-                Button(L10n.playback2025PlusUpsellButtonTitle) {
-                    guard let storiesViewController = SceneHelper.rootViewController() else {
-                        return
-                    }
+                StoryHeader2025(title: subscriptionTier == .none ?  L10n.playback2025PlusUpsellTitle : "Thanks for supporting Pocket Casts!",
+                                description: subscriptionTier == .none ?  L10n.playback2025PlusUpsellDescription : "Your Plus perks unlock extra stats and power features",
+                                subscriptionTier: subscriptionTier == .none ? .plus : subscriptionTier,
+                                topPadding: 0)
+                Button(subscriptionTier == .none ?  L10n.playback2025PlusUpsellButtonTitle : L10n.continue) {
+                    if subscriptionTier == .none {
+                        guard let storiesViewController = SceneHelper.rootViewController() else {
+                            return
+                        }
 
-                    NavigationManager.sharedManager.showUpsellView(from: storiesViewController, source: .endOfYear, flow: SyncManager.isUserLoggedIn() ? .endOfYearUpsell : .endOfYear)
+                        NavigationManager.sharedManager.showUpsellView(from: storiesViewController, source: .endOfYear, flow: SyncManager.isUserLoggedIn() ? .endOfYearUpsell : .endOfYear)
+                    } else {
+                        
+                    }
                 }
-                .buttonStyle(BasicButtonStyle(textColor: .black, backgroundColor: Color.clear, borderColor: .black))
+                .buttonStyle(BasicButtonStyle(textColor: .white, backgroundColor: .black, borderColor: .black))
                 .padding(.horizontal, 24)
                 .padding(.top, 20)
                 .padding(.bottom, 4)
@@ -106,4 +113,8 @@ fileprivate struct CustomVideoPlayerView: UIViewControllerRepresentable {
 
 #Preview("Patron") {
     PaidStoryWallView2025(subscriptionTier: .patron)
+}
+
+#Preview("None") {
+    PaidStoryWallView2025(subscriptionTier: .none)
 }

--- a/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
+++ b/podcasts/End of Year/Stories/EndOfYearStoriesDataSource.swift
@@ -52,8 +52,8 @@ class EndOfYearStoriesDataSource: StoriesDataSource {
         model.footerShareView()
     }
 
-    var indicatorColor: Color {
-        model.indicatorColor
+    func indicatorColor(for storyIndex: Int) -> Color {
+        model.indicatorColor(for: storyIndex)
     }
 
     var primaryBackgroundColor: Color {

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -39,10 +39,10 @@ protocol StoriesDataSource {
     func footerShareView() -> AnyView?
 
     /// Color of the top Story progress indicator
-    var indicatorColor: Color { get }
+    func indicatorColor(for storyIndex: Int) -> Color
 
     /// Style configuration for the story indicators
-    var indicatorStyle: StoryIndicatorStyle { get }
+    func indicatorStyle(for storyIndex: Int) -> StoryIndicatorStyle
 
     /// Color of the primary background
     var primaryBackgroundColor: Color { get }
@@ -64,8 +64,8 @@ extension StoriesDataSource {
 
     var indicatorHeight: CGFloat { 2 }
 
-    var indicatorStyle: StoryIndicatorStyle {
-        StoryIndicatorStyle(height: indicatorHeight)
+    func indicatorStyle(for storyIndex: Int) -> StoryIndicatorStyle {
+        StoryIndicatorStyle(height: indicatorHeight, backgroundColor: indicatorColor(for: storyIndex), foregroundColor: indicatorColor(for: storyIndex))
     }
 }
 

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -303,11 +303,15 @@ private extension StoriesModel {
             switch controller {
             case .replay:
                 NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: controller.rawValue), object: nil, queue: .main) { [weak self] _ in
-                    self?.replay()
+                    DispatchQueue.main.async {
+                        self?.replay()
+                    }
                 }
             case .share:
                 NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: controller.rawValue), object: nil, queue: .main) { [weak self] _ in
-                    self?.share()
+                    DispatchQueue.main.async {
+                        self?.share()
+                    }
                 }
             }
         }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -272,12 +272,12 @@ class StoriesModel: ObservableObject {
         dataSource.footerShareView()
     }
 
-    var indicatorColor: Color {
-        dataSource.indicatorColor
+    func indicatorColor(for storyIndex: Int) -> Color {
+        dataSource.indicatorColor(for: storyIndex)
     }
 
-    var indicatorStyle: StoryIndicatorStyle {
-        dataSource.indicatorStyle
+    func indicatorStyle(for storyIndex: Int) -> StoryIndicatorStyle {
+        dataSource.indicatorStyle(for: storyIndex)
     }
 
     var primaryBackgroundColor: Color {

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -66,7 +66,7 @@ struct StoriesView: View {
             }
 
             header
-                .foregroundStyle(model.indicatorColor)
+                .foregroundStyle(model.indicatorColor(for: model.currentStoryIndex))
 
             // Hide the share button if needed
             if model.showShareButton(index: model.currentStoryIndex) && !model.shouldShowUpsell(), let shareView = model.overlaidShareView() {
@@ -109,10 +109,10 @@ struct StoriesView: View {
 
             VStack(spacing: 15) {
                 let progress = syncProgressModel.progress
-                CircularProgressView(value: progress, stroke: model.indicatorColor, strokeWidth: 6)
+                CircularProgressView(value: progress, stroke: model.indicatorColor(for: model.currentStoryIndex), strokeWidth: 6)
                     .frame(width: 40, height: 40)
                 Text(L10n.loading)
-                    .foregroundColor(model.indicatorColor)
+                    .foregroundColor(model.indicatorColor(for: model.currentStoryIndex))
                     .font(style: .body)
             }
 
@@ -127,7 +127,7 @@ struct StoriesView: View {
             Spacer()
 
             Text(L10n.eoyStoriesFailed)
-                .foregroundColor(model.indicatorColor)
+                .foregroundColor(model.indicatorColor(for: model.currentStoryIndex))
 
             storySwitcher
             header
@@ -138,13 +138,17 @@ struct StoriesView: View {
         }
     }
 
+    var indicatorStyle: StoryIndicatorStyle {
+        return StoryIndicatorStyle(backgroundColor: model.indicatorColor(for: model.currentStoryIndex), foregroundColor: model.indicatorColor(for: model.currentStoryIndex))
+    }
+
     // Header containing the close button and the rectangles
     var header: some View {
         ZStack {
             VStack {
                 HStack(spacing: model.indicatorSpacing) {
                     ForEach(0 ..< model.numberOfStories, id: \.self) { x in
-                        StoryIndicator(index: x, style: model.indicatorStyle, progressModel: model.progressPublisher)
+                        StoryIndicator(index: x, style: model.indicatorStyle(for: model.currentStoryIndex), progressModel: model.progressPublisher)
                     }
                 }
                 .frame(height: model.indicatorHeight)
@@ -156,7 +160,6 @@ struct StoriesView: View {
 
             if model.shouldShowDismissButton() {
                 closeButton
-                    .foregroundColor(model.indicatorColor)
             }
         }
         .padding(.top, Constants.headerTopPadding)

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -50,6 +50,7 @@ struct StoriesView: View {
                     }
                     .environment(\.animated, true)
                     .environment(\.pauseState, pauseState)
+                    .environmentObject(model)
 
                 if model.shouldShowUpsell() {
                     model.paywallView().zIndex(6).onAppear {

--- a/podcasts/Onboarding/Intro Carousel/IntroCarouselDataSource.swift
+++ b/podcasts/Onboarding/Intro Carousel/IntroCarouselDataSource.swift
@@ -47,11 +47,11 @@ class IntroCarouselDataSource: StoriesDataSource {
         nil
     }
 
-    var indicatorColor: Color {
+    func indicatorColor(for storyNumber: Int) -> Color {
         theme.primaryText01
     }
 
-    var indicatorStyle: StoryIndicatorStyle {
+    func indicatorStyle(for storyIndex: Int) -> StoryIndicatorStyle {
         StoryIndicatorStyle(
             height: 4,
             borderRadius: 0, // Square corners for intro

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2249,8 +2249,10 @@ internal enum L10n {
   internal static func playback2025LongestEpisodeTitle(_ p1: Any) -> String {
     return L10n.tr("Localizable", "playback_2025_longest_episode_title", String(describing: p1), fallback: "Your marathon listen: %1$@")
   }
-  /// A description shown in the Playback thanks screen for Pocket Casts Plus subscribers
-  internal static var playback2025PlusThanksDescription: String { return L10n.tr("Localizable", "playback_2025_plus_thanks_description", fallback: "Your Plus perks unlock extra stats and power features") }
+  /// A description shown in the Playback thanks screen for Pocket Casts Plus subscribers. %1$@ argument is your subscription Tier. Ex:  Your Plus perks unlock extra stats and power features"
+  internal static func playback2025PlusThanksDescription(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "playback_2025_plus_thanks_description", String(describing: p1), fallback: "Your %1$@ perks unlock extra stats and power features")
+  }
   /// A title shown in the Playback thanks screen for Pocket Casts Plus subscription
   internal static var playback2025PlusThanksTitle: String { return L10n.tr("Localizable", "playback_2025_plus_thanks_title", fallback: "Thanks for supporting Pocket Casts!") }
   /// A title shown in the button on the upsell screen to get  Pocket Casts Plus

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2249,6 +2249,10 @@ internal enum L10n {
   internal static func playback2025LongestEpisodeTitle(_ p1: Any) -> String {
     return L10n.tr("Localizable", "playback_2025_longest_episode_title", String(describing: p1), fallback: "Your marathon listen: %1$@")
   }
+  /// A description shown in the Playback thanks screen for Pocket Casts Plus subscribers
+  internal static var playback2025PlusThanksDescription: String { return L10n.tr("Localizable", "playback_2025_plus_thanks_description", fallback: "Your Plus perks unlock extra stats and power features") }
+  /// A title shown in the Playback thanks screen for Pocket Casts Plus subscription
+  internal static var playback2025PlusThanksTitle: String { return L10n.tr("Localizable", "playback_2025_plus_thanks_title", fallback: "Thanks for supporting Pocket Casts!") }
   /// A title shown in the button on the upsell screen to get  Pocket Casts Plus
   internal static var playback2025PlusUpsellButtonTitle: String { return L10n.tr("Localizable", "playback_2025_plus_upsell_button_title", fallback: "Get Pocket Casts Plus") }
   /// A description shown in the upsell screen for Pocket Casts Plus subscription

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5778,3 +5778,11 @@
 
 /* A description shown in Playback 2025 to describe the new Podcast Ratings feature */
 "playback_2025_ratings_empty_description" = "Help your favorite creators get discovered by sharing what you love";
+
+/* A title shown in the Playback thanks screen for Pocket Casts Plus subscription */
+"playback_2025_plus_thanks_title" = "Thanks for supporting Pocket Casts!";
+
+/* A description shown in the Playback thanks screen for Pocket Casts Plus subscribers */
+"playback_2025_plus_thanks_description" = "Your Plus perks unlock extra stats and power features";
+
+

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5782,7 +5782,7 @@
 /* A title shown in the Playback thanks screen for Pocket Casts Plus subscription */
 "playback_2025_plus_thanks_title" = "Thanks for supporting Pocket Casts!";
 
-/* A description shown in the Playback thanks screen for Pocket Casts Plus subscribers */
-"playback_2025_plus_thanks_description" = "Your Plus perks unlock extra stats and power features";
+/* A description shown in the Playback thanks screen for Pocket Casts Plus subscribers. %1$@ argument is your subscription Tier. Ex:  Your Plus perks unlock extra stats and power features" */
+"playback_2025_plus_thanks_description" = "Your %1$@ perks unlock extra stats and power features";
 
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-329 <!-- issue number, if applicable -->

| Plus | Patron |
| - | - | 
| <img width="320" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-11-18 at 17 27 55" src="https://github.com/user-attachments/assets/77645259-cd97-4e8e-9670-91ce71c5321b" /> | <img width="320"  alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-11-18 at 17 08 43" src="https://github.com/user-attachments/assets/3d173b9b-57c1-4c23-90cc-c9d4a8ba2830" /> |


<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the Playback code to show the Paywall view even when displaying the Playback for an user with a subscription

## To test

Start the app

- Login with an user that has some stats for 2025 and a active subscription
- Go to Profile -> Settings -> Beta features
- Enable the FF  `End of Year 2025`
- Go to Developer Menu and tap on "End Of Year -> Reset modal/profile badge" and select 2025
- Restart the app
- Go to Profile 
- Check that you see a banner for the playback 2025
- Tap on it
- Advance until you see the Plus Paywall story
- Check if the auto-advance is paused
- Check if the text on the screen and subscription logo is correct
- Check if Tap on continue advances for the first Subscription only story
- Now disable your Subscription or login with an user without a subscription
- Check if you can go up to paywall view, and see the correct content for the paywall
- Check that you can Tap on the button and advance to purchase subscription

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
