### PR TITLE
[Playlists] Use Playlists cache before query

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -249,6 +249,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Upgrades the Effects Player's AudioReadTask to a QOS level of "userInitiated" from "default"
     case effectsPlayerQOSUpgrade
 
+    /// Uses the PlaylistMetadataLoader cache before running the query (the query will update when it's done)
+    case playlistDataCacheBeforeQuery
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -418,6 +421,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .endOfYearLoadIsFirstStory:
 			true
         case .effectsPlayerQOSUpgrade:
+            true
+        case .playlistDataCacheBeforeQuery:
             true
         }
     }

--- a/podcasts/NewPlaylistCell.swift
+++ b/podcasts/NewPlaylistCell.swift
@@ -2,6 +2,7 @@ import UIKit
 import SwiftUI
 import PocketCastsDataModel
 import PocketCastsDependencyInjection
+import PocketCastsUtils
 
 class NewPlaylistCell: ThemeableCell {
     typealias NewPlaylistCellType = NewPlaylistCellViewModel.DisplayType
@@ -124,9 +125,11 @@ class NewPlaylistCell: ThemeableCell {
             guard let self else { return }
             let loadingPlaylist = playlistID
 
-            if let cachedCount = await self.playlistMetadataLoader.cachedCount(for: playlist.uuid) {
-                await MainActor.run {
-                    self.viewModel.episodesCount = cachedCount
+            if FeatureFlag.playlistDataCacheBeforeQuery.enabled {
+                if let cachedCount = await self.playlistMetadataLoader.cachedCount(for: playlist.uuid) {
+                    await MainActor.run {
+                        self.viewModel.episodesCount = cachedCount
+                    }
                 }
             }
 
@@ -144,8 +147,10 @@ class NewPlaylistCell: ThemeableCell {
             guard let self else { return }
             let loadingPlaylist = playlistID
 
-            if let cachedImages = await self.playlistMetadataLoader.cachedImages(for: playlist.uuid) {
-                self.viewModel.images = cachedImages
+            if FeatureFlag.playlistDataCacheBeforeQuery.enabled {
+                if let cachedImages = await self.playlistMetadataLoader.cachedImages(for: playlist.uuid) {
+                    self.viewModel.images = cachedImages
+                }
             }
 
             let images = await self.playlistMetadataLoader.loadImages(for: playlist)

--- a/podcasts/NewPlaylistCell.swift
+++ b/podcasts/NewPlaylistCell.swift
@@ -123,6 +123,13 @@ class NewPlaylistCell: ThemeableCell {
         playlistCountLoadTask = Task { [weak self] in
             guard let self else { return }
             let loadingPlaylist = playlistID
+
+            if let cachedCount = await self.playlistMetadataLoader.cachedCount(for: playlist.uuid) {
+                await MainActor.run {
+                    self.viewModel.episodesCount = cachedCount
+                }
+            }
+
             let count = await self.playlistMetadataLoader.loadCount(for: playlist)
             if self.playlistID != loadingPlaylist {
                 return
@@ -136,6 +143,11 @@ class NewPlaylistCell: ThemeableCell {
         playlistImageLoadTask = Task { [weak self] in
             guard let self else { return }
             let loadingPlaylist = playlistID
+
+            if let cachedImages = await self.playlistMetadataLoader.cachedImages(for: playlist.uuid) {
+                self.viewModel.images = cachedImages
+            }
+
             let images = await self.playlistMetadataLoader.loadImages(for: playlist)
             if self.playlistID != loadingPlaylist {
                 return

--- a/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
+++ b/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
@@ -1,4 +1,5 @@
 import PocketCastsDataModel
+import PocketCastsUtils
 
 actor PlaylistMetadataLoader {
     private var counts: [String: Int] = [:]
@@ -118,7 +119,7 @@ actor PlaylistMetadataLoader {
         let playlist = playlist
         let dataManager = self.dataManager
 
-        return await Task(priority: .userInitiated) {
+        return await Task(priority: FeatureFlag.playlistDataCacheBeforeQuery.enabled ? .medium : .userInitiated) {
             dataManager.allPlaylistEpisodeCount(
                 for: playlist,
                 episodeUuidToAdd: playlist.episodeUuidToAddToQueries(),
@@ -130,7 +131,7 @@ actor PlaylistMetadataLoader {
     private func loadListEpisodes(for playlist: EpisodeFilter) async -> [ListEpisode] {
         let playlist = playlist
         let episodesDataManager = self.episodesDataManager
-        return await Task(priority: .userInitiated) {
+        return await Task(priority: FeatureFlag.playlistDataCacheBeforeQuery.enabled ? .medium : .userInitiated) {
             episodesDataManager.playlistFirstDistinctEpisodes(
                 for: playlist,
                 shouldShowArchived: playlist.showArchivedEpisodes

--- a/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
+++ b/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
@@ -36,12 +36,12 @@ actor PlaylistMetadataLoader {
         self.episodesDataManager = episodesDataManager
     }
 
-    func cachedCount(for playlistID: String) -> Int {
-        return counts[playlistID] ?? 0
+    func cachedCount(for playlistID: String) -> Int? {
+        return counts[playlistID]
     }
 
-    func cachedImages(for playlistID: String) -> [PlaylistArtworkView.ImageItem] {
-        return images[playlistID] ?? []
+    func cachedImages(for playlistID: String) -> [PlaylistArtworkView.ImageItem]? {
+        return images[playlistID]
     }
 
     func loadCount(for playlist: EpisodeFilter) async -> Int {
@@ -91,6 +91,9 @@ actor PlaylistMetadataLoader {
                 if let cached = images[playlistID], cached == items {
                     return cached
                 }
+
+                images[playlistID] = items
+
                 return items
             } catch {
                 return images[playlistID] ?? []


### PR DESCRIPTION
Part of [POC-431](https://linear.app/a8c/issue/POC-431/playback-pauses-while-scrolling-playlists)

This doesn't directly solve the query performance issues but uses a cache + update scheme similar to Android.

The upside is we can show something quicker and downgrade the QoS of the query so it doesn't impact Effects Player.

The downside is that we will be showing out of date data some of the time which will eventually update and lead to pop in.

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
