### PR TITLE
[Dynamic type] Update podcast grid cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Dynamic Type: Update Settings [#3896](https://github.com/Automattic/pocket-casts-ios/pull/3896)
 - Dynamic Type: Update Profile View [#3894](https://github.com/Automattic/pocket-casts-ios/pull/3894)
 - Dynamic Type: Update Episode Detail View [#3926](https://github.com/Automattic/pocket-casts-ios/pull/3926)
+- Dynamic Type: Update Episode Detail View [#3931](https://github.com/Automattic/pocket-casts-ios/pull/3931)
 
 8.5
 -----

--- a/podcasts/FolderPreviewView.swift
+++ b/podcasts/FolderPreviewView.swift
@@ -125,7 +125,8 @@ class FolderPreviewView: UIView {
                 label.numberOfLines = 1
                 label.textColor = UIColor.white
                 label.textAlignment = .center
-                label.font = UIFont.systemFont(ofSize: 11, weight: .semibold)
+                label.font = UIFont.font(ofSize: 11, weight: .semibold, scalingWith: .caption2)
+                label.adjustsFontForContentSizeCategory = true
                 addSubview(label)
 
                 nameLabelVerticalPositionConstraint = label.centerYAnchor.constraint(equalTo: bottomAnchor, constant: -labelBottomMargin)

--- a/podcasts/GridBadgeView.swift
+++ b/podcasts/GridBadgeView.swift
@@ -6,6 +6,7 @@ class GridBadgeView: UIView {
     private let simpleBadge = CircleView()
 
     private var labelWidthConstraint: NSLayoutConstraint!
+    private var labelHeightConstraint: NSLayoutConstraint!
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -45,16 +46,12 @@ class GridBadgeView: UIView {
             simpleBadge.isHidden = true
             badgeLabel.isHidden = false
             badgeLabel.text = count < 99 ? "\(count)" : "99"
-            let metrics = UIFontMetrics(forTextStyle: .largeTitle)
-            if count > 9 {
-                labelWidthConstraint.constant = max(34, metrics.scaledValue(for: 34))
-            } else {
-                labelWidthConstraint.constant = max(25, metrics.scaledValue(for: 25))
-            }
         case .off:
             simpleBadge.isHidden = true
             badgeLabel.isHidden = true
         }
+
+        updateSize()
     }
 
     private func setup() {
@@ -66,8 +63,9 @@ class GridBadgeView: UIView {
         badgeLabel.layer.cornerRadius = 12
         addSubview(badgeLabel)
         labelWidthConstraint = badgeLabel.widthAnchor.constraint(equalToConstant: 25)
+        labelHeightConstraint = badgeLabel.heightAnchor.constraint(equalToConstant: 25)
         NSLayoutConstraint.activate([
-            badgeLabel.heightAnchor.constraint(equalToConstant: 25),
+            labelHeightConstraint,
             labelWidthConstraint,
             badgeLabel.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
@@ -85,6 +83,7 @@ class GridBadgeView: UIView {
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
 
         updateBadgeColors()
+        updateSize()
     }
 
     @objc private func themeDidChange() {
@@ -112,14 +111,18 @@ class GridBadgeView: UIView {
     }
 
     private func updateSize() {
-        guard let text = badgeLabel.text else {
-            return
-        }
         let metrics = UIFontMetrics(forTextStyle: .largeTitle)
-        if text.count > 1 {
+        simpleBadge.updateSizeConstraints(to: max(15, metrics.scaledValue(for: 15)))
+
+        if let text = badgeLabel.text, text.count > 1 {
             labelWidthConstraint.constant = max(34, metrics.scaledValue(for: 34))
         } else {
             labelWidthConstraint.constant = max(25, metrics.scaledValue(for: 25))
         }
+
+        let heightConstraint = max(25, metrics.scaledValue(for: 25))
+        labelHeightConstraint.constant = heightConstraint
+
+        badgeLabel.layer.cornerRadius = heightConstraint / 2
     }
 }

--- a/podcasts/GridBadgeView.swift
+++ b/podcasts/GridBadgeView.swift
@@ -45,10 +45,11 @@ class GridBadgeView: UIView {
             simpleBadge.isHidden = true
             badgeLabel.isHidden = false
             badgeLabel.text = count < 99 ? "\(count)" : "99"
+            let metrics = UIFontMetrics(forTextStyle: .largeTitle)
             if count > 9 {
-                labelWidthConstraint.constant = 34
+                labelWidthConstraint.constant = max(34, metrics.scaledValue(for: 34))
             } else {
-                labelWidthConstraint.constant = 25
+                labelWidthConstraint.constant = max(25, metrics.scaledValue(for: 25))
             }
         case .off:
             simpleBadge.isHidden = true
@@ -57,7 +58,8 @@ class GridBadgeView: UIView {
     }
 
     private func setup() {
-        badgeLabel.font = UIFont.systemFont(ofSize: 13, weight: .bold)
+        badgeLabel.font = UIFont.font(ofSize: 13, weight: .bold, scalingWith: .largeTitle)
+        badgeLabel.adjustsFontForContentSizeCategory = true
         badgeLabel.translatesAutoresizingMaskIntoConstraints = false
         badgeLabel.textAlignment = .center
         badgeLabel.layer.borderWidth = 3
@@ -99,5 +101,25 @@ class GridBadgeView: UIView {
         simpleBadge.borderColor = ThemeColor.primaryUi02()
         simpleBadge.centerColor = ThemeColor.primaryInteractive01()
         simpleBadge.backgroundColor = .clear
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
+            updateSize()
+        }
+    }
+
+    private func updateSize() {
+        guard let text = badgeLabel.text else {
+            return
+        }
+        let metrics = UIFontMetrics(forTextStyle: .largeTitle)
+        if text.count > 1 {
+            labelWidthConstraint.constant = max(34, metrics.scaledValue(for: 34))
+        } else {
+            labelWidthConstraint.constant = max(25, metrics.scaledValue(for: 25))
+        }
     }
 }

--- a/podcasts/GridHelper.swift
+++ b/podcasts/GridHelper.swift
@@ -66,6 +66,9 @@ class GridHelper {
                 divideBy = gridType == .threeByThree ? 3 : 4
             }
         }
+        if  collectionView.traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            divideBy = floor(divideBy / 2)
+        }
 
         let availableWidth = viewWidth - (spacing * (divideBy-1))
         let cellWidth =  availableWidth / divideBy


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-503 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Update podcast grid cells to support dynamic type
| Default | xxxL | AX5 |
| - | - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-10 at 15 41 07" src="https://github.com/user-attachments/assets/b58a7e58-f566-4225-8ca8-31879303b1a9" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-10 at 15 40 59" src="https://github.com/user-attachments/assets/1648cccc-e611-4636-b375-1862a0df0676" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-10 at 15 40 51" src="https://github.com/user-attachments/assets/eb0611ed-6c09-4dce-ac73-bd2fe000f257" /> |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-10 at 15 40 23" src="https://github.com/user-attachments/assets/5386acdb-999d-41c8-9dcf-c91a7a7ddb1d" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-10 at 15 40 35" src="https://github.com/user-attachments/assets/020a6b07-c2ad-44e3-a61a-5ad1d3391e1f" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-10 at 15 40 43" src="https://github.com/user-attachments/assets/27b45c46-5ffc-4bf8-9608-4b1e9045bcf4" /> |

## To test

1. Start the app
2. Open the podcast tab
3. Choose one grid layout
4. Select to show unlistened badges
5. Ensure that you have folders and podcasts in your list
6. Choose the larger grid layout
7. Change Dynamic Type settings and see if folder label, the badge text  update
8. On larger accessibility sizes, the number of cells for row should change
9. Repeat the test with the smaller grid layout

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
