### PR TITLE
[Watch + Up Next] watchOS Sentry logging

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/ServerConfig.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/ServerConfig.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsDataModel
 
 public class ServerConfig {
     public static let shared = ServerConfig()
@@ -9,6 +10,9 @@ public class ServerConfig {
 
     public var syncDelegate: ServerSyncDelegate?
     public var playbackDelegate: ServerPlaybackDelegate?
+
+    /// Error logger for reporting sync errors to crash reporting services (e.g., Sentry)
+    public var errorLogger: ErrorLogger?
 
     public func setBackgroundSessionCompletionHandler(handler: (() -> Void)?) {
         backgroundSessionHandler = handler

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -310,30 +310,38 @@ class UpNextSyncTask: ApiBaseTask {
 
         FileLog.shared.addMessage("UpNextSyncTask: The following \(uuids.count) episodes will be kept: \(uuids)")
 
-        // Calculate how many episodes will be deleted
-        let episodesToDelete = localEpisodes.filter { !uuids.contains($0.uuid) }
-        let deletedCount = episodesToDelete.count
+        let uuidsSet = Set(uuids)
+        let deletedCount = localEpisodes.reduce(0) { count, episode in
+            uuidsSet.contains(episode.uuid) ? count : count + 1
+        }
 
-        // Log to Sentry if episodes are being deleted from the queue
-        // This helps track unexpected queue overwrites
+        // Log to Sentry only if queue is significantly modified to avoid noise from normal sync
+        // Threshold: more than 75% of local queue replaced
+        let deletionPercentage = localEpisodes.count > 0 ? Double(deletedCount) / Double(localEpisodes.count) : 0
+        let isSignificantDeletion = deletionPercentage > 0.75
+
         if deletedCount > 0 {
             let syncReason = reason?.rawValue ?? "unknown"
             FileLog.shared.addMessage("UpNextSyncTask: Deleting \(deletedCount) episodes from queue. Local had \(localEpisodes.count), server sent \(episodes.count), keeping \(uuids.count). Reason: \(syncReason)")
 
-            let overwriteError = UpNextSyncError.queueOverwritten(
-                localCount: localEpisodes.count,
-                serverCount: episodes.count,
-                deletedCount: deletedCount,
-                reason: syncReason
-            )
-            ServerConfig.shared.errorLogger?.log(error: overwriteError, context: [
-                "source": "upnext_sync",
-                "localCount": "\(localEpisodes.count)",
-                "serverCount": "\(episodes.count)",
-                "deletedCount": "\(deletedCount)",
-                "keptCount": "\(uuids.count)",
-                "syncReason": syncReason
-            ])
+            // Only report to error logger for significant overwrites
+            if isSignificantDeletion {
+                let overwriteError = UpNextSyncError.queueOverwritten(
+                    localCount: localEpisodes.count,
+                    serverCount: episodes.count,
+                    deletedCount: deletedCount,
+                    reason: syncReason
+                )
+                ServerConfig.shared.errorLogger?.log(error: overwriteError, context: [
+                    "source": "upnext_sync",
+                    "localCount": "\(localEpisodes.count)",
+                    "serverCount": "\(episodes.count)",
+                    "deletedCount": "\(deletedCount)",
+                    "keptCount": "\(uuids.count)",
+                    "syncReason": syncReason,
+                    "deletionPercentage": String(format: "%.1f", deletionPercentage * 100)
+                ])
+            }
         }
 
         // Remove any episodes that no longer need to be in the queue.

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -3,6 +3,32 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
+/// Errors that can occur during Up Next sync operations
+public enum UpNextSyncError: LocalizedError {
+    case serverSyncFailed(httpStatus: Int)
+    case protobufEncodingFailed(underlyingError: Error)
+    case serverDataDecodeFailed(underlyingError: Error)
+    /// Logged when the Up Next queue is significantly modified by a sync operation
+    case queueOverwritten(localCount: Int, serverCount: Int, deletedCount: Int, reason: String?)
+    /// Logged when an archived episode is re-added to queue during sync (server has stale data)
+    case archivedEpisodeAddedToQueue(uuid: String, title: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .serverSyncFailed(let httpStatus):
+            return "Up Next sync failed with HTTP status: \(httpStatus)"
+        case .protobufEncodingFailed(let error):
+            return "Up Next sync protobuf encoding failed: \(error.localizedDescription)"
+        case .serverDataDecodeFailed(let error):
+            return "Up Next sync server data decode failed: \(error.localizedDescription)"
+        case .queueOverwritten(let localCount, let serverCount, let deletedCount, let reason):
+            return "Up Next queue overwritten: local=\(localCount), server=\(serverCount), deleted=\(deletedCount), reason=\(reason ?? "unknown")"
+        case .archivedEpisodeAddedToQueue(let uuid, let title):
+            return "Up Next sync added archived episode to queue: \(title) (\(uuid))"
+        }
+    }
+}
+
 class UpNextSyncTask: ApiBaseTask {
     private static let processDataLock = NSObject()
 
@@ -27,9 +53,13 @@ class UpNextSyncTask: ApiBaseTask {
                 process(serverData: response, latestActionTime: latestActionTime)
             } else {
                 FileLog.shared.addMessage("UpNextSyncTask: Unable to sync with server got status \(httpStatus)")
+                let syncError = UpNextSyncError.serverSyncFailed(httpStatus: httpStatus)
+                ServerConfig.shared.errorLogger?.log(error: syncError, context: ["source": "upnext_sync", "httpStatus": "\(httpStatus)"])
             }
         } catch {
             FileLog.shared.addMessage("UpNextSyncTask: had issues encoding protobuf \(error.localizedDescription)")
+            let syncError = UpNextSyncError.protobufEncodingFailed(underlyingError: error)
+            ServerConfig.shared.errorLogger?.log(error: syncError, context: ["source": "upnext_sync"])
         }
     }
 
@@ -135,6 +165,8 @@ class UpNextSyncTask: ApiBaseTask {
             clearSyncedData(latestActionTime: latestActionTime)
         } catch {
             FileLog.shared.addMessage("UpNextSyncTask: Failed to decode server data")
+            let syncError = UpNextSyncError.serverDataDecodeFailed(underlyingError: error)
+            ServerConfig.shared.errorLogger?.log(error: syncError, context: ["source": "upnext_sync"])
         }
     }
 
@@ -277,6 +309,32 @@ class UpNextSyncTask: ApiBaseTask {
         }
 
         FileLog.shared.addMessage("UpNextSyncTask: The following \(uuids.count) episodes will be kept: \(uuids)")
+
+        // Calculate how many episodes will be deleted
+        let episodesToDelete = localEpisodes.filter { !uuids.contains($0.uuid) }
+        let deletedCount = episodesToDelete.count
+
+        // Log to Sentry if episodes are being deleted from the queue
+        // This helps track unexpected queue overwrites
+        if deletedCount > 0 {
+            let syncReason = reason?.rawValue ?? "unknown"
+            FileLog.shared.addMessage("UpNextSyncTask: Deleting \(deletedCount) episodes from queue. Local had \(localEpisodes.count), server sent \(episodes.count), keeping \(uuids.count). Reason: \(syncReason)")
+
+            let overwriteError = UpNextSyncError.queueOverwritten(
+                localCount: localEpisodes.count,
+                serverCount: episodes.count,
+                deletedCount: deletedCount,
+                reason: syncReason
+            )
+            ServerConfig.shared.errorLogger?.log(error: overwriteError, context: [
+                "source": "upnext_sync",
+                "localCount": "\(localEpisodes.count)",
+                "serverCount": "\(episodes.count)",
+                "deletedCount": "\(deletedCount)",
+                "keptCount": "\(uuids.count)",
+                "syncReason": syncReason
+            ])
+        }
 
         // Remove any episodes that no longer need to be in the queue.
         DataManager.sharedManager.deleteAllUpNextEpisodesNotIn(uuids: uuids)

--- a/Pocket Casts Watch App/ExtensionDelegate.swift
+++ b/Pocket Casts Watch App/ExtensionDelegate.swift
@@ -1,3 +1,4 @@
+import AutomatticRemoteLogging
 import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
@@ -5,11 +6,21 @@ import WatchKit
 
 class ExtensionDelegate: NSObject, WKApplicationDelegate {
     private var haveAttemptedStateRestore = false
+    private var crashLogging: CrashLogging?
 
     func applicationDidFinishLaunching() {
+        setupCrashLogging()
+
         SessionManager.shared.setup()
         WatchSyncManager.shared.setup()
         restorePreviousStateIfRequired()
+    }
+
+    private func setupCrashLogging() {
+        crashLogging = try? CrashLogging(dataProvider: WatchCrashLoggingDataProvider()).start()
+        if let crashLogging = crashLogging {
+            ServerConfig.shared.errorLogger = WatchCrashLoggingErrorLogger(crashLogging: crashLogging)
+        }
     }
 
     func applicationDidBecomeActive() {
@@ -100,5 +111,38 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
                 FileLog.shared.addMessage("Task scheduling error \(error.localizedDescription)")
             }
         }
+    }
+}
+
+// MARK: - Crash Logging
+
+private class WatchCrashLoggingDataProvider: AutomatticRemoteLogging.CrashLoggingDataProvider {
+    let sentryDSN = ApiCredentials.sentryDSN
+    let userHasOptedOut = false
+    let shouldEnableAutomaticSessionTracking = true
+
+    var currentUser: AutomatticTracksModel.TracksUser? {
+        guard SyncManager.isUserLoggedIn() else {
+            return nil
+        }
+        return TracksUser(userID: ServerSettings.userId, email: ServerSettings.syncingEmail(), username: nil)
+    }
+
+    var buildType: String {
+        #if STAGING
+        return "staging"
+        #elseif DEBUG
+        return "debug"
+        #else
+        return "appStore"
+        #endif
+    }
+}
+
+private struct WatchCrashLoggingErrorLogger: ErrorLogger {
+    let crashLogging: CrashLogging
+
+    func log(error: Error, context: [String: String]?) {
+        crashLogging.logError(error, tags: context ?? [:], level: .warning)
     }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -14281,8 +14281,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/Automattic-Tracks-iOS";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.1.0;
+				branch = "watchos-compatibility";
+				kind = branch;
 			};
 		};
 		468F00CD27CD575C00FFAAAA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1894,6 +1894,8 @@
 		F5BFF9892C6B0A9100A84561 /* Optional+ThrowOnNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BFF9882C6B0A9100A84561 /* Optional+ThrowOnNil.swift */; };
 		F5C1FA212D1283F5007CFDF2 /* AppIcon.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD0D7AF31F6BC564006B673F /* AppIcon.xcassets */; };
 		F5CA25912CC9C30F0013DFF2 /* StoryFooter2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CA25902CC9C30F0013DFF2 /* StoryFooter2024.swift */; };
+		F5CDD79E2F4D1AB400D1B221 /* AutomatticTracks in Frameworks */ = {isa = PBXBuildFile; productRef = F5CDD79D2F4D1AB400D1B221 /* AutomatticTracks */; };
+		F5CDD79F2F4D1AE100D1B221 /* ApiCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462EE0B427024FF3003D67DC /* ApiCredentials.swift */; };
 		F5CFDB622C6DA2D600DE57B2 /* AudioClipExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5CFDB612C6DA2D600DE57B2 /* AudioClipExporter.swift */; };
 		F5D3A0D92B70950100EED067 /* MockURLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D3A0D82B70950100EED067 /* MockURLHandler.swift */; };
 		F5D527382CC81AAD00682CD5 /* EpilogueStory2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5D527372CC81AA700682CD5 /* EpilogueStory2024.swift */; };
@@ -4441,6 +4443,7 @@
 				FF2CD5822B9F4B2D009B58B5 /* Kingfisher in Frameworks */,
 				FF2CD5802B9F4B2D009B58B5 /* PocketCastsUtils in Frameworks */,
 				FF2CD57E2B9F4B2D009B58B5 /* PocketCastsServer in Frameworks */,
+				F5CDD79E2F4D1AB400D1B221 /* AutomatticTracks in Frameworks */,
 				8BE36DEB287352F200E35313 /* PocketCastsDataModel in Frameworks */,
 				8BE36DEE287352F600E35313 /* PocketCastsServer in Frameworks */,
 				8BE36DF42873533F00E35313 /* PocketCastsUtils in Frameworks */,
@@ -9419,6 +9422,7 @@
 				FF2CD57F2B9F4B2D009B58B5 /* PocketCastsUtils */,
 				FF2CD5812B9F4B2D009B58B5 /* Kingfisher */,
 				9A9004CA2E2E6455005879CB /* PocketCastsDependencyInjection */,
+				F5CDD79D2F4D1AB400D1B221 /* AutomatticTracks */,
 			);
 			productName = "Pocket Casts Watch App";
 			productReference = BDD301641EFB9356004A9972 /* Pocket Casts Watch App.app */;
@@ -11728,6 +11732,7 @@
 				FF54BCAA2C5A2F4D00A342E5 /* TranscriptFormat.swift in Sources */,
 				C7811D8A2A90334200FC68B4 /* Unlockable+Bookmarks.swift in Sources */,
 				46C843B927E373B100D1DBF3 /* NowPlayingImage.swift in Sources */,
+				F5CDD79F2F4D1AE100D1B221 /* ApiCredentials.swift in Sources */,
 				BD74F15827F2955D00222785 /* FolderView.swift in Sources */,
 				BD4910CD2457DC86005202CF /* SessionManager+Send.swift in Sources */,
 				4054146F2435B82B00431FD5 /* PlaylistManager.swift in Sources */,
@@ -14526,6 +14531,11 @@
 			productName = PocketCastsUtils;
 		};
 		F5ADE2F62CF52B4800F2CEA7 /* AutomatticTracks */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 46305CEE272B082C003AC87B /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */;
+			productName = AutomatticTracks;
+		};
+		F5CDD79D2F4D1AB400D1B221 /* AutomatticTracks */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 46305CEE272B082C003AC87B /* XCRemoteSwiftPackageReference "Automattic-Tracks-iOS" */;
 			productName = AutomatticTracks;

--- a/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
         "branch" : "watchos-compatibility",
-        "revision" : "d8550ad77f3ba62f23a0bc6bf3f3d434caa696a2"
+        "revision" : "059b372446f72ad771a6de8042aa57e48dc976e1"
       }
     },
     {
@@ -248,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jedisct1/swift-sodium",
       "state" : {
-        "revision" : "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
-        "version" : "0.9.1"
+        "revision" : "e7e799cd1eaa4d0f6d3eab56832e7f4b377f4a4f",
+        "version" : "0.10.0"
       }
     },
     {

--- a/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "revision" : "7442def327dbbc9158c0d780382843e0b7a2e6c9",
-        "version" : "4.1.0"
+        "branch" : "watchos-compatibility",
+        "revision" : "d8550ad77f3ba62f23a0bc6bf3f3d434caa696a2"
       }
     },
     {

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -42,6 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupAnalytics()
 
         DataManager.logger = SentryLogger()
+        ServerConfig.shared.errorLogger = SentryLogger()
 
         appInstallState = appLifecycleAnalytics.checkApplicationInstalledOrUpgraded()
 

--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -4,6 +4,27 @@ import PocketCastsServer
 import PocketCastsUtils
 import WatchConnectivity
 
+/// Errors that can occur during Watch sync operations
+enum WatchSyncError: LocalizedError {
+    case sendMessageFailed(underlyingError: Error)
+    case updateApplicationContextFailed(underlyingError: Error)
+    case missingPayloadData(messageType: String, missingKey: String)
+    case episodeNotFound(uuid: String, operation: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .sendMessageFailed(let error):
+            return "Watch sendMessage failed: \(error.localizedDescription)"
+        case .updateApplicationContextFailed(let error):
+            return "Watch updateApplicationContext failed: \(error.localizedDescription)"
+        case .missingPayloadData(let messageType, let missingKey):
+            return "Watch message '\(messageType)' missing required key: \(missingKey)"
+        case .episodeNotFound(let uuid, let operation):
+            return "Episode not found for Watch \(operation): \(uuid)"
+        }
+    }
+}
+
 class WatchManager: NSObject, WCSessionDelegate {
     static let shared = WatchManager()
 
@@ -309,7 +330,12 @@ class WatchManager: NSObject, WCSessionDelegate {
     }
 
     private func handleAddToUpnext(episodeUuid: String, toTop: Bool) {
-        guard let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else { return }
+        guard let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else {
+            FileLog.shared.addMessage("WatchManager: Episode not found for addToUpNext: \(episodeUuid)")
+            let error = WatchSyncError.episodeNotFound(uuid: episodeUuid, operation: "addToUpNext")
+            CrashLoggingAdapter.sharedManager?.crashLogging?.logError(error, tags: ["source": "watch_upnext"], level: .warning)
+            return
+        }
 
         // remove it first so that this can be used as a move to top/bottom as well
         PlaybackManager.shared.removeIfPlayingOrQueued(episode: episode, fireNotification: false, userInitiated: false)
@@ -317,7 +343,12 @@ class WatchManager: NSObject, WCSessionDelegate {
     }
 
     private func handleRemoveFromUpnext(episodeUuid: String) {
-        guard let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else { return }
+        guard let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else {
+            FileLog.shared.addMessage("WatchManager: Episode not found for removeFromUpNext: \(episodeUuid)")
+            let error = WatchSyncError.episodeNotFound(uuid: episodeUuid, operation: "removeFromUpNext")
+            CrashLoggingAdapter.sharedManager?.crashLogging?.logError(error, tags: ["source": "watch_upnext"], level: .warning)
+            return
+        }
 
         PlaybackManager.shared.removeIfPlayingOrQueued(episode: episode, fireNotification: true, userInitiated: true)
     }


### PR DESCRIPTION
| 📘 Part of: [Watch + Up Next Sync](https://linear.app/a8c/project/ios-watch-up-next-sync-3f36270786fd) |
|:---:|

Completes [PCIOS-537](https://linear.app/a8c/issue/PCIOS-537/integrate-sentry-logging-into-watchos-app-for-better-visibility)

Integration for https://github.com/Automattic/Automattic-Tracks-iOS/pull/317

Integrates Tracks with the watchOS compatibility so that we can log to Sentry.

This should give us better visibility into watchOS issues without having to wait for logs from users.

## Code Changes

  **watchOS Crash Logging**
  - Integrates `AutomatticRemoteLogging` (Tracks/Sentry) into the watchOS app
  - Adds [`WatchCrashLoggingDataProvider`](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/Pocket%20Casts%20Watch%20App/ExtensionDelegate.swift#L131) and [`WatchCrashLoggingErrorLogger`](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/Pocket%20Casts%20Watch%20App/ExtensionDelegate.swift#L151) to ExtensionDelegate
  - Wires up [`ServerConfig.shared.errorLogger`](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/Modules/Server/Sources/PocketCastsServer/Public/ServerConfig.swift#L15) on both iOS ([`AppDelegate`](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/podcasts/AppDelegate.swift#L45)) and watchOS ([`ExtensionDelegate`](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/Pocket%20Casts%20Watch%20App/ExtensionDelegate.swift#L23))

  **Up Next Sync Error Tracking**
  - Adds [`UpNextSyncError`](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift#L7) enum with cases for common sync failures:
    - [`serverSyncFailed`](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift#L56) - HTTP errors during sync
    - [`protobufEncodingFailed`](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift#L61) - Protobuf serialization errors
    - [`serverDataDecodeFailed`](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift#L168) - Response parsing errors
    - [`queueOverwritten`](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift#L330) - Significant queue data replacement (>75% of episodes deleted)
    - `archivedEpisodeAddedToQueue` - Stale server data issues (defined but not yet used)
  - Logs errors to Sentry with relevant context (episode counts, sync reason, deletion percentage)

  **Watch Manager Error Tracking**
  - Adds [`WatchSyncError`](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/podcasts/WatchManager.swift#L8) enum for watch-to-phone sync issues
  - Logs when episodes are not found during Up Next operations from watch

  **Threshold for Queue Overwrite Logging**
  - Only reports `queueOverwritten` errors when [>75% of the local queue is replaced](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/watch-sentry-logging/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift#L319-L322)


### Dependencies

  - Updates `Automattic-Tracks-iOS` to use `watchos-compatibility` branch (temporary until we merge the Tracks PR after verifying here)


## To test

* Build and run the watchOS app
* You can add [this patch](https://github.com/user-attachments/files/25506980/DebugCrashLoggingWatch.patch) to make sure Debug events are sent
* Visit [this page](https://a8c.sentry.io/issues/?environment=debug&project=4503921846583296&statsPeriod=14d) and check that your event appears (you may need to click in to the event to see the full timeline)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
