### PR TITLE
Updates Automattic Tracks iOS dependency

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -13108,7 +13108,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/Automattic-Tracks-iOS";
 			requirement = {
-				branch = "watchos-compatibility";
+				branch = "fix/uiapplication-watchos-non-public-api";
 				kind = branch;
 			};
 		};

--- a/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "branch" : "watchos-compatibility",
-        "revision" : "059b372446f72ad771a6de8042aa57e48dc976e1"
+        "branch" : "fix/uiapplication-watchos-non-public-api",
+        "revision" : "e56a0df548184272b2d27a8421f10b02a5d252b1"
       }
     },
     {


### PR DESCRIPTION
Fixes PCIOS-

## Summary

Updates the Automattic Tracks iOS dependency from the `watchos-compatibility` branch to `fix/uiapplication-watchos-non-public-api`.

The new branch fixes a watchOS App Store submission issue caused by use of `UIApplication` non-public APIs, which Apple flags during validation.

## To test

1. Build the Watch app target and confirm it compiles without errors
2. Run the app on a paired Apple Watch or simulator and verify analytics tracking still works as expected
3. Confirm no App Store submission warnings related to non-public API usage in the Watch target

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.