### PR TITLE
[Playlists] Fix crash in PodcastFilterOverlayController

### DIFF
--- a/podcasts/PCViewController.swift
+++ b/podcasts/PCViewController.swift
@@ -128,6 +128,10 @@ class PCViewController: SimpleNotificationsViewController {
         return closeButton
     }
 
+    func removeThemeChangedObserver() {
+        NotificationCenter.default.removeObserver(self, name: Constants.Notifications.themeChanged, object: nil)
+    }
+
     @objc private func themeDidChange() {
         setupNavBar(animated: false)
         handleThemeChanged()

--- a/podcasts/PCViewController.swift
+++ b/podcasts/PCViewController.swift
@@ -128,10 +128,6 @@ class PCViewController: SimpleNotificationsViewController {
         return closeButton
     }
 
-    func removeThemeChangedObserver() {
-        NotificationCenter.default.removeObserver(self, name: Constants.Notifications.themeChanged, object: nil)
-    }
-
     @objc private func themeDidChange() {
         setupNavBar(animated: false)
         handleThemeChanged()

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -113,6 +113,11 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
         updateRightBarBtn()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        removeThemeChangedObserver()
+    }
+
     func setupNavBar() {
         let backgroundColor: UIColor
         if playlistsRebrandingEnabled {

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -113,11 +113,6 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
         updateRightBarBtn()
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        removeThemeChangedObserver()
-    }
-
     func setupNavBar() {
         let backgroundColor: UIColor
         if playlistsRebrandingEnabled {
@@ -446,8 +441,12 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
     override func handleThemeChanged() {
         super.handleThemeChanged()
         footerView.backgroundColor = AppTheme.viewBackgroundColor()
-        saveButton.backgroundColor = filterToEdit.playlistColor()
-        selectAllSwitch.onTintColor = filterToEdit.playlistColor()
+        if playlistsRebrandingEnabled {
+            saveButton.backgroundColor = AppTheme.colorForStyle(.primaryInteractive01)
+        } else {
+            saveButton.backgroundColor = filterToEdit.playlistColor()
+            selectAllSwitch.onTintColor = filterToEdit.playlistColor()
+        }
         podcastTable.reloadData()
         setupNavBar()
         setupSaveButtonTitle()


### PR DESCRIPTION
Ref. Sentry-7017991593

This PR fixes a crash happening when chancing system appearance while the `PodcastFilterOverlayController` is still open. The PR isolate the unused references in the handle theme did change.

## To test

- Run this branch
- Make sure the app has enable the `Use iOS Light/Dark Mode` and has different themes between dark and light
- Go to playlists and open a Smart Playlist
- Tap Smart Rules then Podcasts
- Swipe down from the top right corner of your phone to show the control center and change the dark/light mode appearance
- Change it
- Confirm the app doesn't crash

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
