### PR TITLE
Add check for unmetered wifi in connection status page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Playlists: introduce DiffableKit to handle cell reloading [#3784](https://github.com/Automattic/pocket-casts-ios/pull/3784)
 - Playlists: improve artwork and counts queries [#3783](https://github.com/Automattic/pocket-casts-ios/pull/3783), [#3807](https://github.com/Automattic/pocket-casts-ios/pull/3807)
 - Improve app performance when trigering multiple downloads [#3809](https://github.com/Automattic/pocket-casts-ios/pull/3809)
+- Add Unmetered Wifi test in Connection Status page [#3825](https://github.com/Automattic/pocket-casts-ios/pull/3825)
 
 8.1.1
 -----

--- a/podcasts/StatusPageViewModel.swift
+++ b/podcasts/StatusPageViewModel.swift
@@ -11,13 +11,15 @@ class StatusPageViewModel: ObservableObject {
         let description: String
         let failureMessage: String
         let urls: [String]
+        let customTest: (() -> Bool)?
         var status: Result = .idle
 
-        init(title: String, description: String, failureMessage: String, urls: [String] = []) {
+        init(title: String, description: String, failureMessage: String, urls: [String] = [], customTest: (() -> Bool)? = nil) {
             self.title = title
             self.description = description
             self.failureMessage = failureMessage
             self.urls = urls
+            self.customTest = customTest
         }
 
         enum Result {
@@ -30,6 +32,14 @@ class StatusPageViewModel: ObservableObject {
             title: L10n.settingsStatusInternet,
             description: L10n.settingsStatusInternetDescription,
             failureMessage: L10n.settingsStatusInternetFailureMessage
+        ),
+        Service(
+            title: L10n.settingsStatusExpensiveNetwork,
+            description: L10n.settingsStatusExpensiveNetworkDescription,
+            failureMessage: L10n.settingsStatusExpensiveNetworkFailureMessage,
+            customTest: {
+                NetworkUtils.shared.isConnectedToUnexpensiveConnection()
+            }
         ),
         Service(
             title: L10n.settingsStatusRefreshService,
@@ -85,7 +95,9 @@ class StatusPageViewModel: ObservableObject {
 
     @MainActor
     private func test(service: Service) async {
-        if service.urls.isEmpty {
+        if let customTest = service.customTest {
+            service.status = customTest() ? .success : .failure
+        } else if service.urls.isEmpty {
             service.status = .success
         } else {
             var responseCodes = [Int?]()

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3711,6 +3711,12 @@ internal enum L10n {
   internal static var settingsStatusDiscover: String { return L10n.tr("Localizable", "settings_status_discover", fallback: "Discover & Search") }
   /// Description for the Discover & Search check.
   internal static var settingsStatusDiscoverDescription: String { return L10n.tr("Localizable", "settings_status_discover_description", fallback: "The discover section of the app, including podcast search.") }
+  /// Title for the service being checked, in this case, whether the network is considered expensive.
+  internal static var settingsStatusExpensiveNetwork: String { return L10n.tr("Localizable", "settings_status_expensive_network", fallback: "Unmetered Wifi") }
+  /// Description for the expensive network check.
+  internal static var settingsStatusExpensiveNetworkDescription: String { return L10n.tr("Localizable", "settings_status_expensive_network_description", fallback: "If successful, this network will be used for downloads on Unmetered Wifi.") }
+  /// Failure message for the expensive network check.
+  internal static var settingsStatusExpensiveNetworkFailureMessage: String { return L10n.tr("Localizable", "settings_status_expensive_network_failure_message", fallback: "Your current network is marked as expensive. Try switching to Wi-Fi or disabling Low Data Mode.") }
   /// Title for the service being checked, in this case, a podcast host URL.
   internal static var settingsStatusHost: String { return L10n.tr("Localizable", "settings_status_host", fallback: "Common Podcast Hosts") }
   /// Description for the podcast host check.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2863,6 +2863,15 @@
 /* Failure message for the Internet check. */
 "settings_status_internet_failure_message" = "Unable to connect to the internet. Try connecting on a different network (e.g. mobile data).";
 
+/* Title for the service being checked, in this case, whether the network is considered expensive. */
+"settings_status_expensive_network" = "Unmetered Wifi";
+
+/* Description for the expensive network check. */
+"settings_status_expensive_network_description" = "If successful, this network will be used for downloads on Unmetered Wifi.";
+
+/* Failure message for the expensive network check. */
+"settings_status_expensive_network_failure_message" = "Your current network is marked as expensive. Try switching to Wi-Fi or disabling Low Data Mode.";
+
 /* Title for the service being checked, in this case, the Pocket Cast's Refresh Service. */
 "settings_status_refresh_service" = "Refresh Service";
 
@@ -5814,5 +5823,3 @@
 
 /* Message to shown then trying to open playback from deep link but it's not available */
 "playback_not_available" = "Playback unavailable";
-
-


### PR DESCRIPTION
Part of [PCIOS-40](https://linear.app/a8c/issue/PCIOS-40/bug-downloading-episodes-via-mobile-data-not-working-as-expected)

Adds a status check for the expensive network via NWPathMonitor.

| Success | Failure |
|--|--|
| <img width="603" height="1311" alt="IMG_4394" src="https://github.com/user-attachments/assets/91642435-5ffe-4b00-8fdf-92b77444868f" /> | <img width="603" height="1311" alt="IMG_4395" src="https://github.com/user-attachments/assets/ca4dd4c7-249c-4a7a-9014-0caf74cd85b4" /> |


## To test

* Open Connection Status page in Help & Feedback
* Verify the new "Unmetered Wifi" status check appears
* Try changing to cellular network
* Re-run connection checks
* ✅ Verify status fails if data is on Standard or Low Data Mode

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
