### PR TITLE
[Search] Avoid empty searches and allow 1 char predictive search

### DIFF
--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -70,7 +70,7 @@ class SearchResultsModel: ObservableObject {
         currentSearchTerm = term
         clearErrors()
 
-        guard term.count > 1, !isTermAnURL(term) else {
+        guard term.trim().count > 1, !isTermAnURL(term) else {
             return
         }
 

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -70,7 +70,7 @@ class SearchResultsModel: ObservableObject {
         currentSearchTerm = term
         clearErrors()
 
-        guard term.trim().count > 1, !isTermAnURL(term) else {
+        guard !term.trim().isEmpty, !isTermAnURL(term) else {
             return
         }
 

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -58,6 +58,9 @@ extension SearchResultsViewController: SearchResultsDelegate {
 
     func performSearch(searchTerm: String, triggeredByTimer: Bool, completion: @escaping (() -> Void)) {
         displaySearch.isSearching = true
+        if searchTerm.trim().isEmpty {
+            completion()
+        }
 
         if FeatureFlag.searchPredictive.enabled, triggeredByTimer {
             searchResults.predictiveSearch(term: searchTerm)
@@ -65,7 +68,7 @@ extension SearchResultsViewController: SearchResultsDelegate {
             searchResults.search(term: searchTerm)
         }
 
-        if !triggeredByTimer {
+        if !triggeredByTimer, !searchTerm.trim().isEmpty {
             searchHistoryModel.add(searchTerm: searchTerm)
         }
 

--- a/podcasts/PCSearchBarController+Search.swift
+++ b/podcasts/PCSearchBarController+Search.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsUtils
 
 extension PCSearchBarController {
     func resetSearchTimer() {
@@ -18,14 +19,18 @@ extension PCSearchBarController {
     @objc private func searchTimerFired() {
         searchTimer = nil
 
-        guard let searchTerm = searchTextField.text else { return }
+        guard let searchTerm = searchTextField.text?.trim() else { return }
+        if FeatureFlag.searchImprovements.enabled {
+            if searchTerm.isEmpty { return }
+        } else {
+            let characterCount = searchTerm.count
+            if characterCount < 2 { return }
 
-        let characterCount = searchTerm.count
-        if characterCount < 2 { return }
+            let lowerCaseSearch = searchTerm.lowercased()
 
-        let lowerCaseSearch = searchTerm.lowercased()
-        if (characterCount == 2 && lowerCaseSearch.startsWith(string: "ht")) || (characterCount == 3 && lowerCaseSearch.startsWith(string: "htt")) || lowerCaseSearch.startsWith(string: "http") { return } // don't auto search for feed URLs
-
+            // don't auto search for feed URLs
+            if (characterCount == 2 && lowerCaseSearch.startsWith(string: "ht")) || (characterCount == 3 && lowerCaseSearch.startsWith(string: "htt")) || lowerCaseSearch.startsWith(string: "http") { return }
+        }
         search(searchTerm: searchTerm, triggerdByTimer: true)
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-382 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR changes search to do the following:

- Trim the search terms before sending to server ( predictive or full search)
- Only send if we have at least 1 char after trimming
- Do no track on the client empty results for predictive search only for full search

The backend needs to have this PR merged: https://github.a8c.com/Automattic/pocket-casts-lambdas/pull/71 before 1 character predictive searches return a value

## To test

- Start the app
- Open Discover
- Tap on Search bar
- Tap one character. Ex: `a`
- Check that suggestions are seen
- Tap an empty string like. Ex: `      `
- Check that no search is triggered and empty results are shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
