### PR TITLE
GRDB Macros: Podcast

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -1,5 +1,6 @@
 import PocketCastsUtils
 import Foundation
+import GRDB
 
 extension Podcast: Sortable {
     public var itemUUID: String {
@@ -19,6 +20,7 @@ class PodcastDataManager {
         return queue
     }()
 
+    /// Legacy column names for non-GRDB code path.
     private let columnNames = [
         "id",
         "addedDate",
@@ -386,17 +388,33 @@ class PodcastDataManager {
     // MARK: - Updates
 
     func save(podcast: Podcast, dbQueue: PCDBQueue) {
-        dbQueue.write { db in
+        let isInsert = podcast.id == 0
+        if isInsert {
+            podcast.id = DBUtils.generateUniqueId()
+        }
+
+        if FeatureFlag.grdbQueryInterface.enabled, let grdbQueue = dbQueue as? GRDBQueue {
+            // GRDB path using PersistableRecord
             do {
-                if podcast.id == 0 {
-                    podcast.id = DBUtils.generateUniqueId()
-                    try db.executeUpdate("INSERT INTO \(DataManager.podcastTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(podcast: podcast))
-                } else {
-                    let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
-                    try db.executeUpdate("UPDATE \(DataManager.podcastTableName) SET \(setStatement) WHERE id = ?", values: self.createValuesFrom(podcast: podcast, includeIdForWhere: true))
+                try grdbQueue.dbPool.write { db in
+                    try podcast.save(db)
                 }
             } catch {
                 FileLog.shared.addMessage("PodcastDataManager.save error: \(error)")
+            }
+        } else {
+            // Legacy path
+            dbQueue.write { db in
+                do {
+                    if isInsert {
+                        try db.executeUpdate("INSERT INTO \(DataManager.podcastTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(podcast: podcast))
+                    } else {
+                        let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
+                        try db.executeUpdate("UPDATE \(DataManager.podcastTableName) SET \(setStatement) WHERE id = ?", values: self.createValuesFrom(podcast: podcast, includeIdForWhere: true))
+                    }
+                } catch {
+                    FileLog.shared.addMessage("PodcastDataManager.save error: \(error)")
+                }
             }
         }
         cachePodcasts(dbQueue: dbQueue)

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -21,7 +21,7 @@ class PodcastDataManager {
     }()
 
     /// Legacy column names for non-GRDB code path.
-    private let columnNames = [
+    let columnNames = [
         "id",
         "addedDate",
         "autoDownloadSetting",

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -1,11 +1,15 @@
 import Foundation
+import GRDB
+import GRDBMacros
 import PocketCastsUtils
 
+@GRDBRecord(table: "SJPodcast")
 public class Podcast: NSObject, Identifiable {
     @objc public var id = 0 as Int64
     @objc public var addedDate: Date?
     @objc public var autoDownloadSetting = 0 as Int32
     @objc public var autoAddToUpNext = 0 as Int32
+    @GRDBColumn("episodeKeepSetting")
     @objc public var autoArchiveEpisodeLimit = 0 as Int32
     @objc public var backgroundColor: String?
     @objc public var detailColor: String? // dark artwork overlay
@@ -56,14 +60,21 @@ public class Podcast: NSObject, Identifiable {
     @objc public var isPrivate = false
     @objc public var fundingURL: String?
 
+    @GRDBIgnore
     public var settings: PodcastSettings = PodcastSettings.defaults
 
     // transient not saved to database
+    @GRDBIgnore
     public var cachedUnreadCount = 0
 
     // if set to an episode UUID, all podcast episodes after the given
     // UUID will be updated
+    @GRDBIgnore
     public var forceRefreshEpisodeFrom: String? = nil
+
+    override public init() {
+        super.init()
+    }
 
     public func autoDownloadOn() -> Bool {
         autoDownloadSetting == AutoDownloadSetting.latest.rawValue

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -72,9 +72,7 @@ public class Podcast: NSObject, Identifiable {
     @GRDBIgnore
     public var forceRefreshEpisodeFrom: String? = nil
 
-    override public init() {
-        super.init()
-    }
+    override public init() {}
 
     public func autoDownloadOn() -> Bool {
         autoDownloadSetting == AutoDownloadSetting.latest.rawValue

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManagerTestCase.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManagerTestCase.swift
@@ -43,13 +43,17 @@ class DataManagerTestCase: XCTestCase {
     /// Runs the provided test block with both SQL and GRDB API implementations.
     ///
     /// - Parameter testBlock: A closure that receives a DataManager and the implementation name.
-    ///                        The implementation name is either "" or "GRDB".
+    ///                        The implementation name is either "SQL" or "GRDB".
     func runWithBothImplementations(_ testBlock: (DataManager, String) throws -> Void) throws {
         // Test with raw SQL query
         let sqlDataManager = DataManager.newTestDataManager()
         try testBlock(sqlDataManager, "SQL")
 
-        // TODO: Test with GRDB implementation
+        // Test with GRDB implementation
+        try featureFlagStore.override(FeatureFlag.grdbQueryInterface, withValue: true)
+        let grdbDataManager = DataManager.newTestDataManager()
+        try testBlock(grdbDataManager, "GRDB")
+        featureFlagStore.resetOverrides()
     }
 
     /// Async version of runWithBothImplementations
@@ -58,7 +62,11 @@ class DataManagerTestCase: XCTestCase {
         let sqlDataManager = DataManager.newTestDataManager()
         try await testBlock(sqlDataManager, "SQL")
 
-        // TODO: Test with GRDB API
+        // Test with GRDB implementation
+        try featureFlagStore.override(FeatureFlag.grdbQueryInterface, withValue: true)
+        let grdbDataManager = DataManager.newTestDataManager()
+        try await testBlock(grdbDataManager, "GRDB")
+        featureFlagStore.resetOverrides()
     }
 
     // MARK: - Common Test Helpers

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastColumnConsistencyTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastColumnConsistencyTests.swift
@@ -1,0 +1,183 @@
+import XCTest
+import GRDB
+@testable import PocketCastsDataModel
+@testable import PocketCastsUtils
+
+/// Tests to ensure the legacy SQL columnNames and GRDB-persisted columns remain in sync.
+/// These tests prevent the issue where GRDB might persist a field that the legacy SQL path ignores
+/// (or vice versa), causing inconsistent behavior when the feature flag is toggled.
+final class PodcastColumnConsistencyTests: DataManagerTestCase {
+
+    /// Access columnNames directly from PodcastDataManager (the source of truth for legacy SQL).
+    private var columnNames: Set<String> {
+        Set(PodcastDataManager().columnNames)
+    }
+
+    // MARK: - Database Schema Tests
+
+    func testDatabaseTableHasExpectedColumns() throws {
+        let dataManager = DataManager.newTestDataManager()
+
+        // Get actual database columns using GRDB introspection
+        guard let grdbQueue = dataManager.dbQueue as? GRDBQueue else {
+            XCTFail("Expected GRDBQueue for database introspection")
+            return
+        }
+
+        let tableColumns = try grdbQueue.dbPool.read { db -> Set<String> in
+            let columns = try db.columns(in: DataManager.podcastTableName)
+            return Set(columns.map { $0.name })
+        }
+
+        // The database should have at least all the columns from columnNames
+        let missingColumns = columnNames.subtracting(tableColumns)
+        XCTAssertTrue(
+            missingColumns.isEmpty,
+            "Database table is missing columns from columnNames: \(missingColumns)"
+        )
+    }
+
+    // MARK: - Round-Trip Tests
+
+    func testSaveAndLoadPreservesAllFields() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            let original = self.createFullyPopulatedPodcast()
+
+            // Save using the current implementation (respects feature flag)
+            dataManager.save(podcast: original)
+
+            // Load it back
+            guard let loaded = dataManager.findPodcast(uuid: original.uuid, includeUnsubscribed: true) else {
+                XCTFail("\(implementationName): Should be able to load saved podcast")
+                return
+            }
+
+            // Verify all persisted fields match
+            XCTAssertEqual(loaded.uuid, original.uuid, "\(implementationName): uuid should match")
+            XCTAssertEqual(loaded.title, original.title, "\(implementationName): title should match")
+            XCTAssertEqual(loaded.author, original.author, "\(implementationName): author should match")
+            XCTAssertEqual(loaded.podcastDescription, original.podcastDescription, "\(implementationName): podcastDescription should match")
+            XCTAssertEqual(loaded.podcastUrl, original.podcastUrl, "\(implementationName): podcastUrl should match")
+            XCTAssertEqual(loaded.imageURL, original.imageURL, "\(implementationName): imageURL should match")
+            XCTAssertEqual(loaded.mediaType, original.mediaType, "\(implementationName): mediaType should match")
+            XCTAssertEqual(loaded.subscribed, original.subscribed, "\(implementationName): subscribed should match")
+            XCTAssertEqual(loaded.sortOrder, original.sortOrder, "\(implementationName): sortOrder should match")
+            XCTAssertEqual(loaded.autoDownloadSetting, original.autoDownloadSetting, "\(implementationName): autoDownloadSetting should match")
+            XCTAssertEqual(loaded.autoAddToUpNext, original.autoAddToUpNext, "\(implementationName): autoAddToUpNext should match")
+            XCTAssertEqual(loaded.autoArchiveEpisodeLimit, original.autoArchiveEpisodeLimit, "\(implementationName): autoArchiveEpisodeLimit should match")
+            XCTAssertEqual(loaded.overrideGlobalEffects, original.overrideGlobalEffects, "\(implementationName): overrideGlobalEffects should match")
+            XCTAssertEqual(loaded.playbackSpeed, original.playbackSpeed, "\(implementationName): playbackSpeed should match")
+            XCTAssertEqual(loaded.boostVolume, original.boostVolume, "\(implementationName): boostVolume should match")
+            XCTAssertEqual(loaded.trimSilenceAmount, original.trimSilenceAmount, "\(implementationName): trimSilenceAmount should match")
+            XCTAssertEqual(loaded.startFrom, original.startFrom, "\(implementationName): startFrom should match")
+            XCTAssertEqual(loaded.skipLast, original.skipLast, "\(implementationName): skipLast should match")
+            XCTAssertEqual(loaded.syncStatus, original.syncStatus, "\(implementationName): syncStatus should match")
+            XCTAssertEqual(loaded.colorVersion, original.colorVersion, "\(implementationName): colorVersion should match")
+            XCTAssertEqual(loaded.pushEnabled, original.pushEnabled, "\(implementationName): pushEnabled should match")
+            XCTAssertEqual(loaded.episodeSortOrder, original.episodeSortOrder, "\(implementationName): episodeSortOrder should match")
+            XCTAssertEqual(loaded.episodeGrouping, original.episodeGrouping, "\(implementationName): episodeGrouping should match")
+            XCTAssertEqual(loaded.showType, original.showType, "\(implementationName): showType should match")
+            XCTAssertEqual(loaded.overrideGlobalArchive, original.overrideGlobalArchive, "\(implementationName): overrideGlobalArchive should match")
+            XCTAssertEqual(loaded.autoArchivePlayedAfter, original.autoArchivePlayedAfter, "\(implementationName): autoArchivePlayedAfter should match")
+            XCTAssertEqual(loaded.autoArchiveInactiveAfter, original.autoArchiveInactiveAfter, "\(implementationName): autoArchiveInactiveAfter should match")
+            XCTAssertEqual(loaded.isPaid, original.isPaid, "\(implementationName): isPaid should match")
+            XCTAssertEqual(loaded.licensing, original.licensing, "\(implementationName): licensing should match")
+            XCTAssertEqual(loaded.showArchived, original.showArchived, "\(implementationName): showArchived should match")
+            XCTAssertEqual(loaded.refreshAvailable, original.refreshAvailable, "\(implementationName): refreshAvailable should match")
+            XCTAssertEqual(loaded.folderUuid, original.folderUuid, "\(implementationName): folderUuid should match")
+            XCTAssertEqual(loaded.usedCustomEffectsBefore, original.usedCustomEffectsBefore, "\(implementationName): usedCustomEffectsBefore should match")
+            XCTAssertEqual(loaded.isPrivate, original.isPrivate, "\(implementationName): isPrivate should match")
+            XCTAssertEqual(loaded.fundingURL, original.fundingURL, "\(implementationName): fundingURL should match")
+        }
+    }
+
+    // MARK: - Ignored Property Tests
+
+    /// Verifies that cachedUnreadCount is NOT persisted (marked with @GRDBIgnore)
+    func testCachedUnreadCountNotPersisted() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            let podcast = Podcast()
+            podcast.uuid = UUID().uuidString.lowercased()
+            podcast.title = "Test Podcast"
+            podcast.addedDate = Date()
+            podcast.cachedUnreadCount = 42  // Set ignored property
+
+            dataManager.save(podcast: podcast)
+
+            // Load it back - cachedUnreadCount should be default (0)
+            guard let loaded = dataManager.findPodcast(uuid: podcast.uuid, includeUnsubscribed: true) else {
+                XCTFail("\(implementationName): Should find saved podcast")
+                return
+            }
+
+            // cachedUnreadCount should be 0 (not persisted)
+            XCTAssertEqual(loaded.cachedUnreadCount, 0, "\(implementationName): cachedUnreadCount should NOT be persisted")
+        }
+    }
+
+    /// Verifies that forceRefreshEpisodeFrom is NOT persisted (marked with @GRDBIgnore)
+    func testForceRefreshEpisodeFromNotPersisted() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            let podcast = Podcast()
+            podcast.uuid = UUID().uuidString.lowercased()
+            podcast.title = "Test Podcast"
+            podcast.addedDate = Date()
+            podcast.forceRefreshEpisodeFrom = "some-episode-uuid"  // Set ignored property
+
+            dataManager.save(podcast: podcast)
+
+            // Load it back - forceRefreshEpisodeFrom should be nil
+            guard let loaded = dataManager.findPodcast(uuid: podcast.uuid, includeUnsubscribed: true) else {
+                XCTFail("\(implementationName): Should find saved podcast")
+                return
+            }
+
+            // forceRefreshEpisodeFrom should be nil (not persisted)
+            XCTAssertNil(loaded.forceRefreshEpisodeFrom, "\(implementationName): forceRefreshEpisodeFrom should NOT be persisted")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func createFullyPopulatedPodcast() -> Podcast {
+        let podcast = Podcast()
+        podcast.uuid = UUID().uuidString.lowercased()
+        podcast.title = "Test Podcast Title"
+        podcast.author = "Test Author"
+        podcast.podcastDescription = "A test podcast description"
+        podcast.podcastHTMLDescription = "<p>A test podcast description</p>"
+        podcast.podcastUrl = "https://example.com/feed.xml"
+        podcast.imageURL = "https://example.com/image.jpg"
+        podcast.mediaType = "audio"
+        podcast.addedDate = Date()
+        podcast.subscribed = 1
+        podcast.sortOrder = 5
+        podcast.autoDownloadSetting = AutoDownloadSetting.latest.rawValue
+        podcast.autoAddToUpNext = AutoAddToUpNextSetting.addLast.rawValue
+        podcast.autoArchiveEpisodeLimit = 10
+        podcast.overrideGlobalEffects = true
+        podcast.playbackSpeed = 1.5
+        podcast.boostVolume = true
+        podcast.trimSilenceAmount = 2
+        podcast.startFrom = 30
+        podcast.skipLast = 15
+        podcast.syncStatus = SyncStatus.synced.rawValue
+        podcast.colorVersion = 2
+        podcast.pushEnabled = true
+        podcast.episodeSortOrder = 2
+        podcast.episodeGrouping = 1
+        podcast.showType = "episodic"
+        podcast.overrideGlobalArchive = true
+        podcast.autoArchivePlayedAfter = 86400
+        podcast.autoArchiveInactiveAfter = 604800
+        podcast.isPaid = false
+        podcast.licensing = 0
+        podcast.showArchived = true
+        podcast.refreshAvailable = true
+        podcast.folderUuid = "folder-uuid-123"
+        podcast.usedCustomEffectsBefore = true
+        podcast.isPrivate = false
+        podcast.fundingURL = "https://example.com/support"
+        return podcast
+    }
+}

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastColumnConsistencyTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastColumnConsistencyTests.swift
@@ -57,6 +57,7 @@ final class PodcastColumnConsistencyTests: DataManagerTestCase {
             XCTAssertEqual(loaded.title, original.title, "\(implementationName): title should match")
             XCTAssertEqual(loaded.author, original.author, "\(implementationName): author should match")
             XCTAssertEqual(loaded.podcastDescription, original.podcastDescription, "\(implementationName): podcastDescription should match")
+            XCTAssertEqual(loaded.podcastHTMLDescription, original.podcastHTMLDescription, "\(implementationName): podcastHTMLDescription should match")
             XCTAssertEqual(loaded.podcastUrl, original.podcastUrl, "\(implementationName): podcastUrl should match")
             XCTAssertEqual(loaded.imageURL, original.imageURL, "\(implementationName): imageURL should match")
             XCTAssertEqual(loaded.mediaType, original.mediaType, "\(implementationName): mediaType should match")
@@ -88,6 +89,25 @@ final class PodcastColumnConsistencyTests: DataManagerTestCase {
             XCTAssertEqual(loaded.usedCustomEffectsBefore, original.usedCustomEffectsBefore, "\(implementationName): usedCustomEffectsBefore should match")
             XCTAssertEqual(loaded.isPrivate, original.isPrivate, "\(implementationName): isPrivate should match")
             XCTAssertEqual(loaded.fundingURL, original.fundingURL, "\(implementationName): fundingURL should match")
+            // Color fields
+            XCTAssertEqual(loaded.backgroundColor, original.backgroundColor, "\(implementationName): backgroundColor should match")
+            XCTAssertEqual(loaded.detailColor, original.detailColor, "\(implementationName): detailColor should match")
+            XCTAssertEqual(loaded.primaryColor, original.primaryColor, "\(implementationName): primaryColor should match")
+            XCTAssertEqual(loaded.secondaryColor, original.secondaryColor, "\(implementationName): secondaryColor should match")
+            XCTAssertEqual(loaded.lastColorDownloadDate, original.lastColorDownloadDate, "\(implementationName): lastColorDownloadDate should match")
+            // Episode metadata fields
+            XCTAssertEqual(loaded.latestEpisodeUuid, original.latestEpisodeUuid, "\(implementationName): latestEpisodeUuid should match")
+            XCTAssertEqual(loaded.latestEpisodeDate, original.latestEpisodeDate, "\(implementationName): latestEpisodeDate should match")
+            XCTAssertEqual(loaded.estimatedNextEpisode, original.estimatedNextEpisode, "\(implementationName): estimatedNextEpisode should match")
+            XCTAssertEqual(loaded.episodeFrequency, original.episodeFrequency, "\(implementationName): episodeFrequency should match")
+            // Thumbnail fields
+            XCTAssertEqual(loaded.lastThumbnailDownloadDate, original.lastThumbnailDownloadDate, "\(implementationName): lastThumbnailDownloadDate should match")
+            XCTAssertEqual(loaded.thumbnailStatus, original.thumbnailStatus, "\(implementationName): thumbnailStatus should match")
+            // Other fields
+            XCTAssertEqual(loaded.podcastCategory, original.podcastCategory, "\(implementationName): podcastCategory should match")
+            XCTAssertEqual(loaded.lastUpdatedAt, original.lastUpdatedAt, "\(implementationName): lastUpdatedAt should match")
+            XCTAssertEqual(loaded.excludeFromAutoArchive, original.excludeFromAutoArchive, "\(implementationName): excludeFromAutoArchive should match")
+            XCTAssertEqual(loaded.fullSyncLastSyncAt, original.fullSyncLastSyncAt, "\(implementationName): fullSyncLastSyncAt should match")
         }
     }
 
@@ -178,6 +198,25 @@ final class PodcastColumnConsistencyTests: DataManagerTestCase {
         podcast.usedCustomEffectsBefore = true
         podcast.isPrivate = false
         podcast.fundingURL = "https://example.com/support"
+        // Color fields
+        podcast.backgroundColor = "#FFFFFF"
+        podcast.detailColor = "#000000"
+        podcast.primaryColor = "#FF0000"
+        podcast.secondaryColor = "#00FF00"
+        podcast.lastColorDownloadDate = Date(timeIntervalSince1970: 1700000000)
+        // Episode metadata fields
+        podcast.latestEpisodeUuid = "latest-episode-uuid-123"
+        podcast.latestEpisodeDate = Date(timeIntervalSince1970: 1700000000)
+        podcast.estimatedNextEpisode = Date(timeIntervalSince1970: 1700100000)
+        podcast.episodeFrequency = "weekly"
+        // Thumbnail fields
+        podcast.lastThumbnailDownloadDate = Date(timeIntervalSince1970: 1700000000)
+        podcast.thumbnailStatus = 2
+        // Other fields
+        podcast.podcastCategory = "Technology"
+        podcast.lastUpdatedAt = "2024-01-01T00:00:00Z"
+        podcast.excludeFromAutoArchive = true
+        podcast.fullSyncLastSyncAt = "2024-01-01T00:00:00Z"
         return podcast
     }
 }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/PodcastDataManagerTests.swift
@@ -857,6 +857,126 @@ final class PodcastDataManagerTests: DataManagerTestCase {
         }
     }
 
+    // MARK: - save Tests (PersistableRecord API)
+
+    func testSaveInsertsNewPodcastWithAllFields() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = Podcast()
+            podcast.uuid = "save-test-uuid"
+            podcast.title = "Save Test Podcast"
+            podcast.author = "Test Author"
+            podcast.addedDate = Date()
+            podcast.subscribed = 1
+            podcast.sortOrder = 5
+            podcast.folderUuid = nil
+            podcast.syncStatus = SyncStatus.notSynced.rawValue
+            podcast.showArchived = true
+            podcast.episodeGrouping = PodcastGrouping.season.rawValue
+            podcast.isPaid = true
+            podcast.overrideGlobalArchive = true
+            podcast.pushEnabled = true
+            podcast.autoAddToUpNext = AutoAddToUpNextSetting.addFirst.rawValue
+            podcast.autoDownloadSetting = AutoDownloadSetting.latest.rawValue
+            podcast.autoArchiveEpisodeLimit = 5
+
+            dataManager.save(podcast: podcast)
+
+            let found = dataManager.findPodcast(uuid: "save-test-uuid")
+            XCTAssertNotNil(found, "\(impl): Should find saved podcast")
+            XCTAssertEqual(found?.uuid, "save-test-uuid", "\(impl): UUID should match")
+            XCTAssertEqual(found?.title, "Save Test Podcast", "\(impl): Title should match")
+            XCTAssertEqual(found?.author, "Test Author", "\(impl): Author should match")
+            XCTAssertEqual(found?.subscribed, 1, "\(impl): subscribed should match")
+            XCTAssertEqual(found?.sortOrder, 5, "\(impl): sortOrder should match")
+            XCTAssertEqual(found?.syncStatus, SyncStatus.notSynced.rawValue, "\(impl): syncStatus should match")
+            XCTAssertEqual(found?.showArchived, true, "\(impl): showArchived should match")
+            XCTAssertEqual(found?.episodeGrouping, PodcastGrouping.season.rawValue, "\(impl): episodeGrouping should match")
+            XCTAssertEqual(found?.isPaid, true, "\(impl): isPaid should match")
+            XCTAssertEqual(found?.isAutoArchiveOverridden, true, "\(impl): overrideGlobalArchive should match")
+            XCTAssertEqual(found?.pushEnabled, true, "\(impl): pushEnabled should match")
+            XCTAssertEqual(found?.autoAddToUpNext, AutoAddToUpNextSetting.addFirst.rawValue, "\(impl): autoAddToUpNext should match")
+            XCTAssertEqual(found?.autoDownloadSetting, AutoDownloadSetting.latest.rawValue, "\(impl): autoDownloadSetting should match")
+            XCTAssertEqual(found?.autoArchiveEpisodeLimit, 5, "\(impl): autoArchiveEpisodeLimit should match")
+        }
+    }
+
+    func testSaveUpdatesExistingPodcast() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = self.createTestPodcast(uuid: "update-test-uuid", title: "Original Title", author: "Original Author", dataManager: dataManager)
+
+            // Update fields
+            podcast.title = "Updated Title"
+            podcast.author = "Updated Author"
+            podcast.showArchived = true
+            podcast.episodeGrouping = PodcastGrouping.season.rawValue
+            podcast.syncStatus = SyncStatus.synced.rawValue
+            dataManager.save(podcast: podcast)
+
+            let found = dataManager.findPodcast(uuid: "update-test-uuid")
+            XCTAssertEqual(found?.title, "Updated Title", "\(impl): Title should be updated")
+            XCTAssertEqual(found?.author, "Updated Author", "\(impl): Author should be updated")
+            XCTAssertEqual(found?.showArchived, true, "\(impl): showArchived should be updated")
+            XCTAssertEqual(found?.episodeGrouping, PodcastGrouping.season.rawValue, "\(impl): episodeGrouping should be updated")
+            XCTAssertEqual(found?.syncStatus, SyncStatus.synced.rawValue, "\(impl): syncStatus should be updated")
+        }
+    }
+
+    func testSaveGeneratesIdIfZero() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = Podcast()
+            podcast.uuid = "id-test-uuid"
+            podcast.title = "ID Test Podcast"
+            podcast.addedDate = Date()
+            podcast.id = 0
+
+            dataManager.save(podcast: podcast)
+
+            XCTAssertNotEqual(podcast.id, 0, "\(impl): ID should be generated")
+
+            let found = dataManager.findPodcast(uuid: "id-test-uuid")
+            XCTAssertNotNil(found, "\(impl): Should find podcast with generated ID")
+            XCTAssertNotEqual(found?.id, 0, "\(impl): Found podcast should have non-zero ID")
+        }
+    }
+
+    func testSavePreservesOptionalFields() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = Podcast()
+            podcast.uuid = "optional-test-uuid"
+            podcast.title = "Optional Fields Test"
+            podcast.addedDate = Date()
+            podcast.podcastDescription = "Test description"
+            podcast.podcastUrl = "https://example.com/feed.xml"
+            podcast.podcastCategory = "Technology"
+            podcast.episodeSortOrder = 2
+
+            dataManager.save(podcast: podcast)
+
+            let found = dataManager.findPodcast(uuid: "optional-test-uuid")
+            XCTAssertEqual(found?.podcastDescription, "Test description", "\(impl): description should be preserved")
+            XCTAssertEqual(found?.podcastUrl, "https://example.com/feed.xml", "\(impl): podcastUrl should be preserved")
+            XCTAssertEqual(found?.podcastCategory, "Technology", "\(impl): podcastCategory should be preserved")
+            XCTAssertEqual(found?.episodeSortOrder, 2, "\(impl): episodeSortOrder should be preserved")
+        }
+    }
+
+    func testSaveWithFolderUuid() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let folder = self.createTestFolder(uuid: "folder-for-podcast", name: "Test Folder", dataManager: dataManager)
+
+            let podcast = Podcast()
+            podcast.uuid = "folder-podcast-uuid"
+            podcast.title = "Podcast in Folder"
+            podcast.addedDate = Date()
+            podcast.folderUuid = folder.uuid
+
+            dataManager.save(podcast: podcast)
+
+            let found = dataManager.findPodcast(uuid: "folder-podcast-uuid")
+            XCTAssertEqual(found?.folderUuid, folder.uuid, "\(impl): folderUuid should be preserved")
+        }
+    }
+
     // MARK: - Helper to create episode for podcast tests
 
     @discardableResult


### PR DESCRIPTION
Part of PCIOS-491

Adds GRDB macros to the Podcast model and implements feature-flagged GRDB save operations.

##  Changes

- Podcast model: Applied `@GRDBRecord` and `@GRDBIgnore` macros for type-safe GRDB conformance
- PodcastDataManager: Added `save()` method using GRDB's PersistableRecord behind `FeatureFlag.grdbQueryInterface`
- Tests: Updated `PodcastDataManagerTests` and updated `DataManagerTestCase` to run against both SQL and GRDB implementations. Also added column consistency tests to verify the current `columnNames` matches our GRDB columns.

## To test

* Test Podcast subscription, unsubscription with `grdbQueryInterface` enabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.