### PR TITLE
Streaming player - Cancel all requests when failing download

### DIFF
--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -367,11 +367,23 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     private func downloadFailed(with error: Error) {
         FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: Download failed with error: \(error)")
         invalidateAndCancelSession(error: error)
+        cancelPendingRequests(with: error)
         let contentType = self.response?.mimeType
         callbackQueue.async { [weak self] in
             guard let self else { return }
             self.callback?(.failed(error), contentType, 0, 0)
         }
+    }
+
+    private func cancelPendingRequests(with error: Error) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        pendingRequests.forEach {
+            $0.finishLoading(with: error)
+        }
+
+        pendingRequests.removeAll()
     }
 
     @objc private func handleAppWillTerminate() {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-551 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates our Resource Loader to cancel all pending request with an error when the download fails.

## To test

1. Start the app
2. Play an episode
3. See if plays correctly
4. Play another episode
5. Break off the internet connection
6. Check if it stops correctly
7. Start the internet connection again
8. Check if you can play the episode again

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
