### PR TITLE
Fix userEpisodeTableName reference in bulkFile deletion

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
@@ -477,7 +477,7 @@ class UserEpisodeDataManager {
                     values.append(episode.uuid)
 
                     let setStatement = "SET \(fields.joined(separator: " = ?, ")) = ?"
-                    try db.executeUpdate("UPDATE \(DataManager.episodeTableName) \(setStatement) WHERE uuid = ?", values: values)
+                    try db.executeUpdate("UPDATE \(DataManager.userEpisodeTableName) \(setStatement) WHERE uuid = ?", values: values)
                 }
                 db.commit()
             } catch {


### PR DESCRIPTION
While adding Unit Tests for SQL Query Improvements I discovered a bug:

We are using `episodeTableName` rather than `userEpisodeTableName` in `UserEpisodeDataManager.bulkUserFileDelete`.

Most spots in the iOS app where we use the `downloadStatus` from that table we cross checked with the downloaded file. However, I found the Apple Watch using the values from the `SJUserEpisode` table without this cross check.

| Before | After |
|--|--|
| <video src="https://github.com/user-attachments/assets/a274fcd3-efc0-4de2-a09d-a786f3a79380"> | <video src="https://github.com/user-attachments/assets/953caea0-5bc5-4cf7-b098-fd826a1fb24f"> |

## To test

- Use a Plus account so you can upload files
- Use a simulator with the watch app attached
- Add a couple of files
- ⋯ > Files Settings > Auto Upload to Cloud
- Tap and hold to bring up multi-select
- Tap ⋯ > “Remove Download”
- Check on the Apple Watch in the Phone play source under Files
- ✅ Verify that the downloaded icon is removed

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
