### PR TITLE
PCIOS-453: iOS: Podcast description can't be collapsed

### DIFF
--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -12,6 +12,7 @@ class RichExpandableLabel: WKWebView {
     private(set) var previousHTML: String = ""
     private(set) var originalHTML: String = ""
     private var isFirstTime = true
+    private var isCollapsible = false
 
     private lazy var linkTapGesture: UITapGestureRecognizer = {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
@@ -58,6 +59,7 @@ class RichExpandableLabel: WKWebView {
         isUserInteractionEnabled = true
         scrollView.isScrollEnabled = false
         navigationDelegate = self
+        addGestureRecognizer(linkTapGesture)
         updateStyle()
     }
 
@@ -159,6 +161,7 @@ class RichExpandableLabel: WKWebView {
     }
 
     @objc private func labelTapped(gesture: UITapGestureRecognizer) {
+        guard isCollapsible else { return }
         if collapsed {
             delegate?.willExpandLabel(self)
             collapsed = false
@@ -178,13 +181,11 @@ class RichExpandableLabel: WKWebView {
 
     private func update() {
         if collapsed {
-            addGestureRecognizer(linkTapGesture)
             let font = UIFont.preferredFont(forTextStyle: .body)
             let newHeight = Self.estimateHeightFor(maxLines: maxLines, lineHeightMultiple: desiredLinedHeightMultiple, font: font)
             heightConstraint.constant = newHeight
             heightChanged?(newHeight)
         } else {
-            removeGestureRecognizer(linkTapGesture)
             heightConstraint.constant = contentHeight
             heightChanged?(contentHeight.rounded(.up))
         }
@@ -213,7 +214,8 @@ class RichExpandableLabel: WKWebView {
     private func updateLinesRequired() {
         evaluateJavaScript("countLines()", completionHandler: { [weak self] lines, error in
             guard let self = self, let linesRequired = lines as? Double else { return }
-            collapsed = Int(linesRequired.rounded(.up)) > self.maxLines
+            isCollapsible = Int(linesRequired.rounded(.up)) > self.maxLines
+            collapsed = isCollapsible
         })
     }
 


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-453/ios-podcast-description-cant-be-collapsed

## Summary
- The podcast description could be expanded by tapping on it, but could not be collapsed back
- Root cause: the tap gesture recognizer was removed from the view whenever the description was expanded, making it impossible to trigger collapse

## Changes
- Added `isCollapsible` property to track whether the description has enough content to need collapsing (more lines than `maxLines`)
- Moved `addGestureRecognizer(linkTapGesture)` to `commonInit()` so the gesture is always present
- Removed the `addGestureRecognizer`/`removeGestureRecognizer` calls from `update()` — the gesture no longer needs to be toggled
- Added `guard isCollapsible else { return }` in `labelTapped` to prevent toggling on short descriptions that don't need collapsing
- Updated `updateLinesRequired()` to set both `isCollapsible` and `collapsed` together

## Testing
- Build and run the app
- Navigate to a podcast with a long description (more than 3 lines)
- Verify the description is initially collapsed
- Tap to expand — the description should expand
- Tap again to collapse — the description should now collapse (this was broken before)
- Verify a podcast with a short description (3 lines or less) does not react to taps

---
🤖 This PR was created autonomously by linear-solver.