### PR TITLE
[Playlists] Playlists list: remove last separator

### DIFF
--- a/podcasts/NewPlaylistCell.swift
+++ b/podcasts/NewPlaylistCell.swift
@@ -147,4 +147,8 @@ class NewPlaylistCell: ThemeableCell {
             }
         }
     }
+
+    func hideSeparator(_ hide: Bool) {
+        separatorView.alpha = hide ? 0 : 1
+    }
 }

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -35,6 +35,7 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
             if let playlist = playlists[safe: indexPath.row] {
                 cell.set(playlistName: playlist.playlistName, isManualPlaylist: playlist.manual)
                 cell.loadMetadata(for: playlist)
+                cell.hideSeparator(indexPath.row == playlists.count - 1)
             }
             return cell
         }


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Removes the last separator in Playlists list

## To test

- Run this branch
- Go to Playlists
- Scroll till the end if the list is long or just observe the last cell
- Confirm the last cell separator is hidden

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
