### PR TITLE
Fix thread dictionary crash

### DIFF
--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -43,7 +43,7 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     var progressManager = DownloadProgressManager()
 
-    lazy var downloadingEpisodesCache: DownloadManagerEpisodesCache = {
+    var downloadingEpisodesCache: DownloadManagerEpisodesCache = {
         if FeatureFlag.downloadsThreadSafeCache.enabled {
             ThreadSafeDictionary<String, BaseEpisode>()
         } else {
@@ -51,7 +51,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
     }()
 
-    lazy var downloadAndStreamEpisodes: DownloadManagerStreamAndDownloadCache = {
+    var downloadAndStreamEpisodes: DownloadManagerStreamAndDownloadCache = {
         if FeatureFlag.downloadsThreadSafeCache.enabled {
             ThreadSafeDictionary<String, AVAssetResourceLoaderDelegate>()
         } else {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR changes the cache initialization to use a non lazy version to that the creation of the dictionary is done on a thread safe way.

## To test

1. Start the app
2. Login with a user that has multiple podcasts
3. Force a sync
4. Play multiple episode and check that everything is working correctly
5. Queue some episode for download
6. Restart the app

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
