### PR TITLE
Delete downloads on unsubscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 8.1
 -----
 - Add Playback 2025 [#3734](https://github.com/Automattic/pocket-casts-ios/issues?q=state%3Aclosed%20label%3A%22%5BProject%5D%20Playback%202025%22)
+- Remove episode downloads on unsubscribe if an episode is not part of the a Manual playlist. [#3761](https://github.com/Automattic/pocket-casts-ios/pull/3761)
 
 8.0.1
 -----

--- a/PocketCastsTests/Helpers/DBTestCase.swift
+++ b/PocketCastsTests/Helpers/DBTestCase.swift
@@ -28,6 +28,7 @@ class DBTestCase: XCTestCase {
     private func setupData() throws {
         let dataManager = Self.dataManager == nil ? try setupDatabase() : Self.dataManager!
         let downloadManager = DownloadManager(dataManager: dataManager)
+        DataManager.sharedManager = dataManager
 
         let podcast = Podcast()
         podcast.uuid = UUID().uuidString

--- a/PocketCastsTests/Tests/Utilities/PodcastManagerTests.swift
+++ b/PocketCastsTests/Tests/Utilities/PodcastManagerTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import PocketCastsDataModel
+import PocketCastsServer
 @testable import podcasts
 
 final class PodcastManagerTests: DBTestCase {
@@ -25,5 +26,89 @@ final class PodcastManagerTests: DBTestCase {
         let error = task.error as? NSError
         XCTAssertEqual(error?.domain, NSURLErrorDomain, "Task should be cancelled")
         XCTAssertEqual(error?.code, NSURLErrorCancelled, "Task should be cancelled")
+    }
+
+    func testCleanupKeepsDownloadsInPlaylist() async throws {
+        ServerSettings.setSyncingEmail(email: "test@example.com")
+        defer { ServerSettings.setSyncingEmail(email: nil) }
+
+        let (_, episode) = makeDownloadedPodcastAndEpisode()
+        let playlist = EpisodeFilter()
+        playlist.uuid = UUID().uuidString
+        playlist.playlistName = "Keep Downloads"
+        playlist.manual = true
+        dataManager.save(playlist: playlist)
+        dataManager.add(episodes: [episode], to: playlist)
+
+        let podcastManager = PodcastManager(dataManager: dataManager, downloadManager: downloadManager)
+        await podcastManager.checkForUnusedPodcasts()
+
+        let refreshedEpisode = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshedEpisode.episodeStatus, DownloadStatus.downloaded.rawValue)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: DownloadManager.shared.pathForEpisode(refreshedEpisode)))
+    }
+
+    func testUnsubscribeRemovesDownloadsInPlaylist() throws {
+        ServerSettings.setSyncingEmail(email: "test@example.com")
+        defer { ServerSettings.setSyncingEmail(email: nil) }
+
+        let (podcast, episode) = makeDownloadedPodcastAndEpisode()
+        let playlist = EpisodeFilter()
+        playlist.uuid = UUID().uuidString
+        playlist.playlistName = "Keep Downloads"
+        playlist.manual = true
+        dataManager.save(playlist: playlist)
+        dataManager.add(episodes: [episode], to: playlist)
+
+        let podcastManager = PodcastManager(dataManager: dataManager, downloadManager: downloadManager)
+        podcastManager.unsubscribe(podcast: podcast)
+
+        let refreshedEpisode = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshedEpisode.episodeStatus, DownloadStatus.notDownloaded.rawValue)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: DownloadManager.shared.pathForEpisode(refreshedEpisode)))
+    }
+
+    func testUnsubscribeRemovesDownloadsNotInPlaylist() throws {
+        ServerSettings.setSyncingEmail(email: "test@example.com")
+        defer { ServerSettings.setSyncingEmail(email: nil) }
+
+        let (podcast, episode) = makeDownloadedPodcastAndEpisode()
+        let podcastManager = PodcastManager(dataManager: dataManager, downloadManager: downloadManager)
+
+        podcastManager.unsubscribe(podcast: podcast)
+
+        let refreshedEpisode = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshedEpisode.episodeStatus, DownloadStatus.notDownloaded.rawValue)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: DownloadManager.shared.pathForEpisode(refreshedEpisode)))
+    }
+
+    private func makeDownloadedPodcastAndEpisode() -> (Podcast, Episode) {
+        let podcast = Podcast()
+        podcast.uuid = UUID().uuidString
+        podcast.subscribed = 0
+        podcast.addedDate = Date().addingTimeInterval(-2.weeks)
+        podcast.syncStatus = SyncStatus.synced.rawValue
+        dataManager.save(podcast: podcast)
+
+        let episode = Episode()
+        episode.uuid = UUID().uuidString
+        episode.podcastUuid = podcast.uuid
+        episode.podcast_id = podcast.id
+        episode.addedDate = podcast.addedDate
+        episode.downloadUrl = "http://example.com/audio"
+        episode.playingStatus = PlayingStatus.notPlayed.rawValue
+        episode.episodeStatus = DownloadStatus.downloaded.rawValue
+        dataManager.save(episode: episode)
+
+        createDownloadedFile(for: episode)
+
+        return (podcast, episode)
+    }
+
+    private func createDownloadedFile(for episode: Episode) {
+        let path = DownloadManager.shared.pathForEpisode(episode)
+        let directory = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: path, contents: Data())
     }
 }

--- a/podcasts/PodcastManager+Cleanup.swift
+++ b/podcasts/PodcastManager+Cleanup.swift
@@ -8,6 +8,14 @@ extension PodcastManager {
         // we don't delete podcasts that haven't been synced or you're still subscribed to
         if podcast.syncStatus == SyncStatus.notSynced.rawValue || podcast.isSubscribed() { return }
 
+        let episodes = dataManager.allEpisodesForPodcast(id: podcast.id)
+
+        // Only delete episodes which aren't contained in a playlist.
+        // This is because episodes can be added to a playlist but not subscribed but we fetch the podcast info anyway for display
+        for episode in episodes where !dataManager.playlistContainsEpisode(episodeUuid: episode.uuid) {
+            EpisodeManager.deleteDownloadedFiles(episode: episode)
+        }
+
         // we don't delete podcasts added to the phone in the last week. This is to prevent stuff you just leave open in discover from being removed
         if let addedDate = podcast.addedDate, abs(addedDate.timeIntervalSinceNow) < 1.week { return }
 

--- a/podcasts/PodcastManager+Delete.swift
+++ b/podcasts/PodcastManager+Delete.swift
@@ -8,6 +8,11 @@ extension PodcastManager {
         let savedFolderUuid = podcast.folderUuid
 
         if SyncManager.isUserLoggedIn() {
+            let episodes = dataManager.allEpisodesForPodcast(id: podcast.id)
+            for episode in episodes {
+                EpisodeManager.deleteDownloadedFiles(episode: episode)
+            }
+
             // if the user has signed in, there's a cleanup task (PodcastManager.deletePodcastIfUnused) that will run later to remove episodes they haven't interacted but we do some basic cleanup here
             // eg: remove downloaded/queued episodes and remove any that are in Up Next
             podcast.folderUuid = nil


### PR DESCRIPTION
Fixes [PCIOS-380](https://linear.app/a8c/issue/PCIOS-380/downloads-are-not-deleted-for-unsubscribed-podcasts)

This changes two behaviors regarding downloads:
* Any time a podcast is unsubscribed from the device, all downloads are removed regardless of playlist status. The user agrees to a prompt to explicitly remove them and this behavior was changed in https://github.com/Automattic/pocket-casts-ios/pull/3538
* Downloads are not removed when running the regular cleanup task if they are part of a manual playlist. This is because the Podcast info may have been fetched for display and we don't know the difference, so this would delete all episodes manually added from Discover from a podcast a user didn't subscribe to.

## To test

### Unsubscribe deletion
Must be signed in to account
1. Subscribe to a podcast from Discover
2. Unsubscribe from the podcast
3. Navigate back to that podcast on Discover
4. ✅ Ensure downloaded episodes are deleted

### Non-subscribed Manual Playlist Episode
1. Add an episode from Discover to a Manual playlist from a podcast you don’t subscribe to
2. Download the episode
3. Pull to refresh
4. ✅ Ensure the download remains

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
