### PR TITLE
[Playback 2025] Defer app prompt and add playbackCompleted event

### DIFF
--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -59,8 +59,6 @@ class StoriesModel: ObservableObject {
 
     private var currentStory: Story?
 
-    private var pendingPlaybackShareEvents: [[String: String]] = []
-
     var numberOfStories: Int {
         dataSource.numberOfStories
     }
@@ -289,7 +287,6 @@ class StoriesModel: ObservableObject {
 
     func stopAndDismiss() {
         pause()
-        trackPendingPlaybackSharesIfNeeded()
         NavigationManager.sharedManager.dismissPresentedViewController()
     }
 
@@ -333,7 +330,7 @@ class StoriesModel: ObservableObject {
     }
 
     func recordPlaybackShare(properties: [String: String]) {
-        pendingPlaybackShareEvents.append(properties)
+        Analytics.track(.playbackShared, properties: properties)
     }
 }
 
@@ -406,16 +403,6 @@ private extension StoriesModel {
     /// Whether some Plus stories should be skipped or not
     func shouldSkipPlusStories() -> Bool {
         !isPaidUser() && !manuallyChanged && currentStoryIsPlus && nextStoryIsPlus()
-    }
-
-    func trackPendingPlaybackSharesIfNeeded() {
-        guard !pendingPlaybackShareEvents.isEmpty else { return }
-
-        pendingPlaybackShareEvents.forEach {
-            Analytics.track(.playbackShared, properties: $0)
-        }
-
-        pendingPlaybackShareEvents.removeAll()
     }
 }
 

--- a/podcasts/SurveyDebugInfoView.swift
+++ b/podcasts/SurveyDebugInfoView.swift
@@ -118,7 +118,7 @@ struct SurveyDebugInfoView: View {
     }
 
     private func presentSurveyWithAnimation(from rootViewController: UIViewController) {
-        UserSatisfactionSurveyManager.shared.presentSurvey(from: rootViewController, event: defaultEvent, skipCheck: true)
+        UserSatisfactionSurveyManager.shared.presentSurvey(from: rootViewController, event: defaultEvent, skipEligibility: true)
     }
 
     private func loadDebugData() {

--- a/podcasts/SurveyDebugInfoView.swift
+++ b/podcasts/SurveyDebugInfoView.swift
@@ -26,8 +26,8 @@ struct SurveyDebugInfoView: View {
                     Text("Result")
                     Spacer()
                     Text(surveyCheckResult.displayReason)
-                        .foregroundColor(surveyCheckResult == .canShow ? .green : .red)
-                        .fontWeight(surveyCheckResult == .canShow ? .bold : .regular)
+                        .foregroundColor(surveyCheckResult.canShow ? .green : .red)
+                        .fontWeight(surveyCheckResult.canShow ? .bold : .regular)
                 }
             }
 
@@ -142,7 +142,7 @@ struct SurveyDebugInfoView: View {
 
         #if !os(watchOS) && !APPCLIP
         surveyCheckResult = UserSatisfactionSurveyManager.shared.checkSurveyEligibility(for: defaultEvent)
-        canShowSurvey = surveyCheckResult == .canShow
+        canShowSurvey = surveyCheckResult.canShow
         #else
         canShowSurvey = false
         #endif

--- a/podcasts/UserSatisfactionSurveyManager.swift
+++ b/podcasts/UserSatisfactionSurveyManager.swift
@@ -19,8 +19,7 @@ public class UserSatisfactionSurveyManager: NSObject {
         set { UserDefaults.standard.set(newValue, forKey: "surveyPlusUpgradeDate") }
     }
 
-    private var deferredSurveyEvents: [SurveyTriggerEvent: [AnyHashable: Any]?] = [:]
-    private var seenReleaseEvents = Set<String>()
+    private var deferredSurveyEvents: [SurveyTriggerEvent: [Date]] = [:]
 
     // MARK: - Survey Entry Points
 
@@ -56,14 +55,14 @@ public class UserSatisfactionSurveyManager: NSObject {
             return !isPlus ? .canShow : .wrongUserType // Free user events
         case .plusUpgraded, .folderCreated, .bookmarkCreated, .customThemeSet, .referralShared:
             return isPlus ? .canShow : .wrongUserType // Plus user events
-        case .playbackShared:
-            return .canShow
+        case .playbackShared, .playbackCompleted:
+            return .deferredEvent
         }
     }
 
     /// Presents the survey view
-    func presentSurvey(from viewController: UIViewController, event: SurveyTriggerEvent, skipCheck: Bool = false) {
-        guard shouldShowSurvey(for: event) || skipCheck else { return }
+    func presentSurvey(from viewController: UIViewController, event: SurveyTriggerEvent, skipEligibility: Bool = false) {
+        guard skipEligibility || shouldShowSurvey(for: event) else { return }
 
         guard let source = SceneHelper.rootViewController() else {
             assertionFailure("WARNING: Root View Controller not found so survey was not presented")
@@ -117,9 +116,7 @@ public class UserSatisfactionSurveyManager: NSObject {
 
         source.present(hostingController, animated: true)
         currentEvent = event
-        if !skipCheck {
-            Settings.addSurveyPresented()
-        }
+        Settings.addSurveyPresented()
         Analytics.track(.userSatisfactionSurveyShown, properties: [
             "trigger_event": event.rawValue,
             "user_type": SubscriptionHelper.hasActiveSubscription() ? "plus" : "free"
@@ -162,16 +159,21 @@ extension UserSatisfactionSurveyManager: UIAdaptivePresentationControllerDelegat
 
 extension UserSatisfactionSurveyManager: AnalyticsAdapter {
     public func track(name: String, properties: [AnyHashable: Any]?) {
-        handleDeferredSurveyReleaseIfNeeded(for: name)
+        let handled = handleDeferredSurveyReleaseIfNeeded(for: name, properties: properties)
 
-        guard let analyticsEvent = mapAnalyticsEventToSurveyTrigger(name: name) else { return }
+        guard handled == false else {
+            // We already triggered a deferred event so skip this
+            return
+        }
+
+        guard let analyticsEvent = mapAnalyticsEventToSurveyTrigger(name: name, properties: properties) else { return }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-            self?.presentSurveyIfEligible(for: analyticsEvent, properties: properties)
+            self?.presentSurveyIfEligible(for: analyticsEvent)
         }
     }
 
-    private func mapAnalyticsEventToSurveyTrigger(name: String) -> SurveyTriggerEvent? {
+    private func mapAnalyticsEventToSurveyTrigger(name: String, properties: [AnyHashable: Any]?) -> SurveyTriggerEvent? {
         switch name {
         case AnalyticsEvent.episodeStarred.eventName:
             return .episodeStarred
@@ -195,51 +197,49 @@ extension UserSatisfactionSurveyManager: AnalyticsAdapter {
             return handleAppOpened()
         case AnalyticsEvent.playbackShared.eventName:
             return .playbackShared
+        case AnalyticsEvent.endOfYearStoryShown.eventName:
+            if (properties as? [String: String])?["story"] == "ending" {
+                return .playbackCompleted
+            }
+            return nil
         default:
             return nil
         }
     }
 
-    private func presentSurveyIfEligible(for event: SurveyTriggerEvent, properties: [AnyHashable: Any]? = nil, allowDeferral: Bool = true) {
-        if let releaseEventName = event.releaseAnalyticsEventName,
-           !seenReleaseEvents.contains(releaseEventName) {
-            if allowDeferral {
-                deferSurveyTrigger(event, properties: properties)
-            }
-            return
-        }
-
-        let result = checkSurveyEligibility(for: event)
+    private func presentSurveyIfEligible(for event: SurveyTriggerEvent, allowDeferral: Bool = true) {
+        let result = allowDeferral ? checkSurveyEligibility(for: event) : .canShow
 
         switch result {
         case .canShow:
             guard let topViewController = SceneHelper.rootViewController() else { return }
-            presentSurvey(from: topViewController, event: event)
-        case .deferredEvent(let deferredEvent) where allowDeferral:
-            deferSurveyTrigger(deferredEvent, properties: properties)
+            presentSurvey(from: topViewController, event: event, skipEligibility: !allowDeferral)
+        case .deferredEvent:
+            deferSurveyTrigger(event)
         default:
             break
         }
     }
 
-    private func deferSurveyTrigger(_ event: SurveyTriggerEvent, properties: [AnyHashable: Any]?) {
-        deferredSurveyEvents[event] = properties
+    private func deferSurveyTrigger(_ event: SurveyTriggerEvent, ) {
+        var dates: [Date] = deferredSurveyEvents[event] ?? []
+        dates.append(Date())
+        deferredSurveyEvents[event] = dates
     }
 
-    private func handleDeferredSurveyReleaseIfNeeded(for analyticsEventName: String) {
-        seenReleaseEvents.insert(analyticsEventName)
-
+    private func handleDeferredSurveyReleaseIfNeeded(for analyticsEventName: String, properties: [AnyHashable: Any]?) -> Bool {
         let readyEvents = deferredSurveyEvents
-            .filter { $0.key.releaseAnalyticsEventName == analyticsEventName }
-            .map { $0.key }
+            .filter { $0.key.shouldShowAnalytics(for: analyticsEventName, properties: properties) }
 
-        readyEvents.forEach { deferredSurveyEvents.removeValue(forKey: $0) }
+        readyEvents.forEach { deferredSurveyEvents.removeValue(forKey: $0.key) }
 
-        readyEvents.forEach { event in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-                self?.presentSurveyIfEligible(for: event, allowDeferral: false)
-            }
+        guard let event = readyEvents.first else { return false }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+            self?.presentSurveyIfEligible(for: event.key, allowDeferral: false)
         }
+
+        return true
     }
 
     private func handleEpisodeCompletion() -> SurveyTriggerEvent? {
@@ -290,9 +290,7 @@ enum SurveyCheckResult {
     case shownRecently
     case userDeclinedRecently
     case wrongUserType
-    case deferredEvent(SurveyTriggerEvent) // For event types that should be prompted later based on another event
-    case analyticsEventTracked(AnalyticsEvent)
-    case analyticsEventMissing(SurveyTriggerEvent)
+    case deferredEvent // For event types that should be prompted later based on another event
 
     var displayReason: String {
         switch self {
@@ -306,12 +304,8 @@ enum SurveyCheckResult {
             return "User declined recently (within 60 days)"
         case .wrongUserType:
             return "Event not applicable for user type"
-        case .deferredEvent(let event):
-            return "Deferred waiting for \(event.rawValue)"
-        case .analyticsEventTracked(let event):
-            return "Tracked analytics event \(event.eventName)"
-        case .analyticsEventMissing(let event):
-            return "No analytics event configured for \(event.rawValue)"
+        case .deferredEvent:
+            return "Deferred waiting for future event"
         }
     }
 
@@ -343,24 +337,19 @@ enum SurveyTriggerEvent: String, CaseIterable {
 
     // Shared events
     case playbackShared = "playback_shared"
+    case playbackCompleted = "playback_completed"
 }
 
 private extension SurveyTriggerEvent {
-    var analyticsEvent: AnalyticsEvent? {
+    func shouldShowAnalytics(for event: String, properties: [AnyHashable: Any]?) -> Bool {
         switch self {
-        case .playbackShared:
-            return .playbackShared
+        case .playbackShared, .playbackCompleted:
+            if AnalyticsEvent.endOfYearStoriesDismissed.eventName == event {
+                return true
+            }
+            return false
         default:
-            return nil
-        }
-    }
-
-    var releaseAnalyticsEventName: String? {
-        switch self {
-        case .playbackShared:
-            return AnalyticsEvent.endOfYearStoriesDismissed.eventName
-        default:
-            return nil
+            return false
         }
     }
 }

--- a/podcasts/UserSatisfactionSurveyManager.swift
+++ b/podcasts/UserSatisfactionSurveyManager.swift
@@ -19,13 +19,16 @@ public class UserSatisfactionSurveyManager: NSObject {
         set { UserDefaults.standard.set(newValue, forKey: "surveyPlusUpgradeDate") }
     }
 
+    private var deferredSurveyEvents: [SurveyTriggerEvent: [AnyHashable: Any]?] = [:]
+    private var seenReleaseEvents = Set<String>()
+
     // MARK: - Survey Entry Points
 
     /// Checks if the survey should be shown based on the event and user context
     func shouldShowSurvey(for event: SurveyTriggerEvent) -> Bool {
         let result = checkSurveyEligibility(for: event)
         FileLog.shared.addMessage("UserSatisfactionSurveyManager: Should show survey for \(event.rawValue): \(result.displayReason)")
-        return result == .canShow
+        return result.canShow
     }
 
     /// Checks survey eligibility and returns the specific reason
@@ -159,15 +162,12 @@ extension UserSatisfactionSurveyManager: UIAdaptivePresentationControllerDelegat
 
 extension UserSatisfactionSurveyManager: AnalyticsAdapter {
     public func track(name: String, properties: [AnyHashable: Any]?) {
+        handleDeferredSurveyReleaseIfNeeded(for: name)
+
         guard let analyticsEvent = mapAnalyticsEventToSurveyTrigger(name: name) else { return }
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-            guard let self = self else { return }
-
-            if self.shouldShowSurvey(for: analyticsEvent) {
-                guard let topViewController = SceneHelper.rootViewController() else { return }
-                self.presentSurvey(from: topViewController, event: analyticsEvent)
-            }
+            self?.presentSurveyIfEligible(for: analyticsEvent, properties: properties)
         }
     }
 
@@ -197,6 +197,48 @@ extension UserSatisfactionSurveyManager: AnalyticsAdapter {
             return .playbackShared
         default:
             return nil
+        }
+    }
+
+    private func presentSurveyIfEligible(for event: SurveyTriggerEvent, properties: [AnyHashable: Any]? = nil, allowDeferral: Bool = true) {
+        if let releaseEventName = event.releaseAnalyticsEventName,
+           !seenReleaseEvents.contains(releaseEventName) {
+            if allowDeferral {
+                deferSurveyTrigger(event, properties: properties)
+            }
+            return
+        }
+
+        let result = checkSurveyEligibility(for: event)
+
+        switch result {
+        case .canShow:
+            guard let topViewController = SceneHelper.rootViewController() else { return }
+            presentSurvey(from: topViewController, event: event)
+        case .deferredEvent(let deferredEvent) where allowDeferral:
+            deferSurveyTrigger(deferredEvent, properties: properties)
+        default:
+            break
+        }
+    }
+
+    private func deferSurveyTrigger(_ event: SurveyTriggerEvent, properties: [AnyHashable: Any]?) {
+        deferredSurveyEvents[event] = properties
+    }
+
+    private func handleDeferredSurveyReleaseIfNeeded(for analyticsEventName: String) {
+        seenReleaseEvents.insert(analyticsEventName)
+
+        let readyEvents = deferredSurveyEvents
+            .filter { $0.key.releaseAnalyticsEventName == analyticsEventName }
+            .map { $0.key }
+
+        readyEvents.forEach { deferredSurveyEvents.removeValue(forKey: $0) }
+
+        readyEvents.forEach { event in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                self?.presentSurveyIfEligible(for: event, allowDeferral: false)
+            }
         }
     }
 
@@ -248,6 +290,9 @@ enum SurveyCheckResult {
     case shownRecently
     case userDeclinedRecently
     case wrongUserType
+    case deferredEvent(SurveyTriggerEvent) // For event types that should be prompted later based on another event
+    case analyticsEventTracked(AnalyticsEvent)
+    case analyticsEventMissing(SurveyTriggerEvent)
 
     var displayReason: String {
         switch self {
@@ -261,6 +306,21 @@ enum SurveyCheckResult {
             return "User declined recently (within 60 days)"
         case .wrongUserType:
             return "Event not applicable for user type"
+        case .deferredEvent(let event):
+            return "Deferred waiting for \(event.rawValue)"
+        case .analyticsEventTracked(let event):
+            return "Tracked analytics event \(event.eventName)"
+        case .analyticsEventMissing(let event):
+            return "No analytics event configured for \(event.rawValue)"
+        }
+    }
+
+    var canShow: Bool {
+        switch self {
+        case .canShow:
+            true
+        default:
+            false
         }
     }
 }
@@ -283,4 +343,24 @@ enum SurveyTriggerEvent: String, CaseIterable {
 
     // Shared events
     case playbackShared = "playback_shared"
+}
+
+private extension SurveyTriggerEvent {
+    var analyticsEvent: AnalyticsEvent? {
+        switch self {
+        case .playbackShared:
+            return .playbackShared
+        default:
+            return nil
+        }
+    }
+
+    var releaseAnalyticsEventName: String? {
+        switch self {
+        case .playbackShared:
+            return AnalyticsEvent.endOfYearStoriesDismissed.eventName
+        default:
+            return nil
+        }
+    }
 }

--- a/podcasts/UserSatisfactionSurveyManager.swift
+++ b/podcasts/UserSatisfactionSurveyManager.swift
@@ -55,7 +55,7 @@ public class UserSatisfactionSurveyManager: NSObject {
             return !isPlus ? .canShow : .wrongUserType // Free user events
         case .plusUpgraded, .folderCreated, .bookmarkCreated, .customThemeSet, .referralShared:
             return isPlus ? .canShow : .wrongUserType // Plus user events
-        case .playbackShared, .playbackCompleted:
+        case .endOfYearStoryShared, .endOfYearCompleted:
             return .deferredEvent
         }
     }
@@ -195,11 +195,11 @@ extension UserSatisfactionSurveyManager: AnalyticsAdapter {
             return handlePlusUpgrade()
         case AnalyticsEvent.applicationOpened.eventName:
             return handleAppOpened()
-        case AnalyticsEvent.playbackShared.eventName:
-            return .playbackShared
+        case AnalyticsEvent.endOfYearStoryShared.eventName:
+            return .endOfYearStoryShared
         case AnalyticsEvent.endOfYearStoryShown.eventName:
             if (properties as? [String: String])?["story"] == "ending" {
-                return .playbackCompleted
+                return .endOfYearCompleted
             }
             return nil
         default:
@@ -336,14 +336,14 @@ enum SurveyTriggerEvent: String, CaseIterable {
     case referralShared = "referral_shared"
 
     // Shared events
-    case playbackShared = "playback_shared"
-    case playbackCompleted = "playback_completed"
+    case endOfYearStoryShared = "end_of_year_story_shared"
+    case endOfYearCompleted = "end_of_year_completed"
 }
 
 private extension SurveyTriggerEvent {
     func shouldShowAnalytics(for event: String, properties: [AnyHashable: Any]?) -> Bool {
         switch self {
-        case .playbackShared, .playbackCompleted:
+        case .endOfYearStoryShared, .endOfYearCompleted:
             if AnalyticsEvent.endOfYearStoriesDismissed.eventName == event {
                 return true
             }


### PR DESCRIPTION
Fixes [PCIOS-361](https://linear.app/a8c/issue/PCIOS-361/prompt-rating-after-completing-playback-copy)

## To test

* Open the Playback 2025 Stories
* Share an image from a story
* ✅ Ensure no app prompt is shown
* Dismiss Playback
* ✅ Ensure the app prompt is shown
* ✅ Ensure the `user_satisfaction_survey_shown` event is tracked with `trigger_event: end_of_year_story_shared `
```
🔵 Tracked: user_satisfaction_survey_shown ["trigger_event": "end_of_year_story_shared", "user_type": "free"]
```
* Tap "Not Really"
* Ensure `user_satisfaction_survey_no_response` event is tracked with `trigger_event: end_of_year_story_shared `
```
🔵 Tracked: user_satisfaction_survey_no_response ["user_type": "free", "trigger_event": "end_of_year_story_shared"]
```

* In Profile > Settings > Developer > Ratings Debug Info > Reset Survey & Reviews
* Open the Playback 2025 Stories
* Advance to the final story
* Dismiss Playback
* ✅ Ensure the app prompt is shown
* ✅ Ensure the `user_satisfaction_survey_shown` event is tracked with `trigger_event: end_of_year_completed `
```
🔵 Tracked: user_satisfaction_survey_shown ["trigger_event": "end_of_year_completed", "user_type": "free"]
```
* Tap "Not Really"
* Ensure `user_satisfaction_survey_yes_response ` event is tracked with `trigger_event: end_of_year_completed `
```
🔵 Tracked: user_satisfaction_survey_yes_response ["user_type": "free", "trigger_event": "end_of_year_completed"]
```

* In Profile > Settings > Developer > Ratings Debug Info > Reset Survey & Reviews
* Open the Playback 2025 Stories
* * Share an image from a story
* ✅ Ensure no app prompt is shown
* Advance to the final story
* Dismiss Playback
* ✅ Ensure the app prompt is shown
* ✅ Ensure the `user_satisfaction_survey_shown` event is tracked with `trigger_event: end_of_year_story_shared ` - the first event that was triggered
```
🔵 Tracked: user_satisfaction_survey_shown ["trigger_event": "end_of_year_story_shared", "user_type": "free"]
```

Generally smoke test the ratings prompt logic as well to ensure prompts aren't shown inadvertently.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
