### PR TITLE
Fix mini player to full player transition animation

### DIFF
--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -290,40 +290,28 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             transitionContext.completeTransition(true)
         }
 
-        // For presenting, use a separate ease animation for properties
-        // that don't need spring physics
-        if isPresenting {
-            UIView.animate(withDuration: duration, delay: 0, options: .curveEaseInOut) {
-                backgroundTransitionView.backgroundColor = toColor
-                backgroundTransitionView.layer.cornerRadius = 0
-                toView?.layer.opacity = 1
-                tabBarSnapshot?.frame = hiddenTabBarFrame
-            } completion: { _ in
-                tabBar?.isHidden = false
-            }
-        }
     }
 
-    /// When presenting use curveEaseInOut. If dismissing, use spring animation
+    /// Use spring animation for both present and dismiss.
+    /// Dismiss carries gesture momentum via initialVelocity; present starts from rest.
     private func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
-        if isPresenting {
-            UIView.animate(withDuration: duration, delay: 0, options: .curveEaseInOut, animations: animations, completion: completion)
-        } else {
-            // stiffness 500 → snappy response; damping 35 → ζ ≈ 0.78 (subtle bounce).
-            // initialVelocity carries the drag momentum directly into the spring.
-            let timingParameters = UISpringTimingParameters(mass: 1, stiffness: 500, damping: 35, initialVelocity: CGVector(dx: 0, dy: springVelocity))
-            let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timingParameters)
-            animator.addCompletion { position in
-                switch position {
-                case .end:
-                    completion?(true)
-                default:
-                    break
-                }
+        // Present: stiffness 400, damping 38 → ζ ≈ 0.95 (lighter, nearly critically damped).
+        // Dismiss: stiffness 500, damping 35 → ζ ≈ 0.78 (snappier, subtle bounce).
+        let stiffness: CGFloat = isPresenting ? 400 : 500
+        let damping: CGFloat = isPresenting ? 38 : 35
+        let velocity = isPresenting ? CGVector.zero : CGVector(dx: 0, dy: springVelocity)
+        let timingParameters = UISpringTimingParameters(mass: 1, stiffness: stiffness, damping: damping, initialVelocity: velocity)
+        let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timingParameters)
+        animator.addCompletion { position in
+            switch position {
+            case .end:
+                completion?(true)
+            default:
+                break
             }
-            animator.addAnimations(animations)
-            animator.startAnimation()
         }
+        animator.addAnimations(animations)
+        animator.startAnimation()
     }
 
     enum Transition {

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -254,7 +254,6 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             artwork?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkFrame
             artwork?.layer.cornerRadius = self.isPresenting ? fullPlayerArtwork.layer.cornerRadius : miniPlayerArtwork.imageView!.layer.cornerRadius
 
-
             // snapshot has its frame changed to account for the shadow
             miniPlayerArtworkSnapshot?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkWithShadowFrame
 

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -199,10 +199,9 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         let backgroundToFrame = isPresenting ? toFrame : miniplayerFrame
 
         // Add a snapshot of the miniplayer and full player.
-        // For dismiss, use afterScreenUpdates:false — views are already on screen,
-        // and skipping the synchronous render pass reduces the setup delay between
-        // gesture end and animation start.
-        let miniPlayerSnapshotView = miniPlayerView.snapshotView(afterScreenUpdates: isPresenting)
+        // Always use afterScreenUpdates:true so the snapshot reflects artwork being
+        // hidden (opacity 0) — otherwise the dismiss snapshot shows double artwork.
+        let miniPlayerSnapshotView = miniPlayerView.snapshotView(afterScreenUpdates: true)
         miniPlayerSnapshotView?.addSubview(UIVisualEffectView(effect: UIBlurEffect(style: .prominent)))
         miniPlayerSnapshotView?.layer.opacity = isPresenting ? 1 : 0
         backgroundTransitionView.addSubview(toView ?? UIView())

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -12,11 +12,13 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
     private let fullPlayerYPosition: CGFloat
 
-    // Spring velocity is defined by pan gesture velocity / distance
+    // Spring velocity is defined by pan gesture velocity / distance.
+    // A positive value means moving in the same direction as the animation (downward, toward mini player).
     private lazy var springVelocity: CGFloat = {
         let miniplayerFrame = fromViewController.view.superview?.convert(fromViewController.view.frame, to: nil) ?? .zero
         let distance = miniplayerFrame.origin.y - fullPlayerYPosition
-        return -1 * dismissVelocity / distance
+        guard distance > 0 else { return 0 }
+        return dismissVelocity / distance
     }()
 
     // When presenting the player, duration is always the same
@@ -101,12 +103,30 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         playerView.setNeedsLayout()
         playerView.layoutIfNeeded()
 
+        // Hide artwork in the layer model tree so the snapshot excludes it
+        // (the artwork overlay will animate it separately).
         if fullPlayerArtwork.image != nil {
             fullPlayerArtwork.layer.opacity = 0
         }
 
-        let toView = playerView.snapshotView(afterScreenUpdates: true)
-        toView?.frame = isPresenting ? containerView.frame : fromFrame
+        // For presenting, capture the full player via drawHierarchy which renders
+        // the complete UIKit view hierarchy (including buttons/labels) into an
+        // off-screen graphics context — no render-server commit that could flash.
+        // For dismissing, skip the player snapshot entirely — the artwork overlay is
+        // the visual anchor, and eliminating this render cuts the setup delay.
+        let toView: UIView?
+        if isPresenting {
+            let renderer = UIGraphicsImageRenderer(bounds: playerView.bounds)
+            let snapshotImage = renderer.image { _ in
+                playerView.drawHierarchy(in: playerView.bounds, afterScreenUpdates: true)
+            }
+            let imageView = UIImageView(image: snapshotImage)
+            imageView.clipsToBounds = true
+            toView = imageView
+            toView?.frame = containerView.frame
+        } else {
+            toView = nil
+        }
 
         // MARK: - Artwork
 
@@ -156,8 +176,10 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         containerView.addSubview(backgroundTransitionView)
         containerView.sendSubviewToBack(backgroundTransitionView)
 
-        // Get the initial and final colors
-        let miniPlayerBackgroundColor = (fromViewController as? MiniPlayerViewController)?.view.backgroundColor
+        // Get the initial and final colors.
+        // Use mainView's background (opaque) rather than the outer view's (.clear)
+        // to prevent see-through during the present cross-fade.
+        let miniPlayerBackgroundColor = (fromViewController as? MiniPlayerViewController)?.mainView.backgroundColor
 
         let fullPlayerBackgroundColor = (toViewController as? PlayerContainerViewController)?.nowPlayingItem.view.backgroundColor
 
@@ -176,8 +198,11 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         let backgroundFromFrame = isPresenting ? miniplayerFrame : backgroundTransitionInitialFrame
         let backgroundToFrame = isPresenting ? toFrame : miniplayerFrame
 
-        // Add a snapshot of the miniplayer and full player
-        let miniPlayerSnapshotView = miniPlayerView.snapshotView(afterScreenUpdates: true)
+        // Add a snapshot of the miniplayer and full player.
+        // For dismiss, use afterScreenUpdates:false — views are already on screen,
+        // and skipping the synchronous render pass reduces the setup delay between
+        // gesture end and animation start.
+        let miniPlayerSnapshotView = miniPlayerView.snapshotView(afterScreenUpdates: isPresenting)
         miniPlayerSnapshotView?.addSubview(UIVisualEffectView(effect: UIBlurEffect(style: .prominent)))
         miniPlayerSnapshotView?.layer.opacity = isPresenting ? 1 : 0
         backgroundTransitionView.addSubview(toView ?? UIView())
@@ -187,7 +212,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         // MARK: - Tab Bar
 
         let tabBar = (toViewController.presentingViewController as? MainTabBarController)?.tabBar
-        let tabBarSnapshot = tabBar?.snapshotView(afterScreenUpdates: true)
+        let tabBarSnapshot = tabBar?.snapshotView(afterScreenUpdates: isPresenting)
         tabBar?.isHidden = true
         tabBarSnapshot?.layer.drawTopBorder()
         let snapshotView = tabBarSnapshot ?? UIView()
@@ -196,7 +221,8 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
         // MARK: - Animations
 
-        // If it has artwork, hide the original ones
+        // Now that playerView is hidden and snapshots/overlays are in place,
+        // safely hide the real artwork — no visible flash possible.
         if artwork?.image != nil {
             fullPlayerArtwork.layer.opacity = 0
             miniPlayerArtwork.layer.opacity = 0
@@ -228,14 +254,23 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             artwork?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkFrame
             artwork?.layer.cornerRadius = self.isPresenting ? fullPlayerArtwork.layer.cornerRadius : miniPlayerArtwork.imageView!.layer.cornerRadius
 
+
             // snapshot has its frame changed to account for the shadow
             miniPlayerArtworkSnapshot?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkWithShadowFrame
 
             // Background
             backgroundTransitionView.frame = backgroundToFrame
+            backgroundTransitionView.backgroundColor = toColor
+            backgroundTransitionView.layer.cornerRadius = self.isPresenting ? 0 : miniPlayerView.layer.cornerRadius
 
             // Miniplayer
             miniPlayerSnapshotView?.layer.opacity = self.isPresenting ? 0 : 1
+
+            // Player
+            toView?.layer.opacity = self.isPresenting ? 1 : 0
+
+            // Tab Bar
+            tabBarSnapshot?.frame = !self.isPresenting ? tabBarFrame : hiddenTabBarFrame
 
             gradientView.layer.opacity = isPresenting ? 0 : 1
         } completion: { completed in
@@ -250,34 +285,21 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
             self.fromViewController.view.layer.opacity = 1
 
+            tabBar?.isHidden = false
+
             transitionContext.completeTransition(true)
         }
 
-        // MARK: - Non-spring animation
-
-        UIView.animate(withDuration: duration, delay: 0, options: isPresenting ? .curveEaseInOut : .curveEaseOut) {
-            // Background
-            backgroundTransitionView.backgroundColor = toColor
-            backgroundTransitionView.layer.cornerRadius = self.isPresenting ? 0 : miniPlayerView.layer.cornerRadius
-            // Player
-            toView?.layer.opacity = self.isPresenting ? 1 : 0
-
-            // Tab Bar
-            tabBarSnapshot?.frame = !self.isPresenting ? tabBarFrame : hiddenTabBarFrame
-        } completion: { _ in
-            tabBar?.isHidden = false
-        }
-
-        // MARK: - Delayed artwork transition
-
-        // We fade from the big artwork to the miniplayer snapshot to ensure
-        // a smooth transition. DispatchQueue is needed because delay conflicts
-        // with snapshotView(afterScreenUpdates: true) (yes...)
-        if !isPresenting {
-            DispatchQueue.main.async {
-                UIView.animate(withDuration: self.duration * 0.3, delay: self.duration * 0.7, options: .curveEaseOut) { [self] in
-                    artwork?.layer.opacity = self.isPresenting ? 1 : 0
-                }
+        // For presenting, use a separate ease animation for properties
+        // that don't need spring physics
+        if isPresenting {
+            UIView.animate(withDuration: duration, delay: 0, options: .curveEaseInOut) {
+                backgroundTransitionView.backgroundColor = toColor
+                backgroundTransitionView.layer.cornerRadius = 0
+                toView?.layer.opacity = 1
+                tabBarSnapshot?.frame = hiddenTabBarFrame
+            } completion: { _ in
+                tabBar?.isHidden = false
             }
         }
     }
@@ -287,9 +309,9 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
         if isPresenting {
             UIView.animate(withDuration: duration, delay: 0, options: .curveEaseInOut, animations: animations, completion: completion)
         } else {
-            // Mass is reduced accordingly to speed. This prevents the miniplayer from boucing really hard if the speed is high
-            let mass = -springVelocity > 20 ? 3 / log2(-springVelocity) : 1
-            let timingParameters = UISpringTimingParameters(mass: mass, stiffness: 400, damping: 30, initialVelocity: CGVector(dx: -springVelocity, dy: springVelocity))
+            // stiffness 500 → snappy response; damping 35 → ζ ≈ 0.78 (subtle bounce).
+            // initialVelocity carries the drag momentum directly into the spring.
+            let timingParameters = UISpringTimingParameters(mass: 1, stiffness: 500, damping: 35, initialVelocity: CGVector(dx: 0, dy: springVelocity))
             let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timingParameters)
             animator.addCompletion { position in
                 switch position {

--- a/podcasts/MiniPlayerViewController+Gestures.swift
+++ b/podcasts/MiniPlayerViewController+Gestures.swift
@@ -30,37 +30,16 @@ extension MiniPlayerViewController: UIGestureRecognizerDelegate {
 
         let velocity = panUpRecognizer.velocity(in: view)
 
-        return abs(velocity.y) > abs(velocity.x)
+        // Only recognize upward swipes (negative y velocity)
+        return velocity.y < 0 && abs(velocity.y) > abs(velocity.x)
     }
 
     @objc private func handlePullingUpGesture(_ recognizer: UIPanGestureRecognizer) {
-        if recognizer.state == UIGestureRecognizer.State.began {
-            aboutToDisplayFullScreenPlayer()
-            rootViewController()?.view.isUserInteractionEnabled = false
-            fullScreenPlayer?.view.isUserInteractionEnabled = false
-            playerOpenState = .beingDragged
-        } else if recognizer.state == UIGestureRecognizer.State.changed {
-            let currentPoint = recognizer.translation(in: view.superview)
-
-            fullScreenPlayer?.view.moveTo(y: fullScreenPlayer!.view.bounds.height + currentPoint.y)
-        } else if recognizer.state == UIGestureRecognizer.State.ended {
-            rootViewController()?.view.isUserInteractionEnabled = true
-            fullScreenPlayer?.view.isUserInteractionEnabled = true
-
-            let endPoint = recognizer.translation(in: view)
-
-            // didn't move far enough
-            if abs(endPoint.y) < MiniPlayerViewController.minMoveAmount {
-                return
-            }
-
-            // the user has moved far enough
+        // Open the full screen player as soon as the upward swipe is recognized,
+        // rather than waiting for the gesture to end. This makes the transition
+        // feel immediate and responsive.
+        if recognizer.state == .began {
             openFullScreenPlayer()
-        } else if recognizer.state == UIGestureRecognizer.State.cancelled {
-            rootViewController()?.view.isUserInteractionEnabled = true
-            fullScreenPlayer?.view.isUserInteractionEnabled = true
-
-            closeFullScreenPlayer()
         }
     }
 


### PR DESCRIPTION
## Summary

A while ago, the animation/transition of the mini player to the full player was changed with PR: #1090 and other changes were made to it with PRs: #1310, #1350, and #1355. There was another one, but I'd have to track that down again. 

Somewhere in between the time that new transition was initially introduced up until now the mini player to full player transition has acquired two main visual glitches and one minor visual occurrence that made the app feel not as polished as it should feel:

1. **Artwork flicker on dismiss** – dragging the player down slowly causes the artwork to flash before animating
2. **Swipe-up delay** – swiping up on the mini player doesn't begin the transition until the finger is lifted
3. **Semi-transparent background on present** – the player background briefly appears translucent during expand (minor, but noticeable and unnecessary in my opinion)

(see videos below)

This PR addresses all three by reworking the snapshot strategy and gesture handling in the custom view controller transition:

- Replace `snapshotView(afterScreenUpdates: true)` with `drawHierarchy(in:afterScreenUpdates:)` for the present snapshot to avoid flicker-inducing render-server commits
- Skip the player snapshot entirely on dismiss — the artwork overlay is the visual anchor, and removing this render eliminates setup delay
- Use `afterScreenUpdates: false` for mini player and tab bar snapshots on dismiss for instant capture
- Trigger `openFullScreenPlayer()` on gesture `.began` instead of `.ended` so the transition starts immediately on swipe-up making the experience feel much more responsive. This will also feel more familiar as this is the same way Apple Podcasts and Apple Music works.
- Use the opaque `mainView.backgroundColor` instead of the clear `view.backgroundColor` for the background transition
- Tune spring parameters (stiffness 500, damping 35) for a snappier, more natural dismiss feel

This PR keeps the spirit of the same newer transition that was introduced, but tweaks it to be more performant, snappier, and without the visual glitches.

## Before / After

https://github.com/user-attachments/assets/32e34b00-8849-41ff-9dec-c07dc3ee70d4

https://github.com/user-attachments/assets/86ed165e-9b73-4cca-b2ee-78524ec129c7

https://github.com/user-attachments/assets/445f1562-2091-4013-9942-335b093a5a0c

https://github.com/user-attachments/assets/034a1e58-b572-4890-b186-ef39ecee24ec

https://github.com/user-attachments/assets/75224912-9fb3-47ea-bb80-9a6097d740b5

## To test

1. Play any podcast so the mini player is visible
2. Tap the mini player to expand — verify no background flash or skeleton flicker
3. Swipe down slowly on the full player, then release — verify no artwork flicker
5. Flick the full player down quickly — verify smooth spring animation
6. Collapse the player, then swipe up on the mini player — verify the transition begins immediately without waiting for finger lift
7. Repeat steps 2–5 in both dark mode and light mode

## Checklist

- [X] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.