### PR TITLE
[Playback 2025] Fix analytics year prop

### DIFF
--- a/podcasts/End of Year/Analytics+story.swift
+++ b/podcasts/End of Year/Analytics+story.swift
@@ -2,6 +2,6 @@ import Foundation
 
 extension Analytics {
     static func track(_ event: AnalyticsEvent, story: String) {
-        Analytics.track(event, properties: ["story": story, "year": EndOfYear.currentYear.literalValue])
+        Analytics.track(event, properties: ["story": story, "current_year": EndOfYear.currentYear.literalValue])
     }
 }

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -130,7 +130,7 @@ struct EndOfYear {
         }
 
         BottomSheetSwiftUIWrapper.present(EndOfYearModal(year: storyModelType.year, model: viewModel), autoSize: true, in: viewController) {
-            Analytics.track(.endOfYearModalDismissed, properties: ["year": EndOfYear.currentYear.literalValue])
+            Analytics.track(.endOfYearModalDismissed, properties: ["current_year": EndOfYear.currentYear.literalValue])
         }
         Settings.setHasShownModalForEndOfYear(true, year: storyModelType.year)
     }
@@ -191,7 +191,7 @@ struct EndOfYear {
         }
 
         viewController.present(storiesViewController, animated: true, completion: nil)
-        Analytics.track(.endOfYearStoriesShown, properties: ["source": source.rawValue, "year": EndOfYear.currentYear.literalValue])
+        Analytics.track(.endOfYearStoriesShown, properties: ["source": source.rawValue, "current_year": EndOfYear.currentYear.literalValue])
     }
 
     static func share(assets: [Any], model: StoriesModel, storyIdentifier: String = "unknown", onDismiss: (() -> Void)? = nil) {
@@ -211,7 +211,7 @@ struct EndOfYear {
             }
 
             if let activity, success {
-                let properties = ["activity": activity.rawValue, "story": storyIdentifier, "from": "button", "year": EndOfYear.currentYear.literalValue]
+                let properties = ["activity": activity.rawValue, "story": storyIdentifier, "from": "button", "current_year": EndOfYear.currentYear.literalValue]
                 Analytics.track(.endOfYearStoryShared, properties: properties)
                 DispatchQueue.main.async {
                     model.recordPlaybackShare(properties: properties.merging(["source": "end_of_year"]) { $1 })

--- a/podcasts/End of Year/Stories/2023/EpilogueStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/EpilogueStory2023.swift
@@ -54,7 +54,7 @@ struct EpilogueStory2023: ShareableStory {
 
                     Button(L10n.eoyStoryReplay) {
                         StoriesController.shared.replay()
-                        Analytics.track(.endOfYearStoryReplayButtonTapped, properties: ["year": "2023"])
+                        Analytics.track(.endOfYearStoryReplayButtonTapped, properties: ["current_year": "2023"])
                     }
                     .buttonStyle(StoriesButtonStyle(color: Constants.backgroundColor, icon: Image("eoy-replay-icon")))
                     .opacity(renderForSharing ? 0 : 1)

--- a/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
+++ b/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
@@ -55,7 +55,7 @@ struct EpilogueStory2024: StoryView {
             StoryFooter2024(title: L10n.eoy2024EpilogueTitle, description: L10n.eoy2024EpilogueDescription)
             Button(L10n.eoyStoryReplay) {
                 StoriesController.shared.replay()
-                Analytics.track(.endOfYearStoryReplayButtonTapped, properties: ["year": "2024"])
+                Analytics.track(.endOfYearStoryReplayButtonTapped, properties: ["current_year": "2024"])
             }
             .buttonStyle(BasicButtonStyle(textColor: .black, backgroundColor: Color.clear, borderColor: .black))
             .allowsHitTesting(true)

--- a/podcasts/End of Year/Stories/2024/PaidStoryWallView2024.swift
+++ b/podcasts/End of Year/Stories/2024/PaidStoryWallView2024.swift
@@ -64,7 +64,7 @@ struct PaidStoryWallView2024: View {
                 .allowsHitTesting(false)
         }
         .onAppear {
-            Analytics.track(.endOfYearUpsellShown, properties: ["year": "2024"])
+            Analytics.track(.endOfYearUpsellShown, properties: ["current_year": "2024"])
             Analytics.track(.endOfYearStoryShown, story: identifier)
         }
     }

--- a/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
@@ -77,7 +77,7 @@ struct Ratings2024Story: ShareableStory {
             Button(L10n.learnAboutRatings) {
                 pauseState.togglePause()
                 openURL = true
-                Analytics.track(.endOfYearLearnRatingsShown, properties: ["year": "2024"])
+                Analytics.track(.endOfYearLearnRatingsShown, properties: ["current_year": "2024"])
             }
             .buttonStyle(BasicButtonStyle(textColor: .black, backgroundColor: Color.clear, borderColor: .black))
             .allowsHitTesting(true)

--- a/podcasts/End of Year/Stories/2025/EpilogueStory2025.swift
+++ b/podcasts/End of Year/Stories/2025/EpilogueStory2025.swift
@@ -53,7 +53,7 @@ struct EpilogueStory2025: StoryView {
             Spacer()
             Button(L10n.eoyStoryReplay) {
                 StoriesController.shared.replay()
-                Analytics.track(.endOfYearStoryReplayButtonTapped, properties: ["year": "2025"])
+                Analytics.track(.endOfYearStoryReplayButtonTapped, properties: ["current_year": "2025"])
             }
             .buttonStyle(BasicButtonStyle(textColor: .black, backgroundColor: foregroundColor))
             .allowsHitTesting(true)

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -82,10 +82,10 @@ struct PaidStoryWallView2025: StoryView {
                         guard let storiesViewController = SceneHelper.rootViewController() else {
                             return
                         }
-                        Analytics.track(.endOfYearUpsellShown, properties: ["year": EndOfYear.currentYear.literalValue])
+                        Analytics.track(.endOfYearUpsellShown, properties: ["current_year": EndOfYear.currentYear.literalValue])
                         NavigationManager.sharedManager.showUpsellView(from: storiesViewController, source: .endOfYear, flow: SyncManager.isUserLoggedIn() ? .endOfYearUpsell : .endOfYear)
                     } else {
-                        Analytics.track(.endOfYearPlusContinued, properties: ["year": EndOfYear.currentYear.literalValue])
+                        Analytics.track(.endOfYearPlusContinued, properties: ["current_year": EndOfYear.currentYear.literalValue])
                         advanceToNextStory()
                     }
                 }

--- a/podcasts/End of Year/Stories/2025/Ratings2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/Ratings2025Story.swift
@@ -76,7 +76,7 @@ struct Ratings2025Story: ShareableStory {
             Button(L10n.learnAboutRatings) {
                 pauseState.togglePause()
                 openURL = true
-                Analytics.track(.endOfYearLearnRatingsShown, properties: ["year": "2025"])
+                Analytics.track(.endOfYearLearnRatingsShown, properties: ["current_year": "2025"])
             }
             .buttonStyle(BasicButtonStyle(textColor: .black, backgroundColor: Color.white, borderColor: .white))
             .allowsHitTesting(true)

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -400,7 +400,7 @@ private extension StoriesModel {
                 if dataSource.numberOfStories > 0, dataSource.shareableStory(for: currentStoryIndex) != nil {
                     let year = EndOfYear.currentYear.literalValue
                     let story = currentStoryIdentifier
-                    let properties = ["story": story, "year": year, "from": "screenshot"]
+                    let properties = ["story": story, "current_year": year, "from": "screenshot"]
                     Analytics.track(.endOfYearStoryShared, properties: properties)
                 }
             }

--- a/podcasts/End of Year/Views/EndOfYearModal.swift
+++ b/podcasts/End of Year/Views/EndOfYearModal.swift
@@ -25,7 +25,7 @@ struct EndOfYearModal: View {
                     .scaledToFit()
                     .clipShape(RoundedRectangle(cornerRadius: 16))
                     .buttonize {
-                        Analytics.track(.endOfYearModalTapped, properties: ["year": EndOfYear.currentYear.literalValue])
+                        Analytics.track(.endOfYearModalTapped, properties: ["current_year": EndOfYear.currentYear.literalValue])
                         NavigationManager.sharedManager.navigateTo(NavigationManager.endOfYearStories, data: nil)
                     }
                 Text(model.description)
@@ -46,13 +46,13 @@ struct EndOfYearModal: View {
         .applyDefaultThemeOptions()
         .onAppear {
             Settings.setHasShownModalForEndOfYear(true, year: year)
-            Analytics.track(.endOfYearModalShown, properties: ["year": EndOfYear.currentYear.literalValue])
+            Analytics.track(.endOfYearModalShown, properties: ["current_year": EndOfYear.currentYear.literalValue])
         }
     }
 
     var showStoriesButton: some View {
         Button(model.buttonTitle) {
-            Analytics.track(.endOfYearModalTapped, properties: ["year": EndOfYear.currentYear.literalValue])
+            Analytics.track(.endOfYearModalTapped, properties: ["current_year": EndOfYear.currentYear.literalValue])
             NavigationManager.sharedManager.navigateTo(NavigationManager.endOfYearStories, data: nil)
         }
         .buttonStyle(RoundedButtonStyle(theme: theme))

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -145,7 +145,7 @@ struct StoriesView: View {
         }
         .background(model.primaryBackgroundColor)
         .onAppear {
-            Analytics.track(.endOfYearStoriesFailedToLoad, properties: ["year": EndOfYear.currentYear.literalValue])
+            Analytics.track(.endOfYearStoriesFailedToLoad, properties: ["current_year": EndOfYear.currentYear.literalValue])
             if EndOfYear.currentYear == .y2025 {
                 model.stopAndDismiss()
                 Toast.show(L10n.playback2025FailedToLoad)

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -363,7 +363,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             Analytics.track(.referralPassBannerShown)
         }
         if row == .endOfYearPrompt {
-            Analytics.track(.endOfYearProfileCardShown, properties: ["year": EndOfYear.currentYear.literalValue])
+            Analytics.track(.endOfYearProfileCardShown, properties: ["current_year": EndOfYear.currentYear.literalValue])
         }
     }
 
@@ -418,7 +418,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             present(navController, animated: true, completion: nil)
         case .endOfYearPrompt:
             dismiss(animated: true)
-            Analytics.track(.endOfYearProfileCardTapped, properties: ["year": EndOfYear.currentYear.literalValue])
+            Analytics.track(.endOfYearProfileCardTapped, properties: ["current_year": EndOfYear.currentYear.literalValue])
             if let endOfYear = (tabBarController as? MainTabBarController)?.endOfYear {
                 endOfYear.showStories(in: self, from: .profile)
             } else {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-403 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
We are updating the analytics prop from `year` to `current_year` on all end of year events.

## To test

1. Start the app
2. Enable Tracks logging
3. Open the playback 2025
4. Check that all events that had `year` now have `current_year`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
