### PR TITLE
Change to bulkAdd for snapshot restore

### DIFF
--- a/podcasts/Up Next History/UpNextHistoryModel.swift
+++ b/podcasts/Up Next History/UpNextHistoryModel.swift
@@ -31,12 +31,10 @@ class UpNextHistoryModel: ObservableObject {
         Task {
             let episodesUuid = dataManager.upNextHistoryEpisodes(entry: entry)
             FileLog.shared.addMessage("UpNextHistory: Restoring entries from \(entry) with episodes: [\(episodesUuid.joined(separator: ","))]")
-            episodesUuid.forEach { episodeUuid in
-                if let episode = dataManager.findBaseEpisode(uuid: episodeUuid) {
-                    PlaybackManager.shared.addToUpNext(episode: episode, ignoringQueueLimit: true, userInitiated: false)
-                }
+            let baseEpisodes = episodesUuid.compactMap { episodeUuid in
+                dataManager.findBaseEpisode(uuid: episodeUuid)
             }
-            PlaybackManager.shared.queue.bulkOperationDidComplete()
+            PlaybackManager.shared.bulkAdd(baseEpisodes, toTop: false)
             PlaybackManager.shared.queue.refreshList(checkForAutoDownload: false)
 
             let upNextQueueCount = PlaybackManager.shared.upNextQueueCount()


### PR DESCRIPTION
Fixes an issue caught in #3718 with the application of the Up Next snapshot.

When we call `PlaybackManager.shared.addToUpNext`, the ``UpNextButton.episodeAdded` is triggered, causing animations to stack up. Instead, we should use `bulkAdd` to apply the snapshot so that we don't trigger those animations.

## To test

* Create an Up Next queue with hundreds of episodes (>500) by selecting all from various podcasts and adding
* Clear the Up Next queue
* Go to Profile > Settings > Up Next History
* Apply an Up Next history snapshot
* ✅ Ensure episodes are added to Up Next queue and results are applied instantly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
