### PR TITLE
Remove fail from playback cell

### DIFF
--- a/podcasts/End of Year/Views/EndOfYearPromptCell.swift
+++ b/podcasts/End of Year/Views/EndOfYearPromptCell.swift
@@ -5,17 +5,21 @@ class EndOfYearPromptCell: ThemeableCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
-        let viewModel: EndOfYearCard.ViewModel
+        var viewModel: EndOfYearCard.ViewModel?
 
         switch EndOfYear.currentYear {
         case .y2022:
-            fatalError("Shouldn't reach this point")
+            assertionFailure("Shouldn't reach this point")
         case .y2023:
             viewModel = .init(title: L10n.eoyTitle, description: L10n.eoyCardDescription, imageName: "23_small", imagePadding: 20, backgroundColor: nil)
         case .y2024:
             viewModel = .init(title: L10n.playback2024FeatureTitle, description: L10n.playback2024FeatureDescription, imageName: "playback-24", imagePadding: 60, backgroundColor: nil)
         case .y2025:
             viewModel = .init(title: L10n.playback2025FeatureTitle, description: L10n.playback2025FeatureDescription, imageName: "playback-25", imagePadding: 0, backgroundColor: Color(hex: "28486A"))
+        }
+
+        guard let viewModel else {
+            return
         }
 
         let childView = UIHostingController(rootView: EndOfYearCard(viewModel: viewModel)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

The playback cell should never be created but this PR tries to remove completely the possibility of a fatalError by replacing it by creating an empty cell.

The rational is that it's better to see an empty cell instead of a crash in production.

## To test

1. Start the app
2. Enable the `end_of_year_2025` FF
3. Check if the cell shows correctly
4. Disable the FF 
5. Check if no cell is shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
