### PR TITLE
PCIOS-541: Fix episode artwork not loading due to cache key mismatch

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -23,8 +23,7 @@ public actor ShowInfoDataRetriever {
         useCacheOnly: Bool = false
     ) async throws -> String? {
         if useCacheOnly {
-            let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
-            let request = URLRequest(url: url)
+            let request = baseRequest(for: podcastUuid)
 
             if let cachedResponse = cache.cachedResponse(for: request),
                 let metadata = extractMetadata(for: episodeUuid, from: cachedResponse.data) {
@@ -62,12 +61,11 @@ public actor ShowInfoDataRetriever {
             return try await task.value
         }
 
-        let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
-        let cachePolicy: URLRequest.CachePolicy = .reloadRevalidatingCacheData
-        var request = URLRequest(url: url, cachePolicy: cachePolicy)
-        request.addLocalizationHeaders()
+        let cacheKey = baseRequest(for: podcastUuid)
+        var request = cacheKey
+        request.cachePolicy = .reloadRevalidatingCacheData
 
-        if let cachedResponse = cache.cachedResponse(for: URLRequest(url: url)) {
+        if let cachedResponse = cache.cachedResponse(for: cacheKey) {
             if let etag = cachedResponse.response.etag {
                 request.setValue(etag, forHTTPHeaderField: ServerConstants.HttpHeaders.ifNoneMatch)
             }
@@ -79,7 +77,7 @@ public actor ShowInfoDataRetriever {
 
         FileLog.shared.addMessage("Show Info: requesting info for podcast \(podcastUuid)")
 
-        let task = Task<Data, Error> { [weak self, request] in
+        let task = Task<Data, Error> { [weak self, request, cacheKey] in
             guard let self else { throw TaskError.nilSelf }
 
             do {
@@ -87,12 +85,12 @@ public actor ShowInfoDataRetriever {
 
                 if response.extractStatusCode() == 200 {
                     let responseToCache = CachedURLResponse(response: response, data: data)
-                    cache.storeCachedResponse(responseToCache, for: request)
+                    cache.storeCachedResponse(responseToCache, for: cacheKey)
                     FileLog.shared.addMessage("Show Info: request succeeded for podcast \(podcastUuid).")
-                } else if let data = cache.cachedResponse(for: request)?.data {
+                } else if let cachedData = cache.cachedResponse(for: cacheKey)?.data {
                     await setDataRequestMapToNil(for: podcastUuid)
-                    FileLog.shared.addMessage("Show Info: request failed for podcast \(podcastUuid). Returning cached data")
-                    return data
+                    FileLog.shared.addMessage("Show Info: returning cached data for podcast \(podcastUuid) (status \(response.extractStatusCode())).")
+                    return cachedData
                 }
 
                 await setDataRequestMapToNil(for: podcastUuid)
@@ -106,6 +104,13 @@ public actor ShowInfoDataRetriever {
         dataRequestMap[podcastUuid] = task
 
         return try await task.value
+    }
+
+    private func baseRequest(for podcastUuid: String) -> URLRequest {
+        let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
+        var request = URLRequest(url: url)
+        request.addLocalizationHeaders()
+        return request
     }
 
     private func setDataRequestMapToNil(for podcastUuid: String) {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-541/episode-artwork-isnt-loaded-for-some-episodes-on-ios

## Summary
- Episode artwork from Show Notes wasn't loading for some episodes due to a `URLCache` key mismatch in `ShowInfoDataRetriever`
- Cache responses were stored with localization headers (`X-UserRegion`, `X-AppLanguage`) but looked up without them, so `URLCache` never matched

## Changes
- Extracted a `baseRequest(for:)` helper in `ShowInfoDataRetriever` that builds a consistent `URLRequest` with localization headers
- Used this consistent request for all cache operations: storage (on 200), lookup (for ETag/Last-Modified headers), and the cache-only fallback path
- This fixes three related issues:
  1. **Cache-only fallback** (offline/timeout): previously always returned `nil` because the lookup request lacked headers
  2. **ETag/Last-Modified conditional requests**: never sent because the cache lookup for previous response headers used a different request key
  3. **304 Not Modified handling**: cache lookup on non-200 responses also missed due to the same key mismatch

## Testing
- Verified `PocketCastsServerTests` pass (33/33 tests)
- Ran `make format` — no changes needed
- Manual verification: the `baseRequest(for:)` method produces the same URL + localization headers used for `storeCachedResponse`, ensuring `URLCache` key consistency across all code paths

---
🤖 This PR was created autonomously by linear-solver.