### PR TITLE
PCIOS-462: Remove shadow on nav bar when scrolling and reduce padding to 16px

### DIFF
--- a/podcasts/Categories/CategoriesModalPicker.swift
+++ b/podcasts/Categories/CategoriesModalPicker.swift
@@ -13,11 +13,11 @@ struct CategoriesModalPicker: View {
 
     private enum Constants {
         enum Padding {
-            static let title = EdgeInsets(top: 26, leading: 20, bottom: 4, trailing: 20)
-            static let cell = EdgeInsets(top: 25, leading: 20, bottom: 25, trailing: 20)
+            static let title = EdgeInsets(top: 26, leading: 16, bottom: 4, trailing: 16)
+            static let cell = EdgeInsets(top: 25, leading: 16, bottom: 25, trailing: 16)
         }
         static let imageSize: CGFloat = 24
-        static let cellSpacing: CGFloat = 20
+        static let cellSpacing: CGFloat = 16
     }
 
     // MARK: Colors
@@ -57,6 +57,8 @@ struct CategoriesModalPicker: View {
                 }
             }
             .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(background)
         }
         .background(background)
     }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-462/ui-remove-shadow-on-nav-bar-when-scrolling-and-reduce-padding-to-16px

## Summary
- Removes the scroll-triggered shadow in the categories modal picker by adding `.scrollContentBackground(.hidden)` to the List view
- Reduces padding and spacing values from 20px to 16px in the categories modal picker

## Changes
- `CategoriesModalPicker.swift`: Changed title padding from `leading: 20, trailing: 20` to `leading: 16, trailing: 16`
- `CategoriesModalPicker.swift`: Changed cell padding from `leading: 20, trailing: 20` to `leading: 16, trailing: 16`
- `CategoriesModalPicker.swift`: Changed `cellSpacing` from `20` to `16`
- `CategoriesModalPicker.swift`: Added `.scrollContentBackground(.hidden)` to the List to remove the shadow that appears when scrolling
- `CategoriesModalPicker.swift`: Added `.background(background)` to the List to maintain the correct background color

## Testing
- Open Discover tab → tap "All Categories" pill → verify no shadow appears at top when scrolling the category list
- Verify padding is visually tighter (16px instead of 20px)

---
🤖 This PR was created autonomously by linear-solver.