### PR TITLE
Remove old mystagingwebsite.com domain

### DIFF
--- a/podcasts/podcasts.entitlements
+++ b/podcasts/podcasts.entitlements
@@ -18,7 +18,6 @@
 		<string>applinks:pcast.pocketcasts.net</string>
 		<string>applinks:pca.st</string>
 		<string>applinks:pocketcasts.com</string>
-		<string>applinks:pocket-casts-main-development.mystagingwebsite.com</string>
 		<string>appclips:pca.st</string>
 		<string>appclips:pcast.pocketcasts.net</string>
 		<string>appclips:pocketcasts.com</string>

--- a/podcasts/podcasts.prototype.entitlements
+++ b/podcasts/podcasts.prototype.entitlements
@@ -12,7 +12,6 @@
 		<string>applinks:pcast.pocketcasts.net</string>
 		<string>applinks:pca.st</string>
 		<string>applinks:pocketcasts.com</string>
-		<string>applinks:pocket-casts-main-development.mystagingwebsite.com</string>
 		<string>appclips:pca.st</string>
 		<string>appclips:pcast.pocketcasts.net</string>
 		<string>appclips:pocketcasts.com</string>

--- a/podcasts/podcastsDebug.entitlements
+++ b/podcasts/podcastsDebug.entitlements
@@ -16,7 +16,6 @@
 		<string>applinks:pcast.pocketcasts.net</string>
 		<string>applinks:pca.st</string>
 		<string>applinks:pocketcasts.com</string>
-		<string>applinks:pocket-casts-main-development.mystagingwebsite.com</string>
 		<string>appclips:pca.st</string>
 		<string>appclips:pcast.pocketcasts.net</string>
 		<string>appclips:pocketcasts.com</string>


### PR DESCRIPTION
Fixes [PCIOS-540](https://linear.app/a8c/issue/PCIOS-540/1password-looks-for-incorrect-url-in-ios-app)

Removes an old associated domain that seems to be flagged in 1Password

## To test

* Run the Prototype build
* See what 1Password suggests
* Verify the `mystagingwebsite.com` does not show up

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
