### PR TITLE
Use Tracks version 4.1.0 which pulls Sentry 9.4.0

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -14278,7 +14278,7 @@
 			repositoryURL = "https://github.com/Automattic/Automattic-Tracks-iOS";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.0;
+				minimumVersion = 4.1.0;
 			};
 		};
 		468F00CD27CD575C00FFAAAA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "revision" : "32f03d5af3625585b9f6da1d4cc1756d77b63aa1",
-        "version" : "4.0.0"
+        "revision" : "7442def327dbbc9158c0d780382843e0b7a2e6c9",
+        "version" : "4.1.0"
       }
     },
     {
@@ -230,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "16cd512711375fa73f25ae5e373f596bdf4251ae",
-        "version" : "8.58.0"
+        "revision" : "f1eefffd88cd6dfe5751159a3b32ff3c8e5b3b32",
+        "version" : "9.4.0"
       }
     },
     {


### PR DESCRIPTION
See [AINFRA-1919: Integrate Tracks Apple 4.1.0 into Pocket Casts iOS](https://linear.app/a8c/issue/AINFRA-1919/integrate-tracks-apple-410-into-pocket-casts-ios)

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->
Not sure how to verify the new Sentry integration end to end without hacking the app to force a crash or something. 

But considering this is just a version bump, I'd say if the tests and prototype build are green, then we should be relatively safe.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

N.A.