### PR TITLE
[Fix] Fix Smart Playlists count query and Tracks casted properties check

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -249,6 +249,10 @@ public class PlaylistQueryBuilder {
         if openCount > closeCount {
             trimmedValues.append(String(repeating: ")", count: openCount - closeCount))
         }
+
+        // Clean up any empty filter groups that may have been created
+        removeEmptyFilterGroups(from: &trimmedValues)
+
         let whereTail = trimmedValues.isEmpty ? "" : " \(trimmedValues)"
 
         return """

--- a/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
+++ b/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
@@ -82,7 +82,7 @@ class TracksAdapter: AnalyticsAdapter, AnonymousIdentifiable {
             }
 
             let value = castedProperties[key]
-            if !(value is Int || value is String || value is Double || value is Bool || value is Float) {
+            if !(value is Int || value is Int32 || value is Int64 || value is String || value is Double || value is Bool || value is Float) {
                 assertionFailure("Tracks event properties value for `\(key)` must be of one the valid types: Int, String, Bool, Double, Float")
                 return
             }


### PR DESCRIPTION
This PR fixes the Smart Playlist count query and adds 2 missing types to the Tracks cast properties

## To test
### Smart Playlist count
- Start from a fresh install
- Skip the login
- Add few podcasts from Discover
- Go to profile and login
- Wait till all podcasts are synced
- Confirm you don't see any SQL error from `PlaylistDataManager.smartPlaylistEpisodeCount`
- Go to Playlists
- Confirm each row count is shown correctly

### Tracks
- From Playlists create a new Smart Playlist
- After tapping on `Create smart playlist` to confirm, confirm no assertion failure catches wrong types

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
