### PR TITLE
Handle new podcast URL format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 8.5
 -----
 - Fix removal of User Episode Files when selecting multiple episodes [#3898](https://github.com/Automattic/pocket-casts-ios/pull/3898)
+- Fix URL handling from iMessage [#3937](https://github.com/Automattic/pocket-casts-ios/pull/3937)
 
 8.4
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Formatting/SignificantDigitsFormatStyle.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Formatting/SignificantDigitsFormatStyle.swift
@@ -11,6 +11,7 @@ public struct SignificantDigitsFormatStyle: FormatStyle {
     public func format(_ value: TimeInterval) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = false
         formatter.usesSignificantDigits = true
         formatter.minimumSignificantDigits = significantDigits
         formatter.maximumSignificantDigits = significantDigits

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -471,27 +471,38 @@ extension AppDelegate {
     func openSharePath(_ path: String, controller: UIViewController, onErrorOpen: URL?) {
         progressDialog = ShiftyLoadingAlert(title: L10n.sharedItemLoading)
         progressDialog?.showAlert(controller, hasProgress: false) {
+            // Parse the URL into path and query components so that any query parameters
+            // (e.g. ?t=123) do not interfere with UUID extraction.
+            let urlComponents = URLComponents(string: path)
+            let cleanPath = urlComponents?.path.isEmpty == false ? urlComponents!.path : path
+            let timestamp: Double? = {
+                guard let queryItems = urlComponents?.queryItems else { return nil }
+                guard let tItem = queryItems.first(where: { $0.name == "t" }) else { return nil }
+                guard let value = tItem.value, let doubleValue = Double(value) else { return nil }
+                return doubleValue
+            }()
+
             // URLs that are already in the format https://pca.st/podcast/da3271a0-69e7-0132-d9fd-5f4c86fd3263 (or /private/) have the podcast UUID in them already so no need to ask the refresh server for it
             // Also handles new format: /podcast/{podcastSlug}/{podcastUuid}/{episodeSlug}/{episodeUuid}
-            if path.contains("/podcast/") || path.contains("/private/") {
+            if cleanPath.contains("/podcast/") || cleanPath.contains("/private/") {
                 // Check for new format with episode: /podcast/{slug}/{podcastUuid}/{episodeSlug}/{episodeUuid}
-                if let podcastRange = path.range(of: "/podcast/") ?? path.range(of: "/private/") {
-                    let afterPodcast = String(path[podcastRange.upperBound...])
+                if let podcastRange = cleanPath.range(of: "/podcast/") ?? cleanPath.range(of: "/private/") {
+                    let afterPodcast = String(cleanPath[podcastRange.upperBound...])
                     let components = afterPodcast.split(separator: "/").map(String.init)
 
                     // New format: 4 components = podcastSlug, podcastUuid, episodeSlug, episodeUuid
                     if components.count == 4 {
                         let podcastUuid = components[1]
                         let episodeUuid = components[3]
-                        self.loadAndShowEpisode(episodeUuid: episodeUuid, podcastUuid: podcastUuid, timestamp: nil)
+                        self.loadAndShowEpisode(episodeUuid: episodeUuid, podcastUuid: podcastUuid, timestamp: timestamp)
                         return
                     }
                 }
 
                 // Original format: just podcast UUID as last component
-                if let lastSlashIndex = path.lastIndex(of: "/") {
-                    let startIndex = path.index(lastSlashIndex, offsetBy: 1)
-                    let uuid = path.suffix(from: startIndex)
+                if let lastSlashIndex = cleanPath.lastIndex(of: "/") {
+                    let startIndex = cleanPath.index(lastSlashIndex, offsetBy: 1)
+                    let uuid = cleanPath.suffix(from: startIndex)
                     let podcastHeader = PodcastHeader(uuid: String(uuid))
                     DispatchQueue.main.async {
                         self.hideProgressDialog()

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -472,7 +472,23 @@ extension AppDelegate {
         progressDialog = ShiftyLoadingAlert(title: L10n.sharedItemLoading)
         progressDialog?.showAlert(controller, hasProgress: false) {
             // URLs that are already in the format https://pca.st/podcast/da3271a0-69e7-0132-d9fd-5f4c86fd3263 (or /private/) have the podcast UUID in them already so no need to ask the refresh server for it
+            // Also handles new format: /podcast/{podcastSlug}/{podcastUuid}/{episodeSlug}/{episodeUuid}
             if path.contains("/podcast/") || path.contains("/private/") {
+                // Check for new format with episode: /podcast/{slug}/{podcastUuid}/{episodeSlug}/{episodeUuid}
+                if let podcastRange = path.range(of: "/podcast/") ?? path.range(of: "/private/") {
+                    let afterPodcast = String(path[podcastRange.upperBound...])
+                    let components = afterPodcast.split(separator: "/").map(String.init)
+
+                    // New format: 4 components = podcastSlug, podcastUuid, episodeSlug, episodeUuid
+                    if components.count == 4 {
+                        let podcastUuid = components[1]
+                        let episodeUuid = components[3]
+                        self.loadAndShowEpisode(episodeUuid: episodeUuid, podcastUuid: podcastUuid, timestamp: nil)
+                        return
+                    }
+                }
+
+                // Original format: just podcast UUID as last component
                 if let lastSlashIndex = path.lastIndex(of: "/") {
                     let startIndex = path.index(lastSlashIndex, offsetBy: 1)
                     let uuid = path.suffix(from: startIndex)


### PR DESCRIPTION
Fixes [PCIOS-486](https://linear.app/a8c/issue/PCIOS-486/cant-open-episode-shares-via-imessage)

Depending on how the URL is opened, the app may receive this URL format and be unable to open it:

https://pocketcasts.com/podcast/all-the-hacks-money-points-life/1856a0c0-731d-0139-3455-0acc26574db2/i-built-an-ai-assistant-that-works-while-i-sleep/c061531a-037a-4b63-8c34-aeeeb3fb2638?t=627,687

Also, this fixes an issue with the truncating formatter for the timestamps. A thousands separator was used for the clip URL:

**Wrong**
```
https://pocketcasts.com/podcast/all-the-hacks-money-points-life/1856a0c0-731d-0139-3455-0acc26574db2/i-built-an-ai-assistant-that-works-while-i-sleep/c061531a-037a-4b63-8c34-aeeeb3fb2638?t=1,627,1,687
```

**Right**
```
https://pocketcasts.com/podcast/all-the-hacks-money-points-life/1856a0c0-731d-0139-3455-0acc26574db2/i-built-an-ai-assistant-that-works-while-i-sleep/c061531a-037a-4b63-8c34-aeeeb3fb2638?t=1627,1687
```

## To test

#### Episode Link
* Share an episode link by navigating to Share > Episode > Copy Link
* Send the link in iMessage
* ✅ Verify that tapping "Open" in the App Clip opens the correct page

#### Podcast Link
* Share a podcast link by navigating to Share > Podcast > Copy Link
* Send the link in iMessage
* ✅ Verify that tapping "Open" in the App Clip opens the correct page

#### Current Position Link
* Share a clip link by navigating to Share > Current Position > Copy Link
* Send the link in iMessage
* ✅ Verify that tapping "Open" in the App Clip opens the correct page

#### Clip Link
* Share a clip link by navigating to Share > Clip > Copy Link
* Send the link in iMessage
* ✅ Verify that tapping "Open" in the App Clip opens the correct page

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
