### PR TITLE
Attempted playback fix

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -272,6 +272,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Optimizes manual playlist queries with improved deduplication
     case optimizeManualPlaylistQueries
 
+    /// Moves the shouldKeepPlaying after we check that the episode is over
+    case checkFinishedTimeBeforeShouldKeepPlaying
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -457,6 +460,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .useCellularNetworkApis:
 			true
         case .optimizeManualPlaylistQueries:
+            true
+        case .checkFinishedTimeBeforeShouldKeepPlaying:
             true
         }
     }

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -701,7 +701,9 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         playToEndObserver = nc.addObserver(forName: NSNotification.Name.AVPlayerItemDidPlayToEndTime, object: nil, queue: nil) { [weak self] notification in
             guard let self = self else { return }
 
-            self.shouldKeepPlaying = false
+            if !FeatureFlag.checkFinishedTimeBeforeShouldKeepPlaying.enabled {
+                self.shouldKeepPlaying = false
+            }
 
             if let itemThatFinished = notification.object as? AVPlayerItem {
                 let duration = CMTimeGetSeconds(itemThatFinished.duration)
@@ -710,6 +712,10 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
                     FileLog.shared.addMessage("Item didn't actually finish got to \(upTo) of \(duration)")
                     return
                 }
+            }
+
+            if FeatureFlag.checkFinishedTimeBeforeShouldKeepPlaying.enabled {
+                self.shouldKeepPlaying = false
             }
 
             PlaybackManager.shared.playerDidFinishPlayingEpisode()

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -712,9 +712,26 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
                 let buffered = self.futureBufferAvailable()
                 let isBuffering = self.buffering()
 
+                // Check if this is a spurious notification (more than 5% away from end)
+                // If it is, we do not want to reset shouldKeepPlaying and will let the player continue on its way
                 if duration > upTo + (duration * 0.05) {
                     FileLog.shared.addMessage("Item didn't actually finish got to \(upTo) of \(duration). Buffered: \(buffered)s, isBuffering: \(isBuffering), loadedTimeRanges: \(itemThatFinished.loadedTimeRanges)")
+
+                    // If buffer is empty, this is likely a streaming issue - let the stall handler deal with it
+                    if itemThatFinished.isPlaybackBufferEmpty {
+                        FileLog.shared.addMessage("Spurious end notification detected: buffer empty, treating as playback stall")
+                    }
+
                     return
+                }
+
+                if FeatureFlag.checkFinishedTimeBeforeShouldKeepPlaying.enabled {
+                    // Additional safeguard: check if buffer is empty (shouldn't be if truly finished)
+                    // A truly finished item should have reached the end naturally, not due to buffer exhaustion
+                    if itemThatFinished.isPlaybackBufferEmpty && !itemThatFinished.isPlaybackLikelyToKeepUp {
+                        FileLog.shared.addMessage("Item reports finished but buffer is empty and playback unlikely to keep up - ignoring")
+                        return
+                    }
                 }
             }
 

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -708,8 +708,12 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             if let itemThatFinished = notification.object as? AVPlayerItem {
                 let duration = CMTimeGetSeconds(itemThatFinished.duration)
                 let upTo = CMTimeGetSeconds(itemThatFinished.currentTime())
+
+                let buffered = self.futureBufferAvailable()
+                let isBuffering = self.buffering()
+
                 if duration > upTo + (duration * 0.05) {
-                    FileLog.shared.addMessage("Item didn't actually finish got to \(upTo) of \(duration)")
+                    FileLog.shared.addMessage("Item didn't actually finish got to \(upTo) of \(duration). Buffered: \(buffered)s, isBuffering: \(isBuffering), loadedTimeRanges: \(itemThatFinished.loadedTimeRanges)")
                     return
                 }
             }


### PR DESCRIPTION
Fixes [PCIOS-417](https://linear.app/a8c/issue/PCIOS-417/playback-stops-with-no-obvious-interruptions)

I wasn't able to reproduce this but I think we should move the `shouldKeepPlaying` until after we detect the actual end. The user's logs indicate we hit the "Item didn't actually finish" log:

```
Item didn't actually finish got to 419.03020408163263 of 3231.529795918367
```

## To test

* Stream episode over cellular and make sure playback works
* Stream episode over throttled connection in the simulator and make sure playback works

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
