### PR TITLE
[Dynamic type] Update privacy settings using the Agent skill

### DIFF
--- a/podcasts/PrivacySettings/PrivacySettingsDataSource.swift
+++ b/podcasts/PrivacySettings/PrivacySettingsDataSource.swift
@@ -22,9 +22,7 @@ class PrivacySettingsDataSource: NSObject, UITableViewDataSource {
             cell.style = .primaryUi02
             cell.textLabel?.textColor = ThemeColor.primaryText02()
             cell.textLabel?.text = L10n.settingsCollectInformationAdditionalInformation
-            cell.textLabel?.font = .font(with: .callout)
-            cell.textLabel?.adjustsFontForContentSizeCategory = true
-            cell.textLabel?.numberOfLines = 0
+            configureDynamicTypeCell(cell)
             return cell
         case 1:
             let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
@@ -39,19 +37,21 @@ class PrivacySettingsDataSource: NSObject, UITableViewDataSource {
             cell.imageView?.image = UIImage()
             cell.textLabel?.textColor = ThemeColor.primaryText02()
             cell.textLabel?.text = L10n.settingsAllowCollectionFirstParty
-            cell.textLabel?.font = .font(with: .callout)
-            cell.textLabel?.adjustsFontForContentSizeCategory = true
-            cell.textLabel?.numberOfLines = 0
+            configureDynamicTypeCell(cell)
             return cell
         default:
             let cell = tableView.dequeueReusableCell(withIdentifier: themeableCellId, for: indexPath) as! ThemeableCell
             cell.textLabel?.textColor = ThemeColor.primaryInteractive01()
-            cell.textLabel?.font = .font(with: .callout)
-            cell.textLabel?.adjustsFontForContentSizeCategory = true
-            cell.textLabel?.numberOfLines = 0
             cell.textLabel?.text = L10n.settingsReadPrivacyPolicy
+            configureDynamicTypeCell(cell)
             return cell
         }
+    }
+
+    private func configureDynamicTypeCell(_ cell: ThemeableCell) {
+        cell.textLabel?.font = .font(with: .callout)
+        cell.textLabel?.adjustsFontForContentSizeCategory = true
+        cell.textLabel?.numberOfLines = 0
     }
 
     @objc private func pushToggled(_ sender: UISwitch) {

--- a/podcasts/PrivacySettings/PrivacySettingsDataSource.swift
+++ b/podcasts/PrivacySettings/PrivacySettingsDataSource.swift
@@ -22,7 +22,8 @@ class PrivacySettingsDataSource: NSObject, UITableViewDataSource {
             cell.style = .primaryUi02
             cell.textLabel?.textColor = ThemeColor.primaryText02()
             cell.textLabel?.text = L10n.settingsCollectInformationAdditionalInformation
-            cell.textLabel?.font = .systemFont(ofSize: 16)
+            cell.textLabel?.font = .font(with: .callout)
+            cell.textLabel?.adjustsFontForContentSizeCategory = true
             cell.textLabel?.numberOfLines = 0
             return cell
         case 1:
@@ -38,13 +39,16 @@ class PrivacySettingsDataSource: NSObject, UITableViewDataSource {
             cell.imageView?.image = UIImage()
             cell.textLabel?.textColor = ThemeColor.primaryText02()
             cell.textLabel?.text = L10n.settingsAllowCollectionFirstParty
-            cell.textLabel?.font = .systemFont(ofSize: 16)
+            cell.textLabel?.font = .font(with: .callout)
+            cell.textLabel?.adjustsFontForContentSizeCategory = true
             cell.textLabel?.numberOfLines = 0
             return cell
         default:
             let cell = tableView.dequeueReusableCell(withIdentifier: themeableCellId, for: indexPath) as! ThemeableCell
             cell.textLabel?.textColor = ThemeColor.primaryInteractive01()
-            cell.textLabel?.font = .systemFont(ofSize: 16)
+            cell.textLabel?.font = .font(with: .callout)
+            cell.textLabel?.adjustsFontForContentSizeCategory = true
+            cell.textLabel?.numberOfLines = 0
             cell.textLabel?.text = L10n.settingsReadPrivacyPolicy
             return cell
         }

--- a/podcasts/PrivacySettings/PrivacySettingsViewController.swift
+++ b/podcasts/PrivacySettings/PrivacySettingsViewController.swift
@@ -17,6 +17,7 @@ class PrivacySettingsViewController: PCViewController, UITableViewDelegate {
 
         title = L10n.settingsPrivacy
         settingsTable.rowHeight = UITableView.automaticDimension
+        settingsTable.estimatedRowHeight = 54
         settingsTable.dataSource = dataSource
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Update Privacy settings labels for dynamic type

| xs | Default | xxxL | AX5 |
| - | - | - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-02 at 10 39 39" src="https://github.com/user-attachments/assets/65f9f6dc-a88d-4591-b54a-48ce342ce55e" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-02 at 10 39 35" src="https://github.com/user-attachments/assets/3d1d9ab7-2453-48fd-b2eb-ddcc6b054ae4" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-02 at 10 39 31" src="https://github.com/user-attachments/assets/5a620595-441f-4334-8058-fc8d6e987aa8" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-02 at 10 39 17" src="https://github.com/user-attachments/assets/a0f53344-b798-46e5-ac9f-0d7812b02cd9" /> |

## To test

1. Start the app
2. Open Profile -> Settings -> Privacy
3. Check if the screen adapts correctly for dynamic type

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
