### PR TITLE
Release media resource loader if not being used 

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -278,6 +278,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Moves the shouldKeepPlaying after we check that the episode is over
     case checkFinishedTimeBeforeShouldKeepPlaying
 
+    /// Allow the release of the Media Exporter when is no longer being used by the player
+    case releaseMediaExporterWhenNoLongerActive
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -467,6 +470,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .useBackgroundQueueForStreamingCallback:
 			true
         case .checkFinishedTimeBeforeShouldKeepPlaying:
+            true
+        case .releaseMediaExporterWhenNoLongerActive:
             true
         }
     }

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -325,7 +325,20 @@ class DownloadManager: NSObject, FilePathProtocol {
         var error: Error?
     }
 
-    private var activeLoaderDelegate: AVAssetResourceLoaderDelegate?
+    private let activeLoaderLock = NSLock()
+    private var _activeLoaderDelegate: AVAssetResourceLoaderDelegate?
+    private var activeLoaderDelegate: AVAssetResourceLoaderDelegate? {
+        get {
+            activeLoaderLock.lock()
+            defer { activeLoaderLock.unlock() }
+            return _activeLoaderDelegate
+        }
+        set {
+            activeLoaderLock.lock()
+            defer { activeLoaderLock.unlock() }
+            _activeLoaderDelegate = newValue
+        }
+    }
 
     func downloadParallelToStream(of episode: BaseEpisode) -> AVPlayerItem? {
         guard let playbackItem = PlaybackItem(episode: episode).createPlayerItem() else {

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -352,6 +352,9 @@ class DownloadManager: NSObject, FilePathProtocol {
             newAsset.resourceLoader.setDelegate(customDelegate, queue: .global(qos: .default))
             newItem = AVPlayerItem(asset: newAsset)
             if FeatureFlag.releaseMediaExporterWhenNoLongerActive.enabled {
+                if let activeMediaExporterDelegate = activeLoaderDelegate as? MediaExporterResourceLoaderDelegate {
+                    activeMediaExporterDelegate.releaseIfDownloadComplete()
+                }
                 activeLoaderDelegate = customDelegate
             }
             return newItem
@@ -408,7 +411,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         newItem = AVPlayerItem(asset: newAsset)
         if FeatureFlag.releaseMediaExporterWhenNoLongerActive.enabled {
             if let activeMediaExporterDelegate = activeLoaderDelegate as? MediaExporterResourceLoaderDelegate {
-                activeMediaExporterDelegate.markToRelease()
+                activeMediaExporterDelegate.releaseIfDownloadComplete()
             }
             activeLoaderDelegate = customLoaderDelegate
         }
@@ -421,7 +424,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             if FeatureFlag.releaseMediaExporterWhenNoLongerActive.enabled,
                let mediaExporterDelegate = downloadAndStreamEpisodes[downloadTaskUUID] as? MediaExporterResourceLoaderDelegate,
                mediaExporterDelegate != activeLoaderDelegate as? MediaExporterResourceLoaderDelegate {
-                mediaExporterDelegate.markToRelease()
+                mediaExporterDelegate.releaseIfDownloadComplete()
             }
             downloadAndStreamEpisodes[downloadTaskUUID] = nil
             guard let episode = dataManager.findBaseEpisode(uuid: downloadTaskUUID) else {

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -325,6 +325,8 @@ class DownloadManager: NSObject, FilePathProtocol {
         var error: Error?
     }
 
+    private var activeLoaderDelegate: AVAssetResourceLoaderDelegate?
+
     func downloadParallelToStream(of episode: BaseEpisode) -> AVPlayerItem? {
         guard let playbackItem = PlaybackItem(episode: episode).createPlayerItem() else {
             return nil
@@ -349,6 +351,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             let newAsset = AVURLAsset(url: customURL)
             newAsset.resourceLoader.setDelegate(customDelegate, queue: .global(qos: .default))
             newItem = AVPlayerItem(asset: newAsset)
+            activeLoaderDelegate = customDelegate
             return newItem
         }
         var wasDownloadingBefore = false
@@ -401,6 +404,10 @@ class DownloadManager: NSObject, FilePathProtocol {
         let newAsset = AVURLAsset(url: customURL)
         newAsset.resourceLoader.setDelegate(customLoaderDelegate, queue: .global(qos: .default))
         newItem = AVPlayerItem(asset: newAsset)
+        if let activeMediaExporterDelegate = activeLoaderDelegate as? MediaExporterResourceLoaderDelegate {
+            activeMediaExporterDelegate.markToRelease()
+        }
+        activeLoaderDelegate = customLoaderDelegate
         Task {
             while !exportStatus.completed {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -414,6 +414,10 @@ class DownloadManager: NSObject, FilePathProtocol {
             }
             downloadingEpisodesCache[downloadTaskUUID] = nil
             removeEpisodeFromCache(episode)
+            if let mediaExporterDelegate = downloadAndStreamEpisodes[downloadTaskUUID] as? MediaExporterResourceLoaderDelegate,
+               mediaExporterDelegate != activeLoaderDelegate as? MediaExporterResourceLoaderDelegate {
+                mediaExporterDelegate.markToRelease()
+            }
             downloadAndStreamEpisodes[downloadTaskUUID] = nil
             guard let episode = dataManager.findBaseEpisode(uuid: downloadTaskUUID) else {
                 return

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -351,7 +351,9 @@ class DownloadManager: NSObject, FilePathProtocol {
             let newAsset = AVURLAsset(url: customURL)
             newAsset.resourceLoader.setDelegate(customDelegate, queue: .global(qos: .default))
             newItem = AVPlayerItem(asset: newAsset)
-            activeLoaderDelegate = customDelegate
+            if FeatureFlag.releaseMediaExporterWhenNoLongerActive.enabled {
+                activeLoaderDelegate = customDelegate
+            }
             return newItem
         }
         var wasDownloadingBefore = false
@@ -404,17 +406,20 @@ class DownloadManager: NSObject, FilePathProtocol {
         let newAsset = AVURLAsset(url: customURL)
         newAsset.resourceLoader.setDelegate(customLoaderDelegate, queue: .global(qos: .default))
         newItem = AVPlayerItem(asset: newAsset)
-        if let activeMediaExporterDelegate = activeLoaderDelegate as? MediaExporterResourceLoaderDelegate {
-            activeMediaExporterDelegate.markToRelease()
+        if FeatureFlag.releaseMediaExporterWhenNoLongerActive.enabled {
+            if let activeMediaExporterDelegate = activeLoaderDelegate as? MediaExporterResourceLoaderDelegate {
+                activeMediaExporterDelegate.markToRelease()
+            }
+            activeLoaderDelegate = customLoaderDelegate
         }
-        activeLoaderDelegate = customLoaderDelegate
         Task {
             while !exportStatus.completed {
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
             }
             downloadingEpisodesCache[downloadTaskUUID] = nil
             removeEpisodeFromCache(episode)
-            if let mediaExporterDelegate = downloadAndStreamEpisodes[downloadTaskUUID] as? MediaExporterResourceLoaderDelegate,
+            if FeatureFlag.releaseMediaExporterWhenNoLongerActive.enabled,
+               let mediaExporterDelegate = downloadAndStreamEpisodes[downloadTaskUUID] as? MediaExporterResourceLoaderDelegate,
                mediaExporterDelegate != activeLoaderDelegate as? MediaExporterResourceLoaderDelegate {
                 mediaExporterDelegate.markToRelease()
             }

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -80,6 +80,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     }
 
     deinit {
+        FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: Releasing loader for \(saveFilePath)")
         invalidateAndCancelSession(shouldResetData: false)
     }
 
@@ -300,6 +301,12 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         } catch {
             FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: failed to write data to file: \(error)")
             invalidateAndCancelSession()
+        }
+    }
+
+    func markToRelease() {
+        if isDownloadComplete {
+            invalidateAndCancelSession(shouldResetData: false)
         }
     }
 

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -304,7 +304,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         }
     }
 
-    func markToRelease() {
+    func releaseIfDownloadComplete() {
         if isDownloadComplete {
             invalidateAndCancelSession(shouldResetData: false)
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
While debugging the media resource loader file handle I found out that our custom resource loader was never been released.
After some investigation I found that the reason is that the our loader and the session used to download the media file where in a strong reference cycle chain.
This happening because the `loader` is the delegate for the session and the [session holds a strong reference for it](https://developer.apple.com/documentation/foundation/urlsession/init(configuration:delegate:delegatequeue:)).

MediaExportResourceLoader <-> URLSession

My initial thought was to break this cycle by invalidating the session when the download was complete.
When I tried that I found out that breaking that reference chain when the download completed made the loader to be free while it was still being used by the AVURLAsset while in play. This is because the [AVAssetResourceLoader does not retain](https://developer.apple.com/documentation/avfoundation/avassetresourceloader/setdelegate(_:queue:)) the custom delegate we provided to it.

So if release the session reference, by invalidating the session at the end of the download we end up releasing the loader, and the asset stop responding for data requests.

So I looked at an alternative method, and end up implementing on the DownloadManager a reference to the last provided Resource Loader Delegate. This way when the DownloadManager starts new one, we can say to the old to be released when/if it completed the download.

In order to be safe I implemented this code around a FF

## To test

1. Start the app
2. Open a Podcast with episodes that are not downloaded
3. Tap play on one episode
4. Check in the console if you see a message like: `MediaExporterResourceLoaderDelegate: Start data request for XXX`
5. Tap on the option to download the episode
6. Now wait a bit, where you can play around seeking forward and back on the episode
7. Now start playing another episode
8. Check if you see in the console a message like: `MediaExporterResourceLoaderDelegate: Releasing loader for` and another message of the type: `MediaExporterResourceLoaderDelegate: Start data request for XXX`
9. Now test it again but you start playing another episode before the download of the first one is finished
10. Check that when start the new episode you don't see the release message, but after a while if the donwload finish you see the release message
11. Now please test again with the FF `releaseMediaExporterWhenNoLongerActive` disabled to see if all works correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
