### PR TITLE
[Playlists] Use DiffableKit in Playlists list

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
@@ -214,7 +214,7 @@ class PlaylistDataManager {
         playlist.syncStatus = SyncStatus.notSynced.rawValue
         dbQueue.write { db in
             do {
-                try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET sortPosition = ?, syncStatus = ? WHERE uuid = ?", values: [playlist.sortPosition, playlist.syncStatus, playlist.uuid])
+                try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET sortPosition = ?, syncStatus = ?, playlistUpdateDate = ? WHERE uuid = ?", values: [playlist.sortPosition, playlist.syncStatus, Date.now, playlist.uuid])
             } catch {
                 FileLog.shared.addMessage("PlaylistDataManager.updatePosition error: \(error)")
             }
@@ -250,7 +250,7 @@ class PlaylistDataManager {
                 }
 
                 playlist.syncStatus = SyncStatus.notSynced.rawValue
-                try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET syncStatus = ? WHERE uuid = ?", values: [playlist.syncStatus, playlist.uuid])
+                try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET syncStatus = ?, playlistUpdateDate = ? WHERE uuid = ?", values: [playlist.syncStatus, Date.now, playlist.uuid])
             } catch {
                 FileLog.shared.addMessage("PlaylistDataManager.moveEpisode error: \(error)")
             }
@@ -283,7 +283,7 @@ class PlaylistDataManager {
                 }
 
                 playlist.syncStatus = SyncStatus.notSynced.rawValue
-                try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET syncStatus = ? WHERE uuid = ?", values: [playlist.syncStatus, playlist.uuid])
+                try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET syncStatus = ?, playlistUpdateDate = ? WHERE uuid = ?", values: [playlist.syncStatus, Date.now, playlist.uuid])
             } catch {
                 FileLog.shared.addMessage("PlaylistDataManager.deleteEpisodes error: \(error)")
             }
@@ -312,7 +312,7 @@ class PlaylistDataManager {
                 let removedCount = db.changes
                 if removedCount > 0 {
                     playlist.syncStatus = SyncStatus.notSynced.rawValue
-                    try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET syncStatus = ? WHERE uuid = ?", values: [playlist.syncStatus, playlist.uuid])
+                    try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET syncStatus = ?, playlistUpdateDate = ? WHERE uuid = ?", values: [playlist.syncStatus, Date.now, playlist.uuid])
                 }
             } catch {
                 FileLog.shared.addMessage("PlaylistDataManager.deleteAllEpisodes error: \(error)")

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
@@ -1,4 +1,5 @@
 import PocketCastsUtils
+import Foundation
 
 class PlaylistDataManager {
     private let columnNames = [
@@ -26,7 +27,8 @@ class PlaylistDataManager {
         "longerThan",
         "shorterThan",
         "manual",
-        "showArchivedEpisodes"
+        "showArchivedEpisodes",
+        "playlistUpdateDate"
     ]
 
     func count(includeDeleted: Bool, dbQueue: PCDBQueue) -> Int {
@@ -323,13 +325,27 @@ class PlaylistDataManager {
             do {
                 if playlist.id == 0 {
                     playlist.id = DBUtils.generateUniqueId()
-                    try db.executeUpdate("INSERT INTO \(DataManager.playlistsTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(playlist: playlist))
+                    try db.executeUpdate("INSERT INTO \(DataManager.playlistsTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(playlist: playlist, updateDate: .now))
                 } else {
                     let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
-                    try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET \(setStatement) WHERE uuid = ?", values: self.createValuesFrom(playlist: playlist, includeUuidForWhere: true))
+                    try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET \(setStatement) WHERE uuid = ?", values: self.createValuesFrom(playlist: playlist, includeUuidForWhere: true, updateDate: .now))
                 }
             } catch {
                 FileLog.shared.addMessage("PlaylistDataManager.save error: \(error)")
+            }
+        }
+    }
+
+    /// Update the playlistUpdateDate for a specific playlist to the given date (defaults to now)
+    func updatePlaylistUpdateDate(for playlist: EpisodeFilter, to date: Date, dbQueue: PCDBQueue) {
+        dbQueue.write { db in
+            do {
+                try db.executeUpdate(
+                    "UPDATE \(DataManager.playlistsTableName) SET playlistUpdateDate = ? WHERE uuid = ?",
+                    values: [date, playlist.uuid]
+                )
+            } catch {
+                FileLog.shared.addMessage("PlaylistDataManager.updatePlaylistUpdateDate error: \(error)")
             }
         }
     }
@@ -534,11 +550,12 @@ class PlaylistDataManager {
         playlist.shorterThan = rs.int(forColumn: "shorterThan")
         playlist.manual = rs.bool(forColumn: "manual")
         playlist.showArchivedEpisodes = rs.bool(forColumn: "showArchivedEpisodes")
+        playlist.playlistUpdateDate = DBUtils.convertDate(value: rs.double(forColumn: "playlistUpdateDate"))
 
         return playlist
     }
 
-    private func createValuesFrom(playlist: EpisodeFilter, includeUuidForWhere: Bool = false) -> [Any] {
+    private func createValuesFrom(playlist: EpisodeFilter, includeUuidForWhere: Bool = false, updateDate: Date? = nil) -> [Any] {
         var values = [Any]()
         values.append(playlist.id)
         values.append(playlist.autoDownloadEpisodes)
@@ -565,6 +582,7 @@ class PlaylistDataManager {
         values.append(playlist.shorterThan)
         values.append(playlist.manual)
         values.append(playlist.showArchivedEpisodes)
+        values.append(DBUtils.nullIfNil(value: updateDate ?? playlist.playlistUpdateDate))
 
         if includeUuidForWhere {
             values.append(playlist.uuid)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -858,6 +858,16 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 70 {
+            do {
+                try db.executeUpdate("ALTER TABLE SJFilteredPlaylist ADD COLUMN playlistUpdateDate REAL;", values: nil)
+                schemaVersion = 70
+            } catch {
+                failedAt(70)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -987,6 +987,10 @@ public class DataManager {
         playlistManager.save(playlist: playlist, dbQueue: dbQueue)
     }
 
+    public func updatePlaylistUpdateDate(for playlist: EpisodeFilter, to date: Date = .now) {
+        playlistManager.updatePlaylistUpdateDate(for: playlist, to: date, dbQueue: dbQueue)
+    }
+
     @discardableResult
     public func add(episodes: [Episode], to playlist: EpisodeFilter) -> Bool {
         playlistManager.add(episodes: episodes, to: playlist, dbQueue: dbQueue)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -30,6 +30,7 @@ public class EpisodeFilter: NSObject {
     @objc public var wasDeleted = false
     @objc public var manual: Bool = false
     @objc public var showArchivedEpisodes: Bool = false
+    @objc public var playlistUpdateDate: Date?
 
     // Internal tracking
     public var isNew: Bool = false

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -2,7 +2,7 @@ import Foundation
 import RegexBuilder
 
 public class PlaylistQueryBuilder {
-    static let episodeLimit: Int = 10000
+    static let episodeLimit: Int = 1000
 
     public enum SelectClause {
         case episode

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistDataManagerTests.swift
@@ -123,4 +123,31 @@ final class PlaylistDataManagerTests: XCTestCase {
         let newAllPlaylists = dataManager.allPlaylists(includeDeleted: true)
         XCTAssertEqual(newAllPlaylists.map(\.sortPosition), [2, 3, 4, 5, 6])
     }
+
+    func testPlaylistUpdateDate() throws {
+        guard let dbPool = try DatabasePool.newTestDatabase() else {
+            throw SQLiteValidator.SQLiteError.failedNewTestDatabase
+        }
+        let queue = GRDBQueue(dbPool: dbPool)
+        DatabaseHelper.setup(queue: queue)
+        let dataManager = DataManager(dbQueue: queue)
+
+        let playlist = EpisodeFilter()
+        playlist.uuid = UUID().uuidString
+        playlist.playlistName = "Playlist 1"
+
+        dataManager.save(playlist: playlist)
+
+        let newPlaylist1 = try XCTUnwrap(dataManager.findPlaylist(uuid: playlist.uuid))
+
+        XCTAssertNotNil(newPlaylist1.playlistUpdateDate)
+
+        let date = Date.now
+
+        dataManager.updatePlaylistUpdateDate(for: newPlaylist1, to: date)
+
+        let newPlaylist2 = try XCTUnwrap(dataManager.findPlaylist(uuid: newPlaylist1.uuid))
+
+        XCTAssertTrue(newPlaylist2.playlistUpdateDate == date)
+    }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -755,6 +755,7 @@
 		9AB645182D5138B200A842C8 /* Pocket Casts App Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = F5D5F7792CEBE769001F492D /* Pocket Casts App Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		9ACB950B2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */; };
 		9ACB950C2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */; };
+		9ACDEF332EE6F632001025B0 /* ListPlaylist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACDEF322EE6F62C001025B0 /* ListPlaylist.swift */; };
 		9AD41AC22EB4E0750048FB8B /* PlaylistDetailViewController+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD41AC12EB4E0700048FB8B /* PlaylistDetailViewController+Analytics.swift */; };
 		9AD809AF2EA12D940050649B /* PlaylistDetailFetchOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD809AE2EA12D850050649B /* PlaylistDetailFetchOperation.swift */; };
 		9AE5043C2DEDF2030027A4AE /* TranscriptContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */; };
@@ -3132,6 +3133,7 @@
 		9AB2900B2ECB7F75006086F9 /* PlaylistPlayAllSheetHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistPlayAllSheetHost.swift; sourceTree = "<group>"; };
 		9AB2900D2ECB82F6006086F9 /* PlaylistPlayAllSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistPlayAllSheet.swift; sourceTree = "<group>"; };
 		9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptiveActionAttributedTextView.swift; sourceTree = "<group>"; };
+		9ACDEF322EE6F62C001025B0 /* ListPlaylist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListPlaylist.swift; sourceTree = "<group>"; };
 		9AD41AC12EB4E0700048FB8B /* PlaylistDetailViewController+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaylistDetailViewController+Analytics.swift"; sourceTree = "<group>"; };
 		9AD809AE2EA12D850050649B /* PlaylistDetailFetchOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistDetailFetchOperation.swift; sourceTree = "<group>"; };
 		9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptContainerViewController.swift; sourceTree = "<group>"; };
@@ -6226,6 +6228,7 @@
 				BD1C46DF27B9E6F600B1D8BB /* HomeGridListItem.swift */,
 				BD74F15227F28F6F00222785 /* HomeGridItem.swift */,
 				BD9D923B21342CC50070D4FD /* ListEpisode.swift */,
+				9ACDEF322EE6F62C001025B0 /* ListPlaylist.swift */,
 				BD023C612251BB4E008A9C6F /* ListHeader.swift */,
 				BD0B68702203DC58002CCE3F /* EpisodeLimitPlaceholder.swift */,
 				409C7939223899A500386495 /* AllArchivedPlaceholder.swift */,
@@ -10697,6 +10700,7 @@
 				BD4FC1DB1FA6E21F0013364F /* PlaylistViewController.swift in Sources */,
 				F57D8F142C66CA230004C4DF /* UnsafeWait.swift in Sources */,
 				FF0F407A2D5E32920036FFE9 /* ThreadSafeDictionary.swift in Sources */,
+				9ACDEF332EE6F632001025B0 /* ListPlaylist.swift in Sources */,
 				405471272163345400341BF6 /* PodcastSelectionHeaderView.swift in Sources */,
 				BD9086A7204E120C00C0C78D /* DescriptiveActionView.swift in Sources */,
 				FF06AFA32CB6928B0099EC9B /* MediaExporterResourceLoaderDelegate.swift in Sources */,

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -33,7 +33,6 @@ struct Constants {
         static let miniPlayerDidDisappear = NSNotification.Name(rawValue: "SJMiniPlayerDisappeared")
         static let miniPlayerDidAppear = NSNotification.Name(rawValue: "SJMiniPlayerAppeared")
         static let playlistChanged = NSNotification.Name(rawValue: "FilterChanged")
-        static let playlistsNeedReload = NSNotification.Name(rawValue: "PlaylistsNeedReload")
         static let playlistTempChange = NSNotification.Name(rawValue: "playlistTempChange")
         static let statusBarHeightChanged = NSNotification.Name(rawValue: "SJBarHeightChanged")
         static let podcastSearchRequest = NSNotification.Name(rawValue: "PodcastSearchRequest")

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -33,9 +33,6 @@ class EpisodeManager: NSObject {
 
         if fireNotification {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodePlayStatusChanged, object: episode.uuid)
-            if FeatureFlag.playlistsRebranding.enabled {
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
-            }
         }
 
         if userInitiated {
@@ -102,9 +99,6 @@ class EpisodeManager: NSObject {
             markAsPlayed(episode: currentEpisode, fireNotification: true, userInitiated: false)
         }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
-        if FeatureFlag.playlistsRebranding.enabled {
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
-        }
 
         analyticsHelper.bulkMarkAsPlayed(count: episodesMinusCurrent.count)
     }
@@ -149,9 +143,6 @@ class EpisodeManager: NSObject {
 
         if fireNotification {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodePlayStatusChanged, object: episode.uuid)
-            if FeatureFlag.playlistsRebranding.enabled {
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
-            }
         }
 
         if userInitiated {
@@ -162,9 +153,6 @@ class EpisodeManager: NSObject {
     class func bulkMarkAsUnPlayed(_ baseEpisodes: [BaseEpisode]) {
         DataManager.sharedManager.bulkMarkAsUnPlayed(baseEpisodes: baseEpisodes, updateSyncFlag: SyncManager.isUserLoggedIn())
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
-        if FeatureFlag.playlistsRebranding.enabled {
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
-        }
 
         analyticsHelper.bulkMarkAsUnplayed(count: baseEpisodes.count)
     }
@@ -187,9 +175,6 @@ class EpisodeManager: NSObject {
 
         if fireNotification {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeArchiveStatusChanged, object: episode.uuid)
-            if FeatureFlag.playlistsRebranding.enabled {
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
-            }
         }
 
         if userInitiated {
@@ -221,9 +206,6 @@ class EpisodeManager: NSObject {
             PlaybackManager.shared.bulkRemoveQueued(uuids: uuids)
         }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
-        if FeatureFlag.playlistsRebranding.enabled {
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
-        }
 
         analyticsHelper.bulkArchiveEpisodes(count: episodes.count)
     }
@@ -240,9 +222,6 @@ class EpisodeManager: NSObject {
 
         if fireNotification {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeArchiveStatusChanged, object: episode.uuid)
-            if FeatureFlag.playlistsRebranding.enabled {
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
-            }
         }
 
         if userInitiated {
@@ -254,9 +233,6 @@ class EpisodeManager: NSObject {
         DataManager.sharedManager.bulkUnarchive(episodes: episodes, updateSyncFlag: SyncManager.isUserLoggedIn())
 
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
-        if FeatureFlag.playlistsRebranding.enabled {
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
-        }
 
         if trackEvent {
             analyticsHelper.bulkUnarchiveEpisodes(count: episodes.count)

--- a/podcasts/ListPlaylist.swift
+++ b/podcasts/ListPlaylist.swift
@@ -1,0 +1,37 @@
+import Foundation
+import PocketCastsDataModel
+
+class ListPlaylist: ListItem, Identifiable, Hashable {
+    let playlist: EpisodeFilter
+
+    var id: String {
+        playlist.uuid
+    }
+
+    override var differenceIdentifier: String {
+        playlist.uuid
+    }
+
+    init(playlist: EpisodeFilter) {
+        self.playlist = playlist
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    static func == (lhs: ListPlaylist, rhs: ListPlaylist) -> Bool {
+        lhs.handleIsEqual(rhs)
+    }
+
+    override func isContentEqual(to source: ListItem) -> Bool {
+        handleIsEqual(source)
+    }
+
+    override func handleIsEqual(_ otherItem: ListItem) -> Bool {
+        guard let rhs = otherItem as? ListPlaylist else { return false }
+
+        return playlist.uuid == rhs.playlist.uuid &&
+        playlist.playlistUpdateDate == rhs.playlist.playlistUpdateDate
+    }
+}

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -176,10 +176,6 @@ class ManualPlaylistsChooserViewController: PCViewController {
             dataManager.save(playlist: playlist)
         }
 
-        if !added.isEmpty || !removed.isEmpty {
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
-        }
-
         dismiss(animated: true) {
             if added.isEmpty {
                 return

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -467,7 +467,6 @@ class PlaylistDetailViewController: FakeNavViewController {
             dismissAction: { [weak self] in
                 self?.dismiss(animated: true) {
                     self?.viewModel.reloadPlaylistAndEpisodes()
-                    NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
                 }
             }
         )

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -169,7 +169,11 @@ class PlaylistDetailViewModel: ObservableObject {
                     self.firstTimeLoading.toggle()
                 }
                 let changeSetTuple = self.buildChangeSet(source: self.episodes, newData: newData)
-                self.onChange(changeSetTuple.1, animated, changeSetTuple.0)
+                let contentHasChanged = changeSetTuple.0
+                if contentHasChanged {
+                    self.dataManager.updatePlaylistUpdateDate(for: self.playlist)
+                }
+                self.onChange(changeSetTuple.1, animated, contentHasChanged)
             }
         }
         operationQueue.addOperation(refreshOperation)

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -20,7 +20,7 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        playlists.count
+        listPlaylistItems.count
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -32,17 +32,17 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
             let cell = cell(tableView, for: NewPlaylistCell.reuseIdentifier) as! NewPlaylistCell
             if cell.tag != indexPath.row { cell.reset() }
             cell.tag = indexPath.row
-            if let playlist = playlists[safe: indexPath.row] {
+            if let playlist = listPlaylistItems[safe: indexPath.row]?.playlist {
                 cell.set(playlistName: playlist.playlistName, isManualPlaylist: playlist.manual)
                 cell.loadMetadata(for: playlist)
-                cell.hideSeparator(indexPath.row == playlists.count - 1)
+                cell.hideSeparator(indexPath.row == listPlaylistItems.count - 1)
             }
             return cell
         }
 
         let cell = cell(tableView, for: PlaylistsViewController.playlistCellId) as! FilterNameCell
 
-        if let filter = playlists[safe: indexPath.row] {
+        if let filter = listPlaylistItems[safe: indexPath.row]?.playlist {
             cell.filterName.text = filter.playlistName
             cell.filterImage.image = filter.iconImage()
             cell.filterImage.tintColor = filter.playlistColor()
@@ -91,7 +91,7 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        if let filter = playlists[safe: indexPath.row] {
+        if let filter = listPlaylistItems[safe: indexPath.row]?.playlist {
             showFilter(filter)
         }
     }
@@ -111,7 +111,7 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete, let playlist = playlists[safe: indexPath.row] {
+        if editingStyle == .delete, let playlist = listPlaylistItems[safe: indexPath.row]?.playlist {
             if FeatureFlag.playlistsRebranding.enabled {
                 showDeleteOptionPicker(for: playlist, at: indexPath, in: tableView)
             } else {
@@ -125,13 +125,13 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         if sourceIndexPath == destinationIndexPath { return }
 
-        let movedObject = playlists[sourceIndexPath.row]
-        playlists.remove(at: sourceIndexPath.row)
-        playlists.insert(movedObject, at: destinationIndexPath.row)
+        let movedObject = listPlaylistItems[sourceIndexPath.row]
+        listPlaylistItems.remove(at: sourceIndexPath.row)
+        listPlaylistItems.insert(movedObject, at: destinationIndexPath.row)
 
         // ok, we've now sorted the list that needed sorting, update the sort positions in the DB and mark that list as not synced
-        for (index, filter) in playlists.enumerated() {
-            DataManager.sharedManager.updatePosition(playlist: filter, newPosition: Int32(index))
+        for (index, filter) in listPlaylistItems.enumerated() {
+            DataManager.sharedManager.updatePosition(playlist: filter.playlist, newPosition: Int32(index))
         }
 
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged)
@@ -173,7 +173,7 @@ extension PlaylistsViewController {
 
     fileprivate func delete(playlist: EpisodeFilter, at indexPath: IndexPath, in tableView: UITableView) {
         PlaylistManager.delete(playlist: playlist, fireEvent: false)
-        playlists.remove(at: indexPath.row)
+        listPlaylistItems.remove(at: indexPath.row)
         tableView.beginUpdates()
         tableView.deleteRows(at: [indexPath], with: .top)
         tableView.endUpdates()
@@ -240,7 +240,7 @@ extension PlaylistsViewController {
             PlaylistManager.DefaultUUIDs.newReleases,
             PlaylistManager.DefaultUUIDs.inProgress
         ]
-        let playlistsUUID = playlists.map { $0.uuid }
+        let playlistsUUID = listPlaylistItems.map { $0.playlist.uuid }
         let playlistsUUIDSet: Set<String> = Set(playlistsUUID)
         if playlistsUUIDSet.count > premadePlaylistUuids.count || premadePlaylistUuids != playlistsUUIDSet {
             return true
@@ -258,7 +258,7 @@ extension PlaylistsViewController {
     }
 
     private func smartPlaylistsTip() -> UIHostingController<AnyView>? {
-        guard let indexPath = filtersTable.indexPathsForVisibleRows?.last, !playlists.isEmpty else { return nil }
+        guard let indexPath = filtersTable.indexPathsForVisibleRows?.last, !listPlaylistItems.isEmpty else { return nil }
         return tip(
             title: L10n.smartPlaylistsTipViewTitle,
             message: L10n.smartPlaylistsTipViewDescription,
@@ -271,7 +271,7 @@ extension PlaylistsViewController {
         guard
             let indexPath = filtersTable.indexPathsForVisibleRows?.first,
             let cell = filtersTable.cellForRow(at: indexPath) as? NewPlaylistCell,
-            !playlists.isEmpty
+            !listPlaylistItems.isEmpty
         else { return }
         let tip = tip(
             title: L10n.playlistsTipDragAndDropTitle,
@@ -335,7 +335,7 @@ extension PlaylistsViewController: UIPopoverPresentationControllerDelegate {
 
 extension PlaylistsViewController: UITableViewDragDelegate, UITableViewDropDelegate {
     func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
-        let movedObject = playlists[indexPath.row]
+        let movedObject = listPlaylistItems[indexPath.row]
         let itemProvider = NSItemProvider(object: "\(movedObject.id)" as NSString)
         return [UIDragItem(itemProvider: itemProvider)]
     }
@@ -346,16 +346,16 @@ extension PlaylistsViewController: UITableViewDragDelegate, UITableViewDropDeleg
         coordinator.items.forEach { item in
             if let sourceIndexPath = item.sourceIndexPath {
                 tableView.performBatchUpdates {
-                    let movedItem = playlists.remove(at: sourceIndexPath.row)
-                    playlists.insert(movedItem, at: destinationIndexPath.row)
+                    let movedItem = listPlaylistItems.remove(at: sourceIndexPath.row)
+                    listPlaylistItems.insert(movedItem, at: destinationIndexPath.row)
                     tableView.moveRow(at: sourceIndexPath, to: destinationIndexPath)
                 }
                 coordinator.drop(item.dragItem, toRowAt: destinationIndexPath)
             }
         }
 
-        for (index, playlist) in playlists.enumerated() {
-            DataManager.sharedManager.updatePosition(playlist: playlist, newPosition: Int32(index))
+        for (index, playlist) in listPlaylistItems.enumerated() {
+            DataManager.sharedManager.updatePosition(playlist: playlist.playlist, newPosition: Int32(index))
         }
 
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged)

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import DifferenceKit
 import UIKit
 import PocketCastsDataModel
 import PocketCastsServer
@@ -22,7 +23,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         }
     }
 
-    var playlists = [EpisodeFilter]() {
+    var listPlaylistItems: [ListPlaylist] = [] {
         didSet {
             if FeatureFlag.playlistsRebranding.enabled {
                 DispatchQueue.main.async { [weak self] in
@@ -61,8 +62,6 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
     var newFilterTip: UIViewController? = nil
 
-    private var cancellables: Set<AnyCancellable> = []
-
     private var firstTimeLoading = true
 
     lazy private var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
@@ -96,9 +95,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
         loadingIndicator = ThemeLoadingIndicator()
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: filtersTable)
-        if FeatureFlag.playlistsRebranding.enabled {
-            addReloadPlaylistsObservers()
-        } else {
+        if !FeatureFlag.playlistsRebranding.enabled {
             setupNewFilterButton()
         }
         handleThemeChanged()
@@ -129,25 +126,17 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if FeatureFlag.playlistsRebranding.enabled {
-            if firstTimeLoading {
-                reloadFilters()
-            }
-        } else {
-            reloadFilters()
-        }
+        reloadFilters()
         setupInformationalBanner()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         updateNavTintColors()
-        if !FeatureFlag.playlistsRebranding.enabled {
-            addCustomObserver(Constants.Notifications.playlistChanged, selector: #selector(filtersUpdated))
-        }
+        addCustomObserver(Constants.Notifications.playlistChanged, selector: #selector(filtersUpdated))
         addCustomObserver(Constants.Notifications.tappedOnSelectedTab, selector: #selector(checkForScrollTap(_:)))
 
-        Analytics.track(.filterListShown, properties: ["filter_count": playlists.count])
+        Analytics.track(.filterListShown, properties: ["filter_count": listPlaylistItems.count])
 
         showPlaylistsTipIfNeeded()
         showOnboardingScreenIfNeeded()
@@ -246,28 +235,47 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
-            playlists = DataManager.sharedManager.allPlaylists(includeDeleted: false)
+
+            let newData = DataManager.sharedManager.allPlaylists(includeDeleted: false).map { ListPlaylist(playlist: $0) }
+
+            if FeatureFlag.playlistsRebranding.enabled {
+                let oldData = self.listPlaylistItems
+
+                let changeSet = StagedChangeset(source: oldData, target: newData)
+
+                if oldData.isContentEqual(to: newData) {
+                    DispatchQueue.main.async {
+                        self.newFilterButton.isHidden = false
+                        self.loadingIndicator.stopAnimating()
+                    }
+                    return
+                }
+
+                DispatchQueue.main.async {
+                    self.newFilterButton.isHidden = false
+                    self.loadingIndicator.stopAnimating()
+                    do {
+                        try SJCommonUtils.catchException { [weak self] in
+                            self?.filtersTable.reload(using: changeSet, with: .fade) { [weak self] newData in
+                                self?.listPlaylistItems = newData
+                            }
+                        }
+                    } catch {
+                        if let data = changeSet.last?.data {
+                            self.listPlaylistItems = data
+                        }
+                        self.filtersTable.reloadData()
+                    }
+                }
+                return
+            }
+
             firstTimeLoading = false
             DispatchQueue.main.async {
                 self.newFilterButton.isHidden = false
                 self.loadingIndicator.stopAnimating()
                 self.filtersTable.reloadData()
             }
-        }
-    }
-
-    private func addReloadPlaylistsObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(filtersUpdated), name: Constants.Notifications.playlistChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(filtersUpdated), name: Constants.Notifications.playlistsNeedReload, object: nil)
-
-        if FeatureFlag.refreshPlaylistOnSubscriptions.enabled {
-            let deleted = NotificationCenter.default.publisher(for: Constants.Notifications.podcastDeleted)
-            let added = NotificationCenter.default.publisher(for: Constants.Notifications.podcastAdded)
-
-            Publishers.Merge(deleted, added).debounce(for: 0.5, scheduler: DispatchQueue.main).sink { [weak self] _ in
-                self?.filtersUpdated()
-            }
-            .store(in: &cancellables)
         }
     }
 
@@ -309,11 +317,11 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
             return
         }
 
-        customRightBtn?.isHidden = playlists.isEmpty
+        customRightBtn?.isHidden = listPlaylistItems.isEmpty
 
         var config: UIContentConfiguration?
 
-        if playlists.isEmpty {
+        if listPlaylistItems.isEmpty {
             // Empty State when playlists is empty
             let title = L10n.playlistsEmptyStateTitle
             let message = L10n.playlistsEmptyStateDescription

--- a/podcasts/SwipeActionsHelper.swift
+++ b/podcasts/SwipeActionsHelper.swift
@@ -174,14 +174,6 @@ enum SwipeActionsHelper {
             if !playlistSourceType.isEmpty {
                 properties["filter_type"] = playlistSourceType
             }
-
-            switch action {
-            case .delete, .unarchive, .archive, .removeFromManualPlaylist:
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistsNeedReload)
-                break
-            default:
-                break
-            }
         }
         Analytics.track(.episodeSwipeActionPerformed, properties: properties)
 


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-392

This PR introduces DiffableKit in Playlists list. This change will allow to reload artwork and count only when specific playlists change. This means we can keep the logic to reload as used to be before and remove additional observers and notifications.

## To test

- Run this branch
- Navigate to Playlists
- Smoke test Manual and Smart Playlsits by changing episodes order, adding/removing episodes etc...
- All changes should be reflected in the list

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
