### PR TITLE
Episode artwork network handling + prefer Show Notes image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Playlists: Add episode to a playlist from episode details [##3943](https://github.com/Automattic/pocket-casts-ios/pull/3943/) 
 - Refresh Now Playing info when Bluetooth device connects [#3964](https://github.com/Automattic/pocket-casts-ios/pull/3964) 
 - Fix logout issue when refreshing in background while device is locked [#3983](https://github.com/Automattic/pocket-casts-ios/pull/3983) 
+- Fix Episode Artwork loading when audio asset image differs from feed [#4017](https://github.com/Automattic/pocket-casts-ios/pull/4017)
 
 8.6
 -----

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -17,7 +17,7 @@ public actor ShowInfoDataRetriever {
         for podcastUuid: String,
         episodeUuid: String
     ) async throws -> String? {
-        if !FeatureFlag.episodesInfoCacheReloadPolicy.enabled || !NetworkUtils.shared.isConnected() {
+        if !NetworkUtils.shared.isConnected() {
             let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
             let request = URLRequest(url: url)
 
@@ -39,7 +39,7 @@ public actor ShowInfoDataRetriever {
         }
 
         let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
-        let cachePolicy: URLRequest.CachePolicy = FeatureFlag.episodesInfoCacheReloadPolicy.enabled ? .reloadRevalidatingCacheData : .reloadIgnoringLocalAndRemoteCacheData
+        let cachePolicy: URLRequest.CachePolicy = .reloadRevalidatingCacheData
         var request = URLRequest(url: url, cachePolicy: cachePolicy)
         request.addLocalizationHeaders()
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -11,13 +11,18 @@ public actor ShowInfoDataRetriever {
         cache = URLCache(memoryCapacity: 1.megabytes, diskCapacity: 100.megabytes, diskPath: "show_notes")
     }
 
-    /// Try to load episode data from cache
-    /// If it's not found, request it
+    /// Try to load episode data from the network
+    /// Falls back to cache if URLSession reports no connection
+    /// - Parameters:
+    ///   - podcastUuid: The podcast UUID
+    ///   - episodeUuid: The episode UUID
+    ///   - useCacheOnly: If true, skip the network request and only check cache
     public func loadEpisodeDataFromCache(
         for podcastUuid: String,
-        episodeUuid: String
+        episodeUuid: String,
+        useCacheOnly: Bool = false
     ) async throws -> String? {
-        if !NetworkUtils.shared.isConnected() {
+        if useCacheOnly {
             let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
             let request = URLRequest(url: url)
 
@@ -26,9 +31,27 @@ public actor ShowInfoDataRetriever {
                 FileLog.shared.addMessage("Show Info: returning cached data for episode \(episodeUuid)")
                 return metadata
             }
+            return nil
         }
 
-        return try await loadEpisodeData(for: podcastUuid, episodeUuid: episodeUuid)
+        do {
+            return try await loadEpisodeData(for: podcastUuid, episodeUuid: episodeUuid)
+        } catch {
+            if isNetworkUnavailableError(error) {
+                FileLog.shared.addMessage("Show Info: network unavailable, falling back to cache for episode \(episodeUuid)")
+                return try await loadEpisodeDataFromCache(for: podcastUuid, episodeUuid: episodeUuid, useCacheOnly: true)
+            }
+            throw error
+        }
+    }
+
+    private func isNetworkUnavailableError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && (
+            nsError.code == NSURLErrorNotConnectedToInternet ||
+            nsError.code == NSURLErrorNetworkConnectionLost ||
+            nsError.code == NSURLErrorDataNotAllowed
+        )
     }
 
     public func loadShowInfoData(

--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -50,7 +50,8 @@ public actor ShowInfoDataRetriever {
         return nsError.domain == NSURLErrorDomain && (
             nsError.code == NSURLErrorNotConnectedToInternet ||
             nsError.code == NSURLErrorNetworkConnectionLost ||
-            nsError.code == NSURLErrorDataNotAllowed
+            nsError.code == NSURLErrorDataNotAllowed ||
+            nsError.code == NSURLErrorTimedOut
         )
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -239,9 +239,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Uses the PlaylistMetadataLoader cache before running the query (the query will update when it's done)
     case playlistDataCacheBeforeQuery
 
-    /// Avoid returning cached episode early and use policy instead
-    case episodesInfoCacheReloadPolicy
-
     /// Ignores play remote commands when other audio is playing
     case ignorePlayWithOtherAudio
 
@@ -457,8 +454,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .playlistDataCacheBeforeQuery:
             true
-        case .episodesInfoCacheReloadPolicy:
-			true
         case .ignorePlayWithOtherAudio:
             true
         case .streamAndDownloadReadFromMemoryBuffer:

--- a/podcasts/EpisodeArtwork.swift
+++ b/podcasts/EpisodeArtwork.swift
@@ -8,6 +8,9 @@ import AVFoundation
 class EpisodeArtwork {
     private let imageManager: ImageManager
 
+    /// Track in-progress artwork load tasks by episode UUID to prevent redundant requests and allow cancellation
+    private var inProgressArtworkLoads: [String: Task<Void, Never>] = [:]
+
     init(imageManager: ImageManager = .sharedManager) {
         self.imageManager = imageManager
     }
@@ -21,23 +24,39 @@ class EpisodeArtwork {
     ///   - podcastUuid: the UUID of the current playing podcast
     ///   - episodeUuid: the UUID of the current playing episode
     func loadEmbeddedImage(asset: AVAsset?, podcastUuid: String, episodeUuid: String) {
-        guard Settings.loadEmbeddedImages, !isCached(episodeUuid: episodeUuid) else {
+        guard Settings.loadEmbeddedImages,
+              !isCached(episodeUuid: episodeUuid),
+              inProgressArtworkLoads[episodeUuid] == nil else {
             return
         }
 
-        Task { [weak self] in
+        let task = Task { [weak self] in
             guard let self else { return }
+
+            defer {
+                self.inProgressArtworkLoads[episodeUuid] = nil
+            }
 
             // Priority 1: Show notes image URL (publisher intent takes precedence)
             if await self.loadArtworkFromShowNotes(podcastUuid: podcastUuid, episodeUuid: episodeUuid) {
                 return
             }
 
+            guard !Task.isCancelled else { return }
+
             // Priority 2: Embedded artwork from audio file metadata
             if let assetEpisodeArtwork = self.loadEpisodeArtwork(from: asset) {
                 self.imageManager.save(assetEpisodeArtwork, for: episodeUuid)
             }
         }
+
+        inProgressArtworkLoads[episodeUuid] = task
+    }
+
+    /// Cancel any in-progress artwork load for the given episode
+    func cancelArtworkLoad(for episodeUuid: String) {
+        inProgressArtworkLoads[episodeUuid]?.cancel()
+        inProgressArtworkLoads[episodeUuid] = nil
     }
 
     func isCached(episodeUuid: String) -> Bool {
@@ -69,6 +88,10 @@ class EpisodeArtwork {
 
         return await withCheckedContinuation { continuation in
             KingfisherManager.shared.retrieveImage(with: url, options: [.processor(resizeProcessor)]) { [weak self] result in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: false)
+                    return
+                }
                 if let image = try? result.get().image {
                     self?.imageManager.save(image, for: episodeUuid)
                     continuation.resume(returning: true)

--- a/podcasts/EpisodeArtwork.swift
+++ b/podcasts/EpisodeArtwork.swift
@@ -12,9 +12,9 @@ class EpisodeArtwork {
         self.imageManager = imageManager
     }
 
-    /// Attempts to load an episode embedded artwork.
-    /// It first tries to load an embedded artwork from the AVAsset.
-    /// If nothing is found, it then request the image from Cache Server Handler.
+    /// Attempts to load episode artwork with the following priority (matching Android):
+    /// 1. Show notes image URL from the server (publisher intent takes precedence)
+    /// 2. Embedded artwork from the AVAsset (ID3 tags)
     /// If an image is retrieved, `episodeEmbeddedArtworkLoaded` notification is triggered
     /// - Parameters:
     ///   - asset: an AVAsset
@@ -25,12 +25,19 @@ class EpisodeArtwork {
             return
         }
 
-        if let assetEpisodeArtwork = loadEpisodeArtwork(from: asset) {
-            imageManager.save(assetEpisodeArtwork, for: episodeUuid)
-            return
-        }
+        Task { [weak self] in
+            guard let self else { return }
 
-        loadEpisodeArtworkFromUrl(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+            // Priority 1: Show notes image URL (publisher intent takes precedence)
+            if await self.loadArtworkFromShowNotes(podcastUuid: podcastUuid, episodeUuid: episodeUuid) {
+                return
+            }
+
+            // Priority 2: Embedded artwork from audio file metadata
+            if let assetEpisodeArtwork = self.loadEpisodeArtwork(from: asset) {
+                self.imageManager.save(assetEpisodeArtwork, for: episodeUuid)
+            }
+        }
     }
 
     func isCached(episodeUuid: String) -> Bool {
@@ -46,25 +53,27 @@ class EpisodeArtwork {
         return artworkItems.compactMap { $0.dataValue.flatMap { UIImage(data: $0) } }.first
     }
 
-    private func loadEpisodeArtworkFromUrl(podcastUuid: String, episodeUuid: String) {
-        Task { [weak self] in
-            guard let self else {
-                return
-            }
+    /// Attempts to load episode artwork from show notes URL.
+    /// - Returns: true if artwork was successfully loaded and saved, false otherwise
+    private func loadArtworkFromShowNotes(podcastUuid: String, episodeUuid: String) async -> Bool {
+        guard let imageUrl = try? await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: podcastUuid, episodeUuid: episodeUuid),
+              let url = URL(string: imageUrl) else {
+            return false
+        }
 
-            guard let imageUrl = try? await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: podcastUuid, episodeUuid: episodeUuid),
-                  let url = URL(string: imageUrl) else {
-                return
-            }
+        // Resize image to avoid really big images that appear
+        // super blurred on CarPlay.
+        // If the image is smaller to the given size, no downsampling is done.
+        let size = imageManager.biggestPodcastImageSize
+        let resizeProcessor = DownsamplingImageProcessor(size: .init(width: size, height: size))
 
-            // Resize image to avoid really big images that appear
-            // super blurred on CarPlay.
-            // If the image is smaller to the given size, no downsampling is done.
-            let size = self.imageManager.biggestPodcastImageSize
-            let resizeProcessor = DownsamplingImageProcessor(size: .init(width: size, height: size))
-            KingfisherManager.shared.retrieveImage(with: url, options: [.processor(resizeProcessor)]) { result in
+        return await withCheckedContinuation { continuation in
+            KingfisherManager.shared.retrieveImage(with: url, options: [.processor(resizeProcessor)]) { [weak self] result in
                 if let image = try? result.get().image {
-                    self.imageManager.save(image, for: episodeUuid)
+                    self?.imageManager.save(image, for: episodeUuid)
+                    continuation.resume(returning: true)
+                } else {
+                    continuation.resume(returning: false)
                 }
             }
         }


### PR DESCRIPTION
Fixes [PCIOS-482](https://linear.app/a8c/issue/PCIOS-482/podcast-artwork-is-displayed-instead-of-episode-artwork-in-episode)

The mp3 file episode artwork was preferred over the feed artwork. This PR changes this to prefer the feed artwork.

I noticed two issues testing this:
* The `NetworkUtils.shared.isConnected()` call was returning `false` for some reason. I think, instead, we should rely on the result of the connection to see if the request succeeds rather than pre-emptively checking connection.
* The Android and Web clients prefer the artwork from the Show Notes endpoint, rather than the one from the audio file. [Here's](https://github.com/Automattic/pocket-casts-android/blob/main/modules/services/repositories/src/main/java/au/com/shiftyjelly/pocketcasts/repositories/images/PocketCastsImageRequestFactory.kt#L98-L101) where Android does this:

```
    private fun RequestType.PodcastEpisode.data(context: Context) = if (useEpisodeArtwork) {
        episode.imageUrl ?: EpisodeFileMetadata.artworkCacheFile(context, episode.uuid).takeIf(File::exists) ?: episode.podcastArtworkUrl(context)
    } else {
        episode.podcastArtworkUrl(context)
    }
```


Also removes the `episodesInfoCacheReloadPolicy` Feature Flag which has been in production since December.

## To test

* Enable the Episode Artwork setting
* Play each of these episodes and ensure episode artwork appears in the player:
  * https://pca.st/episode/383f0386-f506-482d-b245-a6c73675be22
  * https://pca.st/episode/a45b9424-b448-40f6-b7ca-9a778e17e61b

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
