### PR TITLE
Identify bulk-added episodes already in playlists

### DIFF
--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -143,7 +143,17 @@ class ManualPlaylistsChooserViewController: PCViewController {
             let uuids = dataManager.manualPlaylistUUIDs(for: episode.uuid)
             initialSelectedPlaylists = Set(uuids)
         } else {
-            initialSelectedPlaylists = []
+            // For bulk episodes, find playlists that contain ALL selected episodes
+            var playlistsContainingAllEpisodes: Set<String> = []
+            for playlist in manualPlaylists {
+                let allEpisodesInPlaylist = episodes.allSatisfy { episode in
+                    dataManager.manualPlaylistUUIDs(for: episode.uuid).contains(playlist.uuid)
+                }
+                if allEpisodesInPlaylist {
+                    playlistsContainingAllEpisodes.insert(playlist.uuid)
+                }
+            }
+            initialSelectedPlaylists = playlistsContainingAllEpisodes
         }
         newSelectedPlaylists = initialSelectedPlaylists
     }


### PR DESCRIPTION
When adding multiple episodes to a playlist, pre-select playlists that already contain all of the selected episodes.

Made-with: Claude Code

Fixes PCIOS-546 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

<!-- Please include step by step instructions on how to test this PR. -->
1. Add multiple episodes to a manual playlist 
2. Go back to the podcast's episode list
3. Enter multi-select mode and select those same episodes
4. Tap the overflow menu and select "Add to Playlist"
Expected: The playlist containing all episodes should have its checkbox pre-selected

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
