### PR TITLE
Onboarding analytics fixes

### DIFF
--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -33,6 +33,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case noFilters = "no_filters"
     case notifications
     case nowPlayingWidget = "now_playing_widget"
+    case onboarding
     case player
     case playerPlaybackEffects = "player_playback_effects"
     case playerSkipForwardLongPress = "player_skip_forward_long_press"
@@ -72,16 +73,20 @@ class AnalyticsCoordinator {
         PlaybackManager.shared.currentEpisode()?.videoPodcast() ?? false
     }
 
-    #if !os(watchOS) && !APPCLIP
-        var currentAnalyticsSource: AnalyticsSource {
-            if let currentSource = currentSource {
-                self.currentSource = nil
-                return currentSource
-            }
-
-            return (getTopViewController() as? AnalyticsSourceProvider)?.analyticsSource ?? .unknown
+    var currentAnalyticsSource: AnalyticsSource {
+        if let currentSource = currentSource {
+            self.currentSource = nil
+            return currentSource
         }
 
+        #if !os(watchOS) && !APPCLIP
+        return (getTopViewController() as? AnalyticsSourceProvider)?.analyticsSource ?? .unknown
+        #else
+        return .unknown
+        #endif
+    }
+
+#if !os(watchOS) && !APPCLIP
         func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {
             // Only dispatch async on the main thread if needed
             guard Thread.isMainThread else {

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -80,7 +80,7 @@ class AnalyticsCoordinator {
         }
 
         #if !os(watchOS) && !APPCLIP
-        return (getTopViewController() as? AnalyticsSourceProvider)?.analyticsSource ?? .unknown
+        return topAnalyticsSourceProvider()?.analyticsSource ?? .unknown
         #else
         return .unknown
         #endif
@@ -115,6 +115,20 @@ class AnalyticsCoordinator {
             }
             return base
         }
+
+    func topAnalyticsSourceProvider() -> AnalyticsSourceProvider? {
+        guard let topViewController = getTopViewController() else { return nil }
+
+        var candidate: UIViewController? = topViewController
+        while let viewController = candidate {
+            if let provider = viewController as? AnalyticsSourceProvider {
+                return provider
+            }
+            candidate = viewController.parent ?? viewController.presentingViewController
+        }
+
+        return nil
+    }
     #else
         /// NOOP track event to preventing needing to wrap all the events in #if checks
         func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {}

--- a/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
@@ -8,6 +8,8 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
     // Internally track the episode UUIDs that the user is downloading or uploadiung
     private var episodeDownloadQueue: Set<String> = []
     private var episodeUploadQueue: Set<String> = []
+    // Keep track of where a download was initiated so completion/failure logs use the same source
+    private let episodeDownloadSources = ThreadSafeDictionary<String, AnalyticsSource>()
 
     override init() {
         super.init()
@@ -40,21 +42,32 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
     // MARK: - Download
 
     func downloadCancelled(episodeUUID: String) {
+        clearDownloadSource(for: episodeUUID)
         episodeEvent(.episodeDownloadCancelled, uuid: episodeUUID)
     }
 
     func downloaded(episodeUUID: String) {
+        let source = cacheDownloadSource(for: episodeUUID)
         episodeDownloadQueue.insert(episodeUUID)
+        currentSource = source
         episodeEvent(.episodeDownloadQueued, uuid: episodeUUID)
     }
 
     func downloadFinished(episodeUUID: String) {
+        let source = consumeDownloadSource(for: episodeUUID)
+        if let source {
+            currentSource = source
+        }
         episodeEvent(.episodeDownloadFinished, uuid: episodeUUID)
     }
 
     func downloadFailed(episodeUUID: String,
                         podcastUUID: String,
                         extraProperties: [String: Any]) {
+        let source = consumeDownloadSource(for: episodeUUID)
+        if let source {
+            currentSource = source
+        }
         track(.episodeDownloadFailed, properties: ["episode_uuid": episodeUUID,
                                                    "podcast_uuid": podcastUUID,
                                                   ].merging(extraProperties, uniquingKeysWith: { (current, _) in return current }))
@@ -62,7 +75,9 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
 
     func bulkDownloadEpisodes(episodes: [BaseEpisode]) {
         let uuids = episodes.map { $0.uuid }
+        let source = cacheDownloadSource(for: uuids)
         episodeDownloadQueue.formUnion(uuids)
+        currentSource = source
         bulkEvent(.episodeBulkDownloadQueued, count: episodes.count)
     }
 
@@ -153,6 +168,28 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
 }
 
 private extension AnalyticsEpisodeHelper {
+    func cacheDownloadSource(for episodeUUID: String) -> AnalyticsSource {
+        let source = currentAnalyticsSource
+        episodeDownloadSources[episodeUUID] = source
+        return source
+    }
+
+    func cacheDownloadSource(for episodeUUIDs: [String]) -> AnalyticsSource {
+        let source = currentAnalyticsSource
+        episodeUUIDs.forEach { episodeDownloadSources[$0] = source }
+        return source
+    }
+
+    func consumeDownloadSource(for episodeUUID: String) -> AnalyticsSource? {
+        let source = episodeDownloadSources[episodeUUID]
+        episodeDownloadSources[episodeUUID] = nil
+        return source
+    }
+
+    func clearDownloadSource(for episodeUUID: String) {
+        episodeDownloadSources.removeValue(forKey: episodeUUID)
+    }
+
     func episodeEvent(_ event: AnalyticsEvent, episode: BaseEpisode? = nil, uuid: String? = nil) {
         let episodeUUID: String
         if let episode {

--- a/podcasts/Onboarding/Import/ImportViewModel.swift
+++ b/podcasts/Onboarding/Import/ImportViewModel.swift
@@ -146,7 +146,8 @@ extension ImportViewModel {
         guard let navigationController else { return }
         OnboardingFlow.shared.track(.onboardingImportAppSelected, properties: ["app": importsource.id])
 
-        let controller = UIHostingController(rootView: ImportDetailsView(importSource: importsource, viewModel: self).setupDefaultEnvironment())
+        let controller = ImportHostingController(rootView: ImportDetailsView(importSource: importsource, viewModel: self).setupDefaultEnvironment())
+        controller.viewModel = self
 
         navigationController.pushViewController(controller, animated: true)
     }

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -57,7 +57,8 @@ class LoginCoordinator: NSObject, OnboardingModel {
         socialAuthProvider = nil
         OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "sign_in"])
         if FeatureFlag.newOnboardingAccountCreation.enabled {
-            let vc = UIHostingController(rootView: SyncSigninView(coordinator: self, loginAgain: false, onCompleted: { self.navigationController?.presentingViewController?.dismiss(animated: true) }).environmentObject(Theme.sharedTheme))
+            let vc = OnboardingHostingViewController(rootView: SyncSigninView(coordinator: self, loginAgain: false, onCompleted: { self.navigationController?.presentingViewController?.dismiss(animated: true) }).environmentObject(Theme.sharedTheme))
+            vc.viewModel = self
             navigationController?.pushViewController(vc, animated: true)
         } else {
             let controller = SyncSigninViewController()
@@ -83,9 +84,13 @@ class LoginCoordinator: NSObject, OnboardingModel {
             }) {
                 self.interestsContinueTapped(categories: nil)
             }
-            hostingController = UIHostingController(rootView: view.setupDefaultEnvironment())
+            let controller = OnboardingHostingViewController(rootView: view.setupDefaultEnvironment())
+            controller.viewModel = self
+            hostingController = controller
         } else {
-            hostingController = UIHostingController(rootView: OnboardingRecommendationsView(coordinator: self).setupDefaultEnvironment())
+            let controller = OnboardingHostingViewController(rootView: OnboardingRecommendationsView(coordinator: self).setupDefaultEnvironment())
+            controller.viewModel = self
+            hostingController = controller
         }
 
         hostingController.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
@@ -100,7 +105,8 @@ class LoginCoordinator: NSObject, OnboardingModel {
             configuration = .all
         }
         let view = OnboardingRecommendationsView(coordinator: self, viewModel: RecommendationsViewModel(configuration: configuration))
-        let hostingController = UIHostingController(rootView: view.setupDefaultEnvironment())
+        let hostingController = OnboardingHostingViewController(rootView: view.setupDefaultEnvironment())
+        hostingController.viewModel = self
         hostingController.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
         navigationController?.pushViewController(hostingController, animated: true)
     }

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PocketCastsUtils
 
-struct OnboardingFlow {
+struct OnboardingFlow: AnalyticsSourceProvider {
     typealias Context = [String: Any]
 
     static var shared = OnboardingFlow()
@@ -18,7 +18,7 @@ struct OnboardingFlow {
 
         let navigationController = controller as? UINavigationController
 
-        AnalyticsEpisodeHelper.shared.currentSource = .onboarding
+        AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
 
         let flowController: UIViewController
         switch flow {
@@ -103,9 +103,6 @@ struct OnboardingFlow {
         }
         source = .unknown
         currentFlow = .none
-        if AnalyticsEpisodeHelper.shared.currentSource == .onboarding {
-            AnalyticsEpisodeHelper.shared.currentSource = nil
-        }
 
         NotificationCenter.default.post(name: .onboardingFlowDidDismiss, object: nil)
     }
@@ -200,5 +197,9 @@ struct OnboardingFlow {
                 false
             }
         }
+    }
+
+    var analyticsSource: AnalyticsSource {
+        .onboarding
     }
 }

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -18,6 +18,8 @@ struct OnboardingFlow {
 
         let navigationController = controller as? UINavigationController
 
+        AnalyticsEpisodeHelper.shared.currentSource = .onboarding
+
         let flowController: UIViewController
         switch flow {
         case .plusUpsell, .endOfYearUpsell, .suggestedFolderUpsell:
@@ -101,6 +103,9 @@ struct OnboardingFlow {
         }
         source = .unknown
         currentFlow = .none
+        if AnalyticsEpisodeHelper.shared.currentSource == .onboarding {
+            AnalyticsEpisodeHelper.shared.currentSource = nil
+        }
 
         NotificationCenter.default.post(name: .onboardingFlowDidDismiss, object: nil)
     }

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -18,8 +18,6 @@ struct OnboardingFlow: AnalyticsSourceProvider {
 
         let navigationController = controller as? UINavigationController
 
-        AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
-
         let flowController: UIViewController
         switch flow {
         case .plusUpsell, .endOfYearUpsell, .suggestedFolderUpsell:

--- a/podcasts/Onboarding/OnboardingHostingViewController.swift
+++ b/podcasts/Onboarding/OnboardingHostingViewController.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SwiftUI
 
-class OnboardingHostingViewController<Content>: UIHostingController<Content>, UIAdaptivePresentationControllerDelegate where Content: View {
+class OnboardingHostingViewController<Content>: UIHostingController<Content>, UIAdaptivePresentationControllerDelegate, AnalyticsSourceProvider where Content: View {
+    var analyticsSource: AnalyticsSource { .onboarding }
     var navBarIsHidden: Bool = false
     var iconTintColor: UIColor = AppTheme.colorForStyle(.primaryInteractive01)
 
@@ -91,7 +92,8 @@ class OnboardingHostingViewController<Content>: UIHostingController<Content>, UI
     }
 }
 
-class OnboardingModalHostingViewController<Content>: BottomSheetSwiftUIWrapper<Content> where Content: View {
+class OnboardingModalHostingViewController<Content>: BottomSheetSwiftUIWrapper<Content>, AnalyticsSourceProvider where Content: View {
+    var analyticsSource: AnalyticsSource { .onboarding }
     var viewModel: OnboardingModel?
 
     override func viewDidAppear(_ animated: Bool) {

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -109,6 +109,7 @@ struct OnboardingRecommendationsView: View {
 
     @State var searchResults = [PodcastFolderSearchResult]()
     @State var searchTask: Task<Void, Never>?
+    @State private var didTapContinue = false
 
     init(coordinator: LoginCoordinator, viewModel: RecommendationsViewModel = RecommendationsViewModel(configuration: .all)) {
         self.coordinator = coordinator
@@ -158,6 +159,7 @@ struct OnboardingRecommendationsView: View {
 
                     VStack {
                         Button(action: {
+                            didTapContinue = true
                             OnboardingFlow.shared.track(.recommendationsContinueTapped, properties: ["subscriptions": DataManager.sharedManager.podcastCount()])
                             coordinator.recommendationsContinueTapped()
                         }) {
@@ -192,7 +194,9 @@ struct OnboardingRecommendationsView: View {
         .background(theme.primaryUi01)
         .environmentObject(SearchAnalyticsHelper(source: .recommendations))
         .onDisappear {
-            Analytics.track(.recommendationsDismissed, properties: ["subscriptions": DataManager.sharedManager.podcastCount()])
+            if didTapContinue == false {
+                Analytics.track(.recommendationsDismissed, properties: ["subscriptions": DataManager.sharedManager.podcastCount()])
+            }
         }
     }
 


### PR DESCRIPTION
Part of [PCIOS-285](https://linear.app/a8c/issue/PCIOS-285/fix-analytics-event-in-onboarding-and-account-creation-flows)

## To test

1. Enable the `tracksLogging` feature flag in code
2. Do a fresh install so Onboarding is shown
3. Subscribe to podcasts on the recommendations screen
4. ✅ Verify the `episode_download_queued` event is tracked with `source: onboarding` and then on download completion it is logged with `episode_download_finished` with `source: onboarding`.
5. ✅ While navigating through, ensure the `recommendations_dismiss` event is not logged when tapping continue on the recommendations screen
6. Complete the onboarding flow

### Smoke Test

1. Perform episode downloads from the Episode Detail page
2. ✅ Ensure `episode_download_queued` and `episode_download_finished` use `source: episode_detail`
3. Perform episode download by long pressing on the Podcast page
4. ✅ Ensure `episode_download_queued` and `episode_download_finished` use `source: podcast_screen`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
