### PR TITLE
[Playback 2025] Indicators loading fix with larger data sets

### DIFF
--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -158,7 +158,7 @@ struct StoriesView: View {
         ZStack {
             VStack {
                 HStack(spacing: model.indicatorSpacing) {
-                    ForEach(0 ..< (model.isReady ? model.numberOfStories : 0), id: \.self) { x in
+                    ForEach(0 ..< (model.isReady ? model.numberOfStories : 7), id: \.self) { x in
                         StoryIndicator(index: x, style: model.indicatorStyle(for: model.currentStoryIndex), progressModel: model.progressPublisher)
                     }
                 }

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -158,7 +158,7 @@ struct StoriesView: View {
         ZStack {
             VStack {
                 HStack(spacing: model.indicatorSpacing) {
-                    ForEach(0 ..< model.numberOfStories, id: \.self) { x in
+                    ForEach(0 ..< (model.isReady ? model.numberOfStories : 0), id: \.self) { x in
                         StoryIndicator(index: x, style: model.indicatorStyle(for: model.currentStoryIndex), progressModel: model.progressPublisher)
                     }
                 }


### PR DESCRIPTION
Part of PCIOS-375

I ran into a couple of instances where the top indicators didn't load at all for me. I think this is because we now load the stories and indicators and display them without waiting and the `numberOfStories` value isn't automatically updated when that process is complete (so it can remain zero from the view's perspective). Adding `isReady` fixes this, I believe. Now you'll see that loading happen and the progress indicators will appear once `isReady` resolves:

https://github.com/user-attachments/assets/b4ac1491-3476-4309-ac56-0526028bf67f

## To test

1. Start the app with an user that has enough stats for playback
2. Go to Profile
3. Tap on the banner
4. Check if the loading animation shows correctly and goes correctly to the next story
5. Go back and forward in the stories and see if they work correctly
6. Smoke test initial onboarding carousel to see if nothing was impacted there.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
