### PR TITLE
GRDB Macros: Folder

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
@@ -1,7 +1,9 @@
 import PocketCastsUtils
 import Foundation
+import GRDB
 
 class FolderDataManager {
+    /// Legacy column names for non-GRDB code path.
     private let columnNames = [
         "uuid",
         "name",
@@ -37,20 +39,38 @@ class FolderDataManager {
     }
 
     func save(folder: Folder, dbQueue: PCDBQueue) {
-        dbQueue.write { db in
-            do {
-                if folder.uuid.isEmpty {
-                    folder.uuid = UUID().uuidString.lowercased()
-                }
+        if folder.uuid.isEmpty {
+            folder.uuid = UUID().uuidString.lowercased()
+        }
 
-                if cachedFolders.contains(where: { $0.uuid == folder.uuid }) {
-                    let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
-                    try db.executeUpdate("UPDATE \(DataManager.folderTableName) SET \(setStatement) WHERE uuid = ?", values: self.createValuesFrom(folder, includeUuidForWhere: true))
-                } else {
-                    try db.executeUpdate("INSERT INTO \(DataManager.folderTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(folder))
+        let isUpdate = cachedFolders.contains(where: { $0.uuid == folder.uuid })
+
+        if FeatureFlag.grdbQueryInterface.enabled, let grdbQueue = dbQueue as? GRDBQueue {
+            // GRDB path using PersistableRecord
+            do {
+                try grdbQueue.dbPool.write { db in
+                    if isUpdate {
+                        try folder.update(db)
+                    } else {
+                        try folder.insert(db)
+                    }
                 }
             } catch {
                 FileLog.shared.addMessage("FolderDataManager.save error: \(error)")
+            }
+        } else {
+            // Legacy path
+            dbQueue.write { db in
+                do {
+                    if isUpdate {
+                        let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
+                        try db.executeUpdate("UPDATE \(DataManager.folderTableName) SET \(setStatement) WHERE uuid = ?", values: self.createValuesFrom(folder, includeUuidForWhere: true))
+                    } else {
+                        try db.executeUpdate("INSERT INTO \(DataManager.folderTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(folder))
+                    }
+                } catch {
+                    FileLog.shared.addMessage("FolderDataManager.save error: \(error)")
+                }
             }
         }
         cacheFolders(dbQueue: dbQueue)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
@@ -4,7 +4,7 @@ import GRDB
 
 class FolderDataManager {
     /// Legacy column names for non-GRDB code path.
-    private let columnNames = [
+    let columnNames = [
         "uuid",
         "name",
         "color",

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
@@ -43,17 +43,11 @@ class FolderDataManager {
             folder.uuid = UUID().uuidString.lowercased()
         }
 
-        let isUpdate = cachedFolders.contains(where: { $0.uuid == folder.uuid })
-
         if FeatureFlag.grdbQueryInterface.enabled, let grdbQueue = dbQueue as? GRDBQueue {
             // GRDB path using PersistableRecord
             do {
                 try grdbQueue.dbPool.write { db in
-                    if isUpdate {
-                        try folder.update(db)
-                    } else {
-                        try folder.insert(db)
-                    }
+                    try folder.save(db)
                 }
             } catch {
                 FileLog.shared.addMessage("FolderDataManager.save error: \(error)")
@@ -62,7 +56,7 @@ class FolderDataManager {
             // Legacy path
             dbQueue.write { db in
                 do {
-                    if isUpdate {
+                    if self.cachedFolders.contains(where: { $0.uuid == folder.uuid }) {
                         let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
                         try db.executeUpdate("UPDATE \(DataManager.folderTableName) SET \(setStatement) WHERE uuid = ?", values: self.createValuesFrom(folder, includeUuidForWhere: true))
                     } else {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Folder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Folder.swift
@@ -17,9 +17,7 @@ public class Folder: NSObject, Identifiable {
     @GRDBIgnore
     public var cachedUnreadCount = 0
 
-    override public init() {
-        super.init()
-    }
+    override public init() {}
 
     func folderSort() -> FolderSort {
         FolderSort(rawValue: sortType) ?? .dateAddedNewestToOldest

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Folder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Folder.swift
@@ -1,5 +1,8 @@
 import Foundation
+import GRDB
+import GRDBMacros
 
+@GRDBRecord(table: "Folder")
 public class Folder: NSObject, Identifiable {
     @objc public var uuid = ""
     @objc public var name = ""
@@ -11,7 +14,12 @@ public class Folder: NSObject, Identifiable {
     @objc public var syncModified: Int64 = 0
 
     // transient not saved to database
+    @GRDBIgnore
     public var cachedUnreadCount = 0
+
+    override public init() {
+        super.init()
+    }
 
     func folderSort() -> FolderSort {
         FolderSort(rawValue: sortType) ?? .dateAddedNewestToOldest

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManagerTestCase.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManagerTestCase.swift
@@ -43,13 +43,17 @@ class DataManagerTestCase: XCTestCase {
     /// Runs the provided test block with both SQL and GRDB API implementations.
     ///
     /// - Parameter testBlock: A closure that receives a DataManager and the implementation name.
-    ///                        The implementation name is either "" or "GRDB".
+    ///                        The implementation name is either "SQL" or "GRDB".
     func runWithBothImplementations(_ testBlock: (DataManager, String) throws -> Void) throws {
         // Test with raw SQL query
         let sqlDataManager = DataManager.newTestDataManager()
         try testBlock(sqlDataManager, "SQL")
 
-        // TODO: Test with GRDB implementation
+        // Test with GRDB implementation
+        try featureFlagStore.override(FeatureFlag.grdbQueryInterface, withValue: true)
+        let grdbDataManager = DataManager.newTestDataManager()
+        try testBlock(grdbDataManager, "GRDB")
+        featureFlagStore.resetOverrides()
     }
 
     /// Async version of runWithBothImplementations
@@ -58,7 +62,11 @@ class DataManagerTestCase: XCTestCase {
         let sqlDataManager = DataManager.newTestDataManager()
         try await testBlock(sqlDataManager, "SQL")
 
-        // TODO: Test with GRDB API
+        // Test with GRDB implementation
+        try featureFlagStore.override(FeatureFlag.grdbQueryInterface, withValue: true)
+        let grdbDataManager = DataManager.newTestDataManager()
+        try await testBlock(grdbDataManager, "GRDB")
+        featureFlagStore.resetOverrides()
     }
 
     // MARK: - Common Test Helpers

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/FolderColumnConsistencyTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/FolderColumnConsistencyTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+import GRDB
+@testable import PocketCastsDataModel
+@testable import PocketCastsUtils
+
+/// Tests to ensure the legacy SQL columnNames and GRDB-persisted columns remain in sync.
+/// These tests prevent the issue where GRDB might persist a field that the legacy SQL path ignores
+/// (or vice versa), causing inconsistent behavior when the feature flag is toggled.
+final class FolderColumnConsistencyTests: DataManagerTestCase {
+
+    /// Access columnNames directly from FolderDataManager (the source of truth for legacy SQL).
+    private var columnNames: Set<String> {
+        Set(FolderDataManager().columnNames)
+    }
+
+    // MARK: - Database Schema Tests
+
+    func testDatabaseTableHasExpectedColumns() throws {
+        let dataManager = DataManager.newTestDataManager()
+
+        // Get actual database columns using GRDB introspection
+        guard let grdbQueue = dataManager.dbQueue as? GRDBQueue else {
+            XCTFail("Expected GRDBQueue for database introspection")
+            return
+        }
+
+        let tableColumns = try grdbQueue.dbPool.read { db -> Set<String> in
+            let columns = try db.columns(in: DataManager.folderTableName)
+            return Set(columns.map { $0.name })
+        }
+
+        // The database should have at least all the columns from columnNames
+        let missingColumns = columnNames.subtracting(tableColumns)
+        XCTAssertTrue(
+            missingColumns.isEmpty,
+            "Database table is missing columns from columnNames: \(missingColumns)"
+        )
+    }
+
+    // MARK: - Round-Trip Tests
+
+    func testSaveAndLoadPreservesAllFields() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            let original = self.createFullyPopulatedFolder()
+
+            // Save using the current implementation (respects feature flag)
+            dataManager.save(folder: original)
+
+            // Load it back
+            guard let loaded = dataManager.findFolder(uuid: original.uuid) else {
+                XCTFail("\(implementationName): Should be able to load saved folder")
+                return
+            }
+
+            // Verify all persisted fields match
+            XCTAssertEqual(loaded.uuid, original.uuid, "\(implementationName): uuid should match")
+            XCTAssertEqual(loaded.name, original.name, "\(implementationName): name should match")
+            XCTAssertEqual(loaded.color, original.color, "\(implementationName): color should match")
+            XCTAssertEqual(loaded.sortOrder, original.sortOrder, "\(implementationName): sortOrder should match")
+            XCTAssertEqual(loaded.sortType, original.sortType, "\(implementationName): sortType should match")
+            XCTAssertEqual(loaded.wasDeleted, original.wasDeleted, "\(implementationName): wasDeleted should match")
+            XCTAssertEqual(loaded.syncModified, original.syncModified, "\(implementationName): syncModified should match")
+        }
+    }
+
+    // MARK: - Ignored Property Tests
+
+    /// Verifies that cachedUnreadCount is NOT persisted (marked with @GRDBIgnore)
+    func testCachedUnreadCountNotPersisted() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            let folder = Folder()
+            folder.uuid = UUID().uuidString.lowercased()
+            folder.name = "Test Folder"
+            folder.addedDate = Date()
+            folder.cachedUnreadCount = 42  // Set ignored property
+
+            dataManager.save(folder: folder)
+
+            // Load it back - cachedUnreadCount should be default (0)
+            guard let loaded = dataManager.findFolder(uuid: folder.uuid) else {
+                XCTFail("\(implementationName): Should find saved folder")
+                return
+            }
+
+            // cachedUnreadCount should be 0 because it's not persisted
+            XCTAssertEqual(loaded.cachedUnreadCount, 0, "\(implementationName): cachedUnreadCount should NOT be persisted")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func createFullyPopulatedFolder() -> Folder {
+        let folder = Folder()
+        folder.uuid = UUID().uuidString.lowercased()
+        folder.name = "Test Folder"
+        folder.color = 3
+        folder.addedDate = Date()
+        folder.sortOrder = 5
+        folder.sortType = FolderSort.titleAtoZ.rawValue
+        folder.wasDeleted = false
+        folder.syncModified = 123456789
+        return folder
+    }
+}

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/FolderDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/FolderDataManagerTests.swift
@@ -266,6 +266,88 @@ final class FolderDataManagerTests: DataManagerTestCase {
         }
     }
 
+    // MARK: - save Tests (PersistableRecord API)
+
+    func testSaveInsertsNewFolderWithAllFields() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let folder = Folder()
+            folder.uuid = "save-test-uuid"
+            folder.name = "Save Test Folder"
+            folder.color = 5
+            folder.addedDate = Date(timeIntervalSince1970: 1000000)
+            folder.sortOrder = 10
+            folder.sortType = 2
+            folder.wasDeleted = false
+            folder.syncModified = 12345
+
+            dataManager.save(folder: folder)
+
+            let found = dataManager.findFolder(uuid: "save-test-uuid")
+            XCTAssertNotNil(found, "\(impl): Should find saved folder")
+            XCTAssertEqual(found?.uuid, "save-test-uuid", "\(impl): UUID should match")
+            XCTAssertEqual(found?.name, "Save Test Folder", "\(impl): Name should match")
+            XCTAssertEqual(found?.color, 5, "\(impl): Color should match")
+            XCTAssertEqual(found?.sortOrder, 10, "\(impl): Sort order should match")
+            XCTAssertEqual(found?.sortType, 2, "\(impl): Sort type should match")
+            XCTAssertEqual(found?.wasDeleted, false, "\(impl): wasDeleted should match")
+            XCTAssertEqual(found?.syncModified, 12345, "\(impl): syncModified should match")
+        }
+    }
+
+    func testSaveUpdatesExistingFolder() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let folder = self.createTestFolder(uuid: "update-test-uuid", name: "Original Name", color: 1, dataManager: dataManager)
+
+            // Update fields
+            folder.name = "Updated Name"
+            folder.color = 9
+            folder.sortOrder = 99
+            folder.syncModified = 99999
+            dataManager.save(folder: folder)
+
+            let found = dataManager.findFolder(uuid: "update-test-uuid")
+            XCTAssertEqual(found?.name, "Updated Name", "\(impl): Name should be updated")
+            XCTAssertEqual(found?.color, 9, "\(impl): Color should be updated")
+            XCTAssertEqual(found?.sortOrder, 99, "\(impl): Sort order should be updated")
+            XCTAssertEqual(found?.syncModified, 99999, "\(impl): syncModified should be updated")
+        }
+    }
+
+    func testSaveGeneratesUuidIfEmpty() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let folder = Folder()
+            folder.uuid = "" // Empty UUID
+            folder.name = "Auto UUID Folder"
+            folder.addedDate = Date()
+
+            dataManager.save(folder: folder)
+
+            XCTAssertFalse(folder.uuid.isEmpty, "\(impl): UUID should be generated")
+
+            let found = dataManager.findFolder(uuid: folder.uuid)
+            XCTAssertNotNil(found, "\(impl): Should find folder with generated UUID")
+        }
+    }
+
+    func testSavePreservesAddedDate() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let folder = Folder()
+            folder.uuid = "date-test-uuid"
+            folder.name = "Date Test Folder"
+            let originalDate = Date(timeIntervalSince1970: 500000)
+            folder.addedDate = originalDate
+
+            dataManager.save(folder: folder)
+
+            let found = dataManager.findFolder(uuid: "date-test-uuid")
+            XCTAssertNotNil(found?.addedDate, "\(impl): addedDate should be set")
+            // Compare timestamps (allow small variance for floating point)
+            if let foundDate = found?.addedDate {
+                XCTAssertEqual(foundDate.timeIntervalSince1970, originalDate.timeIntervalSince1970, accuracy: 1.0, "\(impl): addedDate should match")
+            }
+        }
+    }
+
     // MARK: - Helper Methods
 
     private func createTestFolder(


### PR DESCRIPTION
Part of PCIOS-491

Adds GRDB macros to the Folder model and implements feature-flagged GRDB save operations.

##  Changes

- Folder model: Applied `@GRDBRecord`, `@GRDBColumn`, and `@GRDBIgnore` macros for type-safe GRDB conformance
- FolderDataManager: Added `save()` method using GRDB's PersistableRecord behind `FeatureFlag.grdbQueryInterface`
- Tests: Added `FolderDataManagerTests` and updated `DataManagerTestCase` to run against both SQL and GRDB implementations. Also added column consistency tests to verify the current `columnNames` matches our GRDB columns.

## To test

* Test Folder creation and display with `grdbQueryInterface` enabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
