### PR TITLE
Add "Add to Playlist" option to Up Next multi-select menu

### DIFF
--- a/podcasts/Enumerations.swift
+++ b/podcasts/Enumerations.swift
@@ -640,7 +640,8 @@ enum MultiSelectAction: Int32, CaseIterable, AnalyticsDescribable {
             return episodes.count == 1 && episodes.allSatisfy({ $0 is Episode })
 
         case .addToPlaylist:
-            return episodes.allSatisfy({ $0 is Episode })
+            // Always show the option; toast will be shown if files are selected
+            return true
 
         default:
             return true

--- a/podcasts/MultiSelectHelper.swift
+++ b/podcasts/MultiSelectHelper.swift
@@ -347,7 +347,16 @@ class MultiSelectHelper {
     }
 
     private class func addToPlaylist(actionDelegate: MultiSelectActionDelegate) {
-        let episodes = actionDelegate.multiSelectedBaseEpisodes().compactMap { $0 as? Episode }
+        let allSelected = actionDelegate.multiSelectedBaseEpisodes()
+        let episodes = allSelected.compactMap { $0 as? Episode }
+
+        // Check if any files (user episodes) are in the selection
+        let containsFiles = allSelected.contains { $0 is UserEpisode }
+        if containsFiles {
+            Toast.show(L10n.playlistManualAddFilesNotSupportedToast)
+            return
+        }
+
         guard !episodes.isEmpty else { return }
 
         let maxPlaylistItems = Constants.Limits.maxFilterItems

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -912,13 +912,15 @@ class Settings: NSObject {
 
     private static let upNextMultiSelectActionsKey = "UpNextMultiSelectActions"
     class func upNextMultiSelectActions() -> [MultiSelectAction] {
+        let defaultActions: [MultiSelectAction] = [.moveToTop, .moveToBottom, .removeFromUpNext, .download, .markAsPlayed, .archive, .addToPlaylist]
         guard let savedInts = UserDefaults.standard.object(forKey: Settings.upNextMultiSelectActionsKey) as? [Int32] else {
-            return [.moveToTop, .moveToBottom, .removeFromUpNext, .download, .markAsPlayed, .archive]
+            return defaultActions
         }
 
         let actions = savedInts.compactMap { MultiSelectAction(rawValue: $0) }
 
-        return actions
+        // Make sure new items are shown
+        return actions + defaultActions.filter { !actions.contains($0) }
     }
 
     class func updateUpNextMultiSelectActions(_ actions: [MultiSelectAction]) {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2471,6 +2471,8 @@ internal enum L10n {
   internal static var playlistManualAddEpisodes: String { return L10n.tr("Localizable", "playlist_manual_add_episodes", fallback: "Add episodes") }
   /// Toast message when adding episodes to a playlist that would exceed the 1000 episode limit
   internal static var playlistManualAddEpisodesAlmostFullToast: String { return L10n.tr("Localizable", "playlist_manual_add_episodes_almost_full_toast", fallback: "Playlist is almost full. Try adding fewer episodes.") }
+  /// Toast message when trying to add files (user episodes) to a playlist
+  internal static var playlistManualAddFilesNotSupportedToast: String { return L10n.tr("Localizable", "playlist_manual_add_files_not_supported_toast", fallback: "Playlists can only contain podcast episodes.") }
   /// Toast message when trying to add more than the max number of episodes to a playlist at once, or creating a new playlist with more than the max. '%1$@' is the max episode count, localized for the user's locale.
   internal static func playlistManualAddTooManyEpisodesToast(_ p1: Any) -> String {
     return L10n.tr("Localizable", "playlist_manual_add_too_many_episodes_toast", String(describing: p1), fallback: "Playlists can only contain up to %1$@ episodes.")

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5627,6 +5627,9 @@
 /* Toast message when adding episodes to a playlist that would exceed the 1000 episode limit */
 "playlist_manual_add_episodes_almost_full_toast" = "Playlist is almost full. Try adding fewer episodes.";
 
+/* Toast message when trying to add files (user episodes) to a playlist */
+"playlist_manual_add_files_not_supported_toast" = "Playlists can only contain podcast episodes.";
+
 /* Text of the placeholder used in the manual playlist detail screen when one episode is archived. */
 "playlist_manual_archived_episode_placeholder" = "Your episode in this playlist has been archived";
 


### PR DESCRIPTION
- Include addToPlaylist in Up Next multi-select actions by default
- Auto-add the option for existing users who saved their action list
- Show toast when selection includes files (user episodes) since playlists can only contain podcast episodes

Made-with: Claude Code

https://github.com/user-attachments/assets/d767ef49-12ac-4eb6-806f-8f5eb1a6a61e



<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

<!-- Please include step by step instructions on how to test this PR. -->
Add podcast episodes to playlist from Up Next
1. Open Up Next
2. Enter multi-select mode
3. Tap the overflow menu and select "Add to Playlist"
4. Expected: The playlist chooser opens, allowing you to add episodes to a playlist

Toast shown when selection includes files
1. Open Up Next containing both podcast episodes and files
2. Enter multi-select mode
3. Select at least one file (user episode) along with podcast episodes
4. Tap the overflow menu and select "Add to Playlist"
5. Expected: Toast appears saying "Playlists can only contain podcast episodes."
6. Expected: The playlist chooser does NOT open



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
