### PR TITLE
[Hotfix] Fix tip for logged out users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 8.2
 -----
 
+8.1.1
+-----
+- Playlists: fix drag and drop tip for logged out users [#3800](https://github.com/Automattic/pocket-casts-ios/pull/3800)
 
 8.1
 -----

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -217,9 +217,8 @@ extension PlaylistsViewController {
             return
         }
 
-        guard SyncManager.isUserLoggedIn() else { return }
-
-        if Settings.shouldShowNewFilterTip,
+        if SyncManager.isUserLoggedIn(),
+           Settings.shouldShowNewFilterTip,
            !hasPremadePlaylists(),
            newFilterTip == nil {
             showNewFilterTip()


### PR DESCRIPTION
Ref. #3782

## To test

1. Start this branch from a fresh install
2. Don't sign in
3. Go to Playlists
4. Create a new playlist
5. Go back
6. Observe the drag and drop tip is shown

### Smoke test default tip

1. Start this branch from a fresh install
2. Don't sign in
3. Go to Playlists
4. Observe no tip is shown
5. Sign in with a user that has already playlists created
6. Go to Playlists
7. Unless the user has only the 2 pre-defined playlists, the tip should not appear
8. Delete the app
9. Install again and create a new user
10. Go to playlists
11. You should see the tip

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
