### PR TITLE
[Playlists] Add nav title when empty state is visible

### DIFF
--- a/podcasts/New Detail/PlaylistDetailViewController+EmptyState.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+EmptyState.swift
@@ -36,6 +36,8 @@ extension PlaylistDetailViewController {
             self.tableView.isHidden = self.viewModel.shouldShowEmptyPlaceholder
         }
 
+        self.emptyStateNavView.isHidden = !viewModel.shouldShowEmptyPlaceholder
+
         if viewModel.shouldShowEmptyPlaceholder {
             // Empty State when playlists is empty
             config = ContentUnavailableConfiguration.emptyState(

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -61,6 +61,23 @@ class PlaylistDetailViewController: FakeNavViewController {
         }
     }
 
+    private lazy var emptyStateNavTitle: UILabel! = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 17, weight: .semibold)
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private(set) lazy var emptyStateNavView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .clear
+        view.isHidden = true
+        view.addSubview(emptyStateNavTitle)
+        return view
+    }()
+
     private var refreshControl: CustomRefreshControl?
 
     var isMultiSelectEnabled = false {
@@ -303,6 +320,8 @@ class PlaylistDetailViewController: FakeNavViewController {
 
         multiSelectFooterBottomConstraint = tableView.bottomAnchor.constraint(equalTo: multiSelectFooter.bottomAnchor)
 
+        view.insertSubview(emptyStateNavView, belowSubview: fakeNavView)
+
         NSLayoutConstraint.activate([
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -335,7 +354,16 @@ class PlaylistDetailViewController: FakeNavViewController {
             multiSelectFooter.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 8.0),
             multiSelectFooter.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -8.0),
             multiSelectFooterBottomConstraint,
-            multiSelectFooter.heightAnchor.constraint(equalToConstant: 64)
+            multiSelectFooter.heightAnchor.constraint(equalToConstant: 64),
+
+            emptyStateNavView.leadingAnchor.constraint(equalTo: fakeNavView.leadingAnchor),
+            emptyStateNavView.trailingAnchor.constraint(equalTo: fakeNavView.trailingAnchor),
+            emptyStateNavView.topAnchor.constraint(equalTo: fakeNavView.topAnchor),
+            emptyStateNavView.bottomAnchor.constraint(equalTo: fakeNavView.bottomAnchor),
+            emptyStateNavTitle.centerXAnchor.constraint(equalTo: emptyStateNavView.centerXAnchor),
+            emptyStateNavTitle.widthAnchor.constraint(lessThanOrEqualToConstant: 200),
+            emptyStateNavTitle.heightAnchor.constraint(equalTo: backBtn.heightAnchor),
+            emptyStateNavView.bottomAnchor.constraint(equalTo: emptyStateNavTitle.bottomAnchor)
         ])
 
         view.layoutSubviews()
@@ -345,6 +373,8 @@ class PlaylistDetailViewController: FakeNavViewController {
         tableView.reloadData()
 
         updateNavColors(bgColor: .clear, titleColor: ThemeColor.primaryText01(), buttonColor: UIColor.white, buttonBackgroundColor: UIColor.black.withAlphaComponent(0.32))
+
+        emptyStateNavTitle.textColor = ThemeColor.primaryText01()
 
         multiSelectHeaderView.backgroundColor = ThemeColor.primaryUi01()
         multiSelectCancelBtn.setTitleColor(ThemeColor.primaryIcon01(), for: .normal)
@@ -428,6 +458,7 @@ class PlaylistDetailViewController: FakeNavViewController {
 
     private func reloadNavTitle() {
         navTitle = viewModel.playlist.playlistName
+        emptyStateNavTitle.text = viewModel.playlist.playlistName
     }
 
     @objc func refreshFilterFromNotification(notification: Notification) {


### PR DESCRIPTION
| 📘 Part of: [Playlists](https://linear.app/a8c/project/ios-playlists-b287949437df/issues?layout=board&ordering=priority&grouping=workflowState&subGrouping=none&showCompletedIssues=all&showSubIssues=true&showTriageIssues=false)
|:---:|

Fixes PCIOS-428

Adds the Playlist name when the empty state is visible. To don't break the fake nav logic which may affect Podcasts too, I added a label which also aligns the title to the button.

| Empty State | Default View | Scrolling |
| :-------: | :-------: | :-------: |
| <img width="590" height="1278" alt="IMG_0566" src="https://github.com/user-attachments/assets/ab06a789-365c-4439-8aea-b566bcb2ca11" /> | <img width="590" height="1278" alt="IMG_0567" src="https://github.com/user-attachments/assets/e20c6cf4-b3e2-4f47-8506-482c78c2fb70" /> | <img width="590" height="1278" alt="IMG_0568" src="https://github.com/user-attachments/assets/085043ad-72fb-463d-a67e-7df8205d205d" /> |


## To test

- Open a playlist with episodes
- Confirm you don't see the title unless you scroll (normal behaviour)
- Create a new Manual or Smart Playlists
- Confirm you see the title when the empty state is visible
- If it's a Manual Playlist add few episodes
- Confirm the title disappear
- Remove all episodes to make it empty
- Confirm the title appears again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
