### PR TITLE
Fix memory release on export progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 -----
 - Add Deselect action from long press [#3786](https://github.com/Automattic/pocket-casts-ios/pull/3786)
 
+8.2.1
+-----
+- Fix memory release issue [#3847](https://github.com/Automattic/pocket-casts-ios/pull/3847)
+
 8.2
 -----
 - Playlists: introduce DiffableKit to handle cell reloading [#3784](https://github.com/Automattic/pocket-casts-ios/pull/3784)

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -272,6 +272,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Optimizes manual playlist queries with improved deduplication
     case optimizeManualPlaylistQueries
 
+    /// Use a background queue for streaming callbacks
+    case useBackgroundQueueForStreamingCallback
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -457,6 +460,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .useCellularNetworkApis:
 			true
         case .optimizeManualPlaylistQueries:
+            true
+        case .useBackgroundQueueForStreamingCallback:
             true
         }
     }

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -319,6 +319,12 @@ class DownloadManager: NSObject, FilePathProtocol {
         return
     }
 
+    private class ExportStatus {
+        var completed: Bool = false
+        var reportedType: String?
+        var error: Error?
+    }
+
     func downloadParallelToStream(of episode: BaseEpisode) -> AVPlayerItem? {
         guard let playbackItem = PlaybackItem(episode: episode).createPlayerItem() else {
             return nil
@@ -370,24 +376,22 @@ class DownloadManager: NSObject, FilePathProtocol {
         let outputURL = URL(fileURLWithPath: tempPathForEpisode(episode), isDirectory: false)
         FileLog.shared.addMessage("DownloadManager stream and download: start downloading \(episode.uuid)")
         let exportPath = outputURL.pathComponents.joined(separator: "/")
-        var exportCompleted = false
-        var downloadError: Error?
-        var reportedContentType: String?
+        let exportStatus =  ExportStatus()
         let originalSizeInBytes = episode.sizeInBytes
-        let customLoaderDelegate = MediaExporterResourceLoaderDelegate(saveFilePath: exportPath) { [weak self] status, contentType, bytesDownloaded, bytesExpected in
+        let customLoaderDelegate = MediaExporterResourceLoaderDelegate(saveFilePath: exportPath) { [weak self, exportStatus] status, contentType, bytesDownloaded, bytesExpected in
             guard let self else {
                 return
             }
-            reportedContentType = contentType
+            exportStatus.reportedType = contentType
             let size = max(100, max(bytesExpected, originalSizeInBytes))
             switch status {
             case .downloading:
                 self.reportProgress(episodeUUID: downloadTaskUUID, totalBytesWritten: bytesDownloaded, totalBytesExpectedToWrite: size)
             case .failed(let error):
-                downloadError = error
-                exportCompleted = true
+                exportStatus.error = error
+                exportStatus.completed = true
             case .completed:
-                exportCompleted = true
+                exportStatus.completed = true
             }
         }
         downloadAndStreamEpisodes[downloadTaskUUID] = customLoaderDelegate
@@ -398,7 +402,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         newAsset.resourceLoader.setDelegate(customLoaderDelegate, queue: .global(qos: .default))
         newItem = AVPlayerItem(asset: newAsset)
         Task {
-            while !exportCompleted {
+            while !exportStatus.completed {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
             downloadingEpisodesCache[downloadTaskUUID] = nil
@@ -407,13 +411,13 @@ class DownloadManager: NSObject, FilePathProtocol {
             guard let episode = dataManager.findBaseEpisode(uuid: downloadTaskUUID) else {
                 return
             }
-            if downloadError == nil {
+            if exportStatus.error == nil {
                 FileLog.shared.addMessage("DownloadManager stream and download: end downloading \(episode.uuid) successfully")
-                processEpisode(episode, downloadedFile: outputURL, reportedContentType: reportedContentType)
+                processEpisode(episode, downloadedFile: outputURL, reportedContentType: exportStatus.reportedType)
             } else {
-                FileLog.shared.addMessage("DownloadManager stream and download: failed downloading \(episode.uuid) -> \(downloadError?.localizedDescription ?? "")")
+                FileLog.shared.addMessage("DownloadManager stream and download: failed downloading \(episode.uuid) -> \(exportStatus.error?.localizedDescription ?? "")")
                 wasDownloadingBefore = episode.downloading()
-                DataManager.sharedManager.saveEpisode(downloadStatus: .notDownloaded, downloadError: downloadError?.localizedDescription, downloadTaskId: nil, episode: episode)
+                DataManager.sharedManager.saveEpisode(downloadStatus: .notDownloaded, downloadError: exportStatus.error?.localizedDescription, downloadTaskId: nil, episode: episode)
                 DataManager.sharedManager.saveEpisode(autoDownloadStatus: .notSpecified, episode: episode)
                 if wasDownloadingBefore {
                     DownloadManager.shared.addToQueue(episodeUuid: episode.uuid, autoDownloadStatus: .autoDownloaded)

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -394,10 +394,10 @@ class DownloadManager: NSObject, FilePathProtocol {
                 exportStatus.completed = true
             }
         }
-        downloadAndStreamEpisodes[downloadTaskUUID] = customLoaderDelegate
         guard let customURL = MediaExporterResourceLoaderDelegate.makeCustomURL(urlAsset.url) else {
             return newItem
         }
+        downloadAndStreamEpisodes[downloadTaskUUID] = customLoaderDelegate
         let newAsset = AVURLAsset(url: customURL)
         newAsset.resourceLoader.setDelegate(customLoaderDelegate, queue: .global(qos: .default))
         newItem = AVPlayerItem(asset: newAsset)

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -50,7 +50,12 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     private let saveFilePath: String
     private let callback: FileExporterProgressReport?
     private lazy var callbackQueue: DispatchQueue = {
-        let queue = DispatchQueue(label: "com.pocketcasts.MediaExporterResourceLoaderDelegate.callback", qos: .default, attributes: [])
+        let queue: DispatchQueue
+        if FeatureFlag.useBackgroundQueueForStreamingCallback.enabled {
+            queue = DispatchQueue(label: "com.pocketcasts.MediaExporterResourceLoaderDelegate.callback", qos: .default, attributes: [])
+        } else {
+            queue = DispatchQueue.main
+        }
         return queue
     }()
 

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -117,7 +117,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         writeBufferDataToFileIfNeeded()
         processPendingRequests()
         let contentType = response?.mimeType
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        DispatchQueue.global(qos: .default).async { [weak self] in
             guard let self else { return }
             self.callback?(.downloading, contentType, Int64(self.fileHandle.fileSize), dataTask.countOfBytesExpectedToReceive)
         }

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -256,6 +256,9 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             if FeatureFlag.streamAndDownloadReadFromMemoryBuffer.enabled, currentOffset < bufferData.count + bytesCached {
                 let start = currentOffset - bytesCached
                 let end = min(currentOffset + requestedLength - bytesCached, bufferData.count)
+                if start >= end {
+                    return false
+                }
                 let dataRequested = bufferData.subdata(in: start..<end)
                 dataRequest.respond(with: dataRequested)
                 return end - start >= requestedLength

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -49,6 +49,10 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
     private let saveFilePath: String
     private let callback: FileExporterProgressReport?
+    private lazy var callbackQueue: DispatchQueue = {
+        let queue = DispatchQueue(label: "com.pocketcasts.MediaExporterResourceLoaderDelegate.callback", qos: .default, attributes: [])
+        return queue
+    }()
 
     enum FileExportStatus {
         case downloading
@@ -117,7 +121,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         writeBufferDataToFileIfNeeded()
         processPendingRequests()
         let contentType = response?.mimeType
-        DispatchQueue.global(qos: .default).async { [weak self] in
+        callbackQueue.async { [weak self] in
             guard let self else { return }
             self.callback?(.downloading, contentType, Int64(self.fileHandle.fileSize), dataTask.countOfBytesExpectedToReceive)
         }
@@ -295,7 +299,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
         isDownloadComplete = true
         let contentType = self.response?.mimeType
-        DispatchQueue.main.async {
+        callbackQueue.async {
             self.callback?(.completed, contentType, Int64(self.fileHandle.fileSize), Int64(self.fileHandle.fileSize))
         }
     }
@@ -347,7 +351,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: Download failed with error: \(error)")
         invalidateAndCancelSession(error: error)
         let contentType = self.response?.mimeType
-        DispatchQueue.main.async { [weak self] in
+        callbackQueue.async { [weak self] in
             guard let self else { return }
             self.callback?(.failed(error), contentType, 0, 0)
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-426 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This tries to ensure that the exporter status variables are kept in memory while the exporter process is run.

This changes ensure that all callback from the exporter are executed on the same queue so there is no early release on complete of exporter while progress is still being reported.

## To test

- Start the app
- Play an episode that is not downloaded
- Check the playback is correct
- Check that the if you press download on that episode while it's being played progress is reported correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
