### PR TITLE
PCIOS-453: iOS: Podcast description can't be collapsed

### DIFF
--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -12,6 +12,7 @@ class RichExpandableLabel: WKWebView {
     private(set) var previousHTML: String = ""
     private(set) var originalHTML: String = ""
     private var isFirstTime = true
+    private var isCollapsible = false
 
     private lazy var linkTapGesture: UITapGestureRecognizer = {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(labelTapped))
@@ -58,6 +59,7 @@ class RichExpandableLabel: WKWebView {
         isUserInteractionEnabled = true
         scrollView.isScrollEnabled = false
         navigationDelegate = self
+        addGestureRecognizer(linkTapGesture)
         updateStyle()
     }
 
@@ -159,6 +161,7 @@ class RichExpandableLabel: WKWebView {
     }
 
     @objc private func labelTapped(gesture: UITapGestureRecognizer) {
+        guard isCollapsible else { return }
         if collapsed {
             delegate?.willExpandLabel(self)
             collapsed = false
@@ -178,13 +181,11 @@ class RichExpandableLabel: WKWebView {
 
     private func update() {
         if collapsed {
-            addGestureRecognizer(linkTapGesture)
             let font = UIFont.preferredFont(forTextStyle: .body)
             let newHeight = Self.estimateHeightFor(maxLines: maxLines, lineHeightMultiple: desiredLinedHeightMultiple, font: font)
             heightConstraint.constant = newHeight
             heightChanged?(newHeight)
         } else {
-            removeGestureRecognizer(linkTapGesture)
             heightConstraint.constant = contentHeight
             heightChanged?(contentHeight.rounded(.up))
         }
@@ -213,7 +214,8 @@ class RichExpandableLabel: WKWebView {
     private func updateLinesRequired() {
         evaluateJavaScript("countLines()", completionHandler: { [weak self] lines, error in
             guard let self = self, let linesRequired = lines as? Double else { return }
-            collapsed = Int(linesRequired.rounded(.up)) > self.maxLines
+            isCollapsible = Int(linesRequired.rounded(.up)) > self.maxLines
+            collapsed = isCollapsible
         })
     }
 


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-453/ios-podcast-description-cant-be-collapsed

## Summary
Fixed a bug where the podcast description could be expanded by tapping, but could not be collapsed. The tap gesture recognizer was being removed from the view when the description expanded, making it impossible to collapse it again.

## Changes
- Always attach the tap gesture recognizer during initialization (`commonInit()`) instead of conditionally adding/removing it
- Track whether the description is actually collapsible (content exceeds `maxLines`) with a new `isCollapsible` flag
- Guard tap toggle in `labelTapped()` to only allow toggling when the description is collapsible
- Set `isCollapsible` before setting `collapsed` state in `updateLinesRequired()`

The collapse animation remains smooth because the height constraint update and `heightChanged` callback flow is unchanged — only the gesture recognizer lifecycle was fixed.

## Testing
- Open any podcast with a long description
- Tap description to expand — should expand smoothly
- Tap expanded description to collapse — should now collapse (previously broken)
- Tap description with short content (not collapsible) — should have no effect

---
🤖 This PR was created autonomously by linear-solver.