### PR TITLE
[Playback 2025] Longest story UI tweak

### DIFF
--- a/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
@@ -35,7 +35,7 @@ struct LongestEpisode2025Story: ShareableStory {
                             .cornerRadius(4)
                             .background {
                                 background(size: proxy.size)
-                                    .padding(.top, 20)
+                                    .padding(.top, 60)
                             }
                     }
                     Spacer()


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

<img width="320" alt="Simulator Screenshot - iPhone 16 - 2025-12-04 at 15 32 00" src="https://github.com/user-attachments/assets/e9fa97b3-41c1-4ac6-9dbf-7994477a56c5" />

## To test

1. Start the app
2. Open the Playback
3. Tap until the longest episode story
4. Check that the top of the image covers the top of the animation
5. Check in different screen sizes

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
