### PR TITLE
Widget logging update and ensure is run on background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add Deselect action from long press [#3786](https://github.com/Automattic/pocket-casts-ios/pull/3786)
 - Fix WatchManager to only report unknown message if it was truly unknown / unprocessed [#3748](https://github.com/Automattic/pocket-casts-ios/issues/3748)
 - Improves Add Episode performance [#3842](https://github.com/Automattic/pocket-casts-ios/pull/3842)
+- Ensure widget playback intent runs in the background [#3846](https://github.com/Automattic/pocket-casts-ios/pull/3846)
 
 8.2
 -----

--- a/podcasts/PlayEpisodeIntent.swift
+++ b/podcasts/PlayEpisodeIntent.swift
@@ -15,6 +15,11 @@ struct PlayEpisodeIntent: AudioPlaybackIntent {
 
     init() {}
 
+    static var openAppWhenRun: Bool { return false }
+
+    @available(iOS 26.0, *)
+    static var supportedModes: IntentModes { return [.background] }
+
     @MainActor
     func perform() async throws -> some IntentResult {
 

--- a/podcasts/PlayEpisodeIntent.swift
+++ b/podcasts/PlayEpisodeIntent.swift
@@ -1,5 +1,6 @@
 import AppIntents
 import WidgetKit
+import PocketCastsUtils
 
 @available(iOS 17, *)
 struct PlayEpisodeIntent: AudioPlaybackIntent {
@@ -22,7 +23,7 @@ struct PlayEpisodeIntent: AudioPlaybackIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult {
-
+        FileLog.shared.addMessage("PlayEpisodeIntent perform called for episode \(episodeUuid)")
         intentPlayback(episodeUuid)
 
         return .result()

--- a/podcasts/WidgetPlayEpisodeIntentExtension.swift
+++ b/podcasts/WidgetPlayEpisodeIntentExtension.swift
@@ -1,8 +1,9 @@
+import PocketCastsUtils
 // Placeholder so that PlayEpisodeIntent can compile in widget extension, but never actually executes
 // because it is a subclass of AudioPlaybackIntent which only runs in the app.
 @available(iOS 17, *)
 extension PlayEpisodeIntent {
     func intentPlayback(_ episodeUuid: String) {
-        print("In Widget intent extension \(episodeUuid)")
+        FileLog.shared.addMessage("PlayEpisodeIntent error: In Widget intent extension \(episodeUuid)")
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the Intent code for ensure that runs in background mode and we have extra logging

## To test

1. Start the app in a real device
2. Add some episode to the UpNext queue
3. Add an Up Next widget to the device that shows the current episode and the next ones
4. Kill the app
5. On the device widget tap play on one of the episodes
6. Check that plays correctly and the app is not sent to the foreground. 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
