### PR TITLE
Makefile Staging build updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ make format
 ## Building and Running
 
 ```bash
-make build
+make build_staging
 ```
 
 ## Cleaning Build Artifacts
@@ -20,31 +20,26 @@ make clean
 ## Running Tests
 
 ```bash
-make test
+make test_staging
 ```
 
 ### Running a Single Test
 
 ```bash
-xcodebuild test -project podcasts.xcodeproj \
-    -scheme pocketcasts \
-    -only-testing:PocketCastsTests/YourTestClass/testMethodName
+make test_staging ONLY_TESTING=PocketCastsTests/YourTestClass/testMethodName
 ```
 
 ### Running Module Tests
 
 ```bash
 # DataModel module tests
-xcodebuild test -project podcasts.xcodeproj -scheme pocketcasts \
-    -only-testing:PocketCastsDataModelTests
+make test_staging ONLY_TESTING=PocketCastsDataModelTests
 
 # Server module tests
-xcodebuild test -project podcasts.xcodeproj -scheme pocketcasts \
-    -only-testing:PocketCastsServerTests
+make test_staging ONLY_TESTING=PocketCastsServerTests
 
 # Utils module tests
-xcodebuild test -project podcasts.xcodeproj -scheme pocketcasts \
-    -only-testing:PocketCastsUtilsTests
+make test_staging ONLY_TESTING=PocketCastsUtilsTests
 ```
 
 ## Architecture

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,18 @@ test: ## Build and run the PocketCastsTests target with Unit Tests using Xcode
         -only-testing:PocketCastsTests \
         -destination 'platform=iOS Simulator,name=$(SIMULATOR_NAME),OS=latest'
 
+build_staging: ## Builds using the Staging configuration
+	xcodebuild -project podcasts.xcodeproj \
+       -scheme "Pocket Casts Staging" \
+       -configuration Staging \
+       -destination 'generic/platform=iOS Simulator' \
+       build
+
+test_staging: ## Build and run Unit Tests using the Staging configuration
+	xcodebuild test -project podcasts.xcodeproj \
+	    -scheme "Pocket Casts Staging" \
+        -only-testing:PocketCastsTests
+
 format: ## Lint and autocorrect linter errors
 	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS) --autocorrect)
 

--- a/Makefile
+++ b/Makefile
@@ -56,14 +56,14 @@ test: ## Build and run the PocketCastsTests target with Unit Tests using Xcode
         -only-testing:PocketCastsTests \
         -destination 'platform=iOS Simulator,name=$(SIMULATOR_NAME),OS=latest'
 
-build_staging: ## Builds using the Staging configuration
+build_staging: ## Builds using the StagingDebug configuration
 	xcodebuild -project podcasts.xcodeproj \
        -scheme "Pocket Casts Staging" \
-       -configuration Staging \
+       -configuration StagingDebug \
        -destination 'generic/platform=iOS Simulator' \
        build
 
-test_staging: ## Build and run Unit Tests using the Staging configuration
+test_staging: ## Build and run Unit Tests using the StagingDebug configuration
 	xcodebuild test -project podcasts.xcodeproj \
 	    -scheme "Pocket Casts Staging" \
         -only-testing:PocketCastsTests

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,12 @@ clean: ## Cleans the build artifacts
        -configuration Debug \
        clean
 
+ONLY_TESTING ?= PocketCastsTests
+
 test: ## Build and run the PocketCastsTests target with Unit Tests using Xcode
 	xcodebuild test -project podcasts.xcodeproj \
 	    -scheme pocketcasts \
-        -only-testing:PocketCastsTests \
+        -only-testing:$(ONLY_TESTING) \
         -destination 'platform=iOS Simulator,name=$(SIMULATOR_NAME),OS=latest'
 
 build_staging: ## Builds using the StagingDebug configuration
@@ -66,7 +68,8 @@ build_staging: ## Builds using the StagingDebug configuration
 test_staging: ## Build and run Unit Tests using the StagingDebug configuration
 	xcodebuild test -project podcasts.xcodeproj \
 	    -scheme "Pocket Casts Staging" \
-        -only-testing:PocketCastsTests
+        -only-testing:$(ONLY_TESTING) \
+        -destination 'platform=iOS Simulator,name=$(SIMULATOR_NAME),OS=latest'
 
 format: ## Lint and autocorrect linter errors
 	$(call run_in_buildtools,$(SWIFTLINT_FROM_BUILDTOOLS) --autocorrect)

--- a/Modules/DataModel/Package.swift
+++ b/Modules/DataModel/Package.swift
@@ -28,7 +28,10 @@ let package = Package(
                 .product(name: "PocketCastsUtils", package: "Utils"),
                 .product(name: "GRDBMacros", package: "GRDBMacros")
             ],
-            path: "Sources"
+            path: "Sources",
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"])
+            ]
         ),
         .testTarget(
             name: "PocketCastsDataModelTests",

--- a/Modules/DataModel/Package.swift
+++ b/Modules/DataModel/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
             ],
             path: "Sources",
             swiftSettings: [
-                .unsafeFlags(["-enable-testing"])
+                .unsafeFlags(["-enable-testing"], .when(configuration: .debug))
             ]
         ),
         .testTarget(

--- a/Modules/Server/Package.swift
+++ b/Modules/Server/Package.swift
@@ -30,6 +30,9 @@ let package = Package(
                 .product(name: "PocketCastsUtils", package: "Utils")
             ],
             path: "Sources",
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"])
+            ],
             linkerSettings: [
                 .linkedFramework("CFNetwork", .when(platforms: [.iOS])),
                 .linkedFramework("AuthenticationServices", .when(platforms: [.iOS, .watchOS]))

--- a/Modules/Server/Package.swift
+++ b/Modules/Server/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
             ],
             path: "Sources",
             swiftSettings: [
-                .unsafeFlags(["-enable-testing"])
+                .unsafeFlags(["-enable-testing"], .when(configuration: .debug))
             ],
             linkerSettings: [
                 .linkedFramework("CFNetwork", .when(platforms: [.iOS])),

--- a/Modules/Utils/Package.swift
+++ b/Modules/Utils/Package.swift
@@ -18,7 +18,10 @@ let package = Package(
     targets: [
         .target(
             name: "PocketCastsUtils",
-            path: "Sources"
+            path: "Sources",
+            swiftSettings: [
+                .unsafeFlags(["-enable-testing"])
+            ]
         ),
         .testTarget(
             name: "PocketCastsUtilsTests",

--- a/Modules/Utils/Package.swift
+++ b/Modules/Utils/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
             name: "PocketCastsUtils",
             path: "Sources",
             swiftSettings: [
-                .unsafeFlags(["-enable-testing"])
+                .unsafeFlags(["-enable-testing"], .when(configuration: .debug))
             ]
         ),
         .testTarget(

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -11696,6 +11696,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEBUG_ACTIVITY_MODE = "";
 				"DEBUG_ACTIVITY_MODE[sdk=iphonesimulator*]" = disable;
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				FIREBASE_SECRETS_PATH = "$(HOME)/.configure/pocketcasts-ios/secrets/GoogleService-Info.plist";
@@ -12789,6 +12790,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEBUG_ACTIVITY_MODE = "";
 				"DEBUG_ACTIVITY_MODE[sdk=iphonesimulator*]" = disable;
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = NO;
 				FIREBASE_SECRETS_PATH = "$(HOME)/.configure/pocketcasts-ios/secrets/GoogleService-Info.plist";
@@ -13024,6 +13026,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEBUG_ACTIVITY_MODE = "";
 				"DEBUG_ACTIVITY_MODE[sdk=iphonesimulator*]" = disable;
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				FIREBASE_SECRETS_PATH = "$(HOME)/.configure/pocketcasts-ios/secrets/GoogleService-Info.plist";
@@ -13082,6 +13085,7 @@
 				COPY_PHASE_STRIP = YES;
 				DEAD_CODE_STRIPPING = NO;
 				DEBUG_ACTIVITY_MODE = "";
+				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FIREBASE_SECRETS_PATH = "$(HOME)/.configure/pocketcasts-ios/secrets/GoogleService-Info.plist";
 				GCC_C_LANGUAGE_STANDARD = gnu99;

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -11665,7 +11665,7 @@
 			};
 			name = Release;
 		};
-		3FD6E0542BFC790F003941C0 /* Staging */ = {
+		3FD6E0542BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3FD6E0612BFC7996003941C0 /* PocketCasts.staging.xcconfig */;
 			buildSettings = {
@@ -11722,9 +11722,9 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E0552BFC790F003941C0 /* Staging */ = {
+		3FD6E0552BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -11747,9 +11747,9 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "podcasts/podcasts-Bridging-Header.h";
 				WRAPPER_EXTENSION = app;
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E0562BFC790F003941C0 /* Staging */ = {
+		3FD6E0562BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
@@ -11774,9 +11774,9 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E0572BFC790F003941C0 /* Staging */ = {
+		3FD6E0572BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
@@ -11801,9 +11801,9 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E0582BFC790F003941C0 /* Staging */ = {
+		3FD6E0582BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -11833,9 +11833,9 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 9.0;
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E0592BFC790F003941C0 /* Staging */ = {
+		3FD6E0592BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
@@ -11869,9 +11869,9 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E05A2BFC790F003941C0 /* Staging */ = {
+		3FD6E05A2BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
@@ -11904,9 +11904,9 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E05B2BFC790F003941C0 /* Staging */ = {
+		3FD6E05B2BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -11942,9 +11942,9 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E05C2BFC790F003941C0 /* Staging */ = {
+		3FD6E05C2BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
@@ -11952,9 +11952,9 @@
 				PODS_ROOT = "${SRCROOT}/Pods";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E05D2BFC790F003941C0 /* Staging */ = {
+		3FD6E05D2BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
@@ -11988,9 +11988,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = podcasts;
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E05E2BFC790F003941C0 /* Staging */ = {
+		3FD6E05E2BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
@@ -12020,9 +12020,9 @@
 				TEST_TARGET_NAME = "Pocket Casts Watch App";
 				WATCHOS_DEPLOYMENT_TARGET = 9.0;
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E05F2BFC790F003941C0 /* Staging */ = {
+		3FD6E05F2BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -12052,9 +12052,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/podcasts.app/podcasts";
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
-		3FD6E0602BFC790F003941C0 /* Staging */ = {
+		3FD6E0602BFC790F003941C0 /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
@@ -12094,7 +12094,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
 		403B5B2A21813FFB00821A54 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -13332,7 +13332,7 @@
 			};
 			name = Debug;
 		};
-		F5D5F7A12CEBE76A001F492D /* Staging */ = {
+		F5D5F7A12CEBE76A001F492D /* StagingDebug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -13385,7 +13385,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = Staging;
+			name = StagingDebug;
 		};
 		F5D5F7A22CEBE76A001F492D /* Prototype */ = {
 			isa = XCBuildConfiguration;
@@ -13504,7 +13504,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2F9099162A4F88B10044FC55 /* Debug */,
-				3FD6E0602BFC790F003941C0 /* Staging */,
+				3FD6E0602BFC790F003941C0 /* StagingDebug */,
 				2F9099172A4F88B10044FC55 /* Prototype */,
 				2F9099182A4F88B10044FC55 /* Release */,
 			);
@@ -13515,7 +13515,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				403B5B2A21813FFB00821A54 /* Debug */,
-				3FD6E05A2BFC790F003941C0 /* Staging */,
+				3FD6E05A2BFC790F003941C0 /* StagingDebug */,
 				BD69A0212266A9E400168459 /* Prototype */,
 				403B5B2B21813FFB00821A54 /* Release */,
 			);
@@ -13526,7 +13526,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				403B5B2D21813FFB00821A54 /* Debug */,
-				3FD6E0592BFC790F003941C0 /* Staging */,
+				3FD6E0592BFC790F003941C0 /* StagingDebug */,
 				BD69A0202266A9E400168459 /* Prototype */,
 				403B5B2E21813FFB00821A54 /* Release */,
 			);
@@ -13537,7 +13537,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4090975C25235DFC00CED68C /* Debug */,
-				3FD6E05B2BFC790F003941C0 /* Staging */,
+				3FD6E05B2BFC790F003941C0 /* StagingDebug */,
 				4090975D25235DFC00CED68C /* Prototype */,
 				4090975E25235DFC00CED68C /* Release */,
 			);
@@ -13548,7 +13548,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				45ECEF8127E910E300C65030 /* Debug */,
-				3FD6E05F2BFC790F003941C0 /* Staging */,
+				3FD6E05F2BFC790F003941C0 /* StagingDebug */,
 				45ECEF8227E910E300C65030 /* Prototype */,
 				45ECEF8327E910E300C65030 /* Release */,
 			);
@@ -13559,7 +13559,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				462EE0C22702532E003D67DC /* Debug */,
-				3FD6E05C2BFC790F003941C0 /* Staging */,
+				3FD6E05C2BFC790F003941C0 /* StagingDebug */,
 				462EE0C32702532E003D67DC /* Prototype */,
 				462EE0C42702532E003D67DC /* Release */,
 			);
@@ -13570,7 +13570,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				4694FA682799C80300E9CF70 /* Debug */,
-				3FD6E05D2BFC790F003941C0 /* Staging */,
+				3FD6E05D2BFC790F003941C0 /* StagingDebug */,
 				4694FA692799C80300E9CF70 /* Prototype */,
 				4694FA6A2799C80300E9CF70 /* Release */,
 			);
@@ -13581,7 +13581,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				46AFC23D27AB19CF004B026F /* Debug */,
-				3FD6E05E2BFC790F003941C0 /* Staging */,
+				3FD6E05E2BFC790F003941C0 /* StagingDebug */,
 				46AFC23E27AB19CF004B026F /* Prototype */,
 				46AFC23F27AB19CF004B026F /* Release */,
 			);
@@ -13592,7 +13592,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				BD3A21151E6CFC2400F42241 /* Debug */,
-				3FD6E0562BFC790F003941C0 /* Staging */,
+				3FD6E0562BFC790F003941C0 /* StagingDebug */,
 				BD69A01C2266A9E400168459 /* Prototype */,
 				BD3A21161E6CFC2400F42241 /* Release */,
 			);
@@ -13603,7 +13603,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				BDBD540C17019B2A0048C8C5 /* Debug */,
-				3FD6E0542BFC790F003941C0 /* Staging */,
+				3FD6E0542BFC790F003941C0 /* StagingDebug */,
 				BD69A0192266A9E400168459 /* Prototype */,
 				BDBD540D17019B2A0048C8C5 /* Release */,
 			);
@@ -13614,7 +13614,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				BDBD540F17019B2A0048C8C5 /* Debug */,
-				3FD6E0552BFC790F003941C0 /* Staging */,
+				3FD6E0552BFC790F003941C0 /* StagingDebug */,
 				BD69A01A2266A9E400168459 /* Prototype */,
 				BDBD541017019B2A0048C8C5 /* Release */,
 			);
@@ -13625,7 +13625,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				BDD301831EFB9356004A9972 /* Debug */,
-				3FD6E0582BFC790F003941C0 /* Staging */,
+				3FD6E0582BFC790F003941C0 /* StagingDebug */,
 				BD69A01E2266A9E400168459 /* Prototype */,
 				BDD301841EFB9356004A9972 /* Release */,
 			);
@@ -13636,7 +13636,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				BDEFBA221E6D3C2300B9024B /* Debug */,
-				3FD6E0572BFC790F003941C0 /* Staging */,
+				3FD6E0572BFC790F003941C0 /* StagingDebug */,
 				BD69A01D2266A9E400168459 /* Prototype */,
 				BDEFBA231E6D3C2300B9024B /* Release */,
 			);
@@ -13647,7 +13647,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				F5D5F7A02CEBE76A001F492D /* Debug */,
-				F5D5F7A12CEBE76A001F492D /* Staging */,
+				F5D5F7A12CEBE76A001F492D /* StagingDebug */,
 				F5D5F7A22CEBE76A001F492D /* Prototype */,
 				F5D5F7A32CEBE76A001F492D /* Release */,
 			);

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Staging.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Staging.xcscheme
@@ -4,8 +4,7 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES"
-      buildArchitectures = "Automatic">
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -21,14 +20,33 @@
                ReferencedContainer = "container:podcasts.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "45ECEF7A27E910E300C65030"
+               BuildableName = "PocketCastsTests.xctest"
+               BlueprintName = "PocketCastsTests"
+               ReferencedContainer = "container:podcasts.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Staging"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:PocketCastsTests/UnitTests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Staging"

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Staging.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Staging.xcscheme
@@ -37,7 +37,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Staging"
+      buildConfiguration = "StagingDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -49,7 +49,7 @@
       </TestPlans>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Staging"
+      buildConfiguration = "StagingDebug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -70,7 +70,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Staging"
+      buildConfiguration = "StagingDebug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -87,10 +87,10 @@
       </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Staging">
+      buildConfiguration = "StagingDebug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Staging"
+      buildConfiguration = "StagingDebug"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
* Renames Staging configuration to StagingDebug
* Updates the Makefile to support `build_staging` and `test_staging` builds
* Updates Agents.md to point to `build_staging` and `test_staging` commands 

## To test

* Start Claude code or other AI session
* Instruct it to run the tests
* Verify `make test_staging` is run

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
