### PR TITLE
Fix issue when connection non existent and then recovers

### DIFF
--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -190,7 +190,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             configuration.timeoutIntervalForRequest = 60 // seconds
             configuration.timeoutIntervalForResource = 3600 * 2 // seconds
 #if !APPCLIP
-            configuration.waitsForConnectivity = true
+            configuration.waitsForConnectivity = false
             configuration.multipathServiceType = .handover // allows switching between celular/wifi
 #endif
         }

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -188,7 +188,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             configuration.networkServiceType = .avStreaming
             configuration.allowsCellularAccess = true
             configuration.timeoutIntervalForRequest = 60 // seconds
-            configuration.timeoutIntervalForResource = 3600 // seconds
+            configuration.timeoutIntervalForResource = 3600 * 2 // seconds
 #if !APPCLIP
             configuration.waitsForConnectivity = true
             configuration.multipathServiceType = .handover // allows switching between celular/wifi

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -81,7 +81,8 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
     deinit {
         FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: Releasing loader for \(saveFilePath)")
-        invalidateAndCancelSession(shouldResetData: false)
+        session?.invalidateAndCancel()
+        session = nil
     }
 
     static let schemePrefix = "custom-"


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-99 <!-- issue number, if applicable -->

This PR fixes an issue when connectivity is non-available when you start playing a non cached episode:

- The resource loader created file
- Network is non existent, stream download fails 
- File was deleted
- Network comes back
- User press play **same episode**
- New stream download is created
- Releasing of previous streamer was deleting the current buffered file

I also set the wait for connectivity for the session to false, because in scenarios where network was non existent streaming download could wait for ever.

## To test

1. Start the app
2. Turn off all connectivity off for the device
3. Tap play on an episode that is not downloaded
4. Check if an error shown up immediately saying that no network is available
5. Turn on connectivity again
6. Tap play again on the same episode 
7. Check that episode plays normally
8. Play other episodes and see if it works correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
