### PR TITLE
GRDB Macros: EpisodeFilter

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
@@ -1,7 +1,9 @@
 import PocketCastsUtils
 import Foundation
+import GRDB
 
 class PlaylistDataManager {
+    /// Legacy column names for non-GRDB code path.
     private let columnNames = [
         "id",
         "autoDownloadEpisodes",
@@ -321,17 +323,34 @@ class PlaylistDataManager {
     }
 
     func save(playlist: EpisodeFilter, dbQueue: PCDBQueue) {
-        dbQueue.write { db in
+        let isInsert = playlist.id == 0
+        if isInsert {
+            playlist.id = DBUtils.generateUniqueId()
+        }
+        playlist.playlistUpdateDate = .now
+
+        if FeatureFlag.grdbQueryInterface.enabled, let grdbQueue = dbQueue as? GRDBQueue {
+            // GRDB path using PersistableRecord
             do {
-                if playlist.id == 0 {
-                    playlist.id = DBUtils.generateUniqueId()
-                    try db.executeUpdate("INSERT INTO \(DataManager.playlistsTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(playlist: playlist, updateDate: .now))
-                } else {
-                    let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
-                    try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET \(setStatement) WHERE uuid = ?", values: self.createValuesFrom(playlist: playlist, includeUuidForWhere: true, updateDate: .now))
+                try grdbQueue.dbPool.write { db in
+                    try playlist.save(db)
                 }
             } catch {
                 FileLog.shared.addMessage("PlaylistDataManager.save error: \(error)")
+            }
+        } else {
+            // Legacy path
+            dbQueue.write { db in
+                do {
+                    if isInsert {
+                        try db.executeUpdate("INSERT INTO \(DataManager.playlistsTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(playlist: playlist, updateDate: .now))
+                    } else {
+                        let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
+                        try db.executeUpdate("UPDATE \(DataManager.playlistsTableName) SET \(setStatement) WHERE uuid = ?", values: self.createValuesFrom(playlist: playlist, includeUuidForWhere: true, updateDate: .now))
+                    }
+                } catch {
+                    FileLog.shared.addMessage("PlaylistDataManager.save error: \(error)")
+                }
             }
         }
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
@@ -4,7 +4,7 @@ import GRDB
 
 class PlaylistDataManager {
     /// Legacy column names for non-GRDB code path.
-    private let columnNames = [
+    let columnNames = [
         "id",
         "autoDownloadEpisodes",
         "customIcon",

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -1,5 +1,8 @@
 import Foundation
+import GRDB
+import GRDBMacros
 
+@GRDBRecord(table: "SJFilteredPlaylist")
 public class EpisodeFilter: NSObject {
     @objc public static let iconTypeCount = 8
     @objc public static let iconsPerType = 5
@@ -10,6 +13,7 @@ public class EpisodeFilter: NSObject {
     @objc public var filterAllPodcasts = false
     @objc public var filterAudioVideoType = 0 as Int32
     @objc public var filterDownloaded = false
+    @GRDBIgnore
     @objc public let filterDownloading = true // we no longer let the user change this, it's just always true
     @objc public var filterFinished = false
     @objc public var filterNotDownloaded = false
@@ -33,12 +37,20 @@ public class EpisodeFilter: NSObject {
     @objc public var playlistUpdateDate: Date?
 
     // Internal tracking
+    @GRDBIgnore
     public var isNew: Bool = false
+    @GRDBIgnore
     public var podcastSmartRuleApplied: Bool = false
+    @GRDBIgnore
     public var episodesSmartRuleApplied: Bool = false
+    @GRDBIgnore
     public var releaseDateSmartRuleApplied: Bool = false
+    @GRDBIgnore
     public var mediaTypeSmartRuleApplied: Bool = false
+    @GRDBIgnore
     public var downloadStatusSmartRuleApplied: Bool = false
+
+    override public init() {}
 
     public func setTitle(_ title: String?, defaultTitle: String) {
         guard let title = title, title.trimmingCharacters(in: .whitespacesAndNewlines).count > 0 else {

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManagerTestCase.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManagerTestCase.swift
@@ -43,13 +43,17 @@ class DataManagerTestCase: XCTestCase {
     /// Runs the provided test block with both SQL and GRDB API implementations.
     ///
     /// - Parameter testBlock: A closure that receives a DataManager and the implementation name.
-    ///                        The implementation name is either "" or "GRDB".
+    ///                        The implementation name is either "SQL" or "GRDB".
     func runWithBothImplementations(_ testBlock: (DataManager, String) throws -> Void) throws {
         // Test with raw SQL query
         let sqlDataManager = DataManager.newTestDataManager()
         try testBlock(sqlDataManager, "SQL")
 
-        // TODO: Test with GRDB implementation
+        // Test with GRDB implementation
+        try featureFlagStore.override(FeatureFlag.grdbQueryInterface, withValue: true)
+        let grdbDataManager = DataManager.newTestDataManager()
+        try testBlock(grdbDataManager, "GRDB")
+        featureFlagStore.resetOverrides()
     }
 
     /// Async version of runWithBothImplementations
@@ -58,7 +62,11 @@ class DataManagerTestCase: XCTestCase {
         let sqlDataManager = DataManager.newTestDataManager()
         try await testBlock(sqlDataManager, "SQL")
 
-        // TODO: Test with GRDB API
+        // Test with GRDB implementation
+        try featureFlagStore.override(FeatureFlag.grdbQueryInterface, withValue: true)
+        let grdbDataManager = DataManager.newTestDataManager()
+        try await testBlock(grdbDataManager, "GRDB")
+        featureFlagStore.resetOverrides()
     }
 
     // MARK: - Common Test Helpers

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/EpisodeFilterColumnConsistencyTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/EpisodeFilterColumnConsistencyTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+import GRDB
+@testable import PocketCastsDataModel
+@testable import PocketCastsUtils
+
+/// Tests to ensure the legacy SQL columnNames and GRDB-persisted columns remain in sync.
+/// These tests prevent the issue where GRDB might persist a field that the legacy SQL path ignores
+/// (or vice versa), causing inconsistent behavior when the feature flag is toggled.
+final class EpisodeFilterColumnConsistencyTests: DataManagerTestCase {
+
+    /// Access columnNames directly from PlaylistDataManager (the source of truth for legacy SQL).
+    private var columnNames: Set<String> {
+        Set(PlaylistDataManager().columnNames)
+    }
+
+    // MARK: - Database Schema Tests
+
+    func testDatabaseTableHasExpectedColumns() throws {
+        let dataManager = DataManager.newTestDataManager()
+
+        // Get actual database columns using GRDB introspection
+        guard let grdbQueue = dataManager.dbQueue as? GRDBQueue else {
+            XCTFail("Expected GRDBQueue for database introspection")
+            return
+        }
+
+        let tableColumns = try grdbQueue.dbPool.read { db -> Set<String> in
+            let columns = try db.columns(in: DataManager.playlistsTableName)
+            return Set(columns.map { $0.name })
+        }
+
+        // The database should have at least all the columns from columnNames
+        let missingColumns = columnNames.subtracting(tableColumns)
+        XCTAssertTrue(
+            missingColumns.isEmpty,
+            "Database table is missing columns from columnNames: \(missingColumns)"
+        )
+    }
+
+    // MARK: - Round-Trip Tests
+
+    func testSaveAndLoadPreservesAllFields() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            let original = self.createFullyPopulatedEpisodeFilter()
+
+            // Save using the current implementation (respects feature flag)
+            dataManager.save(playlist: original)
+
+            // Load it back
+            guard let loaded = dataManager.findPlaylist(uuid: original.uuid) else {
+                XCTFail("\(implementationName): Should be able to load saved filter")
+                return
+            }
+
+            // Verify all persisted fields match
+            XCTAssertEqual(loaded.uuid, original.uuid, "\(implementationName): uuid should match")
+            XCTAssertEqual(loaded.playlistName, original.playlistName, "\(implementationName): playlistName should match")
+            XCTAssertEqual(loaded.customIcon, original.customIcon, "\(implementationName): customIcon should match")
+            XCTAssertEqual(loaded.filterAllPodcasts, original.filterAllPodcasts, "\(implementationName): filterAllPodcasts should match")
+            XCTAssertEqual(loaded.filterAudioVideoType, original.filterAudioVideoType, "\(implementationName): filterAudioVideoType should match")
+            XCTAssertEqual(loaded.filterDownloaded, original.filterDownloaded, "\(implementationName): filterDownloaded should match")
+            XCTAssertEqual(loaded.filterFinished, original.filterFinished, "\(implementationName): filterFinished should match")
+            XCTAssertEqual(loaded.filterNotDownloaded, original.filterNotDownloaded, "\(implementationName): filterNotDownloaded should match")
+            XCTAssertEqual(loaded.filterPartiallyPlayed, original.filterPartiallyPlayed, "\(implementationName): filterPartiallyPlayed should match")
+            XCTAssertEqual(loaded.filterStarred, original.filterStarred, "\(implementationName): filterStarred should match")
+            XCTAssertEqual(loaded.filterUnplayed, original.filterUnplayed, "\(implementationName): filterUnplayed should match")
+            XCTAssertEqual(loaded.filterHours, original.filterHours, "\(implementationName): filterHours should match")
+            XCTAssertEqual(loaded.sortPosition, original.sortPosition, "\(implementationName): sortPosition should match")
+            XCTAssertEqual(loaded.sortType, original.sortType, "\(implementationName): sortType should match")
+            XCTAssertEqual(loaded.podcastUuids, original.podcastUuids, "\(implementationName): podcastUuids should match")
+            XCTAssertEqual(loaded.autoDownloadEpisodes, original.autoDownloadEpisodes, "\(implementationName): autoDownloadEpisodes should match")
+            XCTAssertEqual(loaded.autoDownloadLimit, original.autoDownloadLimit, "\(implementationName): autoDownloadLimit should match")
+            XCTAssertEqual(loaded.filterDuration, original.filterDuration, "\(implementationName): filterDuration should match")
+            XCTAssertEqual(loaded.longerThan, original.longerThan, "\(implementationName): longerThan should match")
+            XCTAssertEqual(loaded.shorterThan, original.shorterThan, "\(implementationName): shorterThan should match")
+            XCTAssertEqual(loaded.syncStatus, original.syncStatus, "\(implementationName): syncStatus should match")
+            XCTAssertEqual(loaded.wasDeleted, original.wasDeleted, "\(implementationName): wasDeleted should match")
+            XCTAssertEqual(loaded.manual, original.manual, "\(implementationName): manual should match")
+            XCTAssertEqual(loaded.showArchivedEpisodes, original.showArchivedEpisodes, "\(implementationName): showArchivedEpisodes should match")
+        }
+    }
+
+    // MARK: - Ignored Property Tests
+
+    /// Verifies that filterDownloading is NOT persisted (marked with @GRDBIgnore)
+    func testFilterDownloadingNotPersisted() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            let filter = EpisodeFilter()
+            filter.uuid = UUID().uuidString.lowercased()
+            filter.playlistName = "Test Filter"
+            // filterDownloading is a let constant set to true, can't change it
+
+            dataManager.save(playlist: filter)
+
+            // Load it back - filterDownloading should always be true (its default)
+            guard let loaded = dataManager.findPlaylist(uuid: filter.uuid) else {
+                XCTFail("\(implementationName): Should find saved filter")
+                return
+            }
+
+            // filterDownloading should be true (its constant default, not persisted)
+            XCTAssertTrue(loaded.filterDownloading, "\(implementationName): filterDownloading should always be true")
+        }
+    }
+
+    /// Verifies that internal tracking properties are NOT persisted (marked with @GRDBIgnore)
+    func testInternalTrackingPropertiesNotPersisted() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            let filter = EpisodeFilter()
+            filter.uuid = UUID().uuidString.lowercased()
+            filter.playlistName = "Test Filter"
+            filter.isNew = true
+            filter.podcastSmartRuleApplied = true
+            filter.episodesSmartRuleApplied = true
+            filter.releaseDateSmartRuleApplied = true
+            filter.mediaTypeSmartRuleApplied = true
+            filter.downloadStatusSmartRuleApplied = true
+
+            dataManager.save(playlist: filter)
+
+            // Load it back - all internal tracking should be default (false)
+            guard let loaded = dataManager.findPlaylist(uuid: filter.uuid) else {
+                XCTFail("\(implementationName): Should find saved filter")
+                return
+            }
+
+            // Internal tracking properties should be false (not persisted)
+            XCTAssertFalse(loaded.isNew, "\(implementationName): isNew should NOT be persisted")
+            XCTAssertFalse(loaded.podcastSmartRuleApplied, "\(implementationName): podcastSmartRuleApplied should NOT be persisted")
+            XCTAssertFalse(loaded.episodesSmartRuleApplied, "\(implementationName): episodesSmartRuleApplied should NOT be persisted")
+            XCTAssertFalse(loaded.releaseDateSmartRuleApplied, "\(implementationName): releaseDateSmartRuleApplied should NOT be persisted")
+            XCTAssertFalse(loaded.mediaTypeSmartRuleApplied, "\(implementationName): mediaTypeSmartRuleApplied should NOT be persisted")
+            XCTAssertFalse(loaded.downloadStatusSmartRuleApplied, "\(implementationName): downloadStatusSmartRuleApplied should NOT be persisted")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func createFullyPopulatedEpisodeFilter() -> EpisodeFilter {
+        let filter = EpisodeFilter()
+        filter.uuid = UUID().uuidString.lowercased()
+        filter.playlistName = "Test Filter"
+        filter.customIcon = 3
+        filter.filterAllPodcasts = true
+        filter.filterAudioVideoType = 1
+        filter.filterDownloaded = true
+        filter.filterFinished = true
+        filter.filterNotDownloaded = false
+        filter.filterPartiallyPlayed = true
+        filter.filterStarred = true
+        filter.filterUnplayed = false
+        filter.filterHours = 24
+        filter.sortPosition = 5
+        filter.sortType = 2
+        filter.podcastUuids = "uuid1,uuid2,uuid3"
+        filter.autoDownloadEpisodes = true
+        filter.autoDownloadLimit = 10
+        filter.filterDuration = true
+        filter.longerThan = 300
+        filter.shorterThan = 3600
+        filter.syncStatus = SyncStatus.synced.rawValue
+        filter.wasDeleted = false
+        filter.manual = false
+        filter.showArchivedEpisodes = true
+        filter.playlistUpdateDate = Date()
+        return filter
+    }
+}

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PlaylistDataManagerTests.swift
@@ -374,4 +374,122 @@ final class PlaylistDataManagerTests: DataManagerTestCase {
             XCTAssertNotNil(found?.playlistUpdateDate, "\(impl): Should have update date")
         }
     }
+
+    // MARK: - save Tests (PersistableRecord API)
+
+    func testSaveInsertsNewPlaylistWithAllFields() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let playlist = EpisodeFilter()
+            playlist.uuid = "save-test-uuid"
+            playlist.playlistName = "Save Test Playlist"
+            playlist.manual = true
+            playlist.sortPosition = 99
+            playlist.syncStatus = SyncStatus.notSynced.rawValue
+            playlist.wasDeleted = false
+            playlist.autoDownloadEpisodes = true
+            playlist.filterHours = 48
+            playlist.filterDuration = true
+            playlist.filterUnplayed = true
+            playlist.filterPartiallyPlayed = true
+            playlist.filterFinished = false
+            playlist.filterStarred = true
+            playlist.filterAllPodcasts = true
+
+            dataManager.save(playlist: playlist)
+
+            let found = dataManager.findPlaylist(uuid: "save-test-uuid")
+            XCTAssertNotNil(found, "\(impl): Should find saved playlist")
+            XCTAssertEqual(found?.uuid, "save-test-uuid", "\(impl): UUID should match")
+            XCTAssertEqual(found?.playlistName, "Save Test Playlist", "\(impl): Name should match")
+            XCTAssertEqual(found?.manual, true, "\(impl): manual should match")
+            XCTAssertEqual(found?.sortPosition, 99, "\(impl): sortPosition should match")
+            XCTAssertEqual(found?.syncStatus, SyncStatus.notSynced.rawValue, "\(impl): syncStatus should match")
+            XCTAssertEqual(found?.wasDeleted, false, "\(impl): wasDeleted should match")
+            XCTAssertEqual(found?.autoDownloadEpisodes, true, "\(impl): autoDownloadEpisodes should match")
+            XCTAssertEqual(found?.filterHours, 48, "\(impl): filterHours should match")
+            XCTAssertEqual(found?.filterDuration, true, "\(impl): filterDuration should match")
+            XCTAssertEqual(found?.filterUnplayed, true, "\(impl): filterUnplayed should match")
+            XCTAssertEqual(found?.filterPartiallyPlayed, true, "\(impl): filterPartiallyPlayed should match")
+            XCTAssertEqual(found?.filterFinished, false, "\(impl): filterFinished should match")
+            XCTAssertEqual(found?.filterStarred, true, "\(impl): filterStarred should match")
+            XCTAssertEqual(found?.filterAllPodcasts, true, "\(impl): filterAllPodcasts should match")
+        }
+    }
+
+    func testSaveUpdatesExistingPlaylist() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let playlist = self.createTestPlaylist(uuid: "update-test-uuid", name: "Original Name", manual: false, dataManager: dataManager)
+
+            // Update fields
+            playlist.playlistName = "Updated Name"
+            playlist.manual = true
+            playlist.autoDownloadEpisodes = true
+            playlist.filterHours = 72
+            playlist.syncStatus = SyncStatus.synced.rawValue
+            dataManager.save(playlist: playlist)
+
+            let found = dataManager.findPlaylist(uuid: "update-test-uuid")
+            XCTAssertEqual(found?.playlistName, "Updated Name", "\(impl): Name should be updated")
+            XCTAssertEqual(found?.manual, true, "\(impl): manual should be updated")
+            XCTAssertEqual(found?.autoDownloadEpisodes, true, "\(impl): autoDownloadEpisodes should be updated")
+            XCTAssertEqual(found?.filterHours, 72, "\(impl): filterHours should be updated")
+            XCTAssertEqual(found?.syncStatus, SyncStatus.synced.rawValue, "\(impl): syncStatus should be updated")
+        }
+    }
+
+    func testSaveGeneratesIdIfZero() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let playlist = EpisodeFilter()
+            playlist.uuid = "id-test-uuid"
+            playlist.playlistName = "ID Test Playlist"
+            playlist.id = 0
+
+            dataManager.save(playlist: playlist)
+
+            XCTAssertNotEqual(playlist.id, 0, "\(impl): ID should be generated")
+
+            let found = dataManager.findPlaylist(uuid: "id-test-uuid")
+            XCTAssertNotNil(found, "\(impl): Should find playlist with generated ID")
+            XCTAssertNotEqual(found?.id, 0, "\(impl): Found playlist should have non-zero ID")
+        }
+    }
+
+    func testSaveUpdatesPlaylistUpdateDate() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let playlist = EpisodeFilter()
+            playlist.uuid = "date-test-uuid"
+            playlist.playlistName = "Date Test Playlist"
+
+            let beforeSave = Date()
+            dataManager.save(playlist: playlist)
+
+            let found = dataManager.findPlaylist(uuid: "date-test-uuid")
+            XCTAssertNotNil(found?.playlistUpdateDate, "\(impl): playlistUpdateDate should be set")
+            if let updateDate = found?.playlistUpdateDate {
+                XCTAssertGreaterThanOrEqual(updateDate, beforeSave.addingTimeInterval(-1), "\(impl): playlistUpdateDate should be recent")
+            }
+        }
+    }
+
+    func testSavePreservesFilterSettings() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let playlist = EpisodeFilter()
+            playlist.uuid = "filter-test-uuid"
+            playlist.playlistName = "Filter Test Playlist"
+            playlist.filterAudioVideoType = 2
+            playlist.filterDownloaded = true
+            playlist.filterNotDownloaded = true
+            playlist.sortType = 3
+            playlist.podcastUuids = "podcast-1,podcast-2,podcast-3"
+
+            dataManager.save(playlist: playlist)
+
+            let found = dataManager.findPlaylist(uuid: "filter-test-uuid")
+            XCTAssertEqual(found?.filterAudioVideoType, 2, "\(impl): filterAudioVideoType should be preserved")
+            XCTAssertEqual(found?.filterDownloaded, true, "\(impl): filterDownloaded should be preserved")
+            XCTAssertEqual(found?.filterNotDownloaded, true, "\(impl): filterNotDownloaded should be preserved")
+            XCTAssertEqual(found?.sortType, 3, "\(impl): sortType should be preserved")
+            XCTAssertEqual(found?.podcastUuids, "podcast-1,podcast-2,podcast-3", "\(impl): podcastUuids should be preserved")
+        }
+    }
 }


### PR DESCRIPTION
Part of PCIOS-491

Adds GRDB macros to the EpisodeFilter model and implements feature-flagged GRDB save operations.

##  Changes

- EpisodeFilter model: Applied `@GRDBRecord` and `@GRDBIgnore` macros for type-safe GRDB conformance
- PlaylistDataManager: Added `save()` method using GRDB's PersistableRecord behind `FeatureFlag.grdbQueryInterface`
- Tests: Updated `PlaylistDataManagerTests` and updated `DataManagerTestCase` to run against both SQL and GRDB implementations. Also added column consistency tests to verify the current `columnNames` matches our GRDB columns.

## To test

* Test Playlist creation and editing with `grdbQueryInterface` enabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.