### PR TITLE
Fix Now Playing on WatchOS 26

### DIFF
--- a/Pocket Casts Watch App/NowPlayingContainerView.swift
+++ b/Pocket Casts Watch App/NowPlayingContainerView.swift
@@ -20,7 +20,7 @@ struct NowPlayingContainerView: View {
                             .tag(2)
                             .animation(.none, value: selection)
                     }
-                    .animation(.easeInOut, value: selection)                    
+                    .animation(.easeInOut, value: selection)
                 }
             } else {
                 NowPlayingEmptyView()

--- a/Pocket Casts Watch App/NowPlayingContainerView.swift
+++ b/Pocket Casts Watch App/NowPlayingContainerView.swift
@@ -15,12 +15,12 @@ struct NowPlayingContainerView: View {
                     TabView(selection: $selection) {
                         NowPlayingOptions(viewModel: viewModel, presentView: $presentedView, optionSelected: $optionSelected)
                             .tag(1)
-                            .animation(.none)
+                            .animation(.none, value: selection)
                         NowPlayingControls(viewModel: viewModel, presentView: $presentedView)
                             .tag(2)
-                            .animation(.none)
+                            .animation(.none, value: selection)
                     }
-                    .animation(.easeInOut)
+                    .animation(.easeInOut, value: selection)                    
                 }
             } else {
                 NowPlayingEmptyView()

--- a/Pocket Casts Watch App/NowPlayingControls.swift
+++ b/Pocket Casts Watch App/NowPlayingControls.swift
@@ -17,6 +17,11 @@ struct NowPlayingControls: View {
                 // To take into account the page indicator view
                 Spacer().frame(height: Constants.pagingIndicatorHeight)
             }
+            .modify { content in
+                if #available(watchOS 10.0, *) {
+                    content.containerRelativeFrame(.vertical)
+                }
+            }
         }
         .modify { content in
             if #available(watchOS 9.4, *) {

--- a/Pocket Casts Watch App/NowPlayingControls.swift
+++ b/Pocket Casts Watch App/NowPlayingControls.swift
@@ -6,7 +6,7 @@ struct NowPlayingControls: View {
     @Binding var presentView: WatchInterfaceType?
 
     var body: some View {
-        ScrollView([], showsIndicators: false) {
+        ScrollView(.vertical, showsIndicators: false) {
             VStack {
                 progressGroup
                     .frame(maxHeight: .infinity)
@@ -18,7 +18,12 @@ struct NowPlayingControls: View {
                 Spacer().frame(height: Constants.pagingIndicatorHeight)
             }
         }
-        .edgesIgnoringSafeArea(.bottom)
+        .modify { content in
+            if #available(watchOS 9.4, *) {
+                content.scrollBounceBehavior(.basedOnSize)
+            }
+        }
+        .ignoresSafeArea(.all, edges: .bottom)
     }
 
     private var progressGroup: some View {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-421 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the Now Playing screen on Watch OS to avoid a layout issue when using iOS 26 Liquid UI.

We consider to turn off LiquidUI using the compiler flag, but it's not available on for WatchOS projects: https://developer.apple.com/forums/thread/803142?answerId=861482022#861482022

## To test

1. Start the app using the Watch scheme on a real Watch
2. Start playing an episode
3. Open the Now playing view
4. Check that the layout of the screen is correct and you can see all the element or if a smaller screen you can scroll vertically

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
