### PR TITLE
Makefile and Agents.md updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,10 @@
+## Formatting
+
+Format all code using the linter formatter:
+```bash
+make format
+```
+
 ## Building and Running
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+## Building and Running
+
+```bash
+make build
+```
+
+## Running Tests
+
+```bash
+make test
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ generate_colors: ## Generate colors and themes based on themes.csv
 generate_code:
 	$(call run_in_buildtools,generate-code-for-resources --config ../swiftgen.yml)
 
-lint:
+lint: ## Lint the codebase
 	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS))
 
 lint_lenient:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,17 @@ lint:
 lint_lenient:
 	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS) --lenient)
 
+build: ## Builds the Debug configuration using Xcode
+	xcodebuild -project podcasts.xcodeproj \
+       -scheme pocketcasts \
+       -configuration Debug \
+       build
+
+test: ## Build and run the PocketCastsTests target with Unit Tests using Xcode
+	xcodebuild test -project podcasts.xcodeproj \
+	    -scheme pocketcasts \
+        -only-testing:PocketCastsTests
+
 format:
 	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS) --autocorrect)
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test: ## Build and run the PocketCastsTests target with Unit Tests using Xcode
 	    -scheme pocketcasts \
         -only-testing:PocketCastsTests
 
-format:
+format: ## Lint and autocorrect linter errors
 	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS) --autocorrect)
 
 upload_dsyms: ## Upload dSYMs


### PR DESCRIPTION
* Adds commands for `build`, `test`, and `format` to our Makefile.
* References these commands from `AGENTS.md` and links that file from `CLAUDE.md`

Having these commands in one place should make things easier for contributors and coding agents to run the correct command for compilation, formatting, and testing.

I think these commands are important enough to any work done on the repo that they probably make sense in `AGENTS.md` rather than as a separate skill.

## To test

### Makefile
* Run `make help`
* ✅ Verify `build`, `test`, and `format` commands appear in the list
* Run `make build`
* ✅ Ensure the project builds
* Run `make test`
* ✅ Ensure unit tests pass
* Run `make format`
* ✅ Ensure swift lint is run and 

### Agent usage
* Run `claude`
* Enter a command like "build this" or "compile this"
* ✅ Ensure the `make build` command is run
* ✅ Ensure the project builds
* Enter a command like "test this" or "run tests"
* ✅ Ensure the `make test` command is run
* ✅ Ensure unit tests pass
* Enter a command like "format code"
* ✅ Ensure the `make format` command is run

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
