### PR TITLE
Feature Flag: Remove `use_sync_response_episode_ids` feature flag

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
@@ -105,11 +105,7 @@ extension BackgroundSyncManager: URLSessionDelegate, URLSessionDownloadDelegate 
             // this is slightly problematic because this might not return the list that was originally synced, but also we can't store that in memory because the app can be killed between start and finish
             // if this turns out to be an issue we could perhaps persist the UUIDs to UserDefaults, or come up with some other solution to this
             let episodesSynced: [Episode]
-            if FeatureFlag.useSyncResponseEpisodeIDs.enabled {
-                episodesSynced = DataManager.sharedManager.unsyncedEpisodes(limit: ServerConstants.Limits.maxEpisodesToSync)
-            } else {
-                episodesSynced = []
-            }
+            episodesSynced = DataManager.sharedManager.unsyncedEpisodes(limit: ServerConstants.Limits.maxEpisodesToSync)
             _ = syncTask.processSyncData(data, httpStatus: httpCode, episodesToSync: episodesSynced)
         }
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -35,9 +35,7 @@ extension SyncTask {
             }
         }
 
-        if FeatureFlag.useSyncResponseEpisodeIDs.enabled {
-            DataManager.sharedManager.markAllSynced(episodeIDs: episodesToImport.map({ $0.uuid }))
-        }
+        DataManager.sharedManager.markAllSynced(episodeIDs: episodesToImport.map({ $0.uuid }))
 
         totalToImport = podcastsToImport.count
         NotificationCenter.default.post(name: ServerNotifications.syncProgressPodcastCount, object: totalToImport)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -211,9 +211,6 @@ class SyncTask: ApiBaseTask {
 
         do {
             DataManager.sharedManager.markAllPodcastsSynced()
-            if !FeatureFlag.useSyncResponseEpisodeIDs.enabled {
-                DataManager.sharedManager.markAllSynced(episodes: episodesToSync)
-            }
             DataManager.sharedManager.markAllPlaylistsSynced()
             DataManager.sharedManager.markAllFoldersSynced()
 

--- a/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+Episodes.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/SyncTaskTests+Episodes.swift
@@ -8,7 +8,6 @@ final class SyncTaskTests_EpisodeImport: XCTestCase {
 
     override func setUp() {
         syncTask = SyncTask(dataManager: DataManager.sharedManager)
-        FeatureFlagMock().set(.useSyncResponseEpisodeIDs, value: true)
     }
 
     override func tearDown() {

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -116,9 +116,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Show Manage Downloaded episode banner/modal when running in low space in the device
     case manageDownloadedEpisodes
 
-    /// Uses the episode IDs from the server's response rather than our local database IDs
-    case useSyncResponseEpisodeIDs
-
     /// Disables logout / keychain clearing when errors occur in the background
     case avoidLogoutInBackground
 
@@ -347,8 +344,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .manageDownloadedEpisodes:
 			true
-        case .useSyncResponseEpisodeIDs:
-            true
         case .avoidLogoutInBackground:
             true
         case .disablePrivateFeedSharing:


### PR DESCRIPTION
remove `use_sync_response_episode_ids` feature flag

## To test

* Make sure syncing Up Next episodes works properly between two devices

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
