### PR TITLE
[Analytics] Add missing Tracks value: NSString

### DIFF
--- a/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
+++ b/podcasts/Analytics/Adapters/Tracks/TracksAdapter.swift
@@ -82,7 +82,7 @@ class TracksAdapter: AnalyticsAdapter, AnonymousIdentifiable {
             }
 
             let value = castedProperties[key]
-            if !(value is Int || value is Int32 || value is Int64 || value is String || value is Double || value is Bool || value is Float) {
+            if !(value is Int || value is Int32 || value is Int64 || value is String || value is NSString || value is Double || value is Bool || value is Float) {
                 assertionFailure("Tracks event properties value for `\(key)` must be of one the valid types: Int, String, Bool, Double, Float")
                 return
             }


### PR DESCRIPTION
Adds missing type to the Tracks adapter

## To test

- Smoke test Tracks work
- Add a widget
- See if any widget events are tracked
- Stop the app
- Delete the widget
- Restart the app
- No assertion failure should be hit

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
