### PR TITLE
[Dynamic type] Grid cell text

### DIFF
--- a/podcasts/PodcastGridCell.xib
+++ b/podcasts/PodcastGridCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -25,13 +25,13 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hVd-gA-oCj" userLabel="ContainerView">
                         <rect key="frame" x="0.0" y="0.0" width="106" height="106"/>
                         <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="The Greatest Podcast In the world with the longest name in the world" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4" userLabel="Podcast Name">
-                                <rect key="frame" x="0.0" y="0.0" width="106" height="106"/>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="The Greatest Podcast In the world with the longest name in the world" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4" userLabel="Podcast Name">
+                                <rect key="frame" x="4" y="0.0" width="98" height="106"/>
                                 <accessibility key="accessibilityConfiguration">
                                     <accessibilityTraits key="traits" button="YES"/>
                                     <bool key="isElement" value="YES"/>
                                 </accessibility>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -53,9 +53,9 @@
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="4" firstAttribute="leading" secondItem="hVd-gA-oCj" secondAttribute="leading" id="6GT-VV-hb0"/>
+                            <constraint firstItem="4" firstAttribute="leading" secondItem="hVd-gA-oCj" secondAttribute="leading" constant="4" id="6GT-VV-hb0"/>
                             <constraint firstItem="8" firstAttribute="leading" secondItem="hVd-gA-oCj" secondAttribute="leading" id="9Md-JU-Igp"/>
-                            <constraint firstItem="4" firstAttribute="trailing" secondItem="hVd-gA-oCj" secondAttribute="trailing" id="EQQ-or-vZK"/>
+                            <constraint firstItem="4" firstAttribute="trailing" secondItem="hVd-gA-oCj" secondAttribute="trailing" constant="-4" id="EQQ-or-vZK"/>
                             <constraint firstItem="v1m-PH-X4D" firstAttribute="bottom" secondItem="hVd-gA-oCj" secondAttribute="bottom" id="IO8-pQ-56J"/>
                             <constraint firstItem="8" firstAttribute="top" secondItem="hVd-gA-oCj" secondAttribute="top" id="KYi-Le-dXb"/>
                             <constraint firstItem="8" firstAttribute="bottom" secondItem="hVd-gA-oCj" secondAttribute="bottom" id="VEf-gY-AwQ"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the text inside podcast grid cell to adapt to Dynamic Type

| xs | Default | xxxL | AX5 |
| - | - | - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-24 at 13 10 48" src="https://github.com/user-attachments/assets/5df54850-c2ab-40ca-a3aa-f8f8a8f6dd97" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-24 at 13 10 44" src="https://github.com/user-attachments/assets/4266eee1-fe62-4fe9-8847-1fb01428d65b" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-24 at 13 09 51" src="https://github.com/user-attachments/assets/55085e1b-f265-4891-9cf1-675652e848c8" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-24 at 13 09 41" src="https://github.com/user-attachments/assets/73594624-b3e4-4ca4-9df6-2bf22262f9e1" /> |

## To test

1. Start the app
3. Follow a Podcast without a valid podcast image. Ex: [Headphones Required](https://pca.st/podcast/5bc9f1a0-5cf9-012e-241c-00163e1b201c)
4. Open Podcast tab
5. Select Grid mode
6. Scroll to the podcast without image.
7. Check if the name of the podcast is shown instead and adapts to Dynamic Type

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.