### PR TITLE
[Dynamic type] Update alignment on up next cells

### DIFF
--- a/podcasts/PlayerCell.xib
+++ b/podcasts/PlayerCell.xib
@@ -40,7 +40,7 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OJf-Is-8tF" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="20" y="12" width="56" height="56"/>
+                        <rect key="frame" x="20" y="6" width="56" height="56"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="56" id="CmK-da-ABR"/>
                             <constraint firstAttribute="height" constant="56" id="Ohc-ER-Sk3"/>
@@ -102,7 +102,7 @@
                     <constraint firstItem="SPL-EK-QpB" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="THB-Gv-8b2"/>
                     <constraint firstItem="oRM-hc-IES" firstAttribute="top" secondItem="wE1-9S-69I" secondAttribute="bottom" constant="4" id="Tna-d1-ajw"/>
                     <constraint firstItem="IaQ-ms-xZi" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="-24" id="W6l-JH-2df"/>
-                    <constraint firstItem="OJf-Is-8tF" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="Z0H-Az-83U"/>
+                    <constraint firstItem="OJf-Is-8tF" firstAttribute="top" secondItem="vxd-V8-but" secondAttribute="top" id="Z0H-Az-83U"/>
                     <constraint firstItem="vxd-V8-but" firstAttribute="leading" secondItem="OJf-Is-8tF" secondAttribute="trailing" constant="8" id="aTa-Qw-wZX"/>
                     <constraint firstItem="oRM-hc-IES" firstAttribute="leading" secondItem="wE1-9S-69I" secondAttribute="leading" id="bI8-92-Yir"/>
                     <constraint firstItem="IaQ-ms-xZi" firstAttribute="trailing" secondItem="OJf-Is-8tF" secondAttribute="leading" constant="-20" id="dAg-4g-2db"/>

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -89,6 +89,7 @@ class UpNextNowPlayingCell: ThemeableCell {
             dateLabel.accessibilityLabel = L10n.queueNowPlayingAccessibility(dateText)
         }
         progressUpdated(animated: false)
+        updateDownloadStatus()
     }
 
     @objc func progressUpdated(animated: Bool = true) {
@@ -174,6 +175,9 @@ class UpNextNowPlayingCell: ThemeableCell {
     }
 
     func updateDownloadStatus() {
+        defer {
+            setNeedsUpdateConstraints()
+        }
         guard let episode = episode else {
             downloadingIndicator.isHidden = true
             downloadedIndicator.isHidden = true
@@ -242,6 +246,8 @@ class UpNextNowPlayingCell: ThemeableCell {
         disclosureImageView.layer.cornerRadius = buttonSize / 2
 
         playingAnimationView.updateSizeConstraints(to: buttonSize)
+
+        updateDownloadStatus()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/UpNextNowPlayingCell.xib
+++ b/podcasts/UpNextNowPlayingCell.xib
@@ -11,18 +11,18 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="72" id="KGk-i7-Jjw" customClass="UpNextNowPlayingCell" customModule="podcasts" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="332" height="72"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="113" id="KGk-i7-Jjw" customClass="UpNextNowPlayingCell" customModule="podcasts" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="332" height="113"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="332" height="72"/>
+                <rect key="frame" x="0.0" y="0.0" width="332" height="113"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lof-Ey-IPR" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="8" y="0.0" width="316" height="72"/>
+                        <rect key="frame" x="8" y="0.0" width="316" height="113"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Drj-gb-CmX">
-                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="72"/>
+                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="113"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" id="3j1-pc-jps"/>
@@ -42,44 +42,52 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MONDAY" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uFH-le-6i7" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="70" y="12" width="178" height="14.5"/>
+                                <rect key="frame" x="70" y="12" width="178" height="23"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Episode Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mhM-ON-FAA" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="70" y="28.5" width="178" height="17"/>
+                                <rect key="frame" x="70" y="37" width="178" height="17"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="1fL-ql-Hfg">
-                                <rect key="frame" x="70" y="48.5" width="40" height="17.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="1fL-ql-Hfg">
+                                <rect key="frame" x="70" y="57" width="48" height="50"/>
                                 <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U8E-BC-Cls">
+                                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="50"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" id="ugk-pc-7Mu"/>
+                                        </constraints>
+                                    </view>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="OzR-Qq-DsV" userLabel="Downloading Indicator">
-                                        <rect key="frame" x="0.0" y="1" width="16" height="16"/>
+                                        <rect key="frame" x="8" y="17" width="16" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="16" id="PFX-gi-0dj"/>
                                             <constraint firstAttribute="height" constant="16" id="sr8-ek-Aog"/>
                                         </constraints>
                                     </activityIndicatorView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="list_downloaded" translatesAutoresizingMaskIntoConstraints="NO" id="KAb-iK-X7U">
-                                        <rect key="frame" x="24" y="1" width="16" height="16"/>
+                                        <rect key="frame" x="32" y="17" width="16" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="16" id="6rq-sD-ThI"/>
                                             <constraint firstAttribute="width" constant="16" id="U0t-bh-rkL"/>
                                         </constraints>
                                     </imageView>
                                 </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="53 Minutes remaining" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TpI-i7-PDk" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="114" y="51.5" width="134" height="11.5"/>
+                                <rect key="frame" x="118" y="60" width="130" height="44"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron-small-right" translatesAutoresizingMaskIntoConstraints="NO" id="t5J-xk-yXq">
-                                <rect key="frame" x="280" y="24" width="24" height="24"/>
+                                <rect key="frame" x="280" y="44.5" width="24" height="24"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.19793450342465754" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="24" id="NrA-vM-793"/>
@@ -87,7 +95,7 @@
                                 </constraints>
                             </imageView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lV7-rK-gas" customClass="NowPlayingAnimationView" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="248" y="24" width="24" height="24"/>
+                                <rect key="frame" x="248" y="44.5" width="24" height="24"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="24" id="4zf-Lx-hH2"/>
                                     <constraint firstAttribute="height" constant="24" id="NU2-Gn-j1e"/>
@@ -104,9 +112,9 @@
                             <constraint firstItem="mhM-ON-FAA" firstAttribute="trailing" secondItem="uFH-le-6i7" secondAttribute="trailing" id="FSB-nj-2a9"/>
                             <constraint firstItem="Drj-gb-CmX" firstAttribute="top" secondItem="lof-Ey-IPR" secondAttribute="top" id="IGm-mv-RZ3"/>
                             <constraint firstItem="uFH-le-6i7" firstAttribute="top" secondItem="lof-Ey-IPR" secondAttribute="top" constant="12" id="JoR-VQ-h4V"/>
-                            <constraint firstItem="oXa-LZ-pvj" firstAttribute="centerY" secondItem="lof-Ey-IPR" secondAttribute="centerY" id="O7c-cP-oFm"/>
+                            <constraint firstItem="oXa-LZ-pvj" firstAttribute="top" secondItem="uFH-le-6i7" secondAttribute="top" id="O7c-cP-oFm"/>
                             <constraint firstItem="t5J-xk-yXq" firstAttribute="centerY" secondItem="lV7-rK-gas" secondAttribute="centerY" id="Pr0-ss-PCS"/>
-                            <constraint firstItem="TpI-i7-PDk" firstAttribute="leading" secondItem="1fL-ql-Hfg" secondAttribute="trailing" constant="4" id="TU0-OR-OXR"/>
+                            <constraint firstItem="TpI-i7-PDk" firstAttribute="leading" secondItem="1fL-ql-Hfg" secondAttribute="trailing" id="TU0-OR-OXR"/>
                             <constraint firstAttribute="bottom" secondItem="Drj-gb-CmX" secondAttribute="bottom" id="ZAC-8g-I6v"/>
                             <constraint firstItem="mhM-ON-FAA" firstAttribute="bottom" secondItem="1fL-ql-Hfg" secondAttribute="top" constant="-3" id="ZXa-pa-dgH"/>
                             <constraint firstItem="Drj-gb-CmX" firstAttribute="leading" secondItem="lof-Ey-IPR" secondAttribute="leading" id="cCP-ta-Oif"/>
@@ -147,7 +155,7 @@
                 <outlet property="roundedBackgroundView" destination="lof-Ey-IPR" id="8GV-BO-i1G"/>
                 <outlet property="timeRemainingLabel" destination="TpI-i7-PDk" id="ntN-2K-WFL"/>
             </connections>
-            <point key="canvasLocation" x="146.37681159420291" y="98.4375"/>
+            <point key="canvasLocation" x="146.37681159420291" y="112.16517857142857"/>
         </tableViewCell>
     </objects>
     <resources>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-525 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
| xs | Default | xxxL | AX5 |
| - | - | - | - | 
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-18 at 22 47 23" src="https://github.com/user-attachments/assets/523272e3-789a-4e8e-9666-ac855be3679a" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-18 at 22 47 15" src="https://github.com/user-attachments/assets/692d293a-77b5-4294-86a8-86a316e57338" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-18 at 22 47 07" src="https://github.com/user-attachments/assets/408440a4-3483-4cf5-a23d-9a5d553c2de5" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-18 at 22 47 00" src="https://github.com/user-attachments/assets/bdc03474-8884-4ee8-975f-e336ed73c442" /> |

## To test

1. Start the app
2. Add some episodes to UpNext
3. Open UpNext
4. Check the remaining time on the current playing episode is correctly aligned
5. Check if podcast images are top aligned with the top label/date

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
