### PR TITLE
Playlists: Add Episode improvements in Manual playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Add Deselect action from long press [#3786](https://github.com/Automattic/pocket-casts-ios/pull/3786)
 - Fix WatchManager to only report unknown message if it was truly unknown / unprocessed [#3748](https://github.com/Automattic/pocket-casts-ios/issues/3748)
+- Improves Add Episode performance [#3842](https://github.com/Automattic/pocket-casts-ios/pull/3842)
 
 8.2
 -----

--- a/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
@@ -110,19 +110,21 @@ final class LocalSearchCoordinator {
         preloadTask = Task { [weak self] in
             guard let self else { return }
 
-            let results = await Task.detached { [dataManager] in
+            let playlistUUIDs = await MainActor.run { self.playlistEpisodeUUIDs }
+
+            let episodeResults = await Task.detached { [dataManager] in
                 let podcastEpisodes = dataManager.allEpisodesForPodcast(id: podcast.id)
                 let sortedEpisodes = podcastEpisodes.sorted { lhs, rhs in
                     let lhsDate = lhs.publishedDate ?? lhs.addedDate ?? .distantPast
                     let rhsDate = rhs.publishedDate ?? rhs.addedDate ?? .distantPast
                     return lhsDate > rhsDate
                 }
-                return sortedEpisodes
+                let availableEpisodes = sortedEpisodes.filter { !playlistUUIDs.contains($0.uuid) }
+                return availableEpisodes.map { EpisodeSearchResult(episode: $0) }
             }.value
 
             await MainActor.run {
-                let availableEpisodes = results.filter { !self.playlistEpisodeUUIDs.contains($0.uuid) }
-                self.episodes = availableEpisodes.map { EpisodeSearchResult(episode: $0) }
+                self.episodes = episodeResults
                 self.isSearchInFlight = false
             }
         }
@@ -190,8 +192,9 @@ final class LocalSearchCoordinator {
             self.episodes = []
         }
 
-        let matchedEpisodes = await Task.detached {
-            DataManager.sharedManager.findEpisodes(with: term, podcastUUID: podcastUuid)
+        let episodeResults = await Task.detached {
+            let matchedEpisodes = DataManager.sharedManager.findEpisodes(with: term, podcastUUID: podcastUuid)
+            return matchedEpisodes.map { EpisodeSearchResult(episode: $0) }
         }.value
 
         guard !Task.isCancelled else {
@@ -209,7 +212,7 @@ final class LocalSearchCoordinator {
                 return
             }
 
-            self.episodes = matchedEpisodes.map { EpisodeSearchResult(episode: $0) }
+            self.episodes = episodeResults
             self.isSearchInFlight = false
         }
     }

--- a/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchCoordinator.swift
@@ -31,9 +31,15 @@ final class LocalSearchCoordinator {
         searchTask?.cancel()
     }
 
-    func refreshPlaylistEpisodes() {
-        let playlistEpisodes = dataManager.playlistEpisodes(for: playlist)
-        playlistEpisodeUUIDs = Set(playlistEpisodes.map { $0.uuid })
+    func refreshPlaylistEpisodes() async {
+        let uuids = await Task.detached { [dataManager, playlist] in
+            let playlistEpisodes = dataManager.playlistEpisodes(for: playlist)
+            return Set(playlistEpisodes.map { $0.uuid })
+        }.value
+
+        await MainActor.run {
+            self.playlistEpisodeUUIDs = uuids
+        }
     }
 
     func scheduleSearch(for trimmedTerm: String, podcastUuid: String?) {
@@ -104,16 +110,21 @@ final class LocalSearchCoordinator {
         preloadTask = Task { [weak self] in
             guard let self else { return }
 
-            let podcastEpisodes = dataManager.allEpisodesForPodcast(id: podcast.id)
-            let sortedEpisodes = podcastEpisodes.sorted { lhs, rhs in
-                let lhsDate = lhs.publishedDate ?? lhs.addedDate ?? .distantPast
-                let rhsDate = rhs.publishedDate ?? rhs.addedDate ?? .distantPast
-                return lhsDate > rhsDate
-            }
+            let results = await Task.detached { [dataManager] in
+                let podcastEpisodes = dataManager.allEpisodesForPodcast(id: podcast.id)
+                let sortedEpisodes = podcastEpisodes.sorted { lhs, rhs in
+                    let lhsDate = lhs.publishedDate ?? lhs.addedDate ?? .distantPast
+                    let rhsDate = rhs.publishedDate ?? rhs.addedDate ?? .distantPast
+                    return lhsDate > rhsDate
+                }
+                return sortedEpisodes
+            }.value
 
-            let availableEpisodes = sortedEpisodes.filter { !self.playlistEpisodeUUIDs.contains($0.uuid) }
-            self.episodes = availableEpisodes.map { EpisodeSearchResult(episode: $0) }
-            self.isSearchInFlight = false
+            await MainActor.run {
+                let availableEpisodes = results.filter { !self.playlistEpisodeUUIDs.contains($0.uuid) }
+                self.episodes = availableEpisodes.map { EpisodeSearchResult(episode: $0) }
+                self.isSearchInFlight = false
+            }
         }
     }
 
@@ -124,63 +135,82 @@ final class LocalSearchCoordinator {
     }
 
     func handleAddEpisode(_ searchResult: EpisodeSearchResult) {
-        guard let episode = dataManager.findEpisode(uuid: searchResult.uuid) else {
-            assertionFailure("Episode should exist")
-            return
+        Task {
+            let result = await Task.detached { [dataManager, playlist] in
+                guard let episode = dataManager.findEpisode(uuid: searchResult.uuid) else {
+                    return (didAdd: false, episode: nil as Episode?, isFull: false)
+                }
+
+                let didAdd = dataManager.add(episodes: [episode], to: playlist)
+                playlist.syncStatus = SyncStatus.notSynced.rawValue
+                dataManager.save(playlist: playlist)
+
+                let isFull = !didAdd
+                return (didAdd: didAdd, episode: episode, isFull: isFull)
+            }.value
+
+            guard let episode = result.episode else {
+                assertionFailure("Episode should exist")
+                return
+            }
+
+            Analytics.track(.filterAddEpisodesEpisodeTapped, properties: ["is_playlist_full": result.isFull])
+
+            guard result.didAdd else {
+                let theme: any ToastTheme = ToastIconTheme(iconName: "option-alert", iconColor: Theme.sharedTheme.primaryIcon01)
+                Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast, theme: theme)
+                return
+            }
+
+            // For now let's track the event directly here to avoid swift concurrency warning using the PlaylistTypeTrackerProvider
+            Analytics.track(
+                .episodeAddedToList,
+                properties:
+                    [
+                        "source": "playlist_editor",
+                        "playlist_name": playlist.playlistName,
+                        "playlist_uuid": playlist.uuid,
+                        "episode_uuid": episode.uuid,
+                        "podcast_uuid": episode.podcastUuid
+                    ]
+            )
+
+            await MainActor.run {
+                self.playlistEpisodeUUIDs.insert(searchResult.uuid)
+                self.episodes.removeAll { $0.uuid == searchResult.uuid }
+                self.addedEpisodeCount += 1
+            }
         }
-
-
-        let didAdd = dataManager.add(episodes: [episode], to: playlist)
-        playlist.syncStatus = SyncStatus.notSynced.rawValue
-        dataManager.save(playlist: playlist)
-
-        let isFull = !didAdd
-
-        Analytics.track(.filterAddEpisodesEpisodeTapped, properties: ["is_playlist_full": isFull])
-
-        guard didAdd else {
-            let theme: any ToastTheme = ToastIconTheme(iconName: "option-alert", iconColor: Theme.sharedTheme.primaryIcon01)
-            Toast.show(L10n.playlistManualAddEpisodeFullPlaylistToast, theme: theme)
-            return
-        }
-
-        // For now let's track the event directly here to avoid swift concurrency warning using the PlaylistTypeTrackerProvider
-        Analytics.track(
-            .episodeAddedToList,
-            properties:
-                [
-                    "source": "playlist_editor",
-                    "playlist_name": playlist.playlistName,
-                    "playlist_uuid": playlist.uuid,
-                    "episode_uuid": episode.uuid,
-                    "podcast_uuid": episode.podcastUuid
-                ]
-        )
-
-        playlistEpisodeUUIDs.insert(searchResult.uuid)
-        episodes.removeAll { $0.uuid == searchResult.uuid }
-        addedEpisodeCount += 1
     }
 
     private func performSearch(term: String, podcastUuid: String) async {
-        currentEpisodeSearchTerm = term
-        currentSearchPodcastUUID = podcastUuid
-        episodes = []
-        let matchedEpisodes = DataManager.sharedManager.findEpisodes(with: term, podcastUUID: podcastUuid)
+        await MainActor.run {
+            self.currentEpisodeSearchTerm = term
+            self.currentSearchPodcastUUID = podcastUuid
+            self.episodes = []
+        }
+
+        let matchedEpisodes = await Task.detached {
+            DataManager.sharedManager.findEpisodes(with: term, podcastUUID: podcastUuid)
+        }.value
 
         guard !Task.isCancelled else {
-            if currentEpisodeSearchTerm == term, currentSearchPodcastUUID == podcastUuid {
-                isSearchInFlight = false
+            await MainActor.run {
+                if self.currentEpisodeSearchTerm == term, self.currentSearchPodcastUUID == podcastUuid {
+                    self.isSearchInFlight = false
+                }
             }
             return
         }
 
-        guard currentEpisodeSearchTerm == term,
-              currentSearchPodcastUUID == podcastUuid else {
-            return
-        }
+        await MainActor.run {
+            guard self.currentEpisodeSearchTerm == term,
+                  self.currentSearchPodcastUUID == podcastUuid else {
+                return
+            }
 
-        episodes = matchedEpisodes.map { EpisodeSearchResult(episode: $0) }
-        isSearchInFlight = false
+            self.episodes = matchedEpisodes.map { EpisodeSearchResult(episode: $0) }
+            self.isSearchInFlight = false
+        }
     }
 }

--- a/podcasts/New Search/Views/Results/LocalSearchPodcastResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchPodcastResultsView.swift
@@ -16,13 +16,18 @@ struct LocalSearchPodcastResultsView: View {
     let searchResults: [PodcastFolderSearchResult]
     let onSelectResult: (PodcastFolderSearchResult) -> Void
     let disableLibraryAnimation: Bool
+    let isLoading: Bool
 
     var body: some View {
-        Group {
-            if currentResults.isEmpty {
-                emptyStateView
-            } else {
+        ZStack {
+            if !currentResults.isEmpty {
                 resultsList
+            }
+
+            if isLoading {
+                loadingOverlay
+            } else if currentResults.isEmpty {
+                emptyStateView
             }
         }
     }
@@ -64,6 +69,12 @@ struct LocalSearchPodcastResultsView: View {
                 .listRowSeparator(.hidden)
                 .listRowBackground(theme.primaryUi01)
         }
+    }
+
+    private var loadingOverlay: some View {
+        ProgressView()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .tint(AppTheme.loadingActivityColor().color)
     }
 
     private var emptyStateView: some View {

--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -132,7 +132,8 @@ private extension LocalSearchView {
             hasAnyPodcastsInFolder: viewModel.hasAnyPodcastsInFolder,
             searchResults: viewModel.searchResultsPodcasts,
             onSelectResult: { handleSelection(for: $0) },
-            disableLibraryAnimation: viewModel.disableLibraryAnimation
+            disableLibraryAnimation: viewModel.disableLibraryAnimation,
+            isLoading: viewModel.isPodcastListLoading
         )
         .background(backgroundColor.ignoresSafeArea())
         .navigationTitle(viewModel.navigationTitle)
@@ -211,7 +212,8 @@ private extension LocalSearchView {
                 hasAnyPodcastsInFolder: viewModel.hasAnyPodcastsInFolder,
                 searchResults: viewModel.searchResultsPodcasts,
                 onSelectResult: { handleSelection(for: $0) },
-                disableLibraryAnimation: viewModel.disableLibraryAnimation
+                disableLibraryAnimation: viewModel.disableLibraryAnimation,
+                isLoading: viewModel.isPodcastListLoading
             )
             .background(backgroundColor.ignoresSafeArea())
             .navigationTitle(viewModel.navigationTitle)

--- a/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
@@ -16,6 +16,7 @@ final class LocalSearchViewModel: ObservableObject {
     @Published private(set) var addedEpisodeCount = 0
     @Published private(set) var searchResultsPodcasts: [PodcastFolderSearchResult] = []
     @Published private(set) var disableLibraryAnimation = false
+    @Published private(set) var defaultLibraryItems: [PodcastFolderSearchResult] = []
 
     let playlist: EpisodeFilter
 
@@ -65,17 +66,23 @@ final class LocalSearchViewModel: ObservableObject {
         return .library
     }
 
-    var defaultLibraryItems: [PodcastFolderSearchResult] {
-        let sortOrder = Settings.homeFolderSortOrder()
-        let items = HomeGridDataHelper.gridItems(orderedBy: sortOrder)
-        return items.compactMap { item in
-            if let podcast = item.podcast {
-                return PodcastFolderSearchResult(from: podcast)
+    private func loadDefaultLibraryItems() async {
+        let items = await Task.detached {
+            let sortOrder = Settings.homeFolderSortOrder()
+            let items = HomeGridDataHelper.gridItems(orderedBy: sortOrder)
+            return items.compactMap { item in
+                if let podcast = item.podcast {
+                    return PodcastFolderSearchResult(from: podcast)
+                }
+                if let folder = item.folder {
+                    return PodcastFolderSearchResult(from: folder)
+                }
+                return nil
             }
-            if let folder = item.folder {
-                return PodcastFolderSearchResult(from: folder)
-            }
-            return nil
+        }.value
+
+        await MainActor.run {
+            self.defaultLibraryItems = items
         }
     }
 
@@ -106,8 +113,12 @@ final class LocalSearchViewModel: ObservableObject {
         configureSearchResultsIfNeeded(searchResultsModel)
         guard !hasAppeared else { return }
         hasAppeared = true
-        loadPodcastsIfNeeded()
-        refreshPlaylistEpisodes()
+
+        Task {
+            await loadDefaultLibraryItems()
+            await loadPodcastsIfNeeded()
+            await refreshPlaylistEpisodes()
+        }
     }
 
     func onDisappear() {
@@ -128,9 +139,11 @@ final class LocalSearchViewModel: ObservableObject {
         selectedPodcast = podcast
         searchText = ""
 
-        episodeCoordinator?.clearResults()
-        episodeCoordinator?.refreshPlaylistEpisodes()
-        episodeCoordinator?.preloadEpisodes(for: selectedPodcast)
+        Task {
+            episodeCoordinator?.clearResults()
+            await episodeCoordinator?.refreshPlaylistEpisodes()
+            episodeCoordinator?.preloadEpisodes(for: selectedPodcast)
+        }
     }
 
     func selectPodcast(_ podcastResult: PodcastFolderSearchResult) {
@@ -152,66 +165,77 @@ final class LocalSearchViewModel: ObservableObject {
         previouslySelectedFolder = folder
         selectedPodcast = nil
         episodeCoordinator?.clearResults()
-        loadPodcastsForSelectedFolder(folder)
-        if !trimmedSearchText.isEmpty {
-            searchText = ""
-        } else {
-            filterPodcasts(using: searchText)
+
+        Task {
+            await loadPodcastsForSelectedFolder(folder)
+            if !trimmedSearchText.isEmpty {
+                searchText = ""
+            } else {
+                await filterPodcasts(using: searchText)
+            }
         }
     }
 
     func clearSelectedPodcast() {
         let searchState = previousPodcastSearchState
         selectedPodcast = nil
-        if let folder = previouslySelectedFolder {
-            selectedFolder = folder
-            loadPodcastsForSelectedFolder(folder)
-            let restoreTerm = searchState?.term ?? ""
-            if searchText != restoreTerm {
-                searchText = restoreTerm
+
+        Task {
+            if let folder = previouslySelectedFolder {
+                selectedFolder = folder
+                await loadPodcastsForSelectedFolder(folder)
+                let restoreTerm = searchState?.term ?? ""
+                if searchText != restoreTerm {
+                    searchText = restoreTerm
+                } else {
+                    await filterPodcasts(using: restoreTerm)
+                }
+            } else if let searchState, !searchState.term.isEmpty {
+                selectedFolder = nil
+                searchResultsPodcasts = searchState.results
+                if searchText != searchState.term {
+                    searchText = searchState.term
+                } else {
+                    await filterPodcasts(using: searchState.term)
+                }
             } else {
-                filterPodcasts(using: restoreTerm)
+                selectedFolder = nil
+                if !searchText.isEmpty {
+                    searchText = ""
+                }
+                await filterPodcasts(using: "")
             }
-        } else if let searchState, !searchState.term.isEmpty {
-            selectedFolder = nil
-            searchResultsPodcasts = searchState.results
-            if searchText != searchState.term {
-                searchText = searchState.term
-            } else {
-                filterPodcasts(using: searchState.term)
+
+            await MainActor.run {
+                self.episodeCoordinator?.clearResults()
             }
-        } else {
-            selectedFolder = nil
-            if !searchText.isEmpty {
-                searchText = ""
-            }
-            filterPodcasts(using: "")
+            previousPodcastSearchState = nil
         }
-        DispatchQueue.main.async { [weak self] in
-            self?.episodeCoordinator?.clearResults()
-        }
-        previousPodcastSearchState = nil
     }
 
     func clearSelectedFolder() {
         selectedFolder = nil
         folderPodcasts = []
         filteredFolderPodcasts = []
-        if let previousState = folderSearchStateStack.popLast() {
-            searchResultsPodcasts = previousState.results
-            if searchText != previousState.term {
-                searchText = previousState.term
+
+        Task {
+            if let previousState = folderSearchStateStack.popLast() {
+                searchResultsPodcasts = previousState.results
+                if searchText != previousState.term {
+                    searchText = previousState.term
+                } else {
+                    await filterPodcasts(using: previousState.term)
+                }
             } else {
-                filterPodcasts(using: previousState.term)
+                searchText = ""
+                await filterPodcasts(using: searchText, disableAnimationsWhenClearing: false)
             }
-        } else {
-            searchText = ""
-            filterPodcasts(using: searchText, disableAnimationsWhenClearing: false)
+
+            await MainActor.run {
+                self.episodeCoordinator?.clearResults()
+            }
+            previouslySelectedFolder = nil
         }
-        DispatchQueue.main.async { [weak self] in
-            self?.episodeCoordinator?.clearResults()
-        }
-        previouslySelectedFolder = nil
     }
 
     func triggerImmediateSearch() {
@@ -271,54 +295,72 @@ final class LocalSearchViewModel: ObservableObject {
             .store(in: &cancellables)
 
         episodeCoordinator = coordinator
-        episodeCoordinator?.refreshPlaylistEpisodes()
-        episodeCoordinator?.preloadEpisodes(for: selectedPodcast)
+
+        Task {
+            await episodeCoordinator?.refreshPlaylistEpisodes()
+            episodeCoordinator?.preloadEpisodes(for: selectedPodcast)
+        }
     }
 
     private var trimmedSearchText: String {
         searchText.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private func loadPodcastsIfNeeded() {
-        filterPodcasts(using: searchText)
+    private func loadPodcastsIfNeeded() async {
+        await filterPodcasts(using: searchText)
     }
 
-    private func loadPodcastsForSelectedFolder(_ folder: Folder) {
-        let podcasts = DataManager.sharedManager.allPodcastsInFolder(folder: folder)
-        let sorted = podcasts.sorted { lhs, rhs in
-            let lhsTitle = lhs.title ?? ""
-            let rhsTitle = rhs.title ?? ""
-            return lhsTitle.localizedCaseInsensitiveCompare(rhsTitle) == .orderedAscending
+    private func loadPodcastsForSelectedFolder(_ folder: Folder) async {
+        let sorted = await Task.detached {
+            let podcasts = DataManager.sharedManager.allPodcastsInFolder(folder: folder)
+            return podcasts.sorted { lhs, rhs in
+                let lhsTitle = lhs.title ?? ""
+                let rhsTitle = rhs.title ?? ""
+                return lhsTitle.localizedCaseInsensitiveCompare(rhsTitle) == .orderedAscending
+            }
+        }.value
+
+        await MainActor.run {
+            self.folderPodcasts = sorted
+            self.filteredFolderPodcasts = sorted
         }
-
-        folderPodcasts = sorted
-        filteredFolderPodcasts = sorted
     }
 
-    private func refreshPlaylistEpisodes() {
-        episodeCoordinator?.refreshPlaylistEpisodes()
+    private func refreshPlaylistEpisodes() async {
+        await episodeCoordinator?.refreshPlaylistEpisodes()
     }
 
     private func handleSearchTextChange(_ newValue: String) {
         switch searchMode {
         case .podcasts:
-            filterPodcasts(using: newValue)
+            Task {
+                await filterPodcasts(using: newValue)
+            }
         case .episodes:
             scheduleEpisodeSearch(with: newValue)
         }
     }
 
-    private func filterPodcasts(using term: String, disableAnimationsWhenClearing: Bool = true) {
+    private func filterPodcasts(using term: String, disableAnimationsWhenClearing: Bool = true) async {
         let trimmed = term.trimmingCharacters(in: .whitespacesAndNewlines)
 
         if selectedFolder != nil {
+            let folderPodcastsCopy = folderPodcasts
+            let filtered: [Podcast]
+
             if trimmed.isEmpty {
-                filteredFolderPodcasts = folderPodcasts
+                filtered = folderPodcastsCopy
             } else {
-                filteredFolderPodcasts = folderPodcasts.filter { podcast in
-                    guard let title = podcast.title else { return false }
-                    return title.localizedCaseInsensitiveContains(trimmed)
-                }
+                filtered = await Task.detached {
+                    folderPodcastsCopy.filter { podcast in
+                        guard let title = podcast.title else { return false }
+                        return title.localizedCaseInsensitiveContains(trimmed)
+                    }
+                }.value
+            }
+
+            await MainActor.run {
+                self.filteredFolderPodcasts = filtered
             }
         } else {
             guard let searchResultsModel else { return }

--- a/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
@@ -17,6 +17,9 @@ final class LocalSearchViewModel: ObservableObject {
     @Published private(set) var searchResultsPodcasts: [PodcastFolderSearchResult] = []
     @Published private(set) var disableLibraryAnimation = false
     @Published private(set) var defaultLibraryItems: [PodcastFolderSearchResult] = []
+    @Published private(set) var isLoadingDefaultLibrary = false
+    @Published private(set) var isLoadingFolderPodcasts = false
+    @Published private(set) var isLoadingPlaylistEpisodes = false
 
     let playlist: EpisodeFilter
 
@@ -67,6 +70,10 @@ final class LocalSearchViewModel: ObservableObject {
     }
 
     private func loadDefaultLibraryItems() async {
+        await MainActor.run {
+            self.isLoadingDefaultLibrary = true
+        }
+
         let items = await Task.detached {
             let sortOrder = Settings.homeFolderSortOrder()
             let items = HomeGridDataHelper.gridItems(orderedBy: sortOrder)
@@ -83,6 +90,7 @@ final class LocalSearchViewModel: ObservableObject {
 
         await MainActor.run {
             self.defaultLibraryItems = items
+            self.isLoadingDefaultLibrary = false
         }
     }
 
@@ -92,6 +100,17 @@ final class LocalSearchViewModel: ObservableObject {
 
     var hasAnyPodcastsInFolder: Bool {
         !folderPodcasts.isEmpty
+    }
+
+    var isPodcastListLoading: Bool {
+        switch podcastListMode {
+        case .library:
+            return isLoadingDefaultLibrary
+        case .folder:
+            return isLoadingFolderPodcasts
+        case .search:
+            return false // Search results use the searchResultsModel which handles its own loading
+        }
     }
 
     var navigationTitle: String {
@@ -139,10 +158,10 @@ final class LocalSearchViewModel: ObservableObject {
         selectedPodcast = podcast
         searchText = ""
 
+        episodeCoordinator?.preloadEpisodes(for: selectedPodcast)
+
         Task {
-            episodeCoordinator?.clearResults()
             await episodeCoordinator?.refreshPlaylistEpisodes()
-            episodeCoordinator?.preloadEpisodes(for: selectedPodcast)
         }
     }
 
@@ -311,6 +330,10 @@ final class LocalSearchViewModel: ObservableObject {
     }
 
     private func loadPodcastsForSelectedFolder(_ folder: Folder) async {
+        await MainActor.run {
+            self.isLoadingFolderPodcasts = true
+        }
+
         let sorted = await Task.detached {
             let podcasts = DataManager.sharedManager.allPodcastsInFolder(folder: folder)
             return podcasts.sorted { lhs, rhs in
@@ -323,11 +346,14 @@ final class LocalSearchViewModel: ObservableObject {
         await MainActor.run {
             self.folderPodcasts = sorted
             self.filteredFolderPodcasts = sorted
+            self.isLoadingFolderPodcasts = false
         }
     }
 
     private func refreshPlaylistEpisodes() async {
+        isLoadingPlaylistEpisodes = true
         await episodeCoordinator?.refreshPlaylistEpisodes()
+        isLoadingPlaylistEpisodes = false
     }
 
     private func handleSearchTextChange(_ newValue: String) {


### PR DESCRIPTION
Fixes [PCIOS-424](https://linear.app/a8c/issue/PCIOS-424/move-add-episode-loading-to-background-with-loading-states)

Adds async loading with loading indcators to the Add Episode screen in Manual Playlists.

https://github.com/user-attachments/assets/92f4afbf-052e-4f84-b1eb-40ab0f5e40b8

## To test

* Use a large database, ideally the 800MB+ one we have available
* Navigate to a Manual playlist
* ✅ Make sure the loading indicator is shown while podcasts load
* Tap a podcast
* ✅ Make sure the loading indicator is shown while episodes load
* Test searching Podcasts and Episodes
* ✅ Ensure empty states still appear when search doesn't match results

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
