### PR TITLE
PCIOS-461: Show full "Society & Culture" category on podcast page

### DIFF
--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -742,8 +742,8 @@ internal enum L10n {
   internal static var discoverBrowseByCategoryScienceAndMedicine: String { return L10n.tr("Localizable", "discover_browse_by_category_science_and_medicine", fallback: "Science & Medicine") }
   /// Title for the podcast category Society
   internal static var discoverBrowseByCategorySociety: String { return L10n.tr("Localizable", "discover_browse_by_category_society", fallback: "Society") }
-  /// Abbreviation for the podcast category Society & Culture, using only "Culture"
-  internal static var discoverBrowseByCategorySocietyAndCulture: String { return L10n.tr("Localizable", "discover_browse_by_category_society_and_culture", fallback: "Culture") }
+  /// Title for the podcast category Society & Culture
+  internal static var discoverBrowseByCategorySocietyAndCulture: String { return L10n.tr("Localizable", "discover_browse_by_category_society_and_culture", fallback: "Society & Culture") }
   /// Abbreviation for the podcast category Religion & Spirituality
   internal static var discoverBrowseByCategorySpirituality: String { return L10n.tr("Localizable", "discover_browse_by_category_spirituality", fallback: "Spirituality") }
   /// Title for the podcast category Sports

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -541,9 +541,6 @@
 /* Title for the podcast category Society & Culture */
 "discover_browse_by_category_society_and_culture" = "Society & Culture";
 
-/* Abbreviation for the podcast category Society & Culture, using only "Culture" */
-"discover_browse_by_category_society_and_culture" = "Culture";
-
 /* Title for the podcast category Sports */
 "discover_browse_by_category_sports" = "Sports";
 


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-461/ios-the-podcast-page-doesnt-show-society-and-culture-only-culture

## Summary
- The podcast detail page was showing "Culture" instead of "Society & Culture" for the category label
- Root cause: `Localizable.strings` had a duplicate key `discover_browse_by_category_society_and_culture` — the second entry (value "Culture") overwrote the first (value "Society & Culture")

## Changes
- Removed the duplicate/abbreviation entry from `en.lproj/Localizable.strings` that was overwriting the correct "Society & Culture" value
- Updated the SwiftGen fallback in `Strings+Generated.swift` from "Culture" to "Society & Culture"

## Testing
- Build succeeds (`make build`)
- All 269 tests pass (`make test`)
- To verify manually: Discover → All Categories → Society & Culture → tap a podcast — the category label should now show "Society & Culture" instead of just "Culture"

---
🤖 This PR was created autonomously by linear-solver.