### PR TITLE
Add cross-platform skill for searching across our repos

### DIFF
--- a/.agents/skills/cross-platform/SKILL.md
+++ b/.agents/skills/cross-platform/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: cross-platform
+description: "Cross-platform codebase exploration for Pocket Casts. Use when asked about Web, iOS, or Server implementation of a feature, or when comparing implementations across platforms."
+---
+
+# Cross-Platform Codebase Exploration
+
+## Repository Locations
+
+Other platform repos are siblings of the root Android repo (not worktrees):
+
+| Platform | Relative to project root | Trunk Branch |
+|----------|--------------------------|--------------|
+| Web | `../pocket-casts-webplayer/` | `develop` |
+| Server | `../pocket-casts-android/` | `main` |
+| iOS | `../pocket-casts-ios/` | `trunk` |
+
+## Finding Repos (Worktree-Safe)
+
+If working in a worktree, first find the root iOS repo:
+
+```bash
+# Get root repo path (works in both root and worktree)
+# --porcelain output is stable for scripting; first entry is always the main worktree
+ROOT=$(git worktree list --porcelain | head -n 1 | awk '{print $2}')
+
+# Platform repos are siblings of the root
+WEB_REPO="$ROOT/../pocket-casts-web"
+IOS_REPO="$ROOT/../pocket-casts-ios"
+```
+
+## Before Exploring
+
+Each repository contains a `CLAUDE.md` at its root. **Read it first** to understand architecture and conventions.
+
+## Branch Sync Procedure
+
+Before exploring code:
+
+1. **Navigate to repo** and check current state:
+   ```bash
+   cd "$WEB_REPO"  # or $ANDROID_REPO or $SERVER_REPO
+   git status --short
+   git branch --show-current
+   ```
+
+2. **If uncommitted/unstaged changes exist** → **ask the user**: stash them, discard, or abort?
+
+3. **Determine target branch**:
+   - If user specified a PR → check out that PR's branch
+   - If on `develop` (Web) `main` (Android) or `trunk` (iOS) → pull latest
+   - If on a different branch → **ask the user**: switch to main/trunk, or stay on current branch?
+
+4. **Sync the branch**:
+   ```bash
+   git checkout <branch>  # if switching
+   git pull
+   ```
+
+## What to Focus On
+
+When comparing or describing implementations:
+
+- Logic flow and feature architecture
+- State transitions
+- DTOs / data models
+- API usage, endpoints, request/response structures
+- Feature flags and configuration patterns
+- Cross-platform differences and similarities
+
+Avoid language-specific syntax unless necessary to explain behavior.
+
+## Example Queries
+
+- "How does iOS handle Up Next syncing?"
+- "Compare podcast following between Android and Web"
+- "What endpoints does the Server use for Up Next sync?"
+- "How are feature flags structured on iOS vs Android?"

--- a/.agents/skills/cross-platform/SKILL.md
+++ b/.agents/skills/cross-platform/SKILL.md
@@ -1,19 +1,18 @@
 ---
 name: cross-platform
-description: "Cross-platform codebase exploration for Pocket Casts. Use when asked about Web, iOS, or Server implementation of a feature, or when comparing implementations across platforms."
+description: "Cross-platform codebase exploration for Pocket Casts. Use when asked about Web, iOS, or Android implementation of a feature, or when comparing implementations across platforms."
 ---
 
 # Cross-Platform Codebase Exploration
 
 ## Repository Locations
 
-Other platform repos are siblings of the root Android repo (not worktrees):
+Other platform repos are siblings of the root iOS repo (not worktrees):
 
 | Platform | Relative to project root | Trunk Branch |
 |----------|--------------------------|--------------|
 | Web | `../pocket-casts-webplayer/` | `develop` |
-| Server | `../pocket-casts-android/` | `main` |
-| iOS | `../pocket-casts-ios/` | `trunk` |
+| Android | `../pocket-casts-android/` | `main` |
 
 ## Finding Repos (Worktree-Safe)
 
@@ -25,8 +24,8 @@ If working in a worktree, first find the root iOS repo:
 ROOT=$(git worktree list --porcelain | head -n 1 | awk '{print $2}')
 
 # Platform repos are siblings of the root
-WEB_REPO="$ROOT/../pocket-casts-web"
-IOS_REPO="$ROOT/../pocket-casts-ios"
+WEB_REPO="$ROOT/../pocket-casts-webplayer"
+ANDROID_REPO="$ROOT/../pocket-casts-android"
 ```
 
 ## Before Exploring
@@ -39,7 +38,7 @@ Before exploring code:
 
 1. **Navigate to repo** and check current state:
    ```bash
-   cd "$WEB_REPO"  # or $ANDROID_REPO or $SERVER_REPO
+   cd "$WEB_REPO"  # or $ANDROID_REPO
    git status --short
    git branch --show-current
    ```


### PR DESCRIPTION
Adds a cross-platform skill allowing agents to explore Pocket Casts codebases across iOS, Web, and Server platforms.

##  What it does

  - Repository Discovery: Provides worktree-safe commands for finding sibling repos (pocket-casts-web, pocket-casts-ios, pocket-casts-android)
  - Branch Sync Procedure: Documents the proper workflow for checking repo state, handling uncommitted changes, and syncing branches before exploration
  - Cross-Platform Focus Areas: Guides exploration toward architecture, state transitions, data models, API usage, and feature flag patterns

## Use Cases

  The skill triggers when users ask questions like:
  - "Compare podcast following between Android and Web"
  - "What endpoints does the Server use for Up Next sync?"
  - "How are feature flags structured on iOS vs Android?"

## To test

This is a documentation/skill file that provides instructions for Claude Code. You will need all of the client repos cloned at the same level as this repo and named the same as their original repository names.

Try: "How is Up Next syncing handled across iOS, Android, and Web?"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
