### PR TITLE
Watch Up Next sync fix

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
@@ -1,0 +1,73 @@
+import Foundation
+import PocketCastsUtils
+
+public enum UpNextComparisonResult: Int {
+    case same
+    case phoneNeedsUpdate
+    case watchNeedsUpdate
+    case notEnoughInformation
+}
+
+public struct UpNextListComparator {
+    public static func compare(phoneEpisodes: [BaseEpisode]?,
+                               phoneUpNextCount: Int,
+                               watchEpisodes: [BaseEpisode],
+                               watchEpisodeCount: Int,
+                               lastServerRefresh: Date?,
+                               lastWatchDataTime: Date) -> UpNextComparisonResult {
+        guard let phoneEpisodes = phoneEpisodes, phoneEpisodes.count > 0 else {
+            if watchEpisodeCount == 0 {
+                return .same
+            } else {
+                return .phoneNeedsUpdate
+            }
+        }
+
+        if phoneUpNextCount > phoneEpisodes.count {
+            return .notEnoughInformation
+        }
+
+        if phoneEpisodes.count == watchEpisodes.count {
+            if watchEpisodes.count == 0 {
+                return .same
+            }
+
+            var allMatch = true
+            for (index, episode) in watchEpisodes.enumerated() {
+                if episode.uuid != phoneEpisodes[index].uuid {
+                    allMatch = false
+                    break
+                }
+            }
+
+            if allMatch {
+                return .same
+            }
+        }
+
+        guard let lastServerRefresh = lastServerRefresh else {
+            FileLog.shared.addMessage("WatchSyncManager: No lastServerRefresh timestamp, returning .notEnoughInformation")
+            return .notEnoughInformation
+        }
+
+        if lastServerRefresh > lastWatchDataTime {
+            FileLog.shared.addMessage("WatchSyncManager: Phone data is newer (lastServerRefresh: \(lastServerRefresh) > lastDataTime: \(lastWatchDataTime)), returning .phoneNeedsUpdate")
+            return .phoneNeedsUpdate
+        } else if lastServerRefresh < lastWatchDataTime {
+            FileLog.shared.addMessage("WatchSyncManager: Watch data is newer (lastServerRefresh: \(lastServerRefresh) < lastDataTime: \(lastWatchDataTime)), returning .watchNeedsUpdate")
+            return .watchNeedsUpdate
+        } else {
+            FileLog.shared.addMessage("WatchSyncManager: Timestamps are equal, returning .same")
+            return .same
+        }
+    }
+}
+
+public struct WatchSyncDecision {
+    public static func shouldPerformBackgroundRefresh(isPlusUser: Bool,
+                                                      isAppInBackground: Bool,
+                                                      comparisonResult: UpNextComparisonResult,
+                                                      isFirstSyncInProgress: Bool) -> Bool {
+        isPlusUser && isAppInBackground && comparisonResult == .watchNeedsUpdate && !isFirstSyncInProgress
+    }
+}

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
@@ -14,7 +14,8 @@ public struct UpNextListComparator {
                                watchEpisodes: [BaseEpisode],
                                watchEpisodeCount: Int,
                                lastServerRefresh: Date?,
-                               lastWatchDataTime: Date) -> UpNextComparisonResult {
+                               lastWatchDataTime: Date,
+                               useConservativeComparison: Bool = true) -> UpNextComparisonResult {
         guard let phoneEpisodes = phoneEpisodes, phoneEpisodes.count > 0 else {
             if watchEpisodeCount == 0 {
                 return .same
@@ -46,8 +47,12 @@ public struct UpNextListComparator {
         }
 
         guard let lastServerRefresh = lastServerRefresh else {
-            FileLog.shared.addMessage("WatchSyncManager: No lastServerRefresh timestamp, returning .notEnoughInformation")
-            return .notEnoughInformation
+            if useConservativeComparison {
+                FileLog.shared.addMessage("WatchSyncManager: No lastServerRefresh timestamp, returning .notEnoughInformation")
+                return .notEnoughInformation
+            } else {
+                return .watchNeedsUpdate
+            }
         }
 
         if lastServerRefresh > lastWatchDataTime {
@@ -57,8 +62,12 @@ public struct UpNextListComparator {
             FileLog.shared.addMessage("WatchSyncManager: Watch data is newer (lastServerRefresh: \(lastServerRefresh) < lastDataTime: \(lastWatchDataTime)), returning .watchNeedsUpdate")
             return .watchNeedsUpdate
         } else {
-            FileLog.shared.addMessage("WatchSyncManager: Timestamps are equal, returning .same")
-            return .same
+            if useConservativeComparison {
+                FileLog.shared.addMessage("WatchSyncManager: Timestamps are equal, returning .same")
+                return .same
+            } else {
+                return .watchNeedsUpdate
+            }
         }
     }
 }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -271,6 +271,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Allow the release of the Media Exporter when is no longer being used by the player
     case releaseMediaExporterWhenNoLongerActive
 
+    /// Fix Watch app overwriting phone's Up Next queue by adding debouncing and fixing timestamp comparison logic
+    case watchUpNextSyncFix
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -454,6 +457,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .dontAutoplayOnRouteChange:
             true
         case .releaseMediaExporterWhenNoLongerActive:
+            true
+        case .watchUpNextSyncFix:
             true
         }
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/General/ContextUpdateDebouncer.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/General/ContextUpdateDebouncer.swift
@@ -1,0 +1,18 @@
+import Combine
+import Foundation
+
+public final class ContextUpdateDebouncer {
+    private let subject = PassthroughSubject<Void, Never>()
+    private var cancellable: AnyCancellable?
+
+    public init(interval: TimeInterval, scheduler: DispatchQueue = .main, handler: @escaping () -> Void) {
+        let debounceInterval = DispatchQueue.SchedulerTimeType.Stride.milliseconds(Int(interval * 1000))
+        cancellable = subject
+            .debounce(for: debounceInterval, scheduler: scheduler)
+            .sink { handler() }
+    }
+
+    public func call() {
+        subject.send(())
+    }
+}

--- a/Pocket Casts Watch App/WatchDataManager.swift
+++ b/Pocket Casts Watch App/WatchDataManager.swift
@@ -1,5 +1,6 @@
 import PocketCastsDataModel
 import WatchKit
+import PocketCastsUtils
 
 class WatchDataManager {
     class func playlists() -> [WatchPlaylist]? {
@@ -173,6 +174,12 @@ class WatchDataManager {
             return 25
         }
         return deleteCount
+    }
+
+    class func updateLastDataTime(to date: Date = Date()) {
+        if FeatureFlag.watchUpNextSyncFix.enabled {
+            UserDefaults.standard.set(date, forKey: WatchConstants.UserDefaults.lastDataTime)
+        }
     }
 
     class func lastDataTime() -> Date {

--- a/Pocket Casts Watch App/WatchSourceViewModel.swift
+++ b/Pocket Casts Watch App/WatchSourceViewModel.swift
@@ -122,11 +122,13 @@ class WatchSourceViewModel: PlaySourceViewModel {
 
     func removeFromUpNext(episode: BaseEpisode) {
         PlaybackManager.shared.removeIfPlayingOrQueued(episode: episode, fireNotification: true)
+        WatchDataManager.updateLastDataTime()
     }
 
     func addToUpNext(episode: BaseEpisode, toTop: Bool) {
         PlaybackManager.shared.removeIfPlayingOrQueued(episode: episode, fireNotification: false)
         PlaybackManager.shared.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: toTop)
+        WatchDataManager.updateLastDataTime()
     }
 
     func archive(episode: BaseEpisode) {
@@ -231,6 +233,7 @@ class WatchSourceViewModel: PlaySourceViewModel {
 
     func clearUpNext() {
         PlaybackManager.shared.queue.clearUpNextList()
+        WatchDataManager.updateLastDataTime()
     }
 
     // MARK: Now Playing

--- a/Pocket Casts Watch App/WatchSyncManager.swift
+++ b/Pocket Casts Watch App/WatchSyncManager.swift
@@ -21,6 +21,7 @@ class WatchSyncManager {
     }
 
     deinit {
+        contextUpdateTimer?.invalidate()
         NotificationCenter.default.removeObserver(self)
     }
 
@@ -75,7 +76,19 @@ class WatchSyncManager {
         UserDefaults.standard.set(true, forKey: updateKey)
     }
 
+    private var contextUpdateTimer: Timer?
+
     @objc func handleContextUpdate() {
+        // Debounce context updates to allow watch to fully process phone's changes
+        // before deciding whether to sync. This prevents the watch from sending
+        // stale Up Next data that could overwrite recent phone changes.
+        contextUpdateTimer?.invalidate()
+        contextUpdateTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
+            self?.processContextUpdate()
+        }
+    }
+
+    private func processContextUpdate() {
         if updateLoginDetailsIfRequired() {
             return
         } else {
@@ -326,13 +339,25 @@ class WatchSyncManager {
         }
 
         guard let lastServerRefresh = ServerSettings.lastRefreshStartTime() else {
-            return .watchNeedsUpdate
+            // If we don't have a timestamp, we can't determine which is newer.
+            // Return .notEnoughInformation rather than defaulting to .watchNeedsUpdate
+            // to prevent the watch from sending stale data to the server.
+            FileLog.shared.addMessage("WatchSyncManager: No lastServerRefresh timestamp, returning .notEnoughInformation")
+            return .notEnoughInformation
         }
 
         if lastServerRefresh > WatchDataManager.lastDataTime() {
+            FileLog.shared.addMessage("WatchSyncManager: Phone data is newer (lastServerRefresh: \(lastServerRefresh) > lastDataTime: \(WatchDataManager.lastDataTime())), returning .phoneNeedsUpdate")
             return .phoneNeedsUpdate
-        } else {
+        } else if lastServerRefresh < WatchDataManager.lastDataTime() {
+            // Only return .watchNeedsUpdate if the watch data is definitively newer
+            FileLog.shared.addMessage("WatchSyncManager: Watch data is newer (lastServerRefresh: \(lastServerRefresh) < lastDataTime: \(WatchDataManager.lastDataTime())), returning .watchNeedsUpdate")
             return .watchNeedsUpdate
+        } else {
+            // If timestamps are equal, consider them the same rather than triggering a sync
+            // This prevents unnecessary syncs that could overwrite data
+            FileLog.shared.addMessage("WatchSyncManager: Timestamps are equal, returning .same")
+            return .same
         }
     }
 

--- a/Pocket Casts Watch App/WatchSyncManager.swift
+++ b/Pocket Casts Watch App/WatchSyncManager.swift
@@ -311,7 +311,8 @@ class WatchSyncManager {
             watchEpisodes: PlaybackManager.shared.allEpisodesInQueue(includeNowPlaying: false),
             watchEpisodeCount: PlaybackManager.shared.queue.upNextCount(),
             lastServerRefresh: ServerSettings.lastRefreshStartTime(),
-            lastWatchDataTime: WatchDataManager.lastDataTime()
+            lastWatchDataTime: WatchDataManager.lastDataTime(),
+            useConservativeComparison: FeatureFlag.watchUpNextSyncFix.enabled
         )
     }
 

--- a/Pocket Casts Watch App/WatchSyncManager.swift
+++ b/Pocket Casts Watch App/WatchSyncManager.swift
@@ -21,7 +21,6 @@ class WatchSyncManager {
     }
 
     deinit {
-        contextUpdateTimer?.invalidate()
         NotificationCenter.default.removeObserver(self)
     }
 
@@ -76,15 +75,18 @@ class WatchSyncManager {
         UserDefaults.standard.set(true, forKey: updateKey)
     }
 
-    private var contextUpdateTimer: Timer?
+    private lazy var contextUpdateDebouncer = ContextUpdateDebouncer(interval: 2.0) { [weak self] in
+        self?.processContextUpdate()
+    }
 
     @objc func handleContextUpdate() {
-        // Debounce context updates to allow watch to fully process phone's changes
-        // before deciding whether to sync. This prevents the watch from sending
-        // stale Up Next data that could overwrite recent phone changes.
-        contextUpdateTimer?.invalidate()
-        contextUpdateTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
-            self?.processContextUpdate()
+        if FeatureFlag.watchUpNextSyncFix.enabled {
+            // Debounce context updates to allow watch to fully process phone's changes
+            // before deciding whether to sync. This prevents the watch from sending
+            // stale Up Next data that could overwrite recent phone changes.
+            contextUpdateDebouncer.call()
+        } else {
+            processContextUpdate()
         }
     }
 
@@ -92,10 +94,12 @@ class WatchSyncManager {
         if updateLoginDetailsIfRequired() {
             return
         } else {
-            if isPlusUser(),
-               WKApplication.shared().applicationState == .background,
-               compareUpNextLists() == .watchNeedsUpdate,
-               !SyncManager.isFirstSyncInProgress() {
+            if WatchSyncDecision.shouldPerformBackgroundRefresh(
+                isPlusUser: isPlusUser(),
+                isAppInBackground: WKApplication.shared().applicationState == .background,
+                comparisonResult: compareUpNextLists(),
+                isFirstSyncInProgress: SyncManager.isFirstSyncInProgress()
+            ) {
                let subscribedPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
                BackgroundSyncManager.shared.performBackgroundRefresh(subscribedPodcasts: subscribedPodcasts)
             } else {
@@ -300,65 +304,15 @@ class WatchSyncManager {
         pendingChangeNotification = .none
     }
 
-    enum upNextComparisonResult: Int {
-        case same, phoneNeedsUpdate, watchNeedsUpdate, notEnoughInformation
-    }
-
-    private func compareUpNextLists() -> upNextComparisonResult {
-        let watchEpisodeCount = PlaybackManager.shared.queue.upNextCount()
-
-        guard let phoneEpisodes = WatchDataManager.upNextEpisodes(), phoneEpisodes.count > 0 else {
-            if watchEpisodeCount == 0 {
-                return .same
-            } else {
-                return .phoneNeedsUpdate
-            }
-        }
-
-        let phoneUpNextCount = WatchDataManager.upNextCount()
-        // The phone sends us a truncated list, and if the total count is higher than that we can't determine which list is newer because we're missing info
-        if phoneUpNextCount > phoneEpisodes.count { return .notEnoughInformation }
-
-        let watchEpisodes = PlaybackManager.shared.allEpisodesInQueue(includeNowPlaying: false)
-        if phoneEpisodes.count == watchEpisodes.count {
-            // if they are both 0, nothing to do
-            if watchEpisodes.count == 0 {
-                return .same
-            }
-
-            var allMatch = true
-            for (index, episode) in watchEpisodes.enumerated() {
-                if episode.uuid != phoneEpisodes[index].uuid {
-                    allMatch = false
-                    break
-                }
-            }
-            if allMatch {
-                return .same
-            }
-        }
-
-        guard let lastServerRefresh = ServerSettings.lastRefreshStartTime() else {
-            // If we don't have a timestamp, we can't determine which is newer.
-            // Return .notEnoughInformation rather than defaulting to .watchNeedsUpdate
-            // to prevent the watch from sending stale data to the server.
-            FileLog.shared.addMessage("WatchSyncManager: No lastServerRefresh timestamp, returning .notEnoughInformation")
-            return .notEnoughInformation
-        }
-
-        if lastServerRefresh > WatchDataManager.lastDataTime() {
-            FileLog.shared.addMessage("WatchSyncManager: Phone data is newer (lastServerRefresh: \(lastServerRefresh) > lastDataTime: \(WatchDataManager.lastDataTime())), returning .phoneNeedsUpdate")
-            return .phoneNeedsUpdate
-        } else if lastServerRefresh < WatchDataManager.lastDataTime() {
-            // Only return .watchNeedsUpdate if the watch data is definitively newer
-            FileLog.shared.addMessage("WatchSyncManager: Watch data is newer (lastServerRefresh: \(lastServerRefresh) < lastDataTime: \(WatchDataManager.lastDataTime())), returning .watchNeedsUpdate")
-            return .watchNeedsUpdate
-        } else {
-            // If timestamps are equal, consider them the same rather than triggering a sync
-            // This prevents unnecessary syncs that could overwrite data
-            FileLog.shared.addMessage("WatchSyncManager: Timestamps are equal, returning .same")
-            return .same
-        }
+    private func compareUpNextLists() -> UpNextComparisonResult {
+        UpNextListComparator.compare(
+            phoneEpisodes: WatchDataManager.upNextEpisodes(),
+            phoneUpNextCount: WatchDataManager.upNextCount(),
+            watchEpisodes: PlaybackManager.shared.allEpisodesInQueue(includeNowPlaying: false),
+            watchEpisodeCount: PlaybackManager.shared.queue.upNextCount(),
+            lastServerRefresh: ServerSettings.lastRefreshStartTime(),
+            lastWatchDataTime: WatchDataManager.lastDataTime()
+        )
     }
 
     func isPlusUser() -> Bool {

--- a/PocketCastsTests/Tests/Watch/WatchSyncManagerTests.swift
+++ b/PocketCastsTests/Tests/Watch/WatchSyncManagerTests.swift
@@ -1,0 +1,264 @@
+import XCTest
+import PocketCastsDataModel
+import PocketCastsUtils
+
+final class WatchSyncManagerTests: XCTestCase {
+    private let debounceInterval: TimeInterval = 0.05
+    private let debounceTimeout: TimeInterval = 0.5
+    private let debounceQueue = DispatchQueue(label: "watch-sync-tests.debounce")
+
+    private func makeEpisode(uuid: String) -> Episode {
+        let episode = Episode()
+        episode.uuid = uuid
+        return episode
+    }
+
+    private func compare(phoneEpisodes: [BaseEpisode]?,
+                         phoneUpNextCount: Int? = nil,
+                         watchEpisodes: [BaseEpisode] = [],
+                         watchEpisodeCount: Int? = nil,
+                         lastServerRefresh: Date? = Date(timeIntervalSince1970: 0),
+                         lastWatchDataTime: Date = Date(timeIntervalSince1970: 0)) -> UpNextComparisonResult {
+        UpNextListComparator.compare(
+            phoneEpisodes: phoneEpisodes,
+            phoneUpNextCount: phoneUpNextCount ?? (phoneEpisodes?.count ?? 0),
+            watchEpisodes: watchEpisodes,
+            watchEpisodeCount: watchEpisodeCount ?? watchEpisodes.count,
+            lastServerRefresh: lastServerRefresh,
+            lastWatchDataTime: lastWatchDataTime
+        )
+    }
+
+    // MARK: - Context Update Debouncing Tests
+
+    func testContextUpdateDebouncing_Specification() {
+        var fireCount = 0
+        let expectation = expectation(description: "debounced")
+        let debouncer = ContextUpdateDebouncer(interval: debounceInterval, scheduler: debounceQueue) {
+            fireCount += 1
+            expectation.fulfill()
+        }
+
+        debouncer.call()
+        debouncer.call()
+        debouncer.call()
+
+        wait(for: [expectation], timeout: debounceTimeout)
+        XCTAssertEqual(fireCount, 1)
+    }
+
+    func testTimerInvalidation_Specification() {
+        let expectation = expectation(description: "no debounce fire after deinit")
+        expectation.isInverted = true
+        var debouncer: ContextUpdateDebouncer? = ContextUpdateDebouncer(interval: debounceInterval, scheduler: debounceQueue) {
+            expectation.fulfill()
+        }
+
+        debouncer?.call()
+        debouncer = nil
+
+        wait(for: [expectation], timeout: debounceTimeout)
+    }
+
+    // MARK: - compareUpNextLists Timestamp Comparison Tests
+
+    func testTimestampComparison_NoTimestamp_ReturnsNotEnoughInformation() {
+        let phoneEpisodes = [makeEpisode(uuid: "phone-1")]
+        let watchEpisodes = [makeEpisode(uuid: "watch-1")]
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: nil,
+            lastWatchDataTime: Date(timeIntervalSince1970: 10)
+        )
+
+        XCTAssertEqual(result, .notEnoughInformation)
+    }
+
+    func testTimestampComparison_PhoneNewer_ReturnsPhoneNeedsUpdate() {
+        let phoneEpisodes = [makeEpisode(uuid: "phone-1")]
+        let watchEpisodes = [makeEpisode(uuid: "watch-1")]
+        let lastServerRefresh = Date(timeIntervalSince1970: 200)
+        let lastWatchDataTime = Date(timeIntervalSince1970: 100)
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: lastServerRefresh,
+            lastWatchDataTime: lastWatchDataTime
+        )
+
+        XCTAssertEqual(result, .phoneNeedsUpdate)
+    }
+
+    func testTimestampComparison_WatchNewer_ReturnsWatchNeedsUpdate() {
+        let phoneEpisodes = [makeEpisode(uuid: "phone-1")]
+        let watchEpisodes = [makeEpisode(uuid: "watch-1")]
+        let lastServerRefresh = Date(timeIntervalSince1970: 100)
+        let lastWatchDataTime = Date(timeIntervalSince1970: 200)
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: lastServerRefresh,
+            lastWatchDataTime: lastWatchDataTime
+        )
+
+        XCTAssertEqual(result, .watchNeedsUpdate)
+    }
+
+    func testTimestampComparison_EqualTimestamps_ReturnsSame() {
+        let phoneEpisodes = [makeEpisode(uuid: "phone-1")]
+        let watchEpisodes = [makeEpisode(uuid: "watch-1")]
+        let lastServerRefresh = Date(timeIntervalSince1970: 100)
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: lastServerRefresh,
+            lastWatchDataTime: lastServerRefresh
+        )
+
+        XCTAssertEqual(result, .same)
+    }
+
+    // MARK: - compareUpNextLists Episode Comparison Tests
+
+    func testEpisodeComparison_BothEmpty_ReturnsSame() {
+        let result = compare(phoneEpisodes: nil, watchEpisodes: [], watchEpisodeCount: 0)
+
+        XCTAssertEqual(result, .same)
+    }
+
+    func testEpisodeComparison_WatchHasEpisodesPhoneEmpty_ReturnsPhoneNeedsUpdate() {
+        let watchEpisodes = [makeEpisode(uuid: "watch-1")]
+
+        let result = compare(
+            phoneEpisodes: nil,
+            watchEpisodes: watchEpisodes,
+            watchEpisodeCount: watchEpisodes.count
+        )
+
+        XCTAssertEqual(result, .phoneNeedsUpdate)
+    }
+
+    func testEpisodeComparison_TruncatedList_ReturnsNotEnoughInformation() {
+        let phoneEpisodes = [makeEpisode(uuid: "phone-1")]
+        let watchEpisodes = [makeEpisode(uuid: "watch-1")]
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            phoneUpNextCount: 2,
+            watchEpisodes: watchEpisodes
+        )
+
+        XCTAssertEqual(result, .notEnoughInformation)
+    }
+
+    func testEpisodeComparison_IdenticalEpisodes_ReturnsSame() {
+        let phoneEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-2")]
+        let watchEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-2")]
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes
+        )
+
+        XCTAssertEqual(result, .same)
+    }
+
+    func testEpisodeComparison_DifferentEpisodes_FallsBackToTimestamp() {
+        let phoneEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-2")]
+        let watchEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-3")]
+        let lastServerRefresh = Date(timeIntervalSince1970: 200)
+        let lastWatchDataTime = Date(timeIntervalSince1970: 100)
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: lastServerRefresh,
+            lastWatchDataTime: lastWatchDataTime
+        )
+
+        XCTAssertEqual(result, .phoneNeedsUpdate)
+    }
+
+    // MARK: - Integration Behavior Tests
+
+    func testIntegration_ContextUpdateFlow_WhenUncertain_ShouldNotTriggerBackgroundSync() {
+        XCTAssertFalse(WatchSyncDecision.shouldPerformBackgroundRefresh(
+            isPlusUser: true,
+            isAppInBackground: true,
+            comparisonResult: .notEnoughInformation,
+            isFirstSyncInProgress: false
+        ))
+        XCTAssertFalse(WatchSyncDecision.shouldPerformBackgroundRefresh(
+            isPlusUser: true,
+            isAppInBackground: true,
+            comparisonResult: .same,
+            isFirstSyncInProgress: false
+        ))
+    }
+
+    func testIntegration_RapidPhoneChanges_ShouldWaitForDebounce() {
+        var fireCount = 0
+        let expectation = expectation(description: "debounced rapid changes")
+        let debouncer = ContextUpdateDebouncer(interval: debounceInterval, scheduler: debounceQueue) {
+            fireCount += 1
+            expectation.fulfill()
+        }
+
+        for _ in 0..<5 {
+            debouncer.call()
+        }
+
+        wait(for: [expectation], timeout: debounceTimeout)
+        XCTAssertEqual(fireCount, 1)
+    }
+
+    // MARK: - Regression Tests for Original Bug
+
+    func testRegression_WatchShouldNotOverwritePhoneWithStaleData() {
+        let phoneEpisodes = [makeEpisode(uuid: "ep-1")]
+        let watchEpisodes = [makeEpisode(uuid: "ep-2")]
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: nil,
+            lastWatchDataTime: Date(timeIntervalSince1970: 100)
+        )
+
+        XCTAssertEqual(result, .notEnoughInformation)
+    }
+
+    func testRegression_EqualTimestampsShouldNotTriggerSync() {
+        let phoneEpisodes = [makeEpisode(uuid: "ep-1")]
+        let watchEpisodes = [makeEpisode(uuid: "ep-2")]
+        let timestamp = Date(timeIntervalSince1970: 100)
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: timestamp,
+            lastWatchDataTime: timestamp
+        )
+
+        XCTAssertEqual(result, .same)
+    }
+
+    func testRegression_NoTimestampShouldNotTriggerSync() {
+        let phoneEpisodes = [makeEpisode(uuid: "ep-1")]
+        let watchEpisodes = [makeEpisode(uuid: "ep-2")]
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: nil,
+            lastWatchDataTime: Date(timeIntervalSince1970: 100)
+        )
+
+        XCTAssertEqual(result, .notEnoughInformation)
+    }
+}

--- a/PocketCastsTests/Tests/Watch/WatchSyncManagerTests.swift
+++ b/PocketCastsTests/Tests/Watch/WatchSyncManagerTests.swift
@@ -18,14 +18,16 @@ final class WatchSyncManagerTests: XCTestCase {
                          watchEpisodes: [BaseEpisode] = [],
                          watchEpisodeCount: Int? = nil,
                          lastServerRefresh: Date? = Date(timeIntervalSince1970: 0),
-                         lastWatchDataTime: Date = Date(timeIntervalSince1970: 0)) -> UpNextComparisonResult {
+                         lastWatchDataTime: Date = Date(timeIntervalSince1970: 0),
+                         useConservativeComparison: Bool = true) -> UpNextComparisonResult {
         UpNextListComparator.compare(
             phoneEpisodes: phoneEpisodes,
             phoneUpNextCount: phoneUpNextCount ?? (phoneEpisodes?.count ?? 0),
             watchEpisodes: watchEpisodes,
             watchEpisodeCount: watchEpisodeCount ?? watchEpisodes.count,
             lastServerRefresh: lastServerRefresh,
-            lastWatchDataTime: lastWatchDataTime
+            lastWatchDataTime: lastWatchDataTime,
+            useConservativeComparison: useConservativeComparison
         )
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -755,8 +755,8 @@
 		9AB645182D5138B200A842C8 /* Pocket Casts App Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = F5D5F7792CEBE769001F492D /* Pocket Casts App Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		9ACB950B2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */; };
 		9ACB950C2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */; };
-		9ACDEF512EE85B52001025B0 /* UIViewController+MultiSelectActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */; };
 		9ACDEF332EE6F632001025B0 /* ListPlaylist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACDEF322EE6F62C001025B0 /* ListPlaylist.swift */; };
+		9ACDEF512EE85B52001025B0 /* UIViewController+MultiSelectActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */; };
 		9AD41AC22EB4E0750048FB8B /* PlaylistDetailViewController+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD41AC12EB4E0700048FB8B /* PlaylistDetailViewController+Analytics.swift */; };
 		9AD809AF2EA12D940050649B /* PlaylistDetailFetchOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD809AE2EA12D850050649B /* PlaylistDetailFetchOperation.swift */; };
 		9AE5043C2DEDF2030027A4AE /* TranscriptContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */; };
@@ -1807,6 +1807,7 @@
 		F5516DBE2E1C9D82005DC201 /* UserSatisfactionSurveyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5516DBD2E1C9D82005DC201 /* UserSatisfactionSurveyView.swift */; };
 		F55275B82CB74E230012B705 /* EndOfYear2023Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55275B72CB74E230012B705 /* EndOfYear2023Story.swift */; };
 		F55275BA2CB74EB60012B705 /* EndOfYear2024Story.swift in Sources */ = {isa = PBXBuildFile; fileRef = F55275B92CB74EB30012B705 /* EndOfYear2024Story.swift */; };
+		F553772E2F16BBFB005382B0 /* WatchSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F553772C2F16BBFB005382B0 /* WatchSyncManagerTests.swift */; };
 		F553A15F2CECF953006581A1 /* EffectsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8032D22123EAD600BFBB03 /* EffectsButton.swift */; };
 		F553A1602CECF95B006581A1 /* SleepTimerButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8032D42123F0AF00BFBB03 /* SleepTimerButton.swift */; };
 		F553A1612CECF979006581A1 /* UIScreen+Sizes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF91A0F52B64159D002A0590 /* UIScreen+Sizes.swift */; };
@@ -3134,8 +3135,8 @@
 		9AB2900B2ECB7F75006086F9 /* PlaylistPlayAllSheetHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistPlayAllSheetHost.swift; sourceTree = "<group>"; };
 		9AB2900D2ECB82F6006086F9 /* PlaylistPlayAllSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistPlayAllSheet.swift; sourceTree = "<group>"; };
 		9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptiveActionAttributedTextView.swift; sourceTree = "<group>"; };
-		9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+MultiSelectActions.swift"; sourceTree = "<group>"; };
 		9ACDEF322EE6F62C001025B0 /* ListPlaylist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListPlaylist.swift; sourceTree = "<group>"; };
+		9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+MultiSelectActions.swift"; sourceTree = "<group>"; };
 		9AD41AC12EB4E0700048FB8B /* PlaylistDetailViewController+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaylistDetailViewController+Analytics.swift"; sourceTree = "<group>"; };
 		9AD809AE2EA12D850050649B /* PlaylistDetailFetchOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistDetailFetchOperation.swift; sourceTree = "<group>"; };
 		9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptContainerViewController.swift; sourceTree = "<group>"; };
@@ -4161,6 +4162,7 @@
 		F5516DBD2E1C9D82005DC201 /* UserSatisfactionSurveyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSatisfactionSurveyView.swift; sourceTree = "<group>"; };
 		F55275B72CB74E230012B705 /* EndOfYear2023Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2023Story.swift; sourceTree = "<group>"; };
 		F55275B92CB74EB30012B705 /* EndOfYear2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndOfYear2024Story.swift; sourceTree = "<group>"; };
+		F553772C2F16BBFB005382B0 /* WatchSyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSyncManagerTests.swift; sourceTree = "<group>"; };
 		F55449442B75935F00F68AE9 /* AppSettings+ImportUserDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppSettings+ImportUserDefaults.swift"; sourceTree = "<group>"; };
 		F554B0172E445E0700056CDF /* OnboardingRecommendationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRecommendationsView.swift; sourceTree = "<group>"; };
 		F554B0192E44682500056CDF /* FadeGradientModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FadeGradientModifier.swift; sourceTree = "<group>"; };
@@ -5359,6 +5361,7 @@
 				8BA6CAFB2C404C1900FB4704 /* Player */,
 				8BF1C61B2881F049007E80BF /* Folders */,
 				8B3295412A5336C600BDFA11 /* Whats New */,
+				F553772D2F16BBFB005382B0 /* Watch */,
 				2F63CE9428809E5A00A34B51 /* ThemeTests.swift */,
 				45ECEF8527E910FB00C65030 /* ShowNotesFormatterUtilsTests.swift */,
 				C79E1E3F28887549008524CB /* PlusUpgradeViewSourceTests.swift */,
@@ -8862,6 +8865,14 @@
 			path = Clip;
 			sourceTree = "<group>";
 		};
+		F553772D2F16BBFB005382B0 /* Watch */ = {
+			isa = PBXGroup;
+			children = (
+				F553772C2F16BBFB005382B0 /* WatchSyncManagerTests.swift */,
+			);
+			path = Watch;
+			sourceTree = "<group>";
+		};
 		F5B6F0DE2C18DF0900AF5150 /* Effects */ = {
 			isa = PBXGroup;
 			children = (
@@ -10442,6 +10453,7 @@
 				8BF1C61D2881F05D007E80BF /* FolderModelTests.swift in Sources */,
 				8BA55A1328CA7425002BECC5 /* XCTestCase+eventually.swift in Sources */,
 				C7D854F328ADD98700877E87 /* AppLifecyleAnalyticsTests.swift in Sources */,
+				F553772E2F16BBFB005382B0 /* WatchSyncManagerTests.swift in Sources */,
 				FF05C9922C0E044C00E41EB3 /* DBTestCase.swift in Sources */,
 				F56295292C0FC14900C44E8A /* DBTestCase.swift in Sources */,
 				C7BF5E4A29083B5300733C1E /* DiscoverCoordinatorTests.swift in Sources */,


### PR DESCRIPTION
Fixes [PCIOS-203](https://linear.app/a8c/issue/PCIOS-203/sync-issue-old-episodes-get-readded-to-up-next-queue-and-new-ones)

This is an attempt to improve reports we've received of Up Next syncing from the Apple Watch overwriting iPhone Up Next queues.

### Root Cause

When the phone sent Up Next updates to the Watch via WatchConnectivity, the Watch would:
  1. React too quickly - Immediately compare queues before fully processing the phone's changes
  2. Make biased sync decisions - The comparison logic defaulted to "watch needs to sync" in ambiguous cases:
    - No timestamp available → assumed Watch was newer
    - Equal timestamps → assumed Watch was newer
  3. Send stale data to server - The Watch would push its outdated queue to the server, which then synced back and overwrote the phone's recent changes

### The Fix
  1. Added 2-second debounce - Delays processing context updates so the Watch fully applies the phone's changes before deciding to sync
  2. Fixed comparison logic - Now returns `.notEnoughInformation` or `.same` in ambiguous cases instead of `.watchNeedsUpdate`
  3. Added feature flag - `watchUpNextSyncFix` controls the conservative comparison behavior
  4. Added logging - FileLog messages help diagnose sync decisions

## To test

* Add several episodes to Up Next on the watch with the Watch play source
* Go back and tap "Refresh Account" to ensure sync occurs
* Switch to the phone and tap "Refresh Now" on profile
* ✅ Ensure Up Next episodes are synced

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
