### PR TITLE
Refactor search to use NOCASE in the query

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -259,8 +259,9 @@ public class PlaylistQueryBuilder {
         PlaylistQueryBuilder.removeEmptyFilterGroups(from: &queryString)
         if let searchTerm {
             let searchClause = playlist.manual ? "WHERE" : "AND"
-            queryString += " \(searchClause) (UPPER(episode.title) LIKE '%\(searchTerm.uppercased())%' ESCAPE '\\'"
-            queryString += " OR UPPER(podcast.title) LIKE '%\(searchTerm.uppercased())%'  ESCAPE '\\')"
+            let lowerSearch = searchTerm.lowercased()
+            queryString += " \(searchClause) (episode.title LIKE '%\(lowerSearch)%' ESCAPE '\\' COLLATE NOCASE"
+            queryString += " OR podcast.title LIKE '%\(lowerSearch)%' ESCAPE '\\' COLLATE NOCASE)"
         }
         if let sort = add(sortFor: sortType), clause != .episodeCount, clause != .allEpisodeCount {
             queryString += " \(sort) "


### PR DESCRIPTION
Fixes [POC-439](https://linear.app/a8c/issue/POC-439/poor-performance-on-episode-search-with-large-playlists)

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
