### PR TITLE
[Playlists] Clear last filter shown

### DIFF
--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -148,6 +148,8 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
         showPlaylistsTipIfNeeded()
         showOnboardingScreenIfNeeded()
+
+        UserDefaults.standard.set(nil, forKey: Constants.UserDefaults.lastFilterShown)
     }
 
     override func viewDidDisappear(_ animated: Bool) {


### PR DESCRIPTION
Fixes [POC-432](https://linear.app/a8c/issue/POC-432/app-opens-to-active-playlist-instead-of-last-used-screen)

## To test

### Last Opened
* Open the Playlists tab
* Open a Playlist
* Close the app
* Open the app
* ✅ Verify that the last opened Playlist is shown

### Clear Last Opened
* Open the Playlists tab
* Navigate to the Playlists list
* Close the app
* Open the app
* ✅ Verify that the Playlists list is shown and not the last Playlist you visited

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
