### PR TITLE
GRDB Macros: Episode

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -4,7 +4,7 @@ import GRDB
 
 class EpisodeDataManager {
     /// Legacy column names for non-GRDB code path.
-    private let columnNames = [
+    let columnNames = [
         "id",
         "addedDate",
         "lastDownloadAttemptDate",

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -1,7 +1,9 @@
 import PocketCastsUtils
 import Foundation
+import GRDB
 
 class EpisodeDataManager {
+    /// Legacy column names for non-GRDB code path.
     private let columnNames = [
         "id",
         "addedDate",
@@ -378,39 +380,76 @@ class EpisodeDataManager {
     }
 
     func save(episode: Episode, dbQueue: PCDBQueue) {
-        dbQueue.write { db in
+        let isInsert = episode.id == 0
+        if isInsert {
+            episode.id = DBUtils.generateUniqueId()
+        }
+
+        if FeatureFlag.grdbQueryInterface.enabled, let grdbQueue = dbQueue as? GRDBQueue {
+            // GRDB path using PersistableRecord
             do {
-                if episode.id == 0 {
-                    episode.id = DBUtils.generateUniqueId()
-                    try db.executeUpdate("INSERT INTO \(DataManager.episodeTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(episode: episode))
-                } else {
-                    let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
-                    try db.executeUpdate("UPDATE \(DataManager.episodeTableName) SET \(setStatement) WHERE id = ?", values: self.createValuesFrom(episode: episode, includeIdForWhere: true))
+                try grdbQueue.dbPool.write { db in
+                    try episode.save(db)
                 }
             } catch {
                 FileLog.shared.addMessage("EpisodeDataManager.save Episode error: \(error)")
             }
-        }
-    }
-
-    func bulkSave(episodes: [Episode], dbQueue: PCDBQueue) {
-        dbQueue.write { db in
-            do {
-                db.beginTransaction()
-
-                for episode in episodes {
-                    if episode.id == 0 {
-                        episode.id = DBUtils.generateUniqueId()
+        } else {
+            // Legacy path
+            dbQueue.write { db in
+                do {
+                    if isInsert {
                         try db.executeUpdate("INSERT INTO \(DataManager.episodeTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(episode: episode))
                     } else {
                         let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
                         try db.executeUpdate("UPDATE \(DataManager.episodeTableName) SET \(setStatement) WHERE id = ?", values: self.createValuesFrom(episode: episode, includeIdForWhere: true))
                     }
+                } catch {
+                    FileLog.shared.addMessage("EpisodeDataManager.save Episode error: \(error)")
                 }
+            }
+        }
+    }
 
-                db.commit()
+    func bulkSave(episodes: [Episode], dbQueue: PCDBQueue) {
+        if FeatureFlag.grdbQueryInterface.enabled, let grdbQueue = dbQueue as? GRDBQueue {
+            // GRDB path using PersistableRecord
+            do {
+                try grdbQueue.dbPool.write { db in
+                    for episode in episodes {
+                        if episode.id == 0 {
+                            episode.id = DBUtils.generateUniqueId()
+                        }
+                        try episode.save(db)
+                    }
+                }
             } catch {
                 FileLog.shared.addMessage("EpisodeDataManager.bulkSave error: \(error)")
+            }
+        } else {
+            // Legacy path
+            dbQueue.write { db in
+                do {
+                    db.beginTransaction()
+
+                    for episode in episodes {
+                        let isInsert = episode.id == 0
+                        if isInsert {
+                            episode.id = DBUtils.generateUniqueId()
+                        }
+
+                        if isInsert {
+                            try db.executeUpdate("INSERT INTO \(DataManager.episodeTableName) (\(self.columnNames.joined(separator: ","))) VALUES \(DBUtils.valuesQuestionMarks(amount: self.columnNames.count))", values: self.createValuesFrom(episode: episode))
+                        } else {
+                            let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
+                            try db.executeUpdate("UPDATE \(DataManager.episodeTableName) SET \(setStatement) WHERE id = ?", values: self.createValuesFrom(episode: episode, includeIdForWhere: true))
+                        }
+                    }
+
+                    db.commit()
+                } catch {
+                    FileLog.shared.addMessage("EpisodeDataManager.bulkSave error: \(error)")
+                }
             }
         }
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -1,12 +1,16 @@
 import Foundation
+import GRDB
+import GRDBMacros
 import PocketCastsUtils
 
+@GRDBRecord(table: "SJEpisode")
 public class Episode: NSObject, BaseEpisode {
     private static let bonusType = "bonus"
     private static let trailerType = "trailer"
 
     @objc public var id = 0 as Int64
     @objc public var addedDate: Date?
+    @GRDBNullDateAsEpoch
     @objc public var lastDownloadAttemptDate: Date?
     @objc public var detailedDescription: String?
     @objc public var downloadErrorDetails: String?
@@ -41,8 +45,10 @@ public class Episode: NSObject, BaseEpisode {
     @objc public var episodeType: String?
     @objc public var archived = false
     @objc public var archivedModified = 0 as Int64
+    @GRDBNullDateAsEpoch
     @objc public var lastArchiveInteractionDate: Date?
     @objc public var excludeFromEpisodeLimit = false
+    @GRDBIgnore
     @objc public var hasOnlyUuid = false
     @objc public var deselectedChapters: String?
     @objc public var deselectedChaptersModified = 0 as Int64

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -40,8 +40,6 @@ public class EpisodeFilter: NSObject {
     public var mediaTypeSmartRuleApplied: Bool = false
     public var downloadStatusSmartRuleApplied: Bool = false
 
-    override public init() {}
-
     public func setTitle(_ title: String?, defaultTitle: String) {
         guard let title = title, title.trimmingCharacters(in: .whitespacesAndNewlines).count > 0 else {
             playlistName = defaultTitle

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -40,6 +40,8 @@ public class EpisodeFilter: NSObject {
     public var mediaTypeSmartRuleApplied: Bool = false
     public var downloadStatusSmartRuleApplied: Bool = false
 
+    override public init() {}
+
     public func setTitle(_ title: String?, defaultTitle: String) {
         guard let title = title, title.trimmingCharacters(in: .whitespacesAndNewlines).count > 0 else {
             playlistName = defaultTitle

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManagerTestCase.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/DataManagerTestCase.swift
@@ -43,13 +43,17 @@ class DataManagerTestCase: XCTestCase {
     /// Runs the provided test block with both SQL and GRDB API implementations.
     ///
     /// - Parameter testBlock: A closure that receives a DataManager and the implementation name.
-    ///                        The implementation name is either "" or "GRDB".
+    ///                        The implementation name is either "SQL" or "GRDB".
     func runWithBothImplementations(_ testBlock: (DataManager, String) throws -> Void) throws {
         // Test with raw SQL query
         let sqlDataManager = DataManager.newTestDataManager()
         try testBlock(sqlDataManager, "SQL")
 
-        // TODO: Test with GRDB implementation
+        // Test with GRDB implementation
+        try featureFlagStore.override(FeatureFlag.grdbQueryInterface, withValue: true)
+        let grdbDataManager = DataManager.newTestDataManager()
+        try testBlock(grdbDataManager, "GRDB")
+        featureFlagStore.resetOverrides()
     }
 
     /// Async version of runWithBothImplementations
@@ -58,7 +62,11 @@ class DataManagerTestCase: XCTestCase {
         let sqlDataManager = DataManager.newTestDataManager()
         try await testBlock(sqlDataManager, "SQL")
 
-        // TODO: Test with GRDB API
+        // Test with GRDB implementation
+        try featureFlagStore.override(FeatureFlag.grdbQueryInterface, withValue: true)
+        let grdbDataManager = DataManager.newTestDataManager()
+        try await testBlock(grdbDataManager, "GRDB")
+        featureFlagStore.resetOverrides()
     }
 
     // MARK: - Common Test Helpers

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/EpisodeColumnConsistencyTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/EpisodeColumnConsistencyTests.swift
@@ -48,7 +48,7 @@ final class EpisodeColumnConsistencyTests: DataManagerTestCase {
             podcast.addedDate = Date()
             dataManager.save(podcast: podcast)
 
-            let original = self.createFullyPopulatedEpisode(podcastUuid: podcast.uuid)
+            let original = self.createFullyPopulatedEpisode(podcastUuid: podcast.uuid, podcastId: podcast.id)
 
             // Save using the current implementation (respects feature flag)
             dataManager.save(episode: original)
@@ -93,6 +93,13 @@ final class EpisodeColumnConsistencyTests: DataManagerTestCase {
             XCTAssertEqual(loaded.deselectedChapters, original.deselectedChapters, "\(implementationName): deselectedChapters should match")
             XCTAssertEqual(loaded.deselectedChaptersModified, original.deselectedChaptersModified, "\(implementationName): deselectedChaptersModified should match")
             XCTAssertEqual(loaded.wasDeleted, original.wasDeleted, "\(implementationName): wasDeleted should match")
+            XCTAssertEqual(loaded.podcast_id, original.podcast_id, "\(implementationName): podcast_id should match")
+            self.assertDatesEqual(loaded.addedDate, original.addedDate, "\(implementationName): addedDate should match")
+            self.assertDatesEqual(loaded.publishedDate, original.publishedDate, "\(implementationName): publishedDate should match")
+            self.assertDatesEqual(loaded.lastDownloadAttemptDate, original.lastDownloadAttemptDate, "\(implementationName): lastDownloadAttemptDate should match")
+            self.assertDatesEqual(loaded.lastPlaybackInteractionDate, original.lastPlaybackInteractionDate, "\(implementationName): lastPlaybackInteractionDate should match")
+            XCTAssertEqual(loaded.lastPlaybackInteractionSyncStatus, original.lastPlaybackInteractionSyncStatus, "\(implementationName): lastPlaybackInteractionSyncStatus should match")
+            self.assertDatesEqual(loaded.lastArchiveInteractionDate, original.lastArchiveInteractionDate, "\(implementationName): lastArchiveInteractionDate should match")
         }
     }
 
@@ -130,10 +137,23 @@ final class EpisodeColumnConsistencyTests: DataManagerTestCase {
 
     // MARK: - Helpers
 
-    private func createFullyPopulatedEpisode(podcastUuid: String) -> Episode {
+    private func assertDatesEqual(_ date1: Date?, _ date2: Date?, _ message: String, file: StaticString = #file, line: UInt = #line) {
+        switch (date1, date2) {
+        case (nil, nil):
+            // Both nil - equal
+            break
+        case (nil, _), (_, nil):
+            XCTFail("\(message) - one date is nil and the other is not", file: file, line: line)
+        case let (d1?, d2?):
+            XCTAssertEqual(d1.timeIntervalSince1970, d2.timeIntervalSince1970, accuracy: 0.001, message, file: file, line: line)
+        }
+    }
+
+    private func createFullyPopulatedEpisode(podcastUuid: String, podcastId: Int64) -> Episode {
         let episode = Episode()
         episode.uuid = UUID().uuidString.lowercased()
         episode.podcastUuid = podcastUuid
+        episode.podcast_id = podcastId
         episode.title = "Test Episode Title"
         episode.episodeDescription = "Short description"
         episode.detailedDescription = "Detailed description of the episode"
@@ -168,6 +188,9 @@ final class EpisodeColumnConsistencyTests: DataManagerTestCase {
         episode.deselectedChapters = "1,3,5"
         episode.deselectedChaptersModified = 777
         episode.wasDeleted = false
+        episode.lastPlaybackInteractionDate = Date()
+        episode.lastPlaybackInteractionSyncStatus = 1
+        episode.lastArchiveInteractionDate = Date()
         return episode
     }
 }

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/EpisodeColumnConsistencyTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/EpisodeColumnConsistencyTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+import GRDB
+@testable import PocketCastsDataModel
+@testable import PocketCastsUtils
+
+/// Tests to ensure the legacy SQL columnNames and GRDB-persisted columns remain in sync.
+/// These tests prevent the issue where GRDB might persist a field that the legacy SQL path ignores
+/// (or vice versa), causing inconsistent behavior when the feature flag is toggled.
+final class EpisodeColumnConsistencyTests: DataManagerTestCase {
+
+    /// Access columnNames directly from EpisodeDataManager (the source of truth for legacy SQL).
+    private var columnNames: Set<String> {
+        Set(EpisodeDataManager().columnNames)
+    }
+
+    // MARK: - Database Schema Tests
+
+    func testDatabaseTableHasExpectedColumns() throws {
+        let dataManager = DataManager.newTestDataManager()
+
+        // Get actual database columns using GRDB introspection
+        guard let grdbQueue = dataManager.dbQueue as? GRDBQueue else {
+            XCTFail("Expected GRDBQueue for database introspection")
+            return
+        }
+
+        let tableColumns = try grdbQueue.dbPool.read { db -> Set<String> in
+            let columns = try db.columns(in: DataManager.episodeTableName)
+            return Set(columns.map { $0.name })
+        }
+
+        // The database should have at least all the columns from columnNames
+        let missingColumns = columnNames.subtracting(tableColumns)
+        XCTAssertTrue(
+            missingColumns.isEmpty,
+            "Database table is missing columns from columnNames: \(missingColumns)"
+        )
+    }
+
+    // MARK: - Round-Trip Tests
+
+    func testSaveAndLoadPreservesAllFields() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            // Create a podcast first since episodes require a parent podcast
+            let podcast = Podcast()
+            podcast.uuid = UUID().uuidString.lowercased()
+            podcast.title = "Test Podcast"
+            podcast.addedDate = Date()
+            dataManager.save(podcast: podcast)
+
+            let original = self.createFullyPopulatedEpisode(podcastUuid: podcast.uuid)
+
+            // Save using the current implementation (respects feature flag)
+            dataManager.save(episode: original)
+
+            // Load it back
+            guard let loaded = dataManager.findEpisode(uuid: original.uuid) else {
+                XCTFail("\(implementationName): Should be able to load saved episode")
+                return
+            }
+
+            // Verify all persisted fields match
+            XCTAssertEqual(loaded.uuid, original.uuid, "\(implementationName): uuid should match")
+            XCTAssertEqual(loaded.podcastUuid, original.podcastUuid, "\(implementationName): podcastUuid should match")
+            XCTAssertEqual(loaded.title, original.title, "\(implementationName): title should match")
+            XCTAssertEqual(loaded.episodeDescription, original.episodeDescription, "\(implementationName): episodeDescription should match")
+            XCTAssertEqual(loaded.detailedDescription, original.detailedDescription, "\(implementationName): detailedDescription should match")
+            XCTAssertEqual(loaded.duration, original.duration, "\(implementationName): duration should match")
+            XCTAssertEqual(loaded.playedUpTo, original.playedUpTo, "\(implementationName): playedUpTo should match")
+            XCTAssertEqual(loaded.playingStatus, original.playingStatus, "\(implementationName): playingStatus should match")
+            XCTAssertEqual(loaded.episodeStatus, original.episodeStatus, "\(implementationName): episodeStatus should match")
+            XCTAssertEqual(loaded.autoDownloadStatus, original.autoDownloadStatus, "\(implementationName): autoDownloadStatus should match")
+            XCTAssertEqual(loaded.sizeInBytes, original.sizeInBytes, "\(implementationName): sizeInBytes should match")
+            XCTAssertEqual(loaded.fileType, original.fileType, "\(implementationName): fileType should match")
+            XCTAssertEqual(loaded.contentType, original.contentType, "\(implementationName): contentType should match")
+            XCTAssertEqual(loaded.downloadUrl, original.downloadUrl, "\(implementationName): downloadUrl should match")
+            XCTAssertEqual(loaded.downloadTaskId, original.downloadTaskId, "\(implementationName): downloadTaskId should match")
+            XCTAssertEqual(loaded.keepEpisode, original.keepEpisode, "\(implementationName): keepEpisode should match")
+            XCTAssertEqual(loaded.cachedFrameCount, original.cachedFrameCount, "\(implementationName): cachedFrameCount should match")
+            XCTAssertEqual(loaded.playingStatusModified, original.playingStatusModified, "\(implementationName): playingStatusModified should match")
+            XCTAssertEqual(loaded.playedUpToModified, original.playedUpToModified, "\(implementationName): playedUpToModified should match")
+            XCTAssertEqual(loaded.durationModified, original.durationModified, "\(implementationName): durationModified should match")
+            XCTAssertEqual(loaded.keepEpisodeModified, original.keepEpisodeModified, "\(implementationName): keepEpisodeModified should match")
+            XCTAssertEqual(loaded.starredModified, original.starredModified, "\(implementationName): starredModified should match")
+            XCTAssertEqual(loaded.downloadErrorDetails, original.downloadErrorDetails, "\(implementationName): downloadErrorDetails should match")
+            XCTAssertEqual(loaded.playbackErrorDetails, original.playbackErrorDetails, "\(implementationName): playbackErrorDetails should match")
+            XCTAssertEqual(loaded.episodeNumber, original.episodeNumber, "\(implementationName): episodeNumber should match")
+            XCTAssertEqual(loaded.seasonNumber, original.seasonNumber, "\(implementationName): seasonNumber should match")
+            XCTAssertEqual(loaded.episodeType, original.episodeType, "\(implementationName): episodeType should match")
+            XCTAssertEqual(loaded.archived, original.archived, "\(implementationName): archived should match")
+            XCTAssertEqual(loaded.archivedModified, original.archivedModified, "\(implementationName): archivedModified should match")
+            XCTAssertEqual(loaded.excludeFromEpisodeLimit, original.excludeFromEpisodeLimit, "\(implementationName): excludeFromEpisodeLimit should match")
+            XCTAssertEqual(loaded.deselectedChapters, original.deselectedChapters, "\(implementationName): deselectedChapters should match")
+            XCTAssertEqual(loaded.deselectedChaptersModified, original.deselectedChaptersModified, "\(implementationName): deselectedChaptersModified should match")
+            XCTAssertEqual(loaded.wasDeleted, original.wasDeleted, "\(implementationName): wasDeleted should match")
+        }
+    }
+
+    // MARK: - Ignored Property Tests
+
+    /// Verifies that hasOnlyUuid is NOT persisted (marked with @GRDBIgnore)
+    func testHasOnlyUuidNotPersisted() throws {
+        try runWithBothImplementations { dataManager, implementationName in
+            // Create a podcast first
+            let podcast = Podcast()
+            podcast.uuid = UUID().uuidString.lowercased()
+            podcast.title = "Test Podcast"
+            podcast.addedDate = Date()
+            dataManager.save(podcast: podcast)
+
+            let episode = Episode()
+            episode.uuid = UUID().uuidString.lowercased()
+            episode.podcastUuid = podcast.uuid
+            episode.title = "Test Episode"
+            episode.addedDate = Date()
+            episode.hasOnlyUuid = true  // Set ignored property
+
+            dataManager.save(episode: episode)
+
+            // Load it back - hasOnlyUuid should be default (false)
+            guard let loaded = dataManager.findEpisode(uuid: episode.uuid) else {
+                XCTFail("\(implementationName): Should find saved episode")
+                return
+            }
+
+            // hasOnlyUuid should be false (not persisted)
+            XCTAssertFalse(loaded.hasOnlyUuid, "\(implementationName): hasOnlyUuid should NOT be persisted")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func createFullyPopulatedEpisode(podcastUuid: String) -> Episode {
+        let episode = Episode()
+        episode.uuid = UUID().uuidString.lowercased()
+        episode.podcastUuid = podcastUuid
+        episode.title = "Test Episode Title"
+        episode.episodeDescription = "Short description"
+        episode.detailedDescription = "Detailed description of the episode"
+        episode.addedDate = Date()
+        episode.lastDownloadAttemptDate = Date()
+        episode.downloadErrorDetails = "Test error"
+        episode.downloadTaskId = "download-task-123"
+        episode.downloadUrl = "https://example.com/episode.mp3"
+        episode.episodeStatus = DownloadStatus.downloaded.rawValue
+        episode.fileType = "audio/mpeg"
+        episode.contentType = "audio/mpeg"
+        episode.keepEpisode = true
+        episode.playedUpTo = 123.45
+        episode.duration = 3600.0
+        episode.playingStatus = PlayingStatus.inProgress.rawValue
+        episode.autoDownloadStatus = AutoDownloadStatus.autoDownloaded.rawValue
+        episode.publishedDate = Date()
+        episode.sizeInBytes = 1024000
+        episode.playingStatusModified = 111
+        episode.playedUpToModified = 222
+        episode.durationModified = 333
+        episode.keepEpisodeModified = 444
+        episode.starredModified = 555
+        episode.playbackErrorDetails = "Playback error"
+        episode.cachedFrameCount = 100
+        episode.episodeNumber = 5
+        episode.seasonNumber = 2
+        episode.episodeType = "full"
+        episode.archived = false
+        episode.archivedModified = 666
+        episode.excludeFromEpisodeLimit = true
+        episode.deselectedChapters = "1,3,5"
+        episode.deselectedChaptersModified = 777
+        episode.wasDeleted = false
+        return episode
+    }
+}

--- a/Modules/DataModel/Tests/PocketCastsDataModelTests/EpisodeDataManagerTests.swift
+++ b/Modules/DataModel/Tests/PocketCastsDataModelTests/EpisodeDataManagerTests.swift
@@ -1107,6 +1107,248 @@ final class EpisodeDataManagerTests: DataManagerTestCase {
         }
     }
 
+    // MARK: - save Tests (PersistableRecord API)
+
+    func testSaveInsertsNewEpisodeWithAllFields() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = self.createTestPodcast(dataManager: dataManager)
+
+            let episode = Episode()
+            episode.uuid = "save-test-uuid"
+            episode.title = "Save Test Episode"
+            episode.podcastUuid = podcast.uuid
+            episode.podcast_id = podcast.id
+            episode.publishedDate = Date(timeIntervalSince1970: 1000000)
+            episode.addedDate = Date(timeIntervalSince1970: 2000000)
+            episode.duration = 3600
+            episode.sizeInBytes = 50000000
+            episode.downloadUrl = "https://example.com/episode.mp3"
+            episode.episodeStatus = DownloadStatus.downloaded.rawValue
+            episode.playingStatus = PlayingStatus.inProgress.rawValue
+            episode.playedUpTo = 1800.5
+            episode.archived = false
+            episode.keepEpisode = true
+            episode.episodeDescription = "This is a test episode description"
+            episode.fileType = "mp3"
+            episode.contentType = "audio/mpeg"
+
+            dataManager.save(episode: episode)
+
+            let found = dataManager.findEpisode(uuid: "save-test-uuid")
+            XCTAssertNotNil(found, "\(impl): Should find saved episode")
+            XCTAssertEqual(found?.uuid, "save-test-uuid", "\(impl): UUID should match")
+            XCTAssertEqual(found?.title, "Save Test Episode", "\(impl): Title should match")
+            XCTAssertEqual(found?.podcastUuid, podcast.uuid, "\(impl): Podcast UUID should match")
+            XCTAssertEqual(found?.podcast_id, podcast.id, "\(impl): Podcast ID should match")
+            XCTAssertEqual(found?.duration, 3600, "\(impl): Duration should match")
+            XCTAssertEqual(found?.sizeInBytes, 50000000, "\(impl): Size should match")
+            XCTAssertEqual(found?.downloadUrl, "https://example.com/episode.mp3", "\(impl): Download URL should match")
+            XCTAssertEqual(found?.episodeStatus, DownloadStatus.downloaded.rawValue, "\(impl): Episode status should match")
+            XCTAssertEqual(found?.playingStatus, PlayingStatus.inProgress.rawValue, "\(impl): Playing status should match")
+            XCTAssertEqual(found?.playedUpTo ?? 0, 1800.5, accuracy: 0.01, "\(impl): Played up to should match")
+            XCTAssertEqual(found?.archived, false, "\(impl): Archived should match")
+            XCTAssertEqual(found?.keepEpisode, true, "\(impl): Keep episode should match")
+            XCTAssertEqual(found?.episodeDescription, "This is a test episode description", "\(impl): Description should match")
+            XCTAssertEqual(found?.fileType, "mp3", "\(impl): File type should match")
+            XCTAssertEqual(found?.contentType, "audio/mpeg", "\(impl): Content type should match")
+        }
+    }
+
+    func testSaveUpdatesExistingEpisode() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = self.createTestPodcast(dataManager: dataManager)
+            let episode = self.createTestEpisode(uuid: "update-test-uuid", podcast: podcast, title: "Original Title", dataManager: dataManager)
+
+            // Update fields
+            episode.title = "Updated Title"
+            episode.playingStatus = PlayingStatus.completed.rawValue
+            episode.playedUpTo = 3600.0
+            episode.archived = true
+            episode.keepEpisode = true
+            dataManager.save(episode: episode)
+
+            let found = dataManager.findEpisode(uuid: "update-test-uuid")
+            XCTAssertEqual(found?.title, "Updated Title", "\(impl): Title should be updated")
+            XCTAssertEqual(found?.playingStatus, PlayingStatus.completed.rawValue, "\(impl): Playing status should be updated")
+            XCTAssertEqual(found?.playedUpTo ?? 0, 3600.0, accuracy: 0.01, "\(impl): Played up to should be updated")
+            XCTAssertEqual(found?.archived, true, "\(impl): Archived should be updated")
+            XCTAssertEqual(found?.keepEpisode, true, "\(impl): Keep episode should be updated")
+        }
+    }
+
+    func testSaveGeneratesIdIfZero() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = self.createTestPodcast(dataManager: dataManager)
+
+            let episode = Episode()
+            episode.id = 0 // Zero ID
+            episode.uuid = "auto-id-episode"
+            episode.podcastUuid = podcast.uuid
+            episode.podcast_id = podcast.id
+            episode.title = "Auto ID Episode"
+            episode.addedDate = Date()
+
+            dataManager.save(episode: episode)
+
+            XCTAssertNotEqual(episode.id, 0, "\(impl): ID should be generated")
+
+            let found = dataManager.findEpisode(uuid: "auto-id-episode")
+            XCTAssertNotNil(found, "\(impl): Should find episode with generated ID")
+            XCTAssertEqual(found?.id, episode.id, "\(impl): ID should match")
+        }
+    }
+
+    func testSavePreservesModifiedFlags() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = self.createTestPodcast(dataManager: dataManager)
+
+            let episode = Episode()
+            episode.uuid = "modified-flags-episode"
+            episode.podcastUuid = podcast.uuid
+            episode.podcast_id = podcast.id
+            episode.title = "Modified Flags Episode"
+            episode.addedDate = Date()
+            episode.playingStatusModified = 12345
+            episode.playedUpToModified = 23456
+            episode.durationModified = 34567
+            episode.archivedModified = 45678
+
+            dataManager.save(episode: episode)
+
+            let found = dataManager.findEpisode(uuid: "modified-flags-episode")
+            XCTAssertEqual(found?.playingStatusModified, 12345, "\(impl): playingStatusModified should be preserved")
+            XCTAssertEqual(found?.playedUpToModified, 23456, "\(impl): playedUpToModified should be preserved")
+            XCTAssertEqual(found?.durationModified, 34567, "\(impl): durationModified should be preserved")
+            XCTAssertEqual(found?.archivedModified, 45678, "\(impl): archivedModified should be preserved")
+        }
+    }
+
+    func testSavePreservesOptionalStrings() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = self.createTestPodcast(dataManager: dataManager)
+
+            let episode = Episode()
+            episode.uuid = "optional-strings-episode"
+            episode.podcastUuid = podcast.uuid
+            episode.podcast_id = podcast.id
+            episode.title = "Optional Strings Episode"
+            episode.addedDate = Date()
+            episode.episodeDescription = "A detailed description"
+            episode.downloadUrl = "https://example.com/download.mp3"
+            episode.downloadTaskId = "task-123"
+            episode.cachedFrameCount = 1000
+
+            dataManager.save(episode: episode)
+
+            let found = dataManager.findEpisode(uuid: "optional-strings-episode")
+            XCTAssertEqual(found?.episodeDescription, "A detailed description", "\(impl): Description should be preserved")
+            XCTAssertEqual(found?.downloadUrl, "https://example.com/download.mp3", "\(impl): Download URL should be preserved")
+            XCTAssertEqual(found?.downloadTaskId, "task-123", "\(impl): Download task ID should be preserved")
+            XCTAssertEqual(found?.cachedFrameCount, 1000, "\(impl): Cached frame count should be preserved")
+        }
+    }
+
+    // MARK: - bulkSave Tests (PersistableRecord API)
+
+    func testBulkSaveUpdatesExistingEpisodes() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = self.createTestPodcast(dataManager: dataManager)
+
+            // Create initial episodes
+            let episode1 = self.createTestEpisode(uuid: "bulk-update-1", podcast: podcast, title: "Original 1", playingStatus: PlayingStatus.notPlayed.rawValue, dataManager: dataManager)
+            let episode2 = self.createTestEpisode(uuid: "bulk-update-2", podcast: podcast, title: "Original 2", playingStatus: PlayingStatus.notPlayed.rawValue, dataManager: dataManager)
+
+            // Modify episodes
+            episode1.title = "Updated 1"
+            episode1.playingStatus = PlayingStatus.completed.rawValue
+            episode2.title = "Updated 2"
+            episode2.playingStatus = PlayingStatus.inProgress.rawValue
+
+            dataManager.bulkSave(episodes: [episode1, episode2])
+
+            let found1 = dataManager.findEpisode(uuid: "bulk-update-1")
+            let found2 = dataManager.findEpisode(uuid: "bulk-update-2")
+
+            XCTAssertEqual(found1?.title, "Updated 1", "\(impl): Episode 1 title should be updated")
+            XCTAssertEqual(found1?.playingStatus, PlayingStatus.completed.rawValue, "\(impl): Episode 1 playing status should be updated")
+            XCTAssertEqual(found2?.title, "Updated 2", "\(impl): Episode 2 title should be updated")
+            XCTAssertEqual(found2?.playingStatus, PlayingStatus.inProgress.rawValue, "\(impl): Episode 2 playing status should be updated")
+        }
+    }
+
+    func testBulkSaveMixedInsertAndUpdate() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = self.createTestPodcast(dataManager: dataManager)
+
+            // Create existing episode
+            let existingEpisode = self.createTestEpisode(uuid: "existing-bulk", podcast: podcast, title: "Existing Episode", dataManager: dataManager)
+
+            // Create new episode to insert
+            let newEpisode = Episode()
+            newEpisode.uuid = "new-bulk"
+            newEpisode.podcastUuid = podcast.uuid
+            newEpisode.podcast_id = podcast.id
+            newEpisode.title = "New Bulk Episode"
+            newEpisode.addedDate = Date()
+
+            // Update existing episode
+            existingEpisode.title = "Updated Existing Episode"
+
+            dataManager.bulkSave(episodes: [existingEpisode, newEpisode])
+
+            let foundExisting = dataManager.findEpisode(uuid: "existing-bulk")
+            let foundNew = dataManager.findEpisode(uuid: "new-bulk")
+
+            XCTAssertEqual(foundExisting?.title, "Updated Existing Episode", "\(impl): Existing episode should be updated")
+            XCTAssertNotNil(foundNew, "\(impl): New episode should be inserted")
+            XCTAssertEqual(foundNew?.title, "New Bulk Episode", "\(impl): New episode title should match")
+        }
+    }
+
+    func testBulkSavePreservesAllFields() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = self.createTestPodcast(dataManager: dataManager)
+
+            var episodes = [Episode]()
+            for i in 0..<3 {
+                let episode = Episode()
+                episode.uuid = "bulk-fields-\(i)"
+                episode.podcastUuid = podcast.uuid
+                episode.podcast_id = podcast.id
+                episode.title = "Bulk Episode \(i)"
+                episode.addedDate = Date()
+                episode.duration = Double(i * 1000)
+                episode.playedUpTo = Double(i * 100)
+                episode.playingStatus = Int32(i)
+                episode.archived = i % 2 == 0
+                episode.keepEpisode = i % 2 == 1
+                episodes.append(episode)
+            }
+
+            dataManager.bulkSave(episodes: episodes)
+
+            for i in 0..<3 {
+                let found = dataManager.findEpisode(uuid: "bulk-fields-\(i)")
+                XCTAssertNotNil(found, "\(impl): Should find bulk saved episode \(i)")
+                XCTAssertEqual(found?.title, "Bulk Episode \(i)", "\(impl): Title should match for episode \(i)")
+                XCTAssertEqual(found?.duration, Double(i * 1000), "\(impl): Duration should match for episode \(i)")
+                XCTAssertEqual(found?.playedUpTo ?? 0, Double(i * 100), accuracy: 0.01, "\(impl): Played up to should match for episode \(i)")
+                XCTAssertEqual(found?.playingStatus, Int32(i), "\(impl): Playing status should match for episode \(i)")
+                XCTAssertEqual(found?.archived, i % 2 == 0, "\(impl): Archived should match for episode \(i)")
+                XCTAssertEqual(found?.keepEpisode, i % 2 == 1, "\(impl): Keep episode should match for episode \(i)")
+            }
+        }
+    }
+
+    func testBulkSaveWithEmptyArrayDoesNotCrash() throws {
+        try runWithBothImplementations { dataManager, impl in
+            // Should not throw or crash
+            dataManager.bulkSave(episodes: [Episode]())
+
+            XCTAssertTrue(true, "\(impl): Should not crash with empty array")
+        }
+    }
+
     // MARK: - Helper method override for additional properties
 
     @discardableResult

--- a/Modules/GRDBMacros/Sources/GRDBMacrosPlugin/GRDBRecordMacro.swift
+++ b/Modules/GRDBMacros/Sources/GRDBMacrosPlugin/GRDBRecordMacro.swift
@@ -357,8 +357,15 @@ public struct GRDBRecordMacro: MemberMacro, ExtensionMacro {
 
             // For properties marked with @GRDBNullDateAsEpoch, use epoch time as default
             // to match legacy SQL behavior for NOT NULL DEFAULT 0 columns.
+            // For Date properties, convert to timeIntervalSince1970 to match raw SQL behavior.
             if prop.nullDateAsEpoch {
-                encodes.append("container[\"\(columnName)\"] = \(prop.name) ?? Date(timeIntervalSince1970: 0)")
+                encodes.append("container[\"\(columnName)\"] = (\(prop.name) ?? Date(timeIntervalSince1970: 0)).timeIntervalSince1970")
+            } else if prop.isDate {
+                if prop.isOptional {
+                    encodes.append("container[\"\(columnName)\"] = \(prop.name)?.timeIntervalSince1970")
+                } else {
+                    encodes.append("container[\"\(columnName)\"] = \(prop.name).timeIntervalSince1970")
+                }
             } else {
                 encodes.append("container[\"\(columnName)\"] = \(prop.name)")
             }


### PR DESCRIPTION
Part of PCIOS-491

Adds GRDB macros to the Episode model and implements feature-flagged GRDB save operations.

##  Changes

- Episode model: Applied `@GRDBRecord` and `@GRDBIgnore` macros for type-safe GRDB conformance
- EpisodeDataManager: Added `save()` method using GRDB's PersistableRecord behind `FeatureFlag.grdbQueryInterface`
- Tests: Updated `EpisodeDataManagerTests` and updated `DataManagerTestCase` to run against both SQL and GRDB implementations. Also added column consistency tests to verify the current `columnNames` matches our GRDB columns.

## To test

* Test Episode addition, lists, Up Next, etc. with `grdbQueryInterface` enabled

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.