### PR TITLE
Airplay speaker fix

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -262,6 +262,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Moves the shouldKeepPlaying after we check that the episode is over
     case checkFinishedTimeBeforeShouldKeepPlaying
 
+    /// Activate audio session to enable multi-speaker selection in route picker
+    case activateAudioSessionForRoutePicker
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -439,6 +442,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .useBackgroundQueueForStreamingCallback:
 			true
         case .checkFinishedTimeBeforeShouldKeepPlaying:
+            true
+        case .activateAudioSessionForRoutePicker:
             true
         }
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -265,6 +265,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Activate audio session to enable multi-speaker selection in route picker
     case activateAudioSessionForRoutePicker
 
+    /// Don't autoplay when route changes
+    case dontAutoplayOnRouteChange
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -444,6 +447,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .checkFinishedTimeBeforeShouldKeepPlaying:
             true
         case .activateAudioSessionForRoutePicker:
+            true
+        case .dontAutoplayOnRouteChange:
             true
         }
     }

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -567,6 +567,15 @@ extension NowPlayingPlayerItemViewController {
 
 extension NowPlayingPlayerItemViewController: AVRoutePickerViewDelegate {
     func routePickerViewWillBeginPresentingRoutes(_ routePickerView: AVRoutePickerView) {
+
+        // This prepares routing options without activating the session
+        // The actual session activation happens when playback begins
+        if FeatureFlag.activateAudioSessionForRoutePicker.enabled {
+            AVAudioSession.sharedInstance().prepareRouteSelectionForPlayback { shouldStartPlayback, routeSelection in
+                FileLog.shared.addMessage("Route selection prepared: shouldStartPlayback=\(shouldStartPlayback), type=\(routeSelection.rawValue)")
+            }
+        }
+
         shelfButtonTapped(.routePicker)
     }
 }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -212,6 +212,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         chromecastBtn.isPointerInteractionEnabled = true
 
         routePicker.delegate = self
+
         #endif
     }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1968,7 +1968,8 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         let reason = changeReason.uintValue
         if let currEpisode = currentEpisode(), playingOverAirplay() && playerSwitchRequired() {
-            load(episode: currEpisode, autoPlay: true, overrideUpNext: false)
+            let autoPlay = FeatureFlag.dontAutoplayOnRouteChange.enabled ? false : true
+            load(episode: currEpisode, autoPlay: autoPlay, overrideUpNext: false)
         } else if reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue {
             player?.routeDidChange(shouldPause: true)
         } else if reason == AVAudioSession.RouteChangeReason.newDeviceAvailable.rawValue || reason == AVAudioSession.RouteChangeReason.override.rawValue {


### PR DESCRIPTION
Fixes [PCIOS-164](https://linear.app/a8c/issue/PCIOS-164/ios-player-no-longer-provides-the-ability-to-airplay-to-multiple-rooms)

This PR contains two changes:
* Fixes the multi-speaker selection by preparing the audio session when the route picker is presented under the `activateAudioSessionForRoutePicker` flag.
* Prevents automatic playback when audio routes changes if an episode was not already playing under the `dontAutoplayOnRouteChange` flag.

I feature flagged both of these because the API around AirPlay route changes is a bit opaque and we could run into issues.

## To test

### Test with nothing playing
* Open the Now Playing screen
* Tap the Airplay Route Selector button
* Tap on an Airplay speaker
* ✅ Verify you see the multi-select option visible
* ✅ Verify nothing begins playing

### Test with other media playing
* Open the Now Playing screen
* Tap the Airplay Route Selector button
* Tap on an Airplay speaker
* ✅ Verify you see the multi-select option visible
* ✅ Verify your playing media switches to speakers

### Test with playing podcast
* Open the Now Playing screen
* Tap the Airplay Route Selector button
* Tap on an Airplay speaker
* ✅ Verify you see the multi-select option visible
* ✅ Verify your playing episode switches to speakers

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
