### PR TITLE
[Dynamic type] Downloads header and banner

### DIFF
--- a/podcasts/DateHeadingView.swift
+++ b/podcasts/DateHeadingView.swift
@@ -23,12 +23,13 @@ class DateHeadingView: UIView {
         topDivider.translatesAutoresizingMaskIntoConstraints = false
         addSubview(topDivider)
 
-        titleLabel = ThemeableLabel(frame: CGRect(x: 20, y: 10, width: bounds.width - 20, height: 30))
-        titleLabel?.font = UIFont.systemFont(ofSize: 22, weight: UIFont.Weight.bold)
+        titleLabel = ThemeableLabel()
         titleLabel?.textAlignment = .natural
         titleLabel?.text = title
-        titleLabel?.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel?.font = UIFont.font(ofSize: 22, weight: UIFont.Weight.bold, scalingWith: .largeTitle)
+        titleLabel?.adjustsFontForContentSizeCategory = true
         addSubview(titleLabel!)
+        titleLabel?.translatesAutoresizingMaskIntoConstraints = false
 
         // setup constraints so that they are all in the right place
         NSLayoutConstraint.activate([
@@ -38,7 +39,9 @@ class DateHeadingView: UIView {
             topDivider.topAnchor.constraint(equalTo: topAnchor),
 
             titleLabel!.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            bottomAnchor.constraint(equalTo: titleLabel!.bottomAnchor, constant: 10)
+            titleLabel!.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+            titleLabel!.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0),
+            titleLabel!.topAnchor.constraint(equalTo: topAnchor, constant: 0)
         ])
 
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)

--- a/podcasts/DownloadsViewController+Table.swift
+++ b/podcasts/DownloadsViewController+Table.swift
@@ -148,12 +148,16 @@ extension DownloadsViewController: UITableViewDelegate, UITableViewDataSource {
         return sectionHeader
     }
 
-    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        cellHeights[indexPath] = cell.frame.size.height
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        cellHeights[indexPath] ?? 80
+        80
     }
 
     // MARK: - Misc

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -11,7 +11,6 @@ class DownloadsViewController: PCViewController {
             refreshContentUnavailable()
         }
     }
-    var cellHeights: [IndexPath: CGFloat] = [:]
 
     private let episodesDataManager = EpisodesDataManager()
 
@@ -25,9 +24,7 @@ class DownloadsViewController: PCViewController {
     @IBOutlet var downloadsTable: UITableView! {
         didSet {
             registerTableCells()
-            registerLongPress()
-            downloadsTable.estimatedRowHeight = 80.0
-            downloadsTable.rowHeight = UITableView.automaticDimension
+            registerLongPress()            
             downloadsTable.allowsMultipleSelectionDuringEditing = true
         }
     }

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -24,7 +24,7 @@ class DownloadsViewController: PCViewController {
     @IBOutlet var downloadsTable: UITableView! {
         didSet {
             registerTableCells()
-            registerLongPress()            
+            registerLongPress()
             downloadsTable.allowsMultipleSelectionDuringEditing = true
         }
     }
@@ -112,13 +112,18 @@ class DownloadsViewController: PCViewController {
         removeAllCustomObservers()
     }
 
+    private var firstShowOfBanner = true
+
     private func showManageDownloadsBanner() {
         guard ManageDownloadsCoordinator.shouldShowBanner
         else {
             downloadsTable.tableHeaderView = nil
             return
         }
-        Analytics.track(.freeUpSpaceBannerShown)
+        if firstShowOfBanner {
+            firstShowOfBanner = false
+            Analytics.track(.freeUpSpaceBannerShown)
+        }
         downloadsTable.tableHeaderView = makeBannerView()
     }
 

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -119,10 +119,10 @@ class DownloadsViewController: PCViewController {
             return
         }
         Analytics.track(.freeUpSpaceBannerShown)
-        downloadsTable.tableHeaderView = bannerView
+        downloadsTable.tableHeaderView = makeBannerView()
     }
 
-    private lazy var bannerView: UIView = {
+    private func makeBannerView() -> UIView {
         let model = ManageDownloadsModel(initialSize: "",
                                          onManageTap: { [weak self] in
             Analytics.track(.freeUpSpaceManageDownloadsTapped, properties: ["source": "downloads"])
@@ -135,7 +135,11 @@ class DownloadsViewController: PCViewController {
         })
         let banner = ManageDownloadsBannerView(dataModel: model).themedUIView
         banner.translatesAutoresizingMaskIntoConstraints = false
-        let wrapperView = UIView(frame: CGRect(x: 116, y: 0, width: 200, height: 132))
+        let largeCategories = Set<UIContentSizeCategory>([.accessibilityExtraLarge, .accessibilityExtraExtraLarge, .accessibilityExtraExtraExtraLarge])
+        let largeSize = largeCategories.contains(traitCollection.preferredContentSizeCategory)
+        let metrics = UIFontMetrics(forTextStyle: .callout)
+        let bannerHeight = metrics.scaledValue(for: largeSize ? 200 : 132)
+        let wrapperView = UIView(frame: CGRect(x: 116, y: 0, width: 200, height: bannerHeight))
         wrapperView.addSubview(banner)
         NSLayoutConstraint.activate([
             banner.leadingAnchor.constraint(equalTo: wrapperView.leadingAnchor, constant: 16),
@@ -144,7 +148,7 @@ class DownloadsViewController: PCViewController {
             banner.bottomAnchor.constraint(equalTo: wrapperView.bottomAnchor, constant: 0),
             ])
         return wrapperView
-    }()
+    }
 
     // MARK: - App Backgrounding
 
@@ -322,6 +326,17 @@ class DownloadsViewController: PCViewController {
         }
 
         return downloadingList
+    }
+
+    private func updateSize() {
+        showManageDownloadsBanner()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
+            updateSize()
+        }
     }
 }
 

--- a/podcasts/ManageDownloadsBannerView.swift
+++ b/podcasts/ManageDownloadsBannerView.swift
@@ -42,20 +42,24 @@ struct ManageDownloadsBannerView: View {
                 .foregroundColor(theme.primaryText01)
             VStack(alignment: .leading, spacing: 8) {
                 Text(L10n.manageDownloadsTitle)
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.callout).fontWeight(.medium)
                     .foregroundColor(theme.primaryText01)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .multilineTextAlignment(.leading)
                 Text(L10n.manageDownloadsDetail(dataModel.sizeOccupied))
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true)
                     .multilineTextAlignment(.leading)
-                    .font(.system(size: 14))
+                    .font(.footnote)
                     .foregroundColor(theme.primaryText02)
                 Button() {
                     dataModel.onManageTap?()
                 } label: {
                     Text(L10n.manageDownloadsAction)
-                        .font(.system(size: 14, weight: .medium))
+                        .font(.footnote).fontWeight(.medium)
                         .foregroundColor(theme.primaryText02Selected)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .multilineTextAlignment(.leading)
                 }
             }
             Spacer()


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
The cells were already resizing correctly but the header and banner not so this updates the Downloads section headers and banner to adapt to dynamic type. 

| xs | Default | xxxL | AX5 |
| - | - | - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-26 at 13 48 33" src="https://github.com/user-attachments/assets/67f0fb19-146b-4989-96a4-f8128f28f901" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-26 at 13 48 29" src="https://github.com/user-attachments/assets/bd1fc9d2-892f-482d-b10e-04b6d62c600b" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-26 at 13 48 24" src="https://github.com/user-attachments/assets/3170ca4e-6bda-4cd5-a628-18fbebf8ea4e" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-26 at 13 48 20" src="https://github.com/user-attachments/assets/c458c0a8-970c-408b-b15f-d677a9b21e0f" /> |


## To test

- Start the app
- Open the Profile tab
- Tap on Downloads
- Scroll around to see if the header adapts to dynamic type
- If you want to see the banner force to true the check on `showManageDownloadsBanner` on `DownloadsViewController`

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
