### PR TITLE
[Playback 2025] Refresh in place after purchase and advance to next story

### DIFF
--- a/Pocket Casts Configuration.storekit
+++ b/Pocket Casts Configuration.storekit
@@ -18,7 +18,7 @@
   ],
   "settings" : {
     "_compatibilityTimeRate" : {
-      "3" : 6
+      "3" : 5
     },
     "_failTransactionsEnabled" : false,
     "_locale" : "en_US",
@@ -70,7 +70,7 @@
         "name" : "Offer Code Redeem Sheet"
       }
     ],
-    "_timeRate" : 1004
+    "_timeRate" : 1000
   },
   "subscriptionGroups" : [
     {

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -43,6 +43,8 @@ struct PaidStoryWallView2025: StoryView {
 
     private let videoAspectRatio = CGFloat(1.37)
 
+    var shouldPause: Bool = true
+
     let plusOnly = false
 
     init(subscriptionTier: SubscriptionTier) {
@@ -84,8 +86,7 @@ struct PaidStoryWallView2025: StoryView {
                         NavigationManager.sharedManager.showUpsellView(from: storiesViewController, source: .endOfYear, flow: SyncManager.isUserLoggedIn() ? .endOfYearUpsell : .endOfYear)
                     } else {
                         Analytics.track(.endOfYearPlusContinued, properties: ["year": EndOfYear.currentYear.literalValue])
-                        //pauseState.togglePause()
-                        storyModel.next()
+                        advanceToNextStory()
                     }
                 }
                 .buttonStyle(BasicButtonStyle(textColor: .white, backgroundColor: .black, borderColor: .black))
@@ -101,15 +102,17 @@ struct PaidStoryWallView2025: StoryView {
                 .ignoresSafeArea()
                 .allowsHitTesting(false)
         }
-        //.onAppear() {
-        //    pauseState.togglePause()
-        //}
         .onChange(of: subscriptionModel.subscriptionTier) { newValue in
-            if newValue != subscriptionTier {
-                pauseState.togglePause()
+            if newValue != subscriptionTier, newValue != .none {
+                pauseState.play()
                 storyModel.next()
             }
         }
+    }
+
+    private func advanceToNextStory() {
+        storyModel.start()
+        storyModel.next()
     }
 
     func onAppear() {

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -10,10 +10,9 @@ fileprivate class SubscriptionModel: ObservableObject {
 
     @Published var subscriptionTier: SubscriptionTier
 
-    init(subscriptionTier: SubscriptionTier) {
-        self.subscriptionTier = subscriptionTier
+    init() {
+        self.subscriptionTier = SubscriptionHelper.activeTier
         ServerNotifications.iapPurchaseCompleted.publisher()
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.refreshTier()
             }
@@ -21,7 +20,9 @@ fileprivate class SubscriptionModel: ObservableObject {
     }
 
     private func refreshTier() {
-        subscriptionTier = SubscriptionHelper.activeTier
+        DispatchQueue.main.async { [weak self] in
+            self?.subscriptionTier = SubscriptionHelper.activeTier
+        }
     }
 }
 
@@ -33,7 +34,8 @@ struct PaidStoryWallView2025: StoryView {
 
     @StateObject private var model = PlusPricingInfoModel()
 
-    @StateObject private var subscriptionModel: SubscriptionModel
+    @StateObject private var subscriptionModel =  SubscriptionModel()
+    private let subscriptionTier: SubscriptionTier
 
     private let foregroundColor = Color.black
 
@@ -44,7 +46,11 @@ struct PaidStoryWallView2025: StoryView {
     let plusOnly = false
 
     init(subscriptionTier: SubscriptionTier) {
-        _subscriptionModel = StateObject(wrappedValue: SubscriptionModel(subscriptionTier: subscriptionTier))
+        self.subscriptionTier = subscriptionTier
+    }
+
+    var tier: SubscriptionTier {
+        return subscriptionModel.subscriptionTier
     }
 
     var body: some View {
@@ -66,11 +72,11 @@ struct PaidStoryWallView2025: StoryView {
                     }
                     .padding(.top, UIScreen.isSmallScreen ? 80 : 110)
                     .allowsHitTesting(false)
-                StoryFooter2025(title: subscriptionModel.subscriptionTier == .none ?  L10n.playback2025PlusUpsellTitle : L10n.playback2025PlusThanksTitle,
-                                description: subscriptionModel.subscriptionTier == .none ?  L10n.playback2025PlusUpsellDescription : L10n.playback2025PlusThanksDescription(subscriptionModel.subscriptionTier.displayNameShort),
-                                subscriptionTier: subscriptionModel.subscriptionTier == .none ? .plus : subscriptionModel.subscriptionTier)
-                Button(subscriptionModel.subscriptionTier == .none ?  L10n.playback2025PlusUpsellButtonTitle : L10n.continue) {
-                    if subscriptionModel.subscriptionTier == .none {
+                StoryFooter2025(title: tier == .none ?  L10n.playback2025PlusUpsellTitle : L10n.playback2025PlusThanksTitle,
+                                description: tier == .none ?  L10n.playback2025PlusUpsellDescription : L10n.playback2025PlusThanksDescription(tier.displayNameShort),
+                                subscriptionTier: tier == .none ? .plus : tier)
+                Button(tier == .none ?  L10n.playback2025PlusUpsellButtonTitle : L10n.continue) {
+                    if tier == .none {
                         guard let storiesViewController = SceneHelper.rootViewController() else {
                             return
                         }
@@ -78,7 +84,7 @@ struct PaidStoryWallView2025: StoryView {
                         NavigationManager.sharedManager.showUpsellView(from: storiesViewController, source: .endOfYear, flow: SyncManager.isUserLoggedIn() ? .endOfYearUpsell : .endOfYear)
                     } else {
                         Analytics.track(.endOfYearPlusContinued, properties: ["year": EndOfYear.currentYear.literalValue])
-                        pauseState.togglePause()
+                        //pauseState.togglePause()
                         storyModel.next()
                     }
                 }
@@ -95,8 +101,14 @@ struct PaidStoryWallView2025: StoryView {
                 .ignoresSafeArea()
                 .allowsHitTesting(false)
         }
-        .onAppear() {
-            pauseState.togglePause()
+        //.onAppear() {
+        //    pauseState.togglePause()
+        //}
+        .onChange(of: subscriptionModel.subscriptionTier) { newValue in
+            if newValue != subscriptionTier {
+                pauseState.togglePause()
+                storyModel.next()
+            }
         }
     }
 
@@ -140,6 +152,7 @@ fileprivate struct CustomVideoPlayerView: UIViewControllerRepresentable {
 
     func updateUIViewController(_ controller: AVPlayerViewController, context: Context) {
         // Handle updates if needed
+        controller.player?.play()
     }
 
     static func dismantleUIViewController(_ uiViewController: AVPlayerViewController, coordinator: ()) {

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -53,7 +53,7 @@ struct PaidStoryWallView2025: StoryView {
                         guard let storiesViewController = SceneHelper.rootViewController() else {
                             return
                         }
-                        Analytics.track(.endOfYearUpsellShown, properties: ["year": "2025"])
+                        Analytics.track(.endOfYearUpsellShown, properties: ["year": EndOfYear.currentYear.literalValue])
                         NavigationManager.sharedManager.showUpsellView(from: storiesViewController, source: .endOfYear, flow: SyncManager.isUserLoggedIn() ? .endOfYearUpsell : .endOfYear)
                     } else {
                         Analytics.track(.endOfYearPlusContinued, properties: ["year": EndOfYear.currentYear.literalValue])

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -1,7 +1,29 @@
 import SwiftUI
 import AVKit
+import Combine
+
 import PocketCastsServer
 import PocketCastsUtils
+
+fileprivate class SubscriptionModel: ObservableObject {
+    private var cancellables = Set<AnyCancellable>()
+
+    @Published var subscriptionTier: SubscriptionTier
+
+    init(subscriptionTier: SubscriptionTier) {
+        self.subscriptionTier = subscriptionTier
+        ServerNotifications.iapPurchaseCompleted.publisher()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.refreshTier()
+            }
+            .store(in: &cancellables)
+    }
+
+    private func refreshTier() {
+        subscriptionTier = SubscriptionHelper.activeTier
+    }
+}
 
 struct PaidStoryWallView2025: StoryView {
     let identifier = "plus_interstitial"
@@ -11,7 +33,7 @@ struct PaidStoryWallView2025: StoryView {
 
     @StateObject private var model = PlusPricingInfoModel()
 
-    let subscriptionTier: SubscriptionTier
+    @StateObject private var subscriptionModel: SubscriptionModel
 
     private let foregroundColor = Color.black
 
@@ -22,7 +44,7 @@ struct PaidStoryWallView2025: StoryView {
     let plusOnly = false
 
     init(subscriptionTier: SubscriptionTier) {
-        self.subscriptionTier = subscriptionTier
+        _subscriptionModel = StateObject(wrappedValue: SubscriptionModel(subscriptionTier: subscriptionTier))
     }
 
     var body: some View {
@@ -44,12 +66,11 @@ struct PaidStoryWallView2025: StoryView {
                     }
                     .padding(.top, UIScreen.isSmallScreen ? 80 : 110)
                     .allowsHitTesting(false)
-                StoryHeader2025(title: subscriptionTier == .none ?  L10n.playback2025PlusUpsellTitle : L10n.playback2025PlusThanksTitle,
-                                description: subscriptionTier == .none ?  L10n.playback2025PlusUpsellDescription : L10n.playback2025PlusThanksDescription(subscriptionTier.displayName),
-                                subscriptionTier: subscriptionTier == .none ? .plus : subscriptionTier,
-                                topPadding: 0)
-                Button(subscriptionTier == .none ?  L10n.playback2025PlusUpsellButtonTitle : L10n.continue) {
-                    if subscriptionTier == .none {
+                StoryFooter2025(title: subscriptionModel.subscriptionTier == .none ?  L10n.playback2025PlusUpsellTitle : L10n.playback2025PlusThanksTitle,
+                                description: subscriptionModel.subscriptionTier == .none ?  L10n.playback2025PlusUpsellDescription : L10n.playback2025PlusThanksDescription(subscriptionModel.subscriptionTier.displayNameShort),
+                                subscriptionTier: subscriptionModel.subscriptionTier == .none ? .plus : subscriptionModel.subscriptionTier)
+                Button(subscriptionModel.subscriptionTier == .none ?  L10n.playback2025PlusUpsellButtonTitle : L10n.continue) {
+                    if subscriptionModel.subscriptionTier == .none {
                         guard let storiesViewController = SceneHelper.rootViewController() else {
                             return
                         }

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -82,6 +82,8 @@ protocol Story {
     /// If the story is available only for Plus users
     var plusOnly: Bool { get }
 
+    var shouldPause: Bool { get }
+
     /// Called when the story actually appears.
     ///
     /// If you use SwiftUI `onAppear` together with preload
@@ -109,6 +111,10 @@ extension Story {
         false
     }
 
+    var shouldPause: Bool {
+        false
+    }
+
     func onAppear() {}
     func onPause() {}
     func onResume() {}
@@ -132,6 +138,14 @@ class PauseState: ObservableObject {
 
     func togglePause() {
         isPaused.toggle()
+    }
+
+    func pause() {
+        isPaused = true
+    }
+
+    func play() {
+        isPaused = false
     }
 }
 

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -393,12 +393,14 @@ private extension StoriesModel {
             }
             .store(in: &cancellables)
 
-        ServerNotifications.iapPurchaseCompleted.publisher()
-        .receive(on: DispatchQueue.main)
-        .sink { [weak self] _ in
-            self?.refresh()
+        if EndOfYear.currentYear != .y2025 {
+            ServerNotifications.iapPurchaseCompleted.publisher()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.refresh()
+            }
+            .store(in: &cancellables)
         }
-        .store(in: &cancellables)
     }
 
     func isPaidUser() -> Bool {

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -182,6 +182,9 @@ class StoriesModel: ObservableObject {
         // Otherwise, the paywall appears in front of the story
         if currentStory?.identifier != story.identifier, !story.plusOnly || isPaidUser() {
             story.onAppear()
+            if story.shouldPause {
+                pause()
+            }
         }
 
         currentStory = story

--- a/podcasts/End of Year/Views/EndOfYearCard.swift
+++ b/podcasts/End of Year/Views/EndOfYearCard.swift
@@ -47,8 +47,15 @@ struct EndOfYearCard: View {
             }
             .background {
                 if FeatureFlag.endOfYear2025.enabled {
-                    Image(viewModel.imageName)
-                        .resizable()
+                    VStack(alignment: .trailing) {
+                        Spacer()
+                        HStack {
+                            Spacer()
+                            Image(viewModel.imageName)
+                                .resizable()
+                                .scaledToFit()
+                        }
+                    }
                 } else {
                     ZStack(alignment: .trailing) {
                         HStack {

--- a/podcasts/SubscriptionTier+L10n.swift
+++ b/podcasts/SubscriptionTier+L10n.swift
@@ -14,7 +14,7 @@ extension SubscriptionTier {
     var displayNameShort: String {
         switch self {
         case .patron: L10n.patron
-        case .plus: L10n.pocketCastsShort
+        case .plus: L10n.pocketCastsPlusShort
         case .none: L10n.pocketCastsShort
         }
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-386 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

1. Start the app on a real device
2. Login with an user without a subscription or use Developer screen to make you Non Plus
3. Open the Playback
4. Advance to the paid plus story
5. Ensure that story is paused at this point
6. Tap on Purchase Plus
7. Go ahead with the purchase
8. After the purchase is complete check if screen advances to the next story, Year over Year compare
9. Test the scenario where the purchase is cancelled and see if you stay on the same screen
10. Test again with a subscription and see if the Continue button on the plus purchase screen works correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
