### PR TITLE
[Playback 2025] Fix year over year 2025 calculations

### DIFF
--- a/PocketCastsTests/Tests/End of Year/YearOverYearCompareTests.swift
+++ b/PocketCastsTests/Tests/End of Year/YearOverYearCompareTests.swift
@@ -84,4 +84,48 @@ struct YearOverYearCompareCalculator {
 
         #expect(isUp, "Comparison should be Up. Instead it's \(comparison)")
     }
+
+    @Test func testUptrend2025() async throws {
+
+        let listened2024: Double = 1000
+        let listened2025: Double = 1200
+
+        let comparison = YearOverYearCompare2025Story.Comparison(in2024: listened2024, in2025: listened2025)
+        let isUp: Bool
+
+        let difference: Double
+        switch comparison {
+            case .up(let diff):
+                isUp = true
+                difference = diff
+            default:
+                isUp = false
+                difference = 0
+        }
+
+        #expect(isUp, "Comparison should be Up")
+        #expect(abs(difference - 0.2) < 0.001, "Difference should be in percentage. Instead it's \(comparison)")
+    }
+
+    @Test func testDowntrend2025() async throws {
+
+        let listened2024: Double = 1000
+        let listened2025: Double = 800
+
+        let comparison = YearOverYearCompare2025Story.Comparison(in2024: listened2024, in2025: listened2025)
+        let isDown: Bool
+
+        let difference: Double
+        switch comparison {
+            case .down(let diff):
+                isDown = true
+                difference = diff
+            default:
+                isDown = false
+                difference = 0
+        }
+
+        #expect(isDown, "Comparison should be Down")
+        #expect(abs(difference - 0.2) < 0.001, "Difference should be in percentage. Instead it's \(comparison)")
+    }
 }

--- a/podcasts/End of Year/Stories/2025/YearOverYearCompare2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/YearOverYearCompare2025Story.swift
@@ -199,7 +199,7 @@ fileprivate class MyFontProvider: AnimationFontProvider {
 }
 
 #Preview("Down") {
-    YearOverYearCompare2025Story(subscriptionTier: .plus, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 968*60*60, totalPlayedTimeLastYear:  1191*60*60))
+    YearOverYearCompare2025Story(subscriptionTier: .plus, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 968*60*60, totalPlayedTimeLastYear: 1191*60*60))
         .body.environment(\.animated, false)
 }
 

--- a/podcasts/End of Year/Stories/2025/YearOverYearCompare2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/YearOverYearCompare2025Story.swift
@@ -80,9 +80,9 @@ struct YearOverYearCompare2025Story: ShareableStory {
            if abs(1 - difference) <= 0.1 {
                 self = .same
             } else if difference > 1 {
-                self = .up(difference)
+                self = .up(difference - 1.0)
             } else {
-                self = .down(difference)
+                self = .down(1.0 - difference)
             }
         }
     }
@@ -161,7 +161,7 @@ struct YearOverYearCompare2025Story: ShareableStory {
     }
 }
 
-final private class LottieTextProvider: AnimationTextProvider, Equatable {
+final private class LottieTextProvider: LegacyAnimationTextProvider, Equatable {
     private let dict: [String: String]
     private let prevYear: Int
     private let currentYear: Int
@@ -199,7 +199,7 @@ fileprivate class MyFontProvider: AnimationFontProvider {
 }
 
 #Preview("Down") {
-    YearOverYearCompare2025Story(subscriptionTier: .plus, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 72000, totalPlayedTimeLastYear: 300000))
+    YearOverYearCompare2025Story(subscriptionTier: .plus, listeningTime: YearOverYearListeningTime(totalPlayedTimeThisYear: 968*60*60, totalPlayedTimeLastYear:  1191*60*60))
         .body.environment(\.animated, false)
 }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-369 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
<img width="357" height="698" alt="Screenshot 2025-11-27 at 13 54 01" src="https://github.com/user-attachments/assets/f5678e5f-6fef-4fde-9a29-885224a9b3e2" />

## To test

1. Start the app with an user with stats and a subscription
2. Go to Profile
3. Open the playback 2025
4. Skip up to year over year stories
5. Check if percentage are correct
6. You may want to check the Previews for the Story and Unit Tests to see if all calculations match up

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
