### PR TITLE
[Playback 2025] Audio session takeover fix

### DIFF
--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -93,8 +93,14 @@ fileprivate struct CustomVideoPlayerView: UIViewControllerRepresentable {
     init(urlString: String, backgroundColor: Color = .clear) {
         self.player = AVQueuePlayer()
         if let videoURL = Bundle.main.url(forResource: urlString, withExtension: "mp4") {
+            if !PlaybackManager.shared.isPlayingEpisode {
+                let session = AVAudioSession.sharedInstance()
+                try? session.setCategory(.ambient, mode: .default, policy: .default, options: [.mixWithOthers])
+                try? session.setActive(true, options: [])
+            }
             let item = AVPlayerItem(url: videoURL)
             self.looper = AVPlayerLooper(player: player, templateItem: item)
+            player.isMuted = true
             player.play()
         } else {
             self.looper = nil
@@ -114,8 +120,17 @@ fileprivate struct CustomVideoPlayerView: UIViewControllerRepresentable {
     func updateUIViewController(_ controller: AVPlayerViewController, context: Context) {
         // Handle updates if needed
     }
-}
 
+    static func dismantleUIViewController(_ uiViewController: AVPlayerViewController, coordinator: ()) {
+        if !PlaybackManager.shared.isPlayingEpisode {
+            do {
+                try AVAudioSession.sharedInstance().setActive(false)
+            } catch let error {
+                FileLog.shared.addMessage("Playback Video Audio Session error: \(error)")
+            }
+        }
+    }
+}
 
 #Preview("Plus") {
     PaidStoryWallView2025(subscriptionTier: .plus)


### PR DESCRIPTION
Fixes audio takeover from the Paywall view.

The background video is triggering the audio to takeover from other apps. I also tried switching to `VideoPlayer` directly in SwiftUI. This does simplify the code but might be better for 8.2 instead of during Code Freeze.

The simplest fix was to change the category to ambient + mixWithOthers so other audio can continue to play.

## To test

### External Audio
* Play music using Music.app or some other third party app
* Go all the way through the playback
* ✅ Ensure the audio remains playing

### Internal Audio
* Play a podcast
* Go all the way through the playback
* ✅ Ensure the audio remains playing

### Mixture (to ensure Audio Session setup)
* Play music using Music.app or some other third party app
* Go through the playback
* ✅ Ensure the audio remains playing
* Complete Playback
* Play a podcast
* ✅ Ensure episode plays back correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
