### PR TITLE
API credentials

### DIFF
--- a/podcasts/Credentials/ApiCredentials.tpl
+++ b/podcasts/Credentials/ApiCredentials.tpl
@@ -38,20 +38,4 @@ struct ApiCredentials {
     /// Instagram App ID
     ///
     static let instagramAppID = "%{instagram_app_id}"
-
-    /// AppsFlyer Dev Key
-    ///
-    static let appsFlyerDevKey = "%{appsflyer_dev_key}"
-    
-    /// A8C Facebook App ID
-    ///
-    static let a8cFBAppID = "%{a8c_fb_app_id}"
-    
-    /// A8C Facebook App Name
-    ///
-    static let a8cFBAppName = "%{a8c_fb_app_name}"
-
-    /// A8C Facebook Client Token
-    ///
-    static let a8cFBClientToken = "%{a8c_fb_client_token}"
 }


### PR DESCRIPTION
Removing AppsFlyer and Facebook credentials added [here](https://github.com/Automattic/pocket-casts-ios/commit/c2ba76be8fd96a67b84d0a9dbfd770c1e1eca29d)

This is a total shot in the dark, but if Apple is picking up on `appsFlyer` as a string in the binary, that might trigger the Tracking binary error.

## To test

* 🟢 CI is green

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
