### PR TITLE
Skip migrations when User Defaults is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 8.7
 -----
-
-
-8.7
------
 - Playlists: Add episode to a playlist from episode details [##3943](https://github.com/Automattic/pocket-casts-ios/pull/3943/) 
 - Refresh Now Playing info when Bluetooth device connects [#3964](https://github.com/Automattic/pocket-casts-ios/pull/3964) 
+- Fix logout issue when refreshing in background while device is locked [#3983](https://github.com/Automattic/pocket-casts-ios/pull/3983) 
 
 8.6
 -----

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -286,6 +286,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Use WCSessionFileTransfer to send logs from watchOS to iPhone instead of sendMessage reply
     case watchLogFileTransfer
 
+    /// Check if protected data is available before running migrations that touch keychain
+    case checkProtectedDataBeforeMigration
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -479,6 +482,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .playlistCacheInvalidation:
             true
         case .watchLogFileTransfer:
+            true
+        case .checkProtectedDataBeforeMigration:
             true
         }
     }

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -8,6 +8,16 @@ extension AppDelegate {
         let defaults = UserDefaults.standard
         let dataManager = DataManager.sharedManager
 
+        // Check if protected data is available before running migrations that touch keychain
+        // This prevents the v5Run migration from incorrectly clearing tokens when the app
+        // launches in the background before the device has been unlocked after a reboot.
+        if FeatureFlag.checkProtectedDataBeforeMigration.enabled {
+            guard UIApplication.shared.isProtectedDataAvailable else {
+                FileLog.shared.addMessage("AppDelegate.checkDefaults skipped - protected data not available")
+                return
+            }
+        }
+
         performUpdateIfRequired(updateKey: "v5Run") {
             // these are considered defaults for a new app install
             SyncManager.clearTokensFromKeyChain()


### PR DESCRIPTION
Fixes [PCIOS-527](https://linear.app/a8c/issue/PCIOS-527/user-logged-out-unexpectedly)

This avoids logging users out when we shouldn't. 

See more context in the ticket but the basic rundown from the logs:

1. Keychain access failed with error `-25308` (`errSecInteractionNotAllowed`)
2. `AppDelegate.checkDefaults v5Run clearTokensFromKeyChain` is logged indicating the v5run migration occurred _after_ keychain errors even though there are many logs prior, indicating this isn't a new install.
3. User has to sign in again after all of this with `SyncSigninViewController.startSignIn`

This may be caused by [application prewarming](https://framna.com/articles/solving-prewarming).

## Questions

Should we do anything else here? Is there something else we should do other than just skip the migration?

## To test

* Test installing the app from fresh to ensure `v5run` occurs
*  Test starting the app again to ensure code isn't triggered

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
