### PR TITLE
Update download modal for dynamic type

### DIFF
--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -29,13 +29,17 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         NotificationCenter.default.addObserver(self, selector: #selector(podcastUpdated(_:)), name: Constants.Notifications.podcastUpdated, object: nil)
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: settingsTable)
         Analytics.track(.settingsAutoDownloadShown)
-        ManageDownloadsCoordinator.showModalIfNeeded(from: self, source: "auto_download")
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         settingsTable.reloadData()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        ManageDownloadsCoordinator.showModalIfNeeded(from: self, source: "auto_download")
     }
 
     // MARK: - UITableView methods

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -37,9 +37,14 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
         settingsTable.reloadData()
     }
 
+    private var firstAppear: Bool = true
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        ManageDownloadsCoordinator.showModalIfNeeded(from: self, source: "auto_download")
+        if firstAppear {
+            firstAppear = false
+            ManageDownloadsCoordinator.showModalIfNeeded(from: self, source: "auto_download")
+        }
     }
 
     // MARK: - UITableView methods

--- a/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
+++ b/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
@@ -48,6 +48,7 @@ class BottomSheetSwiftUIWrapper<ContentView: View>: UIViewController, UISheetPre
                 .edgesIgnoringSafeArea(.all)
                 .environmentObject(Theme.sharedTheme)
         )
+        hostingController.sizingOptions = [.intrinsicContentSize]
         addChild(hostingController)
         stackView.addArrangedSubview(hostingController.view)
         hostingController.didMove(toParent: self)
@@ -104,6 +105,7 @@ class BottomSheetSwiftUIWrapper<ContentView: View>: UIViewController, UISheetPre
         let wrapperController = BottomSheetSwiftUIWrapper(rootView: content, dismissCallback: dismissCallback)
         if autoSize {
             let customDetent = UISheetPresentationController.Detent.custom { _ in
+                wrapperController.updatePreferredContentSize()
                 return wrapperController.customDetentHeight
             }
             wrapperController.presentModally(in: viewController, detents: [customDetent], showingGrabber: showingGrabber)
@@ -114,6 +116,19 @@ class BottomSheetSwiftUIWrapper<ContentView: View>: UIViewController, UISheetPre
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         self.dismissCallback?()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            if let sheetController = sheetPresentationController {
+                updatePreferredContentSize()
+                sheetController.animateChanges {
+                    sheetController.invalidateDetents()
+                }
+            }
+        }
     }
 
 }

--- a/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
+++ b/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
@@ -103,9 +103,13 @@ class BottomSheetSwiftUIWrapper<ContentView: View>: UIViewController, UISheetPre
     /// Present a SwiftUI view as a bottom sheet in the given VC. If `autoSize` is `true`, a custom detent will be calculated based on the view size
     static func present(_ content: ContentView, autoSize: Bool = false, showingGrabber: Bool = false, in viewController: UIViewController, dismissCallback: (()->())? = nil) {
         let wrapperController = BottomSheetSwiftUIWrapper(rootView: content, dismissCallback: dismissCallback)
+        var previousSizeCategory = viewController.traitCollection.preferredContentSizeCategory
         if autoSize {
-            let customDetent = UISheetPresentationController.Detent.custom { _ in
-                wrapperController.updatePreferredContentSize()
+            let customDetent = UISheetPresentationController.Detent.custom { context in
+                if context.containerTraitCollection.preferredContentSizeCategory != previousSizeCategory {
+                    previousSizeCategory = context.containerTraitCollection.preferredContentSizeCategory
+                    wrapperController.updatePreferredContentSize()
+                }
                 return wrapperController.customDetentHeight
             }
             wrapperController.presentModally(in: viewController, detents: [customDetent], showingGrabber: showingGrabber)
@@ -124,8 +128,11 @@ class BottomSheetSwiftUIWrapper<ContentView: View>: UIViewController, UISheetPre
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
             if let sheetController = sheetPresentationController {
                 updatePreferredContentSize()
-                sheetController.animateChanges {
-                    sheetController.invalidateDetents()
+                //Dispatch to main to allow changes in content to reflect
+                DispatchQueue.main.async {
+                    sheetController.animateChanges {
+                        sheetController.invalidateDetents()
+                    }
                 }
             }
         }

--- a/podcasts/ManageDownloadsCoordinator.swift
+++ b/podcasts/ManageDownloadsCoordinator.swift
@@ -25,7 +25,7 @@ class ManageDownloadsCoordinator {
             return
         }
         Analytics.track(.freeUpSpaceModalShown, properties: ["source": source])
-        let modalView = ManageDownloadsModel(initialSize: "", onManageTap: { [weak presentationVC] in
+        let dataModel = ManageDownloadsModel(initialSize: "", onManageTap: { [weak presentationVC] in
             Analytics.track(.freeUpSpaceManageDownloadsTapped, properties: ["source": source])
             presentationVC?.dismiss(animated: true, completion: {
                 presentationVC?.navigationController?.pushViewController(DownloadedFilesViewController(), animated: true)
@@ -35,12 +35,13 @@ class ManageDownloadsCoordinator {
             Settings.manageDownloadsLastCheckDate = Date.now
             presentationVC?.dismiss(animated: true)
         })
-        let themedVC = ThemedHostingController(rootView: ManageDownloadsModalView(dataModel: modalView))
-        if let sheet = themedVC.sheetPresentationController {
-            sheet.detents = [.medium()]
-            sheet.prefersGrabberVisible = true
-        }
-        presentationVC.present(themedVC, animated: true)
+        BottomSheetSwiftUIWrapper.present(
+            ManageDownloadsModalView(dataModel: dataModel).environmentObject(Theme.sharedTheme),
+            autoSize: true,
+            showingGrabber: true,
+            in: presentationVC
+        )
+        return
     }
 
 }

--- a/podcasts/ManageDownloadsCoordinator.swift
+++ b/podcasts/ManageDownloadsCoordinator.swift
@@ -20,8 +20,7 @@ class ManageDownloadsCoordinator {
     }
 
     static func showModalIfNeeded(from presentationVC: UIViewController, source: String) {
-        guard Self.shouldShowBanner
-        else {
+        guard Self.shouldShowBanner else {
             return
         }
         Analytics.track(.freeUpSpaceModalShown, properties: ["source": source])
@@ -36,11 +35,12 @@ class ManageDownloadsCoordinator {
             presentationVC?.dismiss(animated: true)
         })
         BottomSheetSwiftUIWrapper.present(
-            ManageDownloadsModalView(dataModel: dataModel).environmentObject(Theme.sharedTheme),
+            ManageDownloadsModalView(dataModel: dataModel),
             autoSize: true,
             showingGrabber: true,
-            in: presentationVC
-        )
+            in: presentationVC) {
+                Settings.manageDownloadsLastCheckDate = Date.now
+            }
         return
     }
 

--- a/podcasts/ManageDownloadsModalView.swift
+++ b/podcasts/ManageDownloadsModalView.swift
@@ -8,37 +8,39 @@ struct ManageDownloadsModalView: View {
 
     @ObservedObject var dataModel: ManageDownloadsModel
 
+    @ScaledMetric(relativeTo: .largeTitle) private var imageSize = 36
+
     var body: some View {
         VStack(alignment: .center, spacing: 8) {
             Spacer()
             Image("cleanup")
                 .resizable()
-                .frame(width: 40, height: 40)
+                .frame(width: imageSize, height: imageSize)
                 .foregroundColor(theme.primaryText02Selected)
             Text(L10n.manageDownloadsTitle)
-                .font(.system(size: 23, weight: .bold))
+                .font(.title2.bold())
+                .fixedSize(horizontal: false, vertical: true)
                 .foregroundColor(theme.primaryText01)
             Text(L10n.manageDownloadsDetail(dataModel.sizeOccupied))
                 .lineLimit(nil)
                 .fixedSize(horizontal: false, vertical: true)
                 .multilineTextAlignment(.leading)
-                .font(.system(size: 14, weight: .medium))
+                .font(.callout)
                 .foregroundColor(theme.primaryText01)
             Spacer()
             Button() {
                 dataModel.onManageTap?()
             } label: {
                 Text(L10n.manageDownloadsAction)
-                    .font(.system(size: 14, weight: .medium))
             }
             .buttonStyle(RoundedButtonStyle(theme: theme))
             Button() {
                 dataModel.onNotNowTap?()
             } label: {
                 Text(L10n.maybeLater)
-                    .font(.system(size: 14, weight: .medium))
+                    .font(size: 14, style: .subheadline, weight: .medium)
                     .foregroundColor(theme.primaryText01)
-            }.frame(height: 56)
+            }.frame(idealHeight: 56)
         }
         .padding()
         .ignoresSafeArea()

--- a/podcasts/ManageDownloadsModalView.swift
+++ b/podcasts/ManageDownloadsModalView.swift
@@ -41,6 +41,7 @@ struct ManageDownloadsModalView: View {
                     .font(size: 14, style: .subheadline, weight: .medium)
                     .foregroundColor(theme.primaryText01)
             }.frame(idealHeight: 56)
+            Spacer().frame(height: 16)
         }
         .padding()
         .ignoresSafeArea()


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR update the download  manager modal to free up space for dynamic type.
It also updates some icon size and font to make it use the same as other modals.

| xs | Default | xxxL | AX5 |
| - | - | - | - |
|  <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-02 at 19 19 10" src="https://github.com/user-attachments/assets/0d37aa99-11f8-446a-bd5a-c32c26e9cbfb" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-02 at 19 18 58" src="https://github.com/user-attachments/assets/ccbde5ee-af8c-45fe-bc3e-6decdd06d036" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-02 at 19 18 48" src="https://github.com/user-attachments/assets/cf5725fc-ecf7-42a3-9f42-d7c418e01eef" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-02 at 19 18 37" src="https://github.com/user-attachments/assets/8863cf52-c40e-4e5c-aad4-acd0da856bc9" /> |

## To test

To force the banner to show update the `ManageDownloadsCoordinator.shouldShowBanner` method to always return true.

1. Start the app
2. Open Profile -> Settings Downloads
3. The modal show be shown
4. Check if it adapts for dynamic type.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
