### PR TITLE
[Playback 2025] Loading for long delays

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -243,6 +243,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the End of Year 2025 recap
     case endOfYear2025
 
+    /// Enable the End of Year to use first story as loading screen
+    case endOfYearLoadIsFirstStory
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -408,6 +411,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .enableLocalizationHeaders:
             true
         case .endOfYear2025:
+            true
+        case .endOfYearLoadIsFirstStory:
             true
         }
     }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -159,7 +159,7 @@ struct EndOfYear {
         let configuration = StoriesConfiguration()
         if EndOfYear.currentYear == .y2025 {
             configuration.closeAndDismissAfterFinished = true
-            configuration.loadingIsTheFirstStory = true
+            configuration.loadingIsTheFirstStory = FeatureFlag.endOfYearLoadIsFirstStory.enabled
             configuration.defaultStoriesCount = 11
         }
         return configuration

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -160,6 +160,7 @@ struct EndOfYear {
         if EndOfYear.currentYear == .y2025 {
             configuration.closeAndDismissAfterFinished = true
             configuration.loadingIsTheFirstStory = true
+            configuration.defaultStoriesCount = 11
         }
         return configuration
     }

--- a/podcasts/End of Year/Stories/2025/IntroStory2025.swift
+++ b/podcasts/End of Year/Stories/2025/IntroStory2025.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Lottie
+import PocketCastsServer
 
 extension Color {
     static let endOfYear2025Background = Color(hex: "28486A")
@@ -16,6 +17,8 @@ struct IntroStory2025: StoryView {
     @State private var animationProgress: AnimationProgressTime = .zero
 
     @State private var openCircle: Bool = false
+    @State private var animationFinished = false
+    @EnvironmentObject var syncProgressModel: SyncYearListeningProgress
 
     private let afterLoading: Bool
 
@@ -39,7 +42,7 @@ struct IntroStory2025: StoryView {
                 .mask(
                     Circle().scale(scale)
                 )
-                .opacity(opacity)
+                .opacity(animationFinished ? 0 : opacity)
         }
         .onChange(of: animationProgress) { position in
             if afterLoading {
@@ -59,17 +62,31 @@ struct IntroStory2025: StoryView {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(
-            LottieView(animation: .named("end_of_year_2025_intro"))
-                .animationDidFinish({ completed in
-                    loadCallback?()
-                })
-                .configure({ animationView in
-                    animationView.contentMode = .scaleAspectFill
-                })
-                .playbackMode(afterLoading ? .paused(at: .progress(1)) : .playing(.fromProgress(0, toProgress: 1, loopMode: .playOnce)))
-                .getRealtimeAnimationFrame($animationProgress)
-                .scaledToFill()
-                .ignoresSafeArea()
+            ZStack {
+                if animationFinished {
+                    VStack(spacing: 15) {
+                        Spacer()
+                        CircularProgressView(value: syncProgressModel.progress, stroke: .white, strokeWidth: 6)
+                            .frame(width: 40, height: 40)
+                        Spacer()
+                    }
+                } else {
+                    LottieView(animation: .named("end_of_year_2025_intro"))
+                        .animationDidFinish({ completed in
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                                animationFinished = true
+                                loadCallback?()
+                            }
+                        })
+                        .configure({ animationView in
+                            animationView.contentMode = .scaleAspectFill
+                        })
+                        .playbackMode(afterLoading ? .paused(at: .progress(1)) : .playing(.fromProgress(0, toProgress: 1, loopMode: .playOnce)))
+                        .getRealtimeAnimationFrame($animationProgress)
+                        .scaledToFill()
+                        .ignoresSafeArea()
+                }
+            }
         )
         .ignoresSafeArea()
         .background(backgroundColor)

--- a/podcasts/End of Year/Stories/2025/IntroStory2025.swift
+++ b/podcasts/End of Year/Stories/2025/IntroStory2025.swift
@@ -39,6 +39,7 @@ struct IntroStory2025: StoryView {
                 .multilineTextAlignment(.center)
                 .font(size: 25, style: .title, weight: .semibold)
                 .foregroundStyle(backgroundTextColor)
+                .padding(.horizontal, 24)
                 .mask(
                     Circle().scale(scale)
                 )

--- a/podcasts/End of Year/StoriesConfiguration.swift
+++ b/podcasts/End of Year/StoriesConfiguration.swift
@@ -29,4 +29,6 @@ class StoriesConfiguration {
     var indicatorSpacing: CGFloat = 2
 
     var loadingIsTheFirstStory: Bool = false
+
+    var defaultStoriesCount: Int = 7
 }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -111,7 +111,13 @@ class StoriesModel: ObservableObject {
             if self.configuration.loadingIsTheFirstStory {
                 loadingStart()
             }
-            await isReady = dataSource.refresh()
+            let isReady = await dataSource.refresh()
+            //try? await Task.sleep(for: .seconds(8))
+            if configuration.loadingIsTheFirstStory, progress >= 1 {
+                currentStoryIndex = 1
+                Analytics.track(.endOfYearStoryShown, story: "cover")
+            }
+            self.isReady = isReady
             failed = !isReady
         }
     }
@@ -119,12 +125,17 @@ class StoriesModel: ObservableObject {
     func loadingStart() {
         loadingCancellable = publisher.autoconnect().sink(receiveValue: { _ in
             let newProgress = self.progress + (0.01 / EndOfYear.defaultDuration)
-            self.progress = min(newProgress, 0.99)
+            if newProgress < 1 {
+                self.progress = newProgress
+            } else {
+                self.progress = 1
+            }
         })
     }
 
     func loadingEnded() {
         loadingCancellable = nil
+        self.progress = 1.01
     }
 
     func start() {

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -111,7 +111,7 @@ class StoriesModel: ObservableObject {
             if self.configuration.loadingIsTheFirstStory {
                 loadingStart()
             }
-            let isReady = await dataSource.refresh()            
+            let isReady = await dataSource.refresh()
             if configuration.loadingIsTheFirstStory, progress >= 1 {
                 currentStoryIndex = 1
                 Analytics.track(.endOfYearStoryShown, story: "cover")

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -111,8 +111,7 @@ class StoriesModel: ObservableObject {
             if self.configuration.loadingIsTheFirstStory {
                 loadingStart()
             }
-            let isReady = await dataSource.refresh()
-            //try? await Task.sleep(for: .seconds(8))
+            let isReady = await dataSource.refresh()            
             if configuration.loadingIsTheFirstStory, progress >= 1 {
                 currentStoryIndex = 1
                 Analytics.track(.endOfYearStoryShown, story: "cover")

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -160,7 +160,7 @@ struct StoriesView: View {
         ZStack {
             VStack {
                 HStack(spacing: model.indicatorSpacing) {
-                    ForEach(0 ..< (model.isReady ? model.numberOfStories : 7), id: \.self) { x in
+                    ForEach(0 ..< (model.isReady ? model.numberOfStories : model.configuration.defaultStoriesCount), id: \.self) { x in
                         StoryIndicator(index: x, style: model.indicatorStyle(for: model.currentStoryIndex), progressModel: model.progressPublisher)
                     }
                 }

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -53,6 +53,7 @@ struct StoriesView: View {
                     .environment(\.animated, true)
                     .environment(\.pauseState, pauseState)
                     .environmentObject(model)
+                    .environmentObject(syncProgressModel)
 
                 if model.shouldShowUpsell() {
                     model.paywallView().zIndex(6).onAppear {
@@ -111,6 +112,7 @@ struct StoriesView: View {
                     loadAnimationFinished = true
                     model.loadingEnded()
                 }
+                .environmentObject(syncProgressModel)
             } else {
                 Spacer()
                 VStack(spacing: 15) {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-375 <!-- issue number, if applicable -->
Fixes PCIOS-385

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

https://github.com/user-attachments/assets/e58257a5-7e95-4ca3-a813-8c9c7a7b83ce


This PR improves the loading state, to support cases where data takes more than 7s to load.
It shows loading indicator after the animation is complete to indicate that data is still loading.

This PR also adds a feature flag to control the use of intro as loading just to ensure we have a quick way to revert this if something goes wrong.

## To test

1. Start the app with an user that has enough stats for playback. If needed add a sleep on the loading of data, `StoriesModel` class in the `refresh` method  to  check the loading animation.
2. Go to Profile
3. Tap on the banner
4. Check if the loading animation shows correctly and goes correctly to the next story
5. Go back and forward in the stories and see if they work correctly
6. Check if analytics for cover show correctly
7. Test without the delay to see if regular loading also works correctly
8. Smoke test initial onboarding carousel to see if nothing was impacted there.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
