### PR TITLE
[Search] Update analytics events

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -763,6 +763,7 @@ enum AnalyticsEvent: String {
     case searchFilterTapped
     case searchPredictiveShown
     case searchPredictiveTermTapped
+    case searchPredictiveViewAllTapped
 
     // MARK: - Chromecast
 

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -38,8 +38,12 @@ class SearchAnalyticsHelper: ObservableObject {
         Analytics.track(.searchPredictiveFailed, properties: ["source": source, "error_code": (error as NSError).code])
     }
 
-    func trackPredictiveTermTapped() {
-        Analytics.track(.searchPredictiveTermTapped, properties: ["source": source])
+    func trackPredictiveTermTapped(term: String) {
+        Analytics.track(.searchPredictiveTermTapped, properties: ["source": source, "term": term])
+    }
+
+    func trackPredictiveViewAllTapped(term: String) {
+        Analytics.track(.searchPredictiveViewAllTapped, properties: ["source": source, "term": term])
     }
 
     func trackResultTapped(_ searchResult: AnalyticsSearchResultItem) {

--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -85,6 +85,9 @@ struct NewSearchResultsView: View {
                     .listRowSeparatorTint(theme.primaryUi05)
                     .scrollContentBackground(.hidden)
                     .ignoresSafeArea(.keyboard, edges: .bottom)
+                    .onAppear() {
+                        self.searchAnalyticsHelper.trackListShown(displayMode)
+                    }
                 }
             }
         }

--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -94,7 +94,7 @@ struct NewSearchResultsView: View {
     @ViewBuilder var showFullResultsButton: some View {
         Button(action: {
             searchResults.search(term: searchResults.currentSearchTerm)
-            searchAnalyticsHelper.trackPredictiveViewAllTapped(term: searchResults.currentSearchTerm)
+            searchAnalyticsHelper.trackPredictiveViewAllTapped(term: searchResults.currentPredictiveSearchTerm)
         }, label: {
             Text(L10n.searchResultsViewAll(searchResults.currentSearchTerm))
                 .font(style: .subheadline, weight: .medium)

--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -94,6 +94,7 @@ struct NewSearchResultsView: View {
     @ViewBuilder var showFullResultsButton: some View {
         Button(action: {
             searchResults.search(term: searchResults.currentSearchTerm)
+            searchAnalyticsHelper.trackPredictiveViewAllTapped(term: searchResults.currentSearchTerm)
         }, label: {
             Text(L10n.searchResultsViewAll(searchResults.currentSearchTerm))
                 .font(style: .subheadline, weight: .medium)

--- a/podcasts/New Search/Views/Results/PredictiveList.swift
+++ b/podcasts/New Search/Views/Results/PredictiveList.swift
@@ -94,7 +94,7 @@ struct PredictiveList: View {
     func termRow(term: String) -> some View {
         let formattedText = highlightTerm(searchResults.currentPredictiveSearchTerm, on: term)
         Button(action: {
-            searchAnalyticsHelper.trackPredictiveTermTapped()
+            searchAnalyticsHelper.trackPredictiveTermTapped(term: term)
             searchResults.search(term: term)
             searchHistory.add(searchTerm: term)
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastSearchRequest, object: term)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -163,7 +163,7 @@ internal enum L10n {
   /// A common string used throughout the app. Option that determines the behavior of the app after playing an item.
   internal static var afterPlaying: String { return L10n.tr("Localizable", "after_playing", fallback: "After Playing") }
   /// Search Results filter option
-  internal static var allResults: String { return L10n.tr("Localizable", "all_results", fallback: "All Results") }
+  internal static var allResults: String { return L10n.tr("Localizable", "all_results", fallback: "Top Results") }
   /// Autoplay feature announcement description
   internal static var announcementAutoplayDescription: String { return L10n.tr("Localizable", "announcement_autoplay_description", fallback: "If your Up Next queue is empty and you start listening to an episode, Autoplay will keep playing episodes from that show or list.") }
   /// Autoplay feature announcement title

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5682,7 +5682,7 @@
 "interests_select_at_least" = "Select at least %1$@";
 
 /* Search Results filter option */
-"all_results" = "All Results";
+"all_results" = "Top Results";
 
 /// A description of the Playback 2025 feature
 "playback_2025_description" =  "See your top podcasts, categories, listening stats and more. Share with friends and shout out your favourite creators!";


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-345 <!-- issue number, if applicable -->
Fixes PCIOS-359
Fixed PCIOS-358

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

- Adds tracking for pressing View all results and ensure that term parameter is passed.
- Ensures that search_list_show is sent after search is performed
- Update All Results to Top Results

## To test

- Start the app
- Ensure that you have tracksLogging FF enabled
- Tap on the search bar on Discovery or Podcasts
- Type a term without pressing Enter
- Check if predictive results are shown
- Scroll down until you see the footer button: "View all results for `xxx` "
- Tap on it
- Check if `search_predictive_view_all_tapped` is tracked with the term parameter
- Change the search string without pressing Enter
- Tap on one of the terms suggestions
- Check if `search_predictive_term_tapped` is tracked with the term parameter
- Check if `search_list_show` is tracked`
- Check if Pill show `Top Results` instead of `All Results`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
