### PR TITLE
PCIOS-453: iOS: Podcast description can't be collapsed

### DIFF
--- a/podcasts/RichExpandableDescriptionView.swift
+++ b/podcasts/RichExpandableDescriptionView.swift
@@ -58,6 +58,7 @@ class RichExpandableLabel: WKWebView {
         isUserInteractionEnabled = true
         scrollView.isScrollEnabled = false
         navigationDelegate = self
+        addGestureRecognizer(linkTapGesture)
         updateStyle()
     }
 
@@ -178,13 +179,11 @@ class RichExpandableLabel: WKWebView {
 
     private func update() {
         if collapsed {
-            addGestureRecognizer(linkTapGesture)
             let font = UIFont.preferredFont(forTextStyle: .body)
             let newHeight = Self.estimateHeightFor(maxLines: maxLines, lineHeightMultiple: desiredLinedHeightMultiple, font: font)
             heightConstraint.constant = newHeight
             heightChanged?(newHeight)
         } else {
-            removeGestureRecognizer(linkTapGesture)
             heightConstraint.constant = contentHeight
             heightChanged?(contentHeight.rounded(.up))
         }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-453/ios-podcast-description-cant-be-collapsed

## Summary
- The tap gesture recognizer on the podcast description `RichExpandableLabel` (a `WKWebView` subclass) was being removed from the view whenever the description was expanded, making it impossible to collapse it by tapping again.

## Changes
- In `RichExpandableDescriptionView.swift`: moved `addGestureRecognizer(linkTapGesture)` from the `update()` method (where it was only called when `collapsed == true`) into `commonInit()`, so it is registered once and remains attached in both the collapsed and expanded states.
- Removed the corresponding `removeGestureRecognizer(linkTapGesture)` call from the expanded branch of `update()`.

## Testing
- Open the podcast detail page for any podcast with a description longer than 3 lines.
- The description starts collapsed (3 lines visible).
- Tap the description — it expands with an animation. ✅
- Tap the expanded description again — it collapses with the same easeInOut animation. ✅ (was broken before this fix)
- Links within the description still open correctly via the `WKNavigationDelegate`. ✅

---
🤖 This PR was created autonomously by linear-solver.