### PR TITLE
Update playlist episode count preview when selecting playlists

### DIFF
--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -271,6 +271,7 @@ extension ManualPlaylistsChooserViewController: UITableViewDelegate, UITableView
                 } else {
                     self.newSelectedPlaylists.remove(playlist.uuid)
                 }
+                tableView.reloadRows(at: [indexPath], with: .none)
             }
             let isSelected = Binding<Bool>(
                 get: { [weak self] in
@@ -287,7 +288,8 @@ extension ManualPlaylistsChooserViewController: UITableViewDelegate, UITableView
                 isLastRow: indexPath.row == manualPlaylists.count - 1,
                 isSelected: isSelected,
                 canBeDisabled: !episodeIsInPlaylist,
-                analyticsSource: analyticsSource
+                analyticsSource: analyticsSource,
+                additionalEpisodesCount: episodes.count
             )
         }
         return cell

--- a/podcasts/PlaylistCell.swift
+++ b/podcasts/PlaylistCell.swift
@@ -64,7 +64,8 @@ class PlaylistCell: ThemeableCell {
         isLastRow: Bool,
         isSelected: Binding<Bool> = .constant(false),
         canBeDisabled: Bool = false,
-        analyticsSource: String? = nil
+        analyticsSource: String? = nil,
+        additionalEpisodesCount: Int = 0
     ) {
         switch cellType {
         case .count, .plain:
@@ -73,12 +74,15 @@ class PlaylistCell: ThemeableCell {
             accessoryType = .none
         }
 
+        let viewModel = PlaylistCellViewModel(
+            playlist: playlist,
+            displayType: cellType
+        )
+        viewModel.additionalEpisodesCount = additionalEpisodesCount
+
         contentConfiguration = UIHostingConfiguration {
             PlaylistCellView(
-                viewModel: PlaylistCellViewModel(
-                    playlist: playlist,
-                    displayType: cellType
-                ),
+                viewModel: viewModel,
                 isSelected: isSelected,
                 canBeDisabled: canBeDisabled,
                 analyticsSource: analyticsSource

--- a/podcasts/PlaylistCellView.swift
+++ b/podcasts/PlaylistCellView.swift
@@ -22,7 +22,8 @@ struct PlaylistCellView: View {
     private var subtitle: String? {
         switch viewModel.displayType {
         case .check:
-            return L10n.playlistEpisodesCount(viewModel.episodesCount)
+            let displayCount = isSelected ? viewModel.episodesCount + viewModel.additionalEpisodesCount : viewModel.episodesCount
+            return L10n.playlistEpisodesCount(displayCount)
         case .toggle, .count, .plain:
             if viewModel.isSmartPlaylist() {
                 return L10n.smartPlaylist

--- a/podcasts/PlaylistCellViewModel.swift
+++ b/podcasts/PlaylistCellViewModel.swift
@@ -16,6 +16,7 @@ class PlaylistCellViewModel: ObservableObject {
 
     @Published var episodesCount: Int = 0
     @Published var images: [PlaylistArtworkView.ImageItem] = []
+    var additionalEpisodesCount: Int = 0
 
     var isBelowEpisodeLimit: Bool {
 #if DEBUG


### PR DESCRIPTION
Show the updated episode count immediately when toggling a playlist checkbox in the "Add to Playlist" view, reflecting the potential addition before confirming with Done.

Made-with: Claude Code

Fixes PCIOS-548 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

<!-- Please include step by step instructions on how to test this PR. -->
1. Add a single episode or bulk episodes to a Playlist 
2. Check the playlist checkbox
3. see that the episode count is updated to the correct number in the playlist upon checking the box

https://github.com/user-attachments/assets/1dde5acd-ec7f-44cf-b041-f70bb3c4f4ea



## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
