### PR TITLE
Additional logging around cellular downloads

### DIFF
--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -91,11 +91,17 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
 
         removeEpisodeFromCache(episode)
 
+        let sessionType = session === wifiOnlyBackgroundSession ? "wifi-only" : (session === cellularBackgroundSession ? "cellular" : "foreground")
+        let isOnUnexpensiveConnection = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
+        let networkDescription = isOnUnexpensiveConnection ? "unexpensive" : "expensive"
+
         switch error.code {
         case NSURLErrorCancelled:
+            let reason = error.userInfo[NSURLErrorBackgroundTaskCancelledReasonKey] as? Int
+            FileLog.shared.addMessage("DownloadManager: Download cancelled for episode \(episode.displayableTitle()), session: \(sessionType), network: \(networkDescription), reason: \(reason ?? -1)")
+
             if !episode.downloadFailed() {
                 // we already handled this error, since we failed the download ourselves
-                let reason = error.userInfo[NSURLErrorBackgroundTaskCancelledReasonKey] as? Int
                 switch reason {
                 case NSURLErrorCancelledReasonUserForceQuitApplication, NSURLErrorCancelledReasonInsufficientSystemResources:
                     dataManager.saveEpisode(downloadStatus: .queued, downloadTaskId: nil, episode: episode)
@@ -109,11 +115,15 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
 
             return
         case NSURLErrorTimedOut:
+            FileLog.shared.addMessage("DownloadManager: Download timed out for episode \(episode.displayableTitle()), session: \(sessionType), network: \(networkDescription)")
             taskFailure[episode.uuid] = .connectionTimeout
         case NSURLErrorCannotConnectToHost:
+            FileLog.shared.addMessage("DownloadManager: Cannot connect to host for episode \(episode.displayableTitle()), session: \(sessionType), network: \(networkDescription)")
             taskFailure[episode.uuid] = .unknownHost
+        case NSURLErrorNotConnectedToInternet:
+            FileLog.shared.addMessage("DownloadManager: Not connected to internet for episode \(episode.displayableTitle()), session: \(sessionType)")
         default:
-            ()
+            FileLog.shared.addMessage("DownloadManager: Download error for episode \(episode.displayableTitle()), session: \(sessionType), network: \(networkDescription), error code: \(error.code), description: \(error.localizedDescription)")
         }
 
         downloadAttempts.removeValue(forKey: downloadTask.taskIdentifier)

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -213,7 +213,8 @@ class DownloadManager: NSObject, FilePathProtocol {
         markUnplayedAndUnarchiveIfRequired(episode: episode, saveChanges: true)
         dataManager.saveEpisode(downloadStatus: .waitingForWifi, lastDownloadAttemptDate: Date(), autoDownloadStatus: autoDownloadStatus, episode: episode)
 
-        FileLog.shared.addMessage("Queued episode \(episode.displayableTitle()) for later download, autoDownloadStatus: \(autoDownloadStatus)")
+        let networkState = NetworkUtils.shared.isConnectedToUnexpensiveConnection() ? "on unexpensive connection" : "on expensive connection"
+        FileLog.shared.addMessage("DownloadManager: Queued episode \(episode.displayableTitle()) for later download (waitingForWifi), autoDownloadStatus: \(autoDownloadStatus), currently \(networkState)")
 
         if fireNotification {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid)
@@ -494,13 +495,16 @@ class DownloadManager: NSObject, FilePathProtocol {
 
         if FeatureFlag.downloadFixes.enabled {
             if await shouldSkipExistingTask(for: episode, in: sessionToUse, matching: request) {
-                FileLog.shared.addMessage("Download: skipped task for episode: \(episode.uuid)")
+                FileLog.shared.addMessage("DownloadManager: Download skipped task for episode: \(episode.uuid)")
                 return
             }
         }
 
         let userAgentDescription = retryWithoutUserAgent ? "without User-Agent" : "with User-Agent"
-        FileLog.shared.addMessage("Downloading episode \(episode.displayableTitle()), autoDownloadStatus: \(autoDownloadStatus), previousDownloadFailed: \(previousDownloadFailed), \(userAgentDescription)")
+        let sessionDescription = useCellularSession ? "cellular (allowsExpensiveNetworkAccess=true)" : "wifi-only (allowsExpensiveNetworkAccess=false)"
+        let isOnUnexpensiveConnection = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
+        let networkDescription = isOnUnexpensiveConnection ? "unexpensive connection" : "expensive connection"
+        FileLog.shared.addMessage("DownloadManager: Downloading episode \(episode.displayableTitle()), autoDownloadStatus: \(autoDownloadStatus), previousDownloadFailed: \(previousDownloadFailed), \(userAgentDescription), session: \(sessionDescription), network: \(networkDescription)")
         resumeDownload(tempFilePath: tempFilePath, session: sessionToUse, request: request, previousDownloadFailed: previousDownloadFailed, taskId: episode.uuid, estimatedBytes: episode.sizeInBytes, retryWithoutUserAgent: retryWithoutUserAgent)
 
         if fireNotification { NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid) }


### PR DESCRIPTION
Part of [PCIOS-406](https://linear.app/a8c/issue/PCIOS-406/downloading-on-cellular-data-even-when-set-to-only-on-unmetered-wifi)

Only logging so testing can be mostly smoke tests.

## To test

* ✅ Verify downloads work as expected

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
