### PR TITLE
[Playlists] Apply right method to new playlist query for autodownload

### DIFF
--- a/podcasts/FilterEditOptionsViewController.swift
+++ b/podcasts/FilterEditOptionsViewController.swift
@@ -220,6 +220,9 @@ class FilterEditOptionsViewController: PCViewController, UITableViewDelegate, UI
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         let autoDownloadSection = Self.playlistRebrandingIsEnabled ? 1 : 2
         if section == autoDownloadSection {
+            if Self.playlistRebrandingIsEnabled {
+                return filterToEdit.autoDownloadEpisodes ? L10n.episodeCountPluralFormat(filterToEdit.maxAutoDownloadEpisodes().localized()) : L10n.playlistsAutoDownloadOffSubtitle
+            }
             return filterToEdit.autoDownloadEpisodes ? L10n.episodeCountPluralFormat(filterToEdit.maxAutoDownloadEpisodes().localized()) : L10n.autoDownloadOffSubtitle
         }
         return nil

--- a/podcasts/PlaylistManager.swift
+++ b/podcasts/PlaylistManager.swift
@@ -109,13 +109,15 @@ class PlaylistManager {
             guard playlist.autoDownloadEpisodes else { continue }
 
             let query: String
+            let episodes: [Episode]
             if FeatureFlag.playlistsRebranding.enabled {
                 query = PlaylistQueryBuilder.query(clause: .episode, for: playlist, episodeUuidToAdd: playlist.episodeUuidToAddToQueries(), limit: Int(playlist.maxAutoDownloadEpisodes()))
+                episodes = DataManager.sharedManager.findPlaylistEpisodesWhere(query: query, arguments: nil)
             } else {
                 query = PlaylistQueryBuilder.queryFor(filter: playlist, episodeUuidToAdd: playlist.episodeUuidToAddToQueries(), limit: Int(playlist.maxAutoDownloadEpisodes()))
+                episodes = DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: nil)
             }
 
-            let episodes = DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: nil)
             for episode in episodes {
                 if episode.downloaded(pathFinder: DownloadManager.shared) || episode.queued() { continue }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2507,6 +2507,12 @@ internal enum L10n {
   internal static var playlistSmartRulesTitle: String { return L10n.tr("Localizable", "playlist_smart_rules_title", fallback: "Smart rules") }
   /// A common string used throughout the app. Often refers to the Playlists screen.
   internal static var playlists: String { return L10n.tr("Localizable", "playlists", fallback: "Playlists") }
+  /// Subtitle for the auto download setting. This is displayed when the option is turned off.
+  internal static var playlistsAutoDownloadOffSubtitle: String { return L10n.tr("Localizable", "playlists_auto_download_off_subtitle", fallback: "Enable to auto download episodes in this playlist") }
+  /// Subtitle for the auto download setting. This is displayed when the option is turned on. '%1$@' is a placeholder for the number of episodes, this will be more than one.
+  internal static func playlistsAutoDownloadOnPluralFormat(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "playlists_auto_download_on_plural_format", String(describing: p1), fallback: "The first %1$@ episodes in this playlist will be automatically downloaded")
+  }
   /// A placeholder title for a new playlist.
   internal static var playlistsDefaultNewPlaylist: String { return L10n.tr("Localizable", "playlists_default_new_playlist", fallback: "New playlist") }
   /// Option to delete the playlist. It appears in the edit panel from the playlist detail.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5432,6 +5432,12 @@
 /* Playlist Play all button */
 "playlists_play_all" = "Play all";
 
+/* Subtitle for the auto download setting. This is displayed when the option is turned off. */
+"playlists_auto_download_off_subtitle" = "Enable to auto download episodes in this playlist";
+
+/* Subtitle for the auto download setting. This is displayed when the option is turned on. '%1$@' is a placeholder for the number of episodes, this will be more than one. */
+"playlists_auto_download_on_plural_format" = "The first %1$@ episodes in this playlist will be automatically downloaded";
+
 /* A common string used throughout the app. Often refers to the Smart Playlist. */
 "smart_playlist" = "Smart playlist";
 


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-338

This PR fixe the auto download for playlists by using the correct data manager method to apply the query for smart and manual playlists. This PR also fixes a text where the filter word was still present in the Playlist Options screen.

## To test

### Smart Playlist
- Run this branch
- Open a smart playlist detail
- Tap the right top `•••` menu
- Select Playlist Options
- Observer the subtitle of the AutoDownload is `Enable to auto download episodes in this playlist`
- Enable Auto Download
- Select an amount of episodes
- Navigate back to the detail
- Pull down to reload the smart playlist
- Confirm the episodes will start being queued and downloading

### Manual Playlist
- Open a manual playlist detail
- Tap the right top `•••` menu
- Select Playlist Options
- Enable Auto Download
- Select an amount of episodes
- Navigate back to the detail
- Trigger a sync from the profile
- Confirm the episodes will start downloading

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
