### PR TITLE
[Playback 2025] Check loading first FF is applied to first story

### DIFF
--- a/podcasts/End of Year/End of Year 2025/EndOfYear2025StoriesModel.swift
+++ b/podcasts/End of Year/End of Year 2025/EndOfYear2025StoriesModel.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import SwiftUI
 
 class EndOfYear2025StoriesModel: StoryModel {
@@ -90,7 +91,7 @@ class EndOfYear2025StoriesModel: StoryModel {
         defer { firstTime = false }
         switch stories[storyNumber] {
             case .intro:
-                return IntroStory2025(afterLoading: firstTime)
+                return IntroStory2025(afterLoading: FeatureFlag.endOfYearLoadIsFirstStory.enabled && firstTime)
             case .numberOfPodcastsAndEpisodesListened:
                 return NumberListened2025(listenedNumbers: data.listenedNumbers, podcasts: data.top8Podcasts)
             case .topSpot:

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -119,9 +119,11 @@ struct StoriesView: View {
                     let progress = syncProgressModel.progress
                     CircularProgressView(value: progress, stroke: model.indicatorColor(for: model.currentStoryIndex), strokeWidth: 6)
                         .frame(width: 40, height: 40)
-                    Text(L10n.loading)
-                        .foregroundColor(model.indicatorColor(for: model.currentStoryIndex))
-                        .font(style: .body)
+                    if EndOfYear.currentYear != .y2025 {
+                        Text(L10n.loading)
+                            .foregroundColor(model.indicatorColor(for: model.currentStoryIndex))
+                            .font(style: .body)
+                    }
                 }
             }
             header


### PR DESCRIPTION

| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This changes ensures that the FF for load as first story is used on first story and loading text is not show for standard loading.

## To test

1. Start the app
2. Enable the FF endOfYearLoadIsFirstStory
3. Open playback
4. Check that no `Loading` text is shown on start
5. Check that first story after loading, the cover, shows the full animation

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
