### PR TITLE
Feature Flag: Remove `disable_private_feed_sharing` feature flag

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -113,8 +113,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Show Manage Downloaded episode banner/modal when running in low space in the device
     case manageDownloadedEpisodes
 
-    case disablePrivateFeedSharing
-
     /// Enable/Disable the podcast feed reload feature
     case podcastFeedUpdate
 
@@ -336,8 +334,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .manageDownloadedEpisodes:
 			true
-        case .disablePrivateFeedSharing:
-            true
         case .podcastFeedUpdate:
             true
         case .downloadsThreadSafeCache:

--- a/podcasts/SharePodcastsViewController.swift
+++ b/podcasts/SharePodcastsViewController.swift
@@ -136,9 +136,7 @@ class SharePodcastsViewController: PCViewController, UICollectionViewDelegate, U
     private func loadPodcasts() {
         let loadedPodcasts = DataManager.sharedManager.allPodcastsOrderedByTitle()
         for podcast in loadedPodcasts {
-            if FeatureFlag.disablePrivateFeedSharing.enabled {
-                if podcast.isPrivate { continue } // Hide all private podcasts
-            }
+            if podcast.isPrivate { continue } // Hide all private podcasts
             podcasts.append(podcast)
         }
 

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -76,11 +76,9 @@ enum SharingModal {
 
     static func showModal(podcast: Podcast, episode: Episode?, from source: AnalyticsSource, in viewController: UIViewController) {
 
-        if FeatureFlag.disablePrivateFeedSharing.enabled {
-            if podcast.isPrivate {
-                Toast.show(L10n.sharePodcastPrivateNotAvailable)
-                return
-            }
+        if podcast.isPrivate {
+            Toast.show(L10n.sharePodcastPrivateNotAvailable)
+            return
         }
 
         let colors = OptionsPickerRootController.Colors(title: UIColor.white.withAlphaComponent(0.5), background: PlayerColorHelper.playerBackgroundColor01())
@@ -111,11 +109,9 @@ enum SharingModal {
 
     static func show(option: Option, from source: AnalyticsSource, in viewController: UIViewController) {
 
-        if FeatureFlag.disablePrivateFeedSharing.enabled {
-            if option.podcast.isPrivate {
-                Toast.show(L10n.sharePodcastPrivateNotAvailable)
-                return
-            }
+        if option.podcast.isPrivate {
+            Toast.show(L10n.sharePodcastPrivateNotAvailable)
+            return
         }
 
         let sharingDestinations: [ShareDestination] = ShareDestination.displayedApps + [.copyLink, .systemSheet(vc: viewController)]

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -8,11 +8,9 @@ class SharingHelper: NSObject {
     var activityController: UIActivityViewController?
     func shareLinkTo(podcast: Podcast, fromController: UIViewController, fromSource: AnalyticsSource, sourceRect: CGRect, sourceView: UIView) {
 
-        if FeatureFlag.disablePrivateFeedSharing.enabled {
-            guard !podcast.isPrivate else {
-                Toast.show(L10n.sharePodcastPrivateNotAvailable)
-                return
-            }
+        guard !podcast.isPrivate else {
+            Toast.show(L10n.sharePodcastPrivateNotAvailable)
+            return
         }
 
         AnalyticsHelper.sharedPodcast()


### PR DESCRIPTION
Remove `disable_private_feed_sharing` feature flag

## To test

* Add a private feed to your subscriptions
* Try sharing the private feed
* ✅ Ensure sharing doesn't work for the private feed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
