### PR TITLE
Avoid multiple DB queries when there is notification flood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 8.2
 -----
+- Improve app performance when trigering multiple downloads [#3809](https://github.com/Automattic/pocket-casts-ios/pull/3809)
 
 8.1.1
 -----

--- a/podcasts/BadgeHelper.swift
+++ b/podcasts/BadgeHelper.swift
@@ -24,14 +24,14 @@ class BadgeHelper {
                                                     Constants.Notifications.playbackEnded,
                                                     Constants.Notifications.playbackStarted]
 
-        let mergedMany = notifications
+        let mergedNotifications = notifications
             .map { NotificationCenter.default.publisher(for: $0) }
             .reduce(Empty<Notification, Never>().eraseToAnyPublisher()) { acc, pub in
                 acc.merge(with: pub).eraseToAnyPublisher()
             }
             .debounce(for: .seconds(3), scheduler: RunLoop.main)
 
-        cancelable = mergedMany.sink { [weak self] _ in
+        cancelable = mergedNotifications.sink { [weak self] _ in
             self?.updateBadge()
         }
     }

--- a/podcasts/BadgeHelper.swift
+++ b/podcasts/BadgeHelper.swift
@@ -1,30 +1,44 @@
 import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
+import Combine
 
 class BadgeHelper {
     deinit {
         teardown()
     }
 
+    private var cancelable: Cancellable?
+
     func setup() {
-        let notCenter = NotificationCenter.default
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: Constants.Notifications.playlistChanged, object: nil)
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: Constants.Notifications.episodePlayStatusChanged, object: nil)
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: Constants.Notifications.episodeArchiveStatusChanged, object: nil)
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: Constants.Notifications.episodeStarredChanged, object: nil)
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: Constants.Notifications.episodeDownloadStatusChanged, object: nil)
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: Constants.Notifications.manyEpisodesChanged, object: nil)
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: ServerNotifications.podcastsRefreshed, object: nil)
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: Constants.Notifications.opmlImportCompleted, object: nil)
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: Constants.Notifications.episodeDownloaded, object: nil)
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: Constants.Notifications.playbackTrackChanged, object: nil)
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: Constants.Notifications.playbackEnded, object: nil)
-        notCenter.addObserver(self, selector: #selector(updateBadge), name: Constants.Notifications.playbackStarted, object: nil)
+        let notifications: [NSNotification.Name] = [Constants.Notifications.playlistChanged,
+                                                    Constants.Notifications.episodePlayStatusChanged,
+                                                    Constants.Notifications.episodeArchiveStatusChanged,
+                                                    Constants.Notifications.episodeStarredChanged,
+                                                    Constants.Notifications.episodeDownloadStatusChanged,
+                                                    Constants.Notifications.manyEpisodesChanged,
+                                                    ServerNotifications.podcastsRefreshed,
+                                                    Constants.Notifications.opmlImportCompleted,
+                                                    Constants.Notifications.episodeDownloaded,
+                                                    Constants.Notifications.playbackTrackChanged,
+                                                    Constants.Notifications.playbackEnded,
+                                                    Constants.Notifications.playbackStarted]
+
+        let mergedMany = notifications
+            .map { NotificationCenter.default.publisher(for: $0) }
+            .reduce(Empty<Notification, Never>().eraseToAnyPublisher()) { acc, pub in
+                acc.merge(with: pub).eraseToAnyPublisher()
+            }
+            .debounce(for: .seconds(3), scheduler: RunLoop.main)
+
+        cancelable = mergedMany.sink { [weak self] _ in
+            self?.updateBadge()
+        }
     }
 
     func teardown() {
-        NotificationCenter.default.removeObserver(self)
+        cancelable?.cancel()
+        cancelable = nil
     }
 
     @objc func updateBadge() {

--- a/podcasts/ShortcutManager.swift
+++ b/podcasts/ShortcutManager.swift
@@ -1,25 +1,42 @@
 import PocketCastsDataModel
 import UIKit
+import Combine
 
 class ShortcutManager: CustomObserver {
-    func listenForShortcutChanges() {
-        addCustomObserver(Constants.Notifications.playbackStarted, selector: #selector(shortcutsRequireUpdate))
-        addCustomObserver(Constants.Notifications.playbackPaused, selector: #selector(shortcutsRequireUpdate))
-        addCustomObserver(Constants.Notifications.playbackEnded, selector: #selector(shortcutsRequireUpdate))
-        addCustomObserver(Constants.Notifications.playlistChanged, selector: #selector(shortcutsRequireUpdate))
-        addCustomObserver(Constants.Notifications.podcastAdded, selector: #selector(shortcutsRequireUpdate))
 
-        addCustomObserver(Constants.Notifications.episodePlayStatusChanged, selector: #selector(shortcutsRequireUpdate))
-        addCustomObserver(Constants.Notifications.episodeArchiveStatusChanged, selector: #selector(shortcutsRequireUpdate))
-        addCustomObserver(Constants.Notifications.episodeStarredChanged, selector: #selector(shortcutsRequireUpdate))
-        addCustomObserver(Constants.Notifications.episodeDownloadStatusChanged, selector: #selector(shortcutsRequireUpdate))
-        addCustomObserver(Constants.Notifications.manyEpisodesChanged, selector: #selector(shortcutsRequireUpdate))
+    var cancelable: Cancellable?
+
+    func listenForShortcutChanges() {
+        //Cleans up existing observers
+        stopListeningForShortcutChanges()
+
+        let notifications: [NSNotification.Name] = [Constants.Notifications.playbackStarted,
+                                                     Constants.Notifications.playbackPaused,
+                                                     Constants.Notifications.playbackEnded,
+                                                     Constants.Notifications.playlistChanged,
+                                                     Constants.Notifications.podcastAdded,
+                                                     Constants.Notifications.episodePlayStatusChanged,
+                                                     Constants.Notifications.episodeArchiveStatusChanged,
+                                                     Constants.Notifications.episodeStarredChanged,
+                                                     Constants.Notifications.episodeDownloadStatusChanged,
+                                                     Constants.Notifications.manyEpisodesChanged]
+
+        let mergedMany = notifications
+            .map { NotificationCenter.default.publisher(for: $0) }
+            .reduce(Empty<Notification, Never>().eraseToAnyPublisher()) { acc, pub in
+                acc.merge(with: pub).debounce(for: .seconds(3), scheduler: RunLoop.main).eraseToAnyPublisher()
+            }
+
+        cancelable = mergedMany.sink { [weak self] _ in
+            self?.shortcutsRequireUpdate()
+        }
 
         shortcutsRequireUpdate()
     }
 
     func stopListeningForShortcutChanges() {
-        removeAllCustomObservers()
+        cancelable?.cancel()
+        cancelable = nil
     }
 
     @objc private func shortcutsRequireUpdate() {

--- a/podcasts/ShortcutManager.swift
+++ b/podcasts/ShortcutManager.swift
@@ -21,14 +21,14 @@ class ShortcutManager: CustomObserver {
                                                      Constants.Notifications.episodeDownloadStatusChanged,
                                                      Constants.Notifications.manyEpisodesChanged]
 
-        let mergedMany = notifications
+        let mergedNotifications = notifications
             .map { NotificationCenter.default.publisher(for: $0) }
             .reduce(Empty<Notification, Never>().eraseToAnyPublisher()) { acc, pub in
                 acc.merge(with: pub).eraseToAnyPublisher()
             }
             .debounce(for: .seconds(3), scheduler: RunLoop.main)
 
-        cancelable = mergedMany.sink { [weak self] _ in
+        cancelable = mergedNotifications.sink { [weak self] _ in
             self?.shortcutsRequireUpdate()
         }
 

--- a/podcasts/ShortcutManager.swift
+++ b/podcasts/ShortcutManager.swift
@@ -4,7 +4,7 @@ import Combine
 
 class ShortcutManager: CustomObserver {
 
-    var cancelable: Cancellable?
+    private var cancelable: Cancellable?
 
     func listenForShortcutChanges() {
         //Cleans up existing observers
@@ -24,8 +24,9 @@ class ShortcutManager: CustomObserver {
         let mergedMany = notifications
             .map { NotificationCenter.default.publisher(for: $0) }
             .reduce(Empty<Notification, Never>().eraseToAnyPublisher()) { acc, pub in
-                acc.merge(with: pub).debounce(for: .seconds(3), scheduler: RunLoop.main).eraseToAnyPublisher()
+                acc.merge(with: pub).eraseToAnyPublisher()
             }
+            .debounce(for: .seconds(3), scheduler: RunLoop.main)
 
         cancelable = mergedMany.sink { [weak self] _ in
             self?.shortcutsRequireUpdate()


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the Shorcuts and Badge managers to have debouncers to avoid query the playlist count when receiving a flood of notifications. This is specially important when multiple downloads are started.

## To test

1. Start the app
2. Open a podcast
3. Select multiple episodes ( more than 20)
4. Select Download
5. Check the performance of the app, and you don't experience hangs or stutters on the app
6. Smoke test if the Shorcuts in the app still work correctly ( Long Tap on the app icon on the Home screen)
7. Smoke test the badges on the app. You need to go to Profile -> Settings -> Notifications -> New Episodes toggle on -> select badge for a playlist


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
