### PR TITLE
Add episodes to a playlist from multi-select overflow menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 8.6
 -----
-- Playlists: Add episode to a playlist from episode details [##3943](https://github.com/Automattic/pocket-casts-ios/pull/3943/) 
+- Playlists: Add episodes to a playlist from multi-select overflow menu [#4001](https://github.com/Automattic/pocket-casts-ios/pull/4001)
+- Playlists: Add episode to a playlist from episode details [##3943](https://github.com/Automattic/pocket-casts-ios/pull/3943/)
 - Improve cache invalidation for Playlist Count and Artwork [#3927](https://github.com/Automattic/pocket-casts-ios/pull/3927)
 - Dynamic Type: Update UpNext [#3918](https://github.com/Automattic/pocket-casts-ios/pull/3918)
 - Dynamic Type: Update Podcasts list [#3914](https://github.com/Automattic/pocket-casts-ios/pull/3914)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 8.6
 -----
-- Playlists: Add episodes to a playlist from multi-select overflow menu [#4001](https://github.com/Automattic/pocket-casts-ios/pull/4001)
+- Playlists: Add episodes to a playlist from multi-select overflow menu [#4001](https://github.com/Automattic/pocket-casts-ios/pull/4002)
 - Playlists: Add episode to a playlist from episode details [##3943](https://github.com/Automattic/pocket-casts-ios/pull/3943/)
 - Improve cache invalidation for Playlist Count and Artwork [#3927](https://github.com/Automattic/pocket-casts-ios/pull/3927)
 - Dynamic Type: Update UpNext [#3918](https://github.com/Automattic/pocket-casts-ios/pull/3918)

--- a/podcasts/CommonImages.xcassets/plus-circle.imageset/Contents.json
+++ b/podcasts/CommonImages.xcassets/plus-circle.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -515,7 +515,7 @@ extension PlayerAction: AnalyticsDescribable {
 }
 
 enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
-    case playLast = 1, playNext, download, archive, markAsPlayed, star, moveToTop, moveToBottom, removeFromUpNext, unstar, unarchive, removeDownload, markAsUnplayed, delete, share, removeListeningHistory
+    case playLast = 1, playNext, download, archive, markAsPlayed, star, moveToTop, moveToBottom, removeFromUpNext, unstar, unarchive, removeDownload, markAsUnplayed, delete, share, removeListeningHistory, addToPlaylist
 
     func title() -> String {
         switch self {
@@ -551,6 +551,8 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
             return L10n.share
         case .removeListeningHistory:
             return L10n.listeningHistoryRemove
+        case .addToPlaylist:
+            return L10n.playlistManualEpisodeAddToPlaylist
         }
     }
 
@@ -588,6 +590,8 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
             return "podcast-share"
         case .removeListeningHistory:
             return "episode-delete"
+        case .addToPlaylist:
+            return "plus-circle"
         }
     }
 
@@ -625,6 +629,8 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
             return "share"
         case .removeListeningHistory:
             return "listening_history_remove_episode"
+        case .addToPlaylist:
+            return "add_to_playlist"
         }
     }
 
@@ -632,6 +638,9 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
         switch self {
         case .share:
             return episodes.count == 1 && episodes.allSatisfy({ $0 is Episode })
+
+        case .addToPlaylist:
+            return episodes.allSatisfy({ $0 is Episode })
 
         default:
             return true

--- a/podcasts/MultiSelectActionController.swift
+++ b/podcasts/MultiSelectActionController.swift
@@ -277,5 +277,11 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
         if !orderedActions.contains(.share) && hasOnlyShareableEpisodes {
             orderedActions.append(.share)
         }
+
+        // Similarly, addToPlaylist may be missing for users who saved their
+        // action list before this action was added.
+        if !orderedActions.contains(.addToPlaylist) && hasOnlyShareableEpisodes {
+            orderedActions.append(.addToPlaylist)
+        }
     }
 }

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -350,6 +350,12 @@ class MultiSelectHelper {
         let episodes = actionDelegate.multiSelectedBaseEpisodes().compactMap { $0 as? Episode }
         guard !episodes.isEmpty else { return }
 
+        let maxPlaylistItems = Constants.Limits.maxFilterItems
+        if episodes.count > maxPlaylistItems {
+            Toast.show(L10n.playlistManualAddTooManyEpisodesToast(maxPlaylistItems.localized(.decimal)))
+            return
+        }
+
         let presentingVC = actionDelegate.multiSelectPresentingViewController()
         let chooser = ManualPlaylistsChooserViewController(episodes: episodes, analyticsSource: "multi_select")
         let navController = UINavigationController(rootViewController: chooser)

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -42,6 +42,8 @@ class MultiSelectHelper {
             share(actionDelegate: actionDelegate, view: view)
         case .removeListeningHistory:
             removeListeningHistory(actionDelegate: actionDelegate)
+        case .addToPlaylist:
+            addToPlaylist(actionDelegate: actionDelegate)
         }
     }
 
@@ -342,6 +344,18 @@ class MultiSelectHelper {
                                          showArrow: view != nil,
                                          fromSource: .multiSelect
         )
+    }
+
+    private class func addToPlaylist(actionDelegate: MultiSelectActionDelegate) {
+        let episodes = actionDelegate.multiSelectedBaseEpisodes().compactMap { $0 as? Episode }
+        guard !episodes.isEmpty else { return }
+
+        let presentingVC = actionDelegate.multiSelectPresentingViewController()
+        let chooser = ManualPlaylistsChooserViewController(episodes: episodes, analyticsSource: "multi_select")
+        let navController = UINavigationController(rootViewController: chooser)
+        DispatchQueue.main.async {
+            presentingVC.present(navController, animated: true)
+        }
     }
 
     private class func removeListeningHistory(actionDelegate: MultiSelectActionDelegate) {

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -6,6 +6,7 @@ class NewPlaylistViewController: PCViewController {
     enum CreationType: Equatable {
         case `default`
         case addEpisode(episode: Episode)
+        case addEpisodes(episodes: [Episode])
 
         static func == (lhs: Self, rhs: Self) -> Bool {
             switch (lhs, rhs) {
@@ -13,6 +14,8 @@ class NewPlaylistViewController: PCViewController {
                 return true
             case (.addEpisode(let lhsEpisode), .addEpisode(let rhsEpisode)):
                 return lhsEpisode.uuid == rhsEpisode.uuid
+            case (.addEpisodes(let lhsEpisodes), .addEpisodes(let rhsEpisodes)):
+                return lhsEpisodes.map(\.uuid) == rhsEpisodes.map(\.uuid)
             default:
                 return false
             }
@@ -228,6 +231,41 @@ class NewPlaylistViewController: PCViewController {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: playlist)
         } else if case let .addEpisode(episode) = creationType {
             let didAdd = DataManager.sharedManager.add(episodes: [episode], to: playlist)
+            guard didAdd else {
+                let theme: any ToastTheme = ToastIconTheme(iconName: "option-alert", iconColor: Theme.sharedTheme.primaryIcon01)
+                Toast.show(L10n.playlistManualCreateErrorMessage, theme: theme)
+                return
+            }
+
+            Analytics.track(.addToPlaylistsCreateNewPlaylistTapped, properties: ["source": analyticsSource ?? "unknown"])
+
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: playlist)
+
+            Analytics.track(.filterCreated)
+            Analytics.track(.filterCreateAsManualPlaylistTapped)
+
+            if Settings.firstTimePlaylistCreated {
+                Settings.shouldShowDragAndDropTip = true
+            }
+
+            // Dismiss all presented view controllers and show snackbar with navigation action
+            if let rootVC = SceneHelper.rootViewController(includeTopMost: false) {
+                rootVC.dismiss(animated: true) {
+                    Toast.show(L10n.playlistEpisodesAddedToSinglePlaylist(playlist.playlistName), actions: [
+                        .init(title: L10n.bookmarkAddedButtonTitle) {
+                            NavigationManager.sharedManager.navigateTo(
+                                NavigationManager.filterPageKey,
+                                data: [
+                                    NavigationManager.filterUuidKey: playlist.uuid
+                                ]
+                            )
+                        }
+                    ])
+                }
+            }
+            return
+        } else if case let .addEpisodes(episodes) = creationType {
+            let didAdd = DataManager.sharedManager.add(episodes: episodes, to: playlist)
             guard didAdd else {
                 let theme: any ToastTheme = ToastIconTheme(iconName: "option-alert", iconColor: Theme.sharedTheme.primaryIcon01)
                 Toast.show(L10n.playlistManualCreateErrorMessage, theme: theme)

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -265,8 +265,9 @@ class NewPlaylistViewController: PCViewController {
             }
             return
         } else if case let .addEpisodes(episodes) = creationType {
-            if episodes.count > 1000 {
-                Toast.show(L10n.playlistManualAddTooManyEpisodesToast)
+            let maxPlaylistItems = Constants.Limits.maxFilterItems
+            if episodes.count > maxPlaylistItems {
+                Toast.show(L10n.playlistManualAddTooManyEpisodesToast(maxPlaylistItems.localized(.decimal)))
                 return
             }
             let didAdd = DataManager.sharedManager.add(episodes: episodes, to: playlist)

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -265,6 +265,10 @@ class NewPlaylistViewController: PCViewController {
             }
             return
         } else if case let .addEpisodes(episodes) = creationType {
+            if episodes.count > 1000 {
+                Toast.show(L10n.playlistManualAddTooManyEpisodesToast)
+                return
+            }
             let didAdd = DataManager.sharedManager.add(episodes: episodes, to: playlist)
             guard didAdd else {
                 let theme: any ToastTheme = ToastIconTheme(iconName: "option-alert", iconColor: Theme.sharedTheme.primaryIcon01)

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -14,7 +14,7 @@ class ManualPlaylistsChooserViewController: PCViewController {
     private var initialSelectedPlaylists: Set<String> = []
     private var newSelectedPlaylists: Set<String> = []
     private var searchController: PCSearchBarController?
-    private let episode: Episode
+    private let episodes: [Episode]
     private let analyticsSource: String
     private let dataManager = DataManager.sharedManager
 
@@ -50,10 +50,14 @@ class ManualPlaylistsChooserViewController: PCViewController {
         }
     }
 
-    init(episode: Episode, analyticsSource: String) {
-        self.episode = episode
+    init(episodes: [Episode], analyticsSource: String) {
+        self.episodes = episodes
         self.analyticsSource = analyticsSource
         super.init(nibName: nil, bundle: nil)
+    }
+
+    convenience init(episode: Episode, analyticsSource: String) {
+        self.init(episodes: [episode], analyticsSource: analyticsSource)
     }
 
     @MainActor required init?(coder: NSCoder) {
@@ -135,8 +139,12 @@ class ManualPlaylistsChooserViewController: PCViewController {
 
         manualPlaylists = dataManager.allManualPlaylists(includeDeleted: false)
 
-        let uuids = dataManager.manualPlaylistUUIDs(for: episode.uuid)
-        initialSelectedPlaylists = Set(uuids)
+        if episodes.count == 1, let episode = episodes.first {
+            let uuids = dataManager.manualPlaylistUUIDs(for: episode.uuid)
+            initialSelectedPlaylists = Set(uuids)
+        } else {
+            initialSelectedPlaylists = []
+        }
         newSelectedPlaylists = initialSelectedPlaylists
     }
 
@@ -161,11 +169,11 @@ class ManualPlaylistsChooserViewController: PCViewController {
 
         manualPlaylists.forEach { playlist in
             if added.contains(playlist.uuid) {
-                track(episode: episode, added: true, to: playlist)
-                dataManager.add(episodes: [episode], to: playlist)
+                episodes.forEach { track(episode: $0, added: true, to: playlist) }
+                dataManager.add(episodes: episodes, to: playlist)
                 changedPlaylists.insert(playlist)
             }
-            if removed.contains(playlist.uuid) {
+            if removed.contains(playlist.uuid), let episode = episodes.first, episodes.count == 1 {
                 track(episode: episode, added: false, to: playlist)
                 dataManager.deleteEpisodes([episode.uuid], from: playlist)
             }
@@ -278,7 +286,8 @@ extension ManualPlaylistsChooserViewController: UITableViewDelegate, UITableView
 
         Analytics.track(.addToPlaylistsNewPlaylistTapped, properties: ["source": analyticsSource])
 
-        let createPlaylistViewController = NewPlaylistViewController(creationType: .addEpisode(episode: episode), analyticsSource: analyticsSource)
+        guard let firstEpisode = episodes.first else { return }
+        let createPlaylistViewController = NewPlaylistViewController(creationType: .addEpisode(episode: firstEpisode), analyticsSource: analyticsSource)
         navigationController?.pushViewController(createPlaylistViewController, animated: true)
     }
 }

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -195,8 +195,10 @@ class ManualPlaylistsChooserViewController: PCViewController {
             dataManager.save(playlist: playlist)
         }
 
+        let showAddedToast = !added.isEmpty && changedPlaylists.count > 0
+
         dismiss(animated: true) {
-            if added.isEmpty {
+            guard showAddedToast else {
                 return
             }
 

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -167,12 +167,12 @@ class ManualPlaylistsChooserViewController: PCViewController {
 
         var changedPlaylists: Set<EpisodeFilter> = []
 
-        let maxPlaylistItems = 1000
+        let maxPlaylistItems = Constants.Limits.maxFilterItems
 
         manualPlaylists.forEach { playlist in
             if added.contains(playlist.uuid) {
                 if episodes.count > maxPlaylistItems {
-                    Toast.show(L10n.playlistManualAddTooManyEpisodesToast)
+                    Toast.show(L10n.playlistManualAddTooManyEpisodesToast(maxPlaylistItems.localized(.decimal)))
                     return
                 }
                 let currentCount = dataManager.allPlaylistEpisodeCount(for: playlist, episodeUuidToAdd: nil, includingArchivedEpisodes: true)

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -286,8 +286,10 @@ extension ManualPlaylistsChooserViewController: UITableViewDelegate, UITableView
 
         Analytics.track(.addToPlaylistsNewPlaylistTapped, properties: ["source": analyticsSource])
 
-        guard let firstEpisode = episodes.first else { return }
-        let createPlaylistViewController = NewPlaylistViewController(creationType: .addEpisode(episode: firstEpisode), analyticsSource: analyticsSource)
+        let creationType: NewPlaylistViewController.CreationType = episodes.count == 1
+            ? .addEpisode(episode: episodes[0])
+            : .addEpisodes(episodes: episodes)
+        let createPlaylistViewController = NewPlaylistViewController(creationType: creationType, analyticsSource: analyticsSource)
         navigationController?.pushViewController(createPlaylistViewController, animated: true)
     }
 }

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -167,8 +167,19 @@ class ManualPlaylistsChooserViewController: PCViewController {
 
         var changedPlaylists: Set<EpisodeFilter> = []
 
+        let maxPlaylistItems = 1000
+
         manualPlaylists.forEach { playlist in
             if added.contains(playlist.uuid) {
+                if episodes.count > maxPlaylistItems {
+                    Toast.show(L10n.playlistManualAddTooManyEpisodesToast)
+                    return
+                }
+                let currentCount = dataManager.allPlaylistEpisodeCount(for: playlist, episodeUuidToAdd: nil, includingArchivedEpisodes: true)
+                if currentCount + episodes.count > maxPlaylistItems {
+                    Toast.show(L10n.playlistManualAddEpisodesAlmostFullToast)
+                    return
+                }
                 episodes.forEach { track(episode: $0, added: true, to: playlist) }
                 dataManager.add(episodes: episodes, to: playlist)
                 changedPlaylists.insert(playlist)

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -262,6 +262,11 @@ extension ManualPlaylistsChooserViewController: UITableViewDelegate, UITableView
                 guard let self = self else { return }
 
                 if selected {
+                    let maxPlaylistItems = Constants.Limits.maxFilterItems
+                    let currentCount = self.dataManager.allPlaylistEpisodeCount(for: playlist, episodeUuidToAdd: nil, includingArchivedEpisodes: true)
+                    if currentCount + self.episodes.count > maxPlaylistItems {
+                        Toast.show(L10n.playlistManualAddEpisodesAlmostFullToast)
+                    }
                     self.newSelectedPlaylists.insert(playlist.uuid)
                 } else {
                     self.newSelectedPlaylists.remove(playlist.uuid)

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -860,7 +860,7 @@ class Settings: NSObject {
 
     private static let multiSelectActionsKey = "MultiSelectActions"
     class func multiSelectActions() -> [MultiSelectAction] {
-        let defaultActions: [MultiSelectAction] = [.playNext, .playLast, .download, .archive, .share, .markAsPlayed, .star]
+        let defaultActions: [MultiSelectAction] = [.playNext, .playLast, .addToPlaylist, .download, .archive, .share, .markAsPlayed, .star]
         guard let savedInts = UserDefaults.standard.object(forKey: Settings.multiSelectActionsKey) as? [Int32] else {
             return defaultActions
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2471,8 +2471,10 @@ internal enum L10n {
   internal static var playlistManualAddEpisodes: String { return L10n.tr("Localizable", "playlist_manual_add_episodes", fallback: "Add episodes") }
   /// Toast message when adding episodes to a playlist that would exceed the 1000 episode limit
   internal static var playlistManualAddEpisodesAlmostFullToast: String { return L10n.tr("Localizable", "playlist_manual_add_episodes_almost_full_toast", fallback: "Playlist is almost full. Try adding fewer episodes.") }
-  /// Toast message when trying to add more than 1000 episodes to a playlist at once, or creating a new playlist with more than 1000 episodes
-  internal static var playlistManualAddTooManyEpisodesToast: String { return L10n.tr("Localizable", "playlist_manual_add_too_many_episodes_toast", fallback: "Playlists can only contain up to 1,000 episodes.") }
+  /// Toast message when trying to add more than the max number of episodes to a playlist at once, or creating a new playlist with more than the max. '%1$@' is the max episode count, localized for the user's locale.
+  internal static func playlistManualAddTooManyEpisodesToast(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "playlist_manual_add_too_many_episodes_toast", String(describing: p1), fallback: "Playlists can only contain up to %1$@ episodes.")
+  }
   /// Text of the placeholder used in the manual playlist detail screen when one episode is archived.
   internal static var playlistManualArchivedEpisodePlaceholder: String { return L10n.tr("Localizable", "playlist_manual_archived_episode_placeholder", fallback: "Your episode in this playlist has been archived") }
   /// Text of the placeholder used in the manual playlist detail screen when all episodes are archived. '%1$@' represents the number of archived episodes

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2469,6 +2469,10 @@ internal enum L10n {
   internal static var playlistManualAddEpisodeFullPlaylistToast: String { return L10n.tr("Localizable", "playlist_manual_add_episode_full_playlist_toast", fallback: "This playlist is full. Remove a few episodes or start a new one.") }
   /// Manual Playlist: header button title to add new episodes to the playlist
   internal static var playlistManualAddEpisodes: String { return L10n.tr("Localizable", "playlist_manual_add_episodes", fallback: "Add episodes") }
+  /// Toast message when adding episodes to a playlist that would exceed the 1000 episode limit
+  internal static var playlistManualAddEpisodesAlmostFullToast: String { return L10n.tr("Localizable", "playlist_manual_add_episodes_almost_full_toast", fallback: "Playlist is almost full. Try adding fewer episodes.") }
+  /// Toast message when trying to add more than 1000 episodes to a playlist at once, or creating a new playlist with more than 1000 episodes
+  internal static var playlistManualAddTooManyEpisodesToast: String { return L10n.tr("Localizable", "playlist_manual_add_too_many_episodes_toast", fallback: "Playlists can only contain up to 1,000 episodes.") }
   /// Text of the placeholder used in the manual playlist detail screen when one episode is archived.
   internal static var playlistManualArchivedEpisodePlaceholder: String { return L10n.tr("Localizable", "playlist_manual_archived_episode_placeholder", fallback: "Your episode in this playlist has been archived") }
   /// Text of the placeholder used in the manual playlist detail screen when all episodes are archived. '%1$@' represents the number of archived episodes

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5621,8 +5621,8 @@
 /* Toast message when the playlist is full */
 "playlist_manual_add_episode_full_playlist_toast" = "This playlist is full. Remove a few episodes or start a new one.";
 
-/* Toast message when trying to add more than 1000 episodes to a playlist at once, or creating a new playlist with more than 1000 episodes */
-"playlist_manual_add_too_many_episodes_toast" = "Playlists can only contain up to 1,000 episodes.";
+/* Toast message when trying to add more than the max number of episodes to a playlist at once, or creating a new playlist with more than the max. '%1$@' is the max episode count, localized for the user's locale. */
+"playlist_manual_add_too_many_episodes_toast" = "Playlists can only contain up to %1$@ episodes.";
 
 /* Toast message when adding episodes to a playlist that would exceed the 1000 episode limit */
 "playlist_manual_add_episodes_almost_full_toast" = "Playlist is almost full. Try adding fewer episodes.";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5621,6 +5621,12 @@
 /* Toast message when the playlist is full */
 "playlist_manual_add_episode_full_playlist_toast" = "This playlist is full. Remove a few episodes or start a new one.";
 
+/* Toast message when trying to add more than 1000 episodes to a playlist at once, or creating a new playlist with more than 1000 episodes */
+"playlist_manual_add_too_many_episodes_toast" = "Playlists can only contain up to 1,000 episodes.";
+
+/* Toast message when adding episodes to a playlist that would exceed the 1000 episode limit */
+"playlist_manual_add_episodes_almost_full_toast" = "Playlist is almost full. Try adding fewer episodes.";
+
 /* Text of the placeholder used in the manual playlist detail screen when one episode is archived. */
 "playlist_manual_archived_episode_placeholder" = "Your episode in this playlist has been archived";
 


### PR DESCRIPTION
Adds a new `addToPlaylist` MultiSelectAction that presents the ManualPlaylistsChooserViewController for all selected episodes. Refactors ManualPlaylistsChooserViewController to accept [Episode] (with a backward-compatible single-episode convenience init) so it can handle bulk adds. The action is hidden for user-uploaded files, and backward-compat logic ensures it appears for users who already have a saved action order.

Fixes PCIOS-483 <!-- issue number, if applicable -->


## To test

1. Fresh install the app.
2. Go to any podcast.
3. Start multi-selection.
4. You should see add to Up Next as the first rightmost action.
5. Tapping on the overflow menu should show add to playlist action.

## Screenshots or Screencast 

<img width="876" height="789" alt="Screenshot 2026-02-23 at 11 26 23 AM" src="https://github.com/user-attachments/assets/ec61f30d-f86b-4d0b-bf8c-2cd1677b43e0" />


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
