### PR TITLE
GRDB Macros: User Episodes

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
@@ -4,7 +4,7 @@ import GRDB
 
 class UserEpisodeDataManager {
     /// Legacy column names for non-GRDB code path.
-    private let columnNames = [
+    let columnNames = [
         "id",
         "addedDate",
         "lastDownloadAttemptDate",

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
@@ -1,7 +1,9 @@
 import PocketCastsUtils
 import Foundation
+import GRDB
 
 class UserEpisodeDataManager {
+    /// Legacy column names for non-GRDB code path.
     private let columnNames = [
         "id",
         "addedDate",
@@ -208,17 +210,33 @@ class UserEpisodeDataManager {
     // MARK: - Updates
 
     func save(episode: UserEpisode, dbQueue: PCDBQueue) {
-        dbQueue.write { db in
+        let isInsert = episode.id == 0
+        if isInsert {
+            episode.id = DBUtils.generateUniqueId()
+        }
+
+        if FeatureFlag.grdbQueryInterface.enabled, let grdbQueue = dbQueue as? GRDBQueue {
+            // GRDB path using PersistableRecord
             do {
-                if episode.id == 0 {
-                    episode.id = DBUtils.generateUniqueId()
-                    try db.executeUpdate("INSERT INTO \(DataManager.userEpisodeTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(episode: episode))
-                } else {
-                    let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
-                    try db.executeUpdate("UPDATE \(DataManager.userEpisodeTableName) SET \(setStatement) WHERE id = ?", values: self.createValuesFrom(episode: episode, includeIdForWhere: true))
+                try grdbQueue.dbPool.write { db in
+                    try episode.save(db)
                 }
             } catch {
                 FileLog.shared.addMessage("UserEpisodeDataManager.save error: \(error)")
+            }
+        } else {
+            // Legacy path
+            dbQueue.write { db in
+                do {
+                    if isInsert {
+                        try db.executeUpdate("INSERT INTO \(DataManager.userEpisodeTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(episode: episode))
+                    } else {
+                        let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
+                        try db.executeUpdate("UPDATE \(DataManager.userEpisodeTableName) SET \(setStatement) WHERE id = ?", values: self.createValuesFrom(episode: episode, includeIdForWhere: true))
+                    }
+                } catch {
+                    FileLog.shared.addMessage("UserEpisodeDataManager.save error: \(error)")
+                }
             }
         }
     }
@@ -371,23 +389,43 @@ class UserEpisodeDataManager {
     }
 
     func bulkSave(episodes: [UserEpisode], dbQueue: PCDBQueue) {
-        dbQueue.write { db in
+        if FeatureFlag.grdbQueryInterface.enabled, let grdbQueue = dbQueue as? GRDBQueue {
+            // GRDB path using PersistableRecord
             do {
-                db.beginTransaction()
+                try grdbQueue.dbPool.write { db in
+                    for episode in episodes {
+                        let isInsert = episode.id == 0
+                        if isInsert {
+                            episode.id = DBUtils.generateUniqueId()
+                        }
 
-                for episode in episodes {
-                    if episode.id == 0 {
-                        episode.id = DBUtils.generateUniqueId()
-                        try db.executeUpdate("INSERT INTO \(DataManager.userEpisodeTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(episode: episode))
-                    } else {
-                        let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
-                        try db.executeUpdate("UPDATE \(DataManager.userEpisodeTableName) SET \(setStatement) WHERE id = ?", values: self.createValuesFrom(episode: episode, includeIdForWhere: true))
+                        try episode.save(db)
                     }
                 }
-
-                db.commit()
             } catch {
                 FileLog.shared.addMessage("UserEpisodeDataManager.bulkSave error: \(error)")
+            }
+        } else {
+            // Legacy path
+            dbQueue.write { db in
+                do {
+                    db.beginTransaction()
+
+                    for episode in episodes {
+                        let isInsert = episode.id == 0
+                        if isInsert {
+                            episode.id = DBUtils.generateUniqueId()
+                            try db.executeUpdate("INSERT INTO \(DataManager.userEpisodeTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(episode: episode))
+                        } else {
+                            let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
+                            try db.executeUpdate("UPDATE \(DataManager.userEpisodeTableName) SET \(setStatement) WHERE id = ?", values: self.createValuesFrom(episode: episode, includeIdForWhere: true))
+                        }
+                    }
+
+                    db.commit()
+                } catch {
+                    FileLog.shared.addMessage("UserEpisodeDataManager.bulkSave error: \(error)")
+                }
             }
         }
     }
@@ -641,4 +679,5 @@ class UserEpisodeDataManager {
 
         return values
     }
+
 }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
@@ -1,14 +1,21 @@
 import Foundation
+import GRDB
+import GRDBMacros
 
+@GRDBRecord(table: "SJUserEpisode")
 public class UserEpisode: NSObject, BaseEpisode {
     @objc public var id = 0 as Int64
     @objc public var addedDate: Date?
+    @GRDBNullDateAsEpoch
     @objc public var lastDownloadAttemptDate: Date?
     @objc public var downloadErrorDetails: String?
     @objc public var downloadTaskId: String?
     @objc public var downloadUrl: String?
     @objc public var episodeStatus = 0 as Int32
     @objc public var fileType: String?
+    // Note: contentType is saved separately via saveContentType() method.
+    // The legacy SQL code doesn't include it in columnNames, so we ignore it for GRDB compatibility.
+    @GRDBIgnore
     @objc public var contentType: String?
     @objc public var playedUpTo: Double = 0
     @objc public var duration: Double = 0
@@ -31,13 +38,21 @@ public class UserEpisode: NSObject, BaseEpisode {
     @objc public var imageColor = 0 as Int32
     @objc public var imageColorModified = 0 as Int64
     @objc public var hasCustomImage = false
+    @GRDBIgnore
     @objc public var hasOnlyUuid = false
+    // Note: These properties exist on the model but were never added to the SJUserEpisode table.
+    // The legacy SQL code doesn't persist them, so we ignore them for GRDB compatibility.
+    @GRDBIgnore
     @objc public var deselectedChapters: String?
+    @GRDBIgnore
     @objc public var deselectedChaptersModified = 0 as Int64
 
     // UserEpisode's are never archived or starred
+    @GRDBIgnore
     public var archived = false
+    @GRDBIgnore
     public var keepEpisode = false
+    @GRDBIgnore
     public var wasDeleted = false
 
     public var hasBookmarks: Bool {

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManagerTestCase.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManagerTestCase.swift
@@ -43,13 +43,17 @@ class DataManagerTestCase: XCTestCase {
     /// Runs the provided test block with both SQL and GRDB API implementations.
     ///
     /// - Parameter testBlock: A closure that receives a DataManager and the implementation name.
-    ///                        The implementation name is either "" or "GRDB".
+    ///                        The implementation name is either "SQL" or "GRDB".
     func runWithBothImplementations(_ testBlock: (DataManager, String) throws -> Void) throws {
         // Test with raw SQL query
         let sqlDataManager = DataManager.newTestDataManager()
         try testBlock(sqlDataManager, "SQL")
 
-        // TODO: Test with GRDB implementation
+        // Test with GRDB implementation
+        try featureFlagStore.override(FeatureFlag.grdbQueryInterface, withValue: true)
+        let grdbDataManager = DataManager.newTestDataManager()
+        try testBlock(grdbDataManager, "GRDB")
+        featureFlagStore.resetOverrides()
     }
 
     /// Async version of runWithBothImplementations
@@ -58,7 +62,11 @@ class DataManagerTestCase: XCTestCase {
         let sqlDataManager = DataManager.newTestDataManager()
         try await testBlock(sqlDataManager, "SQL")
 
-        // TODO: Test with GRDB API
+        // Test with GRDB implementation
+        try featureFlagStore.override(FeatureFlag.grdbQueryInterface, withValue: true)
+        let grdbDataManager = DataManager.newTestDataManager()
+        try await testBlock(grdbDataManager, "GRDB")
+        featureFlagStore.resetOverrides()
     }
 
     // MARK: - Common Test Helpers

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/UserEpisodeColumnConsistencyTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/UserEpisodeColumnConsistencyTests.swift
@@ -1,0 +1,191 @@
+import XCTest
+import GRDB
+@testable import PocketCastsDataModel
+@testable import PocketCastsUtils
+
+/// Tests to ensure the legacy SQL columnNames and GRDB-persisted columns remain in sync.
+/// These tests prevent the issue where GRDB might persist a field that the legacy SQL path ignores
+/// (or vice versa), causing inconsistent behavior when the feature flag is toggled.
+final class UserEpisodeColumnConsistencyTests: DataManagerTestCase {
+
+    /// Access columnNames directly from UserEpisodeDataManager (the source of truth for legacy SQL).
+    private var columnNames: Set<String> {
+        Set(UserEpisodeDataManager().columnNames)
+    }
+
+    // MARK: - Database Schema Tests
+
+    func testDatabaseTableHasExpectedColumns() throws {
+        let dataManager = DataManager.newTestDataManager()
+
+        // Get actual database columns using GRDB introspection
+        guard let grdbQueue = dataManager.dbQueue as? GRDBQueue else {
+            XCTFail("Expected GRDBQueue for database introspection")
+            return
+        }
+
+        let tableColumns = try grdbQueue.dbPool.read { db -> Set<String> in
+            let columns = try db.columns(in: DataManager.userEpisodeTableName)
+            return Set(columns.map { $0.name })
+        }
+
+        // The database should have at least all the columns from columnNames
+        // (it may have more due to migrations or legacy columns like contentType)
+        let missingColumns = columnNames.subtracting(tableColumns)
+        XCTAssertTrue(
+            missingColumns.isEmpty,
+            "Database table is missing columns from columnNames: \(missingColumns)"
+        )
+    }
+
+    // MARK: - Round-Trip Tests
+
+    func testSaveAndLoadPreservesAllFields() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            let original = self.createFullyPopulatedUserEpisode()
+
+            // Save using the current implementation (respects feature flag)
+            dataManager.save(episode: original)
+
+            // Load it back
+            guard let loaded = dataManager.findUserEpisode(uuid: original.uuid) else {
+                XCTFail("\(implementationName): Should be able to load saved episode")
+                return
+            }
+
+            // Verify all persisted fields match
+            XCTAssertEqual(loaded.uuid, original.uuid, "\(implementationName): uuid should match")
+            XCTAssertEqual(loaded.title, original.title, "\(implementationName): title should match")
+            XCTAssertEqual(loaded.duration, original.duration, "\(implementationName): duration should match")
+            XCTAssertEqual(loaded.playedUpTo, original.playedUpTo, "\(implementationName): playedUpTo should match")
+            XCTAssertEqual(loaded.playingStatus, original.playingStatus, "\(implementationName): playingStatus should match")
+            XCTAssertEqual(loaded.episodeStatus, original.episodeStatus, "\(implementationName): episodeStatus should match")
+            XCTAssertEqual(loaded.uploadStatus, original.uploadStatus, "\(implementationName): uploadStatus should match")
+            XCTAssertEqual(loaded.autoDownloadStatus, original.autoDownloadStatus, "\(implementationName): autoDownloadStatus should match")
+            XCTAssertEqual(loaded.sizeInBytes, original.sizeInBytes, "\(implementationName): sizeInBytes should match")
+            XCTAssertEqual(loaded.fileType, original.fileType, "\(implementationName): fileType should match")
+            XCTAssertEqual(loaded.downloadUrl, original.downloadUrl, "\(implementationName): downloadUrl should match")
+            XCTAssertEqual(loaded.downloadTaskId, original.downloadTaskId, "\(implementationName): downloadTaskId should match")
+            XCTAssertEqual(loaded.uploadTaskId, original.uploadTaskId, "\(implementationName): uploadTaskId should match")
+            XCTAssertEqual(loaded.imageUrl, original.imageUrl, "\(implementationName): imageUrl should match")
+            XCTAssertEqual(loaded.imageColor, original.imageColor, "\(implementationName): imageColor should match")
+            XCTAssertEqual(loaded.hasCustomImage, original.hasCustomImage, "\(implementationName): hasCustomImage should match")
+            XCTAssertEqual(loaded.cachedFrameCount, original.cachedFrameCount, "\(implementationName): cachedFrameCount should match")
+            XCTAssertEqual(loaded.playingStatusModified, original.playingStatusModified, "\(implementationName): playingStatusModified should match")
+            XCTAssertEqual(loaded.playedUpToModified, original.playedUpToModified, "\(implementationName): playedUpToModified should match")
+            XCTAssertEqual(loaded.titleModified, original.titleModified, "\(implementationName): titleModified should match")
+            XCTAssertEqual(loaded.durationModified, original.durationModified, "\(implementationName): durationModified should match")
+            XCTAssertEqual(loaded.imageModified, original.imageModified, "\(implementationName): imageModified should match")
+            XCTAssertEqual(loaded.imageColorModified, original.imageColorModified, "\(implementationName): imageColorModified should match")
+            XCTAssertEqual(loaded.downloadErrorDetails, original.downloadErrorDetails, "\(implementationName): downloadErrorDetails should match")
+            XCTAssertEqual(loaded.playbackErrorDetails, original.playbackErrorDetails, "\(implementationName): playbackErrorDetails should match")
+        }
+    }
+
+    // MARK: - Ignored Property Tests
+
+    /// Verifies that contentType is NOT persisted by save() but IS persisted by saveContentType()
+    func testContentTypeNotPersistedBySave() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            let episode = UserEpisode()
+            episode.uuid = UUID().uuidString
+            episode.title = "ContentType Test"
+            episode.addedDate = Date()
+            episode.contentType = "audio/mpeg"  // Set contentType
+
+            dataManager.save(episode: episode)
+
+            // Load it back - contentType should NOT be saved by save()
+            guard let loaded = dataManager.findUserEpisode(uuid: episode.uuid) else {
+                XCTFail("\(implementationName): Should find saved episode")
+                return
+            }
+
+            // contentType should be nil because save() doesn't persist it
+            XCTAssertNil(loaded.contentType, "\(implementationName): contentType should NOT be persisted by save() - use saveContentType() instead")
+        }
+    }
+
+    func testContentTypePersistedBySaveContentType() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            let episode = UserEpisode()
+            episode.uuid = UUID().uuidString
+            episode.title = "ContentType Test"
+            episode.addedDate = Date()
+            dataManager.save(episode: episode)
+
+            // Use the dedicated method to save contentType
+            dataManager.saveEpisode(contentType: "audio/mpeg", episode: episode)
+
+            guard let loaded = dataManager.findUserEpisode(uuid: episode.uuid) else {
+                XCTFail("\(implementationName): Should find saved episode")
+                return
+            }
+
+            XCTAssertEqual(loaded.contentType, "audio/mpeg", "\(implementationName): contentType should be persisted by saveContentType()")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func assertEpisodesMatch(_ original: UserEpisode, _ loaded: UserEpisode, context: String) {
+        XCTAssertEqual(loaded.uuid, original.uuid, "\(context): uuid should match")
+        XCTAssertEqual(loaded.title, original.title, "\(context): title should match")
+        XCTAssertEqual(loaded.duration, original.duration, "\(context): duration should match")
+        XCTAssertEqual(loaded.playedUpTo, original.playedUpTo, "\(context): playedUpTo should match")
+        XCTAssertEqual(loaded.playingStatus, original.playingStatus, "\(context): playingStatus should match")
+        XCTAssertEqual(loaded.episodeStatus, original.episodeStatus, "\(context): episodeStatus should match")
+        XCTAssertEqual(loaded.uploadStatus, original.uploadStatus, "\(context): uploadStatus should match")
+        XCTAssertEqual(loaded.autoDownloadStatus, original.autoDownloadStatus, "\(context): autoDownloadStatus should match")
+        XCTAssertEqual(loaded.sizeInBytes, original.sizeInBytes, "\(context): sizeInBytes should match")
+        XCTAssertEqual(loaded.fileType, original.fileType, "\(context): fileType should match")
+        XCTAssertEqual(loaded.downloadUrl, original.downloadUrl, "\(context): downloadUrl should match")
+        XCTAssertEqual(loaded.downloadTaskId, original.downloadTaskId, "\(context): downloadTaskId should match")
+        XCTAssertEqual(loaded.uploadTaskId, original.uploadTaskId, "\(context): uploadTaskId should match")
+        XCTAssertEqual(loaded.imageUrl, original.imageUrl, "\(context): imageUrl should match")
+        XCTAssertEqual(loaded.imageColor, original.imageColor, "\(context): imageColor should match")
+        XCTAssertEqual(loaded.hasCustomImage, original.hasCustomImage, "\(context): hasCustomImage should match")
+        XCTAssertEqual(loaded.cachedFrameCount, original.cachedFrameCount, "\(context): cachedFrameCount should match")
+        XCTAssertEqual(loaded.playingStatusModified, original.playingStatusModified, "\(context): playingStatusModified should match")
+        XCTAssertEqual(loaded.playedUpToModified, original.playedUpToModified, "\(context): playedUpToModified should match")
+        XCTAssertEqual(loaded.titleModified, original.titleModified, "\(context): titleModified should match")
+        XCTAssertEqual(loaded.durationModified, original.durationModified, "\(context): durationModified should match")
+        XCTAssertEqual(loaded.imageModified, original.imageModified, "\(context): imageModified should match")
+        XCTAssertEqual(loaded.imageColorModified, original.imageColorModified, "\(context): imageColorModified should match")
+        XCTAssertEqual(loaded.downloadErrorDetails, original.downloadErrorDetails, "\(context): downloadErrorDetails should match")
+        XCTAssertEqual(loaded.playbackErrorDetails, original.playbackErrorDetails, "\(context): playbackErrorDetails should match")
+    }
+
+    private func createFullyPopulatedUserEpisode() -> UserEpisode {
+        let episode = UserEpisode()
+        episode.uuid = UUID().uuidString
+        episode.title = "Test Episode Title"
+        episode.addedDate = Date()
+        episode.lastDownloadAttemptDate = Date()
+        episode.downloadErrorDetails = "Test error"
+        episode.downloadTaskId = "download-task-123"
+        episode.downloadUrl = "https://example.com/episode.mp3"
+        episode.episodeStatus = DownloadStatus.downloaded.rawValue
+        episode.fileType = "audio/mpeg"
+        episode.playedUpTo = 123.45
+        episode.duration = 3600.0
+        episode.durationModified = 111
+        episode.playingStatus = PlayingStatus.inProgress.rawValue
+        episode.autoDownloadStatus = AutoDownloadStatus.autoDownloaded.rawValue
+        episode.publishedDate = Date()
+        episode.sizeInBytes = 1024000
+        episode.playingStatusModified = 222
+        episode.playedUpToModified = 333
+        episode.titleModified = 444
+        episode.playbackErrorDetails = "Playback error"
+        episode.cachedFrameCount = 100
+        episode.uploadStatus = UploadStatus.uploaded.rawValue
+        episode.uploadTaskId = "upload-task-456"
+        episode.imageUrl = "https://example.com/image.jpg"
+        episode.imageModified = 555
+        episode.imageColor = 5
+        episode.imageColorModified = 666
+        episode.hasCustomImage = true
+        return episode
+    }
+}

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/UserEpisodeDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/UserEpisodeDataManagerTests.swift
@@ -401,7 +401,182 @@ final class UserEpisodeDataManagerTests: DataManagerTestCase {
         }
     }
 
-    // MARK: - bulkSave Tests
+    // MARK: - save Tests (PersistableRecord API)
+
+    func testSaveInsertsNewUserEpisodeWithAllFields() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let episode = UserEpisode()
+            episode.uuid = "save-test-uuid"
+            episode.title = "Save Test Episode"
+            episode.addedDate = Date(timeIntervalSince1970: 1000000)
+            episode.duration = 7200
+            episode.playedUpTo = 300.5
+            episode.playingStatus = PlayingStatus.inProgress.rawValue
+            episode.episodeStatus = DownloadStatus.downloaded.rawValue
+            episode.uploadStatus = UploadStatus.uploaded.rawValue
+            episode.autoDownloadStatus = AutoDownloadStatus.autoDownloaded.rawValue
+            episode.sizeInBytes = 1024000
+            episode.fileType = "audio/mpeg"
+            episode.hasCustomImage = true
+            episode.imageColor = 5
+
+            dataManager.save(episode: episode)
+
+            let found = dataManager.findUserEpisode(uuid: "save-test-uuid")
+            XCTAssertNotNil(found, "\(impl): Should find saved user episode")
+            XCTAssertEqual(found?.uuid, "save-test-uuid", "\(impl): UUID should match")
+            XCTAssertEqual(found?.title, "Save Test Episode", "\(impl): Title should match")
+            XCTAssertEqual(found?.duration, 7200, "\(impl): Duration should match")
+            XCTAssertEqual(found?.playedUpTo, 300.5, "\(impl): playedUpTo should match")
+            XCTAssertEqual(found?.playingStatus, PlayingStatus.inProgress.rawValue, "\(impl): playingStatus should match")
+            XCTAssertEqual(found?.episodeStatus, DownloadStatus.downloaded.rawValue, "\(impl): episodeStatus should match")
+            XCTAssertEqual(found?.uploadStatus, UploadStatus.uploaded.rawValue, "\(impl): uploadStatus should match")
+            XCTAssertEqual(found?.autoDownloadStatus, AutoDownloadStatus.autoDownloaded.rawValue, "\(impl): autoDownloadStatus should match")
+            XCTAssertEqual(found?.sizeInBytes, 1024000, "\(impl): sizeInBytes should match")
+            XCTAssertEqual(found?.fileType, "audio/mpeg", "\(impl): fileType should match")
+            XCTAssertEqual(found?.hasCustomImage, true, "\(impl): hasCustomImage should match")
+            XCTAssertEqual(found?.imageColor, 5, "\(impl): imageColor should match")
+        }
+    }
+
+    func testSaveUpdatesExistingUserEpisode() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let episode = self.createTestUserEpisode(uuid: "update-test-uuid", title: "Original Title", duration: 3600, dataManager: dataManager)
+
+            // Update fields
+            episode.title = "Updated Title"
+            episode.duration = 7200
+            episode.playedUpTo = 500.0
+            episode.playingStatus = PlayingStatus.completed.rawValue
+            episode.episodeStatus = DownloadStatus.downloaded.rawValue
+            dataManager.save(episode: episode)
+
+            let found = dataManager.findUserEpisode(uuid: "update-test-uuid")
+            XCTAssertEqual(found?.title, "Updated Title", "\(impl): Title should be updated")
+            XCTAssertEqual(found?.duration, 7200, "\(impl): Duration should be updated")
+            XCTAssertEqual(found?.playedUpTo, 500.0, "\(impl): playedUpTo should be updated")
+            XCTAssertEqual(found?.playingStatus, PlayingStatus.completed.rawValue, "\(impl): playingStatus should be updated")
+            XCTAssertEqual(found?.episodeStatus, DownloadStatus.downloaded.rawValue, "\(impl): episodeStatus should be updated")
+        }
+    }
+
+    func testSaveGeneratesIdIfZero() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let episode = UserEpisode()
+            episode.uuid = "id-test-uuid"
+            episode.title = "ID Test Episode"
+            episode.addedDate = Date()
+            episode.id = 0
+
+            dataManager.save(episode: episode)
+
+            XCTAssertNotEqual(episode.id, 0, "\(impl): ID should be generated")
+
+            let found = dataManager.findUserEpisode(uuid: "id-test-uuid")
+            XCTAssertNotNil(found, "\(impl): Should find episode with generated ID")
+            XCTAssertNotEqual(found?.id, 0, "\(impl): Found episode should have non-zero ID")
+        }
+    }
+
+    func testSavePreservesModifiedFlags() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let episode = UserEpisode()
+            episode.uuid = "modified-test-uuid"
+            episode.title = "Modified Flags Test"
+            episode.addedDate = Date()
+            episode.playingStatusModified = 12345
+            episode.playedUpToModified = 67890
+            episode.titleModified = 11111
+            episode.durationModified = 22222
+            episode.imageModified = 33333
+            episode.imageColorModified = 44444
+
+            dataManager.save(episode: episode)
+
+            let found = dataManager.findUserEpisode(uuid: "modified-test-uuid")
+            XCTAssertEqual(found?.playingStatusModified, 12345, "\(impl): playingStatusModified should be preserved")
+            XCTAssertEqual(found?.playedUpToModified, 67890, "\(impl): playedUpToModified should be preserved")
+            XCTAssertEqual(found?.titleModified, 11111, "\(impl): titleModified should be preserved")
+            XCTAssertEqual(found?.durationModified, 22222, "\(impl): durationModified should be preserved")
+            XCTAssertEqual(found?.imageModified, 33333, "\(impl): imageModified should be preserved")
+            XCTAssertEqual(found?.imageColorModified, 44444, "\(impl): imageColorModified should be preserved")
+        }
+    }
+
+    func testSavePreservesOptionalStrings() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let episode = UserEpisode()
+            episode.uuid = "optional-test-uuid"
+            episode.title = "Optional Strings Test"
+            episode.addedDate = Date()
+            episode.downloadUrl = "https://example.com/episode.mp3"
+            episode.downloadTaskId = "download-task-123"
+            episode.uploadTaskId = "upload-task-456"
+            episode.imageUrl = "https://example.com/image.jpg"
+            episode.downloadErrorDetails = "Test error"
+            episode.playbackErrorDetails = "Playback error"
+
+            dataManager.save(episode: episode)
+
+            let found = dataManager.findUserEpisode(uuid: "optional-test-uuid")
+            XCTAssertEqual(found?.downloadUrl, "https://example.com/episode.mp3", "\(impl): downloadUrl should be preserved")
+            XCTAssertEqual(found?.downloadTaskId, "download-task-123", "\(impl): downloadTaskId should be preserved")
+            XCTAssertEqual(found?.uploadTaskId, "upload-task-456", "\(impl): uploadTaskId should be preserved")
+            XCTAssertEqual(found?.imageUrl, "https://example.com/image.jpg", "\(impl): imageUrl should be preserved")
+            XCTAssertEqual(found?.downloadErrorDetails, "Test error", "\(impl): downloadErrorDetails should be preserved")
+            XCTAssertEqual(found?.playbackErrorDetails, "Playback error", "\(impl): playbackErrorDetails should be preserved")
+        }
+    }
+
+    // MARK: - bulkSave Tests (PersistableRecord API)
+
+    func testBulkSaveUpdatesExistingUserEpisodes() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let episode1 = self.createTestUserEpisode(uuid: "bulk-update-1", title: "Episode 1", dataManager: dataManager)
+            let episode2 = self.createTestUserEpisode(uuid: "bulk-update-2", title: "Episode 2", dataManager: dataManager)
+
+            // Update the episodes
+            episode1.title = "Episode 1 Updated"
+            episode1.playingStatus = PlayingStatus.completed.rawValue
+            episode2.title = "Episode 2 Updated"
+            episode2.playingStatus = PlayingStatus.inProgress.rawValue
+
+            dataManager.bulkSave(episodes: [episode1, episode2])
+
+            let found1 = dataManager.findUserEpisode(uuid: "bulk-update-1")
+            let found2 = dataManager.findUserEpisode(uuid: "bulk-update-2")
+
+            XCTAssertEqual(found1?.title, "Episode 1 Updated", "\(impl): Episode 1 title should be updated")
+            XCTAssertEqual(found1?.playingStatus, PlayingStatus.completed.rawValue, "\(impl): Episode 1 playingStatus should be updated")
+            XCTAssertEqual(found2?.title, "Episode 2 Updated", "\(impl): Episode 2 title should be updated")
+            XCTAssertEqual(found2?.playingStatus, PlayingStatus.inProgress.rawValue, "\(impl): Episode 2 playingStatus should be updated")
+        }
+    }
+
+    func testBulkSaveMixedInsertAndUpdate() throws {
+        try runWithBothImplementations { dataManager, impl in
+            // Create one existing episode
+            let existingEpisode = self.createTestUserEpisode(uuid: "existing-uuid", title: "Existing Episode", dataManager: dataManager)
+
+            // Create a new episode
+            let newEpisode = UserEpisode()
+            newEpisode.uuid = "new-uuid"
+            newEpisode.title = "New Episode"
+            newEpisode.addedDate = Date()
+
+            // Update existing episode
+            existingEpisode.title = "Existing Episode Updated"
+
+            dataManager.bulkSave(episodes: [existingEpisode, newEpisode])
+
+            let foundExisting = dataManager.findUserEpisode(uuid: "existing-uuid")
+            let foundNew = dataManager.findUserEpisode(uuid: "new-uuid")
+
+            XCTAssertEqual(foundExisting?.title, "Existing Episode Updated", "\(impl): Existing episode should be updated")
+            XCTAssertNotNil(foundNew, "\(impl): New episode should be inserted")
+            XCTAssertEqual(foundNew?.title, "New Episode", "\(impl): New episode title should match")
+        }
+    }
 
     func testBulkSaveSavesMultipleUserEpisodes() throws {
         try runWithBothImplementations { dataManager, impl in


### PR DESCRIPTION
Part of PCIOS-491

Adds GRDB macros to the User Episode model and implements feature-flagged GRDB save operations.

##  Changes

- User Episode model: Applied GRDB macros macros for type-safe GRDB conformance
- UserEpisodeDataManager: Added `save()` method using GRDB's PersistableRecord behind `FeatureFlag.grdbQueryInterface`
- Tests: Updated `UserEpisodeDataManagerTests` and updated `DataManagerTestCase` to run against both SQL and GRDB implementations. Also added column consistency tests to verify the current `columnNames` matches our GRDB columns.

## To test

* Test User Episode creation and basic functionality with `grdbQueryInterface` enabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
