### PR TITLE
Fix for archived episodes re-added to UpNext

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -205,6 +205,12 @@ class UpNextSyncTask: ApiBaseTask {
 
                     // 1. If the new episode exists in the local database already, then just add it to the queue
                     if let localEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episodeInfo.uuid) {
+                        // Skip archived episodes - they should not be re-added to Up Next
+                        if let episode = localEpisode as? Episode, episode.archived {
+                            FileLog.shared.addMessage("UpNextSyncTask: Episode \(localEpisode.displayableTitle()) is archived, skipping")
+                            continue
+                        }
+
                         FileLog.shared.addMessage("UpNextSyncTask: Episode \(localEpisode.displayableTitle()) exists in local DB, adding to the queue")
                         // we already have this episode, so all good save the Up Next item
                         newEpisode.podcastUuid = localEpisode.parentIdentifier()


### PR DESCRIPTION
Fixes PCIOS-203

**The Problem**                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                            
  The issue occurs during Up Next synchronization between devices. Here's what's happening:                                                                                                                                                                 
                                                                                                                                                                                                                                                            
  1. Server has outdated Up Next data                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                            
  From the logs:                                                                                                                                                                                                                                            
  - One user has 369 episodes in their server-side Up Next queue and experienced 284 un-archiving incidents                                                                                                                                                 
  - Another user has 28-30 episodes and experienced 54 un-archiving incidents                                                                                                                                                                               
                                                                                                                                                                                                                                                            
  2. Sync doesn't check archived status                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                            
In /Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift:206-212, when incoming episodes from the server are not found in the local Up Next queue, the code never checks if localEpisode.archived == true before adding it back to Up Next.                                                                                   
                                                                                                                                                                                                 
  3. Episodes get un-archived                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                            
 Later, in podcasts/DownloadManager.swift:476-487, when episodes are queued for download, the system detects they're archived and un-archives them.                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
  4. Apple Watch connection                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                            
The logs show WatchManager: Unknown message type: downloadRequest shortly before syncs. When users interact with their Watch, it triggers:                                                                                                                
  - Background refreshes                                                                                                                                                                                                                                    
  - Up Next syncs that pull the server's outdated queue (which still contains archived episodes)                                                                                                                                                            
  - Re-addition of archived episodes to the local queue                                                                                                                                                                                                     
                                                                                                                                                                                                                                                            
**The Fix**                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                            The UpNextSyncTask should check if an episode is archived before re-adding it to the queue. At line 207 in UpNextSyncTask.swift, add an archived status check:                                                                                            
                                                                                                                                                                                                                                                            
  ```if let localEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episodeInfo.uuid) {                                                                                                                                                                 
      // Skip archived episodes                                                                                                                                                                                                                             
      if let episode = localEpisode as? Episode, episode.archived {                                                                                                                                                                                         
          FileLog.shared.addMessage("UpNextSyncTask: Episode \(localEpisode.displayableTitle()) is archived, skipping")                                                                                                                                     
          continue                                                                                                                                                                                                                                          
      }                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                            FileLog.shared.addMessage("UpNextSyncTask: Episode \(localEpisode.displayableTitle()) exists in local DB, adding to the queue")                                                                                                                       
      // ... rest of the code                                                                                                                                                                                                                               
  }
```                                                                       


<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test
Not sure if we were ever able to reproduce this issue consistently. @Automattic/pocket-casts-ios , any idea how to test if this fix makes sense?

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
