### PR TITLE
[Playback 2025] Loading animation

### DIFF
--- a/podcasts/End of Year/End of Year 2025/EndOfYear2025StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2025/EndOfYear2025StoriesModel.swift
@@ -84,10 +84,13 @@ class EndOfYear2025StoriesModel: StoryModel {
         self.stories = stories
     }
 
+    private var firstTime = true
+
     func story(for storyNumber: Int) -> any StoryView {
+        defer { firstTime = false }
         switch stories[storyNumber] {
             case .intro:
-                return IntroStory2025()
+                return IntroStory2025(afterLoading: firstTime)
             case .numberOfPodcastsAndEpisodesListened:
                 return NumberListened2025(listenedNumbers: data.listenedNumbers, podcasts: data.top8Podcasts)
             case .topSpot:

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -159,6 +159,7 @@ struct EndOfYear {
         let configuration = StoriesConfiguration()
         if EndOfYear.currentYear == .y2025 {
             configuration.closeAndDismissAfterFinished = true
+            configuration.loadingIsTheFirstStory = true
         }
         return configuration
     }

--- a/podcasts/End of Year/Stories/2025/IntroStory2025.swift
+++ b/podcasts/End of Year/Stories/2025/IntroStory2025.swift
@@ -17,6 +17,15 @@ struct IntroStory2025: StoryView {
 
     @State private var openCircle: Bool = false
 
+    private let afterLoading: Bool
+
+    let loadCallback: (() -> ())?
+
+    init(afterLoading: Bool, loadCallback: (() -> ())? = nil) {
+        self.loadCallback = loadCallback
+        self.afterLoading = afterLoading
+    }
+
     enum KeyFrames {
         static var circleOpen = CGFloat(110)
     }
@@ -33,23 +42,31 @@ struct IntroStory2025: StoryView {
                 .opacity(opacity)
         }
         .onChange(of: animationProgress) { position in
-            if position > KeyFrames.circleOpen, !openCircle {
-                openCircle = true
-                withAnimation(.easeInOut(duration: 0.005)) {
-                    self.opacity = 1
-                }
-                withAnimation(.easeInOut(duration: 1)) {
-                    self.scale = 10
+            if afterLoading {
+                self.opacity = 1
+                self.scale = 10
+            } else {
+                if position > KeyFrames.circleOpen, !openCircle {
+                    openCircle = true
+                    withAnimation(.easeInOut(duration: 0.005)) {
+                        self.opacity = 1
+                    }
+                    withAnimation(.easeInOut(duration: 1)) {
+                        self.scale = 10
+                    }
                 }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
             LottieView(animation: .named("end_of_year_2025_intro"))
+                .animationDidFinish({ completed in
+                    loadCallback?()
+                })
                 .configure({ animationView in
                     animationView.contentMode = .scaleAspectFill
                 })
-                .playbackMode(.playing(.fromProgress(0, toProgress: 1, loopMode: .playOnce)))
+                .playbackMode(afterLoading ? .paused(at: .progress(1)) : .playing(.fromProgress(0, toProgress: 1, loopMode: .playOnce)))
                 .getRealtimeAnimationFrame($animationProgress)
                 .scaledToFill()
                 .ignoresSafeArea()
@@ -65,6 +82,6 @@ struct IntroStory2025: StoryView {
 
 struct IntroStory2025_Previews: PreviewProvider {
     static var previews: some View {
-        IntroStory2025()
+        IntroStory2025(afterLoading: false)
     }
 }

--- a/podcasts/End of Year/StoriesConfiguration.swift
+++ b/podcasts/End of Year/StoriesConfiguration.swift
@@ -27,4 +27,6 @@ class StoriesConfiguration {
     var indicatorHeight: CGFloat = 2
 
     var indicatorSpacing: CGFloat = 2
+
+    var loadingIsTheFirstStory: Bool = false
 }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -41,7 +41,7 @@ class StoriesModel: ObservableObject {
 
     private let dataSource: StoriesDataSource
     private let publisher: Timer.TimerPublisher
-    private let configuration: StoriesConfiguration
+    let configuration: StoriesConfiguration
     private let progressModel: StoriesProgressModel
 
     private var cancellables = Set<AnyCancellable>()

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -51,6 +51,8 @@ class StoriesModel: ObservableObject {
         currentStory?.duration ?? 0
     }
 
+    private var loadingCancellable: Cancellable?
+
     private var currentStoryIdentifier: String = ""
 
     private var currentStoryIsPlus = false
@@ -99,10 +101,7 @@ class StoriesModel: ObservableObject {
             self?.shareAlertVisibilityChanged(isPresented)
         }
 
-        Task.init {
-            await isReady = dataSource.isReady()
-            failed = !isReady
-        }
+        refresh()
 
         subscribeToNotifications()
     }
@@ -111,9 +110,23 @@ class StoriesModel: ObservableObject {
         isReady = false
 
         Task.init {
+            if self.configuration.loadingIsTheFirstStory {
+                loadingStart()
+            }
             await isReady = dataSource.refresh()
             failed = !isReady
         }
+    }
+
+    func loadingStart() {
+        loadingCancellable = publisher.autoconnect().sink(receiveValue: { _ in
+            let newProgress = self.progress + (0.01 / EndOfYear.defaultDuration)
+            self.progress = min(newProgress, 0.99)
+        })
+    }
+
+    func loadingEnded() {
+        loadingCancellable = nil
     }
 
     func start() {

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -23,7 +23,7 @@ struct StoriesView: View {
 
     @ViewBuilder
     var body: some View {
-        if model.isReady, loadAnimationFinished {
+        if model.isReady, loadAnimationFinished || !model.configuration.loadingIsTheFirstStory {
             stories
             .onAppear {
                 model.start()
@@ -106,7 +106,7 @@ struct StoriesView: View {
     // View shown while data source is preparing
     var loading: some View {
         ZStack {
-            if case EndOfYear.Year.y2025 = EndOfYear.currentYear {
+            if model.configuration.loadingIsTheFirstStory {
                 IntroStory2025(afterLoading: false) {
                     loadAnimationFinished = true
                     model.loadingEnded()

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -11,6 +11,8 @@ struct StoriesView: View {
     /// If it's longer than that, it's considered a gesture
     private let maximumTapTime: Double = 0.35
 
+    @State private var loadAnimationFinished: Bool = false
+
     init(dataSource: StoriesDataSource, configuration: StoriesConfiguration = StoriesConfiguration(), syncProgressModel: SyncYearListeningProgress = .shared) {
         let model = StoriesModel(dataSource: dataSource, configuration: configuration)
         _model = ObservedObject(initialValue: model)
@@ -21,7 +23,7 @@ struct StoriesView: View {
 
     @ViewBuilder
     var body: some View {
-        if model.isReady {
+        if model.isReady, loadAnimationFinished {
             stories
             .onAppear {
                 model.start()
@@ -104,21 +106,21 @@ struct StoriesView: View {
     // View shown while data source is preparing
     var loading: some View {
         ZStack {
-            Spacer()
-
-            VStack(spacing: 15) {
-                let progress = syncProgressModel.progress
-                CircularProgressView(value: progress, stroke: model.indicatorColor(for: model.currentStoryIndex), strokeWidth: 6)
-                    .frame(width: 40, height: 40)
-                if case EndOfYear.Year.y2025 = EndOfYear.currentYear {
-                    EmptyView()
-                } else {
+            if case EndOfYear.Year.y2025 = EndOfYear.currentYear {
+                IntroStory2025(afterLoading: false) {
+                    loadAnimationFinished = true
+                }
+            } else {
+                Spacer()
+                VStack(spacing: 15) {
+                    let progress = syncProgressModel.progress
+                    CircularProgressView(value: progress, stroke: model.indicatorColor(for: model.currentStoryIndex), strokeWidth: 6)
+                        .frame(width: 40, height: 40)
                     Text(L10n.loading)
                         .foregroundColor(model.indicatorColor(for: model.currentStoryIndex))
                         .font(style: .body)
                 }
             }
-
             storySwitcher
             header
         }

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -109,6 +109,7 @@ struct StoriesView: View {
             if case EndOfYear.Year.y2025 = EndOfYear.currentYear {
                 IntroStory2025(afterLoading: false) {
                     loadAnimationFinished = true
+                    model.loadingEnded()
                 }
             } else {
                 Spacer()
@@ -121,7 +122,6 @@ struct StoriesView: View {
                         .font(style: .body)
                 }
             }
-            storySwitcher
             header
         }
         .background(model.primaryBackgroundColor)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-375 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

https://github.com/user-attachments/assets/16631da9-e53e-4046-a654-7f2a8b32971d


## To test

1. Start the app with an user that has enough stats for playback
2. Go to Profile
3. Tap on the banner
4. Check if the loading animation shows correctly and goes correctly to the next story
5. Go back and forward in the stories and see if they work correctly
6. Smoke test initial onboarding carousel to see if nothing was impacted there.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
