### PR TITLE
Use continuation to track export status instead of active polling

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -271,6 +271,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Allow the release of the Media Exporter when is no longer being used by the player
     case releaseMediaExporterWhenNoLongerActive
 
+    /// Use continuation approach to wait for exporter to finish
+    case streamAndCacheWaitWithContinuation
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -454,6 +457,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .dontAutoplayOnRouteChange:
             true
         case .releaseMediaExporterWhenNoLongerActive:
+            true
+        case .streamAndCacheWaitWithContinuation:
             true
         }
     }

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -446,7 +446,13 @@ class DownloadManager: NSObject, FilePathProtocol {
             activeLoaderDelegate = customLoaderDelegate
         }
         Task {
-            await exportStatus.waitCompletion()
+            if FeatureFlag.streamAndCacheWaitWithContinuation.enabled {
+                await exportStatus.waitCompletion()
+            } else {
+                while !exportStatus.completed {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                }
+            }
             downloadingEpisodesCache[downloadTaskUUID] = nil
             removeEpisodeFromCache(episode)
             if FeatureFlag.releaseMediaExporterWhenNoLongerActive.enabled,

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -319,7 +319,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         return
     }
 
-    private class ExportStatus {
+    private actor ExportStatus {
         private var continuation: CheckedContinuation<Void, Never>?
 
         func waitCompletion() async {
@@ -329,7 +329,13 @@ class DownloadManager: NSObject, FilePathProtocol {
             }
         }
 
-        var completed: Bool = false {
+        func updateStatus(completed: Bool, reportedType: String?, error: Error?) {
+            self.reportedType = reportedType
+            self.error = error
+            self.completed = completed
+        }
+
+        private(set) var completed: Bool = false {
             didSet {
                 if completed {
                     continuation?.resume()
@@ -338,8 +344,8 @@ class DownloadManager: NSObject, FilePathProtocol {
             }
         }
 
-        var reportedType: String?
-        var error: Error?
+        private(set) var reportedType: String?
+        private(set) var error: Error?
     }
 
     private let activeLoaderLock = NSLock()
@@ -417,19 +423,19 @@ class DownloadManager: NSObject, FilePathProtocol {
         let exportStatus =  ExportStatus()
         let originalSizeInBytes = episode.sizeInBytes
         let customLoaderDelegate = MediaExporterResourceLoaderDelegate(saveFilePath: exportPath) { [weak self, exportStatus] status, contentType, bytesDownloaded, bytesExpected in
-            guard let self else {
-                return
-            }
-            exportStatus.reportedType = contentType
-            let size = max(100, max(bytesExpected, originalSizeInBytes))
-            switch status {
-            case .downloading:
-                self.reportProgress(episodeUUID: downloadTaskUUID, totalBytesWritten: bytesDownloaded, totalBytesExpectedToWrite: size)
-            case .failed(let error):
-                exportStatus.error = error
-                exportStatus.completed = true
-            case .completed:
-                exportStatus.completed = true
+            Task {
+                guard let self else {
+                    return
+                }
+                let size = max(100, max(bytesExpected, originalSizeInBytes))
+                switch status {
+                case .downloading:
+                    self.reportProgress(episodeUUID: downloadTaskUUID, totalBytesWritten: bytesDownloaded, totalBytesExpectedToWrite: size)
+                case .failed(let error):
+                    await exportStatus.updateStatus(completed: true, reportedType: contentType, error: error)
+                case .completed:
+                    await exportStatus.updateStatus(completed: true, reportedType: contentType, error: nil)
+                }
             }
         }
         guard let customURL = MediaExporterResourceLoaderDelegate.makeCustomURL(urlAsset.url) else {
@@ -449,10 +455,13 @@ class DownloadManager: NSObject, FilePathProtocol {
             if FeatureFlag.streamAndCacheWaitWithContinuation.enabled {
                 await exportStatus.waitCompletion()
             } else {
-                while !exportStatus.completed {
-                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                while await !exportStatus.completed {
+                    try? await Task.sleep(for: .seconds(1))
                 }
             }
+            let exportError = await exportStatus.error
+            let exportReportedType = await exportStatus.reportedType
+
             downloadingEpisodesCache[downloadTaskUUID] = nil
             removeEpisodeFromCache(episode)
             if FeatureFlag.releaseMediaExporterWhenNoLongerActive.enabled,
@@ -464,13 +473,13 @@ class DownloadManager: NSObject, FilePathProtocol {
             guard let episode = dataManager.findBaseEpisode(uuid: downloadTaskUUID) else {
                 return
             }
-            if exportStatus.error == nil {
+            if exportError == nil {
                 FileLog.shared.addMessage("DownloadManager stream and download: end downloading \(episode.uuid) successfully")
-                processEpisode(episode, downloadedFile: outputURL, reportedContentType: exportStatus.reportedType)
+                processEpisode(episode, downloadedFile: outputURL, reportedContentType: exportReportedType)
             } else {
-                FileLog.shared.addMessage("DownloadManager stream and download: failed downloading \(episode.uuid) -> \(exportStatus.error?.localizedDescription ?? "")")
+                FileLog.shared.addMessage("DownloadManager stream and download: failed downloading \(episode.uuid) -> \(exportError?.localizedDescription ?? "")")
                 wasDownloadingBefore = episode.downloading()
-                DataManager.sharedManager.saveEpisode(downloadStatus: .notDownloaded, downloadError: exportStatus.error?.localizedDescription, downloadTaskId: nil, episode: episode)
+                DataManager.sharedManager.saveEpisode(downloadStatus: .notDownloaded, downloadError: exportError?.localizedDescription, downloadTaskId: nil, episode: episode)
                 DataManager.sharedManager.saveEpisode(autoDownloadStatus: .notSpecified, episode: episode)
                 if wasDownloadingBefore {
                     DownloadManager.shared.addToQueue(episodeUuid: episode.uuid, autoDownloadStatus: .autoDownloaded)

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -320,7 +320,24 @@ class DownloadManager: NSObject, FilePathProtocol {
     }
 
     private class ExportStatus {
-        var completed: Bool = false
+        private var continuation: CheckedContinuation<Void, Never>?
+
+        func waitCompletion() async {
+            guard !completed else { return }
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        var completed: Bool = false {
+            didSet {
+                if completed {
+                    continuation?.resume()
+                    continuation = nil
+                }
+            }
+        }
+
         var reportedType: String?
         var error: Error?
     }
@@ -429,9 +446,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             activeLoaderDelegate = customLoaderDelegate
         }
         Task {
-            while !exportStatus.completed {
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-            }
+            await exportStatus.waitCompletion()
             downloadingEpisodesCache[downloadTaskUUID] = nil
             removeEpisodeFromCache(episode)
             if FeatureFlag.releaseMediaExporterWhenNoLongerActive.enabled,


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Use continuation instead of active polling to check exporter completion

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
