### PR TITLE
Avoid retain cycle on media exporter callback

### DIFF
--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -365,7 +365,10 @@ class DownloadManager: NSObject, FilePathProtocol {
         var downloadError: Error?
         var reportedContentType: String?
         let originalSizeInBytes = episode.sizeInBytes
-        let customLoaderDelegate = MediaExporterResourceLoaderDelegate(saveFilePath: exportPath) { status, contentType, bytesDownloaded, bytesExpected in
+        let customLoaderDelegate = MediaExporterResourceLoaderDelegate(saveFilePath: exportPath) { [weak self] status, contentType, bytesDownloaded, bytesExpected in
+            guard let self else {
+                return
+            }
             reportedContentType = contentType
             let size = max(100, max(bytesExpected, originalSizeInBytes))
             switch status {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the progress report callback to not retain self when invoking report.

## To test

1. Start the app
2. Start playing some episode that is not downloaded
3. Tap to download while it's playing

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
