### PR TITLE
Multi-select actions menu and icon size

### DIFF
--- a/podcasts/MultiSelectActionController.swift
+++ b/podcasts/MultiSelectActionController.swift
@@ -295,7 +295,7 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
     }
 
     var fittingHeight: CGFloat {
-        guard self.view != nil else {
+        guard isViewLoaded else {
             return 0
         }
         actionsTable.layoutIfNeeded()

--- a/podcasts/MultiSelectActionController.swift
+++ b/podcasts/MultiSelectActionController.swift
@@ -293,4 +293,12 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
             orderedActions.append(.addToPlaylist)
         }
     }
+
+    var fittingHeight: CGFloat {
+        guard self.view != nil else {
+            return 0
+        }
+        actionsTable.layoutIfNeeded()
+        return actionsTable.contentSize.height + headerView.bounds.height
+    }
 }

--- a/podcasts/MultiSelectFooterView.swift
+++ b/podcasts/MultiSelectFooterView.swift
@@ -164,8 +164,8 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
         if let sheetController = multiSelectActionController.sheetPresentationController {
             sheetController.detents = [.custom(resolver: { context in
                 let maxHeight = context.maximumDetentValue * 0.9
-                let minHeight = max(context.maximumDetentValue * 0.25, multiSelectActionController.fittingHeight)
-                return min(minHeight, maxHeight)
+                let desiredHeight = max(context.maximumDetentValue * 0.25, multiSelectActionController.fittingHeight)
+                return min(desiredHeight, maxHeight)
             }), ]
 
             // The Multiselect Actions VC implements its own grabber UI.

--- a/podcasts/MultiSelectFooterView.swift
+++ b/podcasts/MultiSelectFooterView.swift
@@ -40,6 +40,7 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
             leftActionButton.setImage(UIImage(named: "more"), for: .normal)
             leftActionButton.tintColor = ThemeColor.primaryInteractive02()
             leftActionButton.layer.cornerRadius = 18
+            ensureButtonImage(leftActionButton, size: 24)
         }
     }
 
@@ -49,7 +50,22 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
             rightActionButton.setImage(UIImage(named: "more"), for: .normal)
             rightActionButton.tintColor = ThemeColor.primaryInteractive02()
             rightActionButton.layer.cornerRadius = 18
+            ensureButtonImage(rightActionButton, size: 24)
         }
+    }
+
+    private func ensureButtonImage(_ button: UIButton, size: CGFloat) {
+        guard let imageView = button.imageView else {
+            return
+        }
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate(
+            [
+                imageView.widthAnchor.constraint(equalToConstant: 24),
+                imageView.heightAnchor.constraint(equalToConstant: 24),
+            ]
+        )
+        imageView.contentMode = .scaleAspectFit
     }
 
     @IBOutlet var containerView: UIView! {

--- a/podcasts/MultiSelectFooterView.swift
+++ b/podcasts/MultiSelectFooterView.swift
@@ -61,8 +61,8 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate(
             [
-                imageView.widthAnchor.constraint(equalToConstant: 24),
-                imageView.heightAnchor.constraint(equalToConstant: 24),
+                imageView.widthAnchor.constraint(equalToConstant: size),
+                imageView.heightAnchor.constraint(equalToConstant: size),
             ]
         )
         imageView.contentMode = .scaleAspectFit

--- a/podcasts/MultiSelectFooterView.swift
+++ b/podcasts/MultiSelectFooterView.swift
@@ -142,18 +142,15 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
             setActionsFunc: setActionsFunc,
             themeOverride: themeOverride
         )
-
+        multiSelectActionController.loadViewIfNeeded()
+        multiSelectActionController.view.setNeedsLayout()
         let presentingVC = delegate.multiSelectPresentingViewController()
         if let sheetController = multiSelectActionController.sheetPresentationController {
-            // Create a custom detent height of 45% of the hosting VC as the medium detent
-            // is too large.
-            let hostingControllerHeight = presentingVC.view.bounds.height
-            let sheetDetentHeight = hostingControllerHeight * 0.45
-            if actions.count < 7 {
-                sheetController.detents = [.custom(resolver: { _ in sheetDetentHeight }), ]
-            } else {
-                sheetController.detents = [.medium()]
-            }
+            sheetController.detents = [.custom(resolver: { context in
+                let maxHeight = context.maximumDetentValue * 0.9
+                let minHeight = max(context.maximumDetentValue * 0.25, multiSelectActionController.fittingHeight)
+                return min(minHeight, maxHeight)
+            }), ]
 
             // The Multiselect Actions VC implements its own grabber UI.
             sheetController.prefersGrabberVisible = false


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-545 <!-- issue number, if applicable -->
Fixes PCIOS-544 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR ensures that the multi-selection more menu fits the size of the actions and the icons in the multi-select toolbar have an ensured size of 24x24pt

| 1 | 2 | 3 |
| - | - | - |
|  <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-26 at 12 28 37" src="https://github.com/user-attachments/assets/ca720099-4d2e-4e4c-b194-8708d581d381" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-26 at 12 28 48" src="https://github.com/user-attachments/assets/98c57a77-2136-4c27-95a9-ba687fc28df6" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-02-26 at 12 28 43" src="https://github.com/user-attachments/assets/6e3ce104-8001-4235-a5b5-d6bb70201860" /> |

## To test

1. Start the app
2. Open a Podcast  view
3. Long press on an episode
4. See if the multi-select bar shows
5. Tap on more
6. Check that the menu fits the screen depending on the numbers of actions not letting a lot of empty space bellow it
7. Tap on Edit
8. Add the Add to Playlist to the multi-select action bar
9. Check that the icon fits well in the bar and other icons also have the correct size

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
