### PR TITLE
[Tooling] Improve `new_hotfix_release` lanes to work when there's no release tag

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -502,19 +502,21 @@ platform :ios do
 
     # Parse the provided version into an AppVersion object
     parsed_version = VERSION_FORMATTER.parse(version)
+    # Validate that this is a hotfix version (must have a patch component > 0)
+    UI.user_error!("Invalid hotfix version '#{version}'. Must include a patch number.") unless parsed_version.patch.to_i.positive?
     previous_version = VERSION_FORMATTER.release_version(VERSION_CALCULATOR.previous_patch_version(version: parsed_version))
 
     release_branch_name = "release/#{version}"
     previous_release_branch = "release/#{previous_version}"
 
     # Determine the base for the hotfix branch: either a tag or a release branch
-    base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
+    base_ref_for_hotfix = if git_tag_exists(tag: previous_version, remote: true)
                             previous_version
                           elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
-                            UI.message("ℹ️  Tag #{previous_version} not found. Using release branch #{previous_release_branch} as the base for hotfix instead.")
+                            UI.message("ℹ️  Tag '#{previous_version}' not found on the remote. Using release branch '#{previous_release_branch}' as the base for hotfix instead.")
                             previous_release_branch
                           else
-                            UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")
+                            UI.user_error!("Neither tag '#{previous_version}' nor branch '#{previous_release_branch}' exists on the remote! A hotfix branch cannot be created.")
                           end
 
     # Check versions
@@ -534,20 +536,20 @@ platform :ios do
     UI.user_error!('Aborted by user request') unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Check tags
-    UI.user_error!("Version #{version} already exists! Abort!") if git_tag_exists(tag: version)
+    UI.user_error!("Version '#{version}' already exists on the remote! Abort!") if git_tag_exists(tag: version, remote: true)
 
     # Create the hotfix branch
-    UI.message "Creating hotfix branch from #{base_ref_for_hotfix}..."
+    UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: base_ref_for_hotfix)
-    UI.success "Done! New hotfix branch is: #{git_branch}"
+    UI.success("Done! New hotfix branch is: '#{git_branch}'")
 
     # Bump the hotfix version and build code and write it to the `xcconfig` file
-    UI.message 'Bumping hotfix version and build code...'
+    UI.message('Bumping hotfix version and build code...')
     VERSION_FILE.write(
       version_short: version,
       version_long: build_code_hotfix
     )
-    UI.success "Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}"
+    UI.success("Done! New Release Version: '#{release_version_current}'. New Build Code: '#{build_code_current}'")
 
     commit_version_bump
     push_to_git_remote(set_upstream: true, tags: false)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -538,6 +538,9 @@ platform :ios do
     # Check tags
     UI.user_error!("Version '#{version}' already exists on the remote! Abort!") if git_tag_exists(tag: version, remote: true)
 
+    # Fetch the base ref to ensure it's available locally
+    sh('git', 'fetch', 'origin', base_ref_for_hotfix)
+
     # Create the hotfix branch
     UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: base_ref_for_hotfix)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -505,11 +505,21 @@ platform :ios do
     previous_version = VERSION_FORMATTER.release_version(VERSION_CALCULATOR.previous_patch_version(version: parsed_version))
 
     release_branch_name = "release/#{version}"
+    previous_release_branch = "release/#{previous_version}"
+
+    # Determine the base for the hotfix branch: either a tag or a release branch
+    base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
+                            previous_version
+                          elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
+                            previous_release_branch
+                          else
+                            UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")
+                          end
 
     # Check versions
     message = <<-MESSAGE
 
-      New hotfix branch from tag #{previous_version}: #{release_branch_name}
+      New hotfix branch from #{base_ref_for_hotfix}: #{release_branch_name}
 
       Current release version: #{release_version_current}
       New hotfix version: #{version}
@@ -524,11 +534,10 @@ platform :ios do
 
     # Check tags
     UI.user_error!("Version #{version} already exists! Abort!") if git_tag_exists(tag: version)
-    UI.user_error!("Version #{previous_version} is not tagged! A hotfix branch cannot be created.") unless git_tag_exists(tag: previous_version)
 
     # Create the hotfix branch
-    UI.message 'Creating hotfix branch...'
-    Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: previous_version)
+    UI.message "Creating hotfix branch from #{base_ref_for_hotfix}..."
+    Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: base_ref_for_hotfix)
     UI.success "Done! New hotfix branch is: #{git_branch}"
 
     # Bump the hotfix version and build code and write it to the `xcconfig` file
@@ -1356,15 +1365,15 @@ platform :ios do
     BUILD_CODE_FORMATTER.build_code(version: version)
   end
 
-  # Returns the build code of the app for the code freeze. It is the release version name plus sets the build number to 0
+  # Returns the initial build code for a code freeze (e.g., "1.2.3.0" for release version "1.2.3")
+  # Takes the release version and formats it as a four-part build code with the build number set to 0
   #
   def build_code_code_freeze(version_short: nil)
+    # Use provided version or read the current release version from the .xcconfig file
     version_short ||= VERSION_FILE.read_release_version
-    # Read the current build code from the .xcconfig file and parse it into an AppVersion object
-    # The AppVersion is used because Pocket Casts iOS uses the four part (1.2.3.4) build code format, so the version
-    # calculator can be used to calculate the next four-part version
+    # Parse the release version string (e.g., "1.2.3") into an AppVersion object
     release_version_current = VERSION_FORMATTER.parse(version_short)
-    # Return the formatted build code
+    # Format as four-part build code (e.g., "1.2.3.0")
     BUILD_CODE_FORMATTER.build_code(version: release_version_current)
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -511,6 +511,7 @@ platform :ios do
     base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
                             previous_version
                           elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
+                            UI.message("ℹ️  Tag #{previous_version} not found. Using release branch #{previous_release_branch} as the base for hotfix instead.")
                             previous_release_branch
                           else
                             UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -541,6 +541,8 @@ platform :ios do
     # Fetch the base ref to ensure it's available locally
     sh('git', 'fetch', 'origin', base_ref_for_hotfix)
 
+    ensure_branch_does_not_exist!(release_branch_name)
+
     # Create the hotfix branch
     UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch(release_branch_name, from: base_ref_for_hotfix)


### PR DESCRIPTION
Related to AINFRA-1518

## Description

This PR aims to add more robustness and require less manual intervention to the hotfix creation lane `new_hotfix_release`.

We have observed that sometimes it is possible that the release has been finalized but a release tag isn't present yet for some reason (likely due to the fact that the release hasn't been published yet), so release managers will get an error and require manual intervention.

This PR changes the code so that, if no release tag is present, we start the hotfix branch based on the corresponding release branch.


## Testing instructions

These are some test scenarios that can be simulated:
1. There is a release tag that can be used to create the hotfix branch
2. There's no tag, but there's still a release branch that can be used to create the hotfix branch
3. There's no tag or branch (error)
4. The provided version doesn't have a patch component like `30.6` instead of `30.6.1` (error)

To test it, you can create test branches / tags (⚠️ delete them later or, even better, use [this technique](https://github.com/bloom/DayOne-Apple/pull/27670#issuecomment-3553138802) of pointing your working copy’s `origin` remote to a local bare repo instead ⚠️ ) and run `bundle exec fastlane new_hotfix_release skip_confirm:false version:"$VERSION"` and then answer `no` after the prompt so that the lane execution stops and check the printed values.

For example:
1. Create and push release branch `release/30.6` (which doesn't exist and has no corresponding tag for that version)
2. Run `bundle exec fastlane new_hotfix_release skip_confirm:false version:30.6.1`
3. It should use the `release/30.6` branch instead of trying to use a tag. It should print:
```
ℹ️  Tag '30.6' not found on the remote. Using release branch 'release/30.6' as the base for hotfix instead.

New hotfix branch from release/30.6: release/30.6.1

Current release version: 8.0
New hotfix version: 30.6.1

Current build code: 8.0.0.3
New build code: 30.6.1.0


Do you want to continue? (y/n)
```
