### PR TITLE
[Dynamic type] Player effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Dynamic Type: Country selector [#3986](https://github.com/Automattic/pocket-casts-ios/pull/3986)
 - Dynamic type: Update player more options [#3993](https://github.com/Automattic/pocket-casts-ios/pull/3993)
 - Dynamic type: Update player main view [#3989](https://github.com/Automattic/pocket-casts-ios/pull/3989)
+- Dynamic type: Player effects [#3998](https://github.com/Automattic/pocket-casts-ios/pull/3998)
 
 
 8.5

--- a/podcasts/CustomSegmentedControl.swift
+++ b/podcasts/CustomSegmentedControl.swift
@@ -72,7 +72,7 @@ class CustomSegmentedControl: UIControl {
     private var itemViews = [UIView]()
 
     private var actionCount = 0
-    private var titleFont = UIFont.systemFont(ofSize: 15, weight: .bold)
+    private var titleFont = UIFont.font(ofSize: 15, weight: .bold, scalingWith: .subheadline)
     private let selectionFeedbackGenerator = UISelectionFeedbackGenerator()
 
     private final class SegmentView: UIView {
@@ -180,6 +180,7 @@ class CustomSegmentedControl: UIControl {
                 label.text = action.title
                 label.textAlignment = .center
                 label.font = titleFont
+                label.adjustsFontForContentSizeCategory = true
                 label.adjustsFontSizeToFitWidth = true
                 label.minimumScaleFactor = 0.7
                 segmentView.addSubview(label)

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -8,6 +8,9 @@ class EffectsViewController: SimpleNotificationsViewController {
         didSet {
             headingLbl.style = .playerContrast02
             headingLbl.text = L10n.playbackEffects.localizedUppercase
+            headingLbl.font = UIFont.font(ofSize: 13, weight: .medium, scalingWith: .title1)
+            headingLbl.adjustsFontForContentSizeCategory = true
+
         }
     }
 

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -147,7 +147,7 @@ class EffectsViewController: SimpleNotificationsViewController {
             playbackSettingsSegmentedControl.setTitle(L10n.playbackEffectAllPodcasts, forSegmentAt: 0)
             playbackSettingsSegmentedControl.setTitle(L10n.playbackEffectThisPodcast, forSegmentAt: 1)
 
-            playbackSettingsSegmentedControl.addTarget(self, action: #selector(playbackSettingsDestinationChanged), for: .valueChanged)            
+            playbackSettingsSegmentedControl.addTarget(self, action: #selector(playbackSettingsDestinationChanged), for: .valueChanged)
         }
     }
 

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -574,6 +574,9 @@ class EffectsViewController: SimpleNotificationsViewController {
         speedIcon.updateSizeConstraints(to: iconSize)
         volumeIcon.updateSizeConstraints(to: iconSize)
 
+        let timerSize = max(36, iconMetric.scaledValue(for: 36))
+        speedBtn.updateSizeConstraints(width: 70, height: timerSize)
+
         updateColors()
     }
 }

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -147,7 +147,7 @@ class EffectsViewController: SimpleNotificationsViewController {
             playbackSettingsSegmentedControl.setTitle(L10n.playbackEffectAllPodcasts, forSegmentAt: 0)
             playbackSettingsSegmentedControl.setTitle(L10n.playbackEffectThisPodcast, forSegmentAt: 1)
 
-            playbackSettingsSegmentedControl.addTarget(self, action: #selector(playbackSettingsDestinationChanged), for: .valueChanged)
+            playbackSettingsSegmentedControl.addTarget(self, action: #selector(playbackSettingsDestinationChanged), for: .valueChanged)            
         }
     }
 
@@ -454,9 +454,9 @@ class EffectsViewController: SimpleNotificationsViewController {
             playbackSettingsSegmentedControl.backgroundColor = ThemeColor.playerContrast06()
             playbackSettingsSegmentedControl.selectedSegmentTintColor = ThemeColor.playerContrast01()
 
-            let normalAttribute = [NSAttributedString.Key.foregroundColor: ThemeColor.playerContrast02()]
+            let normalAttribute = [NSAttributedString.Key.foregroundColor: ThemeColor.playerContrast02(), .font: UIFont.font(ofSize: 14, weight: .medium, scalingWith: .largeTitle)]
             playbackSettingsSegmentedControl.setTitleTextAttributes(normalAttribute, for: .normal)
-            let selectedAttribute = [NSAttributedString.Key.foregroundColor: PlayerColorHelper.playerBackgroundColor01()]
+            let selectedAttribute = [NSAttributedString.Key.foregroundColor: PlayerColorHelper.playerBackgroundColor01(), .font: UIFont.font(ofSize: 14, weight: .medium, scalingWith: .largeTitle)]
             playbackSettingsSegmentedControl.setTitleTextAttributes(selectedAttribute, for: .selected)
         } else {
             trimSilenceAmountControl.lineColor = ThemeColor.playerContrast02()
@@ -557,5 +557,23 @@ class EffectsViewController: SimpleNotificationsViewController {
         accessibilityElements.append(volumeBoostSwitch!)
 
         view.accessibilityElements = accessibilityElements
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
+            updateSize()
+        }
+    }
+
+    private func updateSize() {
+        let iconMetric = UIFontMetrics(forTextStyle: .largeTitle)
+        let iconSize = max(24, iconMetric.scaledValue(for: 24))
+        trimIcon.updateSizeConstraints(to: iconSize)
+        speedIcon.updateSizeConstraints(to: iconSize)
+        volumeIcon.updateSizeConstraints(to: iconSize)
+
+        updateColors()
     }
 }

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -39,7 +39,7 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" ambiguous="YES" id="i5M-Pr-FkT">
             <rect key="frame" x="0.0" y="0.0" width="320" height="598"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
@@ -91,292 +91,308 @@
                         <constraint firstItem="LiG-Vu-Be0" firstAttribute="centerX" secondItem="Dp7-EY-xsE" secondAttribute="centerX" id="nhr-pD-EjK"/>
                     </constraints>
                 </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gSi-1e-Tle">
-                    <rect key="frame" x="20" y="68" width="280" height="530"/>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yTq-s1-73n">
+                    <rect key="frame" x="0.0" y="48" width="320" height="570"/>
                     <subviews>
-                        <segmentedControl opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="036-xZ-lLC" userLabel="Playback Settings Segmented">
-                            <rect key="frame" x="0.0" y="28" width="280" height="32"/>
-                            <constraints>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="24" id="Hg5-29-bhj"/>
-                            </constraints>
-                            <segments>
-                                <segment title="First"/>
-                                <segment title="Second"/>
-                            </segments>
-                        </segmentedControl>
-                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5iH-XX-TB6" userLabel="Speed View">
-                            <rect key="frame" x="0.0" y="89" width="280" height="44"/>
+                        <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gSi-1e-Tle">
+                            <rect key="frame" x="20" y="20" width="280" height="530"/>
                             <subviews>
-                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="player_speed" translatesAutoresizingMaskIntoConstraints="NO" id="l8T-5d-1fK" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="10" width="24" height="24"/>
-                                    <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" ambiguous="YES" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="44" y="12" width="49" height="20.5"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X9d-OS-tJn" userLabel="Minus">
-                                    <rect key="frame" x="102" y="0.0" width="44" height="44"/>
-                                    <accessibility key="accessibilityConfiguration" label="Decrease playback speed"/>
+                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="036-xZ-lLC" userLabel="Playback Settings Segmented">
+                                    <rect key="frame" x="0.0" y="28" width="280" height="33"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="44" id="G5X-u5-ezZ"/>
-                                        <constraint firstAttribute="width" constant="44" id="kVv-ay-xSZ"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="32" id="Hg5-29-bhj"/>
                                     </constraints>
-                                    <state key="normal" image="player_effects_less"/>
-                                    <connections>
-                                        <action selector="minusTapped:" destination="-1" eventType="touchUpInside" id="s3h-rh-5OF"/>
-                                    </connections>
-                                </button>
-                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OiT-SV-8zG" userLabel="Speed Button" customClass="ShiftyRoundButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="156" y="4" width="70" height="36"/>
-                                    <viewLayoutGuide key="safeArea" id="GCu-8B-qJc"/>
-                                    <accessibility key="accessibilityConfiguration" label="Playback Speed">
-                                        <accessibilityTraits key="traits" button="YES"/>
-                                        <bool key="isElement" value="YES"/>
-                                    </accessibility>
+                                    <segments>
+                                        <segment title="First"/>
+                                        <segment title="Second"/>
+                                    </segments>
+                                </segmentedControl>
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5iH-XX-TB6" userLabel="Speed View">
+                                    <rect key="frame" x="0.0" y="89" width="280" height="44"/>
+                                    <subviews>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="player_speed" translatesAutoresizingMaskIntoConstraints="NO" id="l8T-5d-1fK" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="10" width="24" height="24"/>
+                                            <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" ambiguous="YES" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="44" y="12" width="49" height="20.5"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X9d-OS-tJn" userLabel="Minus">
+                                            <rect key="frame" x="102" y="0.0" width="44" height="44"/>
+                                            <accessibility key="accessibilityConfiguration" label="Decrease playback speed"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="44" id="G5X-u5-ezZ"/>
+                                                <constraint firstAttribute="width" constant="44" id="kVv-ay-xSZ"/>
+                                            </constraints>
+                                            <state key="normal" image="player_effects_less"/>
+                                            <connections>
+                                                <action selector="minusTapped:" destination="-1" eventType="touchUpInside" id="s3h-rh-5OF"/>
+                                            </connections>
+                                        </button>
+                                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OiT-SV-8zG" userLabel="Speed Button" customClass="ShiftyRoundButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="156" y="4" width="70" height="36"/>
+                                            <viewLayoutGuide key="safeArea" id="GCu-8B-qJc"/>
+                                            <accessibility key="accessibilityConfiguration" label="Playback Speed">
+                                                <accessibilityTraits key="traits" button="YES"/>
+                                                <bool key="isElement" value="YES"/>
+                                            </accessibility>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="70" id="4Iz-7X-TRt"/>
+                                                <constraint firstAttribute="height" constant="36" id="shN-7b-eIP"/>
+                                            </constraints>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="string" keyPath="buttonTitle" value="1x"/>
+                                                <userDefinedRuntimeAttribute type="color" keyPath="strokeColor">
+                                                    <color key="value" red="1" green="1" blue="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </userDefinedRuntimeAttribute>
+                                                <userDefinedRuntimeAttribute type="boolean" keyPath="isOn" value="NO"/>
+                                                <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                    <real key="value" value="3"/>
+                                                </userDefinedRuntimeAttribute>
+                                            </userDefinedRuntimeAttributes>
+                                        </view>
+                                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZiH-JO-EJn" userLabel="Plus">
+                                            <rect key="frame" x="236" y="0.0" width="44" height="44"/>
+                                            <accessibility key="accessibilityConfiguration" label="Increase playback speed"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="44" id="TJH-FD-JMy"/>
+                                                <constraint firstAttribute="height" constant="44" id="YEP-hw-HMw"/>
+                                            </constraints>
+                                            <state key="normal" image="player_effects_more"/>
+                                            <connections>
+                                                <action selector="plusTapped:" destination="-1" eventType="touchUpInside" id="1pq-N3-ZWT"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="70" id="4Iz-7X-TRt"/>
-                                        <constraint firstAttribute="height" constant="36" id="shN-7b-eIP"/>
+                                        <constraint firstItem="l8T-5d-1fK" firstAttribute="centerY" secondItem="5iH-XX-TB6" secondAttribute="centerY" id="2kO-dn-1qy"/>
+                                        <constraint firstItem="ZiH-JO-EJn" firstAttribute="centerY" secondItem="5iH-XX-TB6" secondAttribute="centerY" id="9n9-Io-6xx"/>
+                                        <constraint firstItem="l8T-5d-1fK" firstAttribute="leading" secondItem="5iH-XX-TB6" secondAttribute="leading" id="Ens-YS-SOH"/>
+                                        <constraint firstItem="X9d-OS-tJn" firstAttribute="centerY" secondItem="OiT-SV-8zG" secondAttribute="centerY" id="QHV-jT-NMC"/>
+                                        <constraint firstAttribute="trailing" secondItem="ZiH-JO-EJn" secondAttribute="trailing" id="QsM-kr-nfF"/>
+                                        <constraint firstItem="ZiH-JO-EJn" firstAttribute="leading" secondItem="OiT-SV-8zG" secondAttribute="trailing" constant="10" id="gp4-zR-gsp"/>
+                                        <constraint firstItem="OiT-SV-8zG" firstAttribute="leading" secondItem="X9d-OS-tJn" secondAttribute="trailing" constant="10" id="jX1-Ba-n1v"/>
+                                        <constraint firstItem="X9d-OS-tJn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="7Mt-Tq-MwW" secondAttribute="trailing" constant="4" id="ug7-5u-o29"/>
+                                        <constraint firstItem="7Mt-Tq-MwW" firstAttribute="centerY" secondItem="l8T-5d-1fK" secondAttribute="centerY" id="vgr-tS-BqN"/>
+                                        <constraint firstItem="7Mt-Tq-MwW" firstAttribute="leading" secondItem="l8T-5d-1fK" secondAttribute="trailing" constant="20" id="wCK-VC-Hrq"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="xel-ni-y2Z"/>
+                                        <constraint firstItem="OiT-SV-8zG" firstAttribute="centerY" secondItem="ZiH-JO-EJn" secondAttribute="centerY" id="zbm-LI-yES"/>
                                     </constraints>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="string" keyPath="buttonTitle" value="1x"/>
-                                        <userDefinedRuntimeAttribute type="color" keyPath="strokeColor">
-                                            <color key="value" red="1" green="1" blue="1" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isOn" value="NO"/>
-                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                            <real key="value" value="3"/>
-                                        </userDefinedRuntimeAttribute>
-                                    </userDefinedRuntimeAttributes>
                                 </view>
-                                <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZiH-JO-EJn" userLabel="Plus">
-                                    <rect key="frame" x="236" y="0.0" width="44" height="44"/>
-                                    <accessibility key="accessibilityConfiguration" label="Increase playback speed"/>
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W33-7F-lgX" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="149" width="280" height="1"/>
+                                    <color key="backgroundColor" red="0.41960784313725491" green="0.33743089437484741" blue="0.22742205858230591" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="44" id="TJH-FD-JMy"/>
-                                        <constraint firstAttribute="height" constant="44" id="YEP-hw-HMw"/>
+                                        <constraint firstAttribute="height" constant="1" id="koq-fY-Mbi"/>
                                     </constraints>
-                                    <state key="normal" image="player_effects_more"/>
-                                    <connections>
-                                        <action selector="plusTapped:" destination="-1" eventType="touchUpInside" id="1pq-N3-ZWT"/>
-                                    </connections>
-                                </button>
-                            </subviews>
-                            <constraints>
-                                <constraint firstItem="l8T-5d-1fK" firstAttribute="centerY" secondItem="5iH-XX-TB6" secondAttribute="centerY" id="2kO-dn-1qy"/>
-                                <constraint firstItem="ZiH-JO-EJn" firstAttribute="centerY" secondItem="5iH-XX-TB6" secondAttribute="centerY" id="9n9-Io-6xx"/>
-                                <constraint firstItem="l8T-5d-1fK" firstAttribute="leading" secondItem="5iH-XX-TB6" secondAttribute="leading" id="Ens-YS-SOH"/>
-                                <constraint firstItem="X9d-OS-tJn" firstAttribute="centerY" secondItem="OiT-SV-8zG" secondAttribute="centerY" id="QHV-jT-NMC"/>
-                                <constraint firstAttribute="trailing" secondItem="ZiH-JO-EJn" secondAttribute="trailing" id="QsM-kr-nfF"/>
-                                <constraint firstItem="ZiH-JO-EJn" firstAttribute="leading" secondItem="OiT-SV-8zG" secondAttribute="trailing" constant="10" id="gp4-zR-gsp"/>
-                                <constraint firstItem="OiT-SV-8zG" firstAttribute="leading" secondItem="X9d-OS-tJn" secondAttribute="trailing" constant="10" id="jX1-Ba-n1v"/>
-                                <constraint firstItem="X9d-OS-tJn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="7Mt-Tq-MwW" secondAttribute="trailing" constant="4" id="ug7-5u-o29"/>
-                                <constraint firstItem="7Mt-Tq-MwW" firstAttribute="centerY" secondItem="l8T-5d-1fK" secondAttribute="centerY" id="vgr-tS-BqN"/>
-                                <constraint firstItem="7Mt-Tq-MwW" firstAttribute="leading" secondItem="l8T-5d-1fK" secondAttribute="trailing" constant="20" id="wCK-VC-Hrq"/>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="xel-ni-y2Z"/>
-                                <constraint firstItem="OiT-SV-8zG" firstAttribute="centerY" secondItem="ZiH-JO-EJn" secondAttribute="centerY" id="zbm-LI-yES"/>
-                            </constraints>
-                        </view>
-                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W33-7F-lgX" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="149" width="280" height="1"/>
-                            <color key="backgroundColor" red="0.41960784313725491" green="0.33743089437484741" blue="0.22742205858230591" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="1" id="koq-fY-Mbi"/>
-                            </constraints>
-                        </view>
-                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Im-sp-Xss" userLabel="Trim Silence Switch View">
-                            <rect key="frame" x="0.0" y="166" width="280" height="44"/>
-                            <subviews>
-                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_trim" translatesAutoresizingMaskIntoConstraints="NO" id="vd7-K4-6oP" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
-                                    <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </view>
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Im-sp-Xss" userLabel="Trim Silence Switch View">
+                                    <rect key="frame" x="0.0" y="166" width="280" height="44"/>
+                                    <subviews>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_trim" translatesAutoresizingMaskIntoConstraints="NO" id="vd7-K4-6oP" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
+                                            <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="24" id="Ump-Cb-e7y"/>
+                                                <constraint firstAttribute="width" constant="24" id="aSs-7n-MvH"/>
+                                            </constraints>
+                                        </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Trim Silence" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x0h-Uu-9ZR" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="44" y="2" width="167" height="20.5"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qfX-vN-SOl" customClass="ThemeableSwitch" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="219" y="-2" width="63" height="28"/>
+                                            <accessibility key="accessibilityConfiguration" label="Trim Silence"/>
+                                            <color key="onTintColor" red="0.92475664615631104" green="0.57313865423202515" blue="0.21551844477653503" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <connections>
+                                                <action selector="trimSilenceChanged:" destination="-1" eventType="valueChanged" id="Qwc-3O-qPR"/>
+                                            </connections>
+                                        </switch>
+                                    </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="24" id="Ump-Cb-e7y"/>
-                                        <constraint firstAttribute="width" constant="24" id="aSs-7n-MvH"/>
+                                        <constraint firstItem="x0h-Uu-9ZR" firstAttribute="centerY" secondItem="vd7-K4-6oP" secondAttribute="centerY" id="4Nf-8Z-7nq"/>
+                                        <constraint firstItem="qfX-vN-SOl" firstAttribute="centerY" secondItem="x0h-Uu-9ZR" secondAttribute="centerY" id="Hxw-vR-DIg"/>
+                                        <constraint firstItem="qfX-vN-SOl" firstAttribute="leading" secondItem="x0h-Uu-9ZR" secondAttribute="trailing" constant="8" id="QgA-fc-pe6"/>
+                                        <constraint firstItem="vd7-K4-6oP" firstAttribute="top" secondItem="9Im-sp-Xss" secondAttribute="top" id="axg-bp-REq"/>
+                                        <constraint firstItem="x0h-Uu-9ZR" firstAttribute="leading" secondItem="vd7-K4-6oP" secondAttribute="trailing" constant="20" id="hDk-aa-hOq"/>
+                                        <constraint firstItem="vd7-K4-6oP" firstAttribute="leading" secondItem="9Im-sp-Xss" secondAttribute="leading" id="sBg-9q-Fi1"/>
+                                        <constraint firstAttribute="trailing" secondItem="qfX-vN-SOl" secondAttribute="trailing" id="uQV-Kn-tLV"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="zyL-RT-ftY"/>
                                     </constraints>
-                                </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Trim Silence" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x0h-Uu-9ZR" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="44" y="2" width="167" height="20.5"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qfX-vN-SOl" customClass="ThemeableSwitch" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="219" y="-2" width="63" height="28"/>
-                                    <accessibility key="accessibilityConfiguration" label="Trim Silence"/>
-                                    <color key="onTintColor" red="0.92475664615631104" green="0.57313865423202515" blue="0.21551844477653503" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                    <connections>
-                                        <action selector="trimSilenceChanged:" destination="-1" eventType="valueChanged" id="Qwc-3O-qPR"/>
-                                    </connections>
-                                </switch>
-                            </subviews>
-                            <constraints>
-                                <constraint firstItem="x0h-Uu-9ZR" firstAttribute="centerY" secondItem="vd7-K4-6oP" secondAttribute="centerY" id="4Nf-8Z-7nq"/>
-                                <constraint firstItem="qfX-vN-SOl" firstAttribute="centerY" secondItem="x0h-Uu-9ZR" secondAttribute="centerY" id="Hxw-vR-DIg"/>
-                                <constraint firstItem="qfX-vN-SOl" firstAttribute="leading" secondItem="x0h-Uu-9ZR" secondAttribute="trailing" constant="8" id="QgA-fc-pe6"/>
-                                <constraint firstItem="vd7-K4-6oP" firstAttribute="top" secondItem="9Im-sp-Xss" secondAttribute="top" id="axg-bp-REq"/>
-                                <constraint firstItem="x0h-Uu-9ZR" firstAttribute="leading" secondItem="vd7-K4-6oP" secondAttribute="trailing" constant="20" id="hDk-aa-hOq"/>
-                                <constraint firstItem="vd7-K4-6oP" firstAttribute="leading" secondItem="9Im-sp-Xss" secondAttribute="leading" id="sBg-9q-Fi1"/>
-                                <constraint firstAttribute="trailing" secondItem="qfX-vN-SOl" secondAttribute="trailing" id="uQV-Kn-tLV"/>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="zyL-RT-ftY"/>
-                            </constraints>
-                        </view>
-                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lSS-An-PYk" userLabel="Trim Silence Segmented Control" customClass="CustomSegmentedControl" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="44" y="227" width="236" height="38"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="38" id="joY-sc-tBY"/>
-                            </constraints>
-                        </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" ambiguous="YES" text="Makes episodes shorter by trimming silence when no one is talking." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLf-fa-jTA" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="44" y="277" width="236" height="58"/>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                            <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="displayP3"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ufB-9R-Vqg" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="351" width="280" height="1"/>
-                            <color key="backgroundColor" red="0.41960784309999999" green="0.33743089440000001" blue="0.2274220586" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="1" id="T4l-sT-XYD"/>
-                            </constraints>
-                        </view>
-                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OpL-dz-bb5" userLabel="Volume Boost View">
-                            <rect key="frame" x="0.0" y="368" width="280" height="60"/>
-                            <subviews>
-                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_volumeboost" translatesAutoresizingMaskIntoConstraints="NO" id="pxa-gz-sJt" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
-                                    <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </view>
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lSS-An-PYk" userLabel="Trim Silence Segmented Control" customClass="CustomSegmentedControl" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="44" y="227" width="236" height="38"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="24" id="1QV-6g-47E"/>
-                                        <constraint firstAttribute="height" constant="24" id="mJ1-Gq-vNu"/>
+                                        <constraint firstAttribute="height" constant="38" id="joY-sc-tBY"/>
                                     </constraints>
-                                </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Volume Boost" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5f-PT-klK" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="44" y="0.0" width="171" height="20.5"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                    <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Kq-Z2-EgY" customClass="ThemeableSwitch" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="219" y="-3.5" width="63" height="28"/>
-                                    <accessibility key="accessibilityConfiguration" label="Volume Boost"/>
-                                    <color key="onTintColor" red="0.92475664615631104" green="0.57313865423202515" blue="0.21551844477653503" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                    <connections>
-                                        <action selector="volumeBoostChanged:" destination="-1" eventType="valueChanged" id="GFx-lg-UCb"/>
-                                    </connections>
-                                </switch>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Voices sound louder" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iuh-tf-56P" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="44" y="32.5" width="139.5" height="18"/>
+                                </view>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" ambiguous="YES" text="Makes episodes shorter by trimming silence when no one is talking." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLf-fa-jTA" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="44" y="277" width="236" height="58"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="displayP3"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                            </subviews>
-                            <constraints>
-                                <constraint firstItem="6Kq-Z2-EgY" firstAttribute="leading" secondItem="n5f-PT-klK" secondAttribute="trailing" constant="4" id="47w-de-6VN"/>
-                                <constraint firstItem="pxa-gz-sJt" firstAttribute="top" secondItem="OpL-dz-bb5" secondAttribute="top" id="5av-ja-iAh"/>
-                                <constraint firstItem="pxa-gz-sJt" firstAttribute="leading" secondItem="OpL-dz-bb5" secondAttribute="leading" id="8TZ-YT-h80"/>
-                                <constraint firstItem="6Kq-Z2-EgY" firstAttribute="centerY" secondItem="n5f-PT-klK" secondAttribute="centerY" id="JEY-To-Q0p"/>
-                                <constraint firstAttribute="trailing" secondItem="6Kq-Z2-EgY" secondAttribute="trailing" id="TcI-kL-f6A"/>
-                                <constraint firstItem="n5f-PT-klK" firstAttribute="top" secondItem="OpL-dz-bb5" secondAttribute="top" id="VtG-v9-l3t"/>
-                                <constraint firstItem="Iuh-tf-56P" firstAttribute="top" secondItem="n5f-PT-klK" secondAttribute="bottom" constant="12" id="evO-YP-vix"/>
-                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="hxi-IG-PVF"/>
-                                <constraint firstItem="n5f-PT-klK" firstAttribute="leading" secondItem="pxa-gz-sJt" secondAttribute="trailing" constant="20" id="srX-1h-wSV"/>
-                                <constraint firstItem="Iuh-tf-56P" firstAttribute="leading" secondItem="n5f-PT-klK" secondAttribute="leading" id="vV4-WW-FBp"/>
-                            </constraints>
-                        </view>
-                        <view hidden="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPm-dg-nP6" userLabel="Custom Effects View">
-                            <rect key="frame" x="0.0" y="446" width="280" height="64"/>
-                            <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mmt-Tp-FF7" customClass="PodcastImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="17" y="17" width="30" height="30"/>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ufB-9R-Vqg" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="351" width="280" height="1"/>
+                                    <color key="backgroundColor" red="0.41960784309999999" green="0.33743089440000001" blue="0.2274220586" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="30" id="2jl-Pv-ckQ"/>
-                                        <constraint firstAttribute="height" constant="30" id="nH4-zL-ocq"/>
+                                        <constraint firstAttribute="height" constant="1" id="T4l-sT-XYD"/>
                                     </constraints>
                                 </view>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom effects applied" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JrO-T2-rgm" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="63" y="23" width="159.5" height="18"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                    <color key="textColor" white="1" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1SX-69-2q8">
-                                    <rect key="frame" x="213" y="17" width="47" height="30"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                    <state key="normal" title="CLEAR">
-                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    </state>
-                                    <connections>
-                                        <action selector="clearForPodcastTapped:" destination="-1" eventType="touchUpInside" id="9Ip-UV-EYf"/>
-                                    </connections>
-                                </button>
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OpL-dz-bb5" userLabel="Volume Boost View">
+                                    <rect key="frame" x="0.0" y="368" width="280" height="60"/>
+                                    <subviews>
+                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_volumeboost" translatesAutoresizingMaskIntoConstraints="NO" id="pxa-gz-sJt" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
+                                            <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="24" id="1QV-6g-47E"/>
+                                                <constraint firstAttribute="height" constant="24" id="mJ1-Gq-vNu"/>
+                                            </constraints>
+                                        </imageView>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Volume Boost Volume Boost Volume Boost Volume Boost" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5f-PT-klK" userLabel="Volume Boost" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="44" y="0.0" width="171" height="64.5"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                            <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Kq-Z2-EgY" customClass="ThemeableSwitch" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="219" y="18.5" width="63" height="28"/>
+                                            <accessibility key="accessibilityConfiguration" label="Volume Boost"/>
+                                            <color key="onTintColor" red="0.92475664615631104" green="0.57313865423202515" blue="0.21551844477653503" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <connections>
+                                                <action selector="volumeBoostChanged:" destination="-1" eventType="valueChanged" id="GFx-lg-UCb"/>
+                                            </connections>
+                                        </switch>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" text="Voices sound louder Voices sound louder Voices sound louder" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iuh-tf-56P" userLabel="Voices sound louder" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="44" y="76.5" width="236" height="38"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                            <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="displayP3"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="6Kq-Z2-EgY" firstAttribute="leading" secondItem="n5f-PT-klK" secondAttribute="trailing" constant="4" id="47w-de-6VN"/>
+                                        <constraint firstItem="pxa-gz-sJt" firstAttribute="top" secondItem="OpL-dz-bb5" secondAttribute="top" id="5av-ja-iAh"/>
+                                        <constraint firstItem="pxa-gz-sJt" firstAttribute="leading" secondItem="OpL-dz-bb5" secondAttribute="leading" id="8TZ-YT-h80"/>
+                                        <constraint firstItem="6Kq-Z2-EgY" firstAttribute="centerY" secondItem="n5f-PT-klK" secondAttribute="centerY" id="JEY-To-Q0p"/>
+                                        <constraint firstAttribute="trailing" secondItem="6Kq-Z2-EgY" secondAttribute="trailing" id="TcI-kL-f6A"/>
+                                        <constraint firstItem="n5f-PT-klK" firstAttribute="top" secondItem="OpL-dz-bb5" secondAttribute="top" id="VtG-v9-l3t"/>
+                                        <constraint firstAttribute="trailing" secondItem="Iuh-tf-56P" secondAttribute="trailing" id="eks-3N-g7f"/>
+                                        <constraint firstItem="Iuh-tf-56P" firstAttribute="top" secondItem="n5f-PT-klK" secondAttribute="bottom" constant="12" id="evO-YP-vix"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="hxi-IG-PVF"/>
+                                        <constraint firstItem="n5f-PT-klK" firstAttribute="leading" secondItem="pxa-gz-sJt" secondAttribute="trailing" constant="20" id="srX-1h-wSV"/>
+                                        <constraint firstItem="Iuh-tf-56P" firstAttribute="leading" secondItem="n5f-PT-klK" secondAttribute="leading" id="vV4-WW-FBp"/>
+                                        <constraint firstAttribute="bottom" secondItem="Iuh-tf-56P" secondAttribute="bottom" constant="8" id="zjQ-fq-5xS"/>
+                                    </constraints>
+                                </view>
+                                <view hidden="YES" contentMode="scaleToFill" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPm-dg-nP6" userLabel="Custom Effects View">
+                                    <rect key="frame" x="0.0" y="446" width="280" height="64"/>
+                                    <subviews>
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mmt-Tp-FF7" customClass="PodcastImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="17" y="17" width="30" height="30"/>
+                                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="30" id="2jl-Pv-ckQ"/>
+                                                <constraint firstAttribute="height" constant="30" id="nH4-zL-ocq"/>
+                                            </constraints>
+                                        </view>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom effects applied" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JrO-T2-rgm" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="63" y="23" width="159.5" height="18"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                            <color key="textColor" white="1" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1SX-69-2q8">
+                                            <rect key="frame" x="213" y="17" width="47" height="30"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                            <state key="normal" title="CLEAR">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="clearForPodcastTapped:" destination="-1" eventType="touchUpInside" id="9Ip-UV-EYf"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <color key="backgroundColor" white="1" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstItem="JrO-T2-rgm" firstAttribute="centerY" secondItem="mmt-Tp-FF7" secondAttribute="centerY" id="04o-qB-94K"/>
+                                        <constraint firstAttribute="trailing" secondItem="1SX-69-2q8" secondAttribute="trailing" constant="20" id="AFv-mO-fG9"/>
+                                        <constraint firstAttribute="height" constant="64" id="BSk-fU-Qyn"/>
+                                        <constraint firstItem="JrO-T2-rgm" firstAttribute="leading" secondItem="mmt-Tp-FF7" secondAttribute="trailing" constant="16" id="Csf-Aq-Tzi"/>
+                                        <constraint firstItem="mmt-Tp-FF7" firstAttribute="centerY" secondItem="IPm-dg-nP6" secondAttribute="centerY" id="Tt2-xj-JXv"/>
+                                        <constraint firstItem="mmt-Tp-FF7" firstAttribute="leading" secondItem="IPm-dg-nP6" secondAttribute="leading" constant="17" id="WwT-mx-tmo"/>
+                                        <constraint firstItem="1SX-69-2q8" firstAttribute="centerY" secondItem="JrO-T2-rgm" secondAttribute="centerY" id="g4f-AL-8PV"/>
+                                    </constraints>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                            <integer key="value" value="12"/>
+                                        </userDefinedRuntimeAttribute>
+                                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    </userDefinedRuntimeAttributes>
+                                </view>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
-                                <constraint firstItem="JrO-T2-rgm" firstAttribute="centerY" secondItem="mmt-Tp-FF7" secondAttribute="centerY" id="04o-qB-94K"/>
-                                <constraint firstAttribute="trailing" secondItem="1SX-69-2q8" secondAttribute="trailing" constant="20" id="AFv-mO-fG9"/>
-                                <constraint firstAttribute="height" constant="64" id="BSk-fU-Qyn"/>
-                                <constraint firstItem="JrO-T2-rgm" firstAttribute="leading" secondItem="mmt-Tp-FF7" secondAttribute="trailing" constant="16" id="Csf-Aq-Tzi"/>
-                                <constraint firstItem="mmt-Tp-FF7" firstAttribute="centerY" secondItem="IPm-dg-nP6" secondAttribute="centerY" id="Tt2-xj-JXv"/>
-                                <constraint firstItem="mmt-Tp-FF7" firstAttribute="leading" secondItem="IPm-dg-nP6" secondAttribute="leading" constant="17" id="WwT-mx-tmo"/>
-                                <constraint firstItem="1SX-69-2q8" firstAttribute="centerY" secondItem="JrO-T2-rgm" secondAttribute="centerY" id="g4f-AL-8PV"/>
+                                <constraint firstItem="ufB-9R-Vqg" firstAttribute="top" secondItem="gLf-fa-jTA" secondAttribute="bottom" constant="16" id="0E6-mX-jLj"/>
+                                <constraint firstAttribute="trailing" secondItem="W33-7F-lgX" secondAttribute="trailing" id="1uw-SL-wDZ"/>
+                                <constraint firstItem="9Im-sp-Xss" firstAttribute="top" secondItem="W33-7F-lgX" secondAttribute="bottom" constant="16" id="6D0-mc-NKI"/>
+                                <constraint firstItem="gLf-fa-jTA" firstAttribute="top" secondItem="lSS-An-PYk" secondAttribute="bottom" constant="12" id="7ZB-GF-U7Y"/>
+                                <constraint firstItem="OpL-dz-bb5" firstAttribute="top" secondItem="ufB-9R-Vqg" secondAttribute="bottom" constant="16" id="Abm-cd-8LP"/>
+                                <constraint firstAttribute="trailing" secondItem="ufB-9R-Vqg" secondAttribute="trailing" id="BSC-ua-8cr"/>
+                                <constraint firstItem="W33-7F-lgX" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="CHp-qt-6Zy"/>
+                                <constraint firstAttribute="trailing" secondItem="036-xZ-lLC" secondAttribute="trailing" id="EJv-6L-und"/>
+                                <constraint firstAttribute="trailing" secondItem="9Im-sp-Xss" secondAttribute="trailing" id="Hxz-mG-gjx"/>
+                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="OpL-dz-bb5" secondAttribute="bottom" priority="750" constant="30" id="MWt-9l-w5z"/>
+                                <constraint firstItem="gLf-fa-jTA" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" constant="44" id="PSD-IO-Uq5"/>
+                                <constraint firstItem="OpL-dz-bb5" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="R7C-M9-5xX"/>
+                                <constraint firstItem="5iH-XX-TB6" firstAttribute="top" secondItem="gSi-1e-Tle" secondAttribute="top" priority="750" constant="16" id="RVs-bC-UFy"/>
+                                <constraint firstItem="IPm-dg-nP6" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="UV3-c0-Il8"/>
+                                <constraint firstAttribute="trailing" secondItem="lSS-An-PYk" secondAttribute="trailing" id="VaJ-eF-hMT"/>
+                                <constraint firstAttribute="bottom" secondItem="IPm-dg-nP6" secondAttribute="bottom" constant="20" id="Vl3-DJ-fyS"/>
+                                <constraint firstAttribute="trailing" secondItem="OpL-dz-bb5" secondAttribute="trailing" id="WMi-mv-9ef"/>
+                                <constraint firstItem="gLf-fa-jTA" firstAttribute="top" secondItem="9Im-sp-Xss" secondAttribute="bottom" priority="750" constant="8" id="YRm-qY-ksv"/>
+                                <constraint firstItem="5iH-XX-TB6" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="c1f-G2-C7L"/>
+                                <constraint firstAttribute="trailing" secondItem="5iH-XX-TB6" secondAttribute="trailing" id="ce7-YF-Nmp"/>
+                                <constraint firstItem="ufB-9R-Vqg" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="eak-eP-DVP"/>
+                                <constraint firstItem="W33-7F-lgX" firstAttribute="top" secondItem="5iH-XX-TB6" secondAttribute="bottom" constant="16" id="idz-0B-3MO"/>
+                                <constraint firstItem="lSS-An-PYk" firstAttribute="top" secondItem="9Im-sp-Xss" secondAttribute="bottom" id="jVa-Ec-UuN"/>
+                                <constraint firstItem="IPm-dg-nP6" firstAttribute="top" secondItem="OpL-dz-bb5" secondAttribute="bottom" constant="18" id="lhS-F2-gsF"/>
+                                <constraint firstItem="036-xZ-lLC" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="p1R-mH-jRl"/>
+                                <constraint firstAttribute="trailing" secondItem="gLf-fa-jTA" secondAttribute="trailing" id="snK-ju-S4Y"/>
+                                <constraint firstItem="lSS-An-PYk" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" constant="44" id="tRJ-aI-cQ6"/>
+                                <constraint firstAttribute="trailing" secondItem="IPm-dg-nP6" secondAttribute="trailing" id="vR8-bB-yTY"/>
+                                <constraint firstItem="036-xZ-lLC" firstAttribute="top" secondItem="gSi-1e-Tle" secondAttribute="top" constant="28" id="wRn-O1-auf"/>
+                                <constraint firstItem="9Im-sp-Xss" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="wiP-QQ-J2B"/>
+                                <constraint firstItem="5iH-XX-TB6" firstAttribute="top" secondItem="036-xZ-lLC" secondAttribute="bottom" constant="30" id="xXB-B8-zSM"/>
                             </constraints>
-                            <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                    <integer key="value" value="12"/>
-                                </userDefinedRuntimeAttribute>
-                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
-                            </userDefinedRuntimeAttributes>
                         </view>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="ufB-9R-Vqg" firstAttribute="top" secondItem="gLf-fa-jTA" secondAttribute="bottom" constant="16" id="0E6-mX-jLj"/>
-                        <constraint firstAttribute="trailing" secondItem="W33-7F-lgX" secondAttribute="trailing" id="1uw-SL-wDZ"/>
-                        <constraint firstItem="9Im-sp-Xss" firstAttribute="top" secondItem="W33-7F-lgX" secondAttribute="bottom" constant="16" id="6D0-mc-NKI"/>
-                        <constraint firstItem="gLf-fa-jTA" firstAttribute="top" secondItem="lSS-An-PYk" secondAttribute="bottom" constant="12" id="7ZB-GF-U7Y"/>
-                        <constraint firstItem="OpL-dz-bb5" firstAttribute="top" secondItem="ufB-9R-Vqg" secondAttribute="bottom" constant="16" id="Abm-cd-8LP"/>
-                        <constraint firstAttribute="trailing" secondItem="ufB-9R-Vqg" secondAttribute="trailing" id="BSC-ua-8cr"/>
-                        <constraint firstItem="W33-7F-lgX" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="CHp-qt-6Zy"/>
-                        <constraint firstAttribute="trailing" secondItem="036-xZ-lLC" secondAttribute="trailing" id="EJv-6L-und"/>
-                        <constraint firstAttribute="trailing" secondItem="9Im-sp-Xss" secondAttribute="trailing" id="Hxz-mG-gjx"/>
-                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="OpL-dz-bb5" secondAttribute="bottom" priority="750" constant="30" id="MWt-9l-w5z"/>
-                        <constraint firstItem="gLf-fa-jTA" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" constant="44" id="PSD-IO-Uq5"/>
-                        <constraint firstItem="OpL-dz-bb5" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="R7C-M9-5xX"/>
-                        <constraint firstItem="5iH-XX-TB6" firstAttribute="top" secondItem="gSi-1e-Tle" secondAttribute="top" priority="750" constant="16" id="RVs-bC-UFy"/>
-                        <constraint firstItem="IPm-dg-nP6" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="UV3-c0-Il8"/>
-                        <constraint firstAttribute="trailing" secondItem="lSS-An-PYk" secondAttribute="trailing" id="VaJ-eF-hMT"/>
-                        <constraint firstAttribute="bottom" secondItem="IPm-dg-nP6" secondAttribute="bottom" constant="20" id="Vl3-DJ-fyS"/>
-                        <constraint firstAttribute="trailing" secondItem="OpL-dz-bb5" secondAttribute="trailing" id="WMi-mv-9ef"/>
-                        <constraint firstItem="gLf-fa-jTA" firstAttribute="top" secondItem="9Im-sp-Xss" secondAttribute="bottom" priority="750" constant="8" id="YRm-qY-ksv"/>
-                        <constraint firstItem="5iH-XX-TB6" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="c1f-G2-C7L"/>
-                        <constraint firstAttribute="trailing" secondItem="5iH-XX-TB6" secondAttribute="trailing" id="ce7-YF-Nmp"/>
-                        <constraint firstItem="ufB-9R-Vqg" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="eak-eP-DVP"/>
-                        <constraint firstItem="W33-7F-lgX" firstAttribute="top" secondItem="5iH-XX-TB6" secondAttribute="bottom" constant="16" id="idz-0B-3MO"/>
-                        <constraint firstItem="lSS-An-PYk" firstAttribute="top" secondItem="9Im-sp-Xss" secondAttribute="bottom" id="jVa-Ec-UuN"/>
-                        <constraint firstItem="IPm-dg-nP6" firstAttribute="top" secondItem="OpL-dz-bb5" secondAttribute="bottom" constant="18" id="lhS-F2-gsF"/>
-                        <constraint firstItem="036-xZ-lLC" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="p1R-mH-jRl"/>
-                        <constraint firstAttribute="trailing" secondItem="gLf-fa-jTA" secondAttribute="trailing" id="snK-ju-S4Y"/>
-                        <constraint firstItem="lSS-An-PYk" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" constant="44" id="tRJ-aI-cQ6"/>
-                        <constraint firstAttribute="trailing" secondItem="IPm-dg-nP6" secondAttribute="trailing" id="vR8-bB-yTY"/>
-                        <constraint firstItem="036-xZ-lLC" firstAttribute="top" secondItem="gSi-1e-Tle" secondAttribute="top" constant="28" id="wRn-O1-auf"/>
-                        <constraint firstItem="9Im-sp-Xss" firstAttribute="leading" secondItem="gSi-1e-Tle" secondAttribute="leading" id="wiP-QQ-J2B"/>
-                        <constraint firstItem="5iH-XX-TB6" firstAttribute="top" secondItem="036-xZ-lLC" secondAttribute="bottom" constant="30" id="xXB-B8-zSM"/>
+                        <constraint firstItem="kai-Yh-xjV" firstAttribute="trailing" secondItem="gSi-1e-Tle" secondAttribute="trailing" constant="20" id="0BR-i6-ky3"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="570" id="0JD-py-CNT"/>
+                        <constraint firstItem="gSi-1e-Tle" firstAttribute="top" secondItem="8UN-zx-FOh" secondAttribute="top" id="8Mp-Ix-bzN"/>
+                        <constraint firstItem="8UN-zx-FOh" firstAttribute="bottom" secondItem="gSi-1e-Tle" secondAttribute="bottom" id="8SB-id-lhS"/>
+                        <constraint firstItem="gSi-1e-Tle" firstAttribute="leading" secondItem="kai-Yh-xjV" secondAttribute="leading" constant="20" id="u7T-6o-n5N"/>
                     </constraints>
-                </view>
+                    <viewLayoutGuide key="contentLayoutGuide" id="8UN-zx-FOh"/>
+                    <viewLayoutGuide key="frameLayoutGuide" id="kai-Yh-xjV"/>
+                </scrollView>
             </subviews>
             <color key="backgroundColor" red="0.18413844704627991" green="0.11385995894670486" blue="0.023501332849264145" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
             <constraints>
-                <constraint firstItem="gSi-1e-Tle" firstAttribute="top" secondItem="xDY-er-QkI" secondAttribute="bottom" id="0y8-GB-3dD"/>
-                <constraint firstAttribute="bottom" secondItem="gSi-1e-Tle" secondAttribute="bottom" id="3Gy-DE-Rf9"/>
+                <constraint firstAttribute="bottom" secondItem="yTq-s1-73n" secondAttribute="bottom" constant="20" symbolic="YES" id="F5X-8D-RbT"/>
                 <constraint firstAttribute="trailing" secondItem="xDY-er-QkI" secondAttribute="trailing" id="K7y-jI-UaP"/>
-                <constraint firstItem="gSi-1e-Tle" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="KBP-bP-0Pu"/>
+                <constraint firstAttribute="trailing" secondItem="yTq-s1-73n" secondAttribute="trailing" id="KHg-tX-HZU"/>
                 <constraint firstItem="xDY-er-QkI" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="KKx-bh-4Tu"/>
                 <constraint firstItem="xDY-er-QkI" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Z3k-kk-aXn"/>
-                <constraint firstAttribute="trailing" secondItem="gSi-1e-Tle" secondAttribute="trailing" constant="20" id="aoy-Yd-Uo1"/>
+                <constraint firstItem="yTq-s1-73n" firstAttribute="top" secondItem="xDY-er-QkI" secondAttribute="bottom" id="j5a-2w-CUf"/>
+                <constraint firstItem="yTq-s1-73n" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="obR-ut-WMq"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="-1526.0869565217392" y="-135.26785714285714"/>

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -378,7 +378,7 @@
                     </subviews>
                     <constraints>
                         <constraint firstItem="kai-Yh-xjV" firstAttribute="trailing" secondItem="gSi-1e-Tle" secondAttribute="trailing" constant="20" id="0BR-i6-ky3"/>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="550" id="0JD-py-CNT"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="400" id="0JD-py-CNT"/>
                         <constraint firstItem="gSi-1e-Tle" firstAttribute="top" secondItem="8UN-zx-FOh" secondAttribute="top" id="8Mp-Ix-bzN"/>
                         <constraint firstItem="8UN-zx-FOh" firstAttribute="bottom" secondItem="gSi-1e-Tle" secondAttribute="bottom" id="8SB-id-lhS"/>
                         <constraint firstItem="gSi-1e-Tle" firstAttribute="width" secondItem="kai-Yh-xjV" secondAttribute="width" constant="-40" id="Bq1-Rs-Bmf"/>

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -39,8 +39,8 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" ambiguous="YES" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="598"/>
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="734"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xDY-er-QkI" userLabel="Popup Heading">
@@ -72,7 +72,7 @@
                                 <action selector="closeTapped:" destination="-1" eventType="touchUpInside" id="Fa1-TQ-Foj"/>
                             </connections>
                         </button>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PLAYBACK EFFECTS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2fF-ad-Nz3" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PLAYBACK EFFECTS" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2fF-ad-Nz3" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="20" y="35" width="127.5" height="16"/>
                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="13"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -256,22 +256,22 @@
                                                 <constraint firstAttribute="height" constant="24" id="mJ1-Gq-vNu"/>
                                             </constraints>
                                         </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Volume Boost Volume Boost Volume Boost Volume Boost" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5f-PT-klK" userLabel="Volume Boost" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                            <rect key="frame" x="44" y="0.0" width="171" height="64.5"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" ambiguous="YES" text="Volume Boost" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5f-PT-klK" userLabel="Volume Boost" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="44" y="0.0" width="171" height="20.5"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Kq-Z2-EgY" customClass="ThemeableSwitch" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                            <rect key="frame" x="219" y="18.5" width="63" height="28"/>
+                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Kq-Z2-EgY" customClass="ThemeableSwitch" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="219" y="-3.5" width="63" height="28"/>
                                             <accessibility key="accessibilityConfiguration" label="Volume Boost"/>
                                             <color key="onTintColor" red="0.92475664615631104" green="0.57313865423202515" blue="0.21551844477653503" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <connections>
                                                 <action selector="volumeBoostChanged:" destination="-1" eventType="valueChanged" id="GFx-lg-UCb"/>
                                             </connections>
                                         </switch>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" text="Voices sound louder Voices sound louder Voices sound louder" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iuh-tf-56P" userLabel="Voices sound louder" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                            <rect key="frame" x="44" y="76.5" width="236" height="38"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" ambiguous="YES" text="Voices sound louder" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iuh-tf-56P" userLabel="Voices sound louder" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="44" y="32.5" width="236" height="38"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="displayP3"/>
                                             <nil key="highlightedColor"/>
@@ -375,9 +375,10 @@
                     </subviews>
                     <constraints>
                         <constraint firstItem="kai-Yh-xjV" firstAttribute="trailing" secondItem="gSi-1e-Tle" secondAttribute="trailing" constant="20" id="0BR-i6-ky3"/>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="570" id="0JD-py-CNT"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="550" id="0JD-py-CNT"/>
                         <constraint firstItem="gSi-1e-Tle" firstAttribute="top" secondItem="8UN-zx-FOh" secondAttribute="top" id="8Mp-Ix-bzN"/>
                         <constraint firstItem="8UN-zx-FOh" firstAttribute="bottom" secondItem="gSi-1e-Tle" secondAttribute="bottom" id="8SB-id-lhS"/>
+                        <constraint firstItem="gSi-1e-Tle" firstAttribute="width" secondItem="kai-Yh-xjV" secondAttribute="width" constant="-40" id="Bq1-Rs-Bmf"/>
                         <constraint firstItem="gSi-1e-Tle" firstAttribute="leading" secondItem="kai-Yh-xjV" secondAttribute="leading" constant="20" id="u7T-6o-n5N"/>
                     </constraints>
                     <viewLayoutGuide key="contentLayoutGuide" id="8UN-zx-FOh"/>
@@ -395,7 +396,7 @@
                 <constraint firstItem="yTq-s1-73n" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="obR-ut-WMq"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="-1526.0869565217392" y="-135.26785714285714"/>
+            <point key="canvasLocation" x="-1526.0869565217392" y="-89.732142857142847"/>
         </view>
     </objects>
     <resources>

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -378,12 +378,12 @@
                         </view>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="kai-Yh-xjV" firstAttribute="trailing" secondItem="gSi-1e-Tle" secondAttribute="trailing" constant="20" id="0BR-i6-ky3"/>
+                        <constraint firstItem="8UN-zx-FOh" firstAttribute="trailing" secondItem="gSi-1e-Tle" secondAttribute="trailing" constant="-300" id="0BR-i6-ky3"/>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="400" id="0JD-py-CNT"/>
                         <constraint firstItem="gSi-1e-Tle" firstAttribute="top" secondItem="8UN-zx-FOh" secondAttribute="top" id="8Mp-Ix-bzN"/>
                         <constraint firstItem="8UN-zx-FOh" firstAttribute="bottom" secondItem="gSi-1e-Tle" secondAttribute="bottom" id="8SB-id-lhS"/>
                         <constraint firstItem="gSi-1e-Tle" firstAttribute="width" secondItem="kai-Yh-xjV" secondAttribute="width" constant="-40" id="Bq1-Rs-Bmf"/>
-                        <constraint firstItem="gSi-1e-Tle" firstAttribute="leading" secondItem="kai-Yh-xjV" secondAttribute="leading" constant="20" id="u7T-6o-n5N"/>
+                        <constraint firstItem="gSi-1e-Tle" firstAttribute="leading" secondItem="8UN-zx-FOh" secondAttribute="leading" constant="20" id="u7T-6o-n5N"/>
                     </constraints>
                     <viewLayoutGuide key="contentLayoutGuide" id="8UN-zx-FOh"/>
                     <viewLayoutGuide key="frameLayoutGuide" id="kai-Yh-xjV"/>
@@ -391,7 +391,7 @@
             </subviews>
             <color key="backgroundColor" red="0.18413844704627991" green="0.11385995894670486" blue="0.023501332849264145" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="yTq-s1-73n" secondAttribute="bottom" constant="20" symbolic="YES" id="F5X-8D-RbT"/>
+                <constraint firstAttribute="bottom" secondItem="yTq-s1-73n" secondAttribute="bottom" id="F5X-8D-RbT"/>
                 <constraint firstAttribute="trailing" secondItem="xDY-er-QkI" secondAttribute="trailing" id="K7y-jI-UaP"/>
                 <constraint firstAttribute="trailing" secondItem="yTq-s1-73n" secondAttribute="trailing" id="KHg-tX-HZU"/>
                 <constraint firstItem="xDY-er-QkI" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="KKx-bh-4Tu"/>

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="EffectsViewController" customModule="podcasts" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="EffectsViewController" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
             <connections>
                 <outlet property="clearForPodcastImage" destination="mmt-Tp-FF7" id="FWo-AX-adQ"/>
                 <outlet property="clearForPodcastView" destination="IPm-dg-nP6" id="ged-Fl-88u"/>
@@ -47,7 +46,7 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xDY-er-QkI" userLabel="Popup Heading">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="68"/>
                     <subviews>
-                        <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dp7-EY-xsE" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+                        <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dp7-EY-xsE" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="132" y="8" width="56" height="4"/>
                             <color key="backgroundColor" red="0.63509190082550049" green="0.58443516492843628" blue="0.50978493690490723" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <accessibility key="accessibilityConfiguration" label="Close Effects">
@@ -73,7 +72,7 @@
                                 <action selector="closeTapped:" destination="-1" eventType="touchUpInside" id="Fa1-TQ-Foj"/>
                             </connections>
                         </button>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PLAYBACK EFFECTS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2fF-ad-Nz3" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PLAYBACK EFFECTS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2fF-ad-Nz3" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="20" y="35" width="127.5" height="16"/>
                             <fontDescription key="fontDescription" type="system" weight="medium" pointSize="13"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -96,9 +95,9 @@
                     <rect key="frame" x="20" y="68" width="280" height="530"/>
                     <subviews>
                         <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="036-xZ-lLC" userLabel="Playback Settings Segmented">
-                            <rect key="frame" x="0.0" y="28" width="280" height="25"/>
+                            <rect key="frame" x="0.0" y="28" width="280" height="32"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="24" id="Hg5-29-bhj"/>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="24" id="Hg5-29-bhj"/>
                             </constraints>
                             <segments>
                                 <segment title="First"/>
@@ -106,15 +105,15 @@
                             </segments>
                         </segmentedControl>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5iH-XX-TB6" userLabel="Speed View">
-                            <rect key="frame" x="0.0" y="82" width="280" height="44"/>
+                            <rect key="frame" x="0.0" y="89" width="280" height="44"/>
                             <subviews>
-                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="player_speed" translatesAutoresizingMaskIntoConstraints="NO" id="l8T-5d-1fK" customClass="TintableImageView" customModule="podcasts" customModuleProvider="target">
+                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="player_speed" translatesAutoresizingMaskIntoConstraints="NO" id="l8T-5d-1fK" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="10" width="24" height="24"/>
                                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="44" y="11.5" width="52" height="21.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="44" y="12" width="49" height="20.5"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <nil key="highlightedColor"/>
                                 </label>
@@ -130,7 +129,7 @@
                                         <action selector="minusTapped:" destination="-1" eventType="touchUpInside" id="s3h-rh-5OF"/>
                                     </connections>
                                 </button>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OiT-SV-8zG" userLabel="Speed Button" customClass="ShiftyRoundButton" customModule="podcasts" customModuleProvider="target">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OiT-SV-8zG" userLabel="Speed Button" customClass="ShiftyRoundButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="156" y="4" width="70" height="36"/>
                                     <viewLayoutGuide key="safeArea" id="GCu-8B-qJc"/>
                                     <accessibility key="accessibilityConfiguration" label="Playback Speed">
@@ -180,28 +179,28 @@
                                 <constraint firstItem="OiT-SV-8zG" firstAttribute="centerY" secondItem="ZiH-JO-EJn" secondAttribute="centerY" id="zbm-LI-yES"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W33-7F-lgX" userLabel="Divider" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="142" width="280" height="1"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W33-7F-lgX" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="149" width="280" height="1"/>
                             <color key="backgroundColor" red="0.41960784313725491" green="0.33743089437484741" blue="0.22742205858230591" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="koq-fY-Mbi"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Im-sp-Xss" userLabel="Trim Silence Switch View">
-                            <rect key="frame" x="0.0" y="159" width="280" height="44"/>
+                            <rect key="frame" x="0.0" y="166" width="280" height="44"/>
                             <subviews>
-                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_trim" translatesAutoresizingMaskIntoConstraints="NO" id="vd7-K4-6oP" customClass="TintableImageView" customModule="podcasts" customModuleProvider="target">
+                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_trim" translatesAutoresizingMaskIntoConstraints="NO" id="vd7-K4-6oP" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Trim Silence" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x0h-Uu-9ZR" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="44" y="1.5" width="98" height="21.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Trim Silence" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x0h-Uu-9ZR" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="44" y="2" width="93" height="20.5"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qfX-vN-SOl" customClass="ThemeableSwitch" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="231" y="-3.5" width="51" height="31"/>
+                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qfX-vN-SOl" customClass="ThemeableSwitch" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="219" y="-2" width="63" height="28"/>
                                     <accessibility key="accessibilityConfiguration" label="Trim Silence"/>
                                     <color key="onTintColor" red="0.92475664615631104" green="0.57313865423202515" blue="0.21551844477653503" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <connections>
@@ -219,19 +218,19 @@
                                 <constraint firstAttribute="height" constant="44" id="zyL-RT-ftY"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lSS-An-PYk" userLabel="Trim Silence Segmented Control" customClass="CustomSegmentedControl" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="44" y="203" width="236" height="38"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lSS-An-PYk" userLabel="Trim Silence Segmented Control" customClass="CustomSegmentedControl" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                            <rect key="frame" x="44" y="210" width="236" height="38"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="38" id="joY-sc-tBY"/>
                             </constraints>
                         </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Makes episodes shorter by trimming silence when no one is talking." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLf-fa-jTA" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="44" y="253" width="236" height="82"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Makes episodes shorter by trimming silence when no one is talking." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLf-fa-jTA" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                            <rect key="frame" x="44" y="260" width="236" height="75"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="displayP3"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ufB-9R-Vqg" userLabel="Divider" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ufB-9R-Vqg" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="351" width="280" height="1"/>
                             <color key="backgroundColor" red="0.41960784309999999" green="0.33743089440000001" blue="0.2274220586" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
@@ -241,27 +240,27 @@
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OpL-dz-bb5" userLabel="Volume Boost View">
                             <rect key="frame" x="0.0" y="368" width="280" height="60"/>
                             <subviews>
-                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_volumeboost" translatesAutoresizingMaskIntoConstraints="NO" id="pxa-gz-sJt" customClass="TintableImageView" customModule="podcasts" customModuleProvider="target">
+                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_volumeboost" translatesAutoresizingMaskIntoConstraints="NO" id="pxa-gz-sJt" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Volume Boost" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5f-PT-klK" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="44" y="1.5" width="111.5" height="21.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Volume Boost" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5f-PT-klK" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="44" y="2" width="105.5" height="20.5"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Kq-Z2-EgY" customClass="ThemeableSwitch" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="231" y="-3.5" width="51" height="31"/>
+                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Kq-Z2-EgY" customClass="ThemeableSwitch" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="219" y="-2" width="63" height="28"/>
                                     <accessibility key="accessibilityConfiguration" label="Volume Boost"/>
                                     <color key="onTintColor" red="0.92475664615631104" green="0.57313865423202515" blue="0.21551844477653503" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <connections>
                                         <action selector="volumeBoostChanged:" destination="-1" eventType="valueChanged" id="GFx-lg-UCb"/>
                                     </connections>
                                 </switch>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Voices sound louder" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iuh-tf-56P" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="44" y="35" width="139.5" height="18"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Voices sound louder" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iuh-tf-56P" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="44" y="34.5" width="139.5" height="18"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="displayP3"/>
                                     <nil key="highlightedColor"/>
                                 </label>
@@ -281,7 +280,7 @@
                         <view hidden="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPm-dg-nP6" userLabel="Custom Effects View">
                             <rect key="frame" x="0.0" y="446" width="280" height="64"/>
                             <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mmt-Tp-FF7" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mmt-Tp-FF7" customClass="PodcastImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="17" y="17" width="30" height="30"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
@@ -289,15 +288,15 @@
                                         <constraint firstAttribute="height" constant="30" id="nH4-zL-ocq"/>
                                     </constraints>
                                 </view>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom effects applied" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JrO-T2-rgm" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="63" y="23.5" width="150" height="17"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom effects applied" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JrO-T2-rgm" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="63" y="23" width="159.5" height="18"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                     <color key="textColor" white="1" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1SX-69-2q8">
-                                    <rect key="frame" x="215" y="17.5" width="45" height="29"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <rect key="frame" x="213" y="17" width="47" height="30"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                     <state key="normal" title="CLEAR">
                                         <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </state>

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -97,10 +97,10 @@
                         <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gSi-1e-Tle">
                             <rect key="frame" x="20" y="20" width="280" height="530"/>
                             <subviews>
-                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="036-xZ-lLC" userLabel="Playback Settings Segmented">
+                                <segmentedControl opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="036-xZ-lLC" userLabel="Playback Settings Segmented">
                                     <rect key="frame" x="0.0" y="28" width="280" height="33"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="32" id="Hg5-29-bhj"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="28" id="Hg5-29-bhj"/>
                                     </constraints>
                                     <segments>
                                         <segment title="First"/>
@@ -193,21 +193,21 @@
                                     <rect key="frame" x="0.0" y="166" width="280" height="44"/>
                                     <subviews>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_trim" translatesAutoresizingMaskIntoConstraints="NO" id="vd7-K4-6oP" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
+                                            <rect key="frame" x="0.0" y="6" width="24" height="24"/>
                                             <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="24" id="Ump-Cb-e7y"/>
                                                 <constraint firstAttribute="width" constant="24" id="aSs-7n-MvH"/>
                                             </constraints>
                                         </imageView>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Trim Silence" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x0h-Uu-9ZR" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                            <rect key="frame" x="44" y="2" width="167" height="20.5"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" text="Trim Silence" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x0h-Uu-9ZR" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="44" y="0.0" width="171" height="36"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qfX-vN-SOl" customClass="ThemeableSwitch" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                            <rect key="frame" x="219" y="-2" width="63" height="28"/>
+                                            <rect key="frame" x="219" y="4" width="63" height="28"/>
                                             <accessibility key="accessibilityConfiguration" label="Trim Silence"/>
                                             <color key="onTintColor" red="0.92475664615631104" green="0.57313865423202515" blue="0.21551844477653503" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             <connections>
@@ -216,11 +216,12 @@
                                         </switch>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="x0h-Uu-9ZR" firstAttribute="centerY" secondItem="vd7-K4-6oP" secondAttribute="centerY" id="4Nf-8Z-7nq"/>
+                                        <constraint firstItem="x0h-Uu-9ZR" firstAttribute="top" secondItem="9Im-sp-Xss" secondAttribute="top" id="96j-EB-1cl"/>
                                         <constraint firstItem="qfX-vN-SOl" firstAttribute="centerY" secondItem="x0h-Uu-9ZR" secondAttribute="centerY" id="Hxw-vR-DIg"/>
-                                        <constraint firstItem="qfX-vN-SOl" firstAttribute="leading" secondItem="x0h-Uu-9ZR" secondAttribute="trailing" constant="8" id="QgA-fc-pe6"/>
-                                        <constraint firstItem="vd7-K4-6oP" firstAttribute="top" secondItem="9Im-sp-Xss" secondAttribute="top" id="axg-bp-REq"/>
+                                        <constraint firstItem="qfX-vN-SOl" firstAttribute="leading" secondItem="x0h-Uu-9ZR" secondAttribute="trailing" constant="4" id="QgA-fc-pe6"/>
                                         <constraint firstItem="x0h-Uu-9ZR" firstAttribute="leading" secondItem="vd7-K4-6oP" secondAttribute="trailing" constant="20" id="hDk-aa-hOq"/>
+                                        <constraint firstItem="qfX-vN-SOl" firstAttribute="centerY" secondItem="vd7-K4-6oP" secondAttribute="centerY" id="phf-Q0-7IB"/>
+                                        <constraint firstAttribute="bottom" secondItem="x0h-Uu-9ZR" secondAttribute="bottom" constant="8" id="qGr-xJ-cYW"/>
                                         <constraint firstItem="vd7-K4-6oP" firstAttribute="leading" secondItem="9Im-sp-Xss" secondAttribute="leading" id="sBg-9q-Fi1"/>
                                         <constraint firstAttribute="trailing" secondItem="qfX-vN-SOl" secondAttribute="trailing" id="uQV-Kn-tLV"/>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="zyL-RT-ftY"/>

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -94,7 +94,7 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gSi-1e-Tle">
                     <rect key="frame" x="20" y="68" width="280" height="530"/>
                     <subviews>
-                        <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="036-xZ-lLC" userLabel="Playback Settings Segmented">
+                        <segmentedControl opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="036-xZ-lLC" userLabel="Playback Settings Segmented">
                             <rect key="frame" x="0.0" y="28" width="280" height="32"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="24" id="Hg5-29-bhj"/>
@@ -104,20 +104,20 @@
                                 <segment title="Second"/>
                             </segments>
                         </segmentedControl>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5iH-XX-TB6" userLabel="Speed View">
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5iH-XX-TB6" userLabel="Speed View">
                             <rect key="frame" x="0.0" y="89" width="280" height="44"/>
                             <subviews>
-                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="player_speed" translatesAutoresizingMaskIntoConstraints="NO" id="l8T-5d-1fK" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="player_speed" translatesAutoresizingMaskIntoConstraints="NO" id="l8T-5d-1fK" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="10" width="24" height="24"/>
                                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" ambiguous="YES" text="Speed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Mt-Tq-MwW" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="44" y="12" width="49" height="20.5"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X9d-OS-tJn" userLabel="Minus">
+                                <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X9d-OS-tJn" userLabel="Minus">
                                     <rect key="frame" x="102" y="0.0" width="44" height="44"/>
                                     <accessibility key="accessibilityConfiguration" label="Decrease playback speed"/>
                                     <constraints>
@@ -129,7 +129,7 @@
                                         <action selector="minusTapped:" destination="-1" eventType="touchUpInside" id="s3h-rh-5OF"/>
                                     </connections>
                                 </button>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OiT-SV-8zG" userLabel="Speed Button" customClass="ShiftyRoundButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OiT-SV-8zG" userLabel="Speed Button" customClass="ShiftyRoundButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="156" y="4" width="70" height="36"/>
                                     <viewLayoutGuide key="safeArea" id="GCu-8B-qJc"/>
                                     <accessibility key="accessibilityConfiguration" label="Playback Speed">
@@ -151,7 +151,7 @@
                                         </userDefinedRuntimeAttribute>
                                     </userDefinedRuntimeAttributes>
                                 </view>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZiH-JO-EJn" userLabel="Plus">
+                                <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZiH-JO-EJn" userLabel="Plus">
                                     <rect key="frame" x="236" y="0.0" width="44" height="44"/>
                                     <accessibility key="accessibilityConfiguration" label="Increase playback speed"/>
                                     <constraints>
@@ -175,26 +175,30 @@
                                 <constraint firstItem="X9d-OS-tJn" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="7Mt-Tq-MwW" secondAttribute="trailing" constant="4" id="ug7-5u-o29"/>
                                 <constraint firstItem="7Mt-Tq-MwW" firstAttribute="centerY" secondItem="l8T-5d-1fK" secondAttribute="centerY" id="vgr-tS-BqN"/>
                                 <constraint firstItem="7Mt-Tq-MwW" firstAttribute="leading" secondItem="l8T-5d-1fK" secondAttribute="trailing" constant="20" id="wCK-VC-Hrq"/>
-                                <constraint firstAttribute="height" constant="44" id="xel-ni-y2Z"/>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="xel-ni-y2Z"/>
                                 <constraint firstItem="OiT-SV-8zG" firstAttribute="centerY" secondItem="ZiH-JO-EJn" secondAttribute="centerY" id="zbm-LI-yES"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W33-7F-lgX" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W33-7F-lgX" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="149" width="280" height="1"/>
                             <color key="backgroundColor" red="0.41960784313725491" green="0.33743089437484741" blue="0.22742205858230591" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="koq-fY-Mbi"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Im-sp-Xss" userLabel="Trim Silence Switch View">
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Im-sp-Xss" userLabel="Trim Silence Switch View">
                             <rect key="frame" x="0.0" y="166" width="280" height="44"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_trim" translatesAutoresizingMaskIntoConstraints="NO" id="vd7-K4-6oP" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="24" id="Ump-Cb-e7y"/>
+                                        <constraint firstAttribute="width" constant="24" id="aSs-7n-MvH"/>
+                                    </constraints>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Trim Silence" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x0h-Uu-9ZR" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="44" y="2" width="93" height="20.5"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Trim Silence" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x0h-Uu-9ZR" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="44" y="2" width="167" height="20.5"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <nil key="highlightedColor"/>
@@ -211,47 +215,52 @@
                             <constraints>
                                 <constraint firstItem="x0h-Uu-9ZR" firstAttribute="centerY" secondItem="vd7-K4-6oP" secondAttribute="centerY" id="4Nf-8Z-7nq"/>
                                 <constraint firstItem="qfX-vN-SOl" firstAttribute="centerY" secondItem="x0h-Uu-9ZR" secondAttribute="centerY" id="Hxw-vR-DIg"/>
+                                <constraint firstItem="qfX-vN-SOl" firstAttribute="leading" secondItem="x0h-Uu-9ZR" secondAttribute="trailing" constant="8" id="QgA-fc-pe6"/>
                                 <constraint firstItem="vd7-K4-6oP" firstAttribute="top" secondItem="9Im-sp-Xss" secondAttribute="top" id="axg-bp-REq"/>
                                 <constraint firstItem="x0h-Uu-9ZR" firstAttribute="leading" secondItem="vd7-K4-6oP" secondAttribute="trailing" constant="20" id="hDk-aa-hOq"/>
                                 <constraint firstItem="vd7-K4-6oP" firstAttribute="leading" secondItem="9Im-sp-Xss" secondAttribute="leading" id="sBg-9q-Fi1"/>
                                 <constraint firstAttribute="trailing" secondItem="qfX-vN-SOl" secondAttribute="trailing" id="uQV-Kn-tLV"/>
-                                <constraint firstAttribute="height" constant="44" id="zyL-RT-ftY"/>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="zyL-RT-ftY"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lSS-An-PYk" userLabel="Trim Silence Segmented Control" customClass="CustomSegmentedControl" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="44" y="210" width="236" height="38"/>
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lSS-An-PYk" userLabel="Trim Silence Segmented Control" customClass="CustomSegmentedControl" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                            <rect key="frame" x="44" y="227" width="236" height="38"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="38" id="joY-sc-tBY"/>
                             </constraints>
                         </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Makes episodes shorter by trimming silence when no one is talking." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLf-fa-jTA" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="44" y="260" width="236" height="75"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" ambiguous="YES" text="Makes episodes shorter by trimming silence when no one is talking." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gLf-fa-jTA" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                            <rect key="frame" x="44" y="277" width="236" height="58"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="displayP3"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ufB-9R-Vqg" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ufB-9R-Vqg" userLabel="Divider" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="351" width="280" height="1"/>
                             <color key="backgroundColor" red="0.41960784309999999" green="0.33743089440000001" blue="0.2274220586" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="T4l-sT-XYD"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OpL-dz-bb5" userLabel="Volume Boost View">
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OpL-dz-bb5" userLabel="Volume Boost View">
                             <rect key="frame" x="0.0" y="368" width="280" height="60"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" image="player_volumeboost" translatesAutoresizingMaskIntoConstraints="NO" id="pxa-gz-sJt" customClass="TintableImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="24" id="1QV-6g-47E"/>
+                                        <constraint firstAttribute="height" constant="24" id="mJ1-Gq-vNu"/>
+                                    </constraints>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Volume Boost" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5f-PT-klK" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="44" y="2" width="105.5" height="20.5"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Volume Boost" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5f-PT-klK" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                    <rect key="frame" x="44" y="0.0" width="171" height="20.5"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6Kq-Z2-EgY" customClass="ThemeableSwitch" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="219" y="-2" width="63" height="28"/>
+                                    <rect key="frame" x="219" y="-3.5" width="63" height="28"/>
                                     <accessibility key="accessibilityConfiguration" label="Volume Boost"/>
                                     <color key="onTintColor" red="0.92475664615631104" green="0.57313865423202515" blue="0.21551844477653503" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <connections>
@@ -259,20 +268,21 @@
                                     </connections>
                                 </switch>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Voices sound louder" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iuh-tf-56P" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                    <rect key="frame" x="44" y="34.5" width="139.5" height="18"/>
+                                    <rect key="frame" x="44" y="32.5" width="139.5" height="18"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                     <color key="textColor" red="1" green="1" blue="1" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="displayP3"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                             </subviews>
                             <constraints>
+                                <constraint firstItem="6Kq-Z2-EgY" firstAttribute="leading" secondItem="n5f-PT-klK" secondAttribute="trailing" constant="4" id="47w-de-6VN"/>
                                 <constraint firstItem="pxa-gz-sJt" firstAttribute="top" secondItem="OpL-dz-bb5" secondAttribute="top" id="5av-ja-iAh"/>
                                 <constraint firstItem="pxa-gz-sJt" firstAttribute="leading" secondItem="OpL-dz-bb5" secondAttribute="leading" id="8TZ-YT-h80"/>
                                 <constraint firstItem="6Kq-Z2-EgY" firstAttribute="centerY" secondItem="n5f-PT-klK" secondAttribute="centerY" id="JEY-To-Q0p"/>
                                 <constraint firstAttribute="trailing" secondItem="6Kq-Z2-EgY" secondAttribute="trailing" id="TcI-kL-f6A"/>
-                                <constraint firstItem="n5f-PT-klK" firstAttribute="centerY" secondItem="pxa-gz-sJt" secondAttribute="centerY" id="VtG-v9-l3t"/>
+                                <constraint firstItem="n5f-PT-klK" firstAttribute="top" secondItem="OpL-dz-bb5" secondAttribute="top" id="VtG-v9-l3t"/>
                                 <constraint firstItem="Iuh-tf-56P" firstAttribute="top" secondItem="n5f-PT-klK" secondAttribute="bottom" constant="12" id="evO-YP-vix"/>
-                                <constraint firstAttribute="height" constant="60" id="hxi-IG-PVF"/>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="hxi-IG-PVF"/>
                                 <constraint firstItem="n5f-PT-klK" firstAttribute="leading" secondItem="pxa-gz-sJt" secondAttribute="trailing" constant="20" id="srX-1h-wSV"/>
                                 <constraint firstItem="Iuh-tf-56P" firstAttribute="leading" secondItem="n5f-PT-klK" secondAttribute="leading" id="vV4-WW-FBp"/>
                             </constraints>

--- a/podcasts/EffectsViewController.xib
+++ b/podcasts/EffectsViewController.xib
@@ -296,21 +296,21 @@
                                     <rect key="frame" x="0.0" y="446" width="280" height="64"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mmt-Tp-FF7" customClass="PodcastImageView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                            <rect key="frame" x="17" y="17" width="30" height="30"/>
+                                            <rect key="frame" x="16" y="17" width="30" height="30"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="30" id="2jl-Pv-ckQ"/>
                                                 <constraint firstAttribute="height" constant="30" id="nH4-zL-ocq"/>
                                             </constraints>
                                         </view>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Custom effects applied" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JrO-T2-rgm" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                                            <rect key="frame" x="63" y="23" width="159.5" height="18"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" text="Custom effects applied" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JrO-T2-rgm" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                                            <rect key="frame" x="62" y="4" width="109" height="56"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                             <color key="textColor" white="1" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1SX-69-2q8">
-                                            <rect key="frame" x="213" y="17" width="47" height="30"/>
+                                        <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1SX-69-2q8">
+                                            <rect key="frame" x="181" y="17" width="91" height="30"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                             <state key="normal" title="CLEAR">
                                                 <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -323,11 +323,14 @@
                                     <color key="backgroundColor" white="1" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstItem="JrO-T2-rgm" firstAttribute="centerY" secondItem="mmt-Tp-FF7" secondAttribute="centerY" id="04o-qB-94K"/>
-                                        <constraint firstAttribute="trailing" secondItem="1SX-69-2q8" secondAttribute="trailing" constant="20" id="AFv-mO-fG9"/>
-                                        <constraint firstAttribute="height" constant="64" id="BSk-fU-Qyn"/>
+                                        <constraint firstItem="1SX-69-2q8" firstAttribute="leading" secondItem="JrO-T2-rgm" secondAttribute="trailing" constant="10" id="9Ja-tg-QEq"/>
+                                        <constraint firstAttribute="trailing" secondItem="1SX-69-2q8" secondAttribute="trailing" constant="8" id="AFv-mO-fG9"/>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="64" id="BSk-fU-Qyn"/>
                                         <constraint firstItem="JrO-T2-rgm" firstAttribute="leading" secondItem="mmt-Tp-FF7" secondAttribute="trailing" constant="16" id="Csf-Aq-Tzi"/>
+                                        <constraint firstAttribute="bottom" secondItem="JrO-T2-rgm" secondAttribute="bottom" constant="4" id="Ej6-9Z-cGq"/>
+                                        <constraint firstItem="JrO-T2-rgm" firstAttribute="top" secondItem="IPm-dg-nP6" secondAttribute="top" constant="4" id="SiS-gx-fOr"/>
                                         <constraint firstItem="mmt-Tp-FF7" firstAttribute="centerY" secondItem="IPm-dg-nP6" secondAttribute="centerY" id="Tt2-xj-JXv"/>
-                                        <constraint firstItem="mmt-Tp-FF7" firstAttribute="leading" secondItem="IPm-dg-nP6" secondAttribute="leading" constant="17" id="WwT-mx-tmo"/>
+                                        <constraint firstItem="mmt-Tp-FF7" firstAttribute="leading" secondItem="IPm-dg-nP6" secondAttribute="leading" constant="16" id="WwT-mx-tmo"/>
                                         <constraint firstItem="1SX-69-2q8" firstAttribute="centerY" secondItem="JrO-T2-rgm" secondAttribute="centerY" id="g4f-AL-8PV"/>
                                     </constraints>
                                     <userDefinedRuntimeAttributes>

--- a/podcasts/ShelfActionsViewController.swift
+++ b/podcasts/ShelfActionsViewController.swift
@@ -21,6 +21,8 @@ class ShelfActionsViewController: UIViewController, CheckTranscriptAvailability 
         didSet {
             headingLabel.style = .playerContrast02
             headingLabel.text = L10n.accessibilityMoreActions.localizedUppercase
+            headingLabel.font = UIFont.font(ofSize: 13, weight: .medium, scalingWith: .title1)
+            headingLabel.adjustsFontForContentSizeCategory = true
         }
     }
 
@@ -34,12 +36,16 @@ class ShelfActionsViewController: UIViewController, CheckTranscriptAvailability 
         didSet {
             rearrangeHeader.style = .playerContrast01
             rearrangeHeader.text = L10n.playerActionsRearrangeTitle.localizedCapitalized
+            rearrangeHeader.font = UIFont.font(ofSize: 13, weight: .medium, scalingWith: .title1)
+            rearrangeHeader.adjustsFontForContentSizeCategory = true
         }
     }
 
     @IBOutlet var actionButton: ThemeableUIButton! {
         didSet {
             actionButton.style = .playerContrast01
+            actionButton.titleLabel?.font = UIFont.font(ofSize: 13, weight: .medium, scalingWith: .title1)
+            actionButton.titleLabel?.adjustsFontForContentSizeCategory = true
         }
     }
 

--- a/podcasts/ShelfCell.swift
+++ b/podcasts/ShelfCell.swift
@@ -69,5 +69,7 @@ class ShelfCell: UITableViewCell {
         let iconMetric = UIFontMetrics(forTextStyle: .largeTitle)
         let iconSize = max(24, iconMetric.scaledValue(for: 24))
         actionIcon.updateSizeConstraints(to: iconSize)
+
+        customViewContainer.updateSizeConstraints(to: iconSize)
     }
 }

--- a/podcasts/ShiftyRoundButton.swift
+++ b/podcasts/ShiftyRoundButton.swift
@@ -93,7 +93,7 @@ class ShiftyRoundButton: UIView {
     }
 
     private func updateTextLayerFont() {
-        let uiFont = UIFont.font(ofSize: fontSize, weight: .semibold, scalingWith: .subheadline)
+        let uiFont = UIFont.font(ofSize: fontSize, weight: .semibold, scalingWith: .largeTitle)
         textLayer.string = buttonTitle
         textLayer.foregroundColor = textColor.cgColor
         textLayer.fontSize = uiFont.pointSize
@@ -162,6 +162,7 @@ class ShiftyRoundButton: UIView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
+        lastCGRectRendered = .zero
         updateTextLayerFont()
         setNeedsLayout()
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-532 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Updates the EffectsController in order to support dynamic type. Scrolling was added to support larger types.

| xs | Default | xxxL | AX5 |
| - | - | - | - |
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 19 29 19" src="https://github.com/user-attachments/assets/278f5d54-2e9b-4c0e-aad3-3e2decd5f59d" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 19 29 14" src="https://github.com/user-attachments/assets/ad21ca8b-f598-4610-b923-e4966d0ab3fe" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 19 29 08" src="https://github.com/user-attachments/assets/8e510279-b5a3-44c3-981c-f49eb0d243bb" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 19 28 47" src="https://github.com/user-attachments/assets/378fb1e5-270d-497b-b2ac-f5b4041b9542" /> |

## To test

1. Start the app
2. Play an episode
3. Open the full screen player
4. Open the effects settings
5. Check if screen adapts to different dynamic types

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
