### PR TITLE
[Dynamic Type] Country selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - Dynamic Type: Discovery - Update featured carrousel and cells [#3959](https://github.com/Automattic/pocket-casts-ios/pull/3959)
 - Dynamic type: Update Player chapters [#3957](https://github.com/Automattic/pocket-casts-ios/pull/3957)
 - Dynamic Type: Update exporter to support dynamic type [#3958](https://github.com/Automattic/pocket-casts-ios/pull/3958)
+- Dynamic Type: Country selector [#3986](https://github.com/Automattic/pocket-casts-ios/pull/3986)
+
 
 8.5
 -----

--- a/podcasts/CountryCell.swift
+++ b/podcasts/CountryCell.swift
@@ -2,7 +2,11 @@ import PocketCastsServer
 import UIKit
 
 class CountryCell: ThemeableCell {
-    @IBOutlet var countryName: UILabel!
+    @IBOutlet var countryName: UILabel! {
+        didSet {
+            countryName.font = .font(ofSize: 16, weight: .medium, scalingWith: .callout)
+        }
+    }
     @IBOutlet var countryFlag: UIImageView!
 
     private var region: DiscoverRegion?

--- a/podcasts/CountryCell.xib
+++ b/podcasts/CountryCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="55.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="COr-ju-vUr" customClass="SmartInvertImageView" customModule="podcasts" customModuleProvider="target">
@@ -25,24 +23,30 @@
                             <constraint firstAttribute="height" constant="40" id="bqn-zk-k0J"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Australia" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="93b-IC-PIm" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="88" y="18" width="65.5" height="19.5"/>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Australia" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="93b-IC-PIm" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                        <rect key="frame" x="88" y="0.0" width="216" height="56"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="56" id="QaH-FU-VpB"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                         <color key="textColor" red="0.30196078430000001" green="0.33725490200000002" blue="0.36078431370000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
                 <constraints>
                     <constraint firstItem="COr-ju-vUr" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="1LV-sG-DgA"/>
-                    <constraint firstItem="93b-IC-PIm" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="TB6-vC-C4W"/>
+                    <constraint firstItem="93b-IC-PIm" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="TB6-vC-C4W"/>
                     <constraint firstItem="93b-IC-PIm" firstAttribute="leading" secondItem="COr-ju-vUr" secondAttribute="trailing" constant="16" id="VzA-7H-8Qs"/>
                     <constraint firstItem="COr-ju-vUr" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" constant="16" id="b6Y-Bq-OcU"/>
+                    <constraint firstAttribute="bottom" secondItem="93b-IC-PIm" secondAttribute="bottom" id="b6l-Bi-axp"/>
+                    <constraint firstAttribute="trailing" secondItem="93b-IC-PIm" secondAttribute="trailing" constant="16" id="wWR-YC-szv"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
                 <outlet property="countryFlag" destination="COr-ju-vUr" id="Vev-7q-5bu"/>
                 <outlet property="countryName" destination="93b-IC-PIm" id="Lfv-vO-zLz"/>
             </connections>
+            <point key="canvasLocation" x="-618" y="28"/>
         </tableViewCell>
     </objects>
 </document>

--- a/podcasts/CountryChooserViewController.swift
+++ b/podcasts/CountryChooserViewController.swift
@@ -57,6 +57,10 @@ class CountryChooserViewController: PCViewController, UITableViewDataSource, UIT
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         56
     }
 

--- a/podcasts/CountrySummaryViewController.swift
+++ b/podcasts/CountrySummaryViewController.swift
@@ -9,7 +9,12 @@ class CountrySummaryViewController: UIViewController, DiscoverSummaryProtocol {
     }
 
     @IBOutlet var countryFlag: UIImageView!
-    @IBOutlet var countryName: ThemeableLabel!
+    @IBOutlet var countryName: ThemeableLabel! {
+        didSet {
+            countryName.font = .font(ofSize: 16, weight: .medium, scalingWith: .callout)
+        }
+    }
+
     @IBOutlet var discoverSectionView: ThemeableView! {
         didSet {
             discoverSectionView.style = .primaryUi02

--- a/podcasts/CountrySummaryViewController.xib
+++ b/podcasts/CountrySummaryViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -21,14 +21,14 @@
             <rect key="frame" x="0.0" y="0.0" width="400" height="112"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select Content Region" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sP1-02-h75" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="119" y="20" width="162" height="12"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Select Content Region" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sP1-02-h75" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                    <rect key="frame" x="16" y="20" width="368" height="12"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                     <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WxJ-0n-BDv" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="108.5" y="48" width="183" height="44"/>
+                    <rect key="frame" x="110.5" y="48" width="179.5" height="44"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="rDt-H3-2d2" customClass="SmartInvertImageView" customModule="podcasts" customModuleProvider="target">
                             <rect key="frame" x="10" y="9" width="26" height="26"/>
@@ -37,9 +37,9 @@
                                 <constraint firstAttribute="height" constant="26" id="zDs-bc-eVg"/>
                             </constraints>
                         </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Australia Is Great" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sOC-tE-Hp8" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="46" y="12.5" width="127" height="19.5"/>
-                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Australia Is Great" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sOC-tE-Hp8" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                            <rect key="frame" x="46" y="0.0" width="123.5" height="44"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
@@ -52,8 +52,10 @@
                     <constraints>
                         <constraint firstItem="rDt-H3-2d2" firstAttribute="centerY" secondItem="WxJ-0n-BDv" secondAttribute="centerY" id="4EY-hb-aYU"/>
                         <constraint firstItem="rDt-H3-2d2" firstAttribute="leading" secondItem="WxJ-0n-BDv" secondAttribute="leading" constant="10" id="VdE-Xj-gMR"/>
+                        <constraint firstItem="sOC-tE-Hp8" firstAttribute="top" secondItem="WxJ-0n-BDv" secondAttribute="top" id="YH8-HP-79u"/>
                         <constraint firstAttribute="trailing" secondItem="sOC-tE-Hp8" secondAttribute="trailing" constant="10" id="akU-aO-3ss"/>
-                        <constraint firstAttribute="height" constant="44" id="gPw-n5-FFN"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="gPw-n5-FFN"/>
+                        <constraint firstAttribute="bottom" secondItem="sOC-tE-Hp8" secondAttribute="bottom" id="mZT-2Z-e7j"/>
                         <constraint firstItem="sOC-tE-Hp8" firstAttribute="leading" secondItem="rDt-H3-2d2" secondAttribute="trailing" constant="10" id="mmb-z4-2wq"/>
                         <constraint firstItem="sOC-tE-Hp8" firstAttribute="centerY" secondItem="WxJ-0n-BDv" secondAttribute="centerY" id="oLc-xv-zZA"/>
                     </constraints>
@@ -67,7 +69,10 @@
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="WxJ-0n-BDv" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="PPP-Gg-9mJ"/>
-                <constraint firstItem="sP1-02-h75" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="a8R-CF-oSy"/>
+                <constraint firstAttribute="trailing" secondItem="sP1-02-h75" secondAttribute="trailing" constant="16" id="UCN-Zk-aUb"/>
+                <constraint firstItem="sP1-02-h75" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="16" id="a8R-CF-oSy"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="WxJ-0n-BDv" secondAttribute="trailing" constant="16" id="na5-mN-dIN"/>
+                <constraint firstItem="WxJ-0n-BDv" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="16" id="rmU-zu-v8y"/>
                 <constraint firstItem="sP1-02-h75" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="20" id="x9G-Aq-vQF"/>
                 <constraint firstAttribute="bottom" secondItem="WxJ-0n-BDv" secondAttribute="bottom" constant="20" id="y75-qi-HAh"/>
                 <constraint firstItem="WxJ-0n-BDv" firstAttribute="top" secondItem="sP1-02-h75" secondAttribute="bottom" priority="999" constant="16" id="yYe-Hs-gR3"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-528 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Update country selector in Discover to support dynamic type
| xs | Default | xxxL | AX5 |
| - | - | - | - |
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-20 at 12 23 18" src="https://github.com/user-attachments/assets/1c1e4339-1e09-4007-a288-d14da30dd1a8" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-20 at 12 23 13" src="https://github.com/user-attachments/assets/ecfc884d-6088-4da5-915f-36419db6d73a" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-20 at 12 23 08" src="https://github.com/user-attachments/assets/216390b1-4632-4b32-b347-4d700b7f6f28" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-20 at 12 23 00" src="https://github.com/user-attachments/assets/98d303f8-c6d6-4cb1-9079-fa7edf9520d3" /> |
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-20 at 12 25 02" src="https://github.com/user-attachments/assets/e620f00b-4a27-4a71-88de-b1b94ebcf960" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-20 at 12 24 58" src="https://github.com/user-attachments/assets/adfc1367-d730-44f5-883e-1dc794d99cdc" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-20 at 12 24 54" src="https://github.com/user-attachments/assets/77952b11-4341-45c4-8965-194ba26493f4" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-20 at 12 24 48" src="https://github.com/user-attachments/assets/0780b824-b231-4452-af70-dbda8c2e61fd" /> |

## To test

1. Start the app
2. Open Discover
3. Scroll to the bottom where the country selector is
4. Check if summary adapts to Dynamic Type
5. Tap on it
6. Check if the country picket adapts to Dynamic Type

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
