### PR TITLE
Use Tracks Apple 4.2.0

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -13666,8 +13666,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/Automattic-Tracks-iOS";
 			requirement = {
-				branch = "watchos-compatibility";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.2.0;
 			};
 		};
 		468F00CD27CD575C00FFAAAA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "branch" : "watchos-compatibility",
-        "revision" : "059b372446f72ad771a6de8042aa57e48dc976e1"
+        "revision" : "9090a31edfc86a294694238e96382498a1eb493f",
+        "version" : "4.2.0"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Switched Automattic-Tracks-iOS from `watchos-compatibility` branch pin to version-based dependency on 4.2.0
- The watchOS compatibility changes that were on the branch are now included in the official 4.2.0 release
- Also includes: `logID` setter fix

## Test plan

- [ ] CI passes
- [ ] Verify analytics events are tracked correctly in a local build

---

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*