### PR TITLE
[Analytics] Fix Interests selected analytics

### DIFF
--- a/podcasts/Onboarding/InterestsView.swift
+++ b/podcasts/Onboarding/InterestsView.swift
@@ -40,6 +40,17 @@ class InterestsViewModel: ObservableObject, @unchecked Sendable {
         return categories.filter { selectedCategories.contains($0.id ?? -1) }
     }
 
+    var analyticsCategories: String {
+        let namesSelected: [String] = selectedCategories.compactMap { id in
+            if let category = categories.first(where: { $0.id == id }) {
+                return category.name
+            } else {
+                return "unknown"
+            }
+        }
+        return namesSelected.joined(separator: ",")
+    }
+
     func load() async {
         let page = await DiscoverServerHandler.shared.discoverPage()
         guard let layout = page.0 else {
@@ -225,7 +236,7 @@ struct InterestsView: View {
         VStack {
             Button(action: {
                 continueCallback?(viewModel.fullSelectedCategories)
-                OnboardingFlow.shared.track(.onboardingInterestsContinueTapped, properties: ["categories": Array(viewModel.selectedCategories)])
+                OnboardingFlow.shared.track(.onboardingInterestsContinueTapped, properties: ["categories": viewModel.analyticsCategories])
             }) {
                 Text(viewModel.isMinimumSelectionDone ? L10n.continue : L10n.interestsSelectAtLeast(viewModel.minimumSelectionCount))
                     .textStyle(RoundedButton())

--- a/podcasts/Onboarding/InterestsView.swift
+++ b/podcasts/Onboarding/InterestsView.swift
@@ -48,7 +48,7 @@ class InterestsViewModel: ObservableObject, @unchecked Sendable {
                 return "unknown"
             }
         }
-        return namesSelected.joined(separator: ",")
+        return namesSelected.joined(separator: ", ")
     }
 
     func load() async {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the tracking of the event `onboarding_interests_continue_tapped` to use the categories name instead of the ids and to use comma separated string instead of an Array that is not supported by Tracks.

<img width="320" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2025-11-19 at 15 12 09" src="https://github.com/user-attachments/assets/77523281-09dd-44a3-8ef5-48e2a6e59505" />

## To test

1. Enable the FF for tracksLogging in code to have logs at startup
2. Start the app from scratch
3. Start the onboarding flow
4. Tap on Get Started
5. Select some Interests
6. Tap on Continue
7. Confirm that you see this event logged: `onboarding_interests_continue_tapped ["categories": "True Crime, Comedy,Society & Culture, Technology", "source": "onboarding", "flow": "initial_onboarding"]` where the categories entry reflect the categories you selected 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
