### PR TITLE
[Playback 2025] Last polish

### DIFF
--- a/podcasts/End of Year/Stories/2025/IntroStory2025.swift
+++ b/podcasts/End of Year/Stories/2025/IntroStory2025.swift
@@ -67,8 +67,12 @@ struct IntroStory2025: StoryView {
                 if animationFinished {
                     VStack(spacing: 15) {
                         Spacer()
-                        CircularProgressView(value: syncProgressModel.progress, stroke: .white, strokeWidth: 6)
-                            .frame(width: 40, height: 40)
+                        ZStack {
+                            CircularProgressView(value: 1, stroke: .white.opacity(0.33), strokeWidth: 6)
+                                .frame(width: 40, height: 40)
+                            CircularProgressView(value: 0.5, stroke: .white, strokeWidth: 6)
+                                .frame(width: 40, height: 40)
+                        }
                         Spacer()
                     }
                 } else {

--- a/podcasts/End of Year/Stories/2025/ListeningTime2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/ListeningTime2025Story.swift
@@ -25,8 +25,10 @@ struct ListeningTime2025Story: ShareableStory {
 
     var formattedMinutes: String {
         let formatter = NumberFormatter()
+        formatter.locale = Locale(identifier: "en-us")
         formatter.numberStyle = .decimal
         formatter.groupingSeparator = ","
+        formatter.usesGroupingSeparator = true
         return formatter.string(for: Int(listeningTime / 60.0)) ?? ""
     }
 

--- a/podcasts/End of Year/Stories/2025/ListeningTime2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/ListeningTime2025Story.swift
@@ -25,10 +25,8 @@ struct ListeningTime2025Story: ShareableStory {
 
     var formattedMinutes: String {
         let formatter = NumberFormatter()
-        formatter.locale = Locale(identifier: "en-us")
+        formatter.locale = Locale.current
         formatter.numberStyle = .decimal
-        formatter.groupingSeparator = ","
-        formatter.usesGroupingSeparator = true
         return formatter.string(for: Int(listeningTime / 60.0)) ?? ""
     }
 
@@ -111,8 +109,8 @@ final private class LottieTextProvider: AnimationKeypathTextProvider {
         self.endTime = endTime
         self.currentTime = startTime
         self.formatter = NumberFormatter()
+        formatter.locale = Locale.current
         formatter.numberStyle = .decimal
-        formatter.groupingSeparator = ","
     }
 
     func text(for keypath: Lottie.AnimationKeypath, sourceText: String) -> String? {

--- a/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
@@ -28,16 +28,14 @@ struct LongestEpisode2025Story: ShareableStory {
                 VStack(alignment: .center, spacing: 0) {
                     headerView
                     Spacer()
-                        .frame(height: 40)
-                    ZStack(alignment: .center) {
-                        PodcastImage(uuid: podcast.uuid, size: .page, aspectRatio: nil, contentMode: .fill)
-                            .frame(width: imageSize * imageScale, height: imageSize * imageScale)
-                            .cornerRadius(4)
-                            .background {
-                                background(size: proxy.size)
-                                    .padding(.top, 90)
-                            }
-                    }
+                        .frame(maxHeight: 40)
+                    PodcastImage(uuid: podcast.uuid, size: .page, aspectRatio: nil, contentMode: .fill)
+                        .frame(width: imageSize * imageScale, height: imageSize * imageScale)
+                        .cornerRadius(4)
+                        .background {
+                            background(size: proxy.size).offset(x: 0, y: proxy.size.width / 6)
+                        }
+                        .padding(.bottom, proxy.size.width / 6)
                     Spacer()
                     footerView
                     Spacer()

--- a/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/LongestEpisode2025Story.swift
@@ -14,7 +14,7 @@ struct LongestEpisode2025Story: ShareableStory {
 
     private let backgroundColor = Color(hex: "#17423B")
     private let foregroundColor = Color.white
-    private let imageSize: CGFloat = UIScreen.isSmallScreen ? 180 : 196
+    private let imageSize: CGFloat = UIScreen.isSmallScreen ? 190 : 206
     private let portionFactor: CGFloat = UIScreen.isSmallScreen ? 3.5 : 3.0
 
     @State private var imageScale = CGFloat(1.1)
@@ -35,7 +35,7 @@ struct LongestEpisode2025Story: ShareableStory {
                             .cornerRadius(4)
                             .background {
                                 background(size: proxy.size)
-                                    .padding(.top, 60)
+                                    .padding(.top, 90)
                             }
                     }
                     Spacer()

--- a/podcasts/End of Year/Views/EndOfYearCard.swift
+++ b/podcasts/End of Year/Views/EndOfYearCard.swift
@@ -36,7 +36,7 @@ struct EndOfYearCard: View {
                 if FeatureFlag.endOfYear2025.enabled {
                     Spacer()
                     Rectangle()
-                        .frame(width: 100, height: 1)
+                        .frame(width: 125, height: 1)
                         .opacity(0)
                 } else {
                     Spacer()


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Improves the following:
- Longest episode spacing of animation bellow the image
- Loading indicator has an background
- Listening time number follow device locale and group separator

| 1 | 2 | 3 | 4 |
| - | - | - | - |
|  <img width="480" height="1040" alt="IMG_0082" src="https://github.com/user-attachments/assets/710e2281-00fd-4f86-9e09-343a957fdf51" /> |  <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2025-12-05 at 15 45 44" src="https://github.com/user-attachments/assets/22335c79-bcf3-4479-9900-f307fa4b8f36" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2025-12-05 at 15 45 24" src="https://github.com/user-attachments/assets/435b403c-522f-413e-a28f-ace8e4d8ef16" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2025-12-05 at 16 02 04" src="https://github.com/user-attachments/assets/1cfafc5e-c772-44af-8da2-e5c9dfc850ed" /> |

## To test

1. Start the app
2. Open playback 2025
3. Check if loading indicator has an background circle 
4. Check if longest episode story, that the top of the animation is bellow the image of the podcast
5. Check if listening time story is using the group separator for your device locale.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
