### PR TITLE
Update Automattic-Tracks-iOS to 4.2.1

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -13108,8 +13108,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/Automattic-Tracks-iOS";
 			requirement = {
-				branch = "fix/uiapplication-watchos-non-public-api";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.2.1;
 			};
 		};
 		468F00CD27CD575C00FFAAAA /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {

--- a/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "branch" : "fix/uiapplication-watchos-non-public-api",
-        "revision" : "e56a0df548184272b2d27a8421f10b02a5d252b1"
+        "revision" : "b017a3510c4214f628305686dfd301ee19d7afe6",
+        "version" : "4.2.1"
       }
     },
     {


### PR DESCRIPTION

## Description

Follow up to https://github.com/Automattic/pocket-casts-ios/pull/4041#issuecomment-3989787593

Updates Automattic-Tracks-iOS from the `fix/uiapplication-watchos-non-public-api` branch pin to the 4.2.1 release tag.

4.2.1 includes the same watchOS `UIApplication` non-public API fix that was previously consumed via branch, now properly released.

## Test Steps

- Build and run unit tests — all 275 pass locally.

---

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*