### PR TITLE
Add Claude Code tool permissions and feedback loop instructions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,10 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(make:*)",
+      "Bash(swift package:*)"
+    ]
+  },
   "hooks": {
     "PostToolUse": [
       {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 @AGENTS.md
 
+## Slow commands
+
+`swift`, `xcodebuild`, and `fastlane` commands can take several minutes.
+Account for this when setting `max_turns` on parallel subagents — 40 or higher is a safe default.
+
 ## Opening Pull Requests
 
 Before opening a PR, read the `Dangerfile` and proactively satisfy its checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,5 @@
 @AGENTS.md
+
+## Opening Pull Requests
+
+Before opening a PR, read the `Dangerfile` and proactively satisfy its checks.


### PR DESCRIPTION
## Summary

Adds `make` and `swift package` to the Claude Code team-level allow list so agents can lint, build, and resolve packages without manual approval.

Context: https://linear.app/a8c/issue/AINFRA-1965/add-first-round-of-permissions-allow-lists-to-apple-projects

## Test Plan

- [ ] CI passes