### PR TITLE
[Playback 25] Fix YoY Story Up text and fix seconds conversion

### DIFF
--- a/podcasts/End of Year/Stories/2025/YearOverYearCompare2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/YearOverYearCompare2025Story.swift
@@ -174,8 +174,8 @@ final private class LottieTextProvider: AnimationTextProvider, Equatable {
         prevYear: Double,
         currentYear: Double
     ) {
-        self.prevYear = Int(prevYear)
-        self.currentYear = Int(currentYear)
+        self.prevYear = Int(prevYear/3600)
+        self.currentYear = Int(currentYear/3600)
         dict = [
             "hours_2024": Self.formatted(hours: self.prevYear),
             "hours_2025": Self.formatted(hours: self.currentYear)
@@ -199,21 +199,21 @@ fileprivate class MyFontProvider: AnimationFontProvider {
 }
 
 #Preview("Down") {
-    YearOverYearCompare2025Story(subscriptionTier: .plus, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 20, totalPlayedTimeLastYear: 300))
+    YearOverYearCompare2025Story(subscriptionTier: .plus, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 72000, totalPlayedTimeLastYear: 300000))
         .body.environment(\.animated, false)
 }
 
 #Preview("Up") {
-    YearOverYearCompare2025Story(subscriptionTier: .patron, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 300, totalPlayedTimeLastYear: 200))
+    YearOverYearCompare2025Story(subscriptionTier: .patron, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 203360, totalPlayedTimeLastYear: 173734))
         .body.environment(\.animated, false)
 }
 
 #Preview("Up - Max") {
-    YearOverYearCompare2025Story(subscriptionTier: .plus, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 300, totalPlayedTimeLastYear: 20))
+    YearOverYearCompare2025Story(subscriptionTier: .plus, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 300000, totalPlayedTimeLastYear: 20000))
         .body.environment(\.animated, false)
 }
 
 #Preview("Same") {
-    YearOverYearCompare2025Story(subscriptionTier: .patron, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 30, totalPlayedTimeLastYear: 30))
+    YearOverYearCompare2025Story(subscriptionTier: .patron, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 30000, totalPlayedTimeLastYear: 30000))
         .body.environment(\.animated, false)
 }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2311,7 +2311,7 @@ internal enum L10n {
   /// Playback 2025: Title showed in the Year Over Year Comparison story when the percentage is the same compared to the last year.
   internal static var playback2025YearOverYearComparisonSameTitle: String { return L10n.tr("Localizable", "playback_2025_year_over_year_comparison_same_title", fallback: "Your 2025 listening held steady") }
   /// Playback 2025: Message showed in the Year Over Year Comparison story when the percentage is up compared to the last year.
-  internal static var playback2025YearOverYearComparisonUpMessage: String { return L10n.tr("Localizable", "playback_2025_year_over_year_comparison_up_message", fallback: "Hope you stretched first!") }
+  internal static var playback2025YearOverYearComparisonUpMessage: String { return L10n.tr("Localizable", "playback_2025_year_over_year_comparison_up_message", fallback: "More podcasts, more joy") }
   /// Playback 2025: Title showed in the Year Over Year Comparison story when the percentage is up compared to the last year. %1$@ represent a placeholder for the formatted percentage.
   internal static func playback2025YearOverYearComparisonUpTitle(_ p1: Any) -> String {
     return L10n.tr("Localizable", "playback_2025_year_over_year_comparison_up_title", String(describing: p1), fallback: "Compared to 2024, your listening time skyrocketed %1$@")

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5754,7 +5754,7 @@
 "playback_2025_year_over_year_comparison_up_title" = "Compared to 2024, your listening time skyrocketed %1$@";
 
 /* Playback 2025: Message showed in the Year Over Year Comparison story when the percentage is up compared to the last year. */
-"playback_2025_year_over_year_comparison_up_message" = "Hope you stretched first!";
+"playback_2025_year_over_year_comparison_up_message" = "More podcasts, more joy";
 
 /* Playback 2025: Title showed in the Year Over Year Comparison story when the percentage is the same compared to the last year. */
 "playback_2025_year_over_year_comparison_same_title" = "Your 2025 listening held steady";


### PR DESCRIPTION
| 📘 Part of: [Playback 25](https://linear.app/a8c/project/ios-playback-2025-7fed05fea613/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-347
Fixes PCIOS-348

| Down | Up | Hero | Same |
| :-------: | :-------: | :-------: | :-------: |
| <img width="414" height="811" alt="Screenshot 2025-11-20 at 18 03 55" src="https://github.com/user-attachments/assets/c00c9f9e-53af-46e6-bcca-a601cb095dbe" /> | <img width="417" height="821" alt="Screenshot 2025-11-20 at 18 04 18" src="https://github.com/user-attachments/assets/0f3299bd-7bb6-4495-98d4-da3e711e6130" /> | <img width="413" height="810" alt="Screenshot 2025-11-20 at 18 04 39" src="https://github.com/user-attachments/assets/afc01d48-ae79-4e8d-accb-c5a0b255b82a" /> | <img width="405" height="809" alt="Screenshot 2025-11-20 at 18 05 04" src="https://github.com/user-attachments/assets/0152cae1-4bd8-484a-aa37-2b32c388b353" /> |


## To test

- Run this branch
- Make sure you same listening history
- Make sure your account is a Plus/Patron account or give yourself a Plus/Patron
- Make sure the EOY FFs are on
- Go to Profile
- Start Playback 25 and tap till you arrive at the YoY Story
- If the time you see is not the Up, feel free to mock the Datasource to force it
- Confirm the Up subtitle is the one in the screenshot
- Confirm the values are converted in hours and not in seconds

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
