### PR TITLE
PCIOS-462: UI: Remove shadow on nav bar when scrolling and reduce padding to 16px

### DIFF
--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -200,7 +200,6 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        navigationController?.navigationBar.shadowImage = UIImage()
 
         addEventObservers()
 
@@ -217,7 +216,6 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
         removeAllCustomObservers()
         tableRefreshControl?.parentViewControllerDidDisappear()
         noEpisodesRefreshControl?.parentViewControllerDidDisappear()
-        navigationController?.navigationBar.shadowImage = nil
     }
 
     override func handleAppDidEnterBackground() {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-462/ui-remove-shadow-on-nav-bar-when-scrolling-and-reduce-padding-to-16px

## Summary
- Removed legacy `shadowImage` API usage in `PlaylistViewController` that was causing navigation bar shadow to appear when scrolling
- Verified filter chip padding is already set to 16px (no changes needed)

## Changes
- Removed `navigationController?.navigationBar.shadowImage = UIImage()` from `viewDidAppear(_:)` in PlaylistViewController.swift:203
- Removed `navigationController?.navigationBar.shadowImage = nil` from `viewDidDisappear(_:)` in PlaylistViewController.swift:220

## Technical Details
The navigation bar shadow is now properly controlled by the `UINavigationBarAppearance` configured in the parent `PCViewController` class, which sets `shadowColor` to `nil`. The old `shadowImage` API was overriding this modern appearance configuration.

The filter chip padding was already correctly set to 16px in `FilterChipCollectionView.swift:214` via `UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)`.

## Testing
- Verified that navigation bar no longer shows shadow when scrolling in playlist views
- Confirmed filter chip horizontal padding remains at 16px

---
🤖 This PR was created autonomously by linear-solver.