### PR TITLE
[8.0.1] Playlist toolbar fix

### DIFF
--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -66,14 +66,10 @@ struct LocalSearchView: View {
 
     private var navigationContent: some View {
         NavigationStack(path: $navigationPath) {
-            let heightConstant: CGFloat = 44
             podcastsView
                 .navigationDestination(for: LocalSearchRoute.self) { route in
                     destinationView(for: route)
-                    .padding(.top, heightConstant)
                 }
-                .toolbar(.hidden, for: .navigationBar)
-                .padding(.top, heightConstant)
         }
     }
 
@@ -220,7 +216,6 @@ private extension LocalSearchView {
             .background(backgroundColor.ignoresSafeArea())
             .navigationTitle(viewModel.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar(.hidden, for: .navigationBar)
         case .podcast:
             LocalSearchEpisodeResultsView(
                 isLoading: viewModel.isEpisodeSearchInFlight,
@@ -240,7 +235,6 @@ private extension LocalSearchView {
             .background(backgroundColor.ignoresSafeArea())
             .navigationTitle(viewModel.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar(.hidden, for: .navigationBar)
         }
     }
 


### PR DESCRIPTION
Same as #3739 

## To test

* Navigate to a Manual playlist
* Tap "Add Episodes"
* ✅ Ensure the toolbar is shown along the top with title, close, and done buttons
* Test this across different iOS versions 18.5, 26.1, 26.0

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
