### PR TITLE
Switch to allowsCellularAccess from allowsExpensiveNetworkAccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add Unmetered Wifi test in Connection Status page [#3825](https://github.com/Automattic/pocket-casts-ios/pull/3825)
 - Activate audio session in background to avoid main thread hangs [#3826](https://github.com/Automattic/pocket-casts-ios/pull/3826)
 - Use in-memory streaming buffer to reply to media requests [#3829](https://github.com/Automattic/pocket-casts-ios/pull/3829)
+- Switch to allowsCellularAccess from allowsExpensiveNetworkAccess to improve cellular download handling [#3833](https://github.com/Automattic/pocket-casts-ios/pull/3833)
 
 8.1.1
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -268,7 +268,7 @@ public enum FeatureFlag: String, CaseIterable {
     case activateAudioSessionInBackground
 
     /// Use cellular-specific network APIs instead of expensive network APIs
-    case useCellularNetworkAPIs
+    case useCellularNetworkApis
 
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
@@ -452,7 +452,7 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .activateAudioSessionInBackground:
             true
-        case .useCellularNetworkAPIs:
+        case .useCellularNetworkApis:
             true
         }
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -267,6 +267,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// activates the audio session in the background to avoid locks in the main thread
     case activateAudioSessionInBackground
 
+    /// Use cellular-specific network APIs instead of expensive network APIs
+    case useCellularNetworkAPIs
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -448,6 +451,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .streamAndDownloadReadFromMemoryBuffer:
             true
         case .activateAudioSessionInBackground:
+            true
+        case .useCellularNetworkAPIs:
             true
         }
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/Networking/NetworkUtils.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Networking/NetworkUtils.swift
@@ -30,7 +30,11 @@ public class NetworkUtils {
     // MARK: - Connectivity
 
     public func isConnectedToUnexpensiveConnection() -> Bool {
-        return !monitor.currentPath.isExpensive
+        if FeatureFlag.useCellularNetworkAPIs.enabled {
+            return !monitor.currentPath.usesInterfaceType(.cellular)
+        } else {
+            return !monitor.currentPath.isExpensive
+        }
     }
 
     public func isConnected() -> Bool {

--- a/Modules/Utils/Sources/PocketCastsUtils/Networking/NetworkUtils.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Networking/NetworkUtils.swift
@@ -30,7 +30,7 @@ public class NetworkUtils {
     // MARK: - Connectivity
 
     public func isConnectedToUnexpensiveConnection() -> Bool {
-        if FeatureFlag.useCellularNetworkAPIs.enabled {
+        if FeatureFlag.useCellularNetworkApis.enabled {
             return !monitor.currentPath.usesInterfaceType(.cellular)
         } else {
             return !monitor.currentPath.isExpensive

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -90,7 +90,7 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     lazy var wifiOnlyBackgroundSession: URLSession = {
         var config = URLSessionConfiguration.background(withIdentifier: "au.com.shiftyjelly.PCBackgroundSession")
-        if FeatureFlag.useCellularNetworkAPIs.enabled {
+        if FeatureFlag.useCellularNetworkApis.enabled {
             config.allowsCellularAccess = false
         } else {
             config.allowsExpensiveNetworkAccess = false
@@ -103,7 +103,7 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     lazy var cellularBackgroundSession: URLSession = {
         var config = URLSessionConfiguration.background(withIdentifier: DownloadManager.cellBackgroundSessionId)
-        if FeatureFlag.useCellularNetworkAPIs.enabled {
+        if FeatureFlag.useCellularNetworkApis.enabled {
             config.allowsCellularAccess = true
         } else {
             config.allowsExpensiveNetworkAccess = true

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -90,7 +90,11 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     lazy var wifiOnlyBackgroundSession: URLSession = {
         var config = URLSessionConfiguration.background(withIdentifier: "au.com.shiftyjelly.PCBackgroundSession")
-        config.allowsExpensiveNetworkAccess = false
+        if FeatureFlag.useCellularNetworkAPIs.enabled {
+            config.allowsCellularAccess = false
+        } else {
+            config.allowsExpensiveNetworkAccess = false
+        }
         addStandardConfig(to: &config)
 
         let session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
@@ -99,7 +103,11 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     lazy var cellularBackgroundSession: URLSession = {
         var config = URLSessionConfiguration.background(withIdentifier: DownloadManager.cellBackgroundSessionId)
-        config.allowsExpensiveNetworkAccess = true
+        if FeatureFlag.useCellularNetworkAPIs.enabled {
+            config.allowsCellularAccess = true
+        } else {
+            config.allowsExpensiveNetworkAccess = true
+        }
         addStandardConfig(to: &config)
 
         let session = URLSession(configuration: config, delegate: self, delegateQueue: nil)


### PR DESCRIPTION
Fixes [PCIOS-406](https://linear.app/a8c/issue/PCIOS-406/downloading-on-cellular-data-even-when-set-to-only-on-unmetered-wifi)

This is feature flagged behind `useCellularNetworkAPIs`

## To test

1. Make sure “Only on Unmetered Wifi” is enabled for Auto Download 
2. Make sure “Up Next” is enabled in Auto Download 
3. Make sure “Warn Before Using Data” is enabled in Storage & Data Use 
4. Ensure you’re only connected to cellular data 
5. Add an episode to Up Next 
6. ✅ Verify episode download is queued

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
