### PR TITLE
Handle discover URL

### DIFF
--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -37,6 +37,14 @@ extension AppDelegate {
                 handleReferralsDeepLink(url: incomingURL)
                 return
             }
+
+            if path == "/discover" || path.startsWith(string: "/discover/") {
+                if let url = URL(string: "pktc:/\(path)") {
+                    JLRoutes.routeURL(url)
+                }
+                return
+            }
+
             // Also pass any query params from the share URL to the server to allow support for episode position handling
             // Ex: ?t=123
             let query = components.query.map { "?\($0)" } ?? ""

--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -40,6 +40,7 @@ extension AppDelegate {
 
             if path == "/discover" || path.startsWith(string: "/discover/") {
                 if let url = URL(string: "pktc:/\(path)") {
+                    NavigationManager.sharedManager.dismissPresentedViewController()
                     JLRoutes.routeURL(url)
                 }
                 return


### PR DESCRIPTION
This converts `https://pocketcasts.com/discover` to `pktc://discover` and runs through our normal URL handling

## To test

* Open `https://pocketcasts.com/discover`
* Tap on the "Open" banner or "Open App Clip"
* Ensure the Discover tab is shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
