### PR TITLE
[Playback 2025] Add "year" and "button" properties to end of year share

### DIFF
--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -195,7 +195,7 @@ struct EndOfYear {
             }
 
             if let activity, success {
-                let properties = ["activity": activity.rawValue, "story": storyIdentifier]
+                let properties = ["activity": activity.rawValue, "story": storyIdentifier, "from": "button"]
                 Analytics.track(.endOfYearStoryShared, properties: properties)
                 DispatchQueue.main.async {
                     model.recordPlaybackShare(properties: properties.merging(["source": "end_of_year"]) { $1 })

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -317,6 +317,11 @@ private extension StoriesModel {
             .sink { [weak self] _ in
                 self?.pause()
                 self?.screenshotTaken = true
+
+                let year = EndOfYear.currentYear.literalValue
+                let story = self?.currentStoryIdentifier ?? "unknown"
+                let properties = ["story": story, "year": year, "from": "screenshot"]
+                Analytics.track(.endOfYearStoryShared, properties: properties)
             }
             .store(in: &cancellables)
 

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -16,7 +16,32 @@ class StoriesModel: ObservableObject {
 
     @Published var failed: Bool = false
 
-    @Published var screenshotTaken: Bool = false
+    @Published var screenshotTaken: Bool = false {
+        didSet {
+            guard screenshotTaken else {
+                if shareAlertPresented {
+                    shareAlertPresented = false
+                }
+                return
+            }
+
+            // Present share alert if the story is shareable
+            guard dataSource.shareableStory(for: currentStoryIndex) != nil else {
+                screenshotTaken = false
+                return
+            }
+
+            shareAlertPresented = true
+        }
+    }
+
+    @Published var shareAlertPresented: Bool = false {
+        didSet {
+            if !shareAlertPresented && screenshotTaken {
+                screenshotTaken = false
+            }
+        }
+    }
 
     let activeTier: () -> SubscriptionTier
 

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -16,11 +16,11 @@ class StoriesModel: ObservableObject {
 
     @Published var failed: Bool = false
 
-    @Published var screenshotTaken: Bool = false {
+    private var screenshotTaken: Bool = false {
         didSet {
             guard screenshotTaken else {
-                if shareAlertPresented {
-                    shareAlertPresented = false
+                if shareAlertState.isPresented {
+                    setShareAlertPresented(false)
                 }
                 return
             }
@@ -31,17 +31,11 @@ class StoriesModel: ObservableObject {
                 return
             }
 
-            shareAlertPresented = true
+            setShareAlertPresented(true)
         }
     }
 
-    @Published var shareAlertPresented: Bool = false {
-        didSet {
-            if !shareAlertPresented && screenshotTaken {
-                screenshotTaken = false
-            }
-        }
-    }
+    let shareAlertState: StoriesShareAlertState
 
     let activeTier: () -> SubscriptionTier
 
@@ -98,7 +92,12 @@ class StoriesModel: ObservableObject {
         self.progressModel = progressModel
         self.publisher = Timer.publish(every: 0.01, on: .main, in: .default)
         self.activeTier = activeTier
+        self.shareAlertState = StoriesShareAlertState()
         self.progressModel.progress = progress
+
+        self.shareAlertState.onVisibilityChanged = { [weak self] isPresented in
+            self?.shareAlertVisibilityChanged(isPresented)
+        }
 
         Task.init {
             await isReady = dataSource.isReady()
@@ -323,6 +322,17 @@ class StoriesModel: ObservableObject {
 }
 
 private extension StoriesModel {
+    func setShareAlertPresented(_ presented: Bool) {
+        guard shareAlertState.isPresented != presented else { return }
+        shareAlertState.isPresented = presented
+    }
+
+    func shareAlertVisibilityChanged(_ isPresented: Bool) {
+        if !isPresented && screenshotTaken {
+            screenshotTaken = false
+        }
+    }
+
     func subscribeToNotifications() {
         StoriesController.Notifications.allCases.forEach { [weak self] controller in
             switch controller {
@@ -387,4 +397,15 @@ private extension StoriesModel {
 
         pendingPlaybackShareEvents.removeAll()
     }
+}
+
+final class StoriesShareAlertState: ObservableObject {
+    @Published var isPresented: Bool = false {
+        didSet {
+            guard isPresented != oldValue else { return }
+            onVisibilityChanged?(isPresented)
+        }
+    }
+
+    var onVisibilityChanged: ((Bool) -> Void)?
 }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -340,13 +340,16 @@ private extension StoriesModel {
         UIApplication.userDidTakeScreenshotNotification.publisher()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.pause()
-                self?.screenshotTaken = true
+                guard let self else { return }
+                pause()
+                screenshotTaken = true
 
-                let year = EndOfYear.currentYear.literalValue
-                let story = self?.currentStoryIdentifier ?? "unknown"
-                let properties = ["story": story, "year": year, "from": "screenshot"]
-                Analytics.track(.endOfYearStoryShared, properties: properties)
+                if dataSource.shareableStory(for: currentStoryIndex) != nil {
+                    let year = EndOfYear.currentYear.literalValue
+                    let story = currentStoryIdentifier
+                    let properties = ["story": story, "year": year, "from": "screenshot"]
+                    Analytics.track(.endOfYearStoryShared, properties: properties)
+                }
             }
             .store(in: &cancellables)
 

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -86,7 +86,7 @@ struct StoriesView: View {
         }
         .background(Color.black)
         .alert(L10n.eoyShareThisStoryTitle,
-               isPresented: $model.screenshotTaken) {
+               isPresented: $model.shareAlertPresented) {
             Button(L10n.eoyNotNow) { model.start() }
             Button(L10n.share) { model.share() }.keyboardShortcut(.defaultAction)
         } message: {

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -3,7 +3,6 @@ import PocketCastsServer
 
 struct StoriesView: View {
     @ObservedObject private var model: StoriesModel
-
     @ObservedObject private var syncProgressModel: SyncYearListeningProgress
 
     @Environment(\.accessibilityShowButtonShapes) var showButtonShapes: Bool
@@ -13,7 +12,8 @@ struct StoriesView: View {
     private let maximumTapTime: Double = 0.35
 
     init(dataSource: StoriesDataSource, configuration: StoriesConfiguration = StoriesConfiguration(), syncProgressModel: SyncYearListeningProgress = .shared) {
-        model = StoriesModel(dataSource: dataSource, configuration: configuration)
+        let model = StoriesModel(dataSource: dataSource, configuration: configuration)
+        _model = ObservedObject(initialValue: model)
         self.syncProgressModel = syncProgressModel
     }
 
@@ -85,13 +85,13 @@ struct StoriesView: View {
             }
         }
         .background(Color.black)
-        .alert(L10n.eoyShareThisStoryTitle,
-               isPresented: $model.shareAlertPresented) {
-            Button(L10n.eoyNotNow) { model.start() }
-            Button(L10n.share) { model.share() }.keyboardShortcut(.defaultAction)
-        } message: {
-            Text(L10n.eoyShareThisStoryMessage)
-        }
+        .modifier(
+            ShareAlertModifier(
+                state: model.shareAlertState,
+                shareAction: model.share,
+                notNowAction: model.start
+            )
+        )
         .onChange(of: pauseState.isPaused) { isPaused in
             if isPaused {
                 model.pause()
@@ -283,6 +283,23 @@ private struct CloseButtonStyle: ButtonStyle {
     private enum Constants {
         static let closeButtonPadding: CGFloat = 13
         static let closeButtonRadius: CGFloat = 5
+    }
+}
+
+private struct ShareAlertModifier: ViewModifier {
+    @ObservedObject var state: StoriesShareAlertState
+    let shareAction: () -> Void
+    let notNowAction: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .alert(L10n.eoyShareThisStoryTitle,
+                   isPresented: $state.isPresented) {
+                Button(L10n.eoyNotNow) { notNowAction() }
+                Button(L10n.share) { shareAction() }.keyboardShortcut(.defaultAction)
+            } message: {
+                Text(L10n.eoyShareThisStoryMessage)
+            }
     }
 }
 


### PR DESCRIPTION
Fixes [PCIOS-304](https://linear.app/a8c/issue/PCIOS-304/consider-tracking-screenshots-as-sharing-events)

## To test

### Analytics Changes
* Enable `tracksLogging` feature flag
* Open the Playback 2025 from your profile
* Take a screenshot while one of the stories is visible
* ✅ Ensure that the following event is logged after tapping the button:

```
🔵 Tracked: end_of_year_story_shared ["year": "2025", "from": "screenshot", "story": "number_of_shows"]
```

* Tap the Share button
* ✅ Ensure that the following event is logged:

```
🔵 Tracked: end_of_year_story_share ["year": "2025", "story": "number_of_shows"]
```

* Finish sharing to some destination from the share sheet
* ✅ Ensure that the following event is logged:

```
🔵 Tracked: end_of_year_story_shared ["from": "button", "activity": "com.apple.UIKit.activity.SaveToCameraRoll", "story": "number_of_shows"]
```

### Screenshot alert

* Navigate to a story which isn't shareable, like the first or final stories
* Take a screenshot or use Device > Trigger Screenshot in the simulator
* ✅ Ensure the alert doesn't show after screenshotting these screens
* Navigate to a shareable screen
* Take a screenshot or use Device > Trigger Screenshot in the simulator
* Dismiss the system screenshot screen
* ✅ Ensure the alert is shown after dismissal

https://github.com/user-attachments/assets/36bdb221-ef5f-4485-9b07-90fdc9357d10

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
