### PR TITLE
[Refactor] Use App Intents instead of Siri Intents

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -755,8 +755,8 @@
 		9AB645182D5138B200A842C8 /* Pocket Casts App Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = F5D5F7792CEBE769001F492D /* Pocket Casts App Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		9ACB950B2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */; };
 		9ACB950C2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */; };
-		9ACDEF512EE85B52001025B0 /* UIViewController+MultiSelectActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */; };
 		9ACDEF332EE6F632001025B0 /* ListPlaylist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACDEF322EE6F62C001025B0 /* ListPlaylist.swift */; };
+		9ACDEF512EE85B52001025B0 /* UIViewController+MultiSelectActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */; };
 		9AD41AC22EB4E0750048FB8B /* PlaylistDetailViewController+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD41AC12EB4E0700048FB8B /* PlaylistDetailViewController+Analytics.swift */; };
 		9AD809AF2EA12D940050649B /* PlaylistDetailFetchOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD809AE2EA12D850050649B /* PlaylistDetailFetchOperation.swift */; };
 		9AE5043C2DEDF2030027A4AE /* TranscriptContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */; };
@@ -2142,6 +2142,9 @@
 		FF5381AE2C90FF1500829525 /* ReferralCardMiniView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5381AD2C90FF1500829525 /* ReferralCardMiniView.swift */; };
 		FF5381B12C91C6EF00829525 /* ReferralsOfferInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5381B02C91C6EF00829525 /* ReferralsOfferInfo.swift */; };
 		FF5453EF2DFC6C890045977B /* DiscoveryPageIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5453EE2DFC6C890045977B /* DiscoveryPageIndicatorView.swift */; };
+		FF5495E02F03F2970086F773 /* ShortcutsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5495DF2F03EBCD0086F773 /* ShortcutsProvider.swift */; };
+		FF5495E12F03F35C0086F773 /* ChapterIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5495D52F02FE9A0086F773 /* ChapterIntent.swift */; };
+		FF5495E22F03F3630086F773 /* NextPrevious.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5495D72F02FE9A0086F773 /* NextPrevious.swift */; };
 		FF54BCA92C5A2F3900A342E5 /* TranscriptFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF54BCA82C5A2F3900A342E5 /* TranscriptFormat.swift */; };
 		FF54BCAA2C5A2F4D00A342E5 /* TranscriptFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF54BCA82C5A2F3900A342E5 /* TranscriptFormat.swift */; };
 		FF57FCBE2E37AD9A00D2E966 /* FoldersAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF57FCBD2E37AD9A00D2E966 /* FoldersAnimationView.swift */; };
@@ -2191,6 +2194,8 @@
 		FFD3AB8C2BD15E8F00C562CB /* CircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD3AB8B2BD15E8F00C562CB /* CircleView.swift */; };
 		FFDE41A32DD201AE0065ADDE /* AppClipAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDE41A22DD201A40065ADDE /* AppClipAppDelegate.swift */; };
 		FFE794DD2DA443FF005E4D40 /* NotificationsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFE794DC2DA443F8005E4D40 /* NotificationsCoordinator.swift */; };
+		FFEA96C22F040A7E005D879A /* SleepTimerIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5495D92F02FE9A0086F773 /* SleepTimerIntent.swift */; };
+		FFEA96C32F040A85005D879A /* ExtendSleepTimerIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5495D62F02FE9A0086F773 /* ExtendSleepTimerIntent.swift */; };
 		FFEB45852EBE4A0A00DF5E12 /* PaidStoryWallView2025.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB45842EBE49FD00DF5E12 /* PaidStoryWallView2025.swift */; };
 		FFEB45992EC2031600DF5E12 /* String+SentenceCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFEB45982EC2031000DF5E12 /* String+SentenceCase.swift */; };
 		FFEE599C2EB378B300D4B145 /* Humane-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = FFEE599B2EB378B300D4B145 /* Humane-SemiBold.otf */; };
@@ -3134,8 +3139,8 @@
 		9AB2900B2ECB7F75006086F9 /* PlaylistPlayAllSheetHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistPlayAllSheetHost.swift; sourceTree = "<group>"; };
 		9AB2900D2ECB82F6006086F9 /* PlaylistPlayAllSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistPlayAllSheet.swift; sourceTree = "<group>"; };
 		9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptiveActionAttributedTextView.swift; sourceTree = "<group>"; };
-		9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+MultiSelectActions.swift"; sourceTree = "<group>"; };
 		9ACDEF322EE6F62C001025B0 /* ListPlaylist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListPlaylist.swift; sourceTree = "<group>"; };
+		9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+MultiSelectActions.swift"; sourceTree = "<group>"; };
 		9AD41AC12EB4E0700048FB8B /* PlaylistDetailViewController+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaylistDetailViewController+Analytics.swift"; sourceTree = "<group>"; };
 		9AD809AE2EA12D850050649B /* PlaylistDetailFetchOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistDetailFetchOperation.swift; sourceTree = "<group>"; };
 		9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptContainerViewController.swift; sourceTree = "<group>"; };
@@ -4324,6 +4329,12 @@
 		FF5381AD2C90FF1500829525 /* ReferralCardMiniView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferralCardMiniView.swift; sourceTree = "<group>"; };
 		FF5381B02C91C6EF00829525 /* ReferralsOfferInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralsOfferInfo.swift; sourceTree = "<group>"; };
 		FF5453EE2DFC6C890045977B /* DiscoveryPageIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryPageIndicatorView.swift; sourceTree = "<group>"; };
+		FF5495D52F02FE9A0086F773 /* ChapterIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChapterIntent.swift; sourceTree = "<group>"; };
+		FF5495D62F02FE9A0086F773 /* ExtendSleepTimerIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtendSleepTimerIntent.swift; sourceTree = "<group>"; };
+		FF5495D72F02FE9A0086F773 /* NextPrevious.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextPrevious.swift; sourceTree = "<group>"; };
+		FF5495D82F02FE9A0086F773 /* OpenFilterIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenFilterIntent.swift; sourceTree = "<group>"; };
+		FF5495D92F02FE9A0086F773 /* SleepTimerIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepTimerIntent.swift; sourceTree = "<group>"; };
+		FF5495DF2F03EBCD0086F773 /* ShortcutsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutsProvider.swift; sourceTree = "<group>"; };
 		FF54BCA82C5A2F3900A342E5 /* TranscriptFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptFormat.swift; sourceTree = "<group>"; };
 		FF57373B2B4EB5B100F511C7 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		FF57373C2B4EB5B100F511C7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -7350,6 +7361,7 @@
 		BDBD53F717019B2A0048C8C5 /* Pocket Casts */ = {
 			isa = PBXGroup;
 			children = (
+				FF5495DA2F02FE9A0086F773 /* Intents */,
 				462EE0B127024FF3003D67DC /* Credentials */,
 				BD7D337619F7D48E00B907EA /* podcasts.entitlements */,
 				3FD6E04F2BF735EC003941C0 /* podcasts.prototype.entitlements */,
@@ -9055,6 +9067,19 @@
 			name = SharedUI;
 			sourceTree = "<group>";
 		};
+		FF5495DA2F02FE9A0086F773 /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				FF5495DF2F03EBCD0086F773 /* ShortcutsProvider.swift */,
+				FF5495D52F02FE9A0086F773 /* ChapterIntent.swift */,
+				FF5495D72F02FE9A0086F773 /* NextPrevious.swift */,
+				FF5495D82F02FE9A0086F773 /* OpenFilterIntent.swift */,
+				FF5495D92F02FE9A0086F773 /* SleepTimerIntent.swift */,
+				FF5495D62F02FE9A0086F773 /* ExtendSleepTimerIntent.swift */,
+			);
+			path = Intents;
+			sourceTree = "<group>";
+		};
 		FF68E8BC2DF33AAC00114FC7 /* Horizontal Collection List */ = {
 			isa = PBXGroup;
 			children = (
@@ -10538,6 +10563,7 @@
 				C7891DCA2A6B080F009DA661 /* BookmarksPodcastListController.swift in Sources */,
 				8BB55E3A28FEEE99001D1766 /* StoryShareableProvider.swift in Sources */,
 				408426322134CBE60076D82E /* SmallPagedListSummaryViewController.swift in Sources */,
+				FFEA96C32F040A85005D879A /* ExtendSleepTimerIntent.swift in Sources */,
 				C7FAFF6A2942E78A00329B40 /* HighlightedText.swift in Sources */,
 				BD4098801B9EFE3C007F36BD /* AudioPlayTask.swift in Sources */,
 				40AA12732488AE1F006B9D48 /* MultiSelectFooterView.swift in Sources */,
@@ -10996,6 +11022,7 @@
 				BD95ED6A1BAFA532004335B0 /* CountryChooserViewController.swift in Sources */,
 				C722245C2936CA15006B3B55 /* StoryLogoView.swift in Sources */,
 				8B5BD0B82C50235400C687CB /* Episode+Transcript.swift in Sources */,
+				FF5495E02F03F2970086F773 /* ShortcutsProvider.swift in Sources */,
 				C713D4F52A04C90500A78468 /* ProfileImage.swift in Sources */,
 				466DE3F6278794D50046F722 /* EpisodeListTableViewCell.swift in Sources */,
 				BD056F111F6F8CE800AF8260 /* MainTabBarController.swift in Sources */,
@@ -11150,8 +11177,10 @@
 				F5EA21F82CC1DC370043C780 /* EndOfYear2024StoriesModel.swift in Sources */,
 				BDD6F0342140E1A3005FD8A3 /* ChapterManager.swift in Sources */,
 				BD9A7FEB201EF5E000E3287B /* PodcastEpisodesRefreshOperation.swift in Sources */,
+				FFEA96C22F040A7E005D879A /* SleepTimerIntent.swift in Sources */,
 				46305CF2272B0962003AC87B /* FileLog+FileUpload.swift in Sources */,
 				FF7F89ED2C2AF6DE00FC0ED5 /* TranscriptManager.swift in Sources */,
+				FF5495E12F03F35C0086F773 /* ChapterIntent.swift in Sources */,
 				BD2F3BA62366C17500416633 /* PlayerContainerViewController+Scroll.swift in Sources */,
 				C7DC401E2A67026800883D03 /* Toast.swift in Sources */,
 				BD07B92823583FC900B06FFF /* SettingsTableHeader.swift in Sources */,
@@ -11418,6 +11447,7 @@
 				BDB206AA2191734D00C1E456 /* NowPlayingHelper.swift in Sources */,
 				10DFE9372C5A8D1300957D0A /* ABTestProvider.swift in Sources */,
 				400AB301220BA8DC0003EE21 /* UploadedViewController+Table.swift in Sources */,
+				FF5495E22F03F3630086F773 /* NextPrevious.swift in Sources */,
 				4647623128F70CD0006D005A /* AuthenticationHelper.swift in Sources */,
 				F57626B62C8B56C7009C8225 /* String+SanitizedFileName.swift in Sources */,
 				BDDF8AA2240CE240009BA263 /* PlaylistViewController+Swipe.swift in Sources */,
@@ -12295,6 +12325,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEBUG_ACTIVITY_MODE = "";
 				"DEBUG_ACTIVITY_MODE[sdk=iphonesimulator*]" = disable;
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				FIREBASE_SECRETS_PATH = "$(HOME)/.configure/pocketcasts-ios/secrets/GoogleService-Info.plist";
@@ -13388,6 +13419,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEBUG_ACTIVITY_MODE = "";
 				"DEBUG_ACTIVITY_MODE[sdk=iphonesimulator*]" = disable;
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = NO;
 				FIREBASE_SECRETS_PATH = "$(HOME)/.configure/pocketcasts-ios/secrets/GoogleService-Info.plist";
@@ -13623,6 +13655,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEBUG_ACTIVITY_MODE = "";
 				"DEBUG_ACTIVITY_MODE[sdk=iphonesimulator*]" = disable;
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				FIREBASE_SECRETS_PATH = "$(HOME)/.configure/pocketcasts-ios/secrets/GoogleService-Info.plist";
@@ -13681,6 +13714,7 @@
 				COPY_PHASE_STRIP = YES;
 				DEAD_CODE_STRIPPING = NO;
 				DEBUG_ACTIVITY_MODE = "";
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FIREBASE_SECRETS_PATH = "$(HOME)/.configure/pocketcasts-ios/secrets/GoogleService-Info.plist";
 				GCC_C_LANGUAGE_STANDARD = gnu99;

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -2168,6 +2168,7 @@
 		FF89C0982D81A2D000BC5104 /* PodcastHeaderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF89C0972D81A2C700BC5104 /* PodcastHeaderModel.swift */; };
 		FF89C09A2D81A31D00BC5104 /* PodcastHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF89C0992D81A31700BC5104 /* PodcastHeaderView.swift */; };
 		FF9088ED2E00438500FA1E7C /* HorizontaCollectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9088EC2E00437E00FA1E7C /* HorizontaCollectionModel.swift */; };
+		FF90946D2F06ECAD003137B6 /* OpenFilterIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5495D82F02FE9A0086F773 /* OpenFilterIntent.swift */; };
 		FF91A0F62B64159D002A0590 /* UIScreen+Sizes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0F52B64159D002A0590 /* UIScreen+Sizes.swift */; };
 		FF91A0F82B6BBF33002A0590 /* UpgradeRoundedSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0F72B6BBF33002A0590 /* UpgradeRoundedSegmentedControl.swift */; };
 		FF91A0FA2B6BBFD1002A0590 /* UpgradeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0F92B6BBFD1002A0590 /* UpgradeCard.swift */; };
@@ -11126,6 +11127,7 @@
 				C73CD7A82916E8A900EAE879 /* SwiftUI+Previews.swift in Sources */,
 				BDB002BF211A9E1B00224A55 /* ProgressLine.swift in Sources */,
 				F57498D12DB8430A00892BF0 /* LargeListSummaryCellHeaderView.swift in Sources */,
+				FF90946D2F06ECAD003137B6 /* OpenFilterIntent.swift in Sources */,
 				9A263EC12DA65CC900E895B6 /* InformationalProfileBannerCell.swift in Sources */,
 				C7A110FF2922971100887A90 /* LoginLandingHostingController.swift in Sources */,
 				C7FAFF5B294183AA00329B40 /* CancelConfirmationView.swift in Sources */,

--- a/podcasts/AppPlayEpisodeIntentExtension.swift
+++ b/podcasts/AppPlayEpisodeIntentExtension.swift
@@ -1,7 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsUtils
 
-@available(iOS 17, *)
 extension PlayEpisodeIntent {
     func intentPlayback(_ episodeUuid: String) {
         FileLog.shared.addMessage("PlayEpisodeIntent called for episode \(episodeUuid)")

--- a/podcasts/Base.lproj/Intents.intentdefinition
+++ b/podcasts/Base.lproj/Intents.intentdefinition
@@ -53,11 +53,11 @@
 	<key>INIntentDefinitionNamespace</key>
 	<string>DOik2X</string>
 	<key>INIntentDefinitionSystemVersion</key>
-	<string>21A559</string>
+	<string>25C56</string>
 	<key>INIntentDefinitionToolsBuildVersion</key>
-	<string>13A1030d</string>
+	<string>17B55</string>
 	<key>INIntentDefinitionToolsVersion</key>
-	<string>13.1</string>
+	<string>26.1</string>
 	<key>INIntents</key>
 	<array>
 		<dict>

--- a/podcasts/Intents/ChapterIntent.swift
+++ b/podcasts/Intents/ChapterIntent.swift
@@ -8,16 +8,8 @@ struct ChapterIntent: AppIntent, CustomIntentMigratedAppIntent, PredictableInten
     static var title: LocalizedStringResource = "Skip chapter"
     static var description = IntentDescription("Skip chapter")
 
-    @Parameter(title: "Skip chapter")
-    var skipForward: NextPrevious?
-
-    init() {
-
-    }
-
-    init(defaultSkip: NextPrevious) {
-        self.skipForward = defaultSkip
-    }
+    @Parameter(title: "Skip chapter", default: .next)
+    var skipForward: NextPrevious
 
     static var parameterSummary: some ParameterSummary {
         Summary("Skip to \(\.$skipForward) chapter")
@@ -26,16 +18,13 @@ struct ChapterIntent: AppIntent, CustomIntentMigratedAppIntent, PredictableInten
     static var predictionConfiguration: some IntentPredictionConfiguration {
         IntentPrediction(parameters: (\.$skipForward)) { skipForward in
             DisplayRepresentation(
-                title: "\(skipForward ?? .next) Chapter",
+                title: "\(skipForward) chapter",
                 subtitle: ""
             )
         }
     }
 
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        guard let skipForward else {
-            return .result(dialog: .responseFailure)
-        }
         switch skipForward {
             case .next:
                 let _ = SiriShortcutsManager.shared.skipToNextChapter()

--- a/podcasts/Intents/ChapterIntent.swift
+++ b/podcasts/Intents/ChapterIntent.swift
@@ -1,0 +1,49 @@
+import Foundation
+import AppIntents
+
+struct ChapterIntent: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
+
+    static let intentClassName = "SJChapterIntent"
+
+    static var title: LocalizedStringResource = "Skip chapter"
+    static var description = IntentDescription("Skip chapter")
+
+    @Parameter(title: "Skip chapter", default: .next)
+    var skipForward: NextPrevious
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Skip to \(\.$skipForward) chapter")
+    }
+
+    static var predictionConfiguration: some IntentPredictionConfiguration {
+        IntentPrediction(parameters: (\.$skipForward)) { skipForward in
+            DisplayRepresentation(
+                title: "\(skipForward) Chapter",
+                subtitle: ""
+            )
+        }
+    }
+
+    func perform() async throws -> some ProvidesDialog {
+        switch skipForward {
+            case .next:
+                let _ = SiriShortcutsManager.shared.skipToNextChapter()
+            case .previous:
+                let _ = SiriShortcutsManager.shared.skipToPreviousChapter()
+        }
+        return .result(dialog: .responseSuccess)
+    }
+}
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+fileprivate extension IntentDialog {
+    static var responseSuccess: Self {
+        "Skipped chapter"
+    }
+    static var responseFailure: Self {
+        "Unable to skip chapter"
+    }
+    static var responseFailureNoChapters: Self {
+        "Podcast doesn't support chapters"
+    }
+}

--- a/podcasts/Intents/ChapterIntent.swift
+++ b/podcasts/Intents/ChapterIntent.swift
@@ -8,8 +8,16 @@ struct ChapterIntent: AppIntent, CustomIntentMigratedAppIntent, PredictableInten
     static var title: LocalizedStringResource = "Skip chapter"
     static var description = IntentDescription("Skip chapter")
 
-    @Parameter(title: "Skip chapter", default: .next)
-    var skipForward: NextPrevious
+    @Parameter(title: "Skip chapter")
+    var skipForward: NextPrevious?
+
+    init() {
+
+    }
+
+    init(defaultSkip: NextPrevious) {
+        self.skipForward = defaultSkip
+    }
 
     static var parameterSummary: some ParameterSummary {
         Summary("Skip to \(\.$skipForward) chapter")
@@ -18,13 +26,16 @@ struct ChapterIntent: AppIntent, CustomIntentMigratedAppIntent, PredictableInten
     static var predictionConfiguration: some IntentPredictionConfiguration {
         IntentPrediction(parameters: (\.$skipForward)) { skipForward in
             DisplayRepresentation(
-                title: "\(skipForward) Chapter",
+                title: "\(skipForward ?? .next) Chapter",
                 subtitle: ""
             )
         }
     }
 
-    func perform() async throws -> some ProvidesDialog {
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        guard let skipForward else {
+            return .result(dialog: .responseFailure)
+        }
         switch skipForward {
             case .next:
                 let _ = SiriShortcutsManager.shared.skipToNextChapter()

--- a/podcasts/Intents/ExtendSleepTimerIntent.swift
+++ b/podcasts/Intents/ExtendSleepTimerIntent.swift
@@ -1,0 +1,31 @@
+import Foundation
+import AppIntents
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+struct ExtendSleepTimerIntent: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
+    static let intentClassName = "SJExtendSleepTimerIntent"
+
+    static var title: LocalizedStringResource = "Extend Sleep Timer"
+    static var description = IntentDescription("Extend Sleep Timer")
+
+    @Parameter(title: "Minutes", default: 5)
+    var minutes: Int
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Extend sleep timer by \(\.$minutes) minutes")
+    }
+
+    static var predictionConfiguration: some IntentPredictionConfiguration {
+        IntentPrediction(parameters: (\.$minutes)) { minutes in
+            DisplayRepresentation(
+                title: "Extend sleep timer by 5 minutes",
+                subtitle: ""
+            )
+        }
+    }
+
+    func perform() async throws -> some IntentResult {
+        let _ = SiriShortcutsManager.shared.extendSleepTimer(addTime: minutes)
+        return .result()
+    }
+}

--- a/podcasts/Intents/NextPrevious.swift
+++ b/podcasts/Intents/NextPrevious.swift
@@ -1,0 +1,14 @@
+import Foundation
+import AppIntents
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+enum NextPrevious: String, AppEnum {
+    case next
+    case previous
+
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Skip Chapter")
+    static var caseDisplayRepresentations: [Self: DisplayRepresentation] = [
+        .next: "Next",
+        .previous: "Previous"
+    ]
+}

--- a/podcasts/Intents/OpenFilterIntent.swift
+++ b/podcasts/Intents/OpenFilterIntent.swift
@@ -1,0 +1,34 @@
+import Foundation
+import AppIntents
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+struct OpenFilterIntent: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
+    static let intentClassName = "SJOpenFilterIntent"
+
+    static var title: LocalizedStringResource = "Open Filter"
+    static var description = IntentDescription("Open Filter")
+
+    @Parameter(title: "")
+    var filterUuid: String?
+
+    @Parameter(title: "")
+    var filterName: String?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary()
+    }
+
+    static var predictionConfiguration: some IntentPredictionConfiguration {
+        IntentPrediction(parameters: (\.$filterUuid, \.$filterName)) { filterUuid, filterName in
+            DisplayRepresentation(
+                title: "Open \(filterName!) Filter",
+                subtitle: ""
+            )
+        }
+    }
+
+    func perform() async throws -> some IntentResult {
+        // TODO: Place your refactored intent handler code here.
+        return .result()
+    }
+}

--- a/podcasts/Intents/ShortcutsProvider.swift
+++ b/podcasts/Intents/ShortcutsProvider.swift
@@ -1,0 +1,32 @@
+import Foundation
+import AppIntents
+
+struct ShortcutsProvider: AppShortcutsProvider {
+
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: ChapterIntent(defaultSkip: .previous),
+            phrases: [AppShortcutPhrase(L10n.siriShortcutPreviousChapter)],
+            shortTitle: LocalizedStringResource("siri_shortcut_previous_chapter"),
+            systemImageName: "siri_chapter_previous"
+        )
+        AppShortcut(
+            intent: ChapterIntent(defaultSkip: .next),
+            phrases: [AppShortcutPhrase(L10n.siriShortcutNextChapter)],
+            shortTitle: LocalizedStringResource("siri_shortcut_next_chapter"),
+            systemImageName: "siri_chapter_next"
+        )
+        AppShortcut(
+            intent: SleepTimerIntent(),
+            phrases: ["Set sleep timer for \(.applicationName)"],
+            shortTitle: "Set sleep timer",
+            systemImageName: ""
+        )
+        AppShortcut(
+            intent: ExtendSleepTimerIntent(),
+            phrases: ["Extend sleep timer for \(.applicationName)"],
+            shortTitle: "Extend sleep timer",
+            systemImageName: ""
+        )
+    }
+}

--- a/podcasts/Intents/ShortcutsProvider.swift
+++ b/podcasts/Intents/ShortcutsProvider.swift
@@ -30,5 +30,11 @@ struct ShortcutsProvider: AppShortcutsProvider {
             shortTitle: "Extend sleep timer",
             systemImageName: ""
         )
+        AppShortcut(
+            intent: PlayEpisodeIntent(),
+            phrases: ["Play in \(.applicationName)"],
+            shortTitle: "Play podcast",
+            systemImageName: ""
+        )
     }
 }

--- a/podcasts/Intents/ShortcutsProvider.swift
+++ b/podcasts/Intents/ShortcutsProvider.swift
@@ -1,24 +1,26 @@
-import Foundation
 import AppIntents
+import Foundation
 
 struct ShortcutsProvider: AppShortcutsProvider {
 
+    static var shortcutTileColor = ShortcutTileColor.red
+
     static var appShortcuts: [AppShortcut] {
         AppShortcut(
-            intent: ChapterIntent(defaultSkip: .previous),
-            phrases: [AppShortcutPhrase(L10n.siriShortcutPreviousChapter)],
-            shortTitle: LocalizedStringResource("siri_shortcut_previous_chapter"),
-            systemImageName: "siri_chapter_previous"
-        )
-        AppShortcut(
-            intent: ChapterIntent(defaultSkip: .next),
-            phrases: [AppShortcutPhrase(L10n.siriShortcutNextChapter)],
-            shortTitle: LocalizedStringResource("siri_shortcut_next_chapter"),
-            systemImageName: "siri_chapter_next"
+            intent: ChapterIntent(),
+            phrases: [
+                "Skip to \(\.$skipForward) chapter \(.applicationName)"
+            ],
+            shortTitle: LocalizedStringResource("Skip chapter"),
+            systemImageName: "forward.end"
         )
         AppShortcut(
             intent: SleepTimerIntent(),
-            phrases: ["Set sleep timer for \(.applicationName)"],
+            phrases: [
+                "Set sleep timer for \(.applicationName)",
+                "Setup sleep timer for \(.applicationName)",
+                "Add sleep timer for \(.applicationName)",
+            ],
             shortTitle: "Set sleep timer",
             systemImageName: ""
         )

--- a/podcasts/Intents/SleepTimerIntent.swift
+++ b/podcasts/Intents/SleepTimerIntent.swift
@@ -1,0 +1,35 @@
+import Foundation
+import AppIntents
+
+@available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, *)
+struct SleepTimerIntent: AppIntent, CustomIntentMigratedAppIntent, PredictableIntent {
+    static let intentClassName = "SJSleepTimerIntent"
+
+    static var title: LocalizedStringResource = "Sleep Timer"
+    static var description = IntentDescription("Set Sleep Timer")
+
+    @Parameter(title: "Minutes", default: nil)
+    var minutes: Int?
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Setting sleep timer to \(\.$minutes) minutes")
+    }
+
+    static var predictionConfiguration: some IntentPredictionConfiguration {
+        IntentPrediction(parameters: (\.$minutes)) { minutes in
+            DisplayRepresentation(
+                title: "Set sleep timer",
+                subtitle: ""
+            )
+        }
+    }
+
+    func perform() async throws -> some IntentResult {
+        var duration: TimeInterval = Settings.customSleepTime()
+        if let minutes {
+            duration = TimeInterval(minutes).minutes
+        }
+        let _ = SiriShortcutsManager.shared.sleepTimer(newTime: Int(duration))
+        return .result()
+    }
+}

--- a/podcasts/PlayEpisodeIntent.swift
+++ b/podcasts/PlayEpisodeIntent.swift
@@ -1,10 +1,8 @@
 import AppIntents
 import WidgetKit
 
-@available(iOS 17, *)
-struct PlayEpisodeIntent: AudioPlaybackIntent {
+struct PlayEpisodeIntent: AudioStartingIntent {
     static var title: LocalizedStringResource = "Play episode"
-    static var isDiscoverable = false // for now only to be used in the Now Playing widget
 
     @Parameter(title: "EpisodeUUID")
     var episodeUuid: String

--- a/podcasts/WidgetPlayEpisodeIntentExtension.swift
+++ b/podcasts/WidgetPlayEpisodeIntentExtension.swift
@@ -1,6 +1,5 @@
 // Placeholder so that PlayEpisodeIntent can compile in widget extension, but never actually executes
 // because it is a subclass of AudioPlaybackIntent which only runs in the app.
-@available(iOS 17, *)
 extension PlayEpisodeIntent {
     func intentPlayback(_ episodeUuid: String) {
         print("In Widget intent extension \(episodeUuid)")


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Updating our intents integration for Shortcuts and Siri to use the AppIntents library.

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
