### PR TITLE
Remove notify nodes for Prototype Build steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,9 +61,6 @@ steps:
         artifact_paths:
           - artifacts/*.ipa
           - artifacts/*.app.dSYM.zip
-        notify:
-          - github_commit_status:
-              context: Prototype Build - Build
 
       - label: Prototype Build - Upload
         depends_on: build_prototype
@@ -71,6 +68,3 @@ steps:
         agents:
           queue: mac
         plugins: [$CI_TOOLKIT]
-        notify:
-          - github_commit_status:
-              context: Prototype Build - Upload

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,7 +15,7 @@ steps:
 
   - group: "Linters"
     steps:
-      - label: "☢️ Danger - PR Check"
+      - label: ":danger: PR Check with Danger"
         command: danger
         key: danger
         if: "build.pull_request.id != null"


### PR DESCRIPTION
This way, PRs that have not unblocked the Prototype Build won't be stuck in the yellow state on GitHub because those jobs have not reported (and never will unless the Prototype Build is unblocked).

Before: 

<img width="1784" height="692" alt="image" src="https://github.com/user-attachments/assets/051fa076-24d4-4704-99d9-11d6efc574c6" />

With this PR:

TBD