### PR TITLE
Fix play action in search and analytics property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 -----
 
 
+8.0.1
+-----
+- Fix play/pause button action on search result cells [#3735](https://github.com/Automattic/pocket-casts-ios/pull/3735)
+
 8.0
 -----
 - Add support for Manual Playlists and rebrand Filters as Smart Playlists [#3670](https://github.com/Automattic/pocket-casts-ios/pull/3670)

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -125,14 +125,15 @@ private extension SearchResultCell {
 
     @ViewBuilder
     var tappableContent: some View {
-        if isSelectionEnabled {
-            Button(action: triggerSelectionAction) {
-                rowContent
+        rowContent.background {
+            if isSelectionEnabled {
+                Button(action: triggerSelectionAction) {
+                    Color.clear
+                }
             }
-            .buttonStyle(cellStyle)
-        } else {
-            rowContent
-                .background(disabledBackgroundColor)
+            else {
+                disabledBackgroundColor
+            }
         }
     }
 

--- a/podcasts/PodcastListViewController.swift
+++ b/podcasts/PodcastListViewController.swift
@@ -509,3 +509,11 @@ extension PodcastListViewController {
                                           source: .podcastsList)
     }
 }
+
+// MARK: - Podcast list
+
+extension PodcastListViewController: AnalyticsSourceProvider {
+    var analyticsSource: AnalyticsSource {
+        .podcastsList
+    }
+}


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR ensure that episode cell button in SearchResult cell is on the back so that cell actions can be tappable, for example play.

## To test

1. Start the app
2. Tap on the search bar on Discover 
3. Search for a term, tap Enter
4. Tap on Episodes pill
5. Tap on a Episode play button
6. Check that the event: `playback_play` is tracked with source set ["content_type": "audio", "source": "discover"]` 
7. See that the Episode starts playing
8. Tap on Episode pause button
9. See the episode stops playing
10. Tap on the remain episode cell
11. Check that episode detail opens
12. Tap on the search bar on Podcasts 
13. Search for a term, tap Enter
14. Tap on Episodes pill
15. Tap on a Episode play button
16. Check that the event: `playback_play` is tracked with source set ["content_type": "audio", "source": "podcasts_list"]` 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
