### PR TITLE
Start audio session on background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Playlists: improve artwork and counts queries [#3783](https://github.com/Automattic/pocket-casts-ios/pull/3783), [#3807](https://github.com/Automattic/pocket-casts-ios/pull/3807)
 - Improve app performance when trigering multiple downloads [#3809](https://github.com/Automattic/pocket-casts-ios/pull/3809)
 - Add Unmetered Wifi test in Connection Status page [#3825](https://github.com/Automattic/pocket-casts-ios/pull/3825)
+- Activate audio session in background to avoid main thread hangs [#3826](https://github.com/Automattic/pocket-casts-ios/pull/3826)
 
 8.1.1
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -258,6 +258,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Avoid returning cached episode early and use policy instead
     case episodesInfoCacheReloadPolicy
 
+    /// activates the audio session in the background to avoid locks in the main thread
+    case activateAudioSessionInBackground
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -433,6 +436,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .playlistDataCacheBeforeQuery:
             true
         case .episodesInfoCacheReloadPolicy:
+            true
+        case .activateAudioSessionInBackground:
             true
         }
     }

--- a/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
+++ b/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
@@ -82,7 +82,7 @@ class TracksAdapter: AnalyticsAdapter, AnonymousIdentifiable {
             }
 
             let value = castedProperties[key]
-            if !(value is Int || value is Int32 || value is Int64 || value is String || value is Double || value is Bool || value is Float) {
+            if !(value is Int || value is Int32 || value is Int64 || value is String || value is NSString || value is Double || value is Bool || value is Float) {
                 assertionFailure("Tracks event properties value for `\(key)` must be of one the valid types: Int, String, Bool, Double, Float")
                 return
             }

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -166,6 +166,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     }
 
     @objc func startDataRequest(with url: URL, retryWithoutUserAgent: Bool) {
+        FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: Start data request for \(url)")
         guard session == nil else { return }
 
         let configuration = URLSessionConfiguration.default
@@ -331,6 +332,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     }
 
     private func downloadFailed(with error: Error) {
+        FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: Download failed with error: \(error)")
         invalidateAndCancelSession(error: error)
         let contentType = self.response?.mimeType
         DispatchQueue.main.async { [weak self] in

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1338,21 +1338,36 @@ class PlaybackManager: ServerPlaybackDelegate {
         #endif
 
         shouldDeactivateSession.value = false
-        do {
-            try setAudioSessionProperties()
-            #if os(watchOS)
+
+        #if os(watchOS)
+            do {
+                try setAudioSessionProperties()
                 AVAudioSession.sharedInstance().activate(options: []) { activated, _ in
                     completion?(activated)
                 }
-            #else
-                try AVAudioSession.sharedInstance().setActive(true)
-                FileLog.shared.addMessage("activating audio session succeeded")
-                completion?(true)
-            #endif
-        } catch {
-            FileLog.shared.addMessage("activating audio session failed \(error.localizedDescription)")
-            completion?(false)
-        }
+            } catch {
+                FileLog.shared.addMessage("activating audio session failed \(error.localizedDescription)")
+                completion?(false)
+            }
+        #else
+            // Perform audio session activation on a background queue to avoid blocking the main thread
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                guard let self = self else {
+                    completion?(false)
+                    return
+                }
+                
+                do {
+                    try self.setAudioSessionProperties()
+                    try AVAudioSession.sharedInstance().setActive(true)
+                    FileLog.shared.addMessage("activating audio session succeeded")
+                    completion?(true)
+                } catch {
+                    FileLog.shared.addMessage("activating audio session failed \(error.localizedDescription)")
+                    completion?(false)
+                }
+            }
+        #endif
     }
 
     private func setAudioSessionProperties() throws {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1356,7 +1356,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                     completion?(false)
                     return
                 }
-                
+
                 do {
                     try self.setAudioSessionProperties()
                     try AVAudioSession.sharedInstance().setActive(true)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1350,24 +1350,31 @@ class PlaybackManager: ServerPlaybackDelegate {
                 completion?(false)
             }
         #else
+        if FeatureFlag.activateAudioSessionInBackground.enabled {
             // Perform audio session activation on a background queue to avoid blocking the main thread
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let self = self else {
                     completion?(false)
                     return
                 }
-
-                do {
-                    try self.setAudioSessionProperties()
-                    try AVAudioSession.sharedInstance().setActive(true)
-                    FileLog.shared.addMessage("activating audio session succeeded")
-                    completion?(true)
-                } catch {
-                    FileLog.shared.addMessage("activating audio session failed \(error.localizedDescription)")
-                    completion?(false)
-                }
+                self.activateSession(completion: completion)
             }
+        } else {
+            self.activateSession(completion: completion)
+        }
         #endif
+    }
+
+    private func activateSession(completion: ((Bool) -> Void)?) {
+        do {
+            try self.setAudioSessionProperties()
+            try AVAudioSession.sharedInstance().setActive(true)
+            FileLog.shared.addMessage("activating audio session succeeded")
+            completion?(true)
+        } catch {
+            FileLog.shared.addMessage("activating audio session failed \(error.localizedDescription)")
+            completion?(false)
+        }
     }
 
     private func setAudioSessionProperties() throws {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR tries to fix some widget starting audio issues by starting the audio sessions  on a background thread

## To test

1. Start the app
2. Add some episodes on the UpNext Queue
3. Exit the app
4. Add a Pocket Casts widget on the main screen of the device
5. Kill the app
6. Start playing an episode from the Widget
7. Check that it starts correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
