### PR TITLE
[Dynamic type] Fix two breaking constraints

### DIFF
--- a/podcasts/EpisodeCell.xib
+++ b/podcasts/EpisodeCell.xib
@@ -95,7 +95,7 @@
                                                     <bool key="isElement" value="NO"/>
                                                 </accessibility>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="tpa-cl-8ND"/>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="200" id="tpa-cl-8ND"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <nil key="textColor"/>

--- a/podcasts/EpisodeListSearchController.xib
+++ b/podcasts/EpisodeListSearchController.xib
@@ -36,20 +36,17 @@
                             <rect key="frame" x="16" y="10" width="298" height="36"/>
                             <subviews>
                                 <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="eeU-aw-oKZ" customClass="ThemeLoadingIndicator" customModule="podcasts" customModuleProvider="target">
-                                    <rect key="frame" x="8" y="8" width="23.5" height="20"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" secondItem="eeU-aw-oKZ" secondAttribute="height" multiplier="7:6" id="NRW-c0-4Wo"/>
-                                    </constraints>
+                                    <rect key="frame" x="8" y="8" width="20" height="20"/>
                                 </activityIndicatorView>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" image="custom_search" translatesAutoresizingMaskIntoConstraints="NO" id="At2-Om-SSW">
-                                    <rect key="frame" x="11.5" y="9" width="18" height="18"/>
+                                    <rect key="frame" x="10" y="10" width="16" height="16"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="16" id="Bao-KV-DN5"/>
-                                        <constraint firstAttribute="width" secondItem="At2-Om-SSW" secondAttribute="height" multiplier="1:1" id="X5W-lr-MlV"/>
+                                        <constraint firstAttribute="height" constant="16" id="elZ-D0-1L4"/>
+                                        <constraint firstAttribute="width" constant="16" id="n1g-0s-7ys"/>
                                     </constraints>
                                 </imageView>
                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Search Episodes" textAlignment="natural" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="YWN-oW-0ZD">
-                                    <rect key="frame" x="39.5" y="4" width="232.5" height="28"/>
+                                    <rect key="frame" x="36" y="4" width="236" height="28"/>
                                     <color key="backgroundColor" red="0.035672488410000001" green="1" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                     <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="search" enablesReturnKeyAutomatically="YES"/>
@@ -58,7 +55,7 @@
                                     </connections>
                                 </textField>
                                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" pointerInteraction="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NUs-aB-3ve" userLabel="Clear Search">
-                                    <rect key="frame" x="274" y="9" width="18" height="18"/>
+                                    <rect key="frame" x="276" y="10" width="16" height="16"/>
                                     <accessibility key="accessibilityConfiguration" label="Clear search"/>
                                     <color key="tintColor" red="0.60835868120000003" green="0.8194983602" blue="0.82352894539999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                     <state key="normal" image="search_cancel"/>
@@ -72,17 +69,15 @@
                                 <constraint firstItem="At2-Om-SSW" firstAttribute="leading" secondItem="Wat-Pf-EXJ" secondAttribute="leading" constant="10" id="0Or-7s-Tkq"/>
                                 <constraint firstItem="YWN-oW-0ZD" firstAttribute="leading" secondItem="At2-Om-SSW" secondAttribute="trailing" constant="10" id="16u-f1-85m"/>
                                 <constraint firstAttribute="trailing" secondItem="NUs-aB-3ve" secondAttribute="trailing" constant="6" id="63n-XI-Oj0"/>
-                                <constraint firstAttribute="bottom" secondItem="YWN-oW-0ZD" secondAttribute="bottom" constant="4" id="I8Q-lG-dmA"/>
                                 <constraint firstItem="NUs-aB-3ve" firstAttribute="width" secondItem="At2-Om-SSW" secondAttribute="width" id="M4l-k7-btc"/>
                                 <constraint firstItem="NUs-aB-3ve" firstAttribute="height" secondItem="At2-Om-SSW" secondAttribute="height" id="PSU-e1-NIB"/>
-                                <constraint firstItem="eeU-aw-oKZ" firstAttribute="height" secondItem="YWN-oW-0ZD" secondAttribute="height" constant="-8" id="TXM-rw-AV3"/>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="36" id="Te1-SJ-Fte"/>
                                 <constraint firstItem="YWN-oW-0ZD" firstAttribute="leading" secondItem="eeU-aw-oKZ" secondAttribute="trailing" constant="8" id="XYa-bM-siz"/>
                                 <constraint firstItem="eeU-aw-oKZ" firstAttribute="centerY" secondItem="Wat-Pf-EXJ" secondAttribute="centerY" id="fj4-88-Oub"/>
                                 <constraint firstItem="YWN-oW-0ZD" firstAttribute="top" secondItem="Wat-Pf-EXJ" secondAttribute="top" constant="4" id="haB-5W-Jib"/>
                                 <constraint firstAttribute="trailing" secondItem="YWN-oW-0ZD" secondAttribute="trailing" constant="26" id="j75-I0-CFX"/>
+                                <constraint firstAttribute="bottom" secondItem="YWN-oW-0ZD" secondAttribute="bottom" constant="4" id="syK-Dz-x81"/>
                                 <constraint firstItem="NUs-aB-3ve" firstAttribute="centerY" secondItem="YWN-oW-0ZD" secondAttribute="centerY" id="tN7-y2-WQX"/>
-                                <constraint firstItem="At2-Om-SSW" firstAttribute="height" secondItem="YWN-oW-0ZD" secondAttribute="height" constant="-10" id="tz5-7Q-gMY"/>
                                 <constraint firstItem="At2-Om-SSW" firstAttribute="centerY" secondItem="Wat-Pf-EXJ" secondAttribute="centerY" id="wA4-PR-FnH"/>
                                 <constraint firstItem="eeU-aw-oKZ" firstAttribute="leading" secondItem="Wat-Pf-EXJ" secondAttribute="leading" constant="8" id="xxC-ad-pEM"/>
                             </constraints>
@@ -152,7 +147,6 @@
                         <constraint firstItem="elY-fZ-CTE" firstAttribute="top" relation="greaterThanOrEqual" secondItem="6fg-N7-SIa" secondAttribute="bottom" constant="12" id="TPr-w7-jrT"/>
                         <constraint firstItem="Wat-Pf-EXJ" firstAttribute="leading" secondItem="LW5-CL-eLg" secondAttribute="leading" constant="16" id="TWh-ZP-zKq"/>
                         <constraint firstItem="0Wl-Qr-Alh" firstAttribute="leading" secondItem="Wat-Pf-EXJ" secondAttribute="trailing" constant="12" id="ZW4-wp-Ue9"/>
-                        <constraint firstItem="0Wl-Qr-Alh" firstAttribute="height" secondItem="Wat-Pf-EXJ" secondAttribute="height" id="hho-PG-qD9"/>
                         <constraint firstItem="6fg-N7-SIa" firstAttribute="leading" secondItem="wNf-rq-iBx" secondAttribute="trailing" constant="8" id="mwl-h5-3g9"/>
                         <constraint firstItem="GPT-Sc-fsw" firstAttribute="leading" secondItem="LW5-CL-eLg" secondAttribute="leading" id="oWm-Lf-zFh"/>
                         <constraint firstItem="wNf-rq-iBx" firstAttribute="top" secondItem="GPT-Sc-fsw" secondAttribute="bottom" constant="12" id="r3d-gL-yaz"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR fixes two Xcode warning of breaking constraints when opening this screens on the larger AX5 format:

- Podcast details - search bar
- Playlist - list of episodes

## To test

1. Start the app
2. Enable the larger of accessibility formats for Dynamic Type
3. Open a podcast
4. Scroll around, see that no warning of breaking constraint shows on Xcode console
5. Open playlists
6. Open a playlist with episodes
7. Scroll around, see that no warning of breaking constraint shows on Xcode console

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
