### PR TITLE
Dismiss presented vcs when subscribe route is detected

### DIFF
--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -169,7 +169,13 @@ extension AppDelegate {
 
         // Support for subscribing to a feed URL
         JLRoutes.global().addRoute("/subscribe/*") { [weak self] parameters -> Bool in
-            guard let strongSelf = self, let controller = SceneHelper.rootViewController(), let subscribeUrl = (parameters[JLRouteURLKey] as? URL)?.absoluteString else { return false }
+            guard
+                let strongSelf = self,
+                let rootController = SceneHelper.rootViewController(includeTopMost: false), //I don't want to consider the top most presented but the main root instead
+                let subscribeUrl = (parameters[JLRouteURLKey] as? URL)?.absoluteString
+            else {
+                return false
+            }
 
             let prefix = "pktc://subscribe/"
             if prefix.count >= subscribeUrl.count { return true } // this request is missing a URL
@@ -179,8 +185,8 @@ extension AppDelegate {
             let searchTerm = !feedUrl.hasPrefix("http://") && !feedUrl.hasPrefix("https://") ? "http://\(feedUrl)" : feedUrl
 
             strongSelf.progressDialog = ShiftyLoadingAlert(title: L10n.podcastLoading)
-            controller.dismiss(animated: false, completion: nil)
-            strongSelf.progressDialog?.showAlert(controller, hasProgress: false, completion: {
+            rootController.dismiss(animated: false, completion: nil)
+            strongSelf.progressDialog?.showAlert(rootController, hasProgress: false, completion: {
                 MainServerHandler.shared.podcastSearch(searchTerm: searchTerm) { response in
                     guard let uuid = response?.result?.podcast?.uuid else {
                         DispatchQueue.main.async {

--- a/podcasts/SceneHelper.swift
+++ b/podcasts/SceneHelper.swift
@@ -23,10 +23,13 @@ class SceneHelper {
         return UIWindow(frame: UIScreen.main.bounds)
     }
 
-    class func rootViewController() -> UIViewController? {
+    class func rootViewController(includeTopMost: Bool = true) -> UIViewController? {
         let appScene = connectedScene()?.windows.first(where: { $0.rootViewController is MainTabBarController })
         let rootVC = appScene?.rootViewController
-        return rootVC?.topMostPresentedViewController ?? rootVC
+        if includeTopMost {
+            return rootVC?.topMostPresentedViewController ?? rootVC
+        }
+        return rootVC
     }
 
     /// Returns the main window for the app from the AppDelegate


### PR DESCRIPTION
| 📘 Part of: [General Bug](https://linear.app/a8c/project/general-bugs-41006492b6c8/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-337

This PR fixes the presentation issue when a subscribe URL is tapped from within a webview in our Safari VC, displayed from an episode detail or Full screen player.

Our JLRoutes was trying to present the loading above an already presented view controller, as all the hierarchy wasn't correctly dismissed.

## To test

- Run this branch
- Visit a NYT podcast like [The Daily](https://pca.st/podcast/4eb5b260-c933-0134-10da-25324e2a541d)
- Open an episode detail and scroll the description till the end, when you see _You can also subscribe to your favorite....`
- Tap the URL next to it (ping me if you don't find it)
- Sign in with the credential shared in the issue
- When you see the composition with all podcasts cover tap the + to expand the podcasts app list (see screenshot below)
<img width="553" height="520" alt="SCR-20251126-klwh" src="https://github.com/user-attachments/assets/19ad27e9-833d-414f-bd15-a8e9622955e0" />

- Select Pocket Casts
- Select one of the podcast in the list and tap the + blue button
- Confirm Safari and the episode detail are dismissed and the loading appears
- Confirm after the loading is completed, the selected podcast detail is pushed
- Do the same test from other entry points, also using the deep link I shared in the last message in the issue (ping me if you don't find it)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
