### PR TITLE
Update Up Next limit message

### DIFF
--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2354,7 +2354,7 @@
 "settings_auto_add_limit_subtitle_stop" = "New episodes will stop being added when Up Next reaches %1$@ episodes.";
 
 /* Subtitle explaining the app's behavior when the episode limit is reached and new episodes are added to the top of the Up Next Queue. '%1$@' is a placeholder for the auto add limit. */
-"settings_auto_add_limit_subtitle_top" = "When Up Next reaches %1$@, new episodes auto-added to the top will remove the last episode in the queue. No new episodes will be added to the bottom.";
+"settings_auto_add_limit_subtitle_top" = "When Up Next reaches %1$@, new episodes auto‑added to the top will remove the last episode in the queue. Episodes set to auto‑add to the bottom won’t be added until Up Next is below the limit.";
 
 /* Section header that displays all of the Podcasts that will automatically add new episodes to the Up Next Queue. */
 "settings_auto_add_podcasts" = "Auto-Add Podcasts";
@@ -2801,7 +2801,7 @@
 "settings_up_next_limit" = "Automatically add new episodes to Up Next. New episodes will stop being added when Up Next reaches %1$@.";
 
 /* Informs the user about how the Queue will be adjusted when the episode limit is reached. '%1$@' is a placeholder for the current queue limit. */
-"settings_up_next_limit_add_to_top" = "Automatically add new episodes to Up Next. When Up Next reaches %1$@, new episodes auto-added to the top will remove the last episode in the queue.";
+"settings_up_next_limit_add_to_top" = "Automatically add new episodes to Up Next. When Up Next reaches %1$@, new episodes auto‑added to the top will remove the last episode in the queue. Episodes set to auto‑add to the bottom won’t be added until Up Next is below the limit.";
 
 /* Provides a prompt for the user to toggle on the volume boosting setting. */
 "settings_volume_boost" = "Volume Boost";


### PR DESCRIPTION
Made-with: Cursor

## Description

Update the limit-reached description to clarify what happens for top vs bottom auto-add when Up Next is at the limit.

Fixes # 

## Testing Instructions

1. Go to Profile
2. Go to Settings
3. Go to "Auto Add to Up Next"
4. Select "Only Add to top" in "If Limit Reached"
5. Observe the new copy

## Screenshots or Screencast 

<img width="1440" height="3120" alt="image" src="https://github.com/user-attachments/assets/55890370-0359-4855-8392-b9661bc8f457" />
