### PR TITLE
Widget logging

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -82,21 +82,7 @@ actor LogBuffer {
             secondaryFileContents = ""
         }
 
-        // Include widget logs if available
-        let widgetLogContents: String
-        do {
-            widgetLogContents = try String(contentsOfFile: LogFilePaths.widgetLogFilePath)
-        } catch {
-            widgetLogContents = ""
-        }
-
-        var combinedLog = "\(secondaryFileContents)\n\(mainFileContents)"
-
-        if !widgetLogContents.isEmpty {
-            combinedLog += "\n\n=== WIDGET EXTENSION LOGS ===\n\(widgetLogContents)"
-        }
-
-        return combinedLog
+        return "\(secondaryFileContents)\n\(mainFileContents)"
     }
 }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -82,7 +82,21 @@ actor LogBuffer {
             secondaryFileContents = ""
         }
 
-        return "\(secondaryFileContents)\n\(mainFileContents)"
+        // Include widget logs if available
+        let widgetLogContents: String
+        do {
+            widgetLogContents = try String(contentsOfFile: LogFilePaths.widgetLogFilePath)
+        } catch {
+            widgetLogContents = ""
+        }
+
+        var combinedLog = "\(secondaryFileContents)\n\(mainFileContents)"
+
+        if !widgetLogContents.isEmpty {
+            combinedLog += "\n\n=== WIDGET EXTENSION LOGS ===\n\(widgetLogContents)"
+        }
+
+        return combinedLog
     }
 }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/LogFilePaths.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/LogFilePaths.swift
@@ -6,6 +6,8 @@ public enum LogFilePaths {
 
     public static var debugUploadLog: String { logDirectory + "/uploadDebug.log" }
 
+    public static var widgetUploadLog: String { logDirectory + "/uploadWidgetDebug.log" }
+
     static var mainLogFilePath: String { logDirectory + "/main.log" }
 
     static var backupLogFilePath: String { logDirectory + "/old.log" }

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/LogFilePaths.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/LogFilePaths.swift
@@ -10,8 +10,29 @@ public enum LogFilePaths {
 
     static var backupLogFilePath: String { logDirectory + "/old.log" }
 
+    // Widget extension log file (shared via App Group)
+    public static var widgetLogFilePath: String { sharedLogDirectory + "/widget.log" }
+
     static var logDirectory: String {
         let directory = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/debug_log")
         return directory
+    }
+
+    /// Shared log directory accessible to both the app and widget extension
+    static var sharedLogDirectory: String {
+        let fileManager = FileManager.default
+        guard let containerURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: "group.au.com.shiftyjelly.pocketcasts") else {
+            // Fallback to regular log directory if App Group is unavailable
+            return logDirectory
+        }
+        let sharedDirectory = containerURL.appendingPathComponent("Logs")
+
+        // Create the directory if it doesn't exist
+        var isDirectory: ObjCBool = false
+        if !fileManager.fileExists(atPath: sharedDirectory.path, isDirectory: &isDirectory) {
+            try? fileManager.createDirectory(at: sharedDirectory, withIntermediateDirectories: true, attributes: nil)
+        }
+
+        return sharedDirectory.path
     }
 }

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/WidgetLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/WidgetLog.swift
@@ -1,0 +1,107 @@
+import Foundation
+import os
+
+/// Shared logging for widget extensions
+/// Logs are written to the App Group container so they can be accessed by the main app
+public final class WidgetLog {
+    public static let shared = WidgetLog()
+
+    private let logger = Logger(subsystem: "au.com.shiftyjelly.pocketcasts.widget", category: "Widget")
+    private let fileManager = FileManager.default
+    private let logFilePath: String
+    private let maxLogSize: UInt64 = 500_000 // 500KB max for widget logs
+
+    private init() {
+        self.logFilePath = LogFilePaths.widgetLogFilePath
+
+        // Ensure the log file exists
+        if !fileManager.fileExists(atPath: logFilePath) {
+            fileManager.createFile(atPath: logFilePath, contents: nil, attributes: nil)
+        }
+    }
+
+    /// Add a message to the widget log
+    /// This will be written to a shared file that the main app can read
+    public func addMessage(_ message: String, date: Date = Date()) {
+        // Also log to the OS logger for immediate debugging
+        logger.log("\(message, privacy: .public)")
+
+        // Format the log entry
+        let timestamp = ISO8601DateFormatter().string(from: date)
+        let logEntry = "[\(timestamp)] [WIDGET] \(message)\n"
+
+        // Write to the shared log file
+        writeToFile(logEntry)
+    }
+
+    private func writeToFile(_ message: String) {
+        // Rotate log if it's too large
+        rotateLogs()
+
+        // Append to the log file
+        guard let data = message.data(using: .utf8) else { return }
+
+        if let fileHandle = FileHandle(forWritingAtPath: logFilePath) {
+            defer { fileHandle.closeFile() }
+            fileHandle.seekToEndOfFile()
+            fileHandle.write(data)
+        } else {
+            // If we can't open the file, try to create it and write
+            try? data.write(to: URL(fileURLWithPath: logFilePath), options: .atomic)
+        }
+    }
+
+    private func rotateLogs() {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: logFilePath),
+              let fileSize = attributes[.size] as? UInt64,
+              fileSize > maxLogSize else {
+            return
+        }
+
+        // Delete old backup if it exists
+        let backupPath = logFilePath.replacingOccurrences(of: ".log", with: ".old.log")
+        try? fileManager.removeItem(atPath: backupPath)
+
+        // Move current log to backup
+        try? fileManager.moveItem(atPath: logFilePath, toPath: backupPath)
+
+        // Create new log file
+        fileManager.createFile(atPath: logFilePath, contents: nil, attributes: nil)
+
+        logger.info("Widget log rotated. Old log saved to backup.")
+    }
+
+    /// Read the widget log file contents
+    /// This is primarily used by the main app to display widget logs
+    public func readLog() -> String {
+        let mainLog: String
+        do {
+            mainLog = try String(contentsOfFile: logFilePath, encoding: .utf8)
+        } catch {
+            mainLog = "Unable to read widget log: \(error.localizedDescription)"
+        }
+
+        // Also include backup log if it exists
+        let backupPath = logFilePath.replacingOccurrences(of: ".log", with: ".old.log")
+        let backupLog: String
+        do {
+            backupLog = try String(contentsOfFile: backupPath, encoding: .utf8)
+        } catch {
+            backupLog = ""
+        }
+
+        if backupLog.isEmpty {
+            return mainLog
+        } else {
+            return "\(backupLog)\n--- Current Log ---\n\(mainLog)"
+        }
+    }
+
+    /// Clear the widget log files
+    public func clearLogs() {
+        try? fileManager.removeItem(atPath: logFilePath)
+        try? fileManager.removeItem(atPath: logFilePath.replacingOccurrences(of: ".log", with: ".old.log"))
+        fileManager.createFile(atPath: logFilePath, contents: nil, attributes: nil)
+        logger.info("Widget logs cleared")
+    }
+}

--- a/Modules/Utils/Sources/PocketCastsUtils/Logging/WidgetLog.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Logging/WidgetLog.swift
@@ -104,4 +104,19 @@ public final class WidgetLog {
         fileManager.createFile(atPath: logFilePath, contents: nil, attributes: nil)
         logger.info("Widget logs cleared")
     }
+
+    /// Creates a merged widget log file for upload (similar to watchUploadLog)
+    /// Returns the path to the upload file
+    public func logFileForUpload() -> String? {
+        let uploadFile = LogFilePaths.widgetUploadLog
+
+        do {
+            let logs = readLog()
+            try logs.write(toFile: uploadFile, atomically: true, encoding: .utf8)
+            return uploadFile
+        } catch {
+            logger.error("Failed to create widget upload log: \(error.localizedDescription)")
+            return nil
+        }
+    }
 }

--- a/podcasts/AppPlayEpisodeIntentExtension.swift
+++ b/podcasts/AppPlayEpisodeIntentExtension.swift
@@ -4,10 +4,13 @@ import PocketCastsUtils
 @available(iOS 17, *)
 extension PlayEpisodeIntent {
     func intentPlayback(_ episodeUuid: String) {
+        // Log to both FileLog (main app) and WidgetLog (shared with app)
         FileLog.shared.addMessage("PlayEpisodeIntent called for episode \(episodeUuid)")
+        WidgetLog.shared.addMessage("PlayEpisodeIntent called for episode \(episodeUuid)")
 
         guard let podcastEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else {
             FileLog.shared.addMessage("PlayEpisodeIntent error: episode not found")
+            WidgetLog.shared.addMessage("ERROR: Episode not found - \(episodeUuid)")
             return
         }
 
@@ -15,9 +18,12 @@ extension PlayEpisodeIntent {
         let current = PlaybackManager.shared.currentEpisode()
 
         if current?.uuid == podcastEpisode.uuid {
-            Analytics.track(.widgetInteraction, properties: ["action": PlaybackManager.shared.playing() ? "pause" : "play"])
+            let action = PlaybackManager.shared.playing() ? "pause" : "play"
+            WidgetLog.shared.addMessage("Toggling playback: \(action)")
+            Analytics.track(.widgetInteraction, properties: ["action": action])
             PlaybackActionHelper.playPause()
         } else {
+            WidgetLog.shared.addMessage("Loading new episode: \(podcastEpisode.displayableTitle())")
             // Ideally we should use PlaybackActionHelper here
             // However this can potentially trigger an UI and does a lot of other checks
             // that is not as performant as this call.

--- a/podcasts/SupportConfig.swift
+++ b/podcasts/SupportConfig.swift
@@ -7,6 +7,7 @@ import PocketCastsUtils
 enum SupportCustomField: Int, CaseIterable {
     case debugLog = 360_049_192_052
     case wearableLog = 360_049_192_072
+    case widgetLog = 360_049_192_092  // Widget extension logs (new field)
     case allPodcasts = 360_049_245_291
     case metaData = 360_049_245_311
 
@@ -16,6 +17,8 @@ enum SupportCustomField: Int, CaseIterable {
             return L10n.supportLogsDebug
         case .wearableLog:
             return L10n.supportLogsWearable
+        case .widgetLog:
+            return "Widget Logs"
         case .allPodcasts:
             return L10n.supportLogsPodcasts
         case .metaData:
@@ -26,8 +29,10 @@ enum SupportCustomField: Int, CaseIterable {
     var displayOrder: Int {
         switch self {
         case .debugLog:
-            return 4
+            return 5
         case .wearableLog:
+            return 4
+        case .widgetLog:
             return 3
         case .allPodcasts:
             return 2
@@ -93,7 +98,11 @@ struct SupportConfig: ZDConfig {
             ]).eraseToAnyPublisher()
         }
 
-        return Publishers.MergeMany(debugLog(forDisplay: forDisplay), watchLog(forDisplay: forDisplay))
+        return Publishers.MergeMany(
+            debugLog(forDisplay: forDisplay),
+            watchLog(forDisplay: forDisplay),
+            widgetLog(forDisplay: forDisplay)
+        )
             .collect()
             .receive(on: DispatchQueue.global(qos: .background), options: nil)
             .eraseToAnyPublisher()
@@ -138,6 +147,25 @@ struct SupportConfig: ZDConfig {
         return FileLog.shared.encryptedWatchLogUUID()
             .map { uuid in
                 ZDCustomField(.wearableLog, value: uuid)
+            }
+            .eraseToAnyPublisher()
+    }
+
+    private func widgetLog(forDisplay: Bool) -> AnyPublisher<ZDCustomField, Never> {
+        if forDisplay {
+            // Return the File Contents to show the user
+            return Future { promise in
+                let widgetLogs = WidgetLog.shared.readLog()
+                let displayValue = widgetLogs.isEmpty ? "No widget logs available. Widget logs are created when you interact with widgets." : widgetLogs
+                promise(.success(ZDCustomField(.widgetLog, value: displayValue)))
+            }
+            .eraseToAnyPublisher()
+        }
+
+        // Return the File Name to be enqued for upload
+        return FileLog.shared.encryptedWidgetLogUUID()
+            .map { uuid in
+                ZDCustomField(.widgetLog, value: uuid)
             }
             .eraseToAnyPublisher()
     }

--- a/podcasts/Utilities/DatabaseExport.swift
+++ b/podcasts/Utilities/DatabaseExport.swift
@@ -77,6 +77,11 @@ class DatabaseExport {
                 try moveFile(watchLogFile, exportDirectory: exportDirectory, exportFileName: "watchos-logs.txt")
             }
 
+            let widgetLogFile = await FileLog.shared.widgetLogFileForUpload().awaitFirstValue(in: &cancellables)
+            if let widgetLogFile {
+                try moveFile(widgetLogFile, exportDirectory: exportDirectory, exportFileName: "widget-logs.txt")
+            }
+
             // Write the bundle document
             let exportFile = exportDirectory.appendingPathComponent("export", conformingTo: .pcasts)
             let wrapper = try PCBundleDoc().fileWrapper()

--- a/podcasts/Zendesk/FileLog+FileUpload.swift
+++ b/podcasts/Zendesk/FileLog+FileUpload.swift
@@ -81,10 +81,34 @@ extension FileLog: EventLoggingDelegate {
             .eraseToAnyPublisher()
     }
 
+    func widgetLogFileForUpload() -> AnyPublisher<String?, Never> {
+        Future<String?, Error> { promise in
+            let widgetLogPath = WidgetLog.shared.logFileForUpload()
+            promise(.success(widgetLogPath))
+        }
+        .replaceError(with: FileLog.genericErrorMessage)
+        .eraseToAnyPublisher()
+    }
+
+    public func encryptedWidgetLogUUID() -> AnyPublisher<String, Never> {
+        widgetLogFileForUpload()
+            .tryMap { [unowned self] filePath in
+                guard let filePath = filePath else {
+                    return "No widget logs available"
+                }
+
+                return try self.queueFileUpload(filePath)
+            }
+            .replaceError(with: FileLog.genericErrorMessage)
+            .eraseToAnyPublisher()
+    }
+
     // MARK: - EventLoggingDelegate
 
     public var shouldUploadLogFiles: Bool {
-        FileManager.default.fileExists(atPath: LogFilePaths.debugUploadLog) || FileManager.default.fileExists(atPath: LogFilePaths.watchUploadLog)
+        FileManager.default.fileExists(atPath: LogFilePaths.debugUploadLog) ||
+        FileManager.default.fileExists(atPath: LogFilePaths.watchUploadLog) ||
+        FileManager.default.fileExists(atPath: LogFilePaths.widgetUploadLog)
     }
 
     public func didFinishUploadingLog(_ log: LogFile) {


### PR DESCRIPTION
  Adds shared logging infrastructure for the widget extension to help with debugging:

  - Adds shared logging framework for widget extension debugging
  - Separates widget logs as a standalone upload file (similar to watch logs)
  - Uploads widget logs to a separate field in Zendesk

This enables better debugging of widget-related issues by capturing widget-specific logs in their own file.

## To test

* Run the app and install a widget on your homescreen
* Interact with the widget
* Export the database from Help & Feedback
* Open the export directory
* ✅ Verify that the widget logs are present
* Submit a support ticket from Help & Feedback
* ✅ Verify in Zendesk that the ticket contains the widget logs

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
