### PR TITLE
Add missing filterCreated

### DIFF
--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -235,6 +235,7 @@ class NewPlaylistViewController: PCViewController {
             NavigationManager.sharedManager.navigateTo(NavigationManager.filterPageKey, data: [NavigationManager.filterUuidKey: playlist.uuid])
         }
 
+        Analytics.track(.filterCreated)
         Analytics.track(.filterCreateAsManualPlaylistTapped)
 
         if Settings.firstTimePlaylistCreated {


### PR DESCRIPTION
Add missing `filterCreated` event for manual playlist

## To test

- Run this branch
- Enable tracks log
- Create a new manual playlist
- Observe `filter_created` event is tracked with no smart playlist properties

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
