### PR TITLE
Fix playlist row accessibility

### DIFF
--- a/podcasts/NewPlaylistCellView.swift
+++ b/podcasts/NewPlaylistCellView.swift
@@ -54,6 +54,7 @@ struct NewPlaylistCellView: View {
                 PlaylistArtworkView(items: viewModel.images)
                     .frame(width: 56.0, height: 56.0)
                     .padding(.leading, 16.0)
+                    .accessibilityHidden(true)
             }
             VStack(alignment: .leading, spacing: 2.0) {
                 Text(title)
@@ -66,6 +67,7 @@ struct NewPlaylistCellView: View {
             Spacer()
             accesoryView()
         }
+        .accessibilityElement(children: .combine)
         .background(.clear)
     }
 
@@ -80,6 +82,7 @@ struct NewPlaylistCellView: View {
         case .count:
             HStack(spacing: 5.0) {
                 subtitleView(text: "\(viewModel.episodesCount)")
+                    .accessibilityLabel("\(viewModel.episodesCount) \(L10n.episodes)")
             }
             .padding(.trailing, 8.0)
         default:

--- a/podcasts/PlaylistCellView.swift
+++ b/podcasts/PlaylistCellView.swift
@@ -69,6 +69,7 @@ struct PlaylistCellView: View {
                 PlaylistArtworkView(items: viewModel.images)
                     .frame(width: 56.0, height: 56.0)
                     .padding(.leading, 16.0)
+                    .accessibilityHidden(true)
             }
             VStack(alignment: .leading, spacing: 2.0) {
                 Text(title)


### PR DESCRIPTION
Fixes Playlist Cell accessibility for Voice Over.

Tried to fix this in #3707 but my accessibility changes were only on `PlaylistCellView` and not `NewPlaylistCellView`, probably a timing issue.

## To test

- Enable Voice Over
- Navigate to the Playlist tab
- Scroll through the rows
- ✅ Ensure that each row is read as a single item
- Open a playlist
- Swipe through the top header
- ✅ Ensure that the playlist artwork is a single item and doesn't read "Playlist image" (I checked Apple Music and they don't seem to speak this in playlist songs)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
