### PR TITLE
Remove log tracing

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -54,9 +54,6 @@ actor LogBuffer {
     }
 
     private func appendStringToLog(_ logUpdate: String) {
-        let trace = TraceManager.shared.beginTracing(eventName: "FILE_LOG_WRITE_MESSAGE_TO_FILE")
-        defer { TraceManager.shared.endTracing(trace: trace) }
-
         logRotator.rotateFile(ifSizeExceeds: maxFileSize)
         logPersistence.write(logUpdate)
     }


### PR DESCRIPTION
This is causing unnecessary CPU usage when logging is very active. The tracing data Firebase collects (presumably stack traces) is quite large and leads to these events being processed:

<img width="1306" height="654" alt="CleanShot 2025-11-18 at 16 24 27@2x" src="https://github.com/user-attachments/assets/ffa7c23f-c567-4cdd-8ad9-cbfda9644972" />

The tracing is available [in the Firebase admin](https://console.firebase.google.com/u/0/project/singular-vector-91401/performance/app/ios:au.com.shiftyjelly.podcasts/trends?time=7d) but I don't believe we have used it in a couple years.

## To test

* Check FileLog messages with the in-app log viewer to make sure logging is working

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
