### PR TITLE
Ignore play remote command when other audio is playing

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -258,6 +258,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Avoid returning cached episode early and use policy instead
     case episodesInfoCacheReloadPolicy
 
+    /// Ignores play remote commands when other audio is playing
+    case ignorePlayWithOtherAudio
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -433,6 +436,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .playlistDataCacheBeforeQuery:
             true
         case .episodesInfoCacheReloadPolicy:
+			true
+        case .ignorePlayWithOtherAudio:
             true
         }
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1681,6 +1681,12 @@ class PlaybackManager: ServerPlaybackDelegate {
                     FileLog.shared.addMessage("Remote control: playCommand, treating as play because playing over AirPlay")
                     if !strongSelf.playing() { strongSelf.play() }
                 } else {
+                    if FeatureFlag.ignorePlayWithOtherAudio.enabled {
+                        if AVAudioSession.sharedInstance().isOtherAudioPlaying {
+                            FileLog.shared.addMessage("Remote control: playCommand, ignored because other audio is playing")
+                            return .commandFailed
+                        }
+                    }
                     // we hook play up to play/pause because that's how some headphones/car stereos do it instead of sending distinct play/pause events
                     FileLog.shared.addMessage("Remote control: playCommand, treating as playPause")
                     strongSelf.playPause()


### PR DESCRIPTION
Hopefully fixes [PCIOS-384](https://linear.app/a8c/issue/PCIOS-384/using-airpods-always-launches-pocket-casts)

## To test

- Test with feature flag enabled
- Play audio in another app (Spotify, Apple Music, etc.), then press play on headphones/car stereo
- ✅ Verify Pocket Casts does not start playing

I was unable to reproduce the issue so disabling the flag may make no difference.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
