### PR TITLE
[Watch Up Next] Handle loginDetailsRequest in WatchConnectivity session

### DIFF
--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -204,6 +204,13 @@ class WatchManager: NSObject, WCSessionDelegate {
             if DateUtil.hasEnoughTimePassed(since: ServerSettings.lastRefreshEndTime(), time: 30.minutes) {
                 RefreshManager.shared.refreshPodcasts()
             }
+        } else if WatchConstants.Messages.LoginDetailsRequest.type == messageType {
+            // Watch is requesting login details but message was delivered without reply handler
+            // This can happen with WatchConnectivity timing issues - mark login details as updated
+            // so that updateWatchData() will push the latest login information to the watch.
+            FileLog.shared.addMessage("WatchManager: loginDetailsRequest received without reply handler, pushing data to watch")
+            Settings.setLoginDetailsUpdated()
+            updateWatchData()
         }
     }
 

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -206,10 +206,9 @@ class WatchManager: NSObject, WCSessionDelegate {
             }
         } else if WatchConstants.Messages.LoginDetailsRequest.type == messageType {
             // Watch is requesting login details but message was delivered without reply handler
-            // This can happen with WatchConnectivity timing issues - mark login details as updated
+            // This can happen with WatchConnectivity timing issues
             // so that updateWatchData() will push the latest login information to the watch.
             FileLog.shared.addMessage("WatchManager: loginDetailsRequest received without reply handler, pushing data to watch")
-            Settings.setLoginDetailsUpdated()
             updateWatchData()
         }
     }


### PR DESCRIPTION
| 📘 Part of: [Watch + Up Next Sync](https://linear.app/a8c/project/ios-watch-up-next-sync-3f36270786fd) |
|:---:|

When WatchConnectivity delivers loginDetailsRequest to the wrong delegate method (without reply handler), push data to watch instead of logging unknown message. This prevents excessive 'Unknown message type: loginDetailsRequest' log spam.

## To test

While debugging with Watch connected run the following with LLDB:

```
po WatchManager.shared.session(WCSession.default, didReceiveMessage: ["messageType": "loginDetailsRequest"])
```

Verify log appears:

```
WatchManager: loginDetailsRequest received without reply handler, pushing data to watch
```

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
