### PR TITLE
Onboarding analytics fixes

### DIFF
--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -424,6 +424,7 @@ enum PlusUpgradeViewSource: String {
     case upNextShuffle
     case generatedTranscripts
     case onboarding
+    case onboardingRecommendations = "onboarding_recommendations"
     case suggestedFolders = "suggested_folders"
     case bannerAd = "banner_ad"
     case login

--- a/podcasts/NewEmailViewController.swift
+++ b/podcasts/NewEmailViewController.swift
@@ -114,7 +114,8 @@ class NewEmailViewController: PCViewController, UITextFieldDelegate {
         originalButtonConstant = nextButtonBottomConstraint.constant
 
         updateButtonState()
-        Analytics.track(.createAccountShown)
+
+        OnboardingFlow.shared.track(.createAccountShown)
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -75,7 +75,6 @@ class LoginCoordinator: NSObject, OnboardingModel {
     }
 
     func getStartedTapped() {
-        OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "get_started"])
         OnboardingFlow.shared.updateAnalyticsSource(.onboardingRecommendations)
         let hostingController: UIViewController
         if FeatureFlag.newOnboardingRecommendationChanges.enabled {
@@ -108,7 +107,6 @@ class LoginCoordinator: NSObject, OnboardingModel {
 
     func recommendationsContinueTapped() {
         socialAuthProvider = nil
-        OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "recommendations_continue"])
         let view = LoginLandingView(coordinator: self, fullScreenMode: true)
         let hostingController = LoginLandingHostingController(rootView: view.setupDefaultEnvironment())
         hostingController.viewModel = self

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -76,6 +76,7 @@ class LoginCoordinator: NSObject, OnboardingModel {
 
     func getStartedTapped() {
         OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "get_started"])
+        OnboardingFlow.shared.updateAnalyticsSource(.onboardingRecommendations)
         let hostingController: UIViewController
         if FeatureFlag.newOnboardingRecommendationChanges.enabled {
             let view = InterestsView(continueCallback: { categories in

--- a/podcasts/Onboarding/PodcastSubscribeButton.swift
+++ b/podcasts/Onboarding/PodcastSubscribeButton.swift
@@ -79,6 +79,6 @@ struct PodcastSubscribeButton: View {
 
         PodcastManager.shared.unsubscribe(podcast: podcast)
 
-        Analytics.track(.podcastUnsubscribed, properties: ["source": searchAnalyticsHelper.source, "uuid": podcast.uuid])
+        OnboardingFlow.shared.track(.podcastUnsubscribed, properties: ["source": searchAnalyticsHelper.source, "uuid": podcast.uuid])
     }
 }

--- a/podcasts/Onboarding/PodcastSubscribeButton.swift
+++ b/podcasts/Onboarding/PodcastSubscribeButton.swift
@@ -67,7 +67,7 @@ struct PodcastSubscribeButton: View {
         HapticsHelper.triggerSubscribedHaptic()
 
         let analyticsUuid = podcast.uuid ?? podcast.iTunesId ?? "unknown"
-        Analytics.track(.podcastSubscribed, properties: ["source": searchAnalyticsHelper.source, "uuid": analyticsUuid])
+        OnboardingFlow.shared.track(.podcastSubscribed, properties: ["source": searchAnalyticsHelper.source, "uuid": analyticsUuid])
     }
 
     private func unsubscribe() {


### PR DESCRIPTION
Part of [PCIOS-285](https://linear.app/a8c/issue/PCIOS-285/fix-analytics-event-in-onboarding-and-account-creation-flows)



## To test

Use a fresh install with `tracksLogging` enabled.

* Navigate through the onboarding sequence
* ✅ Verify that tapping "Get Started" does not log `setup_account_button_tapped` but it _does_ log `onboarding_get_started`:

```
🔵 Tracked: onboarding_get_started ["source": "onboarding", "flow": "initial_onboarding"]
```

* Skip through the categories selection
* Subscribe to a podcast in the Recommendations page
* ✅ Verify that `podcast_subscribed` is logged with `flow: initial_onboarding`:
```
🔵 Tracked: podcast_subscribed ["source": "onboarding_recommendations", "uuid": "170a7610-948e-0135-9d21-5bb073f92b78", "flow": "initial_onboarding"]
```

* ✅ Verify that tapping "Continue" in the recommendations does not log `setup_account_button_tapped` but does log `recommendations_continue_tapped `:
```
🔵 Tracked: recommendations_continue_tapped ["subscriptions": 0, "flow": "initial_onboarding", "source": "onboarding_recommendations"]
```

* Tap "Sign up with email"
* ✅ Verify that `setup_account_button_tapped` is logged with `button: create_account`:
```
🔵 Tracked: setup_account_button_tapped ["button": "create_account", "flow": "initial_onboarding", "source": "onboarding_recommendations"]
```
* ✅ Verify that `create_account_shown` is logged with `flow: initial_onboarding`:
```
🔵 Tracked: create_account_shown ["flow": "initial_onboarding", "source": "onboarding_recommendations"]
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
