### PR TITLE
PCIOS-462: UI: Remove shadow on nav bar when scrolling and reduce padding to 16px

### DIFF
--- a/podcasts/FilterDurationViewController.swift
+++ b/podcasts/FilterDurationViewController.swift
@@ -209,9 +209,10 @@ class FilterDurationViewController: PCViewController {
 
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = backgroundColor
-        appearance.shadowColor = .clear
+        appearance.shadowColor = nil
         appearance.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor: ThemeColor.primaryText01()]
         appearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: ThemeColor.primaryText02()]
+        appearance.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
         navigationBar?.scrollEdgeAppearance = appearance
         navigationBar?.standardAppearance = appearance
     }

--- a/podcasts/LargeNavBarViewController.swift
+++ b/podcasts/LargeNavBarViewController.swift
@@ -8,13 +8,14 @@ class LargeNavBarViewController: PCViewController {
         largeTitleFont = UIFont.font(ofSize: 22, weight: .bold, scalingWith: .title2)
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = AppTheme.colorForStyle(.primaryUi01)
-        appearance.shadowColor = .clear
+        appearance.shadowColor = nil
         appearance.largeTitleTextAttributes = [
             NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
         ]
         appearance.titleTextAttributes = [
             NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
         ]
+        appearance.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
         appearance.setBackIndicatorImage(UIImage(named: "nav-back"), transitionMaskImage: UIImage(named: "nav-back"))
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
         navigationController?.navigationBar.standardAppearance = appearance

--- a/podcasts/Onboarding/OnboardingHostingViewController.swift
+++ b/podcasts/Onboarding/OnboardingHostingViewController.swift
@@ -76,6 +76,7 @@ class OnboardingHostingViewController<Content>: UIHostingController<Content>, UI
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
         appearance.shadowColor = nil
+        appearance.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
         navigationController?.navigationBar.standardAppearance = appearance
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
 

--- a/podcasts/PCHostingController.swift
+++ b/podcasts/PCHostingController.swift
@@ -99,6 +99,7 @@ class PCHostingController<Content>: ThemedHostingController<Content> where Conte
             NSAttributedString.Key.font: UIFont.systemFont(ofSize: 31, weight: .bold)
         ]
         appearance.shadowColor = nil
+        appearance.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
 
         UINavigationBar.appearance(for: traits, whenContainedInInstancesOf: [PCHostingController.self]).standardAppearance = appearance
         UINavigationBar.appearance(for: traits, whenContainedInInstancesOf: [PCHostingController.self]).compactAppearance = appearance

--- a/podcasts/PCNavigationController.swift
+++ b/podcasts/PCNavigationController.swift
@@ -47,6 +47,7 @@ class PCNavigationController: UINavigationController, UIGestureRecognizerDelegat
         appearance.backgroundColor = AppTheme.colorForStyle(navStyle, themeOverride: themeOverride)
         appearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(titleStyle, themeOverride: themeOverride)]
         appearance.shadowColor = nil
+        appearance.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
 
         navigationBar.standardAppearance = appearance
         navigationBar.scrollEdgeAppearance = appearance

--- a/podcasts/PCViewController.swift
+++ b/podcasts/PCViewController.swift
@@ -154,6 +154,7 @@ class PCViewController: SimpleNotificationsViewController {
             NSAttributedString.Key.font: largeTitleFont
         ]
         appearance.shadowColor = nil
+        appearance.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
 
         if animated {
             UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -133,6 +133,7 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
 
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = backgroundColor
+        appearance.shadowColor = nil
         appearance.largeTitleTextAttributes = [
             NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01),
             NSAttributedString.Key.font: UIFont.font(ofSize: 22, weight: .bold, scalingWith: .title2)
@@ -140,6 +141,7 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
         appearance.titleTextAttributes = [
             NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
         ]
+        appearance.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
         navigationController?.navigationBar.standardAppearance = appearance
     }

--- a/podcasts/StarredFilterOverlayController.swift
+++ b/podcasts/StarredFilterOverlayController.swift
@@ -75,12 +75,14 @@ class StarredFilterOverlayController: PCViewController {
 
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = AppTheme.colorForStyle(.primaryUi01)
+        appearance.shadowColor = nil
         appearance.largeTitleTextAttributes = [
             NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
         ]
         appearance.titleTextAttributes = [
             NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
         ]
+        appearance.directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
         navigationController?.navigationBar.standardAppearance = appearance
         navigationController?.navigationBar.sizeToFit()


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-462/ui-remove-shadow-on-nav-bar-when-scrolling-and-reduce-padding-to-16px

## Summary
This PR removes the shadow on navigation bars when scrolling and reduces the horizontal padding to 16px across all navigation bar appearances in the iOS app.

## Changes
- Updated all `UINavigationBarAppearance` configurations to set `shadowColor = nil` consistently (previously some used `.clear`)
- Added `directionalLayoutMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)` to all navigation bar appearance configurations
- Modified 8 files:
  - `PCNavigationController.swift`
  - `PCViewController.swift`
  - `LargeNavBarViewController.swift`
  - `PCHostingController.swift`
  - `StarredFilterOverlayController.swift`
  - `PodcastFilterOverlayController.swift`
  - `OnboardingHostingViewController.swift`
  - `FilterDurationViewController.swift`

## Testing
- Changes affect all navigation bars throughout the app
- Both `standardAppearance` and `scrollEdgeAppearance` are updated to ensure consistent behavior when scrolling
- Verified that the formatter passed successfully

---
🤖 This PR was created autonomously by linear-solver.