### PR TITLE
[Playback 2025] Allow deep link to profile and playback

### DIFF
--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -460,7 +460,8 @@ extension AppDelegate {
                   let pathComponents = parameters[JLRouteWildcardComponentsKey] as? [String],
                   let row = pathComponents.first
             else {
-                return false
+                NavigationManager.sharedManager.navigateTo(NavigationManager.settingsProfileKey, data: [:])
+                return true
             }
             NavigationManager.sharedManager.navigateTo(NavigationManager.settingsProfileKey, data: [NavigationManager.profileRowKey: row])
             return true

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -62,6 +62,7 @@ class NavigationManager {
     static let settingsProfileKey = "profilePage"
     static let profileRowKey = "profileRow"
     static let profileRowDownloadsKey = "downloads"
+    static let profileRowEndOfYearKey = "playback"
     static let settingsHeadphoneKey = "headphoneSettings"
     static let settingsRedeemGuestPassKey = "redeemGuestPassPage"
     static let redeemGuestPassURLKey = "redeemGuestPassURLKey"
@@ -292,6 +293,9 @@ class NavigationManager {
         }
         if row == NavigationManager.profileRowDownloadsKey {
             mainController?.navigateToProfile(row: .downloaded, animated: animated)
+        }
+        if row == NavigationManager.profileRowEndOfYearKey {
+            mainController?.navigateToProfile(row: .endOfYearPrompt, animated: animated)
         }
     }
 

--- a/podcasts/NavigationManager.swift
+++ b/podcasts/NavigationManager.swift
@@ -287,6 +287,7 @@ class NavigationManager {
 
     func navigateToProfile(data: NSDictionary?, animated: Bool) {
         guard let row = data?[NavigationManager.profileRowKey] as? String else {
+            mainController?.navigateToProfile(row: nil, animated: animated)
             return
         }
         if row == NavigationManager.profileRowDownloadsKey {

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -423,7 +423,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
                 endOfYear.showStories(in: self, from: .profile)
             } else {
                 //Show warning that playback is not available
-                let alert = UIAlertController(title: "Playback unavailable", message: "Please try again later", preferredStyle: .alert)
+                let alert = UIAlertController(title: L10n.playbackNotAvailable, message: L10n.pleaseTryAgainLater, preferredStyle: .alert)
                 present(alert, animated: true)
             }
         case .bookmarks:

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -422,7 +422,9 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
             if let endOfYear = (tabBarController as? MainTabBarController)?.endOfYear {
                 endOfYear.showStories(in: self, from: .profile)
             } else {
-                assertionFailure("End of Year should exist. Something is wrong with the tabBarController")
+                //Show warning that playback is not available
+                let alert = UIAlertController(title: "Playback unavailable", message: "Please try again later", preferredStyle: .alert)
+                present(alert, animated: true)
             }
         case .bookmarks:
             let bookmarksController = BookmarksProfileListController()

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2334,6 +2334,8 @@ internal enum L10n {
   internal static var playbackEffects: String { return L10n.tr("Localizable", "playback_effects", fallback: "Playback effects") }
   /// A common string used throughout the app. Generic message informing the user that playback failed.
   internal static var playbackFailed: String { return L10n.tr("Localizable", "playback_failed", fallback: "Playback Failed") }
+  /// Message to shown then trying to open playback from deep link but it's not available
+  internal static var playbackNotAvailable: String { return L10n.tr("Localizable", "playback_not_available", fallback: "Playback unavailable") }
   /// Label indicating the current value for the playback speed. '%1$@' is a placeholder for the playback speed and 'x' is meant to read as 'times' as in '1.1 times' for '1.1x'
   internal static func playbackSpeed(_ p1: Any) -> String {
     return L10n.tr("Localizable", "playback_speed", String(describing: p1), fallback: "%1$@x")

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5811,3 +5811,8 @@
 
 /* Message to shown when playback 2025 failed to load */
 "playback_2025_failed_to_load" = "Sorry, we couldn’t load Playback";
+
+/* Message to shown then trying to open playback from deep link but it's not available */
+"playback_not_available" = "Playback unavailable";
+
+


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR allows to deep link directly to profile and playback if available.

## To test

1. Start the app and login an user that  is eligible for Playback
2. Open a tab that is not profile
3. Exit the app
4. Open Safari, and tap the following link `pktc://profile`
5. Confirm opening the app, and see if it opens the Profile tab
6. Switch again to another tab that is not profile
7. Open Safari, and tap the following link `pktc://profile/playback`
5. Check if Playback opens
6. Log out the user
7. Repeat the test above with an user that is not eligible

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
