### PR TITLE
Set Locale to POSIX and TimeZone to GMT for search tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.7
 -----
+- Fix podcast search in non-standard locales [#4019](https://github.com/Automattic/pocket-casts-ios/pull/4019)
 - Playlists: Add episode to a playlist from episode details [##3943](https://github.com/Automattic/pocket-casts-ios/pull/3943/) 
 - Refresh Now Playing info when Bluetooth device connects [#3964](https://github.com/Automattic/pocket-casts-ios/pull/3964) 
 - Fix logout issue when refreshing in background while device is locked [#3983](https://github.com/Automattic/pocket-casts-ios/pull/3983) 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/CombinedSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/CombinedSearchTask.swift
@@ -55,6 +55,8 @@ public class CombinedSearchTask {
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
 

--- a/Modules/Server/Sources/PocketCastsServer/Public/Search/EpisodeSearchTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Search/EpisodeSearchTask.swift
@@ -64,6 +64,8 @@ public class EpisodeSearchTask {
 
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
 


### PR DESCRIPTION
## Description

Fixes search failing when the phone region is set to UK and 24-hour time is off by explicitly setting the locale to `en_US_POSIX` and timezone to GMT for the `DateFormatter` used in JSON decoding.

Fixes: [PCIOS-535](https://linear.app/a8c/issue/PCIOS-535/search-fails-when-phone-region-is-set-to-uk-and-24-hour-time-is-off)

## Changes

- Added `locale` set to `en_US_POSIX` for `DateFormatter` in `CombinedSearchTask.swift`
- Added `timeZone` set to GMT (0 seconds offset) for `DateFormatter` in `CombinedSearchTask.swift`
- Added the same `locale` and `timeZone` settings in `EpisodeSearchTask.swift`

## Why

When parsing fixed-format dates (like ISO 8601), Apple recommends using `en_US_POSIX` locale to ensure consistent parsing regardless of the user's device locale settings. Without this, devices with non-Gregorian calendars or unusual locale configurations could fail to parse the date strings correctly.

The specific issue occurred because the UK region with 12-hour time enabled causes the system to expect AM/PM in date formats, which conflicts with the `HH` (24-hour) format specifier.

Setting the timezone to GMT ensures the date is interpreted in UTC as intended by the `'Z'` suffix in the date format.

| Before | After |
|--|--|
| <img width="603" height="1311" alt="IMG_5103" src="https://github.com/user-attachments/assets/ef992066-041d-491c-8c83-1539aca213fa" /> | <img width="603" height="1311" alt="IMG_5104" src="https://github.com/user-attachments/assets/215bbeb4-d481-4386-8e56-9f702bb51782" /> |

## Testing

- Search for podcasts/episodes in Discover on a device with Region set to UK and 24-Hour Time disabled
- Verify search results appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)