### PR TITLE
[Dynamic type] - Episode detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Dynamic Type: Update Podcast detail [#3892](https://github.com/Automattic/pocket-casts-ios/pull/3892)
 - Dynamic Type: Update Settings [#3896](https://github.com/Automattic/pocket-casts-ios/pull/3896)
 - Dynamic Type: Update Profile View [#3894](https://github.com/Automattic/pocket-casts-ios/pull/3894)
+- Dynamic Type: Update Episode Detail View [#3926](https://github.com/Automattic/pocket-casts-ios/pull/3926)
 
 8.5
 -----

--- a/podcasts/ActionIconButton.swift
+++ b/podcasts/ActionIconButton.swift
@@ -32,15 +32,19 @@ class ActionIconButton: UIButton {
         } else {
             height = rect.height
         }
+        let metrics = UIFontMetrics(forTextStyle: .largeTitle)
         let imageSize: CGFloat = imageView?.image?.size.height ?? 24
-        return CGRect(x: 0, y: imageSize + 10, width: contentRect.width, height: height)
+        let scaledHeight = metrics.scaledValue(for: imageSize)
+        return CGRect(x: 0, y: scaledHeight + 10, width: contentRect.width, height: height)
     }
 
     private var calculatedImageFrame: CGRect? {
-        guard let rect = imageView?.frame else { return nil }
+        guard let baseSize = imageView?.image?.size else { return nil }
         let contentRect = bounds
-
-        return CGRect(x: contentRect.width / 2.0 - rect.width / 2.0, y: 0, width: rect.width, height: rect.height)
+        let metrics = UIFontMetrics(forTextStyle: .largeTitle)
+        let scaledWidth = metrics.scaledValue(for: baseSize.width)
+        let scaledHeight = metrics.scaledValue(for: baseSize.height)
+        return CGRect(x: contentRect.width / 2.0 - scaledWidth / 2.0, y: 0, width: scaledWidth, height: scaledHeight)
     }
 
     override var intrinsicContentSize: CGSize {

--- a/podcasts/ActionIconButton.swift
+++ b/podcasts/ActionIconButton.swift
@@ -26,7 +26,7 @@ class ActionIconButton: UIButton {
 
         let height: CGFloat
         if let text = title(for: .normal) {
-            let size = (text as NSString).size(withAttributes: [.font: UIFont.systemFont(ofSize: 13)])
+            let size = (text as NSString).size(withAttributes: [.font: UIFont.font(ofSize: 13, scalingWith: .footnote)])
             let lines = size.width / contentRect.width
             height = ceil(lines) * size.height
         } else {

--- a/podcasts/AngularProgressIndicator.swift
+++ b/podcasts/AngularProgressIndicator.swift
@@ -47,4 +47,11 @@ class AngularProgressIndicator: UIView {
         addSubview(contentView)
         contentView.layer.insertSublayer(shapeLayer, at: 0)
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        shapeLayer.frame = bounds
+        let radius = frame.width / 2
+        shapeLayer.path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: 2 * radius, height: 2 * radius), cornerRadius: radius).cgPath
+    }
 }

--- a/podcasts/Bookmarks/Episode/EpisodeDetailTabView.swift
+++ b/podcasts/Bookmarks/Episode/EpisodeDetailTabView.swift
@@ -72,12 +72,16 @@ struct EpisodeDetailTabView: View {
 
     @ViewBuilder
     func wrapperView<Content: View>(_ content: () -> Content) -> some View {
-        if isSmallScreen {
-            ScrollView(.horizontal, showsIndicators: false) {
-                content()
-            }
-        } else {
+        ScrollView(.horizontal, showsIndicators: false) {
             content()
+        }
+        .modify { view in
+            if #available(iOS 16.4, *) {
+                view.scrollIndicators(.never)
+                    .scrollBounceBehavior(.basedOnSize, axes: [.horizontal])
+            } else {
+                view
+            }
         }
     }
 }

--- a/podcasts/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/EpisodeDetailViewController+Actions.swift
@@ -181,9 +181,8 @@ extension EpisodeDetailViewController {
             setMessage(title: L10n.podcastDetailsManualUnarchiveTitle,
                        details: L10n.podcastDetailsManualUnarchiveMsg(podcast.autoArchiveEpisodeLimitCount.localized()),
                        imageName: "episode-archive")
-        } else if buttonBottomOffsetConstraint.constant != 20 {
-            messageView.isHidden = true
-            buttonBottomOffsetConstraint.constant = 20
+        } else {
+            messageContainerView.isHidden = true
         }
     }
 
@@ -192,8 +191,7 @@ extension EpisodeDetailViewController {
         messageDetails.text = details
         messageIcon.image = UIImage(named: imageName)
 
-        messageView.isHidden = false
-        buttonBottomOffsetConstraint.constant = messageView.bounds.height + 40
+        messageContainerView.isHidden = false
     }
 
     // MARK: - Helpers

--- a/podcasts/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/EpisodeDetailViewController+ShowNotes.swift
@@ -29,25 +29,6 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
         showNotesWebView.scrollView.isScrollEnabled = false
 
         showNotesWebView.scrollView.showsVerticalScrollIndicator = false
-
-        setupTranscriptExcerptView()
-    }
-
-    func setupTranscriptExcerptView() {
-        let transcriptExcerpt = UIView()
-        transcriptExcerpt.backgroundColor = .clear
-        transcriptExcerpt.translatesAutoresizingMaskIntoConstraints = false
-        transcriptExcerpt.isHidden = true
-        mainScrollView.insertSubview(transcriptExcerpt, aboveSubview: showNotesHolderView)
-
-        NSLayoutConstraint.activate([
-            transcriptExcerpt.leadingAnchor.constraint(equalTo: mainScrollView.leadingAnchor),
-            transcriptExcerpt.trailingAnchor.constraint(equalTo: mainScrollView.trailingAnchor),
-            transcriptExcerpt.bottomAnchor.constraint(equalTo: showNotesHolderView.topAnchor),
-            transcriptExcerpt.heightAnchor.constraint(equalToConstant: 78)
-        ])
-
-        self.transcriptExcerpt = transcriptExcerpt
     }
 
     func loadShowNotes() {
@@ -81,12 +62,15 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
                         }
                     }
                     await MainActor.run { [weak self] in
-                        let view = TranscriptExcerptView(viewModel: viewModel).themedUIView
+                        let vc = ThemedHostingController(rootView: TranscriptExcerptView(viewModel: viewModel))
+                        vc.sizingOptions = [.intrinsicContentSize, .preferredContentSize]
+                        let view = vc.view!
                         view.translatesAutoresizingMaskIntoConstraints = false
+                        self?.addChild(vc)
                         self?.transcriptExcerpt?.addSubview(view)
+                        vc.didMove(toParent: self)
                         view.anchorToAllSidesOf(view: self?.transcriptExcerpt)
                         self?.transcriptExcerpt?.isHidden = false
-                        self?.showNotesHolderTopAnchor?.constant = 78.0
                         self?.showNotesWebViewTopConstraint?.constant = 0.0
                     }
                 } else {

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -54,7 +54,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     @IBOutlet var showNotesHolderTopAnchor: NSLayoutConstraint!
     @IBOutlet var loadingIndicator: UIActivityIndicatorView!
     var showNotesWebViewTopConstraint: NSLayoutConstraint?
-    var transcriptExcerpt: UIView?
+    @IBOutlet var transcriptExcerpt: UIView?
 
     @IBOutlet var mainScrollView: UIScrollView! {
         didSet {

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -68,7 +68,8 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         didSet {
             downloadBtn.titleLabel?.font = UIFont.font(ofSize: 13, weight: .regular, scalingWith: .footnote)
             downloadBtn.titleLabel?.adjustsFontForContentSizeCategory = true
-            downloadBtn.titleLabel?.numberOfLines = 2
+            downloadBtn.titleLabel?.numberOfLines = 3
+            downloadBtn.imageView?.adjustsImageSizeForAccessibilityContentSizeCategory = true
         }
     }
 
@@ -76,7 +77,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         didSet {
             upNextBtn.titleLabel?.font = UIFont.font(ofSize: 13, weight: .regular, scalingWith: .footnote)
             upNextBtn.titleLabel?.adjustsFontForContentSizeCategory = true
-            upNextBtn.titleLabel?.numberOfLines = 2
+            upNextBtn.titleLabel?.numberOfLines = 3
         }
     }
 
@@ -86,7 +87,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         didSet {
             playStatusButton.titleLabel?.font = UIFont.font(ofSize: 13, weight: .regular, scalingWith: .footnote)
             playStatusButton.titleLabel?.adjustsFontForContentSizeCategory = true
-            playStatusButton.titleLabel?.numberOfLines = 2
+            playStatusButton.titleLabel?.numberOfLines = 3
         }
     }
 
@@ -94,7 +95,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         didSet {
             archiveButton.titleLabel?.font = UIFont.font(ofSize: 13, weight: .regular, scalingWith: .footnote)
             archiveButton.titleLabel?.adjustsFontForContentSizeCategory = true
-            archiveButton.titleLabel?.numberOfLines = 2
+            archiveButton.titleLabel?.numberOfLines = 3
         }
     }
 

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -21,13 +21,18 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     }()
 
     @IBOutlet var podcastImage: PodcastImageView!
-    @IBOutlet var episodeName: ThemeableLabel!
+    @IBOutlet var episodeName: ThemeableLabel! {
+        didSet {
+            episodeName.font = UIFont.font(ofSize: 22, weight: .bold, scalingWith: .title2)
+        }
+    }
 
     @IBOutlet var podcastName: UILabel! {
         didSet {
             let tapGesture = UITapGestureRecognizer(target: self, action: #selector(podcastNameTapped))
             podcastName.addGestureRecognizer(tapGesture)
             podcastName.isUserInteractionEnabled = true
+            podcastName.font = UIFont.font(ofSize: 16, weight: .medium, scalingWith: .callout)
         }
     }
 
@@ -59,21 +64,51 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     }
 
     @IBOutlet var buttonsStackView: UIStackView!
-    @IBOutlet var downloadBtn: UIButton!
-    @IBOutlet var upNextBtn: UIButton!
+    @IBOutlet var downloadBtn: UIButton! {
+        didSet {
+            downloadBtn.titleLabel?.font = UIFont.font(ofSize: 13, weight: .regular, scalingWith: .footnote)
+            downloadBtn.titleLabel?.adjustsFontForContentSizeCategory = true
+            downloadBtn.titleLabel?.numberOfLines = 2
+        }
+    }
+
+    @IBOutlet var upNextBtn: UIButton! {
+        didSet {
+            upNextBtn.titleLabel?.font = UIFont.font(ofSize: 13, weight: .regular, scalingWith: .footnote)
+            upNextBtn.titleLabel?.adjustsFontForContentSizeCategory = true
+            upNextBtn.titleLabel?.numberOfLines = 2
+        }
+    }
+
     @IBOutlet var playPauseBtn: PlayPauseButton!
-    @IBOutlet var playStatusButton: UIButton!
-    @IBOutlet var archiveButton: UIButton!
+
+    @IBOutlet var playStatusButton: UIButton! {
+        didSet {
+            playStatusButton.titleLabel?.font = UIFont.font(ofSize: 13, weight: .regular, scalingWith: .footnote)
+            playStatusButton.titleLabel?.adjustsFontForContentSizeCategory = true
+            playStatusButton.titleLabel?.numberOfLines = 2
+        }
+    }
+
+    @IBOutlet var archiveButton: UIButton! {
+        didSet {
+            archiveButton.titleLabel?.font = UIFont.font(ofSize: 13, weight: .regular, scalingWith: .footnote)
+            archiveButton.titleLabel?.adjustsFontForContentSizeCategory = true
+            archiveButton.titleLabel?.numberOfLines = 2
+        }
+    }
 
     @IBOutlet var episodeDate: ThemeableLabel! {
         didSet {
             episodeDate.style = .primaryText02
+            episodeDate.font = UIFont.font(ofSize: 15, weight: .regular, scalingWith: .subheadline)
         }
     }
 
     @IBOutlet var episodeInfo: ThemeableLabel! {
         didSet {
             episodeInfo.style = .primaryText02
+            episodeInfo.font = UIFont.font(ofSize: 15, weight: .regular, scalingWith: .subheadline)
         }
     }
 

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -99,23 +99,10 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         }
     }
 
-    @IBOutlet var episodeDate: ThemeableLabel! {
-        didSet {
-            episodeDate.style = .primaryText02
-            episodeDate.font = UIFont.font(ofSize: 15, weight: .regular, scalingWith: .subheadline)
-        }
-    }
-
     @IBOutlet var episodeInfo: ThemeableLabel! {
         didSet {
             episodeInfo.style = .primaryText02
             episodeInfo.font = UIFont.font(ofSize: 15, weight: .regular, scalingWith: .subheadline)
-        }
-    }
-
-    @IBOutlet var episodeSpacer: ThemeableLabel! {
-        didSet {
-            episodeSpacer.style = .primaryText02
         }
     }
 
@@ -425,8 +412,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
             podcastImage.setPodcast(uuid: uuid, size: .page)
         }
 
-        episodeDate.text = DateFormatHelper.sharedHelper.longLocalizedFormat(episode.publishedDate)
-        episodeInfo.text = episode.displayableTimeLeft()
+        episodeInfo.text = DateFormatHelper.sharedHelper.longLocalizedFormat(episode.publishedDate) + " · " + episode.displayableTimeLeft()
 
         updateStar()
 
@@ -454,8 +440,6 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     }
 
     func updateColors() {
-        episodeDate.themeOverride = themeOverride
-        episodeSpacer.themeOverride = themeOverride
         episodeInfo.themeOverride = themeOverride
         topDivider.themeOverride = themeOverride
         bottomDivider.themeOverride = themeOverride

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -254,6 +254,8 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         Analytics.track(.episodeDetailShown, properties: ["source": viewSource])
 
         didSwitchToTab(.details, animated: false)
+
+        updateSize()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -782,3 +784,20 @@ private enum EpisodeDetailConstants {
     /// This allows it to clear the fake nav bar
     static let topPadding = 56.0
 }
+
+// MARK: - Dynamic Type support
+extension EpisodeDetailViewController {
+
+    func updateSize() {
+        let metric = UIFontMetrics(forTextStyle: .largeTitle)
+        let iconSize = max(24, metric.scaledValue(for: 24))
+        messageIcon.updateSizeConstraints(to: iconSize)
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
+        updateSize()
+    }
+}
+

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -137,19 +137,31 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     @IBOutlet var messageTitle: ThemeableLabel! {
         didSet {
             messageTitle.style = .primaryText01
+            messageTitle.font = UIFont.font(ofSize: 16, weight: .medium, scalingWith: .callout)
         }
     }
 
     @IBOutlet var messageDetails: ThemeableLabel! {
         didSet {
             messageDetails.style = .primaryText02
+            messageDetails.font = UIFont.font(ofSize: 14, weight: .medium, scalingWith: .subheadline)
         }
     }
 
     @IBOutlet var buttonBottomOffsetConstraint: NSLayoutConstraint!
 
-    @IBOutlet var failedToLoadLabel: UILabel!
-    @IBOutlet var tryAgainButton: UIButton!
+    @IBOutlet var failedToLoadLabel: ThemeableLabel! {
+        didSet {
+            failedToLoadLabel.font = UIFont.font(ofSize: 16, weight: .regular, scalingWith: .callout)
+        }
+    }
+
+    @IBOutlet var tryAgainButton: UIButton! {
+        didSet {
+            tryAgainButton.titleLabel?.font = UIFont.font(ofSize: 14, weight: .semibold, scalingWith: .subheadline)
+            tryAgainButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        }
+    }
 
     private var docController: UIDocumentInteractionController?
     private var starButton: UIButton?

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -126,6 +126,8 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
 
     @IBOutlet var playPauseBtnWidth: NSLayoutConstraint!
 
+    @IBOutlet var messageContainerView: UIView!
+
     @IBOutlet var messageView: RoundedBorderView! {
         didSet {
             messageView.getBorderColor = { AppTheme.episodeMessageBorderColor(for: self.themeOverride) }
@@ -147,8 +149,6 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
             messageDetails.font = UIFont.font(ofSize: 14, weight: .medium, scalingWith: .subheadline)
         }
     }
-
-    @IBOutlet var buttonBottomOffsetConstraint: NSLayoutConstraint!
 
     @IBOutlet var failedToLoadLabel: ThemeableLabel! {
         didSet {

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -784,4 +784,3 @@ extension EpisodeDetailViewController {
         updateSize()
     }
 }
-

--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -776,6 +776,7 @@ extension EpisodeDetailViewController {
         let metric = UIFontMetrics(forTextStyle: .largeTitle)
         let iconSize = max(24, metric.scaledValue(for: 24))
         messageIcon.updateSizeConstraints(to: iconSize)
+        downloadIndicator.updateSizeConstraints(to: iconSize)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/EpisodeDetailViewController.xib
+++ b/podcasts/EpisodeDetailViewController.xib
@@ -253,7 +253,7 @@
                                                         <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="21U-r9-JP1" userLabel="Message View" customClass="RoundedBorderView" customModule="podcasts" customModuleProvider="target">
                                                             <rect key="frame" x="12" y="12" width="396" height="106"/>
                                                             <subviews>
-                                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="episode-archive" translatesAutoresizingMaskIntoConstraints="NO" id="IaZ-ts-eDq">
+                                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="episode-archive" translatesAutoresizingMaskIntoConstraints="NO" id="IaZ-ts-eDq" userLabel="message icon">
                                                                     <rect key="frame" x="13" y="13" width="24" height="24"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="24" id="A1U-2a-GAB"/>

--- a/podcasts/EpisodeDetailViewController.xib
+++ b/podcasts/EpisodeDetailViewController.xib
@@ -313,16 +313,16 @@
                                     <rect key="frame" x="0.0" y="546" width="420" height="334"/>
                                     <subviews>
                                         <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="bTC-FT-bUv">
-                                            <rect key="frame" x="200" y="40" width="20" height="20"/>
+                                            <rect key="frame" x="200" y="59.5" width="20" height="20"/>
                                         </activityIndicatorView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unable to find show notes for this episode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gye-vZ-4Rq" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unable to find show notes for this episode" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gye-vZ-4Rq" userLabel="Failed to Load Message" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                             <rect key="frame" x="16" y="20" width="388" height="19.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X1H-6J-Cmx" customClass="ThemeableUIButton" customModule="podcasts" customModuleProvider="target">
-                                            <rect key="frame" x="172.5" y="50" width="75" height="29"/>
+                                            <rect key="frame" x="172.5" y="69.5" width="75" height="29"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
                                             <state key="normal" title="TRY AGAIN"/>
                                             <connections>
@@ -333,13 +333,12 @@
                                     <constraints>
                                         <constraint firstItem="bTC-FT-bUv" firstAttribute="centerX" secondItem="XID-El-uKH" secondAttribute="centerX" id="4uS-HB-pBk"/>
                                         <constraint firstItem="Gye-vZ-4Rq" firstAttribute="leading" secondItem="XID-El-uKH" secondAttribute="leading" constant="16" id="CKA-7o-CaF"/>
-                                        <constraint firstItem="Gye-vZ-4Rq" firstAttribute="centerX" secondItem="X1H-6J-Cmx" secondAttribute="centerX" id="OQb-AJ-ktF"/>
                                         <constraint firstItem="Gye-vZ-4Rq" firstAttribute="top" secondItem="XID-El-uKH" secondAttribute="top" constant="20" id="PL2-Yd-iGe"/>
                                         <constraint firstAttribute="trailing" secondItem="Gye-vZ-4Rq" secondAttribute="trailing" constant="16" id="XhN-FS-LyS"/>
-                                        <constraint firstItem="X1H-6J-Cmx" firstAttribute="top" secondItem="Gye-vZ-4Rq" secondAttribute="top" constant="30" id="Y1j-DO-KYY"/>
+                                        <constraint firstItem="X1H-6J-Cmx" firstAttribute="top" secondItem="Gye-vZ-4Rq" secondAttribute="bottom" constant="30" id="Y1j-DO-KYY"/>
                                         <constraint firstItem="X1H-6J-Cmx" firstAttribute="centerX" secondItem="XID-El-uKH" secondAttribute="centerX" id="m8e-BG-Anf"/>
                                         <constraint firstAttribute="height" constant="334" id="mcc-50-BWR"/>
-                                        <constraint firstItem="bTC-FT-bUv" firstAttribute="top" secondItem="XID-El-uKH" secondAttribute="top" constant="40" id="z4f-GP-4KF"/>
+                                        <constraint firstItem="bTC-FT-bUv" firstAttribute="top" secondItem="Gye-vZ-4Rq" secondAttribute="bottom" constant="20" id="z4f-GP-4KF"/>
                                     </constraints>
                                 </view>
                             </subviews>

--- a/podcasts/EpisodeDetailViewController.xib
+++ b/podcasts/EpisodeDetailViewController.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="dark"/>
+    <accessibilityOverrides isEnabled="YES" dynamicTypePreference="3"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
@@ -17,10 +18,8 @@
                 <outlet property="downloadBtn" destination="1NQ-ec-77c" id="Aua-2A-MsN"/>
                 <outlet property="downloadIndicator" destination="xIt-Zj-tav" id="QHD-Gx-8fk"/>
                 <outlet property="episodeChevron" destination="sEv-1n-DxV" id="CDD-a6-kNC"/>
-                <outlet property="episodeDate" destination="ytP-Wg-gNG" id="RHp-pu-2AQ"/>
                 <outlet property="episodeInfo" destination="i6O-79-oUy" id="L5o-Hb-L6r"/>
                 <outlet property="episodeName" destination="dsg-ff-pnB" id="21O-XU-QDv"/>
-                <outlet property="episodeSpacer" destination="bui-ho-GkT" id="I3V-fJ-25T"/>
                 <outlet property="failedToLoadLabel" destination="Gye-vZ-4Rq" id="7lV-t8-PgR"/>
                 <outlet property="loadingIndicator" destination="bTC-FT-bUv" id="BUh-qL-mST"/>
                 <outlet property="mainScrollView" destination="Ffa-0D-OU4" id="fdv-nX-GrV"/>
@@ -68,36 +67,19 @@
                                                 <constraint firstAttribute="width" relation="lessThanOrEqual" constant="175" id="mbB-ao-L3L"/>
                                             </constraints>
                                         </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" ambiguous="YES" text="50 mins" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i6O-79-oUy" userLabel="Episode Info" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                            <rect key="frame" x="16" y="255" width="388" height="36"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Episode Name" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="18" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dsg-ff-pnB" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                             <rect key="frame" x="16" y="231" width="388" height="26.5"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" ambiguous="YES" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="akC-zS-r4u">
-                                            <rect key="frame" x="114" y="203" width="192" height="18"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3 December 2019" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ytP-Wg-gNG" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="0.0" width="122.5" height="18"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="·" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bui-ho-GkT" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                                    <rect key="frame" x="127.5" y="0.0" width="4.5" height="18"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="50 mins" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i6O-79-oUy" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                                    <rect key="frame" x="137" y="0.0" width="55" height="18"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </stackView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" ambiguous="YES" text="Loading..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mqv-46-8ea" userLabel="Podcast Name">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" ambiguous="YES" text="Loading..." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mqv-46-8ea" userLabel="Podcast Name">
                                             <rect key="frame" x="168.5" y="265.5" width="73.5" height="19.5"/>
                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
                                             <nil key="textColor"/>
@@ -308,15 +290,16 @@
                                         <constraint firstAttribute="trailing" secondItem="uIZ-vc-g2f" secondAttribute="trailing" id="46b-xB-DYg"/>
                                         <constraint firstItem="dsg-ff-pnB" firstAttribute="leading" secondItem="SYi-ag-GDK" secondAttribute="leading" constant="16" id="68d-Oz-Mgl"/>
                                         <constraint firstItem="sEv-1n-DxV" firstAttribute="centerY" secondItem="mqv-46-8ea" secondAttribute="centerY" id="8FF-D7-oYB"/>
-                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mqv-46-8ea" secondAttribute="trailing" constant="40" id="Cu8-Sf-4MD"/>
-                                        <constraint firstItem="dsg-ff-pnB" firstAttribute="top" secondItem="akC-zS-r4u" secondAttribute="bottom" constant="10" id="GLy-9A-UJJ"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mqv-46-8ea" secondAttribute="trailing" constant="32" id="Cu8-Sf-4MD"/>
+                                        <constraint firstItem="dsg-ff-pnB" firstAttribute="top" secondItem="i6O-79-oUy" secondAttribute="bottom" constant="10" id="GLy-9A-UJJ"/>
+                                        <constraint firstItem="i6O-79-oUy" firstAttribute="leading" secondItem="SYi-ag-GDK" secondAttribute="leading" constant="16" id="Str-sk-zh9"/>
                                         <constraint firstAttribute="trailing" secondItem="dsg-ff-pnB" secondAttribute="trailing" constant="16" id="UjW-5V-YVv"/>
-                                        <constraint firstItem="akC-zS-r4u" firstAttribute="centerX" secondItem="SYi-ag-GDK" secondAttribute="centerX" id="VoY-ug-v6h"/>
-                                        <constraint firstItem="akC-zS-r4u" firstAttribute="top" secondItem="4IP-4N-SIa" secondAttribute="bottom" constant="16" id="Wzy-w9-Ed9"/>
+                                        <constraint firstItem="i6O-79-oUy" firstAttribute="top" secondItem="4IP-4N-SIa" secondAttribute="bottom" constant="16" id="YKm-qK-46i"/>
                                         <constraint firstItem="sEv-1n-DxV" firstAttribute="leading" secondItem="mqv-46-8ea" secondAttribute="trailing" constant="2" id="Zso-1u-hEY"/>
+                                        <constraint firstItem="i6O-79-oUy" firstAttribute="trailing" secondItem="SYi-ag-GDK" secondAttribute="trailing" constant="-16" id="aUY-6G-f7j"/>
                                         <constraint firstItem="uIZ-vc-g2f" firstAttribute="top" secondItem="mqv-46-8ea" secondAttribute="bottom" constant="20" id="hTM-25-yKG"/>
                                         <constraint firstItem="mqv-46-8ea" firstAttribute="top" secondItem="dsg-ff-pnB" secondAttribute="bottom" constant="8" id="nLo-3O-J0B"/>
-                                        <constraint firstItem="mqv-46-8ea" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="SYi-ag-GDK" secondAttribute="leading" constant="40" id="oVa-1E-U1g"/>
+                                        <constraint firstItem="mqv-46-8ea" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="SYi-ag-GDK" secondAttribute="leading" constant="32" id="oVa-1E-U1g"/>
                                         <constraint firstItem="uIZ-vc-g2f" firstAttribute="leading" secondItem="SYi-ag-GDK" secondAttribute="leading" id="p4S-eZ-Avc"/>
                                         <constraint firstAttribute="bottom" secondItem="uIZ-vc-g2f" secondAttribute="bottom" constant="-7" id="q61-58-SZm"/>
                                         <constraint firstItem="4IP-4N-SIa" firstAttribute="centerX" secondItem="SYi-ag-GDK" secondAttribute="centerX" id="sbJ-eu-q46"/>

--- a/podcasts/EpisodeDetailViewController.xib
+++ b/podcasts/EpisodeDetailViewController.xib
@@ -12,7 +12,6 @@
             <connections>
                 <outlet property="archiveButton" destination="1WD-bM-NYS" id="1bI-du-Jpj"/>
                 <outlet property="bottomDivider" destination="19d-9v-ihd" id="Z47-BQ-LmZ"/>
-                <outlet property="buttonBottomOffsetConstraint" destination="G4Y-eX-Otg" id="9ZR-Du-F8H"/>
                 <outlet property="buttonsStackView" destination="pbD-yD-5ea" id="cKC-D5-c24"/>
                 <outlet property="containerScrollView" destination="tmT-f0-kSM" id="SBm-po-W7A"/>
                 <outlet property="downloadBtn" destination="1NQ-ec-77c" id="Aua-2A-MsN"/>
@@ -25,6 +24,7 @@
                 <outlet property="failedToLoadLabel" destination="Gye-vZ-4Rq" id="7lV-t8-PgR"/>
                 <outlet property="loadingIndicator" destination="bTC-FT-bUv" id="BUh-qL-mST"/>
                 <outlet property="mainScrollView" destination="Ffa-0D-OU4" id="fdv-nX-GrV"/>
+                <outlet property="messageContainerView" destination="kW8-9S-AJu" id="Ijk-rq-byR"/>
                 <outlet property="messageDetails" destination="aet-FO-Uny" id="rjY-ie-OnY"/>
                 <outlet property="messageIcon" destination="IaZ-ts-eDq" id="cQs-H6-skx"/>
                 <outlet property="messageTitle" destination="QSl-m4-wUL" id="TtU-0F-kAh"/>
@@ -35,7 +35,7 @@
                 <outlet property="podcastImage" destination="4IP-4N-SIa" id="phy-x9-5Dr"/>
                 <outlet property="podcastName" destination="mqv-46-8ea" id="6DY-6X-3xx"/>
                 <outlet property="progressView" destination="Fv5-YL-ggw" id="7Dg-UW-H6k"/>
-                <outlet property="progressWidthConstraint" destination="lXv-7B-jbA" id="ow7-z2-KY2"/>
+                <outlet property="progressWidthConstraint" destination="d8U-cF-JMd" id="22P-XZ-AUe"/>
                 <outlet property="showNotesHolderTopAnchor" destination="pxO-ez-3HU" id="omX-Dn-6PE"/>
                 <outlet property="showNotesHolderView" destination="XID-El-uKH" id="56g-88-xn8"/>
                 <outlet property="showNotesHolderViewHeight" destination="mcc-50-BWR" id="qDt-pl-cxZ"/>
@@ -106,207 +106,222 @@
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="episode-chevron" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sEv-1n-DxV">
                                             <rect key="frame" x="244" y="267.5" width="16" height="16"/>
                                         </imageView>
-                                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mhS-eS-X3U" userLabel="Buttons View">
-                                            <rect key="frame" x="0.0" y="305" width="420" height="235"/>
+                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="uIZ-vc-g2f" userLabel="ActionsView">
+                                            <rect key="frame" x="0.0" y="228" width="420" height="260"/>
                                             <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qhA-bj-I2z" customClass="ThemeDividerView" customModule="podcasts" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="40" width="420" height="1"/>
-                                                    <color key="backgroundColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="1" id="Yec-wv-a4R"/>
-                                                    </constraints>
-                                                </view>
-                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="pbD-yD-5ea">
-                                                    <rect key="frame" x="0.0" y="55" width="420" height="60"/>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mhS-eS-X3U" userLabel="Buttons View">
+                                                    <rect key="frame" x="0.0" y="0.0" width="420" height="130"/>
                                                     <subviews>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gr7-N7-0qa">
-                                                            <rect key="frame" x="0.0" y="0.0" width="70" height="55"/>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qhA-bj-I2z" customClass="ThemeDividerView" customModule="podcasts" customModuleProvider="target">
+                                                            <rect key="frame" x="0.0" y="40" width="420" height="1"/>
+                                                            <color key="backgroundColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="1" id="Yec-wv-a4R"/>
+                                                            </constraints>
+                                                        </view>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="pbD-yD-5ea">
+                                                            <rect key="frame" x="0.0" y="55" width="420" height="55"/>
                                                             <subviews>
-                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xIt-Zj-tav" customClass="AngularProgressIndicator" customModule="podcasts" customModuleProvider="target">
-                                                                    <rect key="frame" x="23" y="0.0" width="24" height="24"/>
+                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gr7-N7-0qa">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="70" height="55"/>
+                                                                    <subviews>
+                                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xIt-Zj-tav" customClass="AngularProgressIndicator" customModule="podcasts" customModuleProvider="target">
+                                                                            <rect key="frame" x="23" y="0.0" width="24" height="24"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="24" id="CI6-Bj-uMm"/>
+                                                                                <constraint firstAttribute="width" constant="24" id="USa-IK-eer"/>
+                                                                            </constraints>
+                                                                        </view>
+                                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" lineBreakMode="wordWrap" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1NQ-ec-77c" customClass="ActionIconButton" customModule="podcasts" customModuleProvider="target">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="70" height="55"/>
+                                                                            <accessibility key="accessibilityConfiguration" label="Download"/>
+                                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                                            <state key="normal" image="episode-download"/>
+                                                                            <connections>
+                                                                                <action selector="downloadTapped:" destination="-1" eventType="touchUpInside" id="dPu-fd-NnZ"/>
+                                                                            </connections>
+                                                                        </button>
+                                                                    </subviews>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="height" constant="24" id="CI6-Bj-uMm"/>
-                                                                        <constraint firstAttribute="width" constant="24" id="USa-IK-eer"/>
+                                                                        <constraint firstItem="1NQ-ec-77c" firstAttribute="top" secondItem="Gr7-N7-0qa" secondAttribute="top" id="0cT-tK-9uv"/>
+                                                                        <constraint firstItem="1NQ-ec-77c" firstAttribute="leading" secondItem="Gr7-N7-0qa" secondAttribute="leading" id="EgU-Sj-vfl"/>
+                                                                        <constraint firstItem="xIt-Zj-tav" firstAttribute="top" secondItem="1NQ-ec-77c" secondAttribute="top" id="JkD-uo-eYv"/>
+                                                                        <constraint firstItem="xIt-Zj-tav" firstAttribute="centerX" secondItem="Gr7-N7-0qa" secondAttribute="centerX" id="NnN-ed-K42"/>
+                                                                        <constraint firstAttribute="trailing" secondItem="1NQ-ec-77c" secondAttribute="trailing" id="Q9x-g7-Vnt"/>
+                                                                        <constraint firstAttribute="bottom" secondItem="1NQ-ec-77c" secondAttribute="bottom" id="hFR-h5-kwS"/>
+                                                                        <constraint firstAttribute="width" constant="70" id="hV3-vR-GAP"/>
                                                                     </constraints>
                                                                 </view>
-                                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" lineBreakMode="wordWrap" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1NQ-ec-77c" customClass="ActionIconButton" customModule="podcasts" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="70" height="55"/>
-                                                                    <accessibility key="accessibilityConfiguration" label="Download"/>
+                                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" lineBreakMode="wordWrap" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="v4S-Or-iDs" customClass="ActionIconButton" customModule="podcasts" customModuleProvider="target">
+                                                                    <rect key="frame" x="70" y="0.0" width="95" height="24"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="95" id="9rn-On-cdD"/>
+                                                                    </constraints>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                                    <state key="normal" image="episode-download"/>
+                                                                    <state key="normal" image="episode-playnext">
+                                                                        <color key="titleColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                    </state>
                                                                     <connections>
-                                                                        <action selector="downloadTapped:" destination="-1" eventType="touchUpInside" id="dPu-fd-NnZ"/>
+                                                                        <action selector="upNextTapped:" destination="-1" eventType="touchUpInside" id="Wn4-2e-SFL"/>
+                                                                    </connections>
+                                                                </button>
+                                                                <view contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="HUn-8V-DZb" userLabel="Spacer View">
+                                                                    <rect key="frame" x="165" y="0.0" width="90" height="55"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="90" id="g9Y-IZ-thm"/>
+                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="oDB-AL-siM"/>
+                                                                    </constraints>
+                                                                </view>
+                                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" lineBreakMode="wordWrap" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6vC-l3-5p9" userLabel="Mark Played Button" customClass="ActionIconButton" customModule="podcasts" customModuleProvider="target">
+                                                                    <rect key="frame" x="255" y="0.0" width="95" height="24"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="95" id="u40-Ap-MBz"/>
+                                                                    </constraints>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                                    <state key="normal" image="episode-markasplayed"/>
+                                                                    <connections>
+                                                                        <action selector="episodeStatusTapped:" destination="-1" eventType="touchUpInside" id="k2I-OX-MKJ"/>
+                                                                    </connections>
+                                                                </button>
+                                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" lineBreakMode="wordWrap" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1WD-bM-NYS" customClass="ActionIconButton" customModule="podcasts" customModuleProvider="target">
+                                                                    <rect key="frame" x="350" y="0.0" width="70" height="24"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="70" id="m4c-gr-c6s"/>
+                                                                    </constraints>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                                    <state key="normal" image="episode-archive">
+                                                                        <color key="titleColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="calibratedRGB"/>
+                                                                    </state>
+                                                                    <connections>
+                                                                        <action selector="archiveTapped:" destination="-1" eventType="touchUpInside" id="zuJ-Np-bgH"/>
                                                                     </connections>
                                                                 </button>
                                                             </subviews>
+                                                        </stackView>
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x4a-0Q-f1h" userLabel="PlayPauseButton" customClass="PlayPauseButton" customModule="podcasts" customModuleProvider="target">
+                                                            <rect key="frame" x="170" y="0.0" width="80" height="80"/>
+                                                            <accessibility key="accessibilityConfiguration" label="Play/Pause Episode"/>
                                                             <constraints>
-                                                                <constraint firstItem="1NQ-ec-77c" firstAttribute="top" secondItem="Gr7-N7-0qa" secondAttribute="top" id="0cT-tK-9uv"/>
-                                                                <constraint firstItem="1NQ-ec-77c" firstAttribute="leading" secondItem="Gr7-N7-0qa" secondAttribute="leading" id="EgU-Sj-vfl"/>
-                                                                <constraint firstItem="xIt-Zj-tav" firstAttribute="top" secondItem="1NQ-ec-77c" secondAttribute="top" id="JkD-uo-eYv"/>
-                                                                <constraint firstItem="xIt-Zj-tav" firstAttribute="centerX" secondItem="Gr7-N7-0qa" secondAttribute="centerX" id="NnN-ed-K42"/>
-                                                                <constraint firstAttribute="trailing" secondItem="1NQ-ec-77c" secondAttribute="trailing" id="Q9x-g7-Vnt"/>
-                                                                <constraint firstAttribute="bottom" secondItem="1NQ-ec-77c" secondAttribute="bottom" id="hFR-h5-kwS"/>
-                                                                <constraint firstAttribute="width" constant="70" id="hV3-vR-GAP"/>
+                                                                <constraint firstAttribute="width" secondItem="x4a-0Q-f1h" secondAttribute="height" multiplier="1:1" id="BiR-C3-bY5"/>
+                                                                <constraint firstAttribute="width" constant="80" id="o5d-Mr-0Jd"/>
+                                                            </constraints>
+                                                            <connections>
+                                                                <action selector="playPauseTapped:" destination="-1" eventType="touchUpInside" id="UOG-yw-JV4"/>
+                                                            </connections>
+                                                        </button>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="19d-9v-ihd" customClass="ThemeDividerView" customModule="podcasts" customModuleProvider="target">
+                                                            <rect key="frame" x="0.0" y="129" width="420" height="1"/>
+                                                            <color key="backgroundColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="1" id="dya-K0-LEK"/>
                                                             </constraints>
                                                         </view>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" lineBreakMode="wordWrap" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="v4S-Or-iDs" customClass="ActionIconButton" customModule="podcasts" customModuleProvider="target">
-                                                            <rect key="frame" x="70" y="0.0" width="95" height="24"/>
+                                                        <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fv5-YL-ggw" userLabel="Progress">
+                                                            <rect key="frame" x="0.0" y="128" width="3.5" height="2"/>
+                                                            <color key="backgroundColor" red="1" green="0.2780970982" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="width" constant="95" id="9rn-On-cdD"/>
+                                                                <constraint firstAttribute="height" constant="2" id="ciz-Wn-nb7"/>
+                                                                <constraint firstAttribute="width" constant="3.5" id="d8U-cF-JMd"/>
                                                             </constraints>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                            <state key="normal" image="episode-playnext">
-                                                                <color key="titleColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                            </state>
-                                                            <connections>
-                                                                <action selector="upNextTapped:" destination="-1" eventType="touchUpInside" id="Wn4-2e-SFL"/>
-                                                            </connections>
-                                                        </button>
-                                                        <view contentMode="scaleToFill" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="HUn-8V-DZb" userLabel="Spacer View">
-                                                            <rect key="frame" x="165" y="0.0" width="90" height="60"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" relation="lessThanOrEqual" constant="90" id="g9Y-IZ-thm"/>
-                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="10" id="oDB-AL-siM"/>
-                                                            </constraints>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                    <integer key="value" value="1"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                            </userDefinedRuntimeAttributes>
                                                         </view>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" lineBreakMode="wordWrap" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6vC-l3-5p9" userLabel="Mark Played Button" customClass="ActionIconButton" customModule="podcasts" customModuleProvider="target">
-                                                            <rect key="frame" x="255" y="0.0" width="95" height="24"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="95" id="u40-Ap-MBz"/>
-                                                            </constraints>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                            <state key="normal" image="episode-markasplayed"/>
-                                                            <connections>
-                                                                <action selector="episodeStatusTapped:" destination="-1" eventType="touchUpInside" id="k2I-OX-MKJ"/>
-                                                            </connections>
-                                                        </button>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" lineBreakMode="wordWrap" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1WD-bM-NYS" customClass="ActionIconButton" customModule="podcasts" customModuleProvider="target">
-                                                            <rect key="frame" x="350" y="0.0" width="70" height="24"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="70" id="m4c-gr-c6s"/>
-                                                            </constraints>
-                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                            <state key="normal" image="episode-archive">
-                                                                <color key="titleColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="calibratedRGB"/>
-                                                            </state>
-                                                            <connections>
-                                                                <action selector="archiveTapped:" destination="-1" eventType="touchUpInside" id="zuJ-Np-bgH"/>
-                                                            </connections>
-                                                        </button>
                                                     </subviews>
-                                                </stackView>
-                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="21U-r9-JP1" userLabel="Message View" customClass="RoundedBorderView" customModule="podcasts" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="125" width="388" height="90"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="trailing" secondItem="pbD-yD-5ea" secondAttribute="trailing" id="59e-Nk-C1p"/>
+                                                        <constraint firstItem="pbD-yD-5ea" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="BWX-ex-wdL"/>
+                                                        <constraint firstItem="x4a-0Q-f1h" firstAttribute="top" secondItem="mhS-eS-X3U" secondAttribute="top" id="D60-kc-yRD"/>
+                                                        <constraint firstAttribute="bottom" secondItem="pbD-yD-5ea" secondAttribute="bottom" constant="20" id="G4Y-eX-Otg" userLabel="bottom = Stack View.bottom + 20"/>
+                                                        <constraint firstItem="Fv5-YL-ggw" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="KKj-1M-omY"/>
+                                                        <constraint firstItem="19d-9v-ihd" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="QZ7-mh-1AT"/>
+                                                        <constraint firstItem="qhA-bj-I2z" firstAttribute="top" secondItem="mhS-eS-X3U" secondAttribute="top" constant="40" id="RkJ-cV-O2z"/>
+                                                        <constraint firstAttribute="bottom" secondItem="Fv5-YL-ggw" secondAttribute="bottom" id="YtV-Z3-RMP"/>
+                                                        <constraint firstAttribute="bottom" secondItem="19d-9v-ihd" secondAttribute="bottom" id="bSM-Vt-1fE"/>
+                                                        <constraint firstItem="qhA-bj-I2z" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="m2o-6F-gLu"/>
+                                                        <constraint firstAttribute="trailing" secondItem="qhA-bj-I2z" secondAttribute="trailing" id="mTn-W5-lEe"/>
+                                                        <constraint firstItem="x4a-0Q-f1h" firstAttribute="centerX" secondItem="mhS-eS-X3U" secondAttribute="centerX" id="mxC-Dg-F4B"/>
+                                                        <constraint firstItem="pbD-yD-5ea" firstAttribute="top" secondItem="mhS-eS-X3U" secondAttribute="top" constant="55" id="qFE-BS-LnB"/>
+                                                        <constraint firstAttribute="trailing" secondItem="19d-9v-ihd" secondAttribute="trailing" id="zFa-Ji-Z7t"/>
+                                                    </constraints>
+                                                </view>
+                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kW8-9S-AJu" userLabel="Message Container View">
+                                                    <rect key="frame" x="0.0" y="130" width="420" height="130"/>
                                                     <subviews>
-                                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="episode-archive" translatesAutoresizingMaskIntoConstraints="NO" id="IaZ-ts-eDq">
-                                                            <rect key="frame" x="13" y="13" width="24" height="24"/>
+                                                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="21U-r9-JP1" userLabel="Message View" customClass="RoundedBorderView" customModule="podcasts" customModuleProvider="target">
+                                                            <rect key="frame" x="12" y="12" width="396" height="106"/>
+                                                            <subviews>
+                                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="episode-archive" translatesAutoresizingMaskIntoConstraints="NO" id="IaZ-ts-eDq">
+                                                                    <rect key="frame" x="13" y="13" width="24" height="24"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="24" id="A1U-2a-GAB"/>
+                                                                        <constraint firstAttribute="width" constant="24" id="ufq-ly-QqW"/>
+                                                                    </constraints>
+                                                                </imageView>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Episode Manually Unarchived" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QSl-m4-wUL" userLabel="message title" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                                                    <rect key="frame" x="49" y="12" width="337" height="19.5"/>
+                                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It won't be auto archived by your new episode limit of 2" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aet-FO-Uny" userLabel="message details" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                                                    <rect key="frame" x="49" y="35.5" width="337" height="33.5"/>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                    <color key="textColor" red="0.53333333329999999" green="0.53333333329999999" blue="0.53333333329999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="width" constant="24" id="6bw-bI-KoS"/>
-                                                                <constraint firstAttribute="height" constant="24" id="qGV-eS-dfu"/>
+                                                                <constraint firstAttribute="trailing" secondItem="QSl-m4-wUL" secondAttribute="trailing" constant="10" id="1N2-DP-UnX"/>
+                                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="90" id="4np-tx-sFq"/>
+                                                                <constraint firstItem="QSl-m4-wUL" firstAttribute="leading" secondItem="IaZ-ts-eDq" secondAttribute="trailing" constant="12" id="aed-AB-AjT"/>
+                                                                <constraint firstItem="IaZ-ts-eDq" firstAttribute="leading" secondItem="21U-r9-JP1" secondAttribute="leading" constant="13" id="cKh-1L-Egx" userLabel="episode-archive.leading = leading + 12"/>
+                                                                <constraint firstItem="aet-FO-Uny" firstAttribute="leading" secondItem="QSl-m4-wUL" secondAttribute="leading" id="dvg-Dh-oMu"/>
+                                                                <constraint firstItem="IaZ-ts-eDq" firstAttribute="top" secondItem="21U-r9-JP1" secondAttribute="top" constant="13" id="eal-vN-cTV" userLabel="episode-archive.top = top + 12"/>
+                                                                <constraint firstItem="aet-FO-Uny" firstAttribute="trailing" secondItem="QSl-m4-wUL" secondAttribute="trailing" id="gai-YX-hce"/>
+                                                                <constraint firstItem="QSl-m4-wUL" firstAttribute="top" secondItem="21U-r9-JP1" secondAttribute="top" constant="12" id="j9C-o7-9cm"/>
+                                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="aet-FO-Uny" secondAttribute="bottom" constant="12" id="o9x-uc-byD"/>
+                                                                <constraint firstItem="aet-FO-Uny" firstAttribute="top" secondItem="QSl-m4-wUL" secondAttribute="bottom" constant="4" id="p9x-nl-N0O"/>
                                                             </constraints>
-                                                        </imageView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Episode Manually Unarchived" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QSl-m4-wUL" userLabel="message title" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                                            <rect key="frame" x="50" y="15.5" width="328" height="19.5"/>
-                                                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
-                                                            <nil key="textColor"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It won't be auto archived by your new episode limit of 2" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aet-FO-Uny" userLabel="message details" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                                            <rect key="frame" x="50" y="40" width="328" height="33.5"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                            <color key="textColor" red="0.53333333329999999" green="0.53333333329999999" blue="0.53333333329999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                            <nil key="highlightedColor"/>
-                                                        </label>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                                    <real key="value" value="8"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </view>
                                                     </subviews>
-                                                    <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="trailing" secondItem="QSl-m4-wUL" secondAttribute="trailing" constant="10" id="1N2-DP-UnX"/>
-                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="90" id="4np-tx-sFq"/>
-                                                        <constraint firstItem="QSl-m4-wUL" firstAttribute="leading" secondItem="IaZ-ts-eDq" secondAttribute="trailing" constant="13" id="aed-AB-AjT"/>
-                                                        <constraint firstItem="IaZ-ts-eDq" firstAttribute="leading" secondItem="21U-r9-JP1" secondAttribute="leading" constant="13" id="cKh-1L-Egx"/>
-                                                        <constraint firstItem="aet-FO-Uny" firstAttribute="leading" secondItem="QSl-m4-wUL" secondAttribute="leading" id="dvg-Dh-oMu"/>
-                                                        <constraint firstItem="IaZ-ts-eDq" firstAttribute="top" secondItem="21U-r9-JP1" secondAttribute="top" constant="13" id="eal-vN-cTV"/>
-                                                        <constraint firstItem="aet-FO-Uny" firstAttribute="trailing" secondItem="QSl-m4-wUL" secondAttribute="trailing" id="gai-YX-hce"/>
-                                                        <constraint firstItem="QSl-m4-wUL" firstAttribute="centerY" secondItem="IaZ-ts-eDq" secondAttribute="centerY" id="j9C-o7-9cm"/>
-                                                        <constraint firstItem="aet-FO-Uny" firstAttribute="top" secondItem="QSl-m4-wUL" secondAttribute="bottom" constant="5" id="p9x-nl-N0O"/>
+                                                        <constraint firstAttribute="trailing" secondItem="21U-r9-JP1" secondAttribute="trailing" constant="12" id="3Wg-0U-zis"/>
+                                                        <constraint firstItem="21U-r9-JP1" firstAttribute="top" secondItem="kW8-9S-AJu" secondAttribute="top" constant="12" id="72O-ij-Tzf" userLabel="Message View.top = top + 8"/>
+                                                        <constraint firstItem="21U-r9-JP1" firstAttribute="leading" secondItem="kW8-9S-AJu" secondAttribute="leading" constant="12" id="8TL-ez-Aao"/>
+                                                        <constraint firstAttribute="bottom" secondItem="21U-r9-JP1" secondAttribute="bottom" constant="12" id="Mfn-NY-K4a" userLabel="bottom = Message View.bottom + 8"/>
                                                     </constraints>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                            <real key="value" value="8"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                    </userDefinedRuntimeAttributes>
-                                                </view>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x4a-0Q-f1h" userLabel="PlayPauseButton" customClass="PlayPauseButton" customModule="podcasts" customModuleProvider="target">
-                                                    <rect key="frame" x="170" y="0.0" width="80" height="80"/>
-                                                    <accessibility key="accessibilityConfiguration" label="Play/Pause Episode"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" secondItem="x4a-0Q-f1h" secondAttribute="height" multiplier="1:1" id="BiR-C3-bY5"/>
-                                                        <constraint firstAttribute="width" constant="80" id="o5d-Mr-0Jd"/>
-                                                    </constraints>
-                                                    <connections>
-                                                        <action selector="playPauseTapped:" destination="-1" eventType="touchUpInside" id="UOG-yw-JV4"/>
-                                                    </connections>
-                                                </button>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="19d-9v-ihd" customClass="ThemeDividerView" customModule="podcasts" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="234" width="420" height="1"/>
-                                                    <color key="backgroundColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="1" id="dya-K0-LEK"/>
-                                                    </constraints>
-                                                </view>
-                                                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fv5-YL-ggw" userLabel="Progress">
-                                                    <rect key="frame" x="0.0" y="233" width="4" height="2"/>
-                                                    <color key="backgroundColor" red="1" green="0.2780970982" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="2" id="ciz-Wn-nb7"/>
-                                                    </constraints>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                            <integer key="value" value="1"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                    </userDefinedRuntimeAttributes>
                                                 </view>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="pbD-yD-5ea" secondAttribute="trailing" id="59e-Nk-C1p"/>
-                                                <constraint firstItem="pbD-yD-5ea" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="BWX-ex-wdL"/>
-                                                <constraint firstItem="x4a-0Q-f1h" firstAttribute="top" secondItem="mhS-eS-X3U" secondAttribute="top" id="D60-kc-yRD"/>
-                                                <constraint firstAttribute="bottom" secondItem="pbD-yD-5ea" secondAttribute="bottom" constant="120" id="G4Y-eX-Otg"/>
-                                                <constraint firstAttribute="bottom" secondItem="21U-r9-JP1" secondAttribute="bottom" constant="20" id="J3W-ik-gYt"/>
-                                                <constraint firstItem="Fv5-YL-ggw" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="KKj-1M-omY"/>
-                                                <constraint firstItem="19d-9v-ihd" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="QZ7-mh-1AT"/>
-                                                <constraint firstItem="qhA-bj-I2z" firstAttribute="top" secondItem="mhS-eS-X3U" secondAttribute="top" constant="40" id="RkJ-cV-O2z"/>
-                                                <constraint firstAttribute="trailing" secondItem="21U-r9-JP1" secondAttribute="trailing" constant="16" id="Y5O-Hy-mgO"/>
-                                                <constraint firstAttribute="bottom" secondItem="Fv5-YL-ggw" secondAttribute="bottom" id="YtV-Z3-RMP"/>
-                                                <constraint firstAttribute="bottom" secondItem="19d-9v-ihd" secondAttribute="bottom" id="bSM-Vt-1fE"/>
-                                                <constraint firstItem="21U-r9-JP1" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" constant="16" id="fXR-iV-aZW"/>
-                                                <constraint firstItem="qhA-bj-I2z" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="m2o-6F-gLu"/>
-                                                <constraint firstAttribute="trailing" secondItem="qhA-bj-I2z" secondAttribute="trailing" id="mTn-W5-lEe"/>
-                                                <constraint firstItem="x4a-0Q-f1h" firstAttribute="centerX" secondItem="mhS-eS-X3U" secondAttribute="centerX" id="mxC-Dg-F4B"/>
-                                                <constraint firstItem="pbD-yD-5ea" firstAttribute="top" secondItem="mhS-eS-X3U" secondAttribute="top" constant="55" id="qFE-BS-LnB"/>
-                                                <constraint firstAttribute="trailing" secondItem="19d-9v-ihd" secondAttribute="trailing" id="zFa-Ji-Z7t"/>
-                                            </constraints>
-                                        </view>
+                                        </stackView>
                                     </subviews>
                                     <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="uIZ-vc-g2f" secondAttribute="trailing" id="46b-xB-DYg"/>
                                         <constraint firstItem="dsg-ff-pnB" firstAttribute="leading" secondItem="SYi-ag-GDK" secondAttribute="leading" constant="16" id="68d-Oz-Mgl"/>
                                         <constraint firstItem="sEv-1n-DxV" firstAttribute="centerY" secondItem="mqv-46-8ea" secondAttribute="centerY" id="8FF-D7-oYB"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mqv-46-8ea" secondAttribute="trailing" constant="40" id="Cu8-Sf-4MD"/>
                                         <constraint firstItem="dsg-ff-pnB" firstAttribute="top" secondItem="akC-zS-r4u" secondAttribute="bottom" constant="10" id="GLy-9A-UJJ"/>
                                         <constraint firstAttribute="trailing" secondItem="dsg-ff-pnB" secondAttribute="trailing" constant="16" id="UjW-5V-YVv"/>
-                                        <constraint firstItem="mhS-eS-X3U" firstAttribute="leading" secondItem="SYi-ag-GDK" secondAttribute="leading" id="V1O-Po-PXt"/>
                                         <constraint firstItem="akC-zS-r4u" firstAttribute="centerX" secondItem="SYi-ag-GDK" secondAttribute="centerX" id="VoY-ug-v6h"/>
                                         <constraint firstItem="akC-zS-r4u" firstAttribute="top" secondItem="4IP-4N-SIa" secondAttribute="bottom" constant="16" id="Wzy-w9-Ed9"/>
                                         <constraint firstItem="sEv-1n-DxV" firstAttribute="leading" secondItem="mqv-46-8ea" secondAttribute="trailing" constant="2" id="Zso-1u-hEY"/>
-                                        <constraint firstItem="mhS-eS-X3U" firstAttribute="top" secondItem="mqv-46-8ea" secondAttribute="bottom" constant="20" id="jJ0-EI-286"/>
-                                        <constraint firstItem="Fv5-YL-ggw" firstAttribute="width" secondItem="SYi-ag-GDK" secondAttribute="width" multiplier="0.01" id="lXv-7B-jbA"/>
+                                        <constraint firstItem="uIZ-vc-g2f" firstAttribute="top" secondItem="mqv-46-8ea" secondAttribute="bottom" constant="20" id="hTM-25-yKG"/>
                                         <constraint firstItem="mqv-46-8ea" firstAttribute="top" secondItem="dsg-ff-pnB" secondAttribute="bottom" constant="8" id="nLo-3O-J0B"/>
                                         <constraint firstItem="mqv-46-8ea" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="SYi-ag-GDK" secondAttribute="leading" constant="40" id="oVa-1E-U1g"/>
+                                        <constraint firstItem="uIZ-vc-g2f" firstAttribute="leading" secondItem="SYi-ag-GDK" secondAttribute="leading" id="p4S-eZ-Avc"/>
+                                        <constraint firstAttribute="bottom" secondItem="uIZ-vc-g2f" secondAttribute="bottom" constant="-7" id="q61-58-SZm"/>
                                         <constraint firstItem="4IP-4N-SIa" firstAttribute="centerX" secondItem="SYi-ag-GDK" secondAttribute="centerX" id="sbJ-eu-q46"/>
                                         <constraint firstItem="mqv-46-8ea" firstAttribute="centerX" secondItem="SYi-ag-GDK" secondAttribute="centerX" constant="-5" id="sgC-t1-vtP"/>
-                                        <constraint firstAttribute="bottom" secondItem="mhS-eS-X3U" secondAttribute="bottom" constant="6" id="xmi-xu-ARI"/>
                                         <constraint firstItem="4IP-4N-SIa" firstAttribute="top" secondItem="SYi-ag-GDK" secondAttribute="top" constant="12" id="zTA-af-M9q"/>
-                                        <constraint firstAttribute="trailing" secondItem="mhS-eS-X3U" secondAttribute="trailing" id="zYZ-o7-5kJ"/>
                                     </constraints>
                                 </view>
                                 <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XID-El-uKH">

--- a/podcasts/EpisodeDetailViewController.xib
+++ b/podcasts/EpisodeDetailViewController.xib
@@ -35,7 +35,7 @@
                 <outlet property="podcastImage" destination="4IP-4N-SIa" id="phy-x9-5Dr"/>
                 <outlet property="podcastName" destination="mqv-46-8ea" id="6DY-6X-3xx"/>
                 <outlet property="progressView" destination="Fv5-YL-ggw" id="7Dg-UW-H6k"/>
-                <outlet property="progressWidthConstraint" destination="d8U-cF-JMd" id="22P-XZ-AUe"/>
+                <outlet property="progressWidthConstraint" destination="oaa-jj-uX6" id="Rkn-On-NEi"/>
                 <outlet property="showNotesHolderTopAnchor" destination="pxO-ez-3HU" id="omX-Dn-6PE"/>
                 <outlet property="showNotesHolderView" destination="XID-El-uKH" id="56g-88-xn8"/>
                 <outlet property="showNotesHolderViewHeight" destination="mcc-50-BWR" id="qDt-pl-cxZ"/>
@@ -217,11 +217,10 @@
                                                             </constraints>
                                                         </view>
                                                         <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fv5-YL-ggw" userLabel="Progress">
-                                                            <rect key="frame" x="0.0" y="128" width="3.5" height="2"/>
+                                                            <rect key="frame" x="0.0" y="128" width="4" height="2"/>
                                                             <color key="backgroundColor" red="1" green="0.2780970982" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="2" id="ciz-Wn-nb7"/>
-                                                                <constraint firstAttribute="width" constant="3.5" id="d8U-cF-JMd"/>
                                                             </constraints>
                                                             <userDefinedRuntimeAttributes>
                                                                 <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -232,10 +231,10 @@
                                                     </subviews>
                                                     <constraints>
                                                         <constraint firstAttribute="trailing" secondItem="pbD-yD-5ea" secondAttribute="trailing" id="59e-Nk-C1p"/>
+                                                        <constraint firstItem="Fv5-YL-ggw" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="97y-Tu-X0q"/>
                                                         <constraint firstItem="pbD-yD-5ea" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="BWX-ex-wdL"/>
                                                         <constraint firstItem="x4a-0Q-f1h" firstAttribute="top" secondItem="mhS-eS-X3U" secondAttribute="top" id="D60-kc-yRD"/>
                                                         <constraint firstAttribute="bottom" secondItem="pbD-yD-5ea" secondAttribute="bottom" constant="20" id="G4Y-eX-Otg" userLabel="bottom = Stack View.bottom + 20"/>
-                                                        <constraint firstItem="Fv5-YL-ggw" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="KKj-1M-omY"/>
                                                         <constraint firstItem="19d-9v-ihd" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="QZ7-mh-1AT"/>
                                                         <constraint firstItem="qhA-bj-I2z" firstAttribute="top" secondItem="mhS-eS-X3U" secondAttribute="top" constant="40" id="RkJ-cV-O2z"/>
                                                         <constraint firstAttribute="bottom" secondItem="Fv5-YL-ggw" secondAttribute="bottom" id="YtV-Z3-RMP"/>
@@ -243,6 +242,7 @@
                                                         <constraint firstItem="qhA-bj-I2z" firstAttribute="leading" secondItem="mhS-eS-X3U" secondAttribute="leading" id="m2o-6F-gLu"/>
                                                         <constraint firstAttribute="trailing" secondItem="qhA-bj-I2z" secondAttribute="trailing" id="mTn-W5-lEe"/>
                                                         <constraint firstItem="x4a-0Q-f1h" firstAttribute="centerX" secondItem="mhS-eS-X3U" secondAttribute="centerX" id="mxC-Dg-F4B"/>
+                                                        <constraint firstItem="Fv5-YL-ggw" firstAttribute="width" secondItem="mhS-eS-X3U" secondAttribute="width" multiplier="0.01" id="oaa-jj-uX6"/>
                                                         <constraint firstItem="pbD-yD-5ea" firstAttribute="top" secondItem="mhS-eS-X3U" secondAttribute="top" constant="55" id="qFE-BS-LnB"/>
                                                         <constraint firstAttribute="trailing" secondItem="19d-9v-ihd" secondAttribute="trailing" id="zFa-Ji-Z7t"/>
                                                     </constraints>

--- a/podcasts/EpisodeDetailViewController.xib
+++ b/podcasts/EpisodeDetailViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -68,42 +68,42 @@
                                                 <constraint firstAttribute="width" relation="lessThanOrEqual" constant="175" id="mbB-ao-L3L"/>
                                             </constraints>
                                         </view>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Episode Name" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="dsg-ff-pnB" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Episode Name" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="18" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dsg-ff-pnB" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                             <rect key="frame" x="16" y="231" width="388" height="26.5"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="akC-zS-r4u">
+                                        <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" ambiguous="YES" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="akC-zS-r4u">
                                             <rect key="frame" x="114" y="203" width="192" height="18"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3 December 2019" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ytP-Wg-gNG" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3 December 2019" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ytP-Wg-gNG" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="0.0" width="122.5" height="18"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="·" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bui-ho-GkT" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="·" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bui-ho-GkT" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                                     <rect key="frame" x="127.5" y="0.0" width="4.5" height="18"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="50 mins" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i6O-79-oUy" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="50 mins" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i6O-79-oUy" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                                     <rect key="frame" x="137" y="0.0" width="55" height="18"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </stackView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" ambiguous="YES" text="Loading..." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mqv-46-8ea">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" ambiguous="YES" text="Loading..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mqv-46-8ea" userLabel="Podcast Name">
                                             <rect key="frame" x="168.5" y="265.5" width="73.5" height="19.5"/>
                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="episode-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="sEv-1n-DxV">
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="episode-chevron" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sEv-1n-DxV">
                                             <rect key="frame" x="244" y="267.5" width="16" height="16"/>
                                         </imageView>
                                         <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mhS-eS-X3U" userLabel="Buttons View">
@@ -132,7 +132,7 @@
                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="top" lineBreakMode="wordWrap" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1NQ-ec-77c" customClass="ActionIconButton" customModule="podcasts" customModuleProvider="target">
                                                                     <rect key="frame" x="0.0" y="0.0" width="70" height="55"/>
                                                                     <accessibility key="accessibilityConfiguration" label="Download"/>
-                                                                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                                     <state key="normal" image="episode-download"/>
                                                                     <connections>
                                                                         <action selector="downloadTapped:" destination="-1" eventType="touchUpInside" id="dPu-fd-NnZ"/>
@@ -154,7 +154,7 @@
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="95" id="9rn-On-cdD"/>
                                                             </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                             <state key="normal" image="episode-playnext">
                                                                 <color key="titleColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             </state>
@@ -174,7 +174,7 @@
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="95" id="u40-Ap-MBz"/>
                                                             </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                             <state key="normal" image="episode-markasplayed"/>
                                                             <connections>
                                                                 <action selector="episodeStatusTapped:" destination="-1" eventType="touchUpInside" id="k2I-OX-MKJ"/>
@@ -185,7 +185,7 @@
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="70" id="m4c-gr-c6s"/>
                                                             </constraints>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                             <state key="normal" image="episode-archive">
                                                                 <color key="titleColor" red="0.56078431370000004" green="0.59215686270000001" blue="0.64313725489999995" alpha="1" colorSpace="calibratedRGB"/>
                                                             </state>
@@ -195,7 +195,7 @@
                                                         </button>
                                                     </subviews>
                                                 </stackView>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="21U-r9-JP1" userLabel="Message View" customClass="RoundedBorderView" customModule="podcasts" customModuleProvider="target">
+                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="21U-r9-JP1" userLabel="Message View" customClass="RoundedBorderView" customModule="podcasts" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="125" width="388" height="90"/>
                                                     <subviews>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="episode-archive" translatesAutoresizingMaskIntoConstraints="NO" id="IaZ-ts-eDq">
@@ -205,13 +205,13 @@
                                                                 <constraint firstAttribute="height" constant="24" id="qGV-eS-dfu"/>
                                                             </constraints>
                                                         </imageView>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Episode Manually Unarchived" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QSl-m4-wUL" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Episode Manually Unarchived" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QSl-m4-wUL" userLabel="message title" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                                             <rect key="frame" x="50" y="15.5" width="328" height="19.5"/>
                                                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It won't be auto archived by your new episode limit of 2" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aet-FO-Uny" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It won't be auto archived by your new episode limit of 2" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aet-FO-Uny" userLabel="message details" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                                             <rect key="frame" x="50" y="40" width="328" height="33.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                             <color key="textColor" red="0.53333333329999999" green="0.53333333329999999" blue="0.53333333329999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -221,7 +221,7 @@
                                                     <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <constraints>
                                                         <constraint firstAttribute="trailing" secondItem="QSl-m4-wUL" secondAttribute="trailing" constant="10" id="1N2-DP-UnX"/>
-                                                        <constraint firstAttribute="height" constant="90" id="4np-tx-sFq"/>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="90" id="4np-tx-sFq"/>
                                                         <constraint firstItem="QSl-m4-wUL" firstAttribute="leading" secondItem="IaZ-ts-eDq" secondAttribute="trailing" constant="13" id="aed-AB-AjT"/>
                                                         <constraint firstItem="IaZ-ts-eDq" firstAttribute="leading" secondItem="21U-r9-JP1" secondAttribute="leading" constant="13" id="cKh-1L-Egx"/>
                                                         <constraint firstItem="aet-FO-Uny" firstAttribute="leading" secondItem="QSl-m4-wUL" secondAttribute="leading" id="dvg-Dh-oMu"/>
@@ -236,7 +236,7 @@
                                                         </userDefinedRuntimeAttribute>
                                                     </userDefinedRuntimeAttributes>
                                                 </view>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x4a-0Q-f1h" customClass="PlayPauseButton" customModule="podcasts" customModuleProvider="target">
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x4a-0Q-f1h" userLabel="PlayPauseButton" customClass="PlayPauseButton" customModule="podcasts" customModuleProvider="target">
                                                     <rect key="frame" x="170" y="0.0" width="80" height="80"/>
                                                     <accessibility key="accessibilityConfiguration" label="Play/Pause Episode"/>
                                                     <constraints>
@@ -315,7 +315,7 @@
                                         <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="bTC-FT-bUv">
                                             <rect key="frame" x="200" y="40" width="20" height="20"/>
                                         </activityIndicatorView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unable to find show notes for this episode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gye-vZ-4Rq" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unable to find show notes for this episode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gye-vZ-4Rq" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                                             <rect key="frame" x="16" y="20" width="388" height="19.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                             <nil key="textColor"/>

--- a/podcasts/EpisodeDetailViewController.xib
+++ b/podcasts/EpisodeDetailViewController.xib
@@ -39,6 +39,7 @@
                 <outlet property="showNotesHolderView" destination="XID-El-uKH" id="56g-88-xn8"/>
                 <outlet property="showNotesHolderViewHeight" destination="mcc-50-BWR" id="qDt-pl-cxZ"/>
                 <outlet property="topDivider" destination="qhA-bj-I2z" id="crr-zD-Bi0"/>
+                <outlet property="transcriptExcerpt" destination="84p-ph-k8a" id="mFq-IO-gUl"/>
                 <outlet property="tryAgainButton" destination="X1H-6J-Cmx" id="YBC-c4-Ei8"/>
                 <outlet property="upNextBtn" destination="v4S-Or-iDs" id="ADZ-Da-7g4"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
@@ -229,10 +230,10 @@
                                                         <constraint firstAttribute="trailing" secondItem="19d-9v-ihd" secondAttribute="trailing" id="zFa-Ji-Z7t"/>
                                                     </constraints>
                                                 </view>
-                                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kW8-9S-AJu" userLabel="Message Container View">
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kW8-9S-AJu" userLabel="Message Container View">
                                                     <rect key="frame" x="0.0" y="130" width="420" height="130"/>
                                                     <subviews>
-                                                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="21U-r9-JP1" userLabel="Message View" customClass="RoundedBorderView" customModule="podcasts" customModuleProvider="target">
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="21U-r9-JP1" userLabel="Message View" customClass="RoundedBorderView" customModule="podcasts" customModuleProvider="target">
                                                             <rect key="frame" x="12" y="12" width="396" height="106"/>
                                                             <subviews>
                                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="episode-archive" translatesAutoresizingMaskIntoConstraints="NO" id="IaZ-ts-eDq" userLabel="message icon">
@@ -283,6 +284,12 @@
                                                         <constraint firstAttribute="bottom" secondItem="21U-r9-JP1" secondAttribute="bottom" constant="12" id="Mfn-NY-K4a" userLabel="bottom = Message View.bottom + 8"/>
                                                     </constraints>
                                                 </view>
+                                                <view contentMode="scaleToFill" id="84p-ph-k8a" userLabel="Excerpt">
+                                                    <rect key="frame" x="0.0" y="260" width="420" height="0.0"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <viewLayoutGuide key="safeArea" id="RyT-mf-9hU"/>
+                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </view>
                                             </subviews>
                                         </stackView>
                                     </subviews>
@@ -307,7 +314,7 @@
                                         <constraint firstItem="4IP-4N-SIa" firstAttribute="top" secondItem="SYi-ag-GDK" secondAttribute="top" constant="12" id="zTA-af-M9q"/>
                                     </constraints>
                                 </view>
-                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XID-El-uKH">
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XID-El-uKH" userLabel="ShowNotesHolderView">
                                     <rect key="frame" x="0.0" y="546" width="420" height="334"/>
                                     <subviews>
                                         <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="bTC-FT-bUv">

--- a/podcasts/FakeNavViewController.swift
+++ b/podcasts/FakeNavViewController.swift
@@ -272,7 +272,7 @@ class FakeNavViewController: PCViewController, UIScrollViewDelegate {
             fakeNavView.backgroundColor = ThemeColor.primaryUi01()
             fakeNavTitle.textColor = AppTheme.mainTextColor()
             updateButtonsBackgroundColors(tintColor: ThemeColor.primaryIcon01(), backgroundColor: .clear)
-            let config = UIImage.SymbolConfiguration(textStyle: UIFont.TextStyle(rawValue: "UICTFontTextStyleEmphasizedBody"), scale: .large)
+            let config = UIImage.SymbolConfiguration(pointSize: 22, weight: .semibold)
             backBtn.setImage(UIImage(systemName: "chevron.backward")?.withConfiguration(config), for: .normal)
             backBtnLeadingConstraint?.constant = 6
         }

--- a/podcasts/ShowNotesFormatter.swift
+++ b/podcasts/ShowNotesFormatter.swift
@@ -19,14 +19,15 @@ class ShowNotesFormatter {
             "<meta http-equiv='Content-Type' content='text/html; charset=utf-16le'>" +
             "<meta name='viewport' content='initial-scale=1.0' />" +
             "<style type='text/css'>" +
-            "body { font-family: '-apple-system'; font-size: 16px; line-height: 22px; letter-spacing: -0.1px;" +
+            ":root { font: -apple-system-body; } " +
+            "body { " +
             "background-color: \(cssBgColor);" +
             "color: \(textColor.hexString());" +
             "margin: 8px 16px; word-wrap: break-word; } " +
             "pre { white-space: pre-wrap; } " +
-            "a { color:\(tintColor.hexString()); font-family:'-apple-system'; text-decoration:underline; } " +
-            "h1,h2,h3,h4,h5,h6 { font-family: '-apple-system'; font-weight: normal; font-size: 16px; padding: 0; } " +
-            "customTitle { font-family: '-apple-system'; font-weight: 500; font-size: 20px; padding: 0; }" +
+            "a { color:\(tintColor.hexString()); text-decoration:underline; } " +
+            "h1,h2,h3,h4,h5,h6 { font-weight: normal; padding: 0; } " +
+            "customTitle { font-size: 1.25rem; font-weight: 500; padding: 0; }" +
             imageTag() +
             "</style>"
 

--- a/podcasts/TranscriptExcerptView.swift
+++ b/podcasts/TranscriptExcerptView.swift
@@ -111,6 +111,7 @@ struct TranscriptExcerptView<ViewModel: TranscriptExcerptViewModeling>: View {
                 }
                 Text(L10n.viewTranscript)
                     .font(size: 15.0, style: .body, weight: .medium)
+                    .fixedSize(horizontal: false, vertical: true)
                     .foregroundStyle(theme.primaryText01)
                     .redacted(if: viewModel.loadingState == .loading)
                 Spacer()

--- a/podcasts/TranscriptExcerptView.swift
+++ b/podcasts/TranscriptExcerptView.swift
@@ -88,6 +88,8 @@ struct TranscriptExcerptView<ViewModel: TranscriptExcerptViewModeling>: View {
         self.viewModel = viewModel
     }
 
+    @ScaledMetric(relativeTo: .largeTitle) private var iconSize = 16
+
     var body: some View {
         ZStack {
             Rectangle()
@@ -102,9 +104,10 @@ struct TranscriptExcerptView<ViewModel: TranscriptExcerptViewModeling>: View {
             HStack(spacing: 12.0) {
                 if viewModel.isGeneratedTranscript {
                     Image("generated_transcript")
+                        .resizable()
                         .renderingMode(.template)
                         .foregroundStyle(theme.primaryIcon02)
-                        .frame(width: 16, height: 16)
+                        .frame(width: iconSize, height: iconSize)
                 }
                 Text(L10n.viewTranscript)
                     .font(size: 15.0, style: .body, weight: .medium)
@@ -112,8 +115,10 @@ struct TranscriptExcerptView<ViewModel: TranscriptExcerptViewModeling>: View {
                     .redacted(if: viewModel.loadingState == .loading)
                 Spacer()
                 Image("listview_arrow")
+                    .resizable()
                     .renderingMode(.template)
                     .foregroundStyle(theme.primaryIcon02)
+                    .frame(width: iconSize/2, height: iconSize)
             }
             .padding(.horizontal, 16.0)
         }


### PR DESCRIPTION
| 📘 Part of: #[Dynamic Type](https://linear.app/a8c/project/ios-support-dynamic-type-across-the-app-be093c5c4111/overview) |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-498 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates Episode Detail to support dynamic types

| xs | Default | xxxL | AX5 |
| - | - | - | - |
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2026-02-09 at 09 58 39" src="https://github.com/user-attachments/assets/ae680ad8-f00f-4ce6-acaa-6b32fc6873d0" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2026-02-09 at 09 58 50" src="https://github.com/user-attachments/assets/a5a5b3ee-4a1e-4627-958f-4348a8b14f9d" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2026-02-09 at 09 58 59" src="https://github.com/user-attachments/assets/a9530447-398f-4678-b71d-d7ef69ae25b9" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 15 - 2026-02-09 at 09 59 23" src="https://github.com/user-attachments/assets/cc16863f-324b-40f4-89ef-73343e0c61a5" /> |


## To test

1. Start the app
2. Open a Podcast
3. Open an Episode detail for the podcast
4. Check if view displays correctly for the current text size
5. Check different states of the buttons: Download, Archive, UpNext, Played
6. Test different sizes of Text size and see if layout adapts correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
