### PR TITLE
VoiceBoostN: add feature flag and settings

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -274,6 +274,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Fix Watch app overwriting phone's Up Next queue by adding debouncing and fixing timestamp comparison logic
     case watchUpNextSyncFix
 
+    /// Enable VoiceBoostN with updated description copy (TestFlight only)
+    case voiceBoostN
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -460,6 +463,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .watchUpNextSyncFix:
             true
+        case .voiceBoostN:
+            BuildEnvironment.current == .testFlight || BuildEnvironment.current == .debug
         }
     }
 

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -247,6 +247,8 @@ struct Constants {
         enum informationalModal {
             static let hasShownViewModal = "hasShownViewModal"
         }
+
+        static let voiceBoostNEnabled = "VoiceBoostNEnabled"
     }
 
     enum Values {

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -81,7 +81,9 @@ class EffectsViewController: SimpleNotificationsViewController {
     @IBOutlet var volumeDescription: ThemeableLabel! {
         didSet {
             volumeDescription.style = .playerContrast02
-            volumeDescription.text = L10n.volumeBoostDescription
+            volumeDescription.text = Settings.isVoiceBoostNEnabled
+                ? L10n.volumeBoostNDescription
+                : L10n.volumeBoostDescription
         }
     }
 
@@ -523,7 +525,9 @@ class EffectsViewController: SimpleNotificationsViewController {
 
         // Set accessibility hints
         trimSilenceSwitch.accessibilityHint = L10n.playerEffectsTrimSilenceDetails
-        volumeBoostSwitch.accessibilityHint = L10n.volumeBoostDescription
+        volumeBoostSwitch.accessibilityHint = Settings.isVoiceBoostNEnabled
+            ? L10n.volumeBoostNDescription
+            : L10n.volumeBoostDescription
 
         // Configure view to allow VoiceOver navigation
         view.accessibilityViewIsModal = true

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -12,8 +12,14 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
 
     let debounce = Debounce(delay: Constants.defaultDebounceTime)
 
-    enum TableRow { case skipForward, skipBack, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, autoplay, autoRestartSleepTimer, shakeToRestartSleepTimer, isLockScreenScrubberDisabled }
-    private var tableData: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .isLockScreenScrubberDisabled, .intelligentPlaybackResumption], [.autoRestartSleepTimer], [.shakeToRestartSleepTimer], [.playUpNextOnTap], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles], [.autoplay]]
+    enum TableRow { case skipForward, skipBack, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, autoplay, autoRestartSleepTimer, shakeToRestartSleepTimer, isLockScreenScrubberDisabled, voiceBoostN }
+    private var tableData: [[TableRow]] {
+        var data: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .isLockScreenScrubberDisabled, .intelligentPlaybackResumption], [.autoRestartSleepTimer], [.shakeToRestartSleepTimer], [.playUpNextOnTap], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles], [.autoplay]]
+        if FeatureFlag.voiceBoostN.enabled {
+            data.append([.voiceBoostN])
+        }
+        return data
+    }
 
     @IBOutlet var settingsTable: UITableView! {
         didSet {
@@ -302,6 +308,16 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
             cell.cellSwitch.addTarget(self, action: #selector(disableLockScreenScrubberToggled(_:)), for: .valueChanged)
 
             return cell
+        case .voiceBoostN:
+            let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
+
+            cell.cellLabel.text = L10n.settingsGeneralVoiceBoostN
+            cell.cellSwitch.isOn = Settings.isVoiceBoostNEnabled
+
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(voiceBoostNToggled(_:)), for: .valueChanged)
+
+            return cell
         }
     }
 
@@ -449,6 +465,8 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
             return L10n.autoRestartSleepTimerDescription
         case .shakeToRestartSleepTimer:
             return L10n.shakeToRestartSleepTimerDescription
+        case .voiceBoostN:
+            return L10n.settingsGeneralVoiceBoostNSubtitle
         default:
             return nil
         }
@@ -573,6 +591,10 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
         Settings.isLockScreenScrubbingDisabled = !sender.isOn
 
         Settings.trackValueToggled(.settingsGeneralDisableLockScreenScrubberToggled, enabled: !sender.isOn)
+    }
+
+    @objc private func voiceBoostNToggled(_ sender: UISwitch) {
+        Settings.isVoiceBoostNEnabled = sender.isOn
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1640,6 +1640,21 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - VoiceBoostN
+
+    static var isVoiceBoostNEnabled: Bool {
+        get {
+            guard FeatureFlag.voiceBoostN.enabled else { return false }
+            if UserDefaults.standard.object(forKey: Constants.UserDefaults.voiceBoostNEnabled) == nil {
+                return true
+            }
+            return UserDefaults.standard.bool(forKey: Constants.UserDefaults.voiceBoostNEnabled)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.UserDefaults.voiceBoostNEnabled)
+        }
+    }
+
     // MARK: - Database (internal)
 
     class var upgradedIndexes: Bool {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3605,6 +3605,10 @@ internal enum L10n {
   internal static var settingsGeneralUpNextTapOffSubtitle: String { return L10n.tr("Localizable", "settings_general_up_next_tap_off_subtitle", fallback: "Tapping an episode in Up Next shows the actions page. Long press plays the episode. Turn on to switch these around.") }
   /// Subtitle explaining the toggle to modify how a tap is handled in the up next queue. This is used when the toggle is on.
   internal static var settingsGeneralUpNextTapOnSubtitle: String { return L10n.tr("Localizable", "settings_general_up_next_tap_on_subtitle", fallback: "Tapping an episode in Up Next will play it. Long press shows episode options. Turn off to switch these around.") }
+  /// Title for the VoiceBoostN setting in Settings > General
+  internal static var settingsGeneralVoiceBoostN: String { return L10n.tr("Localizable", "settings_general_voice_boost_n", fallback: "VoiceBoostN") }
+  /// Subtitle for the VoiceBoostN setting in Settings > General
+  internal static var settingsGeneralVoiceBoostNSubtitle: String { return L10n.tr("Localizable", "settings_general_voice_boost_n_subtitle", fallback: "Use updated Volume Boost with more consistent voice levels.") }
   /// Title for the menu that takes you to the global up next queue settings
   internal static var settingsGlobalSettings: String { return L10n.tr("Localizable", "settings_global_settings", fallback: "Global Settings") }
   /// Label for a settings menu that allows the user to customize headphone action.
@@ -4321,6 +4325,8 @@ internal enum L10n {
   internal static var volumeBoost: String { return L10n.tr("Localizable", "volume_boost", fallback: "Volume Boost") }
   /// A short description of what the Volume Boost feature does
   internal static var volumeBoostDescription: String { return L10n.tr("Localizable", "volume_boost_description", fallback: "Voices sound louder") }
+  /// A short description of what the VoiceBoostN feature does
+  internal static var volumeBoostNDescription: String { return L10n.tr("Localizable", "volume_boost_n_description", fallback: "Voice levels are more consistent") }
   /// A common string used throughout the app. Informs the user that the app is waiting for wifi to reconnect.
   internal static var waitForWifi: String { return L10n.tr("Localizable", "wait_for_wifi", fallback: "Waiting for WiFi") }
   /// A common string used throughout the app. Used to reference the Watch as the playing source with in the Apple Watch App (Phone is the other option for this use case)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1600,6 +1600,15 @@
 /* A short description of what the Volume Boost feature does */
 "volume_boost_description" = "Voices sound louder";
 
+/* A short description of what the VoiceBoostN feature does */
+"volume_boost_n_description" = "Voice levels are more consistent";
+
+/* Title for the VoiceBoostN setting in Settings > General */
+"settings_general_voice_boost_n" = "VoiceBoostN";
+
+/* Subtitle for the VoiceBoostN setting in Settings > General */
+"settings_general_voice_boost_n_subtitle" = "Use updated Volume Boost with more consistent voice levels.";
+
 /* A common string used throughout the app. Catch all prompt to suggest to the user to try the task again. */
 "please_try_again" = "Please try again";
 


### PR DESCRIPTION
Fixes PCIOS-493

Adds feature flag and options for the new Voice Boost with normalization (VoiceBoostN). The idea is:

1. This is available ONLY for TestFlight users
2. Users can disable the new VoiceBoost from Settings > General

## To test

1. Play any episode
2. Open the full player
3. Tap the Playback Effects icon
4. ✅ Volume Boost subtitle should be "Voice levels are more consistent"
5. Dismiss it
6. Go to Settings > General > disable VoiceBoostN
7. Open the full player and Playback Effects again
8. ✅ Copy under Volume Boost should say "Voices sound louder"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
