### PR TITLE
Effects player QOS upgrade

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -246,6 +246,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the End of Year to use first story as loading screen
     case endOfYearLoadIsFirstStory
 
+    /// Upgrades the Effects Player's AudioReadTask to a QOS level of "userInitiated" from "default"
+    case effectsPlayerQOSUpgrade
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -413,6 +416,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .endOfYear2025:
             true
         case .endOfYearLoadIsFirstStory:
+			true
+        case .effectsPlayerQOSUpgrade:
             true
         }
     }

--- a/podcasts/AudioReadTask.swift
+++ b/podcasts/AudioReadTask.swift
@@ -40,7 +40,15 @@ class AudioReadTask {
         self.bufferManager = bufferManager
         cachedFrameCount = frameCount
 
-        readQueue = DispatchQueue(label: "au.com.pocketcasts.ReadQueue", qos: .default, attributes: [], autoreleaseFrequency: .never, target: nil)
+        let qos: DispatchQoS
+
+        if FeatureFlag.effectsPlayerQOSUpgrade.enabled {
+            qos = .userInitiated
+        } else {
+            qos = .default
+        }
+
+        readQueue = DispatchQueue(label: "au.com.pocketcasts.ReadQueue", qos: qos, attributes: [], autoreleaseFrequency: .never, target: nil)
 
         updateRemoveSilenceNumbers()
 


### PR DESCRIPTION
The calculations for the effects player's audio buffer should be happening at a higher QoS level since this directly affects audio playback.

This changes the QoS to `userInitiated` and adds `effectsPlayerQOSUpgrade` in case we need to disable this in production.

## To test

* Enable Trim Silence
* Play audio and ensure nothing is affected

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
