### PR TITLE
[Watch + Up Next] Up Next comparator updates

### DIFF
--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
@@ -15,6 +15,7 @@ public struct UpNextListComparator {
                                watchEpisodeCount: Int,
                                lastServerRefresh: Date?,
                                lastWatchDataTime: Date,
+                               lastLocalQueueChange: Date? = nil,
                                useConservativeComparison: Bool = true) -> UpNextComparisonResult {
         // Handle nil (no phone context received yet) vs empty (phone intentionally sent empty queue)
         guard let phoneEpisodes = phoneEpisodes else {
@@ -69,20 +70,16 @@ public struct UpNextListComparator {
             }
         }
 
-        if lastServerRefresh > lastWatchDataTime {
-            FileLog.shared.addMessage("WatchSyncManager: Phone data is newer (lastServerRefresh: \(lastServerRefresh) > lastDataTime: \(lastWatchDataTime)), returning .phoneNeedsUpdate")
+        // Check if Watch made local queue changes AFTER receiving the latest phone data.
+        // If so, those local changes should sync to the server.
+        if let localChange = lastLocalQueueChange, localChange > lastWatchDataTime {
+            FileLog.shared.addMessage("WatchSyncManager: Local queue change (\(localChange)) is newer than phone data (\(lastWatchDataTime)), returning .phoneNeedsUpdate")
             return .phoneNeedsUpdate
-        } else if lastServerRefresh < lastWatchDataTime {
-            FileLog.shared.addMessage("WatchSyncManager: Watch data is newer (lastServerRefresh: \(lastServerRefresh) < lastDataTime: \(lastWatchDataTime)), returning .watchNeedsUpdate")
-            return .watchNeedsUpdate
-        } else {
-            if useConservativeComparison {
-                FileLog.shared.addMessage("WatchSyncManager: Timestamps are equal, returning .same")
-                return .same
-            } else {
-                return .watchNeedsUpdate
-            }
         }
+
+        // No local changes after phone data - phone is source of truth
+        FileLog.shared.addMessage("WatchSyncManager: No local changes after phone data, returning .watchNeedsUpdate (phone is source of truth)")
+        return .watchNeedsUpdate
     }
 }
 

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
@@ -16,11 +16,25 @@ public struct UpNextListComparator {
                                lastServerRefresh: Date?,
                                lastWatchDataTime: Date,
                                useConservativeComparison: Bool = true) -> UpNextComparisonResult {
-        guard let phoneEpisodes = phoneEpisodes, phoneEpisodes.count > 0 else {
+        // Handle nil (no phone context received yet) vs empty (phone intentionally sent empty queue)
+        guard let phoneEpisodes = phoneEpisodes else {
+            // No phone context received - we don't have enough info to make a decision
             if watchEpisodeCount == 0 {
                 return .same
             } else {
-                return .phoneNeedsUpdate
+                FileLog.shared.addMessage("WatchSyncManager: No phone context received but watch has \(watchEpisodeCount) episodes - Not enough information")
+                return .notEnoughInformation
+            }
+        }
+
+        guard phoneEpisodes.count > 0 else {
+            if watchEpisodeCount == 0 {
+                return .same
+            } else {
+                // Phone explicitly sent empty queue - this is intentional (user cleared queue on phone)
+                // Watch should update FROM phone, not push stale data TO server
+                FileLog.shared.addMessage("WatchSyncManager: Phone sent empty queue but watch has \(watchEpisodeCount) episodes - Watch needs update")
+                return .watchNeedsUpdate
             }
         }
 

--- a/Pocket Casts Watch App/WatchDataManager.swift
+++ b/Pocket Casts Watch App/WatchDataManager.swift
@@ -188,4 +188,21 @@ class WatchDataManager {
         }
         return lastTime
     }
+
+    /// Records when the Watch user explicitly made a local queue change (add/remove/clear).
+    /// This is separate from lastDataTime which tracks when phone data was received.
+    class func recordLocalQueueChange() {
+        guard FeatureFlag.watchUpNextSyncFix.enabled else { return }
+        UserDefaults.standard.set(Date(), forKey: WatchConstants.UserDefaults.lastLocalQueueChange)
+    }
+
+    /// Returns the timestamp of the last local queue change made by the Watch user, or nil if none.
+    class func lastLocalQueueChange() -> Date? {
+        UserDefaults.standard.object(forKey: WatchConstants.UserDefaults.lastLocalQueueChange) as? Date
+    }
+
+    /// Clears the local queue change timestamp after it has been synced.
+    class func clearLocalQueueChange() {
+        UserDefaults.standard.removeObject(forKey: WatchConstants.UserDefaults.lastLocalQueueChange)
+    }
 }

--- a/Pocket Casts Watch App/WatchSourceViewModel.swift
+++ b/Pocket Casts Watch App/WatchSourceViewModel.swift
@@ -122,13 +122,13 @@ class WatchSourceViewModel: PlaySourceViewModel {
 
     func removeFromUpNext(episode: BaseEpisode) {
         PlaybackManager.shared.removeIfPlayingOrQueued(episode: episode, fireNotification: true)
-        WatchDataManager.updateLastDataTime()
+        WatchDataManager.recordLocalQueueChange()
     }
 
     func addToUpNext(episode: BaseEpisode, toTop: Bool) {
         PlaybackManager.shared.removeIfPlayingOrQueued(episode: episode, fireNotification: false)
         PlaybackManager.shared.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: toTop)
-        WatchDataManager.updateLastDataTime()
+        WatchDataManager.recordLocalQueueChange()
     }
 
     func archive(episode: BaseEpisode) {
@@ -233,7 +233,7 @@ class WatchSourceViewModel: PlaySourceViewModel {
 
     func clearUpNext() {
         PlaybackManager.shared.queue.clearUpNextList()
-        WatchDataManager.updateLastDataTime()
+        WatchDataManager.recordLocalQueueChange()
     }
 
     // MARK: Now Playing

--- a/Pocket Casts Watch App/WatchSyncManager.swift
+++ b/Pocket Casts Watch App/WatchSyncManager.swift
@@ -312,6 +312,7 @@ class WatchSyncManager {
             watchEpisodeCount: PlaybackManager.shared.queue.upNextCount(),
             lastServerRefresh: ServerSettings.lastRefreshStartTime(),
             lastWatchDataTime: WatchDataManager.lastDataTime(),
+            lastLocalQueueChange: WatchDataManager.lastLocalQueueChange(),
             useConservativeComparison: FeatureFlag.watchUpNextSyncFix.enabled
         )
     }

--- a/PocketCastsTests/Tests/Watch/WatchSyncManagerTests.swift
+++ b/PocketCastsTests/Tests/Watch/WatchSyncManagerTests.swift
@@ -133,7 +133,7 @@ final class WatchSyncManagerTests: XCTestCase {
         XCTAssertEqual(result, .same)
     }
 
-    func testEpisodeComparison_WatchHasEpisodesPhoneEmpty_ReturnsPhoneNeedsUpdate() {
+    func testEpisodeComparison_WatchHasEpisodesPhoneNil_ReturnsNotEnoughInformation() {
         let watchEpisodes = [makeEpisode(uuid: "watch-1")]
 
         let result = compare(
@@ -142,7 +142,19 @@ final class WatchSyncManagerTests: XCTestCase {
             watchEpisodeCount: watchEpisodes.count
         )
 
-        XCTAssertEqual(result, .phoneNeedsUpdate)
+        XCTAssertEqual(result, .notEnoughInformation)
+    }
+
+    func testEpisodeComparison_WatchHasEpisodesPhoneExplicitlyEmpty_ReturnsWatchNeedsUpdate() {
+        let watchEpisodes = [makeEpisode(uuid: "watch-1")]
+
+        let result = compare(
+            phoneEpisodes: [],
+            watchEpisodes: watchEpisodes,
+            watchEpisodeCount: watchEpisodes.count
+        )
+
+        XCTAssertEqual(result, .watchNeedsUpdate)
     }
 
     func testEpisodeComparison_TruncatedList_ReturnsNotEnoughInformation() {
@@ -217,6 +229,27 @@ final class WatchSyncManagerTests: XCTestCase {
 
         wait(for: [expectation], timeout: debounceTimeout)
         XCTAssertEqual(fireCount, 1)
+    }
+
+    func testIntegration_PhoneClearedQueue_ShouldPullFromPhone() {
+        let watchEpisodes = [makeEpisode(uuid: "watch-1"), makeEpisode(uuid: "watch-2")]
+
+        let comparisonResult = compare(
+            phoneEpisodes: [],
+            phoneUpNextCount: 0,
+            watchEpisodes: watchEpisodes,
+            watchEpisodeCount: watchEpisodes.count,
+            lastServerRefresh: Date(timeIntervalSince1970: 100),
+            lastWatchDataTime: Date(timeIntervalSince1970: 50)
+        )
+
+        XCTAssertEqual(comparisonResult, .watchNeedsUpdate)
+        XCTAssertTrue(WatchSyncDecision.shouldPerformBackgroundRefresh(
+            isPlusUser: true,
+            isAppInBackground: true,
+            comparisonResult: comparisonResult,
+            isFirstSyncInProgress: false
+        ))
     }
 
     // MARK: - Regression Tests for Original Bug

--- a/PocketCastsTests/Tests/Watch/WatchSyncManagerTests.swift
+++ b/PocketCastsTests/Tests/Watch/WatchSyncManagerTests.swift
@@ -19,6 +19,7 @@ final class WatchSyncManagerTests: XCTestCase {
                          watchEpisodeCount: Int? = nil,
                          lastServerRefresh: Date? = Date(timeIntervalSince1970: 0),
                          lastWatchDataTime: Date = Date(timeIntervalSince1970: 0),
+                         lastLocalQueueChange: Date? = nil,
                          useConservativeComparison: Bool = true) -> UpNextComparisonResult {
         UpNextListComparator.compare(
             phoneEpisodes: phoneEpisodes,
@@ -27,6 +28,7 @@ final class WatchSyncManagerTests: XCTestCase {
             watchEpisodeCount: watchEpisodeCount ?? watchEpisodes.count,
             lastServerRefresh: lastServerRefresh,
             lastWatchDataTime: lastWatchDataTime,
+            lastLocalQueueChange: lastLocalQueueChange,
             useConservativeComparison: useConservativeComparison
         )
     }
@@ -78,7 +80,8 @@ final class WatchSyncManagerTests: XCTestCase {
         XCTAssertEqual(result, .notEnoughInformation)
     }
 
-    func testTimestampComparison_PhoneNewer_ReturnsPhoneNeedsUpdate() {
+    func testTimestampComparison_NoLocalChanges_ReturnsWatchNeedsUpdate() {
+        // When there are no local changes, phone is always source of truth
         let phoneEpisodes = [makeEpisode(uuid: "phone-1")]
         let watchEpisodes = [makeEpisode(uuid: "watch-1")]
         let lastServerRefresh = Date(timeIntervalSince1970: 200)
@@ -88,41 +91,49 @@ final class WatchSyncManagerTests: XCTestCase {
             phoneEpisodes: phoneEpisodes,
             watchEpisodes: watchEpisodes,
             lastServerRefresh: lastServerRefresh,
-            lastWatchDataTime: lastWatchDataTime
-        )
-
-        XCTAssertEqual(result, .phoneNeedsUpdate)
-    }
-
-    func testTimestampComparison_WatchNewer_ReturnsWatchNeedsUpdate() {
-        let phoneEpisodes = [makeEpisode(uuid: "phone-1")]
-        let watchEpisodes = [makeEpisode(uuid: "watch-1")]
-        let lastServerRefresh = Date(timeIntervalSince1970: 100)
-        let lastWatchDataTime = Date(timeIntervalSince1970: 200)
-
-        let result = compare(
-            phoneEpisodes: phoneEpisodes,
-            watchEpisodes: watchEpisodes,
-            lastServerRefresh: lastServerRefresh,
-            lastWatchDataTime: lastWatchDataTime
+            lastWatchDataTime: lastWatchDataTime,
+            lastLocalQueueChange: nil
         )
 
         XCTAssertEqual(result, .watchNeedsUpdate)
     }
 
-    func testTimestampComparison_EqualTimestamps_ReturnsSame() {
+    func testTimestampComparison_LocalChangeBeforePhoneData_ReturnsWatchNeedsUpdate() {
+        // Local change happened BEFORE receiving phone data, so phone is still source of truth
         let phoneEpisodes = [makeEpisode(uuid: "phone-1")]
         let watchEpisodes = [makeEpisode(uuid: "watch-1")]
-        let lastServerRefresh = Date(timeIntervalSince1970: 100)
+        let lastServerRefresh = Date(timeIntervalSince1970: 200)
+        let lastWatchDataTime = Date(timeIntervalSince1970: 150)
+        let lastLocalQueueChange = Date(timeIntervalSince1970: 100) // Before phone data
 
         let result = compare(
             phoneEpisodes: phoneEpisodes,
             watchEpisodes: watchEpisodes,
             lastServerRefresh: lastServerRefresh,
-            lastWatchDataTime: lastServerRefresh
+            lastWatchDataTime: lastWatchDataTime,
+            lastLocalQueueChange: lastLocalQueueChange
         )
 
-        XCTAssertEqual(result, .same)
+        XCTAssertEqual(result, .watchNeedsUpdate)
+    }
+
+    func testTimestampComparison_LocalChangeAfterPhoneData_ReturnsPhoneNeedsUpdate() {
+        // Local change happened AFTER receiving phone data, so Watch changes should sync
+        let phoneEpisodes = [makeEpisode(uuid: "phone-1")]
+        let watchEpisodes = [makeEpisode(uuid: "watch-1")]
+        let lastServerRefresh = Date(timeIntervalSince1970: 200)
+        let lastWatchDataTime = Date(timeIntervalSince1970: 100)
+        let lastLocalQueueChange = Date(timeIntervalSince1970: 150) // After phone data
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: lastServerRefresh,
+            lastWatchDataTime: lastWatchDataTime,
+            lastLocalQueueChange: lastLocalQueueChange
+        )
+
+        XCTAssertEqual(result, .phoneNeedsUpdate)
     }
 
     // MARK: - compareUpNextLists Episode Comparison Tests
@@ -182,7 +193,8 @@ final class WatchSyncManagerTests: XCTestCase {
         XCTAssertEqual(result, .same)
     }
 
-    func testEpisodeComparison_DifferentEpisodes_FallsBackToTimestamp() {
+    func testEpisodeComparison_DifferentEpisodes_NoLocalChanges_ReturnsWatchNeedsUpdate() {
+        // When episodes differ but no local changes, phone is source of truth
         let phoneEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-2")]
         let watchEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-3")]
         let lastServerRefresh = Date(timeIntervalSince1970: 200)
@@ -192,7 +204,27 @@ final class WatchSyncManagerTests: XCTestCase {
             phoneEpisodes: phoneEpisodes,
             watchEpisodes: watchEpisodes,
             lastServerRefresh: lastServerRefresh,
-            lastWatchDataTime: lastWatchDataTime
+            lastWatchDataTime: lastWatchDataTime,
+            lastLocalQueueChange: nil
+        )
+
+        XCTAssertEqual(result, .watchNeedsUpdate)
+    }
+
+    func testEpisodeComparison_DifferentEpisodes_WithLocalChanges_ReturnsPhoneNeedsUpdate() {
+        // When episodes differ AND Watch made local changes after phone data, sync Watch to server
+        let phoneEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-2")]
+        let watchEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-3")]
+        let lastServerRefresh = Date(timeIntervalSince1970: 200)
+        let lastWatchDataTime = Date(timeIntervalSince1970: 100)
+        let lastLocalQueueChange = Date(timeIntervalSince1970: 150) // After phone data
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: lastServerRefresh,
+            lastWatchDataTime: lastWatchDataTime,
+            lastLocalQueueChange: lastLocalQueueChange
         )
 
         XCTAssertEqual(result, .phoneNeedsUpdate)
@@ -255,6 +287,7 @@ final class WatchSyncManagerTests: XCTestCase {
     // MARK: - Regression Tests for Original Bug
 
     func testRegression_WatchShouldNotOverwritePhoneWithStaleData() {
+        // When Watch has different data but no local changes, phone is source of truth
         let phoneEpisodes = [makeEpisode(uuid: "ep-1")]
         let watchEpisodes = [makeEpisode(uuid: "ep-2")]
 
@@ -262,25 +295,49 @@ final class WatchSyncManagerTests: XCTestCase {
             phoneEpisodes: phoneEpisodes,
             watchEpisodes: watchEpisodes,
             lastServerRefresh: nil,
-            lastWatchDataTime: Date(timeIntervalSince1970: 100)
+            lastWatchDataTime: Date(timeIntervalSince1970: 100),
+            lastLocalQueueChange: nil
         )
 
+        // With no server refresh timestamp in conservative mode, we don't have enough info
         XCTAssertEqual(result, .notEnoughInformation)
     }
 
-    func testRegression_EqualTimestampsShouldNotTriggerSync() {
+    func testRegression_WatchWithStaleDataNoLocalChanges_ShouldUpdateFromPhone() {
+        // Watch has stale data (old episodes), no local changes → pull from phone
         let phoneEpisodes = [makeEpisode(uuid: "ep-1")]
-        let watchEpisodes = [makeEpisode(uuid: "ep-2")]
-        let timestamp = Date(timeIntervalSince1970: 100)
+        let watchEpisodes = [makeEpisode(uuid: "ep-2"), makeEpisode(uuid: "ep-3"), makeEpisode(uuid: "ep-4")]
+        let lastServerRefresh = Date(timeIntervalSince1970: 100)
+        let lastWatchDataTime = Date(timeIntervalSince1970: 50)
 
         let result = compare(
             phoneEpisodes: phoneEpisodes,
             watchEpisodes: watchEpisodes,
-            lastServerRefresh: timestamp,
-            lastWatchDataTime: timestamp
+            lastServerRefresh: lastServerRefresh,
+            lastWatchDataTime: lastWatchDataTime,
+            lastLocalQueueChange: nil
         )
 
-        XCTAssertEqual(result, .same)
+        XCTAssertEqual(result, .watchNeedsUpdate)
+    }
+
+    func testRegression_WatchLocalChanges_ShouldSyncToServer() {
+        // Watch user made local changes → those should sync to server
+        let phoneEpisodes = [makeEpisode(uuid: "ep-1")]
+        let watchEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-2")]
+        let lastServerRefresh = Date(timeIntervalSince1970: 100)
+        let lastWatchDataTime = Date(timeIntervalSince1970: 50)
+        let lastLocalQueueChange = Date(timeIntervalSince1970: 75) // After phone data
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: lastServerRefresh,
+            lastWatchDataTime: lastWatchDataTime,
+            lastLocalQueueChange: lastLocalQueueChange
+        )
+
+        XCTAssertEqual(result, .phoneNeedsUpdate)
     }
 
     func testRegression_NoTimestampShouldNotTriggerSync() {
@@ -295,5 +352,62 @@ final class WatchSyncManagerTests: XCTestCase {
         )
 
         XCTAssertEqual(result, .notEnoughInformation)
+    }
+
+    // MARK: - Watch Queue Management Tests
+
+    func testWatchQueueManagement_AddEpisodeOnWatch_ShouldSync() {
+        // User adds an episode on Watch after receiving phone data
+        let phoneEpisodes = [makeEpisode(uuid: "ep-1")]
+        let watchEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-2")]
+        let lastWatchDataTime = Date(timeIntervalSince1970: 100)
+        let lastLocalQueueChange = Date(timeIntervalSince1970: 150) // User added ep-2
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: Date(timeIntervalSince1970: 200),
+            lastWatchDataTime: lastWatchDataTime,
+            lastLocalQueueChange: lastLocalQueueChange
+        )
+
+        XCTAssertEqual(result, .phoneNeedsUpdate)
+    }
+
+    func testWatchQueueManagement_RemoveEpisodeOnWatch_ShouldSync() {
+        // User removes an episode on Watch after receiving phone data
+        let phoneEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-2")]
+        let watchEpisodes = [makeEpisode(uuid: "ep-1")]
+        let lastWatchDataTime = Date(timeIntervalSince1970: 100)
+        let lastLocalQueueChange = Date(timeIntervalSince1970: 150) // User removed ep-2
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            lastServerRefresh: Date(timeIntervalSince1970: 200),
+            lastWatchDataTime: lastWatchDataTime,
+            lastLocalQueueChange: lastLocalQueueChange
+        )
+
+        XCTAssertEqual(result, .phoneNeedsUpdate)
+    }
+
+    func testWatchQueueManagement_ClearQueueOnWatch_ShouldSync() {
+        // User clears queue on Watch after receiving phone data
+        let phoneEpisodes = [makeEpisode(uuid: "ep-1"), makeEpisode(uuid: "ep-2")]
+        let watchEpisodes: [BaseEpisode] = []
+        let lastWatchDataTime = Date(timeIntervalSince1970: 100)
+        let lastLocalQueueChange = Date(timeIntervalSince1970: 150) // User cleared queue
+
+        let result = compare(
+            phoneEpisodes: phoneEpisodes,
+            watchEpisodes: watchEpisodes,
+            watchEpisodeCount: 0,
+            lastServerRefresh: Date(timeIntervalSince1970: 200),
+            lastWatchDataTime: lastWatchDataTime,
+            lastLocalQueueChange: lastLocalQueueChange
+        )
+
+        XCTAssertEqual(result, .phoneNeedsUpdate)
     }
 }

--- a/podcasts/WatchConstants.swift
+++ b/podcasts/WatchConstants.swift
@@ -62,6 +62,7 @@ public enum WatchConstants {
         public static let lastContext = "lastContext_v2"
         public static let lastSubscriptionStatusTime = "lastSubscriptionStatusTime"
         public static let lastDataTime = "lastDataTime"
+        public static let lastLocalQueueChange = "lastLocalQueueChange"
     }
 
     public enum Notifications {


### PR DESCRIPTION
| 📘 Part of: [Watch + Up Next Sync](https://linear.app/a8c/project/ios-watch-up-next-sync-3f36270786fd) |
|:---:|

Enhances our comparator function to take into account changes using `lastLocalQueueChange` to better identify the few cases where the watch queue may need to replace the phone queue.

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
