### PR TITLE
[Playback 2025] Fix PaidStoryWall analytics

### DIFF
--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -19,7 +19,7 @@ struct PaidStoryWallView2025: StoryView {
 
     private let videoAspectRatio = CGFloat(1.37)
 
-    let plusOnly = true
+    let plusOnly = false
 
     init(subscriptionTier: SubscriptionTier) {
         self.subscriptionTier = subscriptionTier
@@ -53,7 +53,7 @@ struct PaidStoryWallView2025: StoryView {
                         guard let storiesViewController = SceneHelper.rootViewController() else {
                             return
                         }
-
+                        Analytics.track(.endOfYearUpsellShown, properties: ["year": "2025"])
                         NavigationManager.sharedManager.showUpsellView(from: storiesViewController, source: .endOfYear, flow: SyncManager.isUserLoggedIn() ? .endOfYearUpsell : .endOfYear)
                     } else {
                         Analytics.track(.endOfYearPlusContinued, properties: ["year": EndOfYear.currentYear.literalValue])
@@ -74,11 +74,13 @@ struct PaidStoryWallView2025: StoryView {
                 .ignoresSafeArea()
                 .allowsHitTesting(false)
         }
-        .onAppear {
-            Analytics.track(.endOfYearUpsellShown, properties: ["year": "2025"])
-            Analytics.track(.endOfYearStoryShown, story: identifier)
+        .onAppear() {
             pauseState.togglePause()
         }
+    }
+
+    func onAppear() {
+        Analytics.track(.endOfYearStoryShown, story: identifier)
     }
 }
 

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -179,8 +179,12 @@ class StoriesModel: ObservableObject {
         guard isReady, numberOfStories > 0 else {
             return
         }
-
-        let nextNonPlus = currentStoryIsPlus ? Int(progress.rounded(.down)) + numberOfPlusStoriesAfterTheCurrentOne() + 1 : 0
+        let nextNonPlus: Int
+        if EndOfYear.Year.y2025 == EndOfYear.currentYear {
+            nextNonPlus = Int(progress.rounded(.down)) + numberOfPlusStoriesAfterTheCurrentOne() + 1
+        } else {
+            nextNonPlus = currentStoryIsPlus ? Int(progress.rounded(.down)) + numberOfPlusStoriesAfterTheCurrentOne() + 1: 0
+        }
 
         manuallyChanged = true
 
@@ -192,7 +196,12 @@ class StoriesModel: ObservableObject {
             return
         }
 
-        let previousNonPlus = currentStoryIndex - numberOfPlusStoriesBeforeTheCurrentOne()
+        let previousNonPlus: Int
+        if EndOfYear.Year.y2025 == EndOfYear.currentYear {
+            previousNonPlus = currentStoryIndex - numberOfPlusStoriesBeforeTheCurrentOne() - 1
+        } else {
+            previousNonPlus = currentStoryIndex - numberOfPlusStoriesBeforeTheCurrentOne()
+        }
 
         manuallyChanged = true
 
@@ -257,7 +266,10 @@ class StoriesModel: ObservableObject {
     }
 
     func shouldShowUpsell() -> Bool {
-        currentStoryIsPlus && activeTier() == .none
+        if case EndOfYear.Year.y2025 = EndOfYear.currentYear {
+            return false
+        }
+        return currentStoryIsPlus && activeTier() == .none
     }
 
     func paywallView() -> some View {

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -131,7 +131,7 @@ class StoriesModel: ObservableObject {
 
         // Only trigger onAppear if the story is not plus or user is paid
         // Otherwise, the paywall appears in front of the story
-        if !story.plusOnly || isPaidUser() {
+        if currentStory?.identifier != story.identifier, !story.plusOnly || isPaidUser() {
             story.onAppear()
         }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-346 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates paywall presentation to use different logic for end of year 2025. Instead of showing a Paywall view on front we use a story that is shown at that step. This influences some of the logic around moving forward and backward on the plus story, because we are no longer overlaying the paywal on top of an existing story. It also ensures that analytics events are sent only once when entering the paywall and not when preloading.


## To test

- Start the app
- Login with an user that has some stats for 2025
- Enable tracksLogging FF
- Go to Profile -> Settings -> Beta features
- Enable the FF `End of Year 2025`
- Go to Developer Menu and tap on "End Of Year -> Reset modal/profile badge" and select 2025
- Restart the app
- Go to Profile 
- Check that you see a banner for the playback 2025
- Tap on it

### User with a subscription
- Advance until you get to the paywall view ( the one with the lock video)
- Check that only when you see the paywall page you get the event: `end_of_year_story_shown ["story": "plus_interstitial", "year": "2025"]` and no other event or duplication
- Tap on Continue, check if you see the event `end_of_year_plus_continued ["year": "2025"]`
- And check if it's followed by `end_of_year_story_shown ["year": "2025", "story": "year_over_year"]`

### User without a subscription
- Advance until you get to the paywall view ( the one with the lock video)
- Check that only when you see the paywall page you get the event: `end_of_year_story_shown ["story": "plus_interstitial", "year": "2025"]` and no other event or duplication
- Tap on Get Plus, check if you see the events:
  - end_of_year_upsell_shown ["year": "2025"]
  - plus_promotion_shown ["version": "1", "variant": "A", "source": "endOfYear", "flow": "endOfYearUpsell"]
- Cancel the purchase
- Tap to move forward on the screen
- Check that the plus stories are jumped and no events are show for them ( year-over-year and completion)
- You see the `end_of_year_story_shown ["story": "ending", "year": "2025"]` 


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
