### PR TITLE
[Playlists] Accessibility fixes

### DIFF
--- a/podcasts/New Detail/Playlist Header/PlaylistBlurHeaderView.swift
+++ b/podcasts/New Detail/Playlist Header/PlaylistBlurHeaderView.swift
@@ -14,5 +14,6 @@ struct PlaylistBlurHeaderView: View {
                 Spacer()
             }
         }
+        .accessibilityHidden(true)
     }
 }

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -263,7 +263,7 @@ class PlaylistDetailViewController: FakeNavViewController {
         reloadNavTitle()
         scrollPointToChangeTitle = PodcastHeaderView.Constants.smallImageSize
 
-        addRightAction(image: UIImage(named: "more"), accessibilityLabel: L10n.learnMore, action: #selector(moreTapped))
+        addRightAction(image: UIImage(named: "more"), accessibilityLabel: L10n.accessibilityMoreActions, action: #selector(moreTapped))
 
         closeTapped = { [weak self] in
             _ = self?.navigationController?.popViewController(animated: true)

--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -66,10 +66,14 @@ struct LocalSearchView: View {
 
     private var navigationContent: some View {
         NavigationStack(path: $navigationPath) {
+            let heightConstant: CGFloat = 44
             podcastsView
                 .navigationDestination(for: LocalSearchRoute.self) { route in
                     destinationView(for: route)
+                    .padding(.top, heightConstant)
                 }
+                .toolbar(.hidden, for: .navigationBar)
+                .padding(.top, heightConstant)
         }
     }
 
@@ -216,6 +220,7 @@ private extension LocalSearchView {
             .background(backgroundColor.ignoresSafeArea())
             .navigationTitle(viewModel.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar(.hidden, for: .navigationBar)
         case .podcast:
             LocalSearchEpisodeResultsView(
                 isLoading: viewModel.isEpisodeSearchInFlight,
@@ -235,6 +240,7 @@ private extension LocalSearchView {
             .background(backgroundColor.ignoresSafeArea())
             .navigationTitle(viewModel.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar(.hidden, for: .navigationBar)
         }
     }
 

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -145,6 +145,10 @@ private extension SearchResultCell {
         }
     }
 
+    var episodeIsAvailable: Bool {
+        model.episode != nil && model.episode?.state != .unavailable
+    }
+
     var rowContent: some View {
         HStack(spacing: 12) {
             (model.episode?.podcastUuid ?? model.podcastFolder?.uuid).map {
@@ -187,7 +191,7 @@ private extension SearchResultCell {
             }
             .allowsHitTesting(false)
             Spacer()
-            if model.episode != nil && model.episode?.state != .unavailable {
+            if episodeIsAvailable {
                 if played {
                     Image("list_played", bundle: nil)
                         .resizable()
@@ -209,9 +213,20 @@ private extension SearchResultCell {
                     .buttonStyle(.plain)
                     .frame(width: 32, height: 32)
                     .foregroundColor(theme.primaryInteractive01)
+                    .accessibilityHidden(true)
                 }
             } else if showPodcastSubscribeButton, let result = model.podcastFolder, result.kind == .podcast {
                 SubscribeButtonView(podcastUuid: result.uuid, source: searchAnalyticsHelper.source)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityActions {
+            if episodeIsAvailable {
+                if showEpisodeAddButton {
+                    Button(L10n.accessibilityPlaylistAddEpisode) {
+                        (episodeAddAction ?? action)?()
+                    }
+                }
             }
         }
         .opacity(played || model.episode?.state?.isNormal == false ? 0.5 : 1.0)

--- a/podcasts/PlaylistArtworkView.swift
+++ b/podcasts/PlaylistArtworkView.swift
@@ -62,5 +62,7 @@ struct PlaylistArtworkView: View {
             }
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(L10n.accessibilityPlaylistImage)
     }
 }

--- a/podcasts/PlaylistCellView.swift
+++ b/podcasts/PlaylistCellView.swift
@@ -97,6 +97,7 @@ struct PlaylistCellView: View {
                     }
                 }
         }
+        .accessibilityElement(children: .combine)
         .opacity(shouldDisableRow ? 0.45 : 1.0)
         .onAppear {
             viewModel.loadData()
@@ -114,6 +115,7 @@ struct PlaylistCellView: View {
         case .count:
             HStack(spacing: 5.0) {
                 subtitleView(text: "\(viewModel.episodesCount)")
+                    .accessibilityLabel("\(viewModel.episodesCount) \(L10n.episodes)")
             }
             .padding(.trailing, 8.0)
         case .toggle:

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -77,7 +77,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         } else {
             customRightBtn = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(editTapped))
         }
-        customRightBtn?.accessibilityLabel = L10n.accessibilityMoreActions
+        customRightBtn?.accessibilityLabel = L10n.playlistsDefaultNewPlaylist
 
         title = FeatureFlag.playlistsRebranding.enabled ? L10n.playlists : L10n.filters
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -70,6 +70,8 @@ internal enum L10n {
   internal static func accessibilityPlaylistColor(_ p1: Any) -> String {
     return L10n.tr("Localizable", "accessibility_playlist_color", String(describing: p1), fallback: "Playlist color %1$@")
   }
+  /// An accessibility label used for the playlist image
+  internal static var accessibilityPlaylistImage: String { return L10n.tr("Localizable", "accessibility_playlist_image", fallback: "Playlist image") }
   /// A common string used throughout the app. An accessibility label to inform the user that the selected item is locked behind Pocket Casts Plus subscription.
   internal static var accessibilityPlusOnly: String { return L10n.tr("Localizable", "accessibility_plus_only", fallback: "Locked, Plus Feature") }
   /// Accessibility label fir the profile settings icon in the app. 'Pocket Casts' is treated as a proper noun and hasn't been localized in other places of the app.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -66,6 +66,8 @@ internal enum L10n {
   internal static func accessibilityPlayerEffectsPlaybackSpeed(_ p1: Any) -> String {
     return L10n.tr("Localizable", "accessibility_player_effects_playback_speed", String(describing: p1), fallback: "Playback speed %1$@ times")
   }
+  /// An accessibility label used for the add episode action for the Add Episodes search view
+  internal static var accessibilityPlaylistAddEpisode: String { return L10n.tr("Localizable", "accessibility_playlist_add_episode", fallback: "Add Episode") }
   /// Accessibility hint to inform the user which filter color flag is being used. '%1$@' is a placeholder for the filter color number.
   internal static func accessibilityPlaylistColor(_ p1: Any) -> String {
     return L10n.tr("Localizable", "accessibility_playlist_color", String(describing: p1), fallback: "Playlist color %1$@")

--- a/podcasts/SwiftUI/SearchField.swift
+++ b/podcasts/SwiftUI/SearchField.swift
@@ -57,6 +57,7 @@ struct SearchField: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(width: iconSize, height: iconSize)
                     .foregroundStyle(theme.icon)
+                    .accessibilityHidden(true)
 
                 let prompt = Text(placeholder).foregroundColor(theme.placeholder)
 
@@ -71,6 +72,7 @@ struct SearchField: View {
                         .buttonize {
                             text = ""
                         }
+                        .accessibilityLabel(L10n.clearSearch)
                 }
             }
             .padding(.horizontal, SearchFieldConstants.horizontalPadding)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5420,6 +5420,9 @@
 /* A common string used throughout the app. Often refers to the Playlists screen. */
 "playlists" = "Playlists";
 
+/* An accessibility label used for the playlist image */
+"accessibility_playlist_image" = "Playlist image";
+
 /* Option to delete the playlist. It appears in the edit panel from the playlist detail. */
 "playlists_delete" = "Delete Playlist";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5423,6 +5423,9 @@
 /* An accessibility label used for the playlist image */
 "accessibility_playlist_image" = "Playlist image";
 
+/* An accessibility label used for the add episode action for the Add Episodes search view */
+"accessibility_playlist_add_episode" = "Add Episode";
+
 /* Option to delete the playlist. It appears in the edit panel from the playlist detail. */
 "playlists_delete" = "Delete Playlist";
 


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-internal-testing-b4b2f66c6304/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=team&showCompletedIssues=all&showSubIssues=true&showTriageIssues=true)
|:---:|

Fixes [PCIOS-319](https://linear.app/a8c/issue/PCIOS-319/voiceover-regression-in-announcing-playlist-details)

There are other Voice Over issues I noticed while testing this around Episode Cells, but since they aren't related to Playlists and have been around for a while, I think they should target 8.1.

## To test

### Playlist list
* Enable Voice Over
* Navigate to the Playlist tab
* Scroll through the rows
* ✅ Ensure that each row is read as a single item
* Open a playlist
* Swipe through the top header
* ✅ Ensure that the playlist artwork is a single item and says "Playlist image"

### Episode search
* In a manual playlist, tap "Add Episodes"
* Use Voice Over to swipe through the search screen
* ✅ Ensure that the search field is a single element and doesn't read the icons or decorative images
* Swipe through podcasts
* ✅ Ensure each row is a single element
* Tap on a podcast to navigate to the Episodes list
* Swipe through episode cells
* ✅ Ensure that the row is read as a single item
* ✅ Ensure that actions are available on the cell
* Swipe up or down to cycle through actions and select the "Add Episode" action
* Double tap to activate "Add Episode"
* ✅ Ensure the episode hides and is added to the playlist

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
