### PR TITLE
Remove NSUserTrackingUsageDescription

### DIFF
--- a/podcasts/ca.lproj/InfoPlist.strings
+++ b/podcasts/ca.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts necessita permís per a desar aquesta imatge a la teva biblioteca de fotos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts necessita permís per a desar aquesta imatge a la teva biblioteca de fotos.</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>Fem servir analítiques per millorar l'app i mesurar si les nostres campanyes publicitàries són exitoses.</string>
   </dict>
 </plist>

--- a/podcasts/de.lproj/InfoPlist.strings
+++ b/podcasts/de.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts benötigt die Berechtigung, um dieses Bild in deiner Foto-Bibliothek zu speichern.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts benötigt die Berechtigung, um dieses Bild in deiner Foto-Bibliothek zu speichern.</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>Wir nutzen Analysen, um unsere App zu verbessern und zu messen, ob unsere Werbekampagnen erfolgreich sind.</string>
   </dict>
 </plist>

--- a/podcasts/en.lproj/InfoPlist.strings
+++ b/podcasts/en.lproj/InfoPlist.strings
@@ -15,6 +15,3 @@ NSPhotoLibraryUsageDescription = "Pocket Casts needs permission to save this ima
 
 /* A message that tells the user why the app is requesting add-only access to the user’s photo library. */
 NSPhotoLibraryAddUsageDescription = "Pocket Casts needs permission to save this image to your photo library.";
-
-/* A message that tells the users we want to collect data to be shared with 3rd party libraries */
-NSUserTrackingUsageDescription = "We use analytics to make the app better and to measure if our ad campaigns are successful.";

--- a/podcasts/es-MX.lproj/InfoPlist.strings
+++ b/podcasts/es-MX.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts necesita permiso para guardar esta imagen en tu biblioteca de fotos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts necesita permiso para guardar esta imagen en tu biblioteca de fotos.</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>Utilizamos los análisis para mejorar la aplicación y medir si nuestras campañas publicitarias tienen éxito.</string>
   </dict>
 </plist>

--- a/podcasts/es.lproj/InfoPlist.strings
+++ b/podcasts/es.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts necesita permiso para guardar esta imagen en tu biblioteca de fotos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts necesita permiso para guardar esta imagen en tu biblioteca de fotos.</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>Utilizamos los análisis para mejorar la aplicación y medir si nuestras campañas publicitarias tienen éxito.</string>
   </dict>
 </plist>

--- a/podcasts/fr-CA.lproj/InfoPlist.strings
+++ b/podcasts/fr-CA.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts nécessite une autorisation pour sauvegarder cette image dans votre bibliothèque de photos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts nécessite une autorisation pour sauvegarder cette image dans votre bibliothèque de photos.</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>Nous utilisons les statistiques pour améliorer l’application et mesurer le succès de nos campagnes publicitaires.</string>
   </dict>
 </plist>

--- a/podcasts/fr.lproj/InfoPlist.strings
+++ b/podcasts/fr.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts nécessite une autorisation pour sauvegarder cette image dans votre bibliothèque de photos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts nécessite une autorisation pour sauvegarder cette image dans votre bibliothèque de photos.</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>Nous utilisons les statistiques pour améliorer l’application et mesurer le succès de nos campagnes publicitaires.</string>
   </dict>
 </plist>

--- a/podcasts/it.lproj/InfoPlist.strings
+++ b/podcasts/it.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts necessita dell'autorizzazione per salvare questa immagine nella tua libreria di foto.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts necessita dell'autorizzazione per salvare questa immagine nella tua libreria di foto.</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>Utilizziamo l'analisi per migliorare l'app e per misurare il successo delle nostre campagne pubblicitarie.</string>
   </dict>
 </plist>

--- a/podcasts/ja.lproj/InfoPlist.strings
+++ b/podcasts/ja.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts でこの画像をフォトライブラリに保存するには権限が必要です。</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts でこの画像をフォトライブラリに保存するには権限が必要です。</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>当社ではアナリティクスを使用して、アプリの改良や、広告キャンペーンが成功したかどうかの測定を行っています。</string>
   </dict>
 </plist>

--- a/podcasts/nl.lproj/InfoPlist.strings
+++ b/podcasts/nl.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts heeft toestemming nodig om deze afbeelding op te slaan in je fotobibliotheek.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts heeft toestemming nodig om deze afbeelding op te slaan in je fotobibliotheek.</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>We gebruiken analyses om de app te verbeteren en bij te houden of onze advertentiecampagnes werken.</string>
   </dict>
 </plist>

--- a/podcasts/podcasts-Info.plist
+++ b/podcasts/podcasts-Info.plist
@@ -1039,8 +1039,6 @@
 		<string>SJOpenFilterIntent</string>
 		<string>SJSleepTimerIntent</string>
 	</array>
-	<key>NSUserTrackingUsageDescription</key>
-	<string>We use analytics to make the app better and to measure if our ad campaigns are successful.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>DMSans.ttf</string>

--- a/podcasts/pt-BR.lproj/InfoPlist.strings
+++ b/podcasts/pt-BR.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>O Pocket Casts precisa de permissão para salvar essa imagem em sua biblioteca de fotos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>O Pocket Casts precisa de permissão para salvar essa imagem em sua biblioteca de fotos.</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>Usamos análises para melhorar o aplicativo e avaliar se nossas campanhas publicitárias estão se saindo bem.</string>
   </dict>
 </plist>

--- a/podcasts/ru.lproj/InfoPlist.strings
+++ b/podcasts/ru.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts требуется разрешение на сохранение этого изображения в библиотеке фотографий.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts требуется разрешение на сохранение этого изображения в библиотеке фотографий.</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>Пользуясь аналитическими данными, мы улучшаем приложение и оцениваем успешность рекламных кампаний.</string>
   </dict>
 </plist>

--- a/podcasts/sv.lproj/InfoPlist.strings
+++ b/podcasts/sv.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts behöver tillåtelse att spara den här bilden i ditt fotobibliotek.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts behöver tillåtelse att spara den här bilden i ditt fotobibliotek.</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>Vi använder analyser för att göra appen bättre och för att mäta om våra annonskampanjer är framgångsrika.</string>
   </dict>
 </plist>

--- a/podcasts/zh-Hans.lproj/InfoPlist.strings
+++ b/podcasts/zh-Hans.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts 需获得权限，才能将此图像保存到您的照片库中。</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts 需获得权限，才能将此图像保存到您的照片库中。</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>我们使用分析功能来改进应用程序以及衡量广告活动的成功与否。</string>
   </dict>
 </plist>

--- a/podcasts/zh-Hant.lproj/InfoPlist.strings
+++ b/podcasts/zh-Hant.lproj/InfoPlist.strings
@@ -15,7 +15,5 @@
     <string>Pocket Casts 需要權限才能將此圖片儲存至你的圖庫。</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts 需要權限才能將此圖片儲存至你的圖庫。</string>
-    <key>NSUserTrackingUsageDescription</key>
-    <string>我們使用分析工具來改善應用程式，並衡量廣告行銷活動是否成功。</string>
   </dict>
 </plist>


### PR DESCRIPTION
We no longer need this Info.plist key as AppsFlyer and ATT was removed.

## To test

* CI is green

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
