### PR TITLE
Truncate share clip URLs to 4 digits

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Formatting/SignificantDigitsFormatStyle.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Formatting/SignificantDigitsFormatStyle.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// A format style for trimming a TimeInterval to Significant Digits
+public struct SignificantDigitsFormatStyle: FormatStyle {
+    public let significantDigits: Int
+
+    public init(significantDigits: Int) {
+        self.significantDigits = significantDigits
+    }
+
+    public func format(_ value: TimeInterval) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.usesSignificantDigits = true
+        formatter.minimumSignificantDigits = significantDigits
+        formatter.maximumSignificantDigits = significantDigits
+        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+
+    public func parse(_ value: String) throws -> Double {
+        guard let number = TimeInterval(value) else {
+            throw FormatError.invalidInput
+        }
+        return number
+    }
+
+    public enum FormatError: Error {
+        case invalidInput
+    }
+}

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -276,6 +276,7 @@ extension SharingModal.Option {
     }
 
     var shareURL: String {
+        let formatter = SignificantDigitsFormatStyle(significantDigits: 4)
         switch self {
         case .episode(let episode):
             return episode.shareURL
@@ -288,7 +289,7 @@ extension SharingModal.Option {
         case .clip(let episode, let timeInterval):
             return episode.shareURL + "?t=\(round(timeInterval))"
         case .clipShare(let episode, let clipTime, _):
-            return episode.shareURL + "?t=\(clipTime.start),\(clipTime.end)"
+            return episode.shareURL + "?t=\(clipTime.start.formatted(formatter)),\(clipTime.end.formatted(formatter))"
         }
     }
 }


### PR DESCRIPTION
Fixes [PCIOS-275](https://linear.app/a8c/issue/PCIOS-275/shared-clips-do-not-play)

Truncates the `t` query parameter on clip share URLs.
I decided not to change the other share URLs just because they are already rounding and I figured we can just keep that behavior.

### Before
https://pca.st/episode/e2940e8b-c7da-43bd-abca-8750538acf7c?t=40.05917159763314,72.84023668639051
### After
https://pca.st/episode/e2940e8b-c7da-43bd-abca-8750538acf7c?t=27.87,60.00

## To test

1. Play an episode
2. Share a Clip from the Player
3. Copy the link from the share sheet
4. ✅ Verify that the resulting URL has only 4 digits for the `t` query parameter

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
