### PR TITLE
Deselect selected cell to match select behavior

### DIFF
--- a/podcasts/UITableView+MultiSelect.swift
+++ b/podcasts/UITableView+MultiSelect.swift
@@ -104,8 +104,7 @@ extension UITableView {
     }
 
     func deselectAllAbove(fromIndexPath: IndexPath, to indexPath: IndexPath) {
-        let targetIndexPath = previousIndexPath(from: indexPath) ?? indexPath
-        deselectAllFrom(fromIndexPath: fromIndexPath, toIndexPath: targetIndexPath)
+        deselectAllFrom(fromIndexPath: fromIndexPath, toIndexPath: indexPath)
     }
 
     func deselectAllBelow(indexPath: IndexPath) {

--- a/podcasts/UITableView+MultiSelect.swift
+++ b/podcasts/UITableView+MultiSelect.swift
@@ -111,8 +111,7 @@ extension UITableView {
         guard numberOfSections > 0 else { return }
         let lastSection = numberOfSections - 1
         let lastRow = numberOfRows(inSection: lastSection) - 1
-        let targetIndexPath = nextIndexPath(from: indexPath) ?? indexPath
-        deselectAllFrom(fromIndexPath: targetIndexPath, toIndexPath: IndexPath(row: lastRow, section: lastSection))
+        deselectAllFrom(fromIndexPath: indexPath, toIndexPath: IndexPath(row: lastRow, section: lastSection))
     }
 
     func deselectAllFrom(fromIndexPath: IndexPath, toIndexPath: IndexPath) {


### PR DESCRIPTION
Fixes [PCIOS-427](https://linear.app/a8c/issue/PCIOS-427/when-using-deselect-all-the-tapped-row-should-also-be-deselected)

When selecting episode cells, we select the tapped cell. When deselecting, we were not deselecting the tapped cell. This behavior should be consistent and I think it's safe to use the existing behavior here.

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/413480aa-4d9e-4bce-973d-029c38f79fb7"> | <video src="https://github.com/user-attachments/assets/d97224d1-fa36-41b0-80f5-42462db9bf9b"> |

## To test

* Visit a Podcast page
* Long press to enter the cell selection state
* Long press the cell above the initially selected cell
* Tap "Select all above"
* ✅ Verify that the tapped cell was selected
* Long press that same cell
* Tap "Deselect all above"
* ✅ Verify that the tapped cell was deselected 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
