### PR TITLE
Add ATT tracking prompt

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -755,8 +755,8 @@
 		9AB645182D5138B200A842C8 /* Pocket Casts App Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = F5D5F7792CEBE769001F492D /* Pocket Casts App Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		9ACB950B2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */; };
 		9ACB950C2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */; };
-		9ACDEF512EE85B52001025B0 /* UIViewController+MultiSelectActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */; };
 		9ACDEF332EE6F632001025B0 /* ListPlaylist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACDEF322EE6F62C001025B0 /* ListPlaylist.swift */; };
+		9ACDEF512EE85B52001025B0 /* UIViewController+MultiSelectActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */; };
 		9AD41AC22EB4E0750048FB8B /* PlaylistDetailViewController+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD41AC12EB4E0700048FB8B /* PlaylistDetailViewController+Analytics.swift */; };
 		9AD809AF2EA12D940050649B /* PlaylistDetailFetchOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD809AE2EA12D850050649B /* PlaylistDetailFetchOperation.swift */; };
 		9AE5043C2DEDF2030027A4AE /* TranscriptContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */; };
@@ -1851,6 +1851,8 @@
 		F57D8F142C66CA230004C4DF /* UnsafeWait.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F132C66CA230004C4DF /* UnsafeWait.swift */; };
 		F57D8F162C66CBB80004C4DF /* UnsafeTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F152C66CBB80004C4DF /* UnsafeTransfer.swift */; };
 		F57D8F182C66CDF40004C4DF /* View+CVPixelBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57D8F172C66CDF40004C4DF /* View+CVPixelBuffer.swift */; };
+		F57FFBDD2F1DD8FE00D89D21 /* AppTrackingTransparencyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57FFBDB2F1DD8FE00D89D21 /* AppTrackingTransparencyController.swift */; };
+		F57FFBDE2F1DD8FE00D89D21 /* AppTrackingTransparencyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57FFBDB2F1DD8FE00D89D21 /* AppTrackingTransparencyController.swift */; };
 		F580777C2DEA032A005AFBA6 /* Theme+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = C715EE0E2A0497DB0054A082 /* Theme+Color.swift */; };
 		F58189C22DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */; };
 		F58189C32DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */; };
@@ -3134,8 +3136,8 @@
 		9AB2900B2ECB7F75006086F9 /* PlaylistPlayAllSheetHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistPlayAllSheetHost.swift; sourceTree = "<group>"; };
 		9AB2900D2ECB82F6006086F9 /* PlaylistPlayAllSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistPlayAllSheet.swift; sourceTree = "<group>"; };
 		9ACB950A2E0D9199007238A7 /* DescriptiveActionAttributedTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptiveActionAttributedTextView.swift; sourceTree = "<group>"; };
-		9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+MultiSelectActions.swift"; sourceTree = "<group>"; };
 		9ACDEF322EE6F62C001025B0 /* ListPlaylist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListPlaylist.swift; sourceTree = "<group>"; };
+		9ACDEF502EE85B38001025B0 /* UIViewController+MultiSelectActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+MultiSelectActions.swift"; sourceTree = "<group>"; };
 		9AD41AC12EB4E0700048FB8B /* PlaylistDetailViewController+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaylistDetailViewController+Analytics.swift"; sourceTree = "<group>"; };
 		9AD809AE2EA12D850050649B /* PlaylistDetailFetchOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistDetailFetchOperation.swift; sourceTree = "<group>"; };
 		9AE5043B2DEDF1F80027A4AE /* TranscriptContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptContainerViewController.swift; sourceTree = "<group>"; };
@@ -4182,6 +4184,7 @@
 		F57D8F132C66CA230004C4DF /* UnsafeWait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafeWait.swift; sourceTree = "<group>"; };
 		F57D8F152C66CBB80004C4DF /* UnsafeTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnsafeTransfer.swift; sourceTree = "<group>"; };
 		F57D8F172C66CDF40004C4DF /* View+CVPixelBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+CVPixelBuffer.swift"; sourceTree = "<group>"; };
+		F57FFBDB2F1DD8FE00D89D21 /* AppTrackingTransparencyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTrackingTransparencyController.swift; sourceTree = "<group>"; };
 		F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PodcastInfo+DiscoverPodcast.swift"; sourceTree = "<group>"; };
 		F581ED412CC6F19300A19860 /* ListeningTime2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningTime2024Story.swift; sourceTree = "<group>"; };
 		F581ED432CC6F3A400A19860 /* Top5Podcasts2024Story.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Top5Podcasts2024Story.swift; sourceTree = "<group>"; };
@@ -7956,6 +7959,7 @@
 			isa = PBXGroup;
 			children = (
 				C7C4CAEA28AB05A800CFC8CF /* AnalyticsLoggingAdapter.swift */,
+				F57FFBDC2F1DD8FE00D89D21 /* Apple ATT */,
 				46A6AC0128F5B67D000E6254 /* Crash Logging */,
 				C7C4CAEC28AB0BE300CFC8CF /* Tracks */,
 			);
@@ -8860,6 +8864,14 @@
 				F555980A2C50242800C02EEB /* VideoExporter.swift */,
 			);
 			path = Clip;
+			sourceTree = "<group>";
+		};
+		F57FFBDC2F1DD8FE00D89D21 /* Apple ATT */ = {
+			isa = PBXGroup;
+			children = (
+				F57FFBDB2F1DD8FE00D89D21 /* AppTrackingTransparencyController.swift */,
+			);
+			path = "Apple ATT";
 			sourceTree = "<group>";
 		};
 		F5B6F0DE2C18DF0900AF5150 /* Effects */ = {
@@ -10922,6 +10934,7 @@
 				BDF9DDDB1B8AD29C00E77B35 /* TimeSliderLayer.swift in Sources */,
 				BDB1E4ED1B8C5BCF009AD30F /* FeaturedSummaryViewController.swift in Sources */,
 				BDD3018E1EFB9574004A9972 /* WatchConstants.swift in Sources */,
+				F57FFBDD2F1DD8FE00D89D21 /* AppTrackingTransparencyController.swift in Sources */,
 				F51D90762C73141B00F0A232 /* CGSize+FittingSize.swift in Sources */,
 				8BD7A2382C04F0DD00CF84E8 /* UpNextHistoryViewController.swift in Sources */,
 				463538AE26E8F4AE00BA9D35 /* Server+Strings.swift in Sources */,
@@ -11831,6 +11844,7 @@
 				F5ADE2FC2CF52BB400F2CEA7 /* AnalyticsDescribable+Modules.swift in Sources */,
 				F553A1662CECF9D0006581A1 /* CustomTimeStepper.swift in Sources */,
 				F5F509422CEBF28F007D6E39 /* SJUIUtils.swift in Sources */,
+				F57FFBDE2F1DD8FE00D89D21 /* AppTrackingTransparencyController.swift in Sources */,
 				F5F509282CEBEF01007D6E39 /* PodcastIndexChapterDataRetriever.swift in Sources */,
 				F5F5090C2CEBEB6B007D6E39 /* PlayerContainerViewController+Update.swift in Sources */,
 				F5F509432CEBF298007D6E39 /* PCNavigationController.swift in Sources */,

--- a/podcasts/Analytics/Adapters/Apple ATT/AppTrackingTransparencyController.swift
+++ b/podcasts/Analytics/Adapters/Apple ATT/AppTrackingTransparencyController.swift
@@ -1,0 +1,65 @@
+import AppTrackingTransparency
+import PocketCastsUtils
+
+protocol AppTrackingTransparencyProvider {
+    func shouldShowPrompt() -> Bool
+    func userGaveConsent() -> Bool
+    func userDeniedConsent() -> Bool
+    func userSawPrompt() -> Bool
+    func promptConsentAlert() async -> Bool
+}
+
+class AppTrackingTransparencyController: AppTrackingTransparencyProvider {
+    static let shared = AppTrackingTransparencyController()
+
+    func shouldShowPrompt() -> Bool {
+        return ATTrackingManager.trackingAuthorizationStatus == .notDetermined
+    }
+
+    func userSawPrompt() -> Bool {
+        return ATTrackingManager.trackingAuthorizationStatus != .notDetermined
+    }
+
+    func userGaveConsent() -> Bool {
+        return ATTrackingManager.trackingAuthorizationStatus.isAuthorized
+    }
+
+    func userDeniedConsent() -> Bool {
+        return ATTrackingManager.trackingAuthorizationStatus.isDenied
+    }
+
+    @discardableResult
+    func promptConsentAlert() async -> Bool {
+        guard shouldShowPrompt() else {
+            return false
+        }
+        let authorizationStatus = await ATTrackingManager.requestTrackingAuthorization()
+        FileLog.shared.addMessage("ATT Tracking request authorization: \(authorizationStatus.stringValue)")
+        return true
+    }
+}
+
+extension ATTrackingManager.AuthorizationStatus {
+    fileprivate var isAuthorized: Bool {
+        self == .authorized
+    }
+
+    fileprivate var isDenied: Bool {
+        self == .denied
+    }
+
+    fileprivate var stringValue: String {
+        switch self {
+        case .notDetermined:
+            "Not Determined"
+        case .restricted:
+            "Restricted"
+        case .denied:
+            "Denied"
+        case .authorized:
+            "Authorized"
+        @unknown default:
+            "Unknown"
+        }
+    }
+}

--- a/podcasts/MainTabBarController.swift
+++ b/podcasts/MainTabBarController.swift
@@ -128,6 +128,12 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         showInitialOnboardingIfNeeded()
 
+        if AppTrackingTransparencyController.shared.shouldShowPrompt() {
+            Task {
+                await AppTrackingTransparencyController.shared.promptConsentAlert()
+            }
+        }
+
         updateDatabaseIndexes()
         optimizeDatabaseIfNeeded()
 

--- a/podcasts/PrivacySettings/PrivacySettingsDataSource.swift
+++ b/podcasts/PrivacySettings/PrivacySettingsDataSource.swift
@@ -12,7 +12,7 @@ class PrivacySettingsDataSource: NSObject, UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        4
+        6
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -41,6 +41,23 @@ class PrivacySettingsDataSource: NSObject, UITableViewDataSource {
             cell.textLabel?.font = .systemFont(ofSize: 16)
             cell.textLabel?.numberOfLines = 0
             return cell
+        case 3:
+            let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
+            cell.cellLabel.text = L10n.settingsThirdPartyAnalytics
+            cell.cellSwitch.isOn = AppTrackingTransparencyController.shared.userGaveConsent()
+            cell.cellSwitch.isEnabled = AppTrackingTransparencyController.shared.userSawPrompt()
+            cell.cellSwitch.removeTarget(self, action: nil, for: UIControl.Event.valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(openSettings(_:)), for: UIControl.Event.valueChanged)
+            return cell
+        case 4:
+            let cell = tableView.dequeueReusableCell(withIdentifier: themeableCellWithoutSelectionId, for: indexPath) as! ThemeableCellWithoutSelection
+            cell.style = .primaryUi02
+            cell.imageView?.image = UIImage()
+            cell.textLabel?.textColor = ThemeColor.primaryText02()
+            cell.textLabel?.text = L10n.settingsAllowCollectionThirdParty
+            cell.textLabel?.font = .systemFont(ofSize: 16)
+            cell.textLabel?.numberOfLines = 0
+            return cell
         default:
             let cell = tableView.dequeueReusableCell(withIdentifier: themeableCellId, for: indexPath) as! ThemeableCell
             cell.textLabel?.textColor = ThemeColor.primaryInteractive01()
@@ -55,6 +72,20 @@ class PrivacySettingsDataSource: NSObject, UITableViewDataSource {
             Analytics.shared.optInOfAnalytics()
         } else {
             Analytics.shared.optOutOfAnalytics()
+        }
+    }
+
+    @objc private func openSettings(_ sender: UISwitch) {
+        if sender.isOn {
+            Analytics.track(.analyticsThirdPartyOptIn)
+        } else {
+            Analytics.track(.analyticsThirdPartyOptOut)
+        }
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url, options: [:]) {
+                _ in
+                sender.isOn = AppTrackingTransparencyController.shared.userGaveConsent()
+            }
         }
     }
 }

--- a/podcasts/PrivacySettings/PrivacySettingsViewController.swift
+++ b/podcasts/PrivacySettings/PrivacySettingsViewController.swift
@@ -34,7 +34,7 @@ class PrivacySettingsViewController: PCViewController, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         switch indexPath.row {
-        case 3:
+        case 5:
             NavigationManager.sharedManager.navigateTo(NavigationManager.showPrivacyPolicyPageKey, data: nil)
         default:
             break

--- a/podcasts/ca.lproj/InfoPlist.strings
+++ b/podcasts/ca.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts necessita permís per a desar aquesta imatge a la teva biblioteca de fotos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts necessita permís per a desar aquesta imatge a la teva biblioteca de fotos.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Fem servir analítiques per millorar l'app i mesurar si les nostres campanyes publicitàries són exitoses.</string>
   </dict>
 </plist>

--- a/podcasts/de.lproj/InfoPlist.strings
+++ b/podcasts/de.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts benötigt die Berechtigung, um dieses Bild in deiner Foto-Bibliothek zu speichern.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts benötigt die Berechtigung, um dieses Bild in deiner Foto-Bibliothek zu speichern.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Wir nutzen Analysen, um unsere App zu verbessern und zu messen, ob unsere Werbekampagnen erfolgreich sind.</string>
   </dict>
 </plist>

--- a/podcasts/en.lproj/InfoPlist.strings
+++ b/podcasts/en.lproj/InfoPlist.strings
@@ -15,3 +15,6 @@ NSPhotoLibraryUsageDescription = "Pocket Casts needs permission to save this ima
 
 /* A message that tells the user why the app is requesting add-only access to the user’s photo library. */
 NSPhotoLibraryAddUsageDescription = "Pocket Casts needs permission to save this image to your photo library.";
+
+/* A message that tells the users we want to collect data to be shared with 3rd party libraries */
+NSUserTrackingUsageDescription = "We use analytics to make the app better and to measure if our ad campaigns are successful.";

--- a/podcasts/es-MX.lproj/InfoPlist.strings
+++ b/podcasts/es-MX.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts necesita permiso para guardar esta imagen en tu biblioteca de fotos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts necesita permiso para guardar esta imagen en tu biblioteca de fotos.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Utilizamos los análisis para mejorar la aplicación y medir si nuestras campañas publicitarias tienen éxito.</string>
   </dict>
 </plist>

--- a/podcasts/es.lproj/InfoPlist.strings
+++ b/podcasts/es.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts necesita permiso para guardar esta imagen en tu biblioteca de fotos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts necesita permiso para guardar esta imagen en tu biblioteca de fotos.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Utilizamos los análisis para mejorar la aplicación y medir si nuestras campañas publicitarias tienen éxito.</string>
   </dict>
 </plist>

--- a/podcasts/fr-CA.lproj/InfoPlist.strings
+++ b/podcasts/fr-CA.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts nécessite une autorisation pour sauvegarder cette image dans votre bibliothèque de photos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts nécessite une autorisation pour sauvegarder cette image dans votre bibliothèque de photos.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Nous utilisons les statistiques pour améliorer l’application et mesurer le succès de nos campagnes publicitaires.</string>
   </dict>
 </plist>

--- a/podcasts/fr.lproj/InfoPlist.strings
+++ b/podcasts/fr.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts nécessite une autorisation pour sauvegarder cette image dans votre bibliothèque de photos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts nécessite une autorisation pour sauvegarder cette image dans votre bibliothèque de photos.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Nous utilisons les statistiques pour améliorer l’application et mesurer le succès de nos campagnes publicitaires.</string>
   </dict>
 </plist>

--- a/podcasts/it.lproj/InfoPlist.strings
+++ b/podcasts/it.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts necessita dell'autorizzazione per salvare questa immagine nella tua libreria di foto.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts necessita dell'autorizzazione per salvare questa immagine nella tua libreria di foto.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Utilizziamo l'analisi per migliorare l'app e per misurare il successo delle nostre campagne pubblicitarie.</string>
   </dict>
 </plist>

--- a/podcasts/ja.lproj/InfoPlist.strings
+++ b/podcasts/ja.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts でこの画像をフォトライブラリに保存するには権限が必要です。</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts でこの画像をフォトライブラリに保存するには権限が必要です。</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>当社ではアナリティクスを使用して、アプリの改良や、広告キャンペーンが成功したかどうかの測定を行っています。</string>
   </dict>
 </plist>

--- a/podcasts/nl.lproj/InfoPlist.strings
+++ b/podcasts/nl.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts heeft toestemming nodig om deze afbeelding op te slaan in je fotobibliotheek.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts heeft toestemming nodig om deze afbeelding op te slaan in je fotobibliotheek.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>We gebruiken analyses om de app te verbeteren en bij te houden of onze advertentiecampagnes werken.</string>
   </dict>
 </plist>

--- a/podcasts/podcasts-Info.plist
+++ b/podcasts/podcasts-Info.plist
@@ -1041,6 +1041,8 @@
 		<string>SJOpenFilterIntent</string>
 		<string>SJSleepTimerIntent</string>
 	</array>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>We use analytics to make the app better and to measure if our ad campaigns are successful.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>DMSans.ttf</string>

--- a/podcasts/podcasts-Info.plist
+++ b/podcasts/podcasts-Info.plist
@@ -1030,6 +1030,8 @@
 	<string>Pocket Casts needs permission to save this image to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Pocket Casts needs permission to save this image to your photo library.</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>We use analytics to make the app better and to measure if our ad campaigns are successful.</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>ChapterIntent</string>

--- a/podcasts/pt-BR.lproj/InfoPlist.strings
+++ b/podcasts/pt-BR.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>O Pocket Casts precisa de permissão para salvar essa imagem em sua biblioteca de fotos.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>O Pocket Casts precisa de permissão para salvar essa imagem em sua biblioteca de fotos.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Usamos análises para melhorar o aplicativo e avaliar se nossas campanhas publicitárias estão se saindo bem.</string>
   </dict>
 </plist>

--- a/podcasts/ru.lproj/InfoPlist.strings
+++ b/podcasts/ru.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts требуется разрешение на сохранение этого изображения в библиотеке фотографий.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts требуется разрешение на сохранение этого изображения в библиотеке фотографий.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Пользуясь аналитическими данными, мы улучшаем приложение и оцениваем успешность рекламных кампаний.</string>
   </dict>
 </plist>

--- a/podcasts/sv.lproj/InfoPlist.strings
+++ b/podcasts/sv.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts behöver tillåtelse att spara den här bilden i ditt fotobibliotek.</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts behöver tillåtelse att spara den här bilden i ditt fotobibliotek.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Vi använder analyser för att göra appen bättre och för att mäta om våra annonskampanjer är framgångsrika.</string>
   </dict>
 </plist>

--- a/podcasts/zh-Hans.lproj/InfoPlist.strings
+++ b/podcasts/zh-Hans.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts 需获得权限，才能将此图像保存到您的照片库中。</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts 需获得权限，才能将此图像保存到您的照片库中。</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>我们使用分析功能来改进应用程序以及衡量广告活动的成功与否。</string>
   </dict>
 </plist>

--- a/podcasts/zh-Hant.lproj/InfoPlist.strings
+++ b/podcasts/zh-Hant.lproj/InfoPlist.strings
@@ -15,5 +15,7 @@
     <string>Pocket Casts 需要權限才能將此圖片儲存至你的圖庫。</string>
     <key>NSPhotoLibraryUsageDescription</key>
     <string>Pocket Casts 需要權限才能將此圖片儲存至你的圖庫。</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>我們使用分析工具來改善應用程式，並衡量廣告行銷活動是否成功。</string>
   </dict>
 </plist>


### PR DESCRIPTION
Adds the ATT tracking prompt back and the setting in Settings.

https://github.com/user-attachments/assets/268ea740-d7a4-4323-9024-64006c0fc641

## To test

* Fresh install of the app
* Ensure the ATT Tracking Prompt appears
* Profile > Settings > Privacy > Third-party analytics

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
