### PR TITLE
[Playlists] Add new notification and debounce

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -33,6 +33,7 @@ struct Constants {
         static let miniPlayerDidDisappear = NSNotification.Name(rawValue: "SJMiniPlayerDisappeared")
         static let miniPlayerDidAppear = NSNotification.Name(rawValue: "SJMiniPlayerAppeared")
         static let playlistChanged = NSNotification.Name(rawValue: "FilterChanged")
+        static let playlistsNeedReload = NSNotification.Name(rawValue: "PlaylistsNeedReload")
         static let playlistTempChange = NSNotification.Name(rawValue: "playlistTempChange")
         static let statusBarHeightChanged = NSNotification.Name(rawValue: "SJBarHeightChanged")
         static let podcastSearchRequest = NSNotification.Name(rawValue: "PodcastSearchRequest")

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -33,6 +33,9 @@ class EpisodeManager: NSObject {
 
         if fireNotification {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodePlayStatusChanged, object: episode.uuid)
+            if FeatureFlag.playlistsRebranding.enabled {
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
+            }
         }
 
         if userInitiated {
@@ -99,6 +102,9 @@ class EpisodeManager: NSObject {
             markAsPlayed(episode: currentEpisode, fireNotification: true, userInitiated: false)
         }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
+        if FeatureFlag.playlistsRebranding.enabled {
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
+        }
 
         analyticsHelper.bulkMarkAsPlayed(count: episodesMinusCurrent.count)
     }
@@ -143,6 +149,9 @@ class EpisodeManager: NSObject {
 
         if fireNotification {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodePlayStatusChanged, object: episode.uuid)
+            if FeatureFlag.playlistsRebranding.enabled {
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
+            }
         }
 
         if userInitiated {
@@ -153,6 +162,9 @@ class EpisodeManager: NSObject {
     class func bulkMarkAsUnPlayed(_ baseEpisodes: [BaseEpisode]) {
         DataManager.sharedManager.bulkMarkAsUnPlayed(baseEpisodes: baseEpisodes, updateSyncFlag: SyncManager.isUserLoggedIn())
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
+        if FeatureFlag.playlistsRebranding.enabled {
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
+        }
 
         analyticsHelper.bulkMarkAsUnplayed(count: baseEpisodes.count)
     }
@@ -175,6 +187,9 @@ class EpisodeManager: NSObject {
 
         if fireNotification {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeArchiveStatusChanged, object: episode.uuid)
+            if FeatureFlag.playlistsRebranding.enabled {
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
+            }
         }
 
         if userInitiated {
@@ -206,6 +221,9 @@ class EpisodeManager: NSObject {
             PlaybackManager.shared.bulkRemoveQueued(uuids: uuids)
         }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
+        if FeatureFlag.playlistsRebranding.enabled {
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
+        }
 
         analyticsHelper.bulkArchiveEpisodes(count: episodes.count)
     }
@@ -222,6 +240,9 @@ class EpisodeManager: NSObject {
 
         if fireNotification {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeArchiveStatusChanged, object: episode.uuid)
+            if FeatureFlag.playlistsRebranding.enabled {
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
+            }
         }
 
         if userInitiated {
@@ -233,6 +254,9 @@ class EpisodeManager: NSObject {
         DataManager.sharedManager.bulkUnarchive(episodes: episodes, updateSyncFlag: SyncManager.isUserLoggedIn())
 
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
+        if FeatureFlag.playlistsRebranding.enabled {
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
+        }
 
         if trackEvent {
             analyticsHelper.bulkUnarchiveEpisodes(count: episodes.count)

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -177,6 +177,10 @@ class ManualPlaylistsChooserViewController: PCViewController {
             dataManager.save(playlist: playlist)
         }
 
+        if !added.isEmpty || !removed.isEmpty {
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
+        }
+
         dismiss(animated: true) {
             if added.isEmpty {
                 return

--- a/podcasts/New Detail/PlaylistDetailViewController+Swipe.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+Swipe.swift
@@ -44,7 +44,6 @@ extension PlaylistDetailViewController: SwipeTableViewCellDelegate, SwipeHandler
         if willBeRemoved {
             viewModel.reloadEpisodeList()
         }
-        NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: viewModel.playlist)
     }
 
     func deleteRequested(uuid: String) {} // we don't support this one

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -466,7 +466,8 @@ class PlaylistDetailViewController: FakeNavViewController {
             playlist: viewModel.playlist,
             dismissAction: { [weak self] in
                 self?.dismiss(animated: true) {
-                    NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged)
+                    self?.viewModel.reloadPlaylistAndEpisodes()
+                    NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
                 }
             }
         )

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -35,7 +35,8 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     var snapshot: UIView?
     var previouslyDisplayedDetail = false
     var presentingPlaylistDetail: Bool = false
-    var playlistsNeedReload: Bool = true
+
+    private let debounce = Debounce(delay: Constants.defaultDebounceTime)
 
     @IBOutlet var footerView: ThemeableView! {
         didSet {
@@ -126,7 +127,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         super.viewWillAppear(animated)
 
         if FeatureFlag.playlistsRebranding.enabled {
-            if playlistsNeedReload {
+            if firstTimeLoading {
                 reloadFilters()
             }
         } else {
@@ -172,7 +173,13 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     }
 
     @objc private func filtersUpdated() {
-        reloadFilters()
+        if FeatureFlag.playlistsRebranding.enabled, !firstTimeLoading {
+            debounce.call { [weak self] in
+                self?.reloadFilters()
+            }
+        } else {
+            reloadFilters()
+        }
     }
 
     @IBAction func addNewFilter() {
@@ -236,7 +243,6 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
             guard let self else { return }
             playlists = DataManager.sharedManager.allPlaylists(includeDeleted: false)
             firstTimeLoading = false
-            playlistsNeedReload = false
             DispatchQueue.main.async {
                 self.newFilterButton.isHidden = false
                 self.loadingIndicator.stopAnimating()
@@ -246,15 +252,8 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     }
 
     private func addReloadPlaylistsObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(setPlaylistsToReload), name: Constants.Notifications.playlistChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(setPlaylistsToReload), name: Constants.Notifications.playlistsNeedReload, object: nil)
-    }
-
-    @objc private func setPlaylistsToReload() {
-        if playlistsNeedReload {
-            return
-        }
-        playlistsNeedReload = true
+        NotificationCenter.default.addObserver(self, selector: #selector(filtersUpdated), name: Constants.Notifications.playlistChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(filtersUpdated), name: Constants.Notifications.playlistsNeedReload, object: nil)
     }
 
     private func setupInformationalBanner() {

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -35,6 +35,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     var snapshot: UIView?
     var previouslyDisplayedDetail = false
     var presentingPlaylistDetail: Bool = false
+    var playlistsNeedReload: Bool = true
 
     @IBOutlet var footerView: ThemeableView! {
         didSet {
@@ -91,7 +92,9 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
         loadingIndicator = ThemeLoadingIndicator()
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: filtersTable)
-        if !FeatureFlag.playlistsRebranding.enabled {
+        if FeatureFlag.playlistsRebranding.enabled {
+            addReloadPlaylistsObservers()
+        } else {
             setupNewFilterButton()
         }
         handleThemeChanged()
@@ -121,7 +124,12 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        if firstTimeLoading {
+
+        if FeatureFlag.playlistsRebranding.enabled {
+            if playlistsNeedReload {
+                reloadFilters()
+            }
+        } else {
             reloadFilters()
         }
         setupInformationalBanner()
@@ -227,10 +235,8 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
             playlists = DataManager.sharedManager.allPlaylists(includeDeleted: false)
-            if FeatureFlag.playlistsRebranding.enabled {
-                addObserverIfNeeded()
-            }
             firstTimeLoading = false
+            playlistsNeedReload = false
             DispatchQueue.main.async {
                 self.newFilterButton.isHidden = false
                 self.loadingIndicator.stopAnimating()
@@ -239,9 +245,16 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         }
     }
 
-    private func addObserverIfNeeded() {
-        guard firstTimeLoading else { return }
-        NotificationCenter.default.addObserver(self, selector: #selector(filtersUpdated), name: Constants.Notifications.playlistChanged, object: nil)
+    private func addReloadPlaylistsObservers() {
+        NotificationCenter.default.addObserver(self, selector: #selector(setPlaylistsToReload), name: Constants.Notifications.playlistChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(setPlaylistsToReload), name: Constants.Notifications.playlistsNeedReload, object: nil)
+    }
+
+    @objc private func setPlaylistsToReload() {
+        if playlistsNeedReload {
+            return
+        }
+        playlistsNeedReload = true
     }
 
     private func setupInformationalBanner() {

--- a/podcasts/SwipeActionsHelper.swift
+++ b/podcasts/SwipeActionsHelper.swift
@@ -174,6 +174,14 @@ enum SwipeActionsHelper {
             if !playlistSourceType.isEmpty {
                 properties["filter_type"] = playlistSourceType
             }
+
+            switch action {
+            case .delete, .unarchive, .archive, .removeFromManualPlaylist:
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
+                break
+            default:
+                break
+            }
         }
         Analytics.track(.episodeSwipeActionPerformed, properties: properties)
 


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

This PR adds:
- A notification used only to reload the list. This to avoid using the `playlistChanged` too often.
- It also use a small debounce to avoid both notifications being called close to each other 
- Fixes the swipe actions that need to fire the reload list notitifaction

## To test

- Start from a fresh install and login with a user that has multiple playlists
- Go to Playlists and the list should load
- Smoke test the Playlists list by entering into a detail, change order of episodes to change the artwork
- Smoke test the swipe actions
- Also from a playlist detail open the episode detail to archive/mark as played and see if the reload works
- Test also bulk actions from a playlist detail
- Navigate back and confirm it changes properly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
