### PR TITLE
[Playback 2025] Ensure share message for listening uses the days/hours formats

### DIFF
--- a/podcasts/End of Year/Stories/2024/ListeningTime2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/ListeningTime2024Story.swift
@@ -60,6 +60,10 @@ struct ListeningTime2024Story: ShareableStory {
             StoryShareableText(L10n.eoyStoryListenedToShareText(listeningTime.formattedTime() ?? ""), year: .y2024)
         ]
     }
+
+    static func formattedDayHours(time: Double) -> String {
+        return time.formattedTime() ?? ""
+    }
 }
 
 fileprivate extension Double {

--- a/podcasts/End of Year/Stories/2025/ListeningTime2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/ListeningTime2025Story.swift
@@ -89,7 +89,7 @@ struct ListeningTime2025Story: ShareableStory {
     func sharingAssets() -> [Any] {
         [
             StoryShareableProvider.new(AnyView(self)),
-            StoryShareableText(L10n.eoyStoryListenedToShareText(formattedMinutes), year: .y2025)
+            StoryShareableText(L10n.eoyStoryListenedToShareText(ListeningTime2024Story.formattedDayHours(time: listeningTime)), year: .y2025)
         ]
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
<img width="320" alt="IMG_0786" src="https://github.com/user-attachments/assets/700a7529-7ee7-454e-aba9-ec4ed83aada7" />

## To test

- Start the app
- Login with an user with stats
- Go to Profile
- Tap on Playback banner
- Skip until listening time story
- Press on the share icon
- Share to iMessages
- Check that the share text, indicates days/hours/minutes instead of just a number. Ex: `I spent 22 hours and 4 minutes listening to podcasts this year`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
