### PR TITLE
[Playback 2025 ]Update loading and failed view for playback

### DIFF
--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -66,7 +66,6 @@ struct StoriesView: View {
             }
 
             header
-                .foregroundStyle(model.indicatorColor(for: model.currentStoryIndex))
 
             // Hide the share button if needed
             if model.showShareButton(index: model.currentStoryIndex) && !model.shouldShowUpsell(), let shareView = model.overlaidShareView() {
@@ -111,9 +110,13 @@ struct StoriesView: View {
                 let progress = syncProgressModel.progress
                 CircularProgressView(value: progress, stroke: model.indicatorColor(for: model.currentStoryIndex), strokeWidth: 6)
                     .frame(width: 40, height: 40)
-                Text(L10n.loading)
-                    .foregroundColor(model.indicatorColor(for: model.currentStoryIndex))
-                    .font(style: .body)
+                if case EndOfYear.Year.y2025 = EndOfYear.currentYear {
+                    EmptyView()
+                } else {
+                    Text(L10n.loading)
+                        .foregroundColor(model.indicatorColor(for: model.currentStoryIndex))
+                        .font(style: .body)
+                }
             }
 
             storySwitcher
@@ -125,16 +128,22 @@ struct StoriesView: View {
     var failed: some View {
         ZStack {
             Spacer()
-
-            Text(L10n.eoyStoriesFailed)
-                .foregroundColor(model.indicatorColor(for: model.currentStoryIndex))
-
+            if EndOfYear.currentYear == .y2025 {
+                EmptyView()
+            } else {
+                Text(L10n.eoyStoriesFailed)
+                    .foregroundColor(model.indicatorColor(for: model.currentStoryIndex))
+            }
             storySwitcher
             header
         }
         .background(model.primaryBackgroundColor)
         .onAppear {
             Analytics.track(.endOfYearStoriesFailedToLoad, properties: ["year": EndOfYear.currentYear.literalValue])
+            if EndOfYear.currentYear == .y2025 {
+                model.stopAndDismiss()
+                Toast.show(L10n.playback2025FailedToLoad)
+            }
         }
     }
 
@@ -163,6 +172,7 @@ struct StoriesView: View {
             }
         }
         .padding(.top, Constants.headerTopPadding)
+        .foregroundStyle(model.indicatorColor(for: model.currentStoryIndex))
     }
 
     var closeButton: some View {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2231,7 +2231,7 @@ internal enum L10n {
   internal static var playback2025EndStoryDescription: String { return L10n.tr("Localizable", "playback_2025_end_story_description", fallback: "Share your Playback with friends and show some love to the podcasters who kept you company all year") }
   /// Playback 2025: Title for the last story
   internal static var playback2025EndStoryTitle: String { return L10n.tr("Localizable", "playback_2025_end_story_title", fallback: "Thanks for spending your year with Pocket Casts") }
-  /// Sorry, we couldn’t load Playback
+  /// Message to shown when playback 2025 failed to load
   internal static var playback2025FailedToLoad: String { return L10n.tr("Localizable", "playback_2025_failed_to_load", fallback: "Sorry, we couldn’t load Playback") }
   /// See your listening stats, top podcasts, and more.
   internal static var playback2025FeatureDescription: String { return L10n.tr("Localizable", "playback_2025_feature_description", fallback: "See your listening stats, top podcasts, and more.") }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2231,6 +2231,8 @@ internal enum L10n {
   internal static var playback2025EndStoryDescription: String { return L10n.tr("Localizable", "playback_2025_end_story_description", fallback: "Share your Playback with friends and show some love to the podcasters who kept you company all year") }
   /// Playback 2025: Title for the last story
   internal static var playback2025EndStoryTitle: String { return L10n.tr("Localizable", "playback_2025_end_story_title", fallback: "Thanks for spending your year with Pocket Casts") }
+  /// Sorry, we couldn’t load Playback
+  internal static var playback2025FailedToLoad: String { return L10n.tr("Localizable", "playback_2025_failed_to_load", fallback: "Sorry, we couldn’t load Playback") }
   /// See your listening stats, top podcasts, and more.
   internal static var playback2025FeatureDescription: String { return L10n.tr("Localizable", "playback_2025_feature_description", fallback: "See your listening stats, top podcasts, and more.") }
   /// Playback 2025

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5806,4 +5806,5 @@
 /* A description shown in the Playback thanks screen for Pocket Casts Plus subscribers. %1$@ argument is your subscription Tier. Ex:  Your Plus perks unlock extra stats and power features" */
 "playback_2025_plus_thanks_description" = "Your %1$@ perks unlock extra stats and power features";
 
-
+/* Message to shown when playback 2025 failed to load */
+"playback_2025_failed_to_load" = "Sorry, we couldn’t load Playback";


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-356 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

| Load | Failed |
| - | - |
| <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-11-21 at 18 59 53" src="https://github.com/user-attachments/assets/456f0a0d-5999-4622-bcdb-864954e35905" /> |  <img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-11-21 at 16 51 09" src="https://github.com/user-attachments/assets/d35c1e34-160d-4a92-bdb6-72ea8862fa47" /> |


## To test

- Make sure the Playback 25 FF are on
- Go to profile
- Tap on the banner
- Check if loading switcher and x button on top are white, and no "loading text is visible"
- Reinstall the app
- Make sure the Playback 25 FF are on
- Go to profile
- Turn Wifi Off and check if loading fails and playback is dismissed and a toast shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
