### PR TITLE
Dispatch clip playback play to the main thread

### DIFF
--- a/podcasts/Sharing/Clip/ClipPlaybackManager.swift
+++ b/podcasts/Sharing/Clip/ClipPlaybackManager.swift
@@ -42,8 +42,10 @@ class ClipPlaybackManager: ObservableObject {
         let playbackCMTime = CMTime(seconds: playbackTime, preferredTimescale: .audio)
 
         normalPlaybackManager.activateAudioSession(completion: { [weak self] activated in
-            self?.avPlayer?.seek(to: playbackCMTime)
-            self?.avPlayer?.play()
+            DispatchQueue.main.async { [weak self] in
+                self?.avPlayer?.seek(to: playbackCMTime)
+                self?.avPlayer?.play()
+            }
         })
 
         isPlaying = true

--- a/podcasts/Sharing/Clip/ClipPlaybackManager.swift
+++ b/podcasts/Sharing/Clip/ClipPlaybackManager.swift
@@ -42,9 +42,12 @@ class ClipPlaybackManager: ObservableObject {
         let playbackCMTime = CMTime(seconds: playbackTime, preferredTimescale: .audio)
 
         normalPlaybackManager.activateAudioSession(completion: { [weak self] activated in
-            DispatchQueue.main.async { [weak self] in
-                self?.avPlayer?.seek(to: playbackCMTime)
-                self?.avPlayer?.play()
+            if Thread.current.isMainThread {
+                self?.startPlayer(at: playbackCMTime)
+            } else {
+                DispatchQueue.main.async { [weak self] in
+                    self?.startPlayer(at: playbackCMTime)
+                }
             }
         })
 
@@ -62,6 +65,11 @@ class ClipPlaybackManager: ObservableObject {
                 clipTime.wrappedValue.playback = currentTime
             }
         }).store(in: &cancellables)
+    }
+
+    func startPlayer(at playbackCMTime: CMTime) {
+        avPlayer?.seek(to: playbackCMTime)
+        avPlayer?.play()
     }
 
     func seek(to time: CMTime) {

--- a/podcasts/Sharing/Clip/ClipPlaybackManager.swift
+++ b/podcasts/Sharing/Clip/ClipPlaybackManager.swift
@@ -54,11 +54,7 @@ class ClipPlaybackManager: ObservableObject {
         isPlaying = true
         duration = endTime - startTime
 
-        observePlaybackEnd()
-
         self._clipTime = clipTime
-
-        setupTimeObserver()
 
         $currentTime.sink(receiveValue: { currentTime in
             if let currentTime, currentTime > 0 {
@@ -70,6 +66,8 @@ class ClipPlaybackManager: ObservableObject {
     func startPlayer(at playbackCMTime: CMTime) {
         avPlayer?.seek(to: playbackCMTime)
         avPlayer?.play()
+        setupTimeObserver()
+        observePlaybackEnd()
     }
 
     func seek(to time: CMTime) {


### PR DESCRIPTION
Fixes [PCIOS-487](https://linear.app/a8c/issue/PCIOS-487/preview-is-not-functional-when-creating-a-clip)

This was introduced in #3826 when audio session activation was moved to a background thread.

## To test

* Play an episode
* Share the episode from the player
* Tap the "Clip" option
* Begin playback on the clip
* ✅ Ensure playback begins and can be paused

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
