### PR TITLE
Up Next reorder delay

### DIFF
--- a/PocketCastsTests/PlaybackQueueTests.swift
+++ b/PocketCastsTests/PlaybackQueueTests.swift
@@ -34,6 +34,36 @@ final class PlaybackQueueTests: XCTestCase {
                        "Should not include stale episode UUID in replacement list")
     }
 
+    func testRecentUserInteractionReturnsFalseWhenNoPreviousInteraction() {
+        let playbackQueue = PlaybackQueue()
+
+        XCTAssertFalse(playbackQueue.recentUserInteraction(now: Date(timeIntervalSince1970: 15)))
+    }
+
+    func testRecentUserInteractionReturnsTrueWithinGracePeriod() {
+        let playbackQueue = PlaybackQueue()
+        let interactionTime = Date(timeIntervalSince1970: 1_000)
+        playbackQueue.recordUpNextUserInteraction(at: interactionTime)
+
+        XCTAssertTrue(playbackQueue.recentUserInteraction(now: interactionTime.addingTimeInterval(3)))
+    }
+
+    func testRecentUserInteractionReturnsFalseAtGracePeriodBoundary() {
+        let playbackQueue = PlaybackQueue()
+        let interactionTime = Date(timeIntervalSince1970: 1_000)
+        playbackQueue.recordUpNextUserInteraction(at: interactionTime)
+
+        XCTAssertFalse(playbackQueue.recentUserInteraction(now: interactionTime.addingTimeInterval(10)))
+    }
+
+    func testRecentUserInteractionReturnsFalseOutsideGracePeriod() {
+        let playbackQueue = PlaybackQueue()
+        let interactionTime = Date(timeIntervalSince1970: 1_000)
+        playbackQueue.recordUpNextUserInteraction(at: interactionTime)
+
+        XCTAssertFalse(playbackQueue.recentUserInteraction(now: interactionTime.addingTimeInterval(11)))
+    }
+
     override func tearDown() {
         featureFlagMock.reset()
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -154,6 +154,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         player?.futureBufferAvailable() ?? 0
     }
 
+    func recordUpNextUserInteraction() {
+        queue.recordUpNextUserInteraction()
+    }
+
     func load(episode: BaseEpisode, autoPlay: Bool, overrideUpNext: Bool, saveCurrentEpisode: Bool = true, completion: (() -> Void)? = nil) {
         FileLog.shared.addMessage("Loading \(episode.displayableTitle()) with UUID \(episode.uuid) autoPlay \(autoPlay) overrideUpNext: \(overrideUpNext)")
 

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -8,7 +8,28 @@ class PlaybackQueue: NSObject {
     private var topEpisode: BaseEpisode?
 
     private let syncTimerDelay: TimeInterval = 5
+    private let interactionGracePeriod: TimeInterval = 10
     private var syncTimer: Timer?
+    private var lastUserInteractionTime: Date?
+
+    // MARK: - User Interaction Tracking
+
+    func recordUpNextUserInteraction(at date: Date = Date()) {
+        lastUserInteractionTime = date
+    }
+
+    func recentUserInteraction(now: Date = Date()) -> Bool {
+        remainingInteractionDelay(now: now) != nil
+    }
+
+    private func remainingInteractionDelay(now: Date = Date()) -> TimeInterval? {
+        guard let lastUserInteractionTime else { return nil }
+
+        let elapsed = now.timeIntervalSince(lastUserInteractionTime)
+        let remaining = interactionGracePeriod - elapsed
+
+        return remaining > 0 ? remaining : nil
+    }
 
     // MARK: - Editing
 
@@ -400,27 +421,40 @@ class PlaybackQueue: NSObject {
 
     // MARK: - Sync Timer
 
-    private func startSyncTimer() {
-        cancelSyncTimer()
-
-        // schedule the timer on a thread that has a run loop, the main thread being a good option
-        if Thread.isMainThread {
-            syncTimer = Timer.scheduledTimer(timeInterval: syncTimerDelay, target: self, selector: #selector(syncTimerFired), userInfo: nil, repeats: false)
-        } else {
-            DispatchQueue.main.sync { [weak self] () in
-                guard let self else { return }
-
-                self.syncTimer = Timer.scheduledTimer(timeInterval: self.syncTimerDelay, target: self, selector: #selector(self.syncTimerFired), userInfo: nil, repeats: false)
-            }
-        }
-    }
-
     private func cancelSyncTimer() {
         syncTimer?.invalidate()
         syncTimer = nil
     }
 
+    private func startSyncTimer(after delay: TimeInterval? = nil) {
+        cancelSyncTimer()
+        scheduleSyncTimer(after: delay ?? syncTimerDelay)
+    }
+
+    private func scheduleSyncTimer(after delay: TimeInterval) {
+        let scheduleTimer: () -> Void = { [weak self] in
+            guard let self else { return }
+
+            self.syncTimer = Timer.scheduledTimer(timeInterval: delay, target: self, selector: #selector(self.syncTimerFired), userInfo: nil, repeats: false)
+        }
+
+        // schedule the timer on a thread that has a run loop, the main thread being a good option
+        if Thread.isMainThread {
+            scheduleTimer()
+        } else {
+            DispatchQueue.main.sync {
+                scheduleTimer()
+            }
+        }
+    }
+
     @objc private func syncTimerFired() {
+        if let remainingDelay = remainingInteractionDelay() {
+            FileLog.shared.addMessage("PlaybackQueue: Delaying Up Next sync for \(Int(remainingDelay.rounded(.up))) seconds due to recent interaction")
+            startSyncTimer(after: remainingDelay)
+            return
+        }
+
         RefreshManager.shared.syncUpNext()
     }
 }

--- a/podcasts/UpNextViewController+Table.swift
+++ b/podcasts/UpNextViewController+Table.swift
@@ -212,7 +212,9 @@ extension UpNextViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
         let toSection = tableData[proposedDestinationIndexPath.section]
 
-        if toSection == .upNextSection { return proposedDestinationIndexPath }
+        if toSection == .upNextSection {
+            return proposedDestinationIndexPath
+        }
 
         return IndexPath(row: 0, section: sourceIndexPath.section)
     }

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -401,6 +401,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 extension UpNextViewController {
     @objc func reorderingDidBegin() {
         isReorderInProgress = true
+        PlaybackManager.shared.recordUpNextUserInteraction()
     }
 
     @objc func reorderingDidEnd() {


### PR DESCRIPTION
| | |
|--|--|
| **Android** | https://github.com/Automattic/pocket-casts-android/pull/4862 |

Fixes [PCIOS-419](https://linear.app/a8c/issue/PCIOS-419/dragging-up-next-and-syncing-at-the-same-time)

When we reorder episodes, a timer is started to sync after 5 seconds. However, if other episodes are being reordered while sync is occurring, the data sets can get out of sync. The fix here is to immediately cancel the timer when dragging begins.

https://github.com/user-attachments/assets/1a9205a0-a1d6-4ad6-89ab-0fd072385942

## To test

* Add many items to the Up Next queue
* Use Network Link Conditioner to set network profile to 3G
* Reorder episodes in the Up Next queue using drag and drop in relatively quick succession
* ✅ Verify that episode maintain ordering

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
