### PR TITLE
PCIOS-482: Use episode artwork in episode details when available

### DIFF
--- a/podcasts/EpisodeDetailViewController.swift
+++ b/podcasts/EpisodeDetailViewController.swift
@@ -408,9 +408,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
 
         episodeName.text = episode.displayableTitle()
         podcastName.text = podcast.title
-        if let uuid = episode.parentPodcast()?.uuid {
-            podcastImage.setPodcast(uuid: uuid, size: .page)
-        }
+        podcastImage.setBaseEpisode(episode: episode, size: .page)
 
         episodeInfo.text = DateFormatHelper.sharedHelper.longLocalizedFormat(episode.publishedDate) + " · " + episode.displayableTimeLeft()
 


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-482/podcast-artwork-is-displayed-instead-of-episode-artwork-in-episode

## Summary
When the "use episode artwork" setting is enabled, the episode details screen now displays the episode artwork instead of the podcast artwork. This makes the behavior consistent with the player and the web version of Pocket Casts.

## Changes
- Updated `EpisodeDetailViewController.swift` to use `setBaseEpisode()` instead of `setPodcast()` for loading the artwork
- This change leverages the existing `ImageManager.loadImage(episode:imageView:size:)` method which:
  - Checks if the "use episode artwork" setting is enabled via `Settings.loadEmbeddedImages`
  - Attempts to load episode-specific artwork from embedded metadata or cached sources
  - Falls back to podcast artwork if episode artwork is not available

## Testing
- Built the project successfully with `make build`
- The fix applies the same artwork loading logic that is used in the player, ensuring consistency across the app
- When the "use episode artwork" setting is enabled and an episode has episode artwork, it will now be displayed in the episode details screen

## Technical Details
The `ImageManager.loadImage(episode:)` method already handles the logic for:
1. Checking the user's "use episode artwork" preference
2. Loading embedded artwork from downloaded episode files
3. Checking cached episode artwork
4. Falling back to podcast artwork when episode artwork is unavailable

By using `setBaseEpisode()` instead of `setPodcast()`, we let the existing artwork loading infrastructure handle episode artwork properly.

---
🤖 This PR was created autonomously by linear-solver.