### PR TITLE
Add settings cache reload

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -72,7 +72,8 @@ class PodcastDataManager {
         "folderUuid",
         "usedCustomEffectsBefore",
         "isPrivate",
-        "fundingURL"
+        "fundingURL",
+        "episodesInfoCacheReloadPolicy"
     ]
 
     func setup(dbQueue: PCDBQueue) {
@@ -745,6 +746,7 @@ class PodcastDataManager {
         values.append(podcast.usedCustomEffectsBefore)
         values.append(podcast.isPrivate)
         values.append(DBUtils.nullIfNil(value: podcast.fundingURL))
+        values.append(podcast.episodesInfoCacheReloadPolicy)
 
         if includeIdForWhere {
             values.append(podcast.id)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -868,6 +868,16 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 71 {
+            do {
+                try db.executeUpdate("ALTER TABLE SJPodcast ADD COLUMN episodesInfoCacheReloadPolicy INTEGER NOT NULL DEFAULT 0;", values: nil)
+                schemaVersion = 71
+            } catch {
+                failedAt(71)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
@@ -57,7 +57,7 @@ extension Podcast {
         podcast.usedCustomEffectsBefore = rs.bool(forColumn: "usedCustomEffectsBefore")
         podcast.isPrivate = rs.bool(forColumn: "isPrivate")
         podcast.fundingURL = rs.string(forColumn: "fundingURL")
-
+        podcast.episodesInfoCacheReloadPolicy = rs.int(forColumn: "episodesInfoCacheReloadPolicy")
         return podcast
     }
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -174,13 +174,11 @@ extension Podcast {
 }
 
 extension Podcast {
-    public enum EpisodeInfoCacheReloadPolicy: Int32 {
+    public enum EpisodeInfoCacheReloadPolicy: Int32, CaseIterable {
         case never = 0
         case weekly = 7
         case monthly = 1
-#if DEBUG
-        case debug = 30
-#endif
+        case debug = 15
     }
 
     public var episodesInfoCacheReloadPolicyType: Podcast.EpisodeInfoCacheReloadPolicy {
@@ -205,13 +203,15 @@ extension Podcast {
             component = .day
         case .monthly:
             component = .month
-#if DEBUG
         case .debug:
             component = .second
-#endif
         }
-        if let threshold = Calendar.current.date(byAdding: component, value: -Int(episodesInfoCacheReloadPolicyType.rawValue), to: now) {
-            return date < threshold
+        if let expiry = Calendar.current.date(
+            byAdding: component,
+            value: Int(episodesInfoCacheReloadPolicyType.rawValue),
+            to: date
+        ) {
+            return now >= expiry
         }
         return false
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -55,6 +55,7 @@ public class Podcast: NSObject, Identifiable {
     @objc public var usedCustomEffectsBefore = false
     @objc public var isPrivate = false
     @objc public var fundingURL: String?
+    @objc public var episodesInfoCacheReloadPolicy: Int32 = 0
 
     public var settings: PodcastSettings = PodcastSettings.defaults
 
@@ -169,5 +170,49 @@ extension TrimSilence {
 extension Podcast {
     public override var debugDescription: String {
         "Podcast: \(uuid) - \(title ?? "missing title")"
+    }
+}
+
+extension Podcast {
+    public enum EpisodeInfoCacheReloadPolicy: Int32 {
+        case never = 0
+        case weekly = 7
+        case monthly = 1
+#if DEBUG
+        case debug = 30
+#endif
+    }
+
+    public var episodesInfoCacheReloadPolicyType: Podcast.EpisodeInfoCacheReloadPolicy {
+        .init(rawValue: episodesInfoCacheReloadPolicy) ?? .never
+    }
+
+    /// Returns true if the given date is considered stale based on the podcast's episodesInfoCacheReloadPolicyType.
+    /// - Parameter date: The date to evaluate. If `nil`, this returns true for policies other than `.never`.
+    /// - Returns: `true` if the date is older than the threshold for the current policy (week/month), otherwise `false`.
+    public func isEpisodesInfoCacheStale(
+        since date: Date?,
+        now: Date = .now
+    ) -> Bool {
+        guard let date else { return true }
+
+        let component: Calendar.Component
+
+        switch episodesInfoCacheReloadPolicyType {
+        case .never:
+            return false
+        case .weekly:
+            component = .day
+        case .monthly:
+            component = .month
+#if DEBUG
+        case .debug:
+            component = .second
+#endif
+        }
+        if let threshold = Calendar.current.date(byAdding: component, value: -Int(episodesInfoCacheReloadPolicyType.rawValue), to: now) {
+            return date < threshold
+        }
+        return false
     }
 }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistDataManagerTests.swift
@@ -147,7 +147,10 @@ final class PlaylistDataManagerTests: XCTestCase {
         dataManager.updatePlaylistUpdateDate(for: newPlaylist1, to: date)
 
         let newPlaylist2 = try XCTUnwrap(dataManager.findPlaylist(uuid: newPlaylist1.uuid))
+        let newPlaylist2Date = try XCTUnwrap(newPlaylist2.playlistUpdateDate)
 
-        XCTAssertTrue(newPlaylist2.playlistUpdateDate == date)
+        XCTAssertEqual(newPlaylist2Date.timeIntervalSince1970,
+                       date.timeIntervalSince1970,
+                       accuracy: 0.001)
     }
 }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastDataManagerTests.swift
@@ -42,4 +42,41 @@ final class PodcastDataManagerTests: XCTestCase {
             }
         }
     }
+
+    func testEpisodesInfoCacheStaleNeverPolicyIsFalse() throws {
+        let podcast = Podcast()
+        podcast.episodesInfoCacheReloadPolicy = Podcast.EpisodeInfoCacheReloadPolicy.never.rawValue
+
+        let now = ISO8601DateFormatter().date(from: "2024-01-15T12:00:00Z")!
+
+        let oldDate = Calendar.current.date(byAdding: .year, value: -5, to: now)!
+
+        XCTAssertFalse(podcast.isEpisodesInfoCacheStale(since: oldDate, now: now))
+    }
+
+    func testEpisodesInfoCacheStaleWeeklyPolicyThresholds() throws {
+        let podcast = Podcast()
+        podcast.episodesInfoCacheReloadPolicy = Podcast.EpisodeInfoCacheReloadPolicy.weekly.rawValue
+
+        let now = ISO8601DateFormatter().date(from: "2024-01-15T12:00:00Z")!
+
+        let sixDaysAgo = Calendar.current.date(byAdding: .day, value: -6, to: now)!
+        let eightDaysAgo = Calendar.current.date(byAdding: .day, value: -8, to: now)!
+
+        XCTAssertFalse(podcast.isEpisodesInfoCacheStale(since: sixDaysAgo, now: now))
+        XCTAssertTrue(podcast.isEpisodesInfoCacheStale(since: eightDaysAgo, now: now))
+    }
+
+    func testEpisodesInfoCacheStaleMonthlyPolicyThresholds() throws {
+        let podcast = Podcast()
+        podcast.episodesInfoCacheReloadPolicy = Podcast.EpisodeInfoCacheReloadPolicy.monthly.rawValue
+
+        let now = ISO8601DateFormatter().date(from: "2024-03-31T12:00:00Z")!
+
+        let justUnderOneMonthAgo = Calendar.current.date(byAdding: .day, value: -29, to: now)!
+        let overOneMonthAgo = Calendar.current.date(byAdding: .month, value: -1, to: now)!.addingTimeInterval(-3600) // 1 hour more than one month ago
+
+        XCTAssertFalse(podcast.isEpisodesInfoCacheStale(since: justUnderOneMonthAgo, now: now))
+        XCTAssertTrue(podcast.isEpisodesInfoCacheStale(since: overOneMonthAgo, now: now))
+    }
 }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -19,7 +19,7 @@ public actor ShowInfoDataRetriever {
     ) async throws -> String? {
         if let cachedResponse = cachedResponse(for: podcastUuid, episodeUuid: episodeUuid),
            let metadata = extractMetadata(for: episodeUuid, from: cachedResponse.data) {
-            FileLog.shared.addMessage("Show Info: returning cached data for episode \(episodeUuid)")
+            FileLog.shared.addMessage("Show Info: returning cached data for episode \(episodeUuid) - podcast \(podcastUuid)")
             return metadata
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -17,16 +17,32 @@ public actor ShowInfoDataRetriever {
         for podcastUuid: String,
         episodeUuid: String
     ) async throws -> String? {
-        let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
-        let request = URLRequest(url: url)
-
-        if let cachedResponse = cache.cachedResponse(for: request),
-            let metadata = extractMetadata(for: episodeUuid, from: cachedResponse.data) {
+        if let cachedResponse = cachedResponse(for: podcastUuid, episodeUuid: episodeUuid),
+           let metadata = extractMetadata(for: episodeUuid, from: cachedResponse.data) {
             FileLog.shared.addMessage("Show Info: returning cached data for episode \(episodeUuid)")
             return metadata
         }
 
         return try await loadEpisodeData(for: podcastUuid, episodeUuid: episodeUuid)
+    }
+
+    public func cachedResponseDate(
+        for podcastUuid: String,
+        episodeUuid: String
+    ) async -> Date? {
+        if let cachedResponse = cachedResponse(for: podcastUuid, episodeUuid: episodeUuid),
+           let date = cachedResponse.response.date {
+           return date
+        }
+        return nil
+    }
+
+    public func deleteEpisodeDataFromCache(
+        for podcastUuid: String
+    ) async {
+        let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
+        let request = URLRequest(url: url)
+        cache.removeCachedResponse(for: request)
     }
 
     public func loadShowInfoData(
@@ -107,6 +123,19 @@ public actor ShowInfoDataRetriever {
             }
         }
 
+        return nil
+    }
+
+    private func cachedResponse(
+        for podcastUuid: String,
+        episodeUuid: String
+    ) -> CachedURLResponse? {
+        let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
+        let request = URLRequest(url: url)
+
+        if let cachedResponse = cache.cachedResponse(for: request) {
+            return cachedResponse
+        }
         return nil
     }
 }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -255,6 +255,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Uses the PlaylistMetadataLoader cache before running the query (the query will update when it's done)
     case playlistDataCacheBeforeQuery
 
+    /// Enables the podcast settings to reload the episode info
+    case reloadEpisodeInfoCachePolicy
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -429,6 +432,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .playlistDataCacheBeforeQuery:
             true
+        case .reloadEpisodeInfoCachePolicy:
+            false
         }
     }
 

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -36,6 +36,12 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         return metadata?.showNotes ?? CacheServerHandler.noShowNotesMessage
     }
 
+    public func deleteShowNotes(
+        for podcastUuid: String
+    ) async {
+        await dataRetriever.deleteEpisodeDataFromCache(for: podcastUuid)
+    }
+
     func loadEpisodeArtworkUrl(
         podcastUuid: String,
         episodeUuid: String
@@ -99,6 +105,10 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
             guard let self else { throw TaskError.nilSelf }
 
             do {
+                if FeatureFlag.reloadEpisodeInfoCachePolicy.enabled {
+                    await checkStaleCache(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+                }
+
                 let data = try await dataRetriever.loadEpisodeDataFromCache(for: podcastUuid, episodeUuid: episodeUuid)
                 await setRequestingShowInfoToNil(for: episodeUuid)
                 return await getShowInfo(for: data?.data(using: .utf8))
@@ -111,6 +121,19 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         requestingShowInfo[episodeUuid] = task
 
         return try await task.value
+    }
+
+    private func checkStaleCache(
+        podcastUuid: String,
+        episodeUuid: String
+    ) async {
+        if let date = await dataRetriever.cachedResponseDate(for: podcastUuid, episodeUuid: episodeUuid) {
+            let podcast = DataManager.sharedManager.findPodcast(uuid: podcastUuid, includeUnsubscribed: true)
+            if podcast?.isEpisodesInfoCacheStale(since: date) == true {
+                FileLog.shared.addMessage("Show Info: clearing cache for podcast \(podcastUuid)")
+                await dataRetriever.deleteEpisodeDataFromCache(for: podcastUuid)
+            }
+        }
     }
 
     private func setRequestingShowInfoToNil(for episodeUuid: String) {

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -105,11 +105,7 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
             guard let self else { throw TaskError.nilSelf }
 
             do {
-                if FeatureFlag.reloadEpisodeInfoCachePolicy.enabled {
-                    await checkStaleCache(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
-                }
-
-                let data = try await dataRetriever.loadEpisodeDataFromCache(for: podcastUuid, episodeUuid: episodeUuid)
+                let data = try await refreshAndLoadFromCache(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
                 await setRequestingShowInfoToNil(for: episodeUuid)
                 return await getShowInfo(for: data?.data(using: .utf8))
             } catch {
@@ -123,16 +119,28 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         return try await task.value
     }
 
+    private func refreshAndLoadFromCache(podcastUuid: String, episodeUuid: String) async throws -> String? {
+        if FeatureFlag.reloadEpisodeInfoCachePolicy.enabled {
+            await checkStaleCache(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+        }
+        return try await dataRetriever.loadEpisodeDataFromCache(for: podcastUuid, episodeUuid: episodeUuid)
+    }
+
     private func checkStaleCache(
         podcastUuid: String,
         episodeUuid: String
     ) async {
-        if let date = await dataRetriever.cachedResponseDate(for: podcastUuid, episodeUuid: episodeUuid) {
-            let podcast = DataManager.sharedManager.findPodcast(uuid: podcastUuid, includeUnsubscribed: true)
-            if podcast?.isEpisodesInfoCacheStale(since: date) == true {
-                FileLog.shared.addMessage("Show Info: clearing cache for podcast \(podcastUuid)")
-                await dataRetriever.deleteEpisodeDataFromCache(for: podcastUuid)
-            }
+        guard
+            NetworkUtils.shared.isConnected(),
+            let date = await dataRetriever.cachedResponseDate(for: podcastUuid, episodeUuid: episodeUuid)
+        else {
+            return
+        }
+
+        let podcast = DataManager.sharedManager.findPodcast(uuid: podcastUuid, includeUnsubscribed: true)
+        if podcast?.isEpisodesInfoCacheStale(since: date) == true {
+            FileLog.shared.addMessage("Show Info: clearing cache for podcast \(podcastUuid)")
+            await dataRetriever.deleteEpisodeDataFromCache(for: podcastUuid)
         }
     }
 

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -197,6 +197,14 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
             cell.buttonTitle.text = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
             cell.buttonTitle.textColor = ThemeColor.support05()
             return cell
+        case .episodeInfoCachePolicy:
+            let cell = tableView.dequeueReusableCell(withIdentifier: PodcastSettingsViewController.disclosureCellId, for: indexPath) as! DisclosureCell
+            cell.cellLabel.text = L10n.episodesInfoCacheReloadTitle
+            cell.setImage(imageName: nil)
+
+            cell.cellSecondaryLabel.text = podcast.episodesInfoCacheReloadPolicyType.title
+
+            return cell
         }
     }
 
@@ -206,6 +214,8 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
         let row = tableData()[indexPath.section][indexPath.row]
         if row == .upNextPosition {
             showAutoAddPositionSettings()
+        } else if row == .episodeInfoCachePolicy {
+            showEpisodeInfoCachePolicy()
         } else if row == .feedError {
             Analytics.track(.podcastSettingsFeedErrorTapped)
 
@@ -307,6 +317,8 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
         } else if firstRow == .siriShortcut, let name = podcast.title {
             let format = existingShortcut != nil ? L10n.settingsSiriShortcutMsg : L10n.settingsCreateSiriShortcutMsg
             return format(name)
+        } else if firstRow == .episodeInfoCachePolicy {
+            return L10n.episodesInfoCacheReloadSubtitle
         }
 
         return nil
@@ -341,6 +353,29 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
         settingsTable.reloadData()
 
         Analytics.track(.podcastSettingsAutoAddUpNextPositionOptionChanged, properties: ["value": setting])
+    }
+
+    // MARK: - Episode Info Cache Policy
+
+    private func showEpisodeInfoCachePolicy() {
+        let positionPicker = OptionsPicker(title: L10n.episodesInfoCacheReloadTitle.uppercased())
+#if DEBUG
+        let reloadPolicies: [Podcast.EpisodeInfoCacheReloadPolicy] = Podcast.EpisodeInfoCacheReloadPolicy.allCases
+#else
+        let reloadPolicies: [Podcast.EpisodeInfoCacheReloadPolicy] = [.never, .weekly, .monthly]
+#endif
+        reloadPolicies.forEach { policy in
+            let selected = policy == podcast.episodesInfoCacheReloadPolicyType
+            let action = OptionAction(label: policy.title.capitalized, icon: nil, selected: selected) { [weak self] in
+                guard let self else { return }
+                self.podcast.episodesInfoCacheReloadPolicy = policy.rawValue
+                self.settingsTable.reloadData()
+                DataManager.sharedManager.save(podcast: self.podcast)
+            }
+            positionPicker.addAction(action: action)
+        }
+
+        positionPicker.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     // MARK: - Settings changes
@@ -401,6 +436,11 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
         if playlistsPodcastCanAppearIn().count > 0 {
             data.append([.inFilters])
         }
+
+        if FeatureFlag.reloadEpisodeInfoCachePolicy.enabled {
+            data.append([.episodeInfoCachePolicy])
+        }
+
         data.append([.siriShortcut])
         data.append([.unsubscribe])
 
@@ -427,5 +467,16 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
         viewController.delegate = self
         present(viewController, animated: true, completion: nil)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.openingNonOverlayableWindow)
+    }
+}
+
+extension Podcast.EpisodeInfoCacheReloadPolicy {
+    public var title: String {
+        switch self {
+        case .never: return L10n.timeFormatNever
+        case .weekly: return L10n.releaseFrequencyWeekly
+        case .monthly: return L10n.releaseFrequencyMonthly
+        case .debug: return "Debug"
+        }
     }
 }

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -202,7 +202,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
             cell.cellLabel.text = L10n.episodesInfoCacheReloadTitle
             cell.setImage(imageName: "eac_listening_history_banner", tintColor: podcast.iconTintColor())
 
-            cell.cellSecondaryLabel.text = podcast.episodesInfoCacheReloadPolicyType.title
+            cell.cellSecondaryLabel.text = podcast.episodesInfoCacheReloadPolicyType.title.capitalized
 
             return cell
         }

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -200,7 +200,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
         case .episodeInfoCachePolicy:
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastSettingsViewController.disclosureCellId, for: indexPath) as! DisclosureCell
             cell.cellLabel.text = L10n.episodesInfoCacheReloadTitle
-            cell.setImage(imageName: nil)
+            cell.setImage(imageName: "eac_listening_history_banner", tintColor: podcast.iconTintColor())
 
             cell.cellSecondaryLabel.text = podcast.episodesInfoCacheReloadPolicyType.title
 

--- a/podcasts/PodcastSettingsViewController.swift
+++ b/podcasts/PodcastSettingsViewController.swift
@@ -9,7 +9,7 @@ class PodcastSettingsViewController: PCViewController {
 
     let debounce = Debounce(delay: Constants.defaultDebounceTime)
 
-    enum TableRow { case autoDownload, notifications, upNext, globalUpNext, upNextPosition, playbackEffects, skipFirst, skipLast, autoArchive, inFilters, siriShortcut, unsubscribe, feedError }
+    enum TableRow { case autoDownload, notifications, upNext, globalUpNext, upNextPosition, playbackEffects, skipFirst, skipLast, autoArchive, inFilters, siriShortcut, unsubscribe, feedError, episodeInfoCachePolicy }
 
     var existingShortcut: Any?
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1218,6 +1218,10 @@ internal enum L10n {
   internal static var episodeUnavailableTitle: String { return L10n.tr("Localizable", "episode_unavailable_title", fallback: "Episode Unavailable") }
   /// Refers to an Episode in the plural form.
   internal static var episodes: String { return L10n.tr("Localizable", "episodes", fallback: "Episodes") }
+  /// Podcast settings subtitle used to set the timing to reload the episodes info cache
+  internal static var episodesInfoCacheReloadSubtitle: String { return L10n.tr("Localizable", "episodes_info_cache_reload_subtitle", fallback: "Set how frequently episode info cache should be refreshed") }
+  /// Podcast settings title used to set the timing to reload the episodes info cache
+  internal static var episodesInfoCacheReloadTitle: String { return L10n.tr("Localizable", "episodes_info_cache_reload_title", fallback: "Episodes Info Refresh Time") }
   /// A common string used throughout the app. Generic title informing the user of an Error. Accompanied with an error message.
   internal static var error: String { return L10n.tr("Localizable", "error", fallback: "Error") }
   /// A common string used throughout the app. Generic title informing the user of an Error. General error message used when the app is unable to locate the podcast that was selected. This usually comes from a sharing or import feature.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5811,3 +5811,9 @@
 
 /* Message to shown when playback 2025 failed to load */
 "playback_2025_failed_to_load" = "Sorry, we couldn’t load Playback";
+
+/* Podcast settings title used to set the timing to reload the episodes info cache */
+"episodes_info_cache_reload_title" = "Episodes Info Refresh Time";
+
+/* Podcast settings subtitle used to set the timing to reload the episodes info cache */
+"episodes_info_cache_reload_subtitle" = "Set how frequently episode info cache should be refreshed";


### PR DESCRIPTION
Fixes PCIOS-398

So far episodes info are cached and never reloaded unless the system clears our cache or the user re-install the app. This PR adds the possibility to set a threshold for each podcast to reload the episodes info weekly or monthly.

| Podcast Settings | Options |
| :-------: | :-------: |
| <img width="590" height="1278" alt="IMG_0551" src="https://github.com/user-attachments/assets/8ed33e69-c177-4744-bd0b-f62eaf253dec" /> | <img width="590" height="1278" alt="IMG_0552" src="https://github.com/user-attachments/assets/17258728-4439-427a-b4ed-b94db6fa288a" /> |

This is base on this original PR from Daniele: https://github.com/Automattic/pocket-casts-ios/pull/3792

## To test

- Run this branch and enable `reloadEpisodeInfoCachePolicy` FF
- Go to a podcast and open its settings
- You should see the Settings `Episodes Info Refresh Time` with the option `Never` set
- Tap on it and select `Debug`
- This set the debug option to reload the Episodes Info when opening an episode detail if 15 seconds have passed
- Open the podcast episodes detail
- After loading the episode info re-open the same episode or a new one
- Within the 15 seconds you should get the cached version
- If the threshold is passed you should see the info getting reloaded
- You can also check the logs to help you understand when the cached is returned or when the API is called

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
