### PR TITLE
[Bug] Fix episode empty search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -----
 - Add Playback 2025 [#3734](https://github.com/Automattic/pocket-casts-ios/issues?q=state%3Aclosed%20label%3A%22%5BProject%5D%20Playback%202025%22)
 - Remove episode downloads on unsubscribe if an episode is not part of the a Manual playlist. [#3761](https://github.com/Automattic/pocket-casts-ios/pull/3761)
+- Fix display of empty results when searching for episodes in a Podcast [#3772](https://github.com/Automattic/pocket-casts-ios/pull/3772)
 
 8.0.1
 -----

--- a/podcasts/EpisodesDataManager.swift
+++ b/podcasts/EpisodesDataManager.swift
@@ -127,7 +127,7 @@ class EpisodesDataManager {
         if !podcast.shouldShowArchived {
             whereClauses.append("archived = 0")
         }
-        if let uuids = uuidsToFilter, !uuids.isEmpty { // ignore uuid filtering if uuid list is empty or nil
+        if let uuids = uuidsToFilter { // ignore uuid filtering if uuid list is empty or nil
             whereClauses.append("uuid IN (\(uuids.map { "'\($0)'" }.joined(separator: ",")))")
         }
         let whereStr = whereClauses.joined(separator: " AND ")


### PR DESCRIPTION
This if you send an empty uuids list it means the search didn't return results for it

| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-387 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR fixes the episode search UI to show the empty state when no results are found

<img width="320"  alt="Simulator Screenshot - iPhone 16 - 2025-12-04 at 15 16 01" src="https://github.com/user-attachments/assets/8c0addb9-77a2-41c4-b8bc-2930ca365f08" />


## To test

1. Start the app
2. Open a podcast
3. Tap on the search bar
4. Search for a gibberish term that doesn't exist: `adkjadkasjdkj`
5. Check that the empty results state is shown
6. Now write a term that does exist
7. Check if results are shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
