### PR TITLE
Only reset Show Notes scroll position if episode changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 8.4
 -----
-
+- Maintain Show Notes scroll position when app is opened [#3863](https://github.com/Automattic/pocket-casts-ios/pull/3863)
 
 8.3
 -----

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -105,11 +105,12 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
 
         // everything below here is expensive to do every single update, so limit it to when the episode changes
         if lastEpisodeUuidRendered == episode.uuid { return }
-        lastEpisodeUuidRendered = episode.uuid
         updateColors()
         episodeTitle.text = episode.displayableTitle()
 
         loadShowNotes()
+
+        lastEpisodeUuidRendered = episode.uuid
     }
 
     private func updateColors() {
@@ -130,10 +131,12 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
 
         loadingIndicator.startAnimating()
 
-        Task { [weak self] in
+        Task { [lastEpisodeUuidRendered, weak self] in
             if let showNotes = try? await ShowInfoCoordinator.shared.loadShowNotes(podcastUuid: episode.parentIdentifier(), episodeUuid: episode.uuid) {
                 self?.downloadingShowNotes = false
-                self?.displayShowNotes(showNotes)
+
+                let shouldResetScrollOffset = lastEpisodeUuidRendered != episode.uuid && lastEpisodeUuidRendered != ""
+                self?.displayShowNotes(showNotes, shouldResetScrollOffset: shouldResetScrollOffset)
 
                 // if we get back the no show notes available message, make sure next update we try again
                 if showNotes == CacheServerHandler.noShowNotesMessage {
@@ -147,7 +150,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
         PlayerColorHelper.playerHighlightColor01(for: Theme.ThemeType.dark)
     }
 
-    private func displayShowNotes(_ showNotes: String?) {
+    private func displayShowNotes(_ showNotes: String?, shouldResetScrollOffset: Bool = true) {
         guard let episode = episode else { return }
 
         DispatchQueue.main.async { [weak self] in
@@ -162,7 +165,10 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
                 // We need to ensure that the scroll view offset is back at 0,0 to cater for instances
                 // where the user scrolled the previous show notes
                 // See https://github.com/Automattic/pocket-casts-ios/issues/651
-                strongSelf.showNotesScrollView.setContentOffset(CGPointZero, animated: false)
+
+                if shouldResetScrollOffset {
+                    strongSelf.showNotesScrollView.setContentOffset(CGPointZero, animated: false)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes [PCIOS-428](https://linear.app/a8c/issue/PCIOS-428/now-playing-details-tab-jumps-to-the-top-when-the-app-is-foregrounded)

Updates the Show Notes "Details" tab to only jump back to the top when the episode has changed.

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/87cdf59a-0cdd-4b77-a7a6-895be41dcd1c"> | <video src="https://github.com/user-attachments/assets/cfb2f844-2418-4000-886e-6dff962e7f9a"> |

## To test

### Remains at scroll position
* Play an episode
* Open the Show Notes "Details" tab 
* Background the app
* Reopen the app
* ✅ Ensure the Show Notes remain at the scroll position

### Reset to top
* Play an episode with at least one added to Up Next
* Play the episode and skip near the end
* Open the Show Notes "Details" tab 
* Background the app
* When the next episode begins playing, switch back to the app
* ✅ Ensure the Show Notes are scrolled to the top

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
