### PR TITLE
Update Now Playing on device change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 8.7
 -----
 - Playlists: Add episode to a playlist from episode details [##3943](https://github.com/Automattic/pocket-casts-ios/pull/3943/) 
+- Refresh Now Playing info when Bluetooth device connects [#3964](https://github.com/Automattic/pocket-casts-ios/pull/3964) 
 
 8.6
 -----

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1974,6 +1974,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             player?.routeDidChange(shouldPause: true)
         } else if reason == AVAudioSession.RouteChangeReason.newDeviceAvailable.rawValue || reason == AVAudioSession.RouteChangeReason.override.rawValue {
             player?.routeDidChange(shouldPause: false)
+            updateAllNowPlayingData()
         }
     }
 


### PR DESCRIPTION
Fixes [PCIOS-240](https://linear.app/a8c/issue/PCIOS-240/not-sending-episode-metadata-to-bluetooth-device)

Update our now playing info whenever a route changes. Hopefully, this should trigger any connected bluetooth devices, such as car stereos, to update their information.

## To test

* Ideally, test with a connected car stereo and verify that info is display on screen immediately after connecting
* Smoke test AirPlay and Bluetooth playback

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
