### PR TITLE
[Playback 2025] Fix layout on large text longest episode

### DIFF
--- a/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
@@ -25,21 +25,22 @@ struct LongestEpisode2025Story: ShareableStory {
     var body: some View {
         GeometryReader { proxy in
             ZStack {
-                background(size: proxy.size)
                 VStack(alignment: .center, spacing: 0) {
                     headerView
                     Spacer()
-                        .frame(height: 80)
-                    PodcastImage(uuid: podcast.uuid, size: .page, aspectRatio: nil, contentMode: .fill)
-                        .frame(width: imageSize * imageScale, height: imageSize * imageScale)
-                        .cornerRadius(4)
+                        .frame(height: 40)
+                    ZStack(alignment: .center) {
+                        PodcastImage(uuid: podcast.uuid, size: .page, aspectRatio: nil, contentMode: .fill)
+                            .frame(width: imageSize * imageScale, height: imageSize * imageScale)
+                            .cornerRadius(4)
+                            .background {
+                                background(size: proxy.size)
+                                    .padding(.top, 20)
+                            }
+                    }.border(.red)
                     Spacer()
-                    VStack {
-                        Spacer()
-                        footerView
-                        Spacer()
-                    }
-                    .frame(height: proxy.size.height / portionFactor)
+                    footerView
+                    Spacer()
                 }
             }
         }
@@ -76,21 +77,15 @@ struct LongestEpisode2025Story: ShareableStory {
     }
 
     @ViewBuilder func background(size: CGSize) -> some View {
-        VStack(alignment: .center, spacing: 0) {
-            Spacer()
-            ZStack {
-                LottieView(animation: .named("2025_longest_episode"))
-                    .configure({ animationView in
-                        animationView.contentMode = .scaleAspectFill
-                    })
-                    .playbackMode(renderForSharing ? .paused(at: .progress(1)) : .playing(.fromProgress(0, toProgress: 1, loopMode: .autoReverse)))
-                    .frame(width: size.width, height: size.width)
-                    .scaleEffect(UIScreen.isSmallScreen ? 1.2 : 1.4)
-                    .scaledToFill()
-                    .padding(.top, 40.0)
-            }
-            Spacer()
-        }
+        LottieView(animation: .named("2025_longest_episode"))
+            .configure({ animationView in
+                animationView.contentMode = .scaleAspectFill
+            })
+            .playbackMode(renderForSharing ? .paused(at: .progress(1)) : .playing(.fromProgress(0, toProgress: 1, loopMode: .autoReverse)))
+            .frame(width: size.width, height: size.width)
+            .scaleEffect(UIScreen.isSmallScreen ? 1.2 : 1.4)
+            .scaledToFill()
+//            .padding(.top, 40.0)
     }
 
     func onAppear() {

--- a/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
@@ -85,7 +85,6 @@ struct LongestEpisode2025Story: ShareableStory {
             .frame(width: size.width, height: size.width)
             .scaleEffect(UIScreen.isSmallScreen ? 1.2 : 1.4)
             .scaledToFill()
-//            .padding(.top, 40.0)
     }
 
     func onAppear() {

--- a/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
@@ -37,7 +37,7 @@ struct LongestEpisode2025Story: ShareableStory {
                                 background(size: proxy.size)
                                     .padding(.top, 20)
                             }
-                    }.border(.red)
+                    }
                     Spacer()
                     footerView
                     Spacer()


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-376 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Fix position of animation depending of text size

## To test

1. Start the app on a real device with Display Zoom -> Larger text enabled
2. Login with an user with a subscription and listening stats
3. Open Profile
4. Tap on the Profile Banner
5. Check the different stories to see if they look good
6. Look at Longest Episode story and check if the text does not overlap the animations and it's readable
7. Smoke test with regular Display Zoom to see if all still looks good

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
