### PR TITLE
[Playback 2025] Auto close and dismiss playback when timer expire at last history

### DIFF
--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -155,6 +155,14 @@ struct EndOfYear {
         }
     }
 
+    var configuration: StoriesConfiguration {
+        let configuration = StoriesConfiguration()
+        if EndOfYear.currentYear == .y2025 {
+            configuration.closeAndDismissAfterFinished = true
+        }
+        return configuration
+    }
+
     func showStories(in viewController: UIViewController, from source: EndOfYearPresentationSource) {
         guard let storyModelType else { return }
 
@@ -171,7 +179,7 @@ struct EndOfYear {
 
         let model = storyModelType.init()
 
-        let storiesViewController = StoriesHostingController(rootView: StoriesView(dataSource: EndOfYearStoriesDataSource(model: model)).padding(storiesPadding))
+        let storiesViewController = StoriesHostingController(rootView: StoriesView(dataSource: EndOfYearStoriesDataSource(model: model), configuration: configuration).padding(storiesPadding))
         storiesViewController.view.backgroundColor = .black
         storiesViewController.modalPresentationStyle = presentationMode
 

--- a/podcasts/End of Year/StoriesConfiguration.swift
+++ b/podcasts/End of Year/StoriesConfiguration.swift
@@ -8,6 +8,12 @@ class StoriesConfiguration {
     /// Default value is `false`
     var startOverFromBeginningAfterFinished: Bool = false
 
+    // If set to `true` it will close the playback after the last one finished
+    /// Otherwise, it will just pause on the last one.
+    ///
+    /// Default value is `false`
+    var closeAndDismissAfterFinished: Bool = false
+
     /// The number of stories to preload
     ///
     /// When showing the story number zero, StoriesView will

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -131,6 +131,10 @@ class StoriesModel: ObservableObject {
                     newProgress = 0
                     self.currentStoryIndex = 0
                 }
+                else if self.configuration.closeAndDismissAfterFinished {
+                    Analytics.track(.endOfYearStoriesDismissed, properties: ["source": "auto_progress"])
+                    self.stopAndDismiss()
+                }
                 else {
                     self.pause()
                 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-365 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

- Start the app
- Enable tracksLogging FF
- Login with an user with stats
- Go to Profile
- Tap on Playback banner
- Skip until last history
- Let the timer expires without pressing anything
- Check that the playback closes and the following event is tracked: `end_of_year_stories_dismissed ["source": "auto_progress"]` 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
