### PR TITLE
SwiftLint Batch 1A: add empty checks rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -29,9 +29,18 @@ only_rules:
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 
+  # Prefer using `isEmpty` over comparing `count` to zero.
+  - empty_count
+
   # Arguments can be omitted when matching enums with associated types if they
   # are not used.
   - empty_enum_arguments
+
+  # Prefer using `isEmpty` over comparing to an empty string literal.
+  - empty_string
+
+  # Prefer `contains` over filtering then checking emptiness.
+  - contains_over_filter_is_empty
 
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -455,7 +455,7 @@ class EpisodeDataManager {
     }
 
     func bulkSetStarred(starred: Bool, episodes: [Episode], updateSyncFlag: Bool, dbQueue: PCDBQueue) {
-        if episodes.count == 0 { return }
+        if episodes.isEmpty { return }
 
         dbQueue.write { db in
             do {
@@ -492,7 +492,7 @@ class EpisodeDataManager {
     }
 
     func bulkUserFileDelete(episodes: [Episode], dbQueue: PCDBQueue) {
-        if episodes.count == 0 { return }
+        if episodes.isEmpty { return }
 
         dbQueue.write { db in
             do {
@@ -536,7 +536,7 @@ class EpisodeDataManager {
     }
 
     func saveBulkEpisodeSyncInfo(episodes: [EpisodeBasicData], dbQueue: PCDBQueue) {
-        if episodes.count == 0 { return }
+        if episodes.isEmpty { return }
 
         dbQueue.write { db in
             do {
@@ -900,7 +900,7 @@ class EpisodeDataManager {
     }
 
     func bulkMarkAsPlayed(episodes: [Episode], updateSyncFlag: Bool, dbQueue: PCDBQueue) {
-        if episodes.count == 0 { return }
+        if episodes.isEmpty { return }
 
         dbQueue.write { db in
             do {
@@ -932,7 +932,7 @@ class EpisodeDataManager {
     }
 
     func bulkMarkAsUnPlayed(episodes: [Episode], updateSyncFlag: Bool, dbQueue: PCDBQueue) {
-        if episodes.count == 0 { return }
+        if episodes.isEmpty { return }
 
         dbQueue.write { db in
             do {
@@ -965,7 +965,7 @@ class EpisodeDataManager {
     }
 
     func bulkArchive(episodes: [Episode], markAsNotDownloaded: Bool, markAsPlayed: Bool, updateSyncFlag: Bool, dbQueue: PCDBQueue) {
-        if episodes.count == 0 { return }
+        if episodes.isEmpty { return }
 
         dbQueue.write { db in
             do {
@@ -1000,7 +1000,7 @@ class EpisodeDataManager {
                             values.append(DBUtils.currentUTCTimeInMillis())
                         }
                     }
-                    if fields.count == 0 { continue }
+                    if fields.isEmpty { continue }
 
                     values.append(episode.uuid)
 
@@ -1015,7 +1015,7 @@ class EpisodeDataManager {
     }
 
     func bulkUnarchive(episodes: [Episode], updateSyncFlag: Bool, dbQueue: PCDBQueue) {
-        if episodes.count == 0 { return }
+        if episodes.isEmpty { return }
 
         dbQueue.write { db in
             do {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -427,7 +427,7 @@ class PodcastDataManager {
                 try db.executeUpdate("UPDATE \(DataManager.podcastTableName) SET folderUuid = NULL, syncStatus = \(SyncStatus.notSynced.rawValue) WHERE folderUuid = ?", values: [folderUuid])
 
                 // then set all the ones that should
-                if podcastUuids.count > 0 {
+                if !podcastUuids.isEmpty {
                     try db.executeUpdate("UPDATE \(DataManager.podcastTableName) SET folderUuid = ?, syncStatus = \(SyncStatus.notSynced.rawValue) WHERE uuid IN (\(DataHelper.convertArrayToInString(podcastUuids)))", values: [folderUuid])
                 }
             } catch {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UpNextDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UpNextDataManager.swift
@@ -186,7 +186,7 @@ class UpNextDataManager {
     func deleteAllUpNextEpisodesNotIn(uuids: [String], dbQueue: PCDBQueue) {
         dbQueue.write { db in
             do {
-                if uuids.count == 0 {
+                if uuids.isEmpty {
                     try db.executeUpdate(
                         "DELETE FROM \(DataManager.playlistEpisodeTableName) WHERE playlist_id = ?",
                         values: [UpNextDataManager.upNextPlaylistId]
@@ -203,7 +203,7 @@ class UpNextDataManager {
     }
 
     func deleteAllUpNextEpisodesIn(uuids: [String], dbQueue: PCDBQueue) {
-        guard uuids.count > 0 else { return }
+        guard !uuids.isEmpty else { return }
         dbQueue.write { db in
             do {
                 try db.executeUpdate("DELETE FROM \(DataManager.playlistEpisodeTableName) WHERE episodeUuid IN (\(DataHelper.convertArrayToInString(uuids))) AND playlist_id = ?", values: [UpNextDataManager.upNextPlaylistId])

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
@@ -431,7 +431,7 @@ class UserEpisodeDataManager {
     }
 
     func bulkMarkAsPlayed(episodes: [UserEpisode], updateSyncFlag: Bool, dbQueue: PCDBQueue) {
-        if episodes.count == 0 { return }
+        if episodes.isEmpty { return }
 
         dbQueue.write { db in
             do {
@@ -463,7 +463,7 @@ class UserEpisodeDataManager {
     }
 
     func bulkMarkAsUnPlayed(episodes: [UserEpisode], updateSyncFlag: Bool, dbQueue: PCDBQueue) {
-        if episodes.count == 0 { return }
+        if episodes.isEmpty { return }
 
         dbQueue.write { db in
             do {
@@ -496,7 +496,7 @@ class UserEpisodeDataManager {
     }
 
     func bulkUserFileDelete(episodes: [UserEpisode], dbQueue: PCDBQueue) {
-        if episodes.count == 0 { return }
+        if episodes.isEmpty { return }
 
         dbQueue.write { db in
             do {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -170,7 +170,7 @@ public class DataManager {
 
     public func allUpNextEpisodes() -> [BaseEpisode] {
         let allUpNextEpisodes = upNextManager.allUpNextPlaylistEpisodes(dbQueue: dbQueue)
-        if allUpNextEpisodes.count == 0 { return [BaseEpisode]() }
+        if allUpNextEpisodes.isEmpty { return [BaseEpisode]() }
 
         let episodes = episodeManager.allUpNextEpisodes(dbQueue: dbQueue)
         let userEpisodes = userEpisodeManager.allUpNextEpisodes(dbQueue: dbQueue)
@@ -586,11 +586,11 @@ public class DataManager {
 
     public func bulkUserFileDelete(baseEpisodes: [BaseEpisode]) {
         let episodes = baseEpisodes.compactMap { $0 as? Episode }
-        if episodes.count > 0 {
+        if !episodes.isEmpty {
             episodeManager.bulkUserFileDelete(episodes: episodes, dbQueue: dbQueue)
         }
         let userEpisodes = baseEpisodes.compactMap { $0 as? UserEpisode }
-        if userEpisodes.count > 0 {
+        if !userEpisodes.isEmpty {
             userEpisodeManager.bulkUserFileDelete(episodes: userEpisodes, dbQueue: dbQueue)
         }
     }
@@ -801,12 +801,12 @@ public class DataManager {
 
     public func bulkMarkAsUnPlayed(baseEpisodes: [BaseEpisode], updateSyncFlag: Bool) {
         let episodes = baseEpisodes.compactMap { $0 as? Episode }
-        if episodes.count > 0 {
+        if !episodes.isEmpty {
             episodeManager.bulkMarkAsUnPlayed(episodes: episodes, updateSyncFlag: updateSyncFlag, dbQueue: dbQueue)
         }
 
         let userEpisodes = baseEpisodes.compactMap { $0 as? UserEpisode }
-        if userEpisodes.count > 0 {
+        if !userEpisodes.isEmpty {
             userEpisodeManager.bulkMarkAsUnPlayed(episodes: userEpisodes, updateSyncFlag: updateSyncFlag, dbQueue: dbQueue)
         }
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/BaseEpisode+Encoding.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/BaseEpisode+Encoding.swift
@@ -8,19 +8,19 @@ public extension BaseEpisode {
     }
 
     func decodeInt32FromString(value: String?) -> Int32 {
-        guard let value = value, value.count > 0 else { return 0 }
+        guard let value = value, !value.isEmpty else { return 0 }
 
         return Int32(value) ?? 0
     }
 
     func decodeInt64FromString(value: String?) -> Int64 {
-        guard let value = value, value.count > 0 else { return 0 }
+        guard let value = value, !value.isEmpty else { return 0 }
 
         return Int64(value) ?? 0
     }
 
     func decodeDateFromString(date: String?) -> Date? {
-        guard let date = date, date.count > 0, let doubleVal = Double(date) else { return nil }
+        guard let date = date, !date.isEmpty, let doubleVal = Double(date) else { return nil }
 
         return Date(timeIntervalSince1970: doubleVal)
     }
@@ -38,7 +38,7 @@ public extension BaseEpisode {
     }
 
     func decodeOptionalStringFromString(value: String?) -> String? {
-        guard let value = value, value.count > 0 else { return nil }
+        guard let value = value, !value.isEmpty else { return nil }
 
         return value
     }

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -53,7 +53,7 @@ public class EpisodeFilter: NSObject {
     override public init() {}
 
     public func setTitle(_ title: String?, defaultTitle: String) {
-        guard let title = title, title.trimmingCharacters(in: .whitespacesAndNewlines).count > 0 else {
+        guard let title = title, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             playlistName = defaultTitle
 
             return
@@ -75,7 +75,7 @@ public class EpisodeFilter: NSObject {
     }
 
     public func addPodcast(podcastUuid: String) {
-        if podcastUuids.count == 0 {
+        if podcastUuids.isEmpty {
             filterAllPodcasts = false
             podcastUuids = podcastUuid
         } else {
@@ -91,7 +91,7 @@ public class EpisodeFilter: NSObject {
             podcastUuid == uuid
         })
 
-        if podcasts.count == 0 {
+        if podcasts.isEmpty {
             filterAllPodcasts = true
             podcastUuids = ""
         } else {

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -808,7 +808,7 @@ public class PlaylistQueryBuilder {
         queryString: inout String,
         haveStartedWhere: inout Bool
     ) {
-        if !playlist.filterAllPodcasts, playlist.podcastUuids.count > 0, playlist.podcastUuids != "null" {
+        if !playlist.filterAllPodcasts, !playlist.podcastUuids.isEmpty, playlist.podcastUuids != "null" {
             if haveStartedWhere { queryString += "AND " }
 
             let podcastUuidArr = playlist.podcastUuids.components(separatedBy: ",")
@@ -827,7 +827,7 @@ public class PlaylistQueryBuilder {
         haveStartedWhere: inout Bool
     ) {
         let unsubscribedUuids = DataManager.sharedManager.allUnsubscribedPodcastUuids()
-        if unsubscribedUuids.count > 0 {
+        if !unsubscribedUuids.isEmpty {
             if haveStartedWhere { queryString += "AND " }
 
             queryString += " episode.podcastUuid NOT IN ("
@@ -943,7 +943,7 @@ public class PlaylistQueryBuilder {
         }
 
         // particular podcasts only
-        if !filter.filterAllPodcasts, filter.podcastUuids.count > 0, filter.podcastUuids != "null" {
+        if !filter.filterAllPodcasts, !filter.podcastUuids.isEmpty, filter.podcastUuids != "null" {
             if haveStartedWhere { queryString += "AND " }
 
             let podcastUuidArr = filter.podcastUuids.components(separatedBy: ",")
@@ -957,7 +957,7 @@ public class PlaylistQueryBuilder {
 
         // filter out unsubscribed podcasts
         let unsubscribedUuids = DataManager.sharedManager.allUnsubscribedPodcastUuids()
-        if unsubscribedUuids.count > 0 {
+        if !unsubscribedUuids.isEmpty {
             if haveStartedWhere { queryString += "AND " }
 
             queryString += " podcastUuid NOT IN ("

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
@@ -16,7 +16,7 @@ public struct UpNextListComparator {
                                lastServerRefresh: Date?,
                                lastWatchDataTime: Date,
                                useConservativeComparison: Bool = true) -> UpNextComparisonResult {
-        guard let phoneEpisodes = phoneEpisodes, phoneEpisodes.count > 0 else {
+        guard let phoneEpisodes = phoneEpisodes, !phoneEpisodes.isEmpty else {
             if watchEpisodeCount == 0 {
                 return .same
             } else {
@@ -29,7 +29,7 @@ public struct UpNextListComparator {
         }
 
         if phoneEpisodes.count == watchEpisodes.count {
-            if watchEpisodes.count == 0 {
+            if watchEpisodes.isEmpty {
                 return .same
             }
 

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/MetadataTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/MetadataTask.swift
@@ -46,10 +46,10 @@ class MetadataTask: Operation {
 
     class func updateEpisodeFrom(response: HTTPURLResponse, episode: Episode) {
         let responseHeaders = response.allHeaderFields
-        if responseHeaders.count == 0 { return } // no response headers
+        if responseHeaders.isEmpty { return } // no response headers
 
         var performedUpdate = false
-        if let contentType = responseHeaders[ServerConstants.HttpHeaders.contentType] as? String, contentType.count > 0 {
+        if let contentType = responseHeaders[ServerConstants.HttpHeaders.contentType] as? String, !contentType.isEmpty {
             // if we don't have a content type, or the server said this is a video, change our file type
             if (episode.fileType ?? "").isEmpty || contentType.hasPrefix("video") {
                 DataManager.sharedManager.saveEpisode(fileType: contentType, episode: episode)

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
@@ -116,7 +116,7 @@ class RetrieveCustomFilesTask: ApiBaseTask {
             playbackDelegate.seekToFromSync(time: updatedNowPlayingTime, syncChanges: false, startPlaybackAfterSeek: false)
         }
 
-        if autodownloadEpisodes.count > 0 {
+        if !autodownloadEpisodes.isEmpty {
             ServerConfig.shared.syncDelegate?.autoDownloadUserEpisodes(episodes: autodownloadEpisodes)
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrievePlaylistsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrievePlaylistsTask.swift
@@ -24,7 +24,7 @@ class RetrievePlaylistsTask: ApiBaseTask {
 
             do {
                 let serverPlaylists = try Api_UserPlaylistListResponse(serializedData: responseData).playlists
-                if serverPlaylists.count == 0 {
+                if serverPlaylists.isEmpty {
                     completion?(nil)
 
                     return

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrieveRatingsTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrieveRatingsTask.swift
@@ -28,7 +28,7 @@ class RetrieveRatingsTask: ApiBaseTask, @unchecked Sendable {
             }
 
             let serverRatings = try Api_PodcastRatingsResponse(serializedData: responseData).podcastRatings
-            if serverRatings.count == 0 {
+            if serverRatings.isEmpty {
                 success = true
                 completion?(convertedRatings)
 

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrieveStarredTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/RetrieveStarredTask.swift
@@ -31,7 +31,7 @@ class RetrieveStarredTask: ApiBaseTask {
 
             do {
                 let serverEpisodes = try Api_StarredEpisodesResponse(serializedData: responseData).episodes
-                if serverEpisodes.count == 0 {
+                if serverEpisodes.isEmpty {
                     completion?(convertedEpisodes)
 
                     return

--- a/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
@@ -67,7 +67,7 @@ class SubscriptionStatusTask: ApiBaseTask {
             }
         }
 
-        if podcastSubscriptions.count > 0 {
+        if !podcastSubscriptions.isEmpty {
             SubscriptionHelper.setSubscriptionPodcasts(podcastSubscriptions)
         }
     }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
@@ -114,7 +114,7 @@ class RefreshOperation: Operation {
         let updatedPodcasts = refreshResult.podcastUpdates
         var metadataRequestsQueued = 0
         for podcast in podcasts {
-            guard let podcastEpisodes = updatedPodcasts?[podcast.uuid], podcastEpisodes.count > 0 else { continue }
+            guard let podcastEpisodes = updatedPodcasts?[podcast.uuid], !podcastEpisodes.isEmpty else { continue }
 
             let episodes: [Episode] = podcastEpisodes.reversed().compactMap({ episode in
                 guard let episodeUuid = episode.uuid else { return nil }
@@ -180,7 +180,7 @@ class RefreshOperation: Operation {
 
         let autoAddCandidates = DataManager.sharedManager.autoAddCandidates.candidates()
 
-        if autoAddCandidates.count > 0 {
+        if !autoAddCandidates.isEmpty {
             let startingCount = ServerConfig.shared.playbackDelegate?.upNextQueueCount() ?? 0
             FileLog.shared.addMessage("Checking for auto add to up next episodes in \(autoAddCandidates.count) podcasts that have been updated with auto add to up next turned on limit is \(upNextLimit) starting count is \(startingCount)")
         }

--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
@@ -255,7 +255,7 @@ extension ServerPodcastManager {
     private func cleanupDeletedEpisodes(podcast: Podcast, serverEpisodes: [[String: Any]]) {
         // looks for episodes we have locally, that no longer exist online and that the user hasn't done anything with and deletes them
         let serverUuids = serverEpisodes.compactMap { $0["uuid"] as? String }.map { "'\($0)'" }
-        if serverUuids.count == 0 { return } // don't clean up based on empty episodes results
+        if serverUuids.isEmpty { return } // don't clean up based on empty episodes results
 
         let inStr = serverUuids.joined(separator: ",")
         let playlistTable = DataManager.playlistEpisodeTableName

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncHistoryTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncHistoryTask.swift
@@ -16,7 +16,7 @@ class SyncHistoryTask: ApiBaseTask {
         // find changes if there are any
         var changes = [Api_HistoryChange]()
         let episodesThatNeedSyncing = DataManager.sharedManager.findEpisodesWhere(customWhere: "lastPlaybackInteractionSyncStatus <> \(SyncStatus.synced.rawValue) AND lastPlaybackInteractionDate IS NOT NULL ORDER BY lastPlaybackInteractionDate DESC LIMIT 1000", arguments: nil)
-        if episodesThatNeedSyncing.count > 0 {
+        if !episodesThatNeedSyncing.isEmpty {
             for episode in episodesThatNeedSyncing {
                 if let episodeProto = convertToProto(episode: episode) {
                     changes.append(episodeProto)
@@ -119,7 +119,7 @@ class SyncHistoryTask: ApiBaseTask {
     }
 
     private func historyServerModified() -> Int64? {
-        if let modifiedStr = UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.historyServerLastModified), modifiedStr.count > 0 {
+        if let modifiedStr = UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.historyServerLastModified), !modifiedStr.isEmpty {
             return Int64(modifiedStr)
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -7,7 +7,7 @@ extension SyncTask {
     func changedPodcasts() -> [Api_Record]? {
         let podcastsToSync = DataManager.sharedManager.allUnsyncedPodcasts()
 
-        if podcastsToSync.count == 0 { return nil }
+        if podcastsToSync.isEmpty { return nil }
 
         var podcastRecords = [Api_Record]()
         for podcast in podcastsToSync {
@@ -44,7 +44,7 @@ extension SyncTask {
     }
 
     func changedEpisodes(for episodesToSync: [Episode]) -> [Api_Record]? {
-        if episodesToSync.count == 0 { return nil }
+        if episodesToSync.isEmpty { return nil }
 
         var episodeRecords = [Api_Record]()
         for episode in episodesToSync {
@@ -88,7 +88,7 @@ extension SyncTask {
     func changedFolders() -> [Api_Record]? {
         let foldersToSync = DataManager.sharedManager.allUnsyncedFolders()
 
-        if foldersToSync.count == 0 { return nil }
+        if foldersToSync.isEmpty { return nil }
 
         var folderRecords = [Api_Record]()
         for folder in foldersToSync {
@@ -114,7 +114,7 @@ extension SyncTask {
     func changedPlaylists() -> [Api_Record]? {
         let playlistsToSync = DataManager.sharedManager.allUnsyncedPlaylists()
 
-        if playlistsToSync.count == 0 { return nil }
+        if playlistsToSync.isEmpty { return nil }
 
         var playlistRecords = [Api_Record]()
         for playlist in playlistsToSync {
@@ -130,7 +130,7 @@ extension SyncTask {
 
     private func createSyncUserPlaylist(from filter: EpisodeFilter) -> Api_SyncUserPlaylist {
         var playlistRecord = Api_SyncUserPlaylist()
-        playlistRecord.allPodcasts.value = filter.podcastUuids.count == 0
+        playlistRecord.allPodcasts.value = filter.podcastUuids.isEmpty
         playlistRecord.uuid = filter.uuid
         playlistRecord.originalUuid = filter.uuid // server side this field is important, because it will remain the same case DO NOT REMOVE
         playlistRecord.isDeleted.value = filter.wasDeleted

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -378,7 +378,7 @@ extension SyncTask {
                 DataManager.sharedManager.save(episode: episode)
             }
 
-            if episodesToDelete.count > 0 {
+            if !episodesToDelete.isEmpty {
                 DataManager.sharedManager.rawDeleteEpisodes(Array(episodesToDelete), from: playlist)
             }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -41,7 +41,7 @@ class SyncTask: ApiBaseTask {
     }
 
     func incrementalSyncRequest(token: String) -> URLRequest? {
-        guard let lastServerModified = UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.lastModifiedServerDate), lastServerModified.count > 0, let url = URL(string: ServerConstants.Urls.api() + "user/sync/update") else {
+        guard let lastServerModified = UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.lastModifiedServerDate), !lastServerModified.isEmpty, let url = URL(string: ServerConstants.Urls.api() + "user/sync/update") else {
             return nil
         }
 
@@ -55,7 +55,7 @@ class SyncTask: ApiBaseTask {
     }
 
     private func performSync(token: String) {
-        if let lastServerModified = UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.lastModifiedServerDate), lastServerModified.count > 0 {
+        if let lastServerModified = UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.lastModifiedServerDate), !lastServerModified.isEmpty {
             if ServerSettings.homeGridNeedsRefresh() {
                 performHomeGridRefresh()
             }

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -97,7 +97,7 @@ class UpNextSyncTask: ApiBaseTask {
 
             // all other add/remove actions
             let actions = DataManager.sharedManager.findUpdateActions()
-            if actions.count > 0 {
+            if !actions.isEmpty {
                 for action in actions {
                     if action.utcTime > latestActionTime {
                         latestActionTime = action.utcTime
@@ -155,7 +155,7 @@ class UpNextSyncTask: ApiBaseTask {
         guard let localEpisodes = ServerConfig.shared.playbackDelegate?.allEpisodesInQueue(includeNowPlaying: true) else { return }
         if localEpisodes.count == episodes.count {
             // if they are both 0, nothing to do
-            if localEpisodes.count == 0 {
+            if localEpisodes.isEmpty {
                 FileLog.shared.addMessage("UpNextSyncTask: no local or remote episodes, no action required")
                 return
             }
@@ -179,7 +179,7 @@ class UpNextSyncTask: ApiBaseTask {
 
         let episodePlayingBeforeChanges = ServerConfig.shared.playbackDelegate?.currentEpisode()
         var uuids = [String]()
-        if modifiedList.count > 0 {
+        if !modifiedList.isEmpty {
             for (index, episodeInfo) in modifiedList.enumerated() {
                 uuids.append(episodeInfo.uuid)
 
@@ -268,7 +268,7 @@ class UpNextSyncTask: ApiBaseTask {
             // removed unintentionally.
             let localUUIDs = localEpisodes.compactMap { uuids.contains($0.uuid) ? nil : $0.uuid }
 
-            if localUUIDs.count != 0 {
+            if !localUUIDs.isEmpty {
                 FileLog.shared.addMessage("UpNextSyncTask: Merging \(localEpisodes.count) local episodes that were not in the remote server call")
 
                 uuids.append(contentsOf: localUUIDs)
@@ -296,10 +296,10 @@ class UpNextSyncTask: ApiBaseTask {
         if let episodePlayingBeforeChanges = episodePlayingBeforeChanges, let currentlyPlaying = ServerConfig.shared.playbackDelegate?.isNowPlayingEpisode(episodeUuid: episodePlayingBeforeChanges.uuid), currentlyPlaying == false {
             // currently playing episode has changed
             ServerConfig.shared.playbackDelegate?.playingEpisodeChangedExternally()
-        } else if episodePlayingBeforeChanges == nil, modifiedList.count > 0 {
+        } else if episodePlayingBeforeChanges == nil, !modifiedList.isEmpty {
             // nothing was playing but now it is
             ServerConfig.shared.playbackDelegate?.playingEpisodeChangedExternally()
-        } else if episodePlayingBeforeChanges != nil, modifiedList.count == 0 {
+        } else if episodePlayingBeforeChanges != nil, modifiedList.isEmpty {
             // there was something playing but it should no longer be playing
             ServerConfig.shared.playbackDelegate?.playingEpisodeChangedExternally()
         }
@@ -388,7 +388,7 @@ class UpNextSyncTask: ApiBaseTask {
     }
 
     private func upNextServerModified() -> Int64? {
-        if let modifiedStr = UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.upNextServerLastModified), modifiedStr.count > 0 {
+        if let modifiedStr = UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.upNextServerLastModified), !modifiedStr.isEmpty {
             return Int64(modifiedStr)
         }
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Upload/UploadManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Upload/UploadManager.swift
@@ -141,7 +141,7 @@ public class UploadManager: NSObject {
         guard let taskId = taskId else { return }
 
         session.getTasksWithCompletionHandler { [weak self] _, uploadTasks, _ in
-            if uploadTasks.count == 0 { return }
+            if uploadTasks.isEmpty { return }
 
             for task in uploadTasks {
                 if taskId == task.taskDescription {
@@ -172,7 +172,7 @@ public class UploadManager: NSObject {
 
     private func resumeUpload(episode: UserEpisode, session: URLSession, previousUploadFailed: Bool, taskId: String?) {
         session.getTasksWithCompletionHandler { [weak self] _, uploadTasks, _ in
-            if uploadTasks.count == 0 {
+            if uploadTasks.isEmpty {
                 self?.startUpload(episode: episode, session: session, previousUploadFailed: previousUploadFailed, taskId: taskId)
                 return
             }

--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+formatTime.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/Double+formatTime.swift
@@ -24,7 +24,7 @@ extension Double {
             output.append(minsSeconds)
         }
 
-        if output.count == 0 {
+        if output.isEmpty {
             let components = DateComponents(calendar: Calendar.current, second: secs)
             return DateComponentsFormatter.localizedString(from: components, unitsStyle: .full)
         }

--- a/Pocket Casts Watch App/MenuRow.swift
+++ b/Pocket Casts Watch App/MenuRow.swift
@@ -18,7 +18,7 @@ struct MenuRow: View {
     }
 
     var countText: String {
-        guard count > 0 else {
+        guard !isEmpty else {
             return "0"
         }
         let ammendedCount = count > 99 ? "99+" : "\(count)"
@@ -26,7 +26,7 @@ struct MenuRow: View {
     }
 
     var accessibilityLabel: String {
-        if count > 0 {
+        if !isEmpty {
             return "\(label), \(count)"
         } else {
             return label
@@ -47,7 +47,7 @@ struct MenuRow: View {
                         .clipShape(RoundedRectangle(cornerSize: CGSize(width: 9, height: 9)))
                         .foregroundColor(.black)
                 }
-                .opacity(count > 0 ? 1 : 0)
+                .opacity(!isEmpty ? 1 : 0)
             }
             .accessibilityLabel(accessibilityLabel)
         } icon: {

--- a/Pocket Casts Watch App/PhoneSourceViewModel.swift
+++ b/Pocket Casts Watch App/PhoneSourceViewModel.swift
@@ -255,7 +255,7 @@ class PhoneSourceViewModel: PlaySourceViewModel {
 
     func nowPlayingTitle(forEpisode episode: BaseEpisode) -> String? {
         let chapterTitle = WatchDataManager.nowPlayingChapterTitle()
-        return chapterTitle.count > 0 ? chapterTitle : episode.title
+        return !chapterTitle.isEmpty ? chapterTitle : episode.title
     }
 
     func nowPlayingSubTitle(forEpisode episode: BaseEpisode) -> String? {

--- a/Pocket Casts Watch App/SourceInterfaceModel.swift
+++ b/Pocket Casts Watch App/SourceInterfaceModel.swift
@@ -58,7 +58,7 @@ class SourceInterfaceModel: ObservableObject {
     }
 
     func removeAllCustomObservers() {
-        if customObservers.count == 0 { return }
+        if customObservers.isEmpty { return }
 
         let notCenter = NotificationCenter.default
         for name in customObservers {
@@ -68,7 +68,7 @@ class SourceInterfaceModel: ObservableObject {
     }
 
     private func containsObserver(_ name: Notification.Name) -> Bool {
-        if customObservers.count == 0 { return false }
+        if customObservers.isEmpty { return false }
 
         return customObservers.contains(name)
     }

--- a/Pocket Casts Watch App/WatchSyncManager+Autodownload.swift
+++ b/Pocket Casts Watch App/WatchSyncManager+Autodownload.swift
@@ -11,7 +11,7 @@ extension WatchSyncManager {
         let autodownloadCount = WatchDataManager.upNextAutoDownloadCount()
         let allQueued = PlaybackManager.shared.allEpisodesInQueue(includeNowPlaying: true)
 
-        guard autodownloadCount > 0, allQueued.count > 0 else {
+        guard autodownloadCount > 0, !allQueued.isEmpty else {
             return
         }
 

--- a/PodcastsIntents/PlayMediaIntentHandler.swift
+++ b/PodcastsIntents/PlayMediaIntentHandler.swift
@@ -63,7 +63,7 @@ class PlayMediaIntentHandler: NSObject, INPlayMediaIntentHandling {
         do {
             let deserializedData = try JSONDecoder().decode([CommonUpNextItem].self, from: upNextData)
 
-            guard deserializedData.count > 0 else { return nil }
+            guard !deserializedData.isEmpty else { return nil }
 
             let episodes = deserializedData
             guard let nowPlayingEpisode = episodes.first else { return nil }

--- a/Screenshot Automation Watch/Watch_GenerateScreenshots.swift
+++ b/Screenshot Automation Watch/Watch_GenerateScreenshots.swift
@@ -78,7 +78,7 @@ extension Watch_GenerateScreenshots {
 
     private func navigateBackToSourceSelection() {
         _ = app.navigationBars.buttons.firstMatch.waitForExistence(timeout: 5)
-        while app.navigationBars.buttons.allElementsBoundByIndex.count > 0 {
+        while !app.navigationBars.buttons.allElementsBoundByIndex.isEmpty {
             app.navigationBars.buttons.firstMatch.waitForThenTap()
             _ = app.navigationBars.buttons.firstMatch.waitForExistence(timeout: 5)
         }

--- a/WidgetExtension/Common/CommonWidgetHelper.swift
+++ b/WidgetExtension/Common/CommonWidgetHelper.swift
@@ -78,7 +78,7 @@ class CommonWidgetHelper {
     }
 
     class func topWidgetEpisodesFrom(_ commonItems: [CommonUpNextItem]) -> [WidgetEpisode]? {
-        guard commonItems.count > 0 else { return nil }
+        guard !commonItems.isEmpty else { return nil }
 
         let widgetEpisodes = commonItems.map { WidgetEpisode(commonItem: $0) }
 

--- a/WidgetExtension/Up Next/UpNextProvider.swift
+++ b/WidgetExtension/Up Next/UpNextProvider.swift
@@ -30,11 +30,11 @@ struct UpNextProvider: TimelineProvider {
         let widgetData = WidgetData.shared
         widgetData.reload()
 
-        if let filterEpisodes = widgetData.topFilterEpisodes, filterEpisodes.count > 0 {
+        if let filterEpisodes = widgetData.topFilterEpisodes, !filterEpisodes.isEmpty {
             let entry = upNextEntry(episodes: filterEpisodes, data: widgetData, imageCountToCache: context.family.imageCount)
             let timeline = Timeline(entries: [entry], policy: .never)
             completion(timeline)
-        } else if let upNextEpisodes = widgetData.upNextEpisodes, upNextEpisodes.count > 0 {
+        } else if let upNextEpisodes = widgetData.upNextEpisodes, !upNextEpisodes.isEmpty {
             let entry = upNextEntry(episodes: upNextEpisodes, data: widgetData, imageCountToCache: context.family.imageCount)
             let timeline = Timeline(entries: [entry], policy: .atEnd)
             completion(timeline)
@@ -45,7 +45,7 @@ struct UpNextProvider: TimelineProvider {
     }
 
     private func upNextEntry(episodes: [WidgetEpisode]?, data: WidgetData, imageCountToCache: Int = 0) -> UpNextEntry {
-        if let episodes = episodes, episodes.count > 0, imageCountToCache > 0 {
+        if let episodes = episodes, !episodes.isEmpty, imageCountToCache > 0 {
             for episode in episodes.prefix(imageCountToCache) {
                 episode.loadImageData()
             }

--- a/WidgetExtension/Up Next/UpNextWidgetEntryView.swift
+++ b/WidgetExtension/Up Next/UpNextWidgetEntryView.swift
@@ -16,7 +16,7 @@ struct UpNextWidgetEntryView: View {
 
     var body: some View {
         Group {
-            if let episodes = entry.episodes, episodes.count > 0 {
+            if let episodes = entry.episodes, !episodes.isEmpty {
                 if family == .systemMedium {
                     UpNextMediumWidgetView(episodes: episodes, filterName: entry.filterName, isPlaying: entry.isPlaying)
                 } else {

--- a/podcasts/AEXML.swift
+++ b/podcasts/AEXML.swift
@@ -96,7 +96,7 @@ open class AEXMLElement: NSObject {
         } else {
             let filtered = children.filter { $0.name == key }
             let errorElement = AEXMLElement(AEXMLElement.errorElementName, value: "element <\(key)> not found")
-            return filtered.count > 0 ? filtered.first! : errorElement
+            return !filtered.isEmpty ? filtered.first! : errorElement
         }
     }
 
@@ -120,7 +120,7 @@ open class AEXMLElement: NSObject {
                     found.append(element)
                 }
             }
-            return found.count > 0 ? found : nil
+            return !found.isEmpty ? found : nil
         } else {
             return nil
         }
@@ -230,18 +230,18 @@ open class AEXMLElement: NSObject {
         xml += indentation(parentsCount - 1)
         xml += "<\(name)"
 
-        if attributes.count > 0 {
+        if !attributes.isEmpty {
             // insert attributes
             for (key, value) in attributes {
                 xml += " \(key)=\"\(escapeString(value))\""
             }
         }
 
-        if value == nil, children.count == 0 {
+        if value == nil, children.isEmpty {
             // close element
             xml += " />"
         } else {
-            if children.count > 0 {
+            if !children.isEmpty {
                 // add children
                 xml += ">\n"
                 for child in children {

--- a/podcasts/AVFileUtil.swift
+++ b/podcasts/AVFileUtil.swift
@@ -44,7 +44,7 @@ class AVFileUtil: NSObject {
         let titleMetaData = AVMetadataItem.metadataItems(from: asset.commonMetadata, filteredByIdentifier: AVMetadataIdentifier.commonIdentifierTitle)
 
         if let metaData = titleMetaData.first {
-            if let title = metaData.stringValue, title.count > 0 {
+            if let title = metaData.stringValue, !title.isEmpty {
                 titleHandler(title)
                 return
             }
@@ -66,7 +66,7 @@ class AVFileUtil: NSObject {
         }
 
         var biggestImage: UIImage?
-        if artworkImages.count == 0 {
+        if artworkImages.isEmpty {
             artworkHandler(nil)
             return
         } else if artworkImages.count == 1 {

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -132,7 +132,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
         } else {
             var newTableRows: [[TableRow]] = [accountOptions, [.privacyPolicy, .termsOfUse], [.logout], [.deleteAccount]]
 
-            if let subscriptionPodcasts = SubscriptionHelper.subscriptionPodcasts(), subscriptionPodcasts.count > 0 {
+            if let subscriptionPodcasts = SubscriptionHelper.subscriptionPodcasts(), !subscriptionPodcasts.isEmpty {
                 newTableRows[0].insert(.supporterContributions, at: 0)
             }
 

--- a/podcasts/AddCustomViewController.swift
+++ b/podcasts/AddCustomViewController.swift
@@ -450,7 +450,7 @@ class AddCustomViewController: PCViewController, UITextFieldDelegate {
     }
 
     @objc func textFieldDidChange(_ textField: UITextField) {
-        if let typedText = nameTextfield.text, typedText.count > 0 {
+        if let typedText = nameTextfield.text, !typedText.isEmpty {
             nameLabel.text = typedText
             name = typedText
             nameLabel.style = .primaryText02

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -298,7 +298,7 @@ extension AppDelegate {
         JLRoutes.global().addRoute("/redeem/promo/*") { [weak self] parameters -> Bool in
             guard self != nil else { return false }
             var promoCode: String?
-            if let pathComponents = parameters[JLRouteWildcardComponentsKey] as? [String], pathComponents.count > 0 {
+            if let pathComponents = parameters[JLRouteWildcardComponentsKey] as? [String], !pathComponents.isEmpty {
                 promoCode = pathComponents[0]
             }
 
@@ -310,7 +310,7 @@ extension AppDelegate {
         JLRoutes.global().addRoute("/premium/podcast/*") { [weak self] parameters -> Bool in
             guard self != nil else { return false }
 
-            if let pathComponents = parameters[JLRouteWildcardComponentsKey] as? [String], pathComponents.count > 0, let podcastTitle = parameters["title"] as? String {
+            if let pathComponents = parameters[JLRouteWildcardComponentsKey] as? [String], !pathComponents.isEmpty, let podcastTitle = parameters["title"] as? String {
                 let uuid = pathComponents[0]
 
                 if SyncManager.isUserLoggedIn() {
@@ -334,7 +334,7 @@ extension AppDelegate {
 
         JLRoutes.global().addRoute("/premium/supporter-contributions/*") { [weak self] parameters -> Bool in
             guard self != nil else { return false }
-            if let pathComponents = parameters[JLRouteWildcardComponentsKey] as? [String], pathComponents.count > 0 {
+            if let pathComponents = parameters[JLRouteWildcardComponentsKey] as? [String], !pathComponents.isEmpty {
                 let uuid = pathComponents[0]
 
                 if SyncManager.isUserLoggedIn() {

--- a/podcasts/BaseEpisode+Formatting.swift
+++ b/podcasts/BaseEpisode+Formatting.swift
@@ -57,7 +57,7 @@ extension BaseEpisode {
             var informationLabelStr = duration > 0 ? displayableTimeLeft() : L10n.unknownDuration
 
             if includeSize, sizeInBytes > 0 {
-                if informationLabelStr.count == 0 {
+                if informationLabelStr.isEmpty {
                     informationLabelStr = SizeFormatter.shared.noDecimalFormat(bytes: sizeInBytes)
                 } else {
                     informationLabelStr += " • \(SizeFormatter.shared.noDecimalFormat(bytes: sizeInBytes))"

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -196,7 +196,7 @@ private extension BookmarkSortOption {
 extension Array where Element == Bookmark {
 
     func includePodcasts(using dataManager: DataManager = .sharedManager) -> [Element] {
-        guard count > 0 else { return [] }
+        guard !isEmpty else { return [] }
 
         let podcasts = uniquePodcasts(using: dataManager)
 
@@ -212,7 +212,7 @@ extension Array where Element == Bookmark {
     /// Updates an array of Bookmarks and sets the `episode` property to the `BaseEpisode` from the `episodeUuid`
     /// This tries to be efficient by only fetching the unique episodes from the database
     func includeEpisodes(using dataManager: DataManager = .sharedManager) -> [Element] {
-        guard count > 0 else { return [] }
+        guard !isEmpty else { return [] }
 
         let episodes = uniqueEpisodes(using: dataManager)
 

--- a/podcasts/CarPlaySceneDelegate+Tabs.swift
+++ b/podcasts/CarPlaySceneDelegate+Tabs.swift
@@ -30,7 +30,7 @@ extension CarPlaySceneDelegate {
         // the podcast tab is always what CarPlay opens first, however it doesn't show the Now Playing tab unless something is actively playing
         // so with that in mind if the user has something in Up Next and Pocket Casts is paused, help them find their now playing stuff by adding that as a section here
         let upNextEpisodes = PlaybackManager.shared.allEpisodesInQueue(includeNowPlaying: true)
-        if upNextEpisodes.count > 0 {
+        if !upNextEpisodes.isEmpty {
             let truncatedList = Array(upNextEpisodes.prefix(8))
             let imageRowItem = createUpNextImageItem(episodes: truncatedList)
 

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -120,7 +120,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
 
     private func loadPodcasts() {
         guard let delegate = delegate, let category, let source = delegate.replaceRegionCode(string: category.source) else { return }
-        if loadingIndicator.isAnimating || podcasts.count > 0 { return }
+        if loadingIndicator.isAnimating || !podcasts.isEmpty { return }
 
         noNetworkView.isHidden = true
         loadingIndicator.startAnimating()

--- a/podcasts/CategorySummaryViewController.swift
+++ b/podcasts/CategorySummaryViewController.swift
@@ -87,7 +87,7 @@ class CategorySummaryViewController: UIViewController, UITableViewDataSource, UI
     }
 
     private func setTableHeight() {
-        let requiredHeight = categories.count > 0 ? (categories.count * 56) : 200
+        let requiredHeight = !categories.isEmpty ? (categories.count * 56) : 200
         categoryHeightConstraint.constant = CGFloat(requiredHeight)
     }
 }

--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -91,7 +91,7 @@ class ChapterManager {
 
     @discardableResult
     func updateCurrentChapter(time: TimeInterval) -> Bool {
-        if chapters.count == 0 { return false }
+        if chapters.isEmpty { return false }
 
         let chapters = chaptersForTime(time)
         let hasChanged = currentChapters != chapters

--- a/podcasts/CustomObserver.swift
+++ b/podcasts/CustomObserver.swift
@@ -14,7 +14,7 @@ class CustomObserver: NSObject {
     }
 
     func removeAllCustomObservers() {
-        if customObservers.count == 0 { return }
+        if customObservers.isEmpty { return }
 
         let notCenter = NotificationCenter.default
         for name in customObservers {
@@ -24,7 +24,7 @@ class CustomObserver: NSObject {
     }
 
     private func containsObserver(_ name: Notification.Name) -> Bool {
-        if customObservers.count == 0 { return false }
+        if customObservers.isEmpty { return false }
 
         return customObservers.contains(name)
     }

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -104,7 +104,7 @@ class DiscoverCollectionViewController: PCViewController {
             return
         }
 
-        guard items.count > 0 else {
+        guard !items.isEmpty else {
             handleEmptyResults()
             return
         }

--- a/podcasts/DownloadManager+SessionManagement.swift
+++ b/podcasts/DownloadManager+SessionManagement.swift
@@ -70,7 +70,7 @@ extension DownloadManager {
             }
         }
 
-        if episodeUuids.count == 0 { return }
+        if episodeUuids.isEmpty { return }
 
         for episodeUuid in episodeUuids {
             guard let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else { continue }

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -188,7 +188,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
 
         // Update all the downloaded files existing protections
-        guard let paths = FileManager.default.subpaths(atPath: podcastsDirectory), paths.count > 0 else {
+        guard let paths = FileManager.default.subpaths(atPath: podcastsDirectory), !paths.isEmpty else {
             return
         }
 
@@ -507,7 +507,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
 
         // make sure the URL is valid and has a supported scheme: only http and https are allowed
-        guard let url = downloadUrl, let scheme = url.scheme, scheme.count > 0, scheme.caseInsensitiveCompare("http") == .orderedSame || scheme.caseInsensitiveCompare("https") == .orderedSame else {
+        guard let url = downloadUrl, let scheme = url.scheme, !scheme.isEmpty, scheme.caseInsensitiveCompare("http") == .orderedSame || scheme.caseInsensitiveCompare("https") == .orderedSame else {
             dataManager.saveEpisode(downloadStatus: .downloadFailed, downloadError: L10n.downloadErrorContactAuthor, downloadTaskId: nil, episode: episode)
 
             logDownload(episode, failure: .malformedHost)
@@ -679,7 +679,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         guard let taskId = taskId else { return }
 
         session.getTasksWithCompletionHandler { [weak self] _, _, downloadTasks in
-            if downloadTasks.count == 0 { return }
+            if downloadTasks.isEmpty { return }
 
             for task in downloadTasks {
                 if let taskDescription = task.taskDescription, taskId == taskDescription {
@@ -692,7 +692,7 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     private func cancelTask(_ task: URLSessionDownloadTask, for episode: BaseEpisode) {
         task.cancel { [weak self] data in
-            if let data = data, data.count > 0, let tempFilePath = self?.tempPathForEpisode(episode) {
+            if let data = data, !data.isEmpty, let tempFilePath = self?.tempPathForEpisode(episode) {
                 do {
                     try data.write(to: URL(fileURLWithPath: tempFilePath), options: .atomic)
                 } catch {

--- a/podcasts/DownloadedFilesViewController.swift
+++ b/podcasts/DownloadedFilesViewController.swift
@@ -68,7 +68,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
                 cell.selectButton.addTarget(self, action: #selector(DownloadedFilesViewController.unplayedToggled(_:)), for: .touchUpInside)
 
                 let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: Int64(unplayedSize))
-                cell.subtitleLabel.text = sizeAsStr == "" ? SizeFormatter.shared.placeholder : sizeAsStr
+                cell.subtitleLabel.text = sizeAsStr.isEmpty ? SizeFormatter.shared.placeholder : sizeAsStr
             case 1:
                 cell.titleLabel.text = L10n.inProgress
                 cell.setSelectedState(deleteInProgress)
@@ -76,7 +76,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
                 cell.selectButton.addTarget(self, action: #selector(DownloadedFilesViewController.inProgressToggled(_:)), for: .touchUpInside)
 
                 let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: Int64(inProgressSize))
-                cell.subtitleLabel.text = sizeAsStr == "" ? SizeFormatter.shared.placeholder : sizeAsStr
+                cell.subtitleLabel.text = sizeAsStr.isEmpty ? SizeFormatter.shared.placeholder : sizeAsStr
             case 2:
                 cell.titleLabel.text = L10n.statusPlayed
                 cell.setSelectedState(deletePlayed)
@@ -84,7 +84,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
                 cell.selectButton.addTarget(self, action: #selector(DownloadedFilesViewController.playedToggled(_:)), for: .touchUpInside)
 
                 let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: Int64(playedSize))
-                cell.subtitleLabel.text = sizeAsStr == "" ? SizeFormatter.shared.placeholder : sizeAsStr
+                cell.subtitleLabel.text = sizeAsStr.isEmpty ? SizeFormatter.shared.placeholder : sizeAsStr
             default:
                 break
             }
@@ -104,7 +104,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
 
             let total = totalDeleteSize()
             let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: Int64(total))
-            cell.statValue.text = sizeAsStr == "" ? SizeFormatter.shared.placeholder : sizeAsStr
+            cell.statValue.text = sizeAsStr.isEmpty ? SizeFormatter.shared.placeholder : sizeAsStr
             return cell
         case 3:
             let cell = tableView.dequeueReusableCell(withIdentifier: buttonCellId, for: indexPath) as! DestructiveButtonCell

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -209,7 +209,7 @@ class DownloadsViewController: PCViewController {
             let newData = self.episodesDataManager.downloadedEpisodes()
 
             DispatchQueue.main.sync {
-                self.downloadsTable.isHidden = (newData.count == 0)
+                self.downloadsTable.isHidden = (newData.isEmpty)
                 self.episodes = newData
                 self.downloadsTable.reloadData()
             }
@@ -246,7 +246,7 @@ class DownloadsViewController: PCViewController {
         }
         optionsPicker.addAction(action: settingsAction)
 
-        if failedEpisodes().count > 0 {
+        if !failedEpisodes().isEmpty {
             let retryAction = OptionAction(label: L10n.downloadsRetryFailedDownloads, icon: "option-download-retry") { [weak self] in
                 Analytics.track(.downloadsOptionsModalOptionTapped, properties: ["option": "retry_failed_downloads"])
                 self?.retryAllFailed(sender)
@@ -254,7 +254,7 @@ class DownloadsViewController: PCViewController {
             optionsPicker.addAction(action: retryAction)
         }
 
-        if downloadingEpisodes().count > 0 {
+        if !downloadingEpisodes().isEmpty {
             let stopAction = OptionAction(label: L10n.downloadsStopAllDownloads, icon: "option-cross-circle") { [weak self] in
                 Analytics.track(.downloadsOptionsModalOptionTapped, properties: ["option": "stop_all_downloads"])
                 self?.pauseAllDownloads()

--- a/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
@@ -20,7 +20,7 @@ struct Ratings2024Story: ShareableStory {
 
     var body: some View {
         Group {
-            if ratings.count == 0 {
+            if ratings.isEmpty {
                 emptyView()
             } else {
                 VStack(alignment: .leading) {
@@ -150,7 +150,7 @@ struct Ratings2024Story: ShareableStory {
     }
 
     func hideShareButton() -> Bool {
-        ratings.count == 0
+        ratings.isEmpty
     }
 }
 

--- a/podcasts/End of Year/Stories/2025/Ratings2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/Ratings2025Story.swift
@@ -22,7 +22,7 @@ struct Ratings2025Story: ShareableStory {
 
     var body: some View {
         Group {
-            if ratings.count == 0 {
+            if ratings.isEmpty {
                 emptyView()
             } else {
                 columnsView()
@@ -177,7 +177,7 @@ struct Ratings2025Story: ShareableStory {
     }
 
     func hideShareButton() -> Bool {
-        ratings.count == 0
+        ratings.isEmpty
     }
 }
 

--- a/podcasts/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/EpisodeDetailViewController+Actions.swift
@@ -116,7 +116,7 @@ extension EpisodeDetailViewController {
         } else {
             downloadBtn.setImage(UIImage(named: "episode-download"), for: .normal)
             let sizeAsStr = episode.sizeInBytes == 0 ? "" : SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
-            downloadBtn.setTitle(sizeAsStr == "" ? L10n.download : sizeAsStr, for: .normal)
+            downloadBtn.setTitle(sizeAsStr.isEmpty ? L10n.download : sizeAsStr, for: .normal)
             downloadBtn.accessibilityLabel = L10n.download
         }
 

--- a/podcasts/EpisodeListSearchController+Search.swift
+++ b/podcasts/EpisodeListSearchController+Search.swift
@@ -11,7 +11,7 @@ extension EpisodeListSearchController: UITextFieldDelegate {
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if let searchTerm = textField.text, searchTerm.count > 0 {
+        if let searchTerm = textField.text, !searchTerm.isEmpty {
             textField.resignFirstResponder()
             cancelSearchTimer()
             search(searchTerm: searchTerm)
@@ -23,7 +23,7 @@ extension EpisodeListSearchController: UITextFieldDelegate {
     func handleTextFieldDidChange() {
         let searchTerm = searchTextField.text
 
-        if let searchTerm = searchTerm, searchTerm.count > 0 {
+        if let searchTerm = searchTerm, !searchTerm.isEmpty {
             clearSearchBtn.isHidden = false
             resetSearchTimer()
         } else {

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -41,7 +41,7 @@ class EpisodeManager: NSObject {
     }
 
     class func bulkMarkAsPlayed(episodes: [BaseEpisode], updateSyncFlag: Bool) {
-        guard episodes.count > 0 else { return }
+        guard !episodes.isEmpty else { return }
         var episodesToArchive = [Episode]()
         var episodesToMarkAsPlayed = [Episode]()
         var userEpisodeToMarkAsPlayed = [UserEpisode]()
@@ -72,15 +72,15 @@ class EpisodeManager: NSObject {
         let uuids = episodesMinusCurrent.map(\.uuid)
         PlaybackManager.shared.bulkRemoveQueued(uuids: uuids)
 
-        if episodesToArchive.count > 0 {
+        if !episodesToArchive.isEmpty {
             DataManager.sharedManager.bulkArchive(episodes: episodesToArchive, markAsNotDownloaded: true, markAsPlayed: true, updateSyncFlag: updateSyncFlag)
         }
 
-        if episodesToMarkAsPlayed.count > 0 {
+        if !episodesToMarkAsPlayed.isEmpty {
             DataManager.sharedManager.bulkMarkAsPlayed(episodes: episodesToMarkAsPlayed, updateSyncFlag: updateSyncFlag)
         }
 
-        if userEpisodeToMarkAsPlayed.count > 0 {
+        if !userEpisodeToMarkAsPlayed.isEmpty {
             DataManager.sharedManager.bulkMarkAsPlayed(episodes: userEpisodeToMarkAsPlayed, updateSyncFlag: updateSyncFlag)
 
             #if !APPCLIP

--- a/podcasts/FakeNavViewController.swift
+++ b/podcasts/FakeNavViewController.swift
@@ -179,7 +179,7 @@ class FakeNavViewController: PCViewController, UIScrollViewDelegate {
             button.layer.masksToBounds = true
         }
         button.translatesAutoresizingMaskIntoConstraints = false
-        if rightActionButtons.count == 0 {
+        if rightActionButtons.isEmpty {
             // if there are no other buttons, anchor this one to the edge
             let margin: CGFloat = 16
             NSLayoutConstraint.activate([

--- a/podcasts/FilterChipCollectionView.swift
+++ b/podcasts/FilterChipCollectionView.swift
@@ -113,14 +113,14 @@ class FilterChipCollectionView: UICollectionView, UICollectionViewDelegate, UICo
                 selectedOptions += 1
             }
             if filter.filterPartiallyPlayed {
-                if returnedString.count > 0 {
+                if !returnedString.isEmpty {
                     returnedString.append(", ")
                 }
                 returnedString.append(L10n.inProgress)
                 selectedOptions += 1
             }
             if filter.filterFinished {
-                if returnedString.count > 0 {
+                if !returnedString.isEmpty {
                     returnedString.append(", ")
                 }
                 returnedString.append(L10n.statusPlayed)

--- a/podcasts/FilterPreviewViewController.swift
+++ b/podcasts/FilterPreviewViewController.swift
@@ -198,8 +198,8 @@ class FilterPreviewViewController: LargeNavBarViewController, FilterChipActionDe
     func refreshEpisodes(animated: Bool) {
         let refreshOperation = PlaylistRefreshOperation(playlist: newFilter) { [weak self] newData in
             guard let strongSelf = self else { return }
-            strongSelf.previewTable.isHidden = (newData.count == 0)
-            strongSelf.noEpisodeView.isHidden = (newData.count != 0)
+            strongSelf.previewTable.isHidden = (newData.isEmpty)
+            strongSelf.noEpisodeView.isHidden = (!newData.isEmpty)
             if animated {
                 let oldData = strongSelf.episodes
                 let changeSet = StagedChangeset(source: oldData, target: newData)

--- a/podcasts/IAPHelper.swift
+++ b/podcasts/IAPHelper.swift
@@ -82,7 +82,7 @@ class IAPHelper: NSObject {
     }
 
     func getProduct(for identifier: IAPProductID) -> SKProduct! {
-        guard productsArray.count > 0 else {
+        guard !productsArray.isEmpty else {
             requestProductInfo()
             return nil
         }
@@ -137,7 +137,7 @@ class IAPHelper: NSObject {
     }
 
     /// Whether the products have been loaded from StoreKit
-    var hasLoadedProducts: Bool { productsArray.count > 0 }
+    var hasLoadedProducts: Bool { !productsArray.isEmpty }
 
     public func getWeeklyReferencePrice(for identifier: IAPProductID) -> Double? {
         guard let product = getProduct(for: identifier) else { return nil }
@@ -253,7 +253,7 @@ extension IAPHelper: SKProductsRequestDelegate {
     func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
         defer { isRequestingProducts = false }
 
-        if response.products.count > 0 {
+        if !response.products.isEmpty {
             productsArray = response.products
 
             // Update the trial eligibility

--- a/podcasts/IncomingShareListViewController.swift
+++ b/podcasts/IncomingShareListViewController.swift
@@ -111,7 +111,7 @@ class IncomingShareListViewController: PCViewController, UITableViewDelegate, UI
     }
 
     private func subscribeNext(loadingAlert: ShiftyLoadingAlert) {
-        if podcasts.count == 0 {
+        if podcasts.isEmpty {
             DispatchQueue.main.async { () in
                 loadingAlert.hideAlert(true)
                 self.dismiss(animated: true, completion: nil)

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -71,7 +71,7 @@ class MultiSelectHelper {
         let uploadedEpisodes = selectedEpisodes.filter { $0.uploaded() }
 
         let confirmPicker: OptionsPicker
-        if downloadedEpisodes.count == 0 {
+        if downloadedEpisodes.isEmpty {
             confirmPicker = OptionsPicker(title: nil)
             let deleteFromCloudAction = OptionAction(label: L10n.deleteFromCloud, icon: nil) { () in
                 DispatchQueue.global().async {
@@ -85,7 +85,7 @@ class MultiSelectHelper {
 
             let warningMessage = deleteFileMessage(uploadedEpisodes.count)
             confirmPicker.addDescriptiveActions(title: L10n.deleteFromCloud, message: warningMessage, icon: "episode-delete", actions: [deleteFromCloudAction])
-        } else if uploadedEpisodes.count == 0 {
+        } else if uploadedEpisodes.isEmpty {
             confirmPicker = OptionsPicker(title: nil)
             let deleteFromDeviceAction = OptionAction(label: L10n.deleteFromDeviceOnly, icon: nil) { () in
                 DispatchQueue.global().async {

--- a/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
@@ -159,7 +159,7 @@ extension PlaylistDetailViewController {
     }
 
     private func downloadableCount(listEpisodes: [ListEpisode]) -> Int {
-        if listEpisodes.count == 0 { return 0 }
+        if listEpisodes.isEmpty { return 0 }
         var count = 0
 
         for listEpisode in listEpisodes {

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -95,7 +95,7 @@ class PlaylistDetailViewController: FakeNavViewController {
                         self.searchController.searchTextField.resignFirstResponder()
                     }
                     self.track(.filterMultiSelectEntered)
-                    if self.selectedEpisodes.count == 0, self.longPressMultiSelectIndexPath == nil, !self.multiSelectGestureInProgress {
+                    if self.selectedEpisodes.isEmpty, self.longPressMultiSelectIndexPath == nil, !self.multiSelectGestureInProgress {
                         self.tableView.scrollToRow(at: IndexPath(row: NSNotFound, section: 1), at: .top, animated: true)
                     }
                     self.multiSelectFooter.setSelectedCount(count: self.selectedEpisodes.count)

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -64,7 +64,7 @@ struct PodcastsCarouselView: View {
                         }
                     }
                 }
-            } else if searchResults.podcasts.count > 0 {
+            } else if !searchResults.podcasts.isEmpty {
                 let fillerPodcast = fillerPodcast()
 
                 // If needed, fill the results with filler podcasts to make sure the sizing and positioning is consistent

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -97,7 +97,7 @@ struct SearchResultsView: View {
                         }
                     ]
                 )
-            } else if searchResults.episodes.count > 0 {
+            } else if !searchResults.episodes.isEmpty {
                 ForEach(searchResults.episodes.prefix(Constants.maxNumberOfEpisodes), id: \.self) { episode in
                     let played = searchResults.playedEpisodesUUIDs.contains(episode.uuid)
                     SearchResultCell(episode: episode, result: nil, played: played)

--- a/podcasts/NotificationsHelper.swift
+++ b/podcasts/NotificationsHelper.swift
@@ -129,7 +129,7 @@ class NotificationsHelper: NSObject, UNUserNotificationCenterDelegate {
 
     private func handleEpisodeNotification(response: UNNotificationResponse, completionHandler: @escaping () -> Void) {
 
-        guard let episodeUuid = response.notification.request.content.userInfo["eu"] as? String, episodeUuid.count > 0 else {
+        guard let episodeUuid = response.notification.request.content.userInfo["eu"] as? String, !episodeUuid.isEmpty else {
             completionHandler()
             return
         }

--- a/podcasts/NowPlayingHelper.swift
+++ b/podcasts/NowPlayingHelper.swift
@@ -45,7 +45,7 @@ class NowPlayingHelper {
     }
 
     private class func titleForNowPlayingInfo(episode: BaseEpisode, currentChapters: Chapters) -> String {
-        if currentChapters.title.count > 0, Settings.publishChapterTitlesEnabled() {
+        if !currentChapters.title.isEmpty, Settings.publishChapterTitlesEnabled() {
             return currentChapters.title
         }
 
@@ -69,7 +69,7 @@ class NowPlayingHelper {
         nowPlayingInfo[MPMediaItemPropertyDiscNumber] = NSNumber(value: 1)
 
         let episodeTitle = titleForNowPlayingInfo(episode: episode, currentChapters: currentChapters)
-        if episodeTitle.count > 0 {
+        if !episodeTitle.isEmpty {
             nowPlayingInfo[MPMediaItemPropertyTitle] = episodeTitle as NSString
         }
 
@@ -95,7 +95,7 @@ class NowPlayingHelper {
             nowPlayingInfo[MPMediaItemPropertyPodcastTitle] = safeCharacterPodcastTitle as NSString
 
             // genre
-            if let podcastCategory = parentPodcast.podcastCategory, podcastCategory.count > 0 {
+            if let podcastCategory = parentPodcast.podcastCategory, !podcastCategory.isEmpty {
                 nowPlayingInfo[MPMediaItemPropertyGenre] = podcastCategory as NSString
             } else {
                 nowPlayingInfo[MPMediaItemPropertyGenre] = "Podcast" as NSString

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -110,7 +110,7 @@ extension NowPlayingPlayerItemViewController {
             episodeInfoView.isHidden = true
             chapterInfoView.isHidden = false
 
-            chapterName.text = chapters.title.count > 0 ? chapters.title : playingEpisode.displayableTitle()
+            chapterName.text = !chapters.title.isEmpty ? chapters.title : playingEpisode.displayableTitle()
 
             chapterSkipBackBtn.isEnabled = !visibleChapter.isFirst
             chapterSkipFwdBtn.isEnabled = !visibleChapter.isLast
@@ -177,8 +177,8 @@ extension NowPlayingPlayerItemViewController {
             return
         }
         let chapters = PlaybackManager.shared.chaptersForTime(time: time)
-        if chapters.count > 0 {
-            episodeName.text = chapters.title.count > 0 ? chapters.title : playingEpisode.displayableTitle()
+        if !chapters.isEmpty {
+            episodeName.text = !chapters.title.isEmpty ? chapters.title : playingEpisode.displayableTitle()
             updateChapterProgress(for: chapters.visibleChapter, playheadPosition: time)
             updateUpTo(upTo: time, duration: chapters.duration, moveSlider: false)
             chapterCounter.text = L10n.playerChapterCount((chapters.index + 1).localized(), PlaybackManager.shared.chapterCount().localized())

--- a/podcasts/OpmlImporter.swift
+++ b/podcasts/OpmlImporter.swift
@@ -35,7 +35,7 @@ class OpmlImporter: Operation, XMLParserDelegate {
             // parse OPML file
             let parser = XMLParser(contentsOf: opmlFileUrl)
             parser?.delegate = self
-            guard let parsed = parser?.parse(), parsed, parsedUrls.count > 0 else {
+            guard let parsed = parser?.parse(), parsed, !parsedUrls.isEmpty else {
                 DispatchQueue.main.sync {
                     if let progressWindow = self.progressWindow {
                         progressWindow.hideAlert(false)
@@ -57,7 +57,7 @@ class OpmlImporter: Operation, XMLParserDelegate {
             importPodcasts(urls: parsedUrls)
 
             var amountOfTimesPolled = 0
-            while amountOfTimesPolled < 20, pollUuids.count > 0 {
+            while amountOfTimesPolled < 20, !pollUuids.isEmpty {
                 amountOfTimesPolled += 1
 
                 let pollUuidsToSend = pollUuids

--- a/podcasts/PCSearchBarController+TextFieldDelegate.swift
+++ b/podcasts/PCSearchBarController+TextFieldDelegate.swift
@@ -12,7 +12,7 @@ extension PCSearchBarController: UITextFieldDelegate {
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if let searchTerm = textField.text, searchTerm.count > 0 {
+        if let searchTerm = textField.text, !searchTerm.isEmpty {
             textField.resignFirstResponder()
             cancelSearchTimer()
             search(searchTerm: searchTerm, triggerdByTimer: false)
@@ -24,7 +24,7 @@ extension PCSearchBarController: UITextFieldDelegate {
     @objc func textFieldDidChange() {
         let searchTerm = searchTextField.text
 
-        if let searchTerm = searchTerm, searchTerm.count > 0 {
+        if let searchTerm = searchTerm, !searchTerm.isEmpty {
             clearSearchBtn.isHidden = false
             searchDelegate?.searchTermChanged(searchTerm)
             resetSearchTimer()

--- a/podcasts/PCViewController.swift
+++ b/podcasts/PCViewController.swift
@@ -60,7 +60,7 @@ class PCViewController: SimpleNotificationsViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if let title = title, title.count > 0 {
+        if let title = title, !title.isEmpty {
             setupNavBar(animated: animated)
         }
         refreshRightButtons()

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -783,7 +783,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     func playingOverAirplay() -> Bool {
         let currentRoute = AVAudioSession.sharedInstance().currentRoute
 
-        if currentRoute.outputs.count == 0 { return false }
+        if currentRoute.outputs.isEmpty { return false }
 
         let currentOutput = currentRoute.outputs[0]
         if currentOutput.portType.rawValue == AVAudioSession.Port.airPlay.rawValue {
@@ -1151,7 +1151,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
 
         // it's technically possible to try and add just the now playing episode, in which case there's nothing more to do
-        if episodesToAdd.count == 0 {
+        if episodesToAdd.isEmpty {
             queue.bulkOperationDidComplete()
 
             return

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -294,7 +294,7 @@ class PlaybackQueue: NSObject {
         if includeNowPlaying { return DataManager.sharedManager.allUpNextEpisodes() }
 
         var episodes = DataManager.sharedManager.allUpNextEpisodes()
-        if episodes.count == 0 { return episodes }
+        if episodes.isEmpty { return episodes }
 
         episodes.removeFirst()
 
@@ -303,7 +303,7 @@ class PlaybackQueue: NSObject {
 
     func allEpisodeUuids() -> [BaseEpisode] {
         var episodes = DataManager.sharedManager.allUpNextEpisodeUuids()
-        if episodes.count == 0 { return episodes }
+        if episodes.isEmpty { return episodes }
 
         episodes.removeFirst()
 

--- a/podcasts/PlaylistManager.swift
+++ b/podcasts/PlaylistManager.swift
@@ -135,7 +135,7 @@ class PlaylistManager {
         if playlists.isEmpty { return }
 
         for playlist in playlists {
-            guard !playlist.filterAllPodcasts, playlist.podcastUuids.count > 0 else { continue }
+            guard !playlist.filterAllPodcasts, !playlist.podcastUuids.isEmpty else { continue }
 
             var podcastUuids = playlist.podcastUuids.components(separatedBy: ",")
             guard let indexOfUuid = podcastUuids.firstIndex(of: podcastUuid) else { continue }

--- a/podcasts/PlaylistShortcutsViewController.swift
+++ b/podcasts/PlaylistShortcutsViewController.swift
@@ -190,22 +190,22 @@ class PlaylistShortcutsViewController: PCViewController, UITableViewDelegate, UI
     }
 
     func enabledSection() -> Int {
-        enabledShortcuts.count > 0 ? 0 : -1
+        !enabledShortcuts.isEmpty ? 0 : -1
     }
 
     func availableSection() -> Int {
         if enabledSection() == 0 {
-            return availableRows.count > 0 ? 1 : -1
+            return !availableRows.isEmpty ? 1 : -1
         }
         return 0
     }
 
     private func reloadData() {
         tableData = []
-        if enabledShortcuts.count > 0 {
+        if !enabledShortcuts.isEmpty {
             tableData.append(.enabledSection)
         }
-        if availableRows.count > 0 {
+        if !availableRows.isEmpty {
             tableData.append(.availableSection)
         }
         DispatchQueue.main.async {

--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -488,7 +488,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
             strongSelf.firstTimeLoading = false
             strongSelf.loadingIndicator.stopAnimating()
 
-            strongSelf.tableView.isHidden = (newData.count == 0)
+            strongSelf.tableView.isHidden = (newData.isEmpty)
             if animated {
                 let oldData = strongSelf.episodes
                 let changeSet = StagedChangeset(source: oldData, target: newData)
@@ -511,7 +511,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
         DispatchQueue.global().async { [weak self] in
             guard let self = self else { return }
 
-            if self.episodes.count == 0 { return }
+            if self.episodes.isEmpty { return }
 
             var haveFoundFirst = false
             for listEpisode in self.episodes {
@@ -531,7 +531,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
         DispatchQueue.global().async { [weak self] in
             guard let self = self else { return }
 
-            if self.episodes.count == 0 { return }
+            if self.episodes.isEmpty { return }
 
             self.downloadItems(allEpisodes: self.episodes)
         }
@@ -541,7 +541,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
         DispatchQueue.global().async { [weak self] in
             guard let self = self else { return }
 
-            if self.episodes.count == 0 { return }
+            if self.episodes.isEmpty { return }
             self.queueItems(allEpisodes: self.episodes)
         }
     }
@@ -578,7 +578,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
     }
 
     func downloadableCount(listEpisodes: [ListEpisode]) -> Int {
-        if listEpisodes.count == 0 { return 0 }
+        if listEpisodes.isEmpty { return 0 }
         var count = 0
 
         for listEpisode in listEpisodes {

--- a/podcasts/PodcastChapterParser.swift
+++ b/podcasts/PodcastChapterParser.swift
@@ -85,7 +85,7 @@ class PodcastChapterParser {
                 try SJCommonUtils.catchException {
                     let customHeaders = [ServerConstants.HttpHeaders.userAgent: ServerConstants.Values.appUserAgent]
                     let movieAsset = AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": customHeaders])
-                    guard let chapters = MNAVChapterReader.chapters(from: movieAsset) as? [MNAVChapter], chapters.count > 0 else {
+                    guard let chapters = MNAVChapterReader.chapters(from: movieAsset) as? [MNAVChapter], !chapters.isEmpty else {
                         completion([])
                         return
                     }

--- a/podcasts/PodcastChooserViewController.swift
+++ b/podcasts/PodcastChooserViewController.swift
@@ -96,7 +96,7 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
             selectedUuids.remove(at: index)
             Analytics.track(.settingsSelectPodcastsPodcastToggled, properties: ["uuid": podcastUuid, "enabled": false, "source": analyticsSource])
             // to support things like playlist editting that need to know about all/none selected events send a different event when it gets to 0
-            if selectedUuids.count == 0, allowSelectAll {
+            if selectedUuids.isEmpty, allowSelectAll {
                 delegate?.bulkSelectionChange(selected: false)
             } else {
                 delegate?.podcastUnselected(podcast: podcastUuid)

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -227,7 +227,7 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
 
     @objc private func saveTapped(sender: Any) {
         let podcasts = currentPodcastsSource()
-        if selectedUuids.count == podcasts.count || selectedUuids.count == 0 {
+        if selectedUuids.count == podcasts.count || selectedUuids.isEmpty {
             filterToEdit.podcastUuids = ""
             filterToEdit.filterAllPodcasts = true
         } else {

--- a/podcasts/PodcastManager+Cleanup.swift
+++ b/podcasts/PodcastManager+Cleanup.swift
@@ -17,7 +17,7 @@ extension PodcastManager {
         let interactedEpisodes = dataManager.allEpisodesForPodcast(id: podcast.id).filter { $0.userHasInteractedWithEpisode() }
 
         // we can safely delete podcasts where the user hasn't interacted with any of the episodes
-        if interactedEpisodes.count == 0 {
+        if interactedEpisodes.isEmpty {
             let episodes = dataManager.allEpisodesForPodcast(id: podcast.id)
             await downloadManager.cancelTasks(for: episodes)
 
@@ -29,7 +29,7 @@ extension PodcastManager {
 
     func deleteGhostEpisodesIfNeeded() {
         let episodes = dataManager.findGhostEpisodes()
-        guard episodes.count != 0 else {
+        guard !episodes.isEmpty else {
             return
         }
 
@@ -40,7 +40,7 @@ extension PodcastManager {
 
         episodes.forEach { episode in
             guard
-                episode.uuid.count != 0,
+                !episode.uuid.isEmpty,
                 episode.userHasInteractedWithEpisode() == false
             else {
                 return
@@ -65,7 +65,7 @@ extension PodcastManager {
         let allPaidPodcasts = dataManager.allPaidPodcasts()
 
         let licenseRestrictedPodcasts = allPaidPodcasts.filter { $0.licensing == PodcastLicensing.deleteEpisodesAfterExpiry.rawValue }
-        if licenseRestrictedPodcasts.count == 0 { return }
+        if licenseRestrictedPodcasts.isEmpty { return }
 
         for podcast in licenseRestrictedPodcasts {
             guard let subscription = SubscriptionHelper.subscriptionForPodcast(uuid: podcast.uuid) else { continue }

--- a/podcasts/PodcastPickerModel.swift
+++ b/podcasts/PodcastPickerModel.swift
@@ -88,9 +88,9 @@ class PodcastPickerModel: ObservableObject {
 
 extension PodcastPickerModel {
     func trackSearchIfNeeded(oldValue: String, newValue: String) {
-        if oldValue.count == 0 && newValue.count > 0 {
+        if oldValue.isEmpty && !newValue.isEmpty {
             Analytics.track(.folderPodcastPickerSearchPerformed)
-        } else if oldValue.count > 0 && newValue.count == 0 {
+        } else if !oldValue.isEmpty && newValue.isEmpty {
             Analytics.track(.folderPodcastPickerSearchCleared)
         }
     }

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -398,7 +398,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
             data[1].append(.globalUpNext)
         }
 
-        if playlistsPodcastCanAppearIn().count > 0 {
+        if !playlistsPodcastCanAppearIn().isEmpty {
             data.append([.inFilters])
         }
         data.append([.siriShortcut])

--- a/podcasts/PodcastViewController+MultiSelect.swift
+++ b/podcasts/PodcastViewController+MultiSelect.swift
@@ -67,11 +67,11 @@ extension PodcastViewController {
         } else {
             let shouldSelectAll = multiSelectAllBtn.title(for: .normal) == L10n.selectAll
             if shouldSelectAll {
-                guard let allObjects = episodeInfo[safe: 1]?.elements, allObjects.count > 0 else { return }
+                guard let allObjects = episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
                 episodesTable.selectAllBelow(fromIndexPath: IndexPath(row: 0, section: PodcastViewController.allEpisodesSection))
             } else {
                 episodesTable.deselectAll()
-                if selectedEpisodes.count != 0 { // special case where hidden (archived) episodes are selected
+                if !selectedEpisodes.isEmpty { // special case where hidden (archived) episodes are selected
                     selectedEpisodes.removeAll()
                 }
             }

--- a/podcasts/PodcastViewController.swift
+++ b/podcasts/PodcastViewController.swift
@@ -164,7 +164,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             }
 
             if self.isMultiSelectEnabled {
-                if self.selectedEpisodes.count == 0, self.longPressMultiSelectIndexPath == nil, !self.multiSelectGestureInProgress {
+                if self.selectedEpisodes.isEmpty, self.longPressMultiSelectIndexPath == nil, !self.multiSelectGestureInProgress {
                     self.tableView().scrollToRow(at: IndexPath(row: NSNotFound, section: PodcastViewController.allEpisodesSection), at: .top, animated: true)
                 }
                 self.multiSelectFooter.setSelectedCount(count: self.selectedEpisodes.count)
@@ -997,7 +997,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         guard let podcast = podcast else { return }
 
         DispatchQueue.global().async { [weak self] in
-            guard let allObjects = self?.episodeInfo[safe: 1]?.elements, allObjects.count > 0 else { return }
+            guard let allObjects = self?.episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
 
             var count = 0
             for object in allObjects {
@@ -1021,7 +1021,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     func downloadAllTapped() {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self, let allObjects = self.episodeInfo[safe: 1]?.elements, allObjects.count > 0 else { return }
+            guard let self = self, let allObjects = self.episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
 
             let episodes = allObjects.compactMap { ($0 as? ListEpisode)?.episode }
             AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
@@ -1093,7 +1093,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     private func episodesForSeason(_ season: Int) -> [ListEpisode] {
         guard let allObjects = self.episodeInfo[safe: 1]?.elements,
-              allObjects.count > 0
+              !allObjects.isEmpty
         else {
             return []
         }
@@ -1162,7 +1162,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     func queueAllTapped() {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self, let allObjects = self.episodeInfo[safe: 1]?.elements, allObjects.count > 0 else { return }
+            guard let self = self, let allObjects = self.episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
             self.queueItems(allObjects: allObjects)
         }
     }
@@ -1186,7 +1186,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func downloadableEpisodeCount(items: [ListItem]? = nil) -> Int {
-        guard let allObjects = items == nil ? episodeInfo[safe: 1]?.elements : items, allObjects.count > 0 else { return 0 }
+        guard let allObjects = items == nil ? episodeInfo[safe: 1]?.elements : items, !allObjects.isEmpty else { return 0 }
 
         var count = 0
 
@@ -1562,7 +1562,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         guard let podcast = podcast else { return }
 
         DispatchQueue.global().async { [weak self] in
-            guard let allObjects = self?.episodeInfo[safe: 1]?.elements, allObjects.count > 0 else { return }
+            guard let allObjects = self?.episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
 
             var haveFoundFirst = false
             for object in allObjects {

--- a/podcasts/PromotionViewController.swift
+++ b/podcasts/PromotionViewController.swift
@@ -80,7 +80,7 @@ class PromotionViewController: UIViewController, SyncSigninDelegate, AccountUpda
 
         (view as? ThemeableView)?.style = .primaryUi01
 
-        if let code = promoCode, code.count > 0 {
+        if let code = promoCode, !code.isEmpty {
             if SyncManager.isUserLoggedIn() {
                 redeemCode()
             } else {

--- a/podcasts/SceneDelegate.swift
+++ b/podcasts/SceneDelegate.swift
@@ -37,7 +37,7 @@ class SceneDelegate: UIResponder, UISceneDelegate, UIWindowSceneDelegate {
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        guard URLContexts.count > 0, let url = URLContexts.first?.url, let rootViewController = window?.rootViewController else {
+        guard !URLContexts.isEmpty, let url = URLContexts.first?.url, let rootViewController = window?.rootViewController else {
             return
         }
         _ = appDelegate()?.handleOpenUrl(url: url, rootViewController: rootViewController)

--- a/podcasts/SharePodcastsViewController.swift
+++ b/podcasts/SharePodcastsViewController.swift
@@ -130,7 +130,7 @@ class SharePodcastsViewController: PCViewController, UICollectionViewDelegate, U
             self.selectAllBtn.layoutIfNeeded()
         }
 
-        nextBtn.isEnabled = selectedPodcasts.count > 0
+        nextBtn.isEnabled = !selectedPodcasts.isEmpty
     }
 
     private func loadPodcasts() {

--- a/podcasts/SharePublishViewController.swift
+++ b/podcasts/SharePublishViewController.swift
@@ -189,7 +189,7 @@ class SharePublishViewController: PCViewController, UICollectionViewDelegate, UI
         CATransaction.begin()
         CATransaction.setCompletionBlock {
             self.animationCompleted = true
-            if !self.sharingFailed, self.sharingUrl.count > 0 {
+            if !self.sharingFailed, !self.sharingUrl.isEmpty {
                 self.sharingDidSucceed(self.sharingUrl)
             }
         }
@@ -258,7 +258,7 @@ class SharePublishViewController: PCViewController, UICollectionViewDelegate, UI
     private func transitionToShareFailed() {
         removeAllAnimatedCells()
 
-        if listDescription.text.count == 0 {
+        if listDescription.text.isEmpty {
             descriptionPlaceholder.isHidden = false
         }
         podcastCollectionView.isHidden = false
@@ -325,13 +325,13 @@ class SharePublishViewController: PCViewController, UICollectionViewDelegate, UI
     }
 
     func textViewDidChange(_ textView: UITextView) {
-        descriptionPlaceholder.isHidden = textView.text.count > 0
+        descriptionPlaceholder.isHidden = !textView.text.isEmpty
     }
 
     @IBAction func nameDidChange(_ sender: AnyObject) {
         let name = listName.text == nil ? "" : listName.text!
 
-        shareBtn.isEnabled = name.count > 0
+        shareBtn.isEnabled = !name.isEmpty
     }
 
     // MARK: - Orientation

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -154,7 +154,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
             if let showNotes = try? await ShowInfoCoordinator.shared.loadShowNotes(podcastUuid: episode.parentIdentifier(), episodeUuid: episode.uuid) {
                 self?.downloadingShowNotes = false
 
-                let shouldResetScrollOffset = lastEpisodeUuidRendered != episode.uuid && lastEpisodeUuidRendered != ""
+                let shouldResetScrollOffset = lastEpisodeUuidRendered != episode.uuid && !lastEpisodeUuidRendered.isEmpty
                 self?.displayShowNotes(showNotes, shouldResetScrollOffset: shouldResetScrollOffset)
 
                 // if we get back the no show notes available message, make sure next update we try again

--- a/podcasts/SimpleNotificationsViewController.swift
+++ b/podcasts/SimpleNotificationsViewController.swift
@@ -12,7 +12,7 @@ class SimpleNotificationsViewController: UIViewController {
     }
 
     func removeAllCustomObservers() {
-        if customObservers.count == 0 { return }
+        if customObservers.isEmpty { return }
 
         let notCenter = NotificationCenter.default
         for name in customObservers {
@@ -22,7 +22,7 @@ class SimpleNotificationsViewController: UIViewController {
     }
 
     private func containsObserver(_ name: Notification.Name) -> Bool {
-        if customObservers.count == 0 { return false }
+        if customObservers.isEmpty { return false }
 
         return customObservers.contains(name)
     }

--- a/podcasts/SiriPodcastSearchManager.swift
+++ b/podcasts/SiriPodcastSearchManager.swift
@@ -9,7 +9,7 @@ class SiriPodcastSearchManager {
         do {
             let subscribedPodcasts = try JSONDecoder().decode([SiriPodcastItem].self, from: serializedPodcasts)
 
-            guard subscribedPodcasts.count > 0 else { return nil }
+            guard !subscribedPodcasts.isEmpty else { return nil }
 
             let podcastNames = subscribedPodcasts.map(\.name)
 

--- a/podcasts/SiriSettingsViewController.swift
+++ b/podcasts/SiriSettingsViewController.swift
@@ -173,11 +173,11 @@ class SiriSettingsViewController: PCViewController, UITableViewDelegate, UITable
 
     private func reloadData() {
         var newSections = [sections]()
-        if enabledShortcuts.count > 0 {
+        if !enabledShortcuts.isEmpty {
             newSections.append(.enabledSection)
         }
 
-        if suggestedShortcuts.count > 0 {
+        if !suggestedShortcuts.isEmpty {
             newSections.append(.suggestedSection)
         }
 
@@ -278,7 +278,7 @@ class SiriSettingsViewController: PCViewController, UITableViewDelegate, UITable
 
     func editVoiceShortcutViewController(_ controller: INUIEditVoiceShortcutViewController, didDeleteVoiceShortcutWithIdentifier deletedVoiceShortcutIdentifier: UUID) {
         let shortcutsToDelete = enabledShortcuts.filter { $0.identifier == deletedVoiceShortcutIdentifier }
-        if shortcutsToDelete.count > 0 {
+        if !shortcutsToDelete.isEmpty {
             deleteEnabledShortcut(voiceShortcut: shortcutsToDelete[0])
         }
         navigationController?.popToViewController(self, animated: false)

--- a/podcasts/StarredViewController.swift
+++ b/podcasts/StarredViewController.swift
@@ -106,7 +106,7 @@ class StarredViewController: PCViewController {
                 DispatchQueue.main.sync { [weak self] in
                     guard let strongSelf = self else { return }
                     strongSelf.loadingIndicator.stopAnimating()
-                    strongSelf.starredTable.isHidden = (newData.count == 0)
+                    strongSelf.starredTable.isHidden = (newData.isEmpty)
                     if animated {
                         let changeSet = StagedChangeset(source: oldData, target: newData)
                         strongSelf.starredTable.reload(using: changeSet, with: .none, setData: { data in
@@ -128,7 +128,7 @@ class StarredViewController: PCViewController {
             let newData = self.episodesDataManager.starredEpisodes()
 
             DispatchQueue.main.sync {
-                self.starredTable.isHidden = (newData.count == 0)
+                self.starredTable.isHidden = (newData.isEmpty)
                 if animated {
                     let changeSet = StagedChangeset(source: oldData, target: newData)
                     self.starredTable.reload(using: changeSet, with: .none, setData: { data in

--- a/podcasts/StorageAndDataUseViewController.swift
+++ b/podcasts/StorageAndDataUseViewController.swift
@@ -59,7 +59,7 @@ class StorageAndDataUseViewController: PCViewController, UITableViewDelegate, UI
 
             let fileSize = EpisodeManager.downloadSizeOfAllEpisodes()
             let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: Int64(fileSize))
-            cell.cellSecondaryLabel.text = sizeAsStr == "" ? SizeFormatter.shared.placeholder : sizeAsStr
+            cell.cellSecondaryLabel.text = sizeAsStr.isEmpty ? SizeFormatter.shared.placeholder : sizeAsStr
 
             return cell
         } else {

--- a/podcasts/SuggestedFoldersModel.swift
+++ b/podcasts/SuggestedFoldersModel.swift
@@ -82,7 +82,7 @@ class SuggestedFoldersModel: ObservableObject {
     }
 
     var userHasExistingFolders: Bool {
-        return dataManager.allFolders().count > 0
+        return !dataManager.allFolders().isEmpty
     }
 
     var userIsSignedIn: Bool {

--- a/podcasts/SupporterContributionsViewController.swift
+++ b/podcasts/SupporterContributionsViewController.swift
@@ -55,7 +55,7 @@ class SupporterContributionsViewController: PCViewController, UITableViewDelegat
         }
 
         if bundle.podcasts?.count == 1 {
-            guard let subscription = bundleSubscriptions?[indexPath.row].podcasts.first, subscription.uuid.count > 0 else {
+            guard let subscription = bundleSubscriptions?[indexPath.row].podcasts.first, !subscription.uuid.isEmpty else {
                 cell.isLoading = true
                 cell.heartView.setGradientColors(light: AppTheme.podcastHeartLightRedGradientColor(), dark: AppTheme.podcastHeartDarkRedGradientColor())
 

--- a/podcasts/UIViewController+requestReview.swift
+++ b/podcasts/UIViewController+requestReview.swift
@@ -9,7 +9,7 @@ extension UIViewController {
     ///     - delay: The number of seconds this function will wait before showing
     ///     the modal.
     func requestReview(delay: Double) {
-        guard Settings.reviewRequestDates().count == 0 else { return }
+        guard Settings.reviewRequestDates().isEmpty else { return }
 
         Task { @MainActor [weak self] in
             guard let self else { return }

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -60,7 +60,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     var selectedPlayListEpisodes = [PlaylistEpisode]() {
         didSet {
             multiSelectActionBar.setSelectedCount(count: selectedPlayListEpisodes.count)
-            if selectedPlayListEpisodes.count == 0 {
+            if selectedPlayListEpisodes.isEmpty {
                 contentInseter.isMultiSelectEnabled = false
             } else {
                 contentInseter.isMultiSelectEnabled = true

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -238,7 +238,7 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
 
     func reloadLocalFiles() {
         uploadedEpisodes = episodesDataManager.uploadedEpisodes()
-        uploadsTable.isHidden = (uploadedEpisodes.count == 0)
+        uploadsTable.isHidden = (uploadedEpisodes.isEmpty)
 
         uploadsTable.reloadData()
         updateHeaderView()

--- a/podcasts/UserEpisode+Formatting.swift
+++ b/podcasts/UserEpisode+Formatting.swift
@@ -23,7 +23,7 @@ extension UserEpisode {
         var informationLabelStr = duration > 0 ? displayableTimeLeft() : L10n.unknownDuration
 
         if includeSize, sizeInBytes > 0 {
-            if informationLabelStr.count == 0 {
+            if informationLabelStr.isEmpty {
                 informationLabelStr = SizeFormatter.shared.noDecimalFormat(bytes: sizeInBytes)
             } else {
                 informationLabelStr += " • \(SizeFormatter.shared.noDecimalFormat(bytes: sizeInBytes))"

--- a/podcasts/UserEpisodeManager.swift
+++ b/podcasts/UserEpisodeManager.swift
@@ -59,7 +59,7 @@ struct UserEpisodeManager {
 
     static func updateUserEpisodes() {
         let episodes = DataManager.sharedManager.unsyncedUserEpisodes()
-        if episodes.count > 0 {
+        if !episodes.isEmpty {
             ApiServerHandler.shared.uploadFilesUpdateRequest(episodes: episodes, completion: { _ in })
         }
 
@@ -127,12 +127,12 @@ struct UserEpisodeManager {
 
     static func checkForPendingCloudDeletes() {
         let allCloudDeletes = DataManager.sharedManager.findUserEpisodesWithUploadStatus(.deleteFromCloudPending)
-        if allCloudDeletes.count > 0 {
+        if !allCloudDeletes.isEmpty {
             ApiServerHandler.shared.processPendingCloudDeletes(episodes: allCloudDeletes, deleteCompletedHandler: nil)
         }
 
         let allLocalAndCloudDeletes = DataManager.sharedManager.findUserEpisodesWithUploadStatus(.deleteFromCloudAndLocalPending)
-        if allLocalAndCloudDeletes.count > 0 {
+        if !allLocalAndCloudDeletes.isEmpty {
             ApiServerHandler.shared.processPendingCloudDeletes(episodes: allLocalAndCloudDeletes) { episode in
                 UserEpisodeManager.deleteFromDevice(userEpisode: episode, removeFromPlaybackQueue: false)
             }

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -548,7 +548,7 @@ class WatchManager: NSObject, WCSessionDelegate {
         var upNextList = [[String: Any]]()
 
         let upNextEpisodes = PlaybackManager.shared.allEpisodesInQueue(includeNowPlaying: false)
-        if upNextEpisodes.count == 0 { return upNextList }
+        if upNextEpisodes.isEmpty { return upNextList }
 
         let truncatedList = Array(upNextEpisodes.prefix(Constants.Limits.maxListItemsToSendToWatch))
         for episode in truncatedList {
@@ -577,7 +577,7 @@ class WatchManager: NSObject, WCSessionDelegate {
 
     private func serializePodcastArchiveSettings() -> [[String: Any]]? {
         let podcastsWithOverride = DataManager.sharedManager.allOverrideGlobalArchivePodcasts()
-        guard podcastsWithOverride.count > 0 else { return nil }
+        guard !podcastsWithOverride.isEmpty else { return nil }
 
         var podcastArchiveSettings = [[String: Any]]()
         podcastsWithOverride.forEach {

--- a/podcasts/WatchNowPlayingHelper.swift
+++ b/podcasts/WatchNowPlayingHelper.swift
@@ -46,7 +46,7 @@ class WatchNowPlayingHelper {
         nowPlayingInfo[MPMediaItemPropertyDiscNumber] = NSNumber(value: 1)
 
         let episodeTitle = titleForNowPlayingInfo(episode: episode)
-        if episodeTitle.count > 0 {
+        if !episodeTitle.isEmpty {
             nowPlayingInfo[MPMediaItemPropertyTitle] = episodeTitle as NSString
         }
 

--- a/podcasts/WidgetHelper.swift
+++ b/podcasts/WidgetHelper.swift
@@ -27,7 +27,7 @@ class WidgetHelper {
 
     func updateAllWidgets() {
         WidgetCenter.shared.getCurrentConfigurations { result in
-            guard case .success = result, let widgets = try? result.get(), widgets.count > 0 else { return }
+            guard case .success = result, let widgets = try? result.get(), !widgets.isEmpty else { return }
 
             if widgets.contains(where: { $0.kind == "Now_Playing_Widget" }) {
                 self.publishAppIcon()
@@ -227,7 +227,7 @@ class WidgetHelper {
         do {
             var upNextUuids = [String]()
             let upNextEpisodes = PlaybackManager.shared.allEpisodesInQueue(includeNowPlaying: true)
-            if upNextEpisodes.count > 0 {
+            if !upNextEpisodes.isEmpty {
                 let numUpNextUuids = max(0, min(WidgetHelper.maxUpNextToPublish, upNextEpisodes.count - 1))
                 upNextUuids = upNextEpisodes[0 ... numUpNextUuids].map(\.uuid)
             }


### PR DESCRIPTION
This PR was created by Codex using GPT-5.3-codex as part of an experiment in autonomous agents working across multiple repos. The result was not satisfactory.

---

Batch 1A rollout for SwiftLint rules:\n- empty_count\n- empty_string\n- contains_over_filter_is_empty\n\nExecution notes:\n- Started from up-to-date default branch worktree\n- Applied SwiftLint --fix first where repo-native plugin workflow was available\n- Applied agentic fixes for remaining violations in this batch\n\nPinned SwiftLint fix/lint run complete; no remaining Batch 1A violations.\n\nHuman merge only.