### PR TITLE
[Analytics] Add event for banner tap on plus banner

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -40,6 +40,7 @@ enum AnalyticsEvent: String {
     case plusPromotionPrivacyPolicyTapped
     case plusPromotionTermsAndConditionsTapped
     case plusPromotionDetailsTapped
+    case plusPromotionBannerButtonTapped
 
     // MARK: - Setup Account
 

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
@@ -18,6 +18,7 @@ class PlusAccountPromptTableCell: ThemeableCell {
         let view: UIView
         if FeatureFlag.newOnboardingUpgrade.enabled {
             view = UpgradeBannerView(viewModel: UpgradeAccountViewModel(upgradeTier: .plus, selectedProduct: .yearly, viewSource: .profile, flowSource: .accountScreen), onSubscribeTap: {
+                Analytics.track(.plusPromotionBannerButtonTapped, properties: ["source": PlusUpgradeViewSource.profile.rawValue, "flow": OnboardingFlow.Flow.plusAccountUpgrade.rawValue])
                 let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: model.parentController, source: .profile, context: nil)
                 model.parentController?.present(controller, animated: true)
             }).themedUIView


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

- Start the app
- Ensure that you have tracksLogging FF enabled
- Login with an user without a subscription
- Go to profile -> Account
- Tap on the button on the plus promotion banner
- Check if the event `plusPromotionBannerButtonTapped` is tracked

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
