### PR TITLE
[Playlists] Playlists list artwork query improvements

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -2,6 +2,8 @@ import Foundation
 import RegexBuilder
 
 public class PlaylistQueryBuilder {
+    static let episodeLimit: Int = 10000
+
     public enum SelectClause {
         case episode
         case episodeCount
@@ -167,7 +169,7 @@ public class PlaylistQueryBuilder {
                   ON episode.podcast_id = podcast.id
                 WHERE episode.archived = 0 \(values)\(addedUuid ? ")" : ""))
                 \(sortClause)
-                LIMIT 1000
+                LIMIT \(episodeLimit)
             )
         ),
         numbered_episodes AS (
@@ -219,6 +221,7 @@ public class PlaylistQueryBuilder {
             ON episode.uuid = playlist.episodeUuid
           WHERE playlist.playlist_uuid = '\(playlistUUID)'
           \(shouldShowArchived ? "" : "AND episode.archived = 0")
+          LIMIT \(episodeLimit)
         )
         SELECT *
         FROM ordered_episodes

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -154,27 +154,36 @@ public class PlaylistQueryBuilder {
         values: String,
         addedUuid: Bool
     ) -> String {
-        var query = """
-        WITH numbered_episodes AS (
-            SELECT episode.*,
+        let sortClause = add(sortFor: sortType) ?? ""
+        var sortClauseStripped = sortClause.replacingOccurrences(of: "ORDER BY", with: "")
+        sortClauseStripped = sortClauseStripped.replacingOccurrences(of: "episode.", with: "")
+
+        return """
+        WITH limited_episodes AS (
+            SELECT * FROM (
+                SELECT episode.*
+                FROM \(DataManager.episodeTableName) episode
+                LEFT JOIN \(DataManager.podcastTableName) podcast
+                  ON episode.podcast_id = podcast.id
+                WHERE episode.archived = 0 \(values)\(addedUuid ? ")" : ""))
+                \(sortClause)
+                LIMIT 1000
+            )
+        ),
+        numbered_episodes AS (
+            SELECT *,
                    ROW_NUMBER() OVER (
-                     PARTITION BY episode.podcast_id
-                    \(add(sortFor: sortType) ?? "")
+                       PARTITION BY podcast_id
+                       ORDER BY \(sortClauseStripped)
                    ) AS rn
-            FROM \(DataManager.episodeTableName) episode
-            LEFT JOIN \(DataManager.podcastTableName) podcast
-              ON episode.podcast_id = podcast.id
-            WHERE episode.archived = 0 \(values)\(addedUuid ? ")" : ""))
+            FROM limited_episodes
         )
         SELECT *
         FROM numbered_episodes
         WHERE rn = 1
-        \(add(sortFor: sortType)?.replacingOccurrences(of: "episode", with: "numbered_episodes") ?? "")
+        ORDER BY \(sortClauseStripped)
         LIMIT \(limit)
         """
-
-        PlaylistQueryBuilder.removeEmptyFilterGroups(from: &query)
-        return query
     }
 
     private static func manualPlaylistFirstDistinctEpisodes(

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -2,7 +2,7 @@ import Foundation
 import RegexBuilder
 
 public class PlaylistQueryBuilder {
-    static let episodeLimit: Int = 10000
+    static let episodeLimit: Int = 1000
 
     public enum SelectClause {
         case episode

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -160,7 +160,7 @@ public class PlaylistQueryBuilder {
         var sortClauseStripped = sortClause.replacingOccurrences(of: "ORDER BY", with: "")
         sortClauseStripped = sortClauseStripped.replacingOccurrences(of: "episode.", with: "")
 
-        return """
+        var query = """
         WITH limited_episodes AS (
             SELECT * FROM (
                 SELECT episode.*
@@ -186,6 +186,8 @@ public class PlaylistQueryBuilder {
         ORDER BY \(sortClauseStripped)
         LIMIT \(limit)
         """
+        PlaylistQueryBuilder.removeEmptyFilterGroups(from: &query)
+        return query
     }
 
     private static func manualPlaylistFirstDistinctEpisodes(

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -249,6 +249,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Upgrades the Effects Player's AudioReadTask to a QOS level of "userInitiated" from "default"
     case effectsPlayerQOSUpgrade
 
+    /// Uses the PlaylistMetadataLoader cache before running the query (the query will update when it's done)
+    case playlistDataCacheBeforeQuery
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -418,6 +421,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .endOfYearLoadIsFirstStory:
 			true
         case .effectsPlayerQOSUpgrade:
+            true
+        case .playlistDataCacheBeforeQuery:
             true
         }
     }

--- a/podcasts/NewPlaylistCell.swift
+++ b/podcasts/NewPlaylistCell.swift
@@ -2,6 +2,7 @@ import UIKit
 import SwiftUI
 import PocketCastsDataModel
 import PocketCastsDependencyInjection
+import PocketCastsUtils
 
 class NewPlaylistCell: ThemeableCell {
     typealias NewPlaylistCellType = NewPlaylistCellViewModel.DisplayType
@@ -124,9 +125,11 @@ class NewPlaylistCell: ThemeableCell {
             guard let self else { return }
             let loadingPlaylist = playlistID
 
-            if let cachedCount = await self.playlistMetadataLoader.cachedCount(for: playlist.uuid) {
-                await MainActor.run {
-                    self.viewModel.episodesCount = cachedCount
+            if FeatureFlag.playlistDataCacheBeforeQuery.enabled {
+                if let cachedCount = await self.playlistMetadataLoader.cachedCount(for: playlist.uuid) {
+                    await MainActor.run {
+                        self.viewModel.episodesCount = cachedCount
+                    }
                 }
             }
 
@@ -144,8 +147,10 @@ class NewPlaylistCell: ThemeableCell {
             guard let self else { return }
             let loadingPlaylist = playlistID
 
-            if let cachedImages = await self.playlistMetadataLoader.cachedImages(for: playlist.uuid) {
-                self.viewModel.images = cachedImages
+            if FeatureFlag.playlistDataCacheBeforeQuery.enabled {
+                if let cachedImages = await self.playlistMetadataLoader.cachedImages(for: playlist.uuid) {
+                    self.viewModel.images = cachedImages
+                }
             }
 
             let images = await self.playlistMetadataLoader.loadImages(for: playlist)

--- a/podcasts/NewPlaylistCell.swift
+++ b/podcasts/NewPlaylistCell.swift
@@ -123,6 +123,13 @@ class NewPlaylistCell: ThemeableCell {
         playlistCountLoadTask = Task { [weak self] in
             guard let self else { return }
             let loadingPlaylist = playlistID
+
+            if let cachedCount = await self.playlistMetadataLoader.cachedCount(for: playlist.uuid) {
+                await MainActor.run {
+                    self.viewModel.episodesCount = cachedCount
+                }
+            }
+
             let count = await self.playlistMetadataLoader.loadCount(for: playlist)
             if self.playlistID != loadingPlaylist {
                 return
@@ -136,6 +143,11 @@ class NewPlaylistCell: ThemeableCell {
         playlistImageLoadTask = Task { [weak self] in
             guard let self else { return }
             let loadingPlaylist = playlistID
+
+            if let cachedImages = await self.playlistMetadataLoader.cachedImages(for: playlist.uuid) {
+                self.viewModel.images = cachedImages
+            }
+
             let images = await self.playlistMetadataLoader.loadImages(for: playlist)
             if self.playlistID != loadingPlaylist {
                 return

--- a/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
+++ b/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
@@ -1,4 +1,5 @@
 import PocketCastsDataModel
+import PocketCastsUtils
 
 actor PlaylistMetadataLoader {
     private var counts: [String: Int] = [:]
@@ -118,7 +119,7 @@ actor PlaylistMetadataLoader {
         let playlist = playlist
         let dataManager = self.dataManager
 
-        return await Task(priority: .userInitiated) {
+        return await Task(priority: FeatureFlag.playlistDataCacheBeforeQuery.enabled ? .medium : .userInitiated) {
             dataManager.allPlaylistEpisodeCount(
                 for: playlist,
                 episodeUuidToAdd: playlist.episodeUuidToAddToQueries(),
@@ -130,7 +131,7 @@ actor PlaylistMetadataLoader {
     private func loadListEpisodes(for playlist: EpisodeFilter) async -> [ListEpisode] {
         let playlist = playlist
         let episodesDataManager = self.episodesDataManager
-        return await Task(priority: .userInitiated) {
+        return await Task(priority: FeatureFlag.playlistDataCacheBeforeQuery.enabled ? .medium : .userInitiated) {
             episodesDataManager.playlistFirstDistinctEpisodes(
                 for: playlist,
                 shouldShowArchived: playlist.showArchivedEpisodes

--- a/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
+++ b/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
@@ -36,12 +36,12 @@ actor PlaylistMetadataLoader {
         self.episodesDataManager = episodesDataManager
     }
 
-    func cachedCount(for playlistID: String) -> Int {
-        return counts[playlistID] ?? 0
+    func cachedCount(for playlistID: String) -> Int? {
+        return counts[playlistID]
     }
 
-    func cachedImages(for playlistID: String) -> [PlaylistArtworkView.ImageItem] {
-        return images[playlistID] ?? []
+    func cachedImages(for playlistID: String) -> [PlaylistArtworkView.ImageItem]? {
+        return images[playlistID]
     }
 
     func loadCount(for playlist: EpisodeFilter) async -> Int {
@@ -91,6 +91,9 @@ actor PlaylistMetadataLoader {
                 if let cached = images[playlistID], cached == items {
                     return cached
                 }
+
+                images[playlistID] = items
+
                 return items
             } catch {
                 return images[playlistID] ?? []


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-393
Fixes PCIOS-394

Adds the LIMIT to the max allowed episodes count. This should reduce the size of both queries for smart and manual playlists. It reflects the same behaviour of the detail view.

This PR also includes the changes @bjtitus added in #3777

## To test

1. Run this branch
2. Go to playlists
3. Scroll to the list
4. Open few playlists and change the order of episodes
5. Navigate back to confirm the artwork composition reflects the detail

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
