### PR TITLE
Keep downloads during sync process for unsubscribed podcasts (#3794)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 8.2
 -----
 
+8.1.1
+-----
+- Keep episode downloads from missing podcasts during sync [#3799](https://github.com/Automattic/pocket-casts-ios/pull/3799)
 
 8.1
 -----

--- a/PocketCastsTests/Tests/Utilities/PodcastManagerTests.swift
+++ b/PocketCastsTests/Tests/Utilities/PodcastManagerTests.swift
@@ -48,6 +48,20 @@ final class PodcastManagerTests: DBTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: DownloadManager.shared.pathForEpisode(refreshedEpisode)))
     }
 
+    func testCleanupKeepsDownloadsNotInPlaylist() async throws {
+        ServerSettings.setSyncingEmail(email: "test@example.com")
+        defer { ServerSettings.setSyncingEmail(email: nil) }
+
+        let (_, episode) = makeDownloadedPodcastAndEpisode()
+
+        let podcastManager = PodcastManager(dataManager: dataManager, downloadManager: downloadManager)
+        await podcastManager.checkForUnusedPodcasts()
+
+        let refreshedEpisode = try XCTUnwrap(dataManager.findEpisode(uuid: episode.uuid))
+        XCTAssertEqual(refreshedEpisode.episodeStatus, DownloadStatus.downloaded.rawValue)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: DownloadManager.shared.pathForEpisode(refreshedEpisode)))
+    }
+
     func testUnsubscribeRemovesDownloadsInPlaylist() throws {
         ServerSettings.setSyncingEmail(email: "test@example.com")
         defer { ServerSettings.setSyncingEmail(email: nil) }

--- a/podcasts/PodcastManager+Cleanup.swift
+++ b/podcasts/PodcastManager+Cleanup.swift
@@ -8,14 +8,6 @@ extension PodcastManager {
         // we don't delete podcasts that haven't been synced or you're still subscribed to
         if podcast.syncStatus == SyncStatus.notSynced.rawValue || podcast.isSubscribed() { return }
 
-        let episodes = dataManager.allEpisodesForPodcast(id: podcast.id)
-
-        // Only delete episodes which aren't contained in a playlist.
-        // This is because episodes can be added to a playlist but not subscribed but we fetch the podcast info anyway for display
-        for episode in episodes where !dataManager.playlistContainsEpisode(episodeUuid: episode.uuid) {
-            EpisodeManager.deleteDownloadedFiles(episode: episode)
-        }
-
         // we don't delete podcasts added to the phone in the last week. This is to prevent stuff you just leave open in discover from being removed
         if let addedDate = podcast.addedDate, abs(addedDate.timeIntervalSinceNow) < 1.week { return }
 


### PR DESCRIPTION
Hotfix merge for #3794 

## To test

* Download an episode by browsing an unsubscribed show in Discover
* ✅ Ensure the download completes
* Refresh in Profile
* ✅ Ensure the download remains

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
