### PR TITLE
And simulator detection on the make test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ BUNDLE=rbenv exec bundle
 LANG_VAR=LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 FASTLANE=$(LANG_VAR) $(BUNDLE) exec fastlane
 SWIFTLINT_FROM_BUILDTOOLS=swiftlint lint --working-directory .. --quiet
+# Parse the human-readable output of simctl
+SIMULATOR_NAME = $(shell xcrun simctl list devices available \
+	| grep "iPhone" \
+	| tail -1 | sed 's/^[[:space:]]*//' | sed 's/ *(.*) *$$//')
 
 .PHONY: help build clean test lint lint_lenient format install_dependencies
 
@@ -49,7 +53,8 @@ clean: ## Cleans the build artifacts
 test: ## Build and run the PocketCastsTests target with Unit Tests using Xcode
 	xcodebuild test -project podcasts.xcodeproj \
 	    -scheme pocketcasts \
-        -only-testing:PocketCastsTests
+        -only-testing:PocketCastsTests \
+        -destination 'platform=iOS Simulator,name=$(SIMULATOR_NAME),OS=latest'
 
 format: ## Lint and autocorrect linter errors
 	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS) --autocorrect)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR improve the make file test step in order to detect an available simulator to run the tests.

## To test

1. Pull this PR
2. On the command line run: make test
3. Check if it's able to build and run tests

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
