### PR TITLE
Makefile updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,12 @@ make format
 make build
 ```
 
+## Cleaning Build Artifacts
+
+```bash
+make clean
+```
+
 ## Running Tests
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ build: ## Builds the Debug configuration using Xcode
 	xcodebuild -project podcasts.xcodeproj \
        -scheme pocketcasts \
        -configuration Debug \
+       -destination 'generic/platform=iOS Simulator' \
        build
 
 clean: ## Cleans the build artifacts

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ LANG_VAR=LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 FASTLANE=$(LANG_VAR) $(BUNDLE) exec fastlane
 SWIFTLINT_FROM_BUILDTOOLS=swiftlint lint --working-directory .. --quiet
 
+.PHONY: help build clean test lint lint_lenient format install_dependencies
+
 define run_in_buildtools
 	@pushd BuildTools && \
 	export SDKROOT=$$(xcrun --sdk macosx --show-sdk-path) && \

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ build: ## Builds the Debug configuration using Xcode
        -configuration Debug \
        build
 
+clean: ## Cleans the build artifacts
+	xcodebuild -project podcasts.xcodeproj \
+       -scheme pocketcasts \
+       -configuration Debug \
+       clean
+
 test: ## Build and run the PocketCastsTests target with Unit Tests using Xcode
 	xcodebuild test -project podcasts.xcodeproj \
 	    -scheme pocketcasts \

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -472,7 +472,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .voiceBoostN:
             false
         case .grdbQueryInterface:
-            false
+            true
         case .playlistCacheInvalidation:
             true
         }


### PR DESCRIPTION
* Adds `make clean` so that the project can clean
* Adds `PHONY` declarations for commands. By default, Makefile assumes these are file targets but they are really commands.

## To test

* Run `make clean` to ensure any build products are cleaned
* Run `make build` multiple times and ensure it doesn't produce "Up to date"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
