### PR TITLE
Remove sorting from `cachePodcasts`

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -667,7 +667,7 @@ class PodcastDataManager {
 
         dbQueue.read { db in
             do {
-                let resultSet = try db.executeQuery("SELECT * from \(DataManager.podcastTableName) ORDER BY sortOrder ASC", values: nil)
+                let resultSet = try db.executeQuery("SELECT * from \(DataManager.podcastTableName)", values: nil)
                 defer { resultSet.close() }
 
                 var newPodcasts = [String: Podcast]()


### PR DESCRIPTION
While testing SQL Query changes with unit tests, I caught this slightly confusing behavior:

Since `PodcastDataManager.cachedPodcasts` uses a Dictionary, the results are not sorted, despite `PodcastDataManager.cachePodcasts` including `ORDER BY sortOrder ASC`.

Podcast sort order: Changed `PodcastDataManager.cachePodcasts` to remove the `ORDER BY` since we are not maintaining sort order anyway.

# Tests

It seems confusing that the results of the `cachePodcasts` query are sorted but then that sort is not really used. This removes `ORDER BY` to make this clearer. It should also improve query performance on this as well.

* Test podcast sort order in the Podcasts tab
* Test podcast sort order from the Folder. selection screen
* Test podcast sort order from the Add Episodes screen in a Manual Playlist

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
