### PR TITLE
Add free disk space to support info

### DIFF
--- a/podcasts/DebugInfo.swift
+++ b/podcasts/DebugInfo.swift
@@ -1,7 +1,17 @@
+import Foundation
 import PocketCastsServer
 import PocketCastsUtils
 
 struct DebugInfo {
+    private static func formattedFreeDiskSpace() -> String {
+        guard let documentURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first,
+              let values = try? documentURL.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey]),
+              let capacity = values.volumeAvailableCapacityForImportantUsage else {
+            return "Unknown"
+        }
+        return capacity.formatted(.byteCount(style: .file))
+    }
+
     static func string(optOut: Bool) -> String {
         let syncEmail: String
         if SyncManager.isUserLoggedIn(), let email = ServerSettings.syncingEmail() {
@@ -20,7 +30,8 @@ struct DebugInfo {
         OS: \(DeviceUtil.systemVersion ?? "Unknown")
         Local Time: \(localTime)
         UTC Time: \(gmtTime)
-        Watch App Installed: \(WatchManager.shared.isWatchAppInstalled ? "yes" : "no")\n
+        Watch App Installed: \(WatchManager.shared.isWatchAppInstalled ? "yes" : "no")
+        Free Disk Space: \(formattedFreeDiskSpace())\n
         """
 
         guard !optOut else { return debugString }


### PR DESCRIPTION
Adds the amount of free disk space to support info.

This should help us troubleshoot failed downloads, potential app reinstalls, etc.

## To test

* Open Help & Feedback
* "Contact Support" at the bottom
* Tap "Get Support"
* Tap "Attached Logs"
* Verify the Meta Data field includes the "Free Disk Space"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
