### PR TITLE
[Playlists] Smart Playlist flow update

### DIFF
--- a/podcasts/New Creation/New Preview/Rules/SmartPlaylistRulesView.swift
+++ b/podcasts/New Creation/New Preview/Rules/SmartPlaylistRulesView.swift
@@ -99,10 +99,6 @@ fileprivate struct SmartPlaylistRulesInPreviewSection: View {
     var body: some View {
         Group {
             if !enabledRules.isEmpty {
-                Text(L10n.playlistSmartPreviewEnabledRules)
-                    .font(size: 22.0, style: .body, weight: .bold)
-                    .foregroundStyle(theme.primaryText01)
-                    .listRowClearStyle()
                 SmartPlaylistRulesContainerView(
                     rules: enabledRules,
                     action: action
@@ -121,7 +117,7 @@ fileprivate struct SmartPlaylistRulesInPreviewSection: View {
                     .padding(.vertical, 16.0)
                     .padding(.leading, -18.0)
                 } label: {
-                    Text(L10n.playlistSmartPreviewOtherRules)
+                    Text(L10n.playlistSmartPreviewMoreRules)
                         .font(size: 22.0, style: .body, weight: .bold)
                         .foregroundStyle(theme.primaryText01)
                         .listRowClearStyle()

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2516,7 +2516,7 @@ internal enum L10n {
   /// Smart Playlist preview: title for the enabled rules section
   internal static var playlistSmartPreviewEnabledRules: String { return L10n.tr("Localizable", "playlist_smart_preview_enabled_rules", fallback: "Enabled rules") }
   /// Smart Playlist preview: title for the available rules section
-  internal static var playlistSmartPreviewOtherRules: String { return L10n.tr("Localizable", "playlist_smart_preview_other_rules", fallback: "Other options") }
+  internal static var playlistSmartPreviewMoreRules: String { return L10n.tr("Localizable", "playlist_smart_preview_more_rules", fallback: "More rules") }
   /// Header subtitle for smart rule podcasts when select all is on
   internal static var playlistSmartRulePodcastsHeaderSubtitleAutoAdd: String { return L10n.tr("Localizable", "playlist_smart_rule_podcasts_header_subtitle_auto_add", fallback: "New podcasts you follow will be automatically added.") }
   /// Header subtitle for smart rule podcasts when select all is off

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5526,7 +5526,7 @@
 "playlist_smart_preview_enabled_rules" = "Enabled rules";
 
 /* Smart Playlist preview: title for the available rules section */
-"playlist_smart_preview_other_rules" = "Other options";
+"playlist_smart_preview_more_rules" = "More rules";
 
 /* Smart Playlist preview: title when editing the Smart Playlist rules */
 "playlist_smart_rules_title" = "Smart rules";


### PR DESCRIPTION
| 📘 Part of: [Playtlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-399

This removes "Enabled rules" header when creating a playlist and changes "Other options" copy to "More rules".

| Before | After |
| :-------: | :-------: |
| <img width="590" height="1278" alt="IMG_0547" src="https://github.com/user-attachments/assets/52f9e9e4-7f77-48b2-86d1-ebfe3f753d94" /> | <img width="590" height="1278" alt="IMG_0548" src="https://github.com/user-attachments/assets/e75ade8b-f96b-412d-85e2-4d32a235d076" /> |


## To test

1. Start creating a smart playlist.
2. Save any rule.
3. You should not see "Enabled rules" header.
4. You should see "More rules" section.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
