### PR TITLE
Remove downloads when unsubscribing from a podcast

### DIFF
--- a/PocketCastsTests/Helpers/DBTestCase.swift
+++ b/PocketCastsTests/Helpers/DBTestCase.swift
@@ -28,6 +28,7 @@ class DBTestCase: XCTestCase {
     private func setupData() throws {
         let dataManager = Self.dataManager == nil ? try setupDatabase() : Self.dataManager!
         let downloadManager = DownloadManager(dataManager: dataManager)
+        DataManager.sharedManager = dataManager
 
         let podcast = Podcast()
         podcast.uuid = UUID().uuidString

--- a/PocketCastsTests/Tests/Utilities/PodcastManagerTests.swift
+++ b/PocketCastsTests/Tests/Utilities/PodcastManagerTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import PocketCastsDataModel
+import PocketCastsServer
 @testable import podcasts
 
 final class PodcastManagerTests: DBTestCase {
@@ -25,5 +26,69 @@ final class PodcastManagerTests: DBTestCase {
         let error = task.error as? NSError
         XCTAssertEqual(error?.domain, NSURLErrorDomain, "Task should be cancelled")
         XCTAssertEqual(error?.code, NSURLErrorCancelled, "Task should be cancelled")
+    }
+
+    func testUnsubscribeKeepsDownloadsInPlaylist() throws {
+        ServerSettings.setSyncingEmail(email: "test@example.com")
+        defer { ServerSettings.setSyncingEmail(email: nil) }
+
+        let (podcast, episode) = makeDownloadedPodcastAndEpisode()
+        let playlist = EpisodeFilter()
+        playlist.uuid = UUID().uuidString
+        playlist.playlistName = "Keep Downloads"
+        playlist.manual = true
+        dataManager.save(playlist: playlist)
+        dataManager.add(episodes: [episode], to: playlist)
+
+        let podcastManager = PodcastManager(dataManager: dataManager, downloadManager: downloadManager)
+        podcastManager.unsubscribe(podcast: podcast)
+
+        let refreshedEpisode = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshedEpisode.episodeStatus, DownloadStatus.downloaded.rawValue)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: DownloadManager.shared.pathForEpisode(refreshedEpisode)))
+    }
+
+    func testUnsubscribeRemovesDownloadsNotInPlaylist() throws {
+        ServerSettings.setSyncingEmail(email: "test@example.com")
+        defer { ServerSettings.setSyncingEmail(email: nil) }
+
+        let (podcast, episode) = makeDownloadedPodcastAndEpisode()
+        let podcastManager = PodcastManager(dataManager: dataManager, downloadManager: downloadManager)
+
+        podcastManager.unsubscribe(podcast: podcast)
+
+        let refreshedEpisode = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshedEpisode.episodeStatus, DownloadStatus.notDownloaded.rawValue)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: DownloadManager.shared.pathForEpisode(refreshedEpisode)))
+    }
+
+    private func makeDownloadedPodcastAndEpisode() -> (Podcast, Episode) {
+        let podcast = Podcast()
+        podcast.uuid = UUID().uuidString
+        podcast.subscribed = 0
+        podcast.addedDate = Date().addingTimeInterval(-2.weeks)
+        podcast.syncStatus = SyncStatus.synced.rawValue
+        dataManager.save(podcast: podcast)
+
+        let episode = Episode()
+        episode.uuid = UUID().uuidString
+        episode.podcastUuid = podcast.uuid
+        episode.podcast_id = podcast.id
+        episode.addedDate = podcast.addedDate
+        episode.downloadUrl = "http://example.com/audio"
+        episode.playingStatus = PlayingStatus.notPlayed.rawValue
+        episode.episodeStatus = DownloadStatus.downloaded.rawValue
+        dataManager.save(episode: episode)
+
+        createDownloadedFile(for: episode)
+
+        return (podcast, episode)
+    }
+
+    private func createDownloadedFile(for episode: Episode) {
+        let path = DownloadManager.shared.pathForEpisode(episode)
+        let directory = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: path, contents: Data())
     }
 }

--- a/podcasts/PodcastManager+Cleanup.swift
+++ b/podcasts/PodcastManager+Cleanup.swift
@@ -8,24 +8,32 @@ extension PodcastManager {
         // we don't delete podcasts that haven't been synced or you're still subscribed to
         if podcast.syncStatus == SyncStatus.notSynced.rawValue || podcast.isSubscribed() { return }
 
+        let episodes = dataManager.allEpisodesForPodcast(id: podcast.id)
+
+        // Remove queued/downloaded episodes that aren't in a playlist/Up Next
+        for episode in episodes where !episodeShouldBePreservedOnUnsubscribe(episode) {
+            downloadManager.removeFromQueue(episode: episode, fireNotification: false, userInitiated: false)
+            EpisodeManager.deleteDownloadedFiles(episode: episode)
+        }
+
         // we don't delete podcasts added to the phone in the last week. This is to prevent stuff you just leave open in discover from being removed
         if let addedDate = podcast.addedDate, abs(addedDate.timeIntervalSinceNow) < 1.week { return }
-
-        // we don't delete podcasts which have any episodes in a playlist or Up Next
-        if dataManager.playlistContainsPodcast(podcastUuid: podcast.uuid) { return }
 
         let interactedEpisodes = dataManager.allEpisodesForPodcast(id: podcast.id).filter { $0.userHasInteractedWithEpisode() }
 
         // we can safely delete podcasts where the user hasn't interacted with any of the episodes
         if interactedEpisodes.count == 0 {
             if FeatureFlag.downloadFixes.enabled {
-                let episodes = dataManager.allEpisodesForPodcast(id: podcast.id)
                 await downloadManager.cancelTasks(for: episodes)
             }
             // Delete all the episodes for the podcast that we're deleting
             dataManager.deleteAllEpisodesInPodcast(podcastId: podcast.id)
             dataManager.delete(podcast: podcast)
         }
+    }
+
+    func episodeShouldBePreservedOnUnsubscribe(_ episode: Episode) -> Bool {
+        dataManager.playlistContainsEpisode(episodeUuid: episode.uuid) || PlaybackManager.shared.inUpNext(episode: episode)
     }
 
     func deleteGhostEpisodesIfNeeded() {

--- a/podcasts/PodcastManager+Delete.swift
+++ b/podcasts/PodcastManager+Delete.swift
@@ -9,7 +9,12 @@ extension PodcastManager {
 
         if SyncManager.isUserLoggedIn() {
             // if the user has signed in, there's a cleanup task (PodcastManager.deletePodcastIfUnused) that will run later to remove episodes they haven't interacted but we do some basic cleanup here
-            // eg: remove downloaded/queued episodes and remove any that are in Up Next
+            let episodes = dataManager.allEpisodesForPodcast(id: podcast.id)
+            for episode in episodes where !episodeShouldBePreservedOnUnsubscribe(episode) {
+                downloadManager.removeFromQueue(episode: episode, fireNotification: false, userInitiated: false)
+                EpisodeManager.deleteDownloadedFiles(episode: episode)
+            }
+
             podcast.folderUuid = nil
             podcast.subscribed = 0
             podcast.autoArchiveEpisodeLimit = 0


### PR DESCRIPTION
Fixes [PCIOS-380](https://linear.app/a8c/issue/PCIOS-380/downloads-are-not-deleted-for-unsubscribed-podcasts)

## To test

1. Must be signed in to account
2. Subscribe to a podcast from Discover
3. Unsubscribe from the podcast
4. Navigate back to that podcast on Discover
5. ✅ Ensure downloaded episodes are deleted

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
