### PR TITLE
[Playback 2025] Ensure sync for year is done based on model year

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -190,9 +190,9 @@ class PodcastExistsHelper {
 }
 
 public class YearListeningHistory {
-    public static func sync() -> Bool {
+    public static func sync(_ year: Int) -> Bool {
         var syncResults: [Bool] = []
-        let yearsToSync: [Int32] = SubscriptionHelper.hasActiveSubscription() ? [2024, 2023, 2022] : [2024, 2023]
+        let yearsToSync: [Int32] = [Int32(year), Int32(year - 1)]
 
         let dispatchGroup = DispatchGroup()
         yearsToSync.forEach { yearToSync in

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -229,7 +229,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let model = EndOfYear2023StoriesModel()
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { syncCalled = true; return true })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { year in syncCalled = true; return true })
         Settings.setHasSyncedEpisodesForPlayback(true, year: 2023)
 
         endOfYearManager.isFullListeningHistoryToReturn = false
@@ -243,7 +243,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let model = EndOfYear2023StoriesModel()
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { syncCalled = true; return true })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { year in syncCalled = true; return true })
         Settings.setHasSyncedEpisodesForPlayback(true, year: 2023)
 
         endOfYearManager.isFullListeningHistoryToReturn = false
@@ -261,7 +261,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let model = EndOfYear2023StoriesModel()
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { year in syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
         Settings.setHasSyncedEpisodesForPlayback(false, year: 2023)
         endOfYearManager.isFullListeningHistoryToReturn = false
         _ = await builder.build()
@@ -278,7 +278,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let model = EndOfYear2023StoriesModel()
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { year in syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
         Settings.setHasSyncedEpisodesForPlayback(false, year: 2023)
         endOfYearManager.isFullListeningHistoryToReturn = false
         _ = await builder.build()

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -84,6 +84,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         setupRoutes()
 
+        if Settings.shouldResultEndOfYearSyncStatus {
+            Settings.setHasSyncedEpisodesForPlayback(false, year: 2025)
+            Settings.setHasSyncedEpisodesForPlaybackAsPlusUser(false, year: 2025)
+            Settings.shouldResultEndOfYearSyncStatus = false
+        }
+
+
         NotificationsHelper.shared.register(checkToken: false)
 
         DispatchQueue.global().async { [weak self] in

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -188,6 +188,7 @@ struct Constants {
         static let playlistsOnboarding = "NewPlaylistsOnboarding"
         static let firstTimePlaylistCreated = "FirstTimePlaylistCreated"
         static let saveCurrentUpNextQueueIntoPlaylist = "SaveCurrentUpNextQueueIntoPlaylist"
+        static let shouldResultEndOfYearSyncStatus = "ShouldResultEndOfYearSyncStatus"
 
         enum headphones {
             static let previousAction = SettingValue("headphones.previousAction",

--- a/podcasts/End of Year/EndOfYearStoriesBuilder.swift
+++ b/podcasts/End of Year/EndOfYearStoriesBuilder.swift
@@ -11,9 +11,9 @@ class EndOfYearStoriesBuilder {
 
     private var hasActiveSubscription: () -> Bool
 
-    private let sync: (() -> Bool)?
+    private let sync: ((Int) -> Bool)?
 
-    init(dataManager: DataManager = DataManager.sharedManager, model: StoryModel, sync: (() -> Bool)? = YearListeningHistory.sync, hasActiveSubscription: @escaping () -> Bool = SubscriptionHelper.hasActiveSubscription) {
+    init(dataManager: DataManager = DataManager.sharedManager, model: StoryModel, sync: ((Int) -> Bool)? = YearListeningHistory.sync, hasActiveSubscription: @escaping () -> Bool = SubscriptionHelper.hasActiveSubscription) {
         self.dataManager = dataManager
         self.model = model
         self.sync = sync
@@ -30,7 +30,7 @@ class EndOfYearStoriesBuilder {
             if SyncManager.isUserLoggedIn(),
                !Settings.hasSyncedEpisodesForPlayback(year: modelType.year) ||
                 (Settings.hasSyncedEpisodesForPlayback(year: modelType.year) && Settings.hasSyncedEpisodesForPlaybackAsPlusUser(year: modelType.year) != hasActiveSubscription()) || model.shouldLoadData(in: dataManager) {
-                let syncedWithSuccess = sync?()
+                let syncedWithSuccess = sync?(modelType.year)
 
                 if syncedWithSuccess == true {
                     Settings.setHasSyncedEpisodesForPlayback(true, year: modelType.year)

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -468,11 +468,11 @@ class Settings: NSObject {
     }
 
     class func displayableVersion() -> String {
-        #if STAGING
-            return L10n.appVersion(Settings.appVersion(), Settings.buildNumber()) + " - STAGING"
-        #else
-            return L10n.appVersion(Settings.appVersion(), Settings.buildNumber())
-        #endif
+#if STAGING
+        return L10n.appVersion(Settings.appVersion(), Settings.buildNumber()) + " - STAGING"
+#else
+        return L10n.appVersion(Settings.appVersion(), Settings.buildNumber())
+#endif
     }
 
     class func buildNumber() -> String {
@@ -802,10 +802,10 @@ class Settings: NSObject {
             playerActions = SettingsStore.appSettings.playerShelf
                 .compactMap { action in
                     switch action {
-                    case .known(let present):
-                        return present
-                    case .unknown:
-                        return nil
+                        case .known(let present):
+                            return present
+                        case .unknown:
+                            return nil
                     }
                 }
                 .filter { $0.isAvailable }
@@ -820,10 +820,10 @@ class Settings: NSObject {
         if FeatureFlag.newSettingsStorage.enabled {
             let unknowns = SettingsStore.appSettings.playerShelf.compactMap { action -> ActionOption? in
                 switch action {
-                case .known:
-                    return nil
-                case .unknown(let absent):
-                    return .unknown(absent)
+                    case .known:
+                        return nil
+                    case .unknown(let absent):
+                        return .unknown(absent)
                 }
             }
             SettingsStore.appSettings.playerShelf = actions.map({ .known($0) }) + unknowns
@@ -1547,6 +1547,15 @@ class Settings: NSObject {
         }
         set {
             UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.saveCurrentUpNextQueueIntoPlaylist)
+        }
+    }
+
+    static var shouldResultEndOfYearSyncStatus: Bool {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.shouldResultEndOfYearSyncStatus) as? Bool ?? true
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.shouldResultEndOfYearSyncStatus)
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Ensure that the year of the model and the previous are correctly sync

## To test

1. Start the app
2. Open Profile
3. Open the playback 2025
4. Check that the new data as all info from all devices.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
