### PR TITLE
[Playlists] Up Next History snapshot fix

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UpNextHistoryManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UpNextHistoryManager.swift
@@ -2,6 +2,18 @@ import PocketCastsUtils
 import Foundation
 
 public class UpNextHistoryManager {
+    private let columnNames = [
+        "id",
+        "episodePosition",
+        "episodeUuid",
+        "playlist_id",
+        "upcoming",
+        "timeModified",
+        "wasDeleted",
+        "title",
+        "podcastUuid",
+    ]
+
     /// The number of days to keep the snapshots
     private let periodOfSnapshot: TimeInterval = 14.days
 
@@ -12,7 +24,7 @@ public class UpNextHistoryManager {
     func snapshot(dbQueue: PCDBQueue) {
         dbQueue.write { db in
             do {
-                try db.executeUpdate("INSERT INTO PlaylistEpisodeHistory SELECT *, ? as 'date' FROM SJPlaylistEpisode", values: [Date()])
+                try db.executeUpdate("INSERT INTO PlaylistEpisodeHistory SELECT \(columnNames.joined(separator: ",")), ? as 'date' FROM SJPlaylistEpisode WHERE playlist_id = ?", values: [Date(), UpNextDataManager.upNextPlaylistId])
                 try db.executeUpdate("DELETE FROM PlaylistEpisodeHistory WHERE date <= ?", values: [Date().addingTimeInterval(-periodOfSnapshot)])
             } catch {
                 FileLog.shared.addMessage("UpNextHistoryManager.snapshot error: \(error)")

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -634,6 +634,8 @@ internal enum L10n {
   internal static var createClip: String { return L10n.tr("Localizable", "create_clip", fallback: "Create clip") }
   /// Title for the screen where a user starts creating a filter
   internal static var createFilter: String { return L10n.tr("Localizable", "create_filter", fallback: "Create Filter") }
+  /// Create snapshot
+  internal static var createUpNextSnapshot: String { return L10n.tr("Localizable", "create_up_next_snapshot", fallback: "Create snapshot") }
   /// Description for modal explaining Creator Picks
   internal static var creatorPickModalDescription: String { return L10n.tr("Localizable", "creator_pick_modal_description", fallback: "Creator Picks are podcasts recommended by the show's creator using Podroll.") }
   /// Text used for the "Learn more" link in the modal explaining Creator Picks

--- a/podcasts/Up Next History/UpNextHistoryModel.swift
+++ b/podcasts/Up Next History/UpNextHistoryModel.swift
@@ -43,4 +43,8 @@ class UpNextHistoryModel: ObservableObject {
             FileLog.shared.addMessage("UpNextHistory: Restored Up Next Queue to \(upNextQueueCount) episodes")
         }
     }
+
+    func createSnapshot() {
+        dataManager.snapshotUpNext()
+    }
 }

--- a/podcasts/Up Next History/UpNextHistoryView.swift
+++ b/podcasts/Up Next History/UpNextHistoryView.swift
@@ -43,6 +43,7 @@ struct UpNextHistoryView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 Button("Create snapshot", systemImage: "plus") {
                     model.createSnapshot()
+                    model.loadEntries()
                 }
             }
         })

--- a/podcasts/Up Next History/UpNextHistoryView.swift
+++ b/podcasts/Up Next History/UpNextHistoryView.swift
@@ -41,7 +41,7 @@ struct UpNextHistoryView: View {
         .navigationTitle(L10n.upNextHistory)
         .toolbar(content: {
             ToolbarItem(placement: .topBarTrailing) {
-                Button("Create snapshot", systemImage: "plus") {
+                Button(L10n.createUpNextSnapshot, systemImage: "plus") {
                     model.createSnapshot()
                     model.loadEntries()
                 }

--- a/podcasts/Up Next History/UpNextHistoryView.swift
+++ b/podcasts/Up Next History/UpNextHistoryView.swift
@@ -39,6 +39,13 @@ struct UpNextHistoryView: View {
             model.loadEntries()
         }
         .navigationTitle(L10n.upNextHistory)
+        .toolbar(content: {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Create snapshot", systemImage: "plus") {
+                    model.createSnapshot()
+                }
+            }
+        })
         .applyDefaultThemeOptions()
     }
 }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4474,6 +4474,9 @@
 /* Title of a screen that display Up Next history */
 "up_next_history" = "Up Next History";
 
+/* Create snapshot */
+"create_up_next_snapshot" = "Create snapshot";
+
 /* A message explaining how to use the Up Next history */
 "up_next_history_explanation" = "A list of recent updates to Up Next due to changes on other devices. To view the episodes and have the option to restore them, tap any entry.";
 


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/playlists-internal-testing-b4b2f66c6304/issues?layout=list&ordering=priority&grouping=workflowState&subGrouping=team&showCompletedIssues=all&showSubIssues=true&showTriageIssues=true)
|:---:|

Fixes [PCIOS-341](https://linear.app/a8c/issue/PCIOS-341/up-next-snapshots-are-broken-with-playlists)

* This fixes an Up Next History snapshot bug by explicitly listing the columns for the playlist history so changes to `SJPlaylistEpisode` don't affect the `PlaylistEpisodeHistory` table.
* Adds a Plus button to create a new Up Next snapshot on demand. **SHOULD THIS BE ADDED?** We could show this only in debug but it's very useful for triggering this logic.

## To test

* Navigate to Profile > Settings > Up Next History
* Tap the + button
* Ensure a snapshot is created
* Smoke test the snapshot creationg and restore functionality

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
