### PR TITLE
[Playlists] Return earlier if empty upnext

### DIFF
--- a/podcasts/New Detail/PlaylistDetailViewController+PlayAll.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+PlayAll.swift
@@ -11,6 +11,13 @@ extension PlaylistDetailViewController: UISheetPresentationControllerDelegate, P
             guard let self else { return }
             let hasDifferencesWithUpNext = await self.checkDifferencesWithUpNext()
             if hasDifferencesWithUpNext {
+                if PlaybackManager.shared.queue.upNextCount() == 0 {
+                    // there's nothing to over-write, so nothing to confirm either
+                    await MainActor.run {
+                        self.viewModel.playAllEpisodes()
+                    }
+                    return
+                }
                 await MainActor.run {
                     let sheet = PlaylistPlayAllSheetHost(delegate: self)
                     self.present(sheet, animated: true)
@@ -51,12 +58,6 @@ extension PlaylistDetailViewController: UISheetPresentationControllerDelegate, P
 
     func onTapSaveAndReplace() {
         presentedViewController?.dismiss(animated: true)
-
-        if PlaybackManager.shared.queue.upNextCount() == 0 {
-            // there's nothing to over-write, so nothing to confirm either
-            viewModel.playAllEpisodes()
-            return
-        }
 
         track(
             .filterPlayAllReplaceAndPlayTapped,


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-342

#3704 moved the check of empty UpNext too late. This PR fixes it.

## To test

- Run this branch
- Go to the UpNext and clear it
- Open a Playlist
- Tap on Play all
- [ ] Confirm there's no Sheet presented
- [ ] Confirm it starts playing
- Open another playlist while playing
- Tap Play all
- [ ] Confirm the Sheet is presented
- Smoke test the UI is not blocked and Play all always work

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
