### PR TITLE
Fix folder color picker showing grays for colors 8-11

### DIFF
--- a/podcasts/AppTheme.swift
+++ b/podcasts/AppTheme.swift
@@ -693,6 +693,10 @@ class AppTheme {
         case 5: return ThemeColor.filter06()
         case 6: return ThemeColor.filter07()
         case 7: return ThemeColor.filter08()
+        case 8: return ThemeColor.filter09()
+        case 9: return ThemeColor.filter10()
+        case 10: return ThemeColor.filter11()
+        case 11: return ThemeColor.filter12()
         default: return ThemeColor.filter08()
         }
     }


### PR DESCRIPTION
The folderColor function was missing mappings for color IDs 8-11, causing them to fall through to the default case and display as gray (filter08).

This bug was introduced when the radioactive theme was removed in commit 974221c50 in [AppTheme.swift](https://github.com/Automattic/pocket-casts-ios/commit/974221c50#diff-d31e501f965951327ed7bd3520db040e2892929c0ae17e189411669b9432e767L732-L735)

This adds the missing mappings:
- case 8: filter09 (light purple)
- case 9: filter10 (teal)
- case 10: filter11 (blue)
- case 11: filter12 (brown)

| Before | After |
|--|--|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro + AW - 2026-01-28 at 09 41 58" src="https://github.com/user-attachments/assets/92a47d68-bcaa-4a7a-9ecd-7811f52f4567" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro + AW - 2026-01-28 at 10 41 40" src="https://github.com/user-attachments/assets/38d390a3-c909-4f54-859e-37d3ed0c9f1b" /> |


## To test

* Edit a folder
* ✅ Ensure colors show more than the gray options shown in the Before screenshot

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
