### PR TITLE
[Dynamic type] Podcast settings auto-archive and playback effects

### DIFF
--- a/podcasts/PodcastArchiveViewController+Table.swift
+++ b/podcasts/PodcastArchiveViewController+Table.swift
@@ -101,6 +101,10 @@ extension PodcastArchiveViewController: UITableViewDataSource, UITableViewDelega
     // MARK: - Table Config
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        section == 0 ? CGFloat.leastNonzeroMagnitude : UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
         section == 0 ? CGFloat.leastNonzeroMagnitude : 19
     }
 

--- a/podcasts/PodcastArchiveViewController.swift
+++ b/podcasts/PodcastArchiveViewController.swift
@@ -5,6 +5,7 @@ class PodcastArchiveViewController: PCViewController {
     @IBOutlet var archiveTable: UITableView! {
         didSet {
             registerCells()
+            archiveTable.rowHeight = UITableView.automaticDimension
         }
     }
 

--- a/podcasts/PodcastEffectsViewController+Table.swift
+++ b/podcasts/PodcastEffectsViewController+Table.swift
@@ -154,6 +154,10 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
     // MARK: - Table Config
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        section == 0 ? CGFloat.leastNonzeroMagnitude : UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
         section == 0 ? CGFloat.leastNonzeroMagnitude : 19
     }
 

--- a/podcasts/PodcastEffectsViewController.swift
+++ b/podcasts/PodcastEffectsViewController.swift
@@ -5,6 +5,7 @@ class PodcastEffectsViewController: PCViewController {
     @IBOutlet var effectsTable: UITableView! {
         didSet {
             registerCells()
+            effectsTable.rowHeight = UITableView.automaticDimension
         }
     }
 

--- a/podcasts/TimeStepperCell.xib
+++ b/podcasts/TimeStepperCell.xib
@@ -24,7 +24,7 @@
                             <constraint firstAttribute="height" constant="24" id="mpO-kU-UDK"/>
                         </constraints>
                     </imageView>
-                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="253" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Skip First" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="12" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="06e-3Z-E2J" userLabel="Main Label" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                    <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="253" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" text="Skip First" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="06e-3Z-E2J" userLabel="Main Label" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
                         <rect key="frame" x="48" y="0.0" width="116.5" height="66"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="64" id="rmM-57-yPt"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Fix tables on podcast settings archive and effects to allow growth of cells
| xs | Default | xxxL | AX5 |
| - | - | - | - |
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 17 26 21" src="https://github.com/user-attachments/assets/6542fd43-898e-4754-be2c-cfb840cd4141" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 17 26 16" src="https://github.com/user-attachments/assets/1d9d5f93-f26b-4df3-873a-2eb263e27d52" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 17 26 11" src="https://github.com/user-attachments/assets/febb92e6-d35c-4f64-a622-da6647298edc" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 17 26 05" src="https://github.com/user-attachments/assets/7972d4e9-ad90-4f00-805b-838acf60a931" /> |
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 17 25 41" src="https://github.com/user-attachments/assets/6bf05f8f-3140-4a06-b3f5-a1e4edf37d05" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 17 25 37" src="https://github.com/user-attachments/assets/c6550310-36a5-4848-9df9-2062b079ae62" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 17 25 33" src="https://github.com/user-attachments/assets/25be5c51-2527-4aba-af0d-69aceff31536" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-22 at 17 25 25" src="https://github.com/user-attachments/assets/58571ce1-28e2-4ab9-9282-9f0ff1cd5072" /> |

## To test

1. Start app
2. Open a podcast
3. Open podcast settings
4. Tap on Playback Effects
5. Check if changes on dynamic type make rows growth
6. Go Back
7. Tap on Auto-Archive
8. Check if changes on dynamic type make rows growth

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
