### PR TITLE
[Playlists] Ensure action text do not wrap to next line

### DIFF
--- a/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
+++ b/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
@@ -101,6 +101,7 @@ struct PlaylistHeaderView: View {
                 Text(title)
                     .font(style: .subheadline, weight: .medium)
                     .foregroundStyle(color)
+                    .lineLimit(1)
                     .multilineTextAlignment(.leading)
                     .fixedSize(horizontal: false, vertical: true)
             }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-372 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Ensure that action button on manual playlist to do not expand to a second line.

| Before | After |
| - | - |
|  <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-12-02 at 15 51 15" src="https://github.com/user-attachments/assets/fb552a8f-2b4b-4627-9dd1-6a4162d99d54" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-12-02 at 15 43 48" src="https://github.com/user-attachments/assets/0aac2ccb-b2b5-452d-9095-dd1275711293" /> |

## To test

1. Start the app
2. Set device to large text settings or use a language where Add Episodes is a larger text
3. Open Playlists
4. Open a manual playlist
5. Check that the Add Episode buttons does not go to the next line

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
