### PR TITLE
[Dynamic Type] Discovery Fix gradient overlay size

### DIFF
--- a/podcasts/HorizontalCollectionList.swift
+++ b/podcasts/HorizontalCollectionList.swift
@@ -71,7 +71,7 @@ struct HorizontalCollectionList: View {
                 Spacer().frame(height: 4)
             }
             .foregroundColor(.clear)
-            .frame(minWidth: adjustedRowHeight, minHeight: adjustedRowHeight / 2)
+            .frame(width: adjustedRowHeight, height: adjustedRowHeight / 2)            
             .background(
                 LinearGradient(
                     stops: [

--- a/podcasts/HorizontalCollectionList.swift
+++ b/podcasts/HorizontalCollectionList.swift
@@ -71,7 +71,7 @@ struct HorizontalCollectionList: View {
                 Spacer().frame(height: 4)
             }
             .foregroundColor(.clear)
-            .frame(width: adjustedRowHeight, height: adjustedRowHeight / 2)            
+            .frame(width: adjustedRowHeight, height: adjustedRowHeight / 2)
             .background(
                 LinearGradient(
                     stops: [


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
| Before | After |
| - | - |
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-23 at 10 23 40" src="https://github.com/user-attachments/assets/2286d3d7-2ef4-469d-af4d-bd093ff54a35" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-23 at 10 21 17" src="https://github.com/user-attachments/assets/968f9756-53a3-4ec4-b0c4-d41d0e795d50" /> |

## To test

1. Start the app
2. Open Discovery
3. Scroll down to a Network Highlight section
4. Check if the gradient looks correct and only affects half cell vertically

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
