### PR TITLE
[Playlists] Fix separator view color

### DIFF
--- a/podcasts/NewPlaylistCell.swift
+++ b/podcasts/NewPlaylistCell.swift
@@ -43,6 +43,8 @@ class NewPlaylistCell: ThemeableCell {
 
         updateColor()
 
+        separatorView.backgroundColor = AppTheme.colorForStyle(.primaryUi05)
+
         separatorInset = UIEdgeInsets(top: 0, left: .greatestFiniteMagnitude, bottom: 0, right: 0)
         layoutMargins = .zero
         preservesSuperviewLayoutMargins = false
@@ -52,6 +54,7 @@ class NewPlaylistCell: ThemeableCell {
 
         addSubview(artworkImageSource)
         addSubview(separatorView)
+        bringSubviewToFront(separatorView)
         NSLayoutConstraint.activate([
             hostingController.view.topAnchor.constraint(equalTo: topAnchor),
             hostingController.view.bottomAnchor.constraint(equalTo: bottomAnchor),
@@ -84,6 +87,11 @@ class NewPlaylistCell: ThemeableCell {
         let theme = themeOverride ?? Theme.sharedTheme.activeTheme
 
         overrideUserInterfaceStyle = theme.isDark ? .dark : .light
+    }
+
+    override func updateColor() {
+        super.updateColor()
+        separatorView.backgroundColor = AppTheme.colorForStyle(.primaryUi05)
     }
 
     @MainActor required init?(coder: NSCoder) {


### PR DESCRIPTION
Fix playlists list separator view color.

## To test

- Run this branch
- Go to playlists
- Confirm the cell separator is visible
- Change theme
- Go back to playlists
- Confirm it changes properly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
