### PR TITLE
Feature Flag: Remove `error_logout_handling` feature flag

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -109,17 +109,13 @@ class TokenHelper {
             if isApplicationBackgrounded() {
                 FileLog.shared.addMessage("TokenHelper: Skipped logout in background due to error: \(String(describing: error))")
             } else {
-                if ServerConfig.avoidLogoutOnError {
-                    // if the user doesn't have an email and password or SSO token, they aren't going to be able to acquire a sync token
-                    switch error as? APIError {
-                    case APIError.TOKEN_DEAUTH?, APIError.PERMISSION_DENIED?:
-                        tokenCleanUp()
-                    default:
-                        // Do nothing so the user is not disrupted in the case of non-auth errors
-                        FileLog.shared.addMessage("TokenHelper: Unable to acquire token but avoided logout due to error: \(String(describing: error))")
-                    }
-                } else {
+                // if the user doesn't have an email and password or SSO token, they aren't going to be able to acquire a sync token
+                switch error as? APIError {
+                case APIError.TOKEN_DEAUTH?, APIError.PERMISSION_DENIED?:
                     tokenCleanUp()
+                default:
+                    // Do nothing so the user is not disrupted in the case of non-auth errors
+                    FileLog.shared.addMessage("TokenHelper: Unable to acquire token but avoided logout due to error: \(String(describing: error))")
                 }
             }
 
@@ -189,18 +185,12 @@ class TokenHelper {
                 SyncManager.signout()
             }
 
-            if ServerConfig.avoidLogoutOnError {
-                let errorResponse = ApiServerHandler.extractErrorResponse(data: responseData, response: response, error: nil)
-                throw errorResponse ?? .UNKNOWN
-            }
+            let errorResponse = ApiServerHandler.extractErrorResponse(data: responseData, response: response, error: nil)
+            throw errorResponse ?? .UNKNOWN
         } catch let error {
             FileLog.shared.addMessage("TokenHelper acquireToken failed \(error.localizedDescription)")
-            if ServerConfig.avoidLogoutOnError {
-                throw error
-            }
+            throw error
         }
-
-        return nil
     }
 
 
@@ -213,10 +203,8 @@ class TokenHelper {
                 return
             }
         } catch let error {
-            if ServerConfig.avoidLogoutOnError {
-                completion(.failure(error))
-                return
-            }
+            completion(.failure(error))
+            return
         }
 
         Task {

--- a/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -199,18 +199,16 @@ public extension ApiServerHandler {
             }
         #endif
 
-        if ServerConfig.avoidLogoutOnError {
-            switch statusCode {
-            case 400, 401:
-                // The request or token is likely broken. Trying again could work.
-                return APIError.TOKEN_DEAUTH
-            case 403:
-                // This is specifically due to permissions issues. It is unlikely a retry on this request would succeed. Not sure how this would apply to the `/token` endpoint.
-                // See https://web.archive.org/web/20190904190534/https://www.dirv.me/blog/2011/07/18/understanding-403-forbidden/index.html
-                return APIError.PERMISSION_DENIED
-            default:
-                ()
-            }
+        switch statusCode {
+        case 400, 401:
+            // The request or token is likely broken. Trying again could work.
+            return APIError.TOKEN_DEAUTH
+        case 403:
+            // This is specifically due to permissions issues. It is unlikely a retry on this request would succeed. Not sure how this would apply to the `/token` endpoint.
+            // See https://web.archive.org/web/20190904190534/https://www.dirv.me/blog/2011/07/18/understanding-403-forbidden/index.html
+            return APIError.PERMISSION_DENIED
+        default:
+            ()
         }
 
         return nil

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerConfig.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerConfig.swift
@@ -3,8 +3,6 @@ import Foundation
 public class ServerConfig {
     public static let shared = ServerConfig()
 
-    public static var avoidLogoutOnError = false
-
     private var backgroundSessionHandler: (() -> Void)?
 
     // MARK: - App values required for Server communication

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -14,9 +14,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Whether End Of Year feature is enabled
     case endOfYear
 
-    /// Avoid logging out user on non-authorization HTTP errors
-    case errorLogoutHandling
-
     /// Store settings as JSON in User Defaults (global) or SQLite (podcast)
     case newSettingsStorage
 
@@ -282,8 +279,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .firebaseLogging:
             false
         case .endOfYear:
-            false
-        case .errorLogoutHandling:
             false
         case .newSettingsStorage:
             shouldEnableSyncedSettings

--- a/Pocket Casts App Clip/AppClipAppDelegate.swift
+++ b/Pocket Casts App Clip/AppClipAppDelegate.swift
@@ -36,17 +36,11 @@ class AppClipAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
 
         FirebaseManager.refreshRemoteConfig() { [weak self] status in
             self?.updateRemoteFeatureFlags()
-            ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
         }
     }
 
     private func updateRemoteFeatureFlags(forceReload: Bool = false) {
         guard BuildEnvironment.current != .debug || forceReload else { return }
-
-        if FeatureFlag.errorLogoutHandling.enabled != Settings.errorLogoutHandling {
-            ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
-            try? FeatureFlagOverrideStore().override(FeatureFlag.errorLogoutHandling, withValue: Settings.errorLogoutHandling)
-        }
 
         try? FeatureFlagOverrideStore().override(FeatureFlag.slumber, withValue: Settings.slumberPromoCode?.isEmpty == false)
 

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -325,17 +325,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         FirebaseManager.refreshRemoteConfig() { [weak self] status in
             self?.updateEndOfYearRemoteValue()
             self?.updateRemoteFeatureFlags()
-            ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
         }
     }
 
     func updateRemoteFeatureFlags(forceReload: Bool = false) {
         guard BuildEnvironment.current != .debug || forceReload else { return }
-
-        if FeatureFlag.errorLogoutHandling.enabled != Settings.errorLogoutHandling {
-            ServerConfig.avoidLogoutOnError = FeatureFlag.errorLogoutHandling.enabled
-            try? FeatureFlagOverrideStore().override(FeatureFlag.errorLogoutHandling, withValue: Settings.errorLogoutHandling)
-        }
 
         if FeatureFlag.newSettingsStorage.enabled != Settings.newSettingsStorage {
             if FeatureFlag.newSettingsStorage.enabled {


### PR DESCRIPTION
Remove `error_logout_handling` feature flag

## To test

You can override `token` in `acquireToken` and trigger the `else` block but a code review should mostly suffice. Overally, use the app and make sure you don't see any logout behavior.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
