### PR TITLE
Fix crash on screenshotting before playback is loaded

### DIFF
--- a/podcasts/End of Year/Stories/2025/IntroStory2025.swift
+++ b/podcasts/End of Year/Stories/2025/IntroStory2025.swift
@@ -70,7 +70,7 @@ struct IntroStory2025: StoryView {
                         ZStack {
                             CircularProgressView(value: 1, stroke: .white.opacity(0.33), strokeWidth: 6)
                                 .frame(width: 40, height: 40)
-                            CircularProgressView(value: 0.5, stroke: .white, strokeWidth: 6)
+                            CircularProgressView(value: self.syncProgressModel.progress, stroke: .white, strokeWidth: 6)
                                 .frame(width: 40, height: 40)
                         }
                         Spacer()

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -26,7 +26,7 @@ class StoriesModel: ObservableObject {
             }
 
             // Present share alert if the story is shareable
-            guard dataSource.shareableStory(for: currentStoryIndex) != nil else {
+            guard dataSource.numberOfStories > 0, dataSource.shareableStory(for: currentStoryIndex) != nil else {
                 screenshotTaken = false
                 return
             }
@@ -397,7 +397,7 @@ private extension StoriesModel {
                 pause()
                 screenshotTaken = true
 
-                if dataSource.shareableStory(for: currentStoryIndex) != nil {
+                if dataSource.numberOfStories > 0, dataSource.shareableStory(for: currentStoryIndex) != nil {
                     let year = EndOfYear.currentYear.literalValue
                     let story = currentStoryIdentifier
                     let properties = ["story": story, "year": year, "from": "screenshot"]


### PR DESCRIPTION
Hotfix merge of https://github.com/Automattic/pocket-casts-ios/pull/3785

## To test

1. Start the app
2. Open Profile
3. Start playback
4. Try to take a screenshot the moment it opens to see if no crash happens

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
