### PR TITLE
[Playlists] Refresh Playlist cell on podcast subscription/unsubscription

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -249,6 +249,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Upgrades the Effects Player's AudioReadTask to a QOS level of "userInitiated" from "default"
     case effectsPlayerQOSUpgrade
 
+    /// Refreshes by listening to notifications for podcast subscribe/unsubscribe
+    case refreshPlaylistOnSubscriptions
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -418,6 +421,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .endOfYearLoadIsFirstStory:
 			true
         case .effectsPlayerQOSUpgrade:
+            true
+        case .refreshPlaylistOnSubscriptions:
             true
         }
     }

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
+import Combine
 
 class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     @IBOutlet var filtersTable: ThemeableTable! {
@@ -59,6 +60,8 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     }
 
     var newFilterTip: UIViewController? = nil
+
+    private var cancellables: Set<AnyCancellable> = []
 
     private var firstTimeLoading = true
 
@@ -256,6 +259,16 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     private func addReloadPlaylistsObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(filtersUpdated), name: Constants.Notifications.playlistChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(filtersUpdated), name: Constants.Notifications.playlistsNeedReload, object: nil)
+
+        if FeatureFlag.refreshPlaylistOnSubscriptions.enabled {
+            let deleted = NotificationCenter.default.publisher(for: Constants.Notifications.podcastDeleted)
+            let added = NotificationCenter.default.publisher(for: Constants.Notifications.podcastAdded)
+
+            Publishers.Merge(deleted, added).debounce(for: 0.5, scheduler: DispatchQueue.main).sink { [weak self] _ in
+                self?.filtersUpdated()
+            }
+            .store(in: &cancellables)
+        }
     }
 
     private func setupInformationalBanner() {


### PR DESCRIPTION
Fixes [PCIOS-391](https://linear.app/a8c/issue/PCIOS-391/refresh-playlist-artwork-on-subscribe-unsubscribe)

## To test

* Add a podcast to a Smart Playlist
* Unsubscribe from the podcast
* Navigate to the Playlist screen
* Ensure the podcast is no longer in the cell artwork and the count has updated

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
