### PR TITLE
[Dynamic Type] Account creation banner in section header to allow dynamic resize

### DIFF
--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -89,7 +89,30 @@ extension PlaylistsViewController: UITableViewDelegate, UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        CGFloat.leastNormalMagnitude
+        if informationalBannerCoordinator.shouldShowBanner() {
+            return UITableView.automaticDimension
+        } else {
+            return CGFloat.leastNormalMagnitude
+        }
+    }
+
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        if !informationalBannerCoordinator.shouldShowBanner() {
+            return nil
+        }
+        return informationalBannerCoordinator.tableHeaderView(size: CGSize(width: filtersTable.bounds.width, height: 135)) {
+            UIView.animate(withDuration: 0.5) { [weak self] in
+                self?.filtersTable.reloadData()
+            }
+        }
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        if informationalBannerCoordinator.shouldShowBanner() {
+            return 135
+        } else {
+            return CGFloat.leastNormalMagnitude
+        }
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -72,7 +72,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
     private var firstTimeLoading = true
 
-    lazy private var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
+    lazy var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
         let invertedColor: Bool? = FeatureFlag.playlistsRebranding.enabled ? true : nil
         let bannerType: InformationalBannerType = FeatureFlag.playlistsRebranding.enabled ? .playlists : .filters
         let viewModel = InformationalBannerViewModel(bannerType: bannerType, invertedColor: invertedColor)
@@ -151,7 +151,6 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         }
 
         reloadFilters()
-        setupInformationalBanner()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -299,21 +298,6 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
                 self.newFilterButton.isHidden = false
                 self.loadingIndicator.stopAnimating()
                 self.filtersTable.reloadData()
-            }
-        }
-    }
-
-    private func setupInformationalBanner() {
-        if !informationalBannerCoordinator.shouldShowBanner() {
-            filtersTable.tableHeaderView = nil
-            return
-        }
-        if filtersTable.tableHeaderView != nil {
-            return
-        }
-        filtersTable.tableHeaderView = informationalBannerCoordinator.tableHeaderView(size: CGSize(width: filtersTable.bounds.width, height: 135)) {
-            UIView.animate(withDuration: 0.5) { [weak self] in
-                self?.filtersTable.tableHeaderView = nil
             }
         }
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-521 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the creation of the account creation banner in playlist to use a section header to support dynamic sizing.

| xs | Default | xxxL | AX5 |
| - | - | - | - |
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-23 at 11 25 24" src="https://github.com/user-attachments/assets/c56774af-df7d-43c0-98b7-878357173b98" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-23 at 11 25 20" src="https://github.com/user-attachments/assets/2c054669-5396-46a9-86ea-8cbe7916820f" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-23 at 11 25 15" src="https://github.com/user-attachments/assets/9cf8bf0d-0087-48ec-9bcf-c5f01a345288" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-23 at 11 25 03" src="https://github.com/user-attachments/assets/37465784-445b-4ca0-a9ca-d3669eda32ea" /> |

## To test

1. Start the app from scratch without a user account logged in
2. Go to playlists
3. Check if the account banner creation is show
4. Check if dynamic type resize works correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
