### PR TITLE
Add flow to purchase events

### DIFF
--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -672,6 +672,10 @@ private extension IAPHelper {
         if let source = OnboardingFlow.shared.source {
             properties["source"] = source.rawValue
         }
+
+        let flow = OnboardingFlow.shared.currentFlow
+        properties["flow"] = flow.rawValue
+
         if let error = error {
             properties["error_code"] = error.code
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
The source field is not enough to distinguish all the purchase paths and we need to add the `flow` to make that distinction

## To test

1. Ensure that you have the tracksLogging FF enabled
2. Start the app from clean install
3. Start the initial onboarding flow with a new user and go up to the Plus purchase screen
4. Start the IAP flow
5. First time on Apple IAP screen press X to cancel. Check if the event: `purchase_cancelled` is tracked and the flow property is set to `initial_onboarding`
6. Tap on purchase again this time disconnect the network and see if you get the purchase to error out. Check if the event: `purchase_failed` is tracked and the flow property is set to `initial_onboarding`
7. Tap purchase again ( ensure that you network on this time). Complete the purchase check if the event: `purchase_successful` is tracked and flow property is set to `initial_onboarding`
8. Smoke test the app using other upgrade scenarios (folders, bookmarks, profile) and check if the flow property is set

## Checklists
- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
