### PR TITLE
Dynamic type UI adjustments

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/UILabel+Attributed.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Extensions/UI/UILabel+Attributed.swift
@@ -35,5 +35,9 @@
 
             attributedText = attributedString
         }
+
+        func updateNumberOfLines(regular: Int, accessibility: Int) {
+            self.numberOfLines = traitCollection.preferredContentSizeCategory.isAccessibilityCategory ? accessibility : regular
+        }
     }
 #endif

--- a/podcasts/DiscoverFeaturedView.swift
+++ b/podcasts/DiscoverFeaturedView.swift
@@ -35,7 +35,7 @@ class DiscoverFeaturedView: ThemeableView {
     @IBOutlet var podcastAuthor: ThemeableLabel! {
         didSet {
             podcastAuthor.style = .contrast03
-            podcastAuthor.font = .font(ofSize: 15, weight: .bold, scalingWith: .subheadline)
+            podcastAuthor.font = .font(ofSize: 15, weight: .regular, scalingWith: .subheadline)
             podcastAuthor.adjustsFontForContentSizeCategory = true
             podcastAuthor.numberOfLines = 2
         }

--- a/podcasts/DiscoverPodcastTableCell.swift
+++ b/podcasts/DiscoverPodcastTableCell.swift
@@ -150,6 +150,9 @@ class DiscoverPodcastTableCell: ThemeableCell {
         subscribeButton.updateSizeConstraints(to: iconSize)
 
         podcastImageLeadingConstraint.constant = max(32, metric.scaledValue(for: 32))
+
+        podcastTitle.updateNumberOfLines(regular: 1, accessibility: 3)
+        podcastAuthor.updateNumberOfLines(regular: 1, accessibility: 3)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/DiscoverPodcastTableCell.xib
+++ b/podcasts/DiscoverPodcastTableCell.xib
@@ -43,29 +43,29 @@
                         </userDefinedRuntimeAttributes>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Rbl-a3-omI">
-                        <rect key="frame" x="97" y="10" width="189" height="67"/>
+                        <rect key="frame" x="97" y="10" width="173" height="67"/>
                         <subviews>
                             <view contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="MVF-W3-399">
-                                <rect key="frame" x="0.0" y="0.0" width="189" height="4"/>
+                                <rect key="frame" x="0.0" y="0.0" width="173" height="8"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="4" id="8b9-z3-WvO"/>
+                                    <constraint firstAttribute="height" constant="8" id="JkU-Rc-1F1"/>
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="top" verticalHuggingPriority="252" text="Podcast Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PhF-0P-gW1" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="8" width="189" height="18"/>
+                                <rect key="frame" x="0.0" y="12" width="173" height="18"/>
                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
                                 <color key="textColor" red="0.30196078431372547" green="0.33725490196078434" blue="0.36078431372549019" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1" verticalHuggingPriority="251" text="Author" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fFP-ej-ygw" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="30" width="189" height="18"/>
+                                <rect key="frame" x="0.0" y="34" width="173" height="18"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <color key="textColor" red="0.5607843137254902" green="0.59215686274509804" blue="0.6470588235294118" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="D2a-t3-Rvs">
-                                <rect key="frame" x="0.0" y="52" width="189" height="15"/>
+                                <rect key="frame" x="0.0" y="56" width="173" height="11"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                         </subviews>
@@ -91,11 +91,11 @@
                     <constraint firstAttribute="trailing" secondItem="SCC-oJ-G9x" secondAttribute="trailing" constant="16" id="Rh9-28-RbQ"/>
                     <constraint firstItem="0Ds-zk-cf6" firstAttribute="top" secondItem="OJ3-BB-GTf" secondAttribute="top" id="UdP-Mo-Dog"/>
                     <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="OJ3-BB-GTf" secondAttribute="bottom" id="WTx-xz-P46"/>
-                    <constraint firstItem="SCC-oJ-G9x" firstAttribute="leading" secondItem="Rbl-a3-omI" secondAttribute="trailing" constant="-6" id="bX2-2l-Et1"/>
+                    <constraint firstItem="SCC-oJ-G9x" firstAttribute="leading" secondItem="Rbl-a3-omI" secondAttribute="trailing" constant="10" id="bX2-2l-Et1"/>
                     <constraint firstItem="0Ds-zk-cf6" firstAttribute="leading" secondItem="OJ3-BB-GTf" secondAttribute="leading" id="bxa-G3-HTt"/>
                     <constraint firstItem="OJ3-BB-GTf" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="dR4-yn-WIm"/>
                     <constraint firstItem="0Ds-zk-cf6" firstAttribute="height" secondItem="OJ3-BB-GTf" secondAttribute="height" id="dr5-Ij-NUB"/>
-                    <constraint firstItem="Rbl-a3-omI" firstAttribute="leading" secondItem="0Ds-zk-cf6" secondAttribute="trailing" constant="10" id="fPk-Ff-reC"/>
+                    <constraint firstItem="Rbl-a3-omI" firstAttribute="leading" secondItem="OJ3-BB-GTf" secondAttribute="trailing" constant="10" id="fPk-Ff-reC"/>
                     <constraint firstItem="SCC-oJ-G9x" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="jJC-qI-VFh"/>
                     <constraint firstItem="Rbl-a3-omI" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="le5-pM-6kg"/>
                     <constraint firstItem="OJ3-BB-GTf" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="35" id="tgE-Fj-xcP"/>

--- a/podcasts/DiscoverPodcastTableCell.xib
+++ b/podcasts/DiscoverPodcastTableCell.xib
@@ -4,6 +4,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -42,18 +43,34 @@
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </imageView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="top" verticalHuggingPriority="252" text="Podcast Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PhF-0P-gW1" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="97" y="15" width="173" height="18"/>
-                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
-                        <color key="textColor" red="0.30196078431372547" green="0.33725490196078434" blue="0.36078431372549019" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1" verticalHuggingPriority="251" text="Author" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fFP-ej-ygw" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="97" y="37" width="173" height="46"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                        <color key="textColor" red="0.5607843137254902" green="0.59215686274509804" blue="0.6470588235294118" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Rbl-a3-omI">
+                        <rect key="frame" x="97" y="10" width="189" height="67"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="MVF-W3-399">
+                                <rect key="frame" x="0.0" y="0.0" width="189" height="4"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="4" id="8b9-z3-WvO"/>
+                                </constraints>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="top" verticalHuggingPriority="252" text="Podcast Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PhF-0P-gW1" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="8" width="189" height="18"/>
+                                <fontDescription key="fontDescription" type="system" weight="medium" pointSize="15"/>
+                                <color key="textColor" red="0.30196078431372547" green="0.33725490196078434" blue="0.36078431372549019" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1" verticalHuggingPriority="251" text="Author" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fFP-ej-ygw" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="30" width="189" height="18"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                <color key="textColor" red="0.5607843137254902" green="0.59215686274509804" blue="0.6470588235294118" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="D2a-t3-Rvs">
+                                <rect key="frame" x="0.0" y="52" width="189" height="15"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
+                        </subviews>
+                    </stackView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SCC-oJ-G9x" userLabel="Subscribe Button" customClass="BouncyButton" customModule="podcasts" customModuleProvider="target">
                         <rect key="frame" x="280" y="31.5" width="24" height="24"/>
                         <accessibility key="accessibilityConfiguration" label="Subscribe"/>
@@ -68,24 +85,21 @@
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="SCC-oJ-G9x" firstAttribute="leading" secondItem="fFP-ej-ygw" secondAttribute="trailing" constant="10" id="2rw-F4-VZe"/>
+                    <constraint firstAttribute="bottom" secondItem="Rbl-a3-omI" secondAttribute="bottom" constant="10" id="0td-GM-okm"/>
                     <constraint firstItem="0Ds-zk-cf6" firstAttribute="width" secondItem="OJ3-BB-GTf" secondAttribute="width" id="4mJ-db-vSx"/>
                     <constraint firstItem="l3O-C3-pI5" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="8" id="8ks-KF-Vl9"/>
-                    <constraint firstAttribute="bottom" secondItem="fFP-ej-ygw" secondAttribute="bottom" constant="4" id="BkM-5H-aew"/>
                     <constraint firstItem="OJ3-BB-GTf" firstAttribute="top" secondItem="l3O-C3-pI5" secondAttribute="top" id="C9H-e6-6Er"/>
                     <constraint firstAttribute="trailing" secondItem="SCC-oJ-G9x" secondAttribute="trailing" constant="16" id="Rh9-28-RbQ"/>
                     <constraint firstItem="0Ds-zk-cf6" firstAttribute="top" secondItem="OJ3-BB-GTf" secondAttribute="top" id="UdP-Mo-Dog"/>
                     <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="OJ3-BB-GTf" secondAttribute="bottom" id="WTx-xz-P46"/>
+                    <constraint firstItem="SCC-oJ-G9x" firstAttribute="leading" secondItem="Rbl-a3-omI" secondAttribute="trailing" constant="-6" id="bX2-2l-Et1"/>
                     <constraint firstItem="0Ds-zk-cf6" firstAttribute="leading" secondItem="OJ3-BB-GTf" secondAttribute="leading" id="bxa-G3-HTt"/>
-                    <constraint firstItem="PhF-0P-gW1" firstAttribute="leading" secondItem="OJ3-BB-GTf" secondAttribute="trailing" constant="10" id="d7a-H0-ysE"/>
                     <constraint firstItem="OJ3-BB-GTf" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="dR4-yn-WIm"/>
                     <constraint firstItem="0Ds-zk-cf6" firstAttribute="height" secondItem="OJ3-BB-GTf" secondAttribute="height" id="dr5-Ij-NUB"/>
+                    <constraint firstItem="Rbl-a3-omI" firstAttribute="leading" secondItem="0Ds-zk-cf6" secondAttribute="trailing" constant="10" id="fPk-Ff-reC"/>
                     <constraint firstItem="SCC-oJ-G9x" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="jJC-qI-VFh"/>
-                    <constraint firstItem="fFP-ej-ygw" firstAttribute="top" secondItem="PhF-0P-gW1" secondAttribute="bottom" constant="4" id="o4c-ao-B9H"/>
-                    <constraint firstItem="SCC-oJ-G9x" firstAttribute="leading" secondItem="PhF-0P-gW1" secondAttribute="trailing" constant="10" id="pgv-VK-r6F"/>
-                    <constraint firstItem="fFP-ej-ygw" firstAttribute="leading" secondItem="OJ3-BB-GTf" secondAttribute="trailing" constant="10" id="rXa-3q-PpW"/>
+                    <constraint firstItem="Rbl-a3-omI" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="le5-pM-6kg"/>
                     <constraint firstItem="OJ3-BB-GTf" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="35" id="tgE-Fj-xcP"/>
-                    <constraint firstItem="PhF-0P-gW1" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="topMargin" id="yav-wC-cMb"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
@@ -103,5 +117,8 @@
     </objects>
     <resources>
         <image name="discover_add" width="24" height="24"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/podcasts/DiscoverPodcastTableCell.xib
+++ b/podcasts/DiscoverPodcastTableCell.xib
@@ -4,7 +4,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -48,7 +47,7 @@
                         <subviews>
                             <view contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="MVF-W3-399">
                                 <rect key="frame" x="0.0" y="0.0" width="189" height="4"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="4" id="8b9-z3-WvO"/>
                                 </constraints>
@@ -67,7 +66,7 @@
                             </label>
                             <view contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="D2a-t3-Rvs">
                                 <rect key="frame" x="0.0" y="52" width="189" height="15"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                         </subviews>
                     </stackView>
@@ -117,8 +116,5 @@
     </objects>
     <resources>
         <image name="discover_add" width="24" height="24"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>

--- a/podcasts/EpisodeCell.swift
+++ b/podcasts/EpisodeCell.swift
@@ -600,6 +600,9 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
         selectCircleView.updateSizeConstraints(to: tickSize)
         selectTickImageView.layer.cornerRadius = tickSize / 2
         selectCircleView.layer.cornerRadius = tickSize / 2
+
+        episodeTitle.updateNumberOfLines(regular: 1, accessibility: 3)
+        dayName.updateNumberOfLines(regular: 1, accessibility: 3)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/EpisodeCell.swift
+++ b/podcasts/EpisodeCell.swift
@@ -601,8 +601,9 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
         selectTickImageView.layer.cornerRadius = tickSize / 2
         selectCircleView.layer.cornerRadius = tickSize / 2
 
-        episodeTitle.updateNumberOfLines(regular: 1, accessibility: 3)
+        episodeTitle.updateNumberOfLines(regular: 2, accessibility: 3)
         dayName.updateNumberOfLines(regular: 1, accessibility: 3)
+        informationLabel.updateNumberOfLines(regular: 1, accessibility: 3)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/EpisodePreviewCell.swift
+++ b/podcasts/EpisodePreviewCell.swift
@@ -55,5 +55,9 @@ class EpisodePreviewCell: ThemeableCell {
         let imageSize = max(56, metric.scaledValue(for: 56))
 
         episodeImage.updateSizeConstraints(to: imageSize)
+
+        episodeTitle.updateNumberOfLines(regular: 2, accessibility: 3)
+        dateLabel.updateNumberOfLines(regular: 2, accessibility: 3)
+        durationLabel.updateNumberOfLines(regular: 1, accessibility: 3)
     }
 }

--- a/podcasts/GridHelper.swift
+++ b/podcasts/GridHelper.swift
@@ -70,7 +70,8 @@ class GridHelper {
                 divideBy = gridType == .threeByThree ? 3 : 4
             }
         }
-        if  collectionView.traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+        let largerSizes = Set<UIContentSizeCategory>([.accessibilityExtraLarge, .accessibilityExtraExtraLarge, .accessibilityExtraExtraExtraLarge])
+        if  largerSizes.contains(collectionView.traitCollection.preferredContentSizeCategory) {
             divideBy = floor(divideBy / 2)
         }
 

--- a/podcasts/GridHelper.swift
+++ b/podcasts/GridHelper.swift
@@ -46,10 +46,12 @@ class GridHelper {
         let viewWidth = collectionView.bounds.width - collectionView.contentInset.left - collectionView.contentInset.right
         let viewHeight = collectionView.bounds.height
 
+        let largerSizes = Set<UIContentSizeCategory>([.accessibilityExtraLarge, .accessibilityExtraExtraLarge, .accessibilityExtraExtraExtraLarge])
+
         if gridType == .list {
             let metric = UIFontMetrics(forTextStyle: .title3)
             var baseSize = CGFloat(65)
-            if  collectionView.traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            if  largerSizes.contains(collectionView.traitCollection.preferredContentSizeCategory) {
                 baseSize = 85
             }
             let imageSize = max(baseSize, metric.scaledValue(for: baseSize))
@@ -70,7 +72,7 @@ class GridHelper {
                 divideBy = gridType == .threeByThree ? 3 : 4
             }
         }
-        let largerSizes = Set<UIContentSizeCategory>([.accessibilityExtraLarge, .accessibilityExtraExtraLarge, .accessibilityExtraExtraExtraLarge])
+
         if  largerSizes.contains(collectionView.traitCollection.preferredContentSizeCategory) {
             divideBy = floor(divideBy / 2)
         }

--- a/podcasts/MultiSelectActionCell.xib
+++ b/podcasts/MultiSelectActionCell.xib
@@ -10,15 +10,15 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="MultiSelectCellId" rowHeight="112" id="KGk-i7-Jjw" customClass="MultiSelectActionCell" customModule="podcasts" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="84"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="MultiSelectCellId" rowHeight="72" id="KGk-i7-Jjw" customClass="MultiSelectActionCell" customModule="podcasts" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="72"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="84"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="72"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u1B-Jj-2iM" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="68" y="0.0" width="236" height="84"/>
+                        <rect key="frame" x="68" y="0.0" width="236" height="72"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="72" id="kfm-Fy-kb1"/>
                         </constraints>
@@ -27,7 +27,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ain-qK-o3x">
-                        <rect key="frame" x="20" y="30" width="24" height="24"/>
+                        <rect key="frame" x="20" y="24" width="24" height="24"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="24" id="E9x-O6-g98"/>
                             <constraint firstAttribute="height" constant="24" id="gYr-xe-Dr4"/>
@@ -48,7 +48,7 @@
                 <outlet property="iconView" destination="Ain-qK-o3x" id="2Vb-Vg-Loq"/>
                 <outlet property="nameLabel" destination="u1B-Jj-2iM" id="jy1-dK-cZ3"/>
             </connections>
-            <point key="canvasLocation" x="137.68115942028987" y="101.78571428571428"/>
+            <point key="canvasLocation" x="137.68115942028987" y="97.767857142857139"/>
         </tableViewCell>
     </objects>
 </document>

--- a/podcasts/MultiSelectActionCell.xib
+++ b/podcasts/MultiSelectActionCell.xib
@@ -10,24 +10,24 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="MultiSelectCellId" rowHeight="73" id="KGk-i7-Jjw" customClass="MultiSelectActionCell" customModule="podcasts" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="MultiSelectCellId" rowHeight="112" id="KGk-i7-Jjw" customClass="MultiSelectActionCell" customModule="podcasts" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="84"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="84"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u1B-Jj-2iM" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="68" y="0.0" width="236" height="44"/>
+                        <rect key="frame" x="68" y="0.0" width="236" height="84"/>
                         <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="kfm-Fy-kb1"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="72" id="kfm-Fy-kb1"/>
                         </constraints>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Ain-qK-o3x">
-                        <rect key="frame" x="20" y="10" width="24" height="24"/>
+                        <rect key="frame" x="20" y="30" width="24" height="24"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="24" id="E9x-O6-g98"/>
                             <constraint firstAttribute="height" constant="24" id="gYr-xe-Dr4"/>
@@ -48,7 +48,7 @@
                 <outlet property="iconView" destination="Ain-qK-o3x" id="2Vb-Vg-Loq"/>
                 <outlet property="nameLabel" destination="u1B-Jj-2iM" id="jy1-dK-cZ3"/>
             </connections>
-            <point key="canvasLocation" x="139" y="89"/>
+            <point key="canvasLocation" x="137.68115942028987" y="101.78571428571428"/>
         </tableViewCell>
     </objects>
 </document>

--- a/podcasts/PlayerCell.swift
+++ b/podcasts/PlayerCell.swift
@@ -256,6 +256,9 @@ class PlayerCell: ThemeableSwipeCell {
         let tickSize = max(24, metric.scaledValue(for: 24))
         selectTickImageView.updateSizeConstraints(to: tickSize)
         selectTickImageView.layer.cornerRadius = tickSize / 2
+
+        episodeTitle.updateNumberOfLines(regular: 1, accessibility: 3)
+        dayName.updateNumberOfLines(regular: 1, accessibility: 2)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/PlayerCell.xib
+++ b/podcasts/PlayerCell.xib
@@ -40,20 +40,20 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OJf-Is-8tF" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="20" y="6" width="56" height="56"/>
+                        <rect key="frame" x="20" y="12" width="56" height="56"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="56" id="CmK-da-ABR"/>
                             <constraint firstAttribute="height" constant="56" id="Ohc-ER-Sk3"/>
                         </constraints>
                     </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="250" text="DAY NAME" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vxd-V8-but" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="84" y="6" width="228" height="13.5"/>
+                        <rect key="frame" x="84" y="10" width="228" height="13.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                         <color key="textColor" white="1" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="749" text="Glow In The Dark Sharks can be real snarks" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wE1-9S-69I" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="84" y="21.5" width="212" height="24.5"/>
+                        <rect key="frame" x="84" y="25.5" width="212" height="20.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
@@ -93,7 +93,7 @@
                 </subviews>
                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstItem="vxd-V8-but" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="6" id="3jl-q6-Kuk"/>
+                    <constraint firstItem="vxd-V8-but" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="3jl-q6-Kuk"/>
                     <constraint firstAttribute="trailing" secondItem="oRM-hc-IES" secondAttribute="trailing" id="6cL-cZ-UKS"/>
                     <constraint firstItem="IaQ-ms-xZi" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="7mz-gA-2Vu"/>
                     <constraint firstItem="wE1-9S-69I" firstAttribute="leading" secondItem="OJf-Is-8tF" secondAttribute="trailing" constant="8" id="8aj-Ja-L8V"/>
@@ -102,7 +102,7 @@
                     <constraint firstItem="SPL-EK-QpB" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="THB-Gv-8b2"/>
                     <constraint firstItem="oRM-hc-IES" firstAttribute="top" secondItem="wE1-9S-69I" secondAttribute="bottom" constant="4" id="Tna-d1-ajw"/>
                     <constraint firstItem="IaQ-ms-xZi" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="-24" id="W6l-JH-2df"/>
-                    <constraint firstItem="OJf-Is-8tF" firstAttribute="top" secondItem="vxd-V8-but" secondAttribute="top" id="Z0H-Az-83U"/>
+                    <constraint firstItem="OJf-Is-8tF" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="Z0H-Az-83U"/>
                     <constraint firstItem="vxd-V8-but" firstAttribute="leading" secondItem="OJf-Is-8tF" secondAttribute="trailing" constant="8" id="aTa-Qw-wZX"/>
                     <constraint firstItem="oRM-hc-IES" firstAttribute="leading" secondItem="wE1-9S-69I" secondAttribute="leading" id="bI8-92-Yir"/>
                     <constraint firstItem="IaQ-ms-xZi" firstAttribute="trailing" secondItem="OJf-Is-8tF" secondAttribute="leading" constant="-20" id="dAg-4g-2db"/>

--- a/podcasts/PlayerChapterCell.xib
+++ b/podcasts/PlayerChapterCell.xib
@@ -25,6 +25,7 @@
                                 <color key="backgroundColor" white="1" alpha="0.15329035659509202" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" id="jBd-mB-N0I"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="ksw-4K-GXj"/>
                                 </constraints>
                             </view>
                         </subviews>

--- a/podcasts/PodcastChooserCell.swift
+++ b/podcasts/PodcastChooserCell.swift
@@ -31,6 +31,8 @@ class PodcastChooserCell: ThemeableCell {
         let metric = UIFontMetrics(forTextStyle: .largeTitle)
         let size = max(metric.scaledValue(for: 56), 56)
         podcastImage.updateSizeConstraints(to: size)
+
+        podcastName.updateNumberOfLines(regular: 2, accessibility: 3)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/PodcastFilterSelectionCell.swift
+++ b/podcasts/PodcastFilterSelectionCell.swift
@@ -97,5 +97,8 @@ class PodcastFilterSelectionCell: ThemeableCell {
 
         let imageSize = max(52, metric.scaledValue(for: 52))
         podcastImage?.updateSizeConstraints(to: imageSize)
+
+        podcastTitle.updateNumberOfLines(regular: 1, accessibility: 3)
+        podcastAuthor.updateNumberOfLines(regular: 1, accessibility: 3)
     }
 }

--- a/podcasts/PodcastListCell.swift
+++ b/podcasts/PodcastListCell.swift
@@ -82,6 +82,8 @@ class PodcastListCell: ThemeableCollectionCell {
                 break
         }
         unplayedBadge.layoutIfNeeded()
+
+        podcastTitle.updateNumberOfLines(regular: 1, accessibility: 3)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/ShelfActionsViewController.swift
+++ b/podcasts/ShelfActionsViewController.swift
@@ -44,7 +44,7 @@ class ShelfActionsViewController: UIViewController, CheckTranscriptAvailability 
     @IBOutlet var actionButton: ThemeableUIButton! {
         didSet {
             actionButton.style = .playerContrast01
-            actionButton.titleLabel?.font = UIFont.font(ofSize: 13, weight: .medium, scalingWith: .title1)
+            actionButton.titleLabel?.font = UIFont.font(ofSize: 17, weight: .semibold, scalingWith: .title1)
             actionButton.titleLabel?.adjustsFontForContentSizeCategory = true
         }
     }

--- a/podcasts/ShelfCell.xib
+++ b/podcasts/ShelfCell.xib
@@ -48,7 +48,7 @@
                             </label>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="QsO-yw-QTt"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="72" id="QsO-yw-QTt"/>
                         </constraints>
                     </stackView>
                 </subviews>

--- a/podcasts/SleepTimerViewController.xib
+++ b/podcasts/SleepTimerViewController.xib
@@ -39,11 +39,11 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="408" height="532"/>
+            <rect key="frame" x="0.0" y="0.0" width="408" height="500"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nxz-IC-HCU" userLabel="Current Option">
-                    <rect key="frame" x="0.0" y="0.0" width="408" height="498"/>
+                    <rect key="frame" x="0.0" y="0.0" width="408" height="466"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E6q-a6-BhY" customClass="SleepTimerButton" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="170" y="60" width="68" height="68"/>
@@ -57,7 +57,7 @@
                             </constraints>
                         </button>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="4:59" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vyF-KA-sb1" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="144" y="144" width="120" height="84"/>
+                            <rect key="frame" x="144" y="131" width="120" height="65"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="65" id="K6U-Bm-L8g"/>
                             </constraints>
@@ -66,7 +66,7 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sleeping when episode ends" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sWl-Fm-Fg5" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="16" y="144" width="376" height="74"/>
+                            <rect key="frame" x="16" y="144" width="376" height="42"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="27" id="ZGO-cQ-xa7"/>
                             </constraints>
@@ -75,9 +75,9 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="sG9-ye-AOp">
-                            <rect key="frame" x="20" y="278" width="368" height="200"/>
+                            <rect key="frame" x="20" y="246" width="368" height="200"/>
                             <subviews>
-                                <view contentMode="scaleToFill" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TXG-Ts-uOu" customClass="UIButton">
+                                <view contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="TXG-Ts-uOu" customClass="UIButton">
                                     <rect key="frame" x="0.0" y="0.0" width="368" height="56"/>
                                     <accessibility key="accessibilityConfiguration" label="Add five minutes">
                                         <accessibilityTraits key="traits" button="YES"/>
@@ -90,7 +90,7 @@
                                         <action selector="plusFiveTapped:" destination="-1" eventType="touchUpInside" id="oCT-cT-NHN"/>
                                     </connections>
                                 </view>
-                                <view contentMode="scaleToFill" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="YYx-nN-wS9" customClass="UIButton">
+                                <view contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YYx-nN-wS9" customClass="UIButton">
                                     <rect key="frame" x="0.0" y="72" width="368" height="56"/>
                                     <accessibility key="accessibilityConfiguration" label="Change to end of episode">
                                         <accessibilityTraits key="traits" button="YES"/>
@@ -103,7 +103,7 @@
                                         <action selector="endOfEpisodeActiveTapped:" destination="-1" eventType="touchUpInside" id="QzU-4Z-oMb"/>
                                     </connections>
                                 </view>
-                                <view contentMode="scaleToFill" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EOQ-B1-4Zt" customClass="UIButton">
+                                <view contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EOQ-B1-4Zt" customClass="UIButton">
                                     <rect key="frame" x="0.0" y="144" width="368" height="56"/>
                                     <accessibility key="accessibilityConfiguration" label="Cancel Timer">
                                         <accessibilityTraits key="traits" button="YES"/>
@@ -144,7 +144,7 @@
                     </variation>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VIr-G3-c6n" userLabel="List of Options">
-                    <rect key="frame" x="0.0" y="0.0" width="408" height="532"/>
+                    <rect key="frame" x="0.0" y="0.0" width="408" height="500"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NpZ-qP-qnr" userLabel="Popup Heading" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="408" height="68"/>
@@ -178,7 +178,7 @@
                             </constraints>
                         </view>
                         <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HO2-dO-eLB">
-                            <rect key="frame" x="0.0" y="68" width="408" height="464"/>
+                            <rect key="frame" x="0.0" y="68" width="408" height="432"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="DJb-Yj-WkR">
                                     <rect key="frame" x="20" y="0.0" width="368" height="395"/>

--- a/podcasts/SmallListCell.swift
+++ b/podcasts/SmallListCell.swift
@@ -21,10 +21,15 @@ class SmallListCell: ThemeableCollectionCell {
         }
     }
 
-    @IBOutlet var podcastTitle: ThemeableLabel!
+    @IBOutlet var podcastTitle: ThemeableLabel! {
+        didSet {
+            podcastTitle.font = .font(ofSize: 16, weight: .medium, scalingWith: .callout)
+        }
+    }
     @IBOutlet var podcastAuthor: ThemeableLabel! {
         didSet {
             podcastAuthor.style = .primaryText02
+            podcastAuthor.font = .font(ofSize: 14, weight: .regular, scalingWith: .subheadline)
         }
     }
 
@@ -125,7 +130,7 @@ class SmallListCell: ThemeableCollectionCell {
 
         podcastImage.updateSizeConstraints(to: max(48, metric.scaledValue(for: 48)))
 
-        subscribeButton.updateSizeConstraints(to: max(24, metric.scaledValue(for: 24)))
+        subscribeButton.updateSizeConstraints(to: max(44, metric.scaledValue(for: 44)))
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/SmallListCell.xib
+++ b/podcasts/SmallListCell.xib
@@ -29,19 +29,41 @@
                             <action selector="subscribeTapped:" destination="gTV-IL-0wX" eventType="touchUpInside" id="XGG-tb-PXz"/>
                         </connections>
                     </button>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" text="A very large title that should grow to the next line" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bUF-uV-U8H" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="56" y="4" width="249" height="19.5"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="A very large author that show grow to the next line" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FTw-UR-Z1t" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="56" y="26.5" width="249" height="18"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                        <color key="textColor" red="0.5607843137254902" green="0.59215686274509804" blue="0.64313725490196083" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="fOp-WR-qVy">
+                        <rect key="frame" x="56" y="3" width="241" height="92"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" verticalCompressionResistancePriority="248" translatesAutoresizingMaskIntoConstraints="NO" id="Rla-LP-MtP">
+                                <rect key="frame" x="0.0" y="0.0" width="241" height="22.5"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" text="A very large title that should grow to the next line" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bUF-uV-U8H" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="25.5" width="241" height="19.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="19" id="TO4-nj-GAk"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="A very large author that show grow to the next line" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FTw-UR-Z1t" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="48" width="241" height="19"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="19" id="Bld-hY-KIk"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                <color key="textColor" red="0.5607843137254902" green="0.59215686274509804" blue="0.64313725490196083" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="eTD-aU-OQh">
+                                <rect key="frame" x="0.0" y="70" width="241" height="22"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="eTD-aU-OQh" firstAttribute="height" secondItem="Rla-LP-MtP" secondAttribute="height" id="3qR-8f-bVh"/>
+                        </constraints>
+                    </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bYh-d7-bzs" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="25" width="48" height="48"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -55,14 +77,11 @@
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
                 <constraint firstItem="bYh-d7-bzs" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="7FH-vv-a4a"/>
-                <constraint firstItem="VUU-Ww-mYR" firstAttribute="leading" secondItem="FTw-UR-Z1t" secondAttribute="trailing" id="AiJ-bY-MR0"/>
-                <constraint firstItem="bUF-uV-U8H" firstAttribute="leading" secondItem="bYh-d7-bzs" secondAttribute="trailing" constant="8" id="HZO-L1-zYo"/>
-                <constraint firstItem="FTw-UR-Z1t" firstAttribute="leading" secondItem="bUF-uV-U8H" secondAttribute="leading" id="Kej-NW-1EM"/>
-                <constraint firstItem="FTw-UR-Z1t" firstAttribute="top" secondItem="bUF-uV-U8H" secondAttribute="bottom" constant="3" id="Xg7-wf-uKJ"/>
-                <constraint firstItem="VUU-Ww-mYR" firstAttribute="leading" secondItem="bUF-uV-U8H" secondAttribute="trailing" id="ZMF-n9-RaF"/>
+                <constraint firstItem="fOp-WR-qVy" firstAttribute="leading" secondItem="bYh-d7-bzs" secondAttribute="trailing" constant="8" id="HRD-BS-TCG"/>
+                <constraint firstAttribute="bottom" secondItem="fOp-WR-qVy" secondAttribute="bottom" constant="3" id="PdU-U1-BRj"/>
+                <constraint firstItem="VUU-Ww-mYR" firstAttribute="leading" secondItem="fOp-WR-qVy" secondAttribute="trailing" constant="8" id="TlE-uc-2G2"/>
+                <constraint firstItem="fOp-WR-qVy" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="3" id="YsE-r6-oKq"/>
                 <constraint firstAttribute="trailing" secondItem="VUU-Ww-mYR" secondAttribute="trailing" id="chm-dl-ku3"/>
-                <constraint firstItem="bUF-uV-U8H" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="4" id="nkH-FJ-Pko"/>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="FTw-UR-Z1t" secondAttribute="bottom" constant="4" id="oOU-S9-UC3"/>
                 <constraint firstItem="bYh-d7-bzs" firstAttribute="centerY" secondItem="gTV-IL-0wX" secondAttribute="centerY" id="tN6-1J-7cZ"/>
                 <constraint firstItem="VUU-Ww-mYR" firstAttribute="centerY" secondItem="gTV-IL-0wX" secondAttribute="centerY" id="uFk-pc-iqL"/>
             </constraints>

--- a/podcasts/SmallListCell.xib
+++ b/podcasts/SmallListCell.xib
@@ -33,30 +33,24 @@
                         <rect key="frame" x="56" y="3" width="241" height="92"/>
                         <subviews>
                             <view contentMode="scaleToFill" verticalCompressionResistancePriority="248" translatesAutoresizingMaskIntoConstraints="NO" id="Rla-LP-MtP">
-                                <rect key="frame" x="0.0" y="0.0" width="241" height="22.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="241" height="23"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" text="A very large title that should grow to the next line" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bUF-uV-U8H" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="25.5" width="241" height="19.5"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="19" id="TO4-nj-GAk"/>
-                                </constraints>
+                                <rect key="frame" x="0.0" y="26" width="241" height="19.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="A very large author that show grow to the next line" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FTw-UR-Z1t" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="48" width="241" height="19"/>
+                                <rect key="frame" x="0.0" y="48.5" width="241" height="18"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="19" id="Bld-hY-KIk"/>
-                                </constraints>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <color key="textColor" red="0.5607843137254902" green="0.59215686274509804" blue="0.64313725490196083" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="eTD-aU-OQh">
-                                <rect key="frame" x="0.0" y="70" width="241" height="22"/>
+                                <rect key="frame" x="0.0" y="69.5" width="241" height="22.5"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                         </subviews>

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -248,6 +248,9 @@ class UpNextNowPlayingCell: ThemeableCell {
         playingAnimationView.updateSizeConstraints(to: buttonSize)
 
         updateDownloadStatus()
+
+        episodeTitle.updateNumberOfLines(regular: 1, accessibility: 3)
+        dateLabel.updateNumberOfLines(regular: 1, accessibility: 2)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -28,7 +28,7 @@ class UpNextNowPlayingCell: ThemeableCell {
     @IBOutlet var downloadedIndicator: UIImageView!
     @IBOutlet var downloadingIndicator: UIActivityIndicatorView! {
         didSet {
-            //downloadingIndicator.transform = CGAffineTransform(scaleX: 0.75, y: 0.75)
+            downloadingIndicator.transform = CGAffineTransform(scaleX: 1, y: 1)
         }
     }
 

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -28,7 +28,7 @@ class UpNextNowPlayingCell: ThemeableCell {
     @IBOutlet var downloadedIndicator: UIImageView!
     @IBOutlet var downloadingIndicator: UIActivityIndicatorView! {
         didSet {
-            downloadingIndicator.transform = CGAffineTransform(scaleX: 1, y: 1)
+            downloadingIndicator.transform = CGAffineTransform(scaleX: 0.75, y: 0.75)
         }
     }
 
@@ -170,7 +170,7 @@ class UpNextNowPlayingCell: ThemeableCell {
             disclosureImageView.backgroundColor = AppTheme.colorForStyle(.primaryUi05, themeOverride: themeOverride)
             disclosureImageView.tintColor = AppTheme.colorForStyle(.primaryInteractive01, themeOverride: themeOverride)
         }
-
+        downloadingIndicator.color = AppTheme.colorForStyle(.primaryIcon01, themeOverride: themeOverride)
         playingAnimationView.setFillColor(AppTheme.colorForStyle(.primaryText01, themeOverride: themeOverride))
     }
 

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -28,7 +28,7 @@ class UpNextNowPlayingCell: ThemeableCell {
     @IBOutlet var downloadedIndicator: UIImageView!
     @IBOutlet var downloadingIndicator: UIActivityIndicatorView! {
         didSet {
-            downloadingIndicator.transform = CGAffineTransform(scaleX: 0.75, y: 0.75)
+            //downloadingIndicator.transform = CGAffineTransform(scaleX: 0.75, y: 0.75)
         }
     }
 

--- a/podcasts/UpNextNowPlayingCell.xib
+++ b/podcasts/UpNextNowPlayingCell.xib
@@ -29,7 +29,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oXa-LZ-pvj" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="12" y="12" width="48" height="48"/>
+                                <rect key="frame" x="12" y="32.5" width="48" height="48"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="48" id="Ikt-fn-OqM"/>
@@ -42,7 +42,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MONDAY" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uFH-le-6i7" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="70" y="12" width="178" height="23"/>
+                                <rect key="frame" x="70" y="10" width="178" height="25"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -56,32 +56,32 @@
                             <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="1fL-ql-Hfg">
                                 <rect key="frame" x="70" y="57" width="48" height="50"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U8E-BC-Cls">
-                                        <rect key="frame" x="0.0" y="0.0" width="0.0" height="50"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" id="ugk-pc-7Mu"/>
-                                        </constraints>
-                                    </view>
                                     <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="OzR-Qq-DsV" userLabel="Downloading Indicator">
-                                        <rect key="frame" x="8" y="17" width="16" height="16"/>
+                                        <rect key="frame" x="0.0" y="17" width="16" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="16" id="PFX-gi-0dj"/>
                                             <constraint firstAttribute="height" constant="16" id="sr8-ek-Aog"/>
                                         </constraints>
                                     </activityIndicatorView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="list_downloaded" translatesAutoresizingMaskIntoConstraints="NO" id="KAb-iK-X7U">
-                                        <rect key="frame" x="32" y="17" width="16" height="16"/>
+                                        <rect key="frame" x="24" y="17" width="16" height="16"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="16" id="6rq-sD-ThI"/>
                                             <constraint firstAttribute="width" constant="16" id="U0t-bh-rkL"/>
                                         </constraints>
                                     </imageView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U8E-BC-Cls">
+                                        <rect key="frame" x="48" y="0.0" width="0.0" height="50"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" id="ugk-pc-7Mu"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="53 Minutes remaining" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TpI-i7-PDk" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="118" y="60" width="130" height="44"/>
+                                <rect key="frame" x="118" y="57" width="130" height="50"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="13"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -111,8 +111,8 @@
                             <constraint firstItem="mhM-ON-FAA" firstAttribute="top" secondItem="uFH-le-6i7" secondAttribute="bottom" constant="2" id="FDE-I4-Ijn"/>
                             <constraint firstItem="mhM-ON-FAA" firstAttribute="trailing" secondItem="uFH-le-6i7" secondAttribute="trailing" id="FSB-nj-2a9"/>
                             <constraint firstItem="Drj-gb-CmX" firstAttribute="top" secondItem="lof-Ey-IPR" secondAttribute="top" id="IGm-mv-RZ3"/>
-                            <constraint firstItem="uFH-le-6i7" firstAttribute="top" secondItem="lof-Ey-IPR" secondAttribute="top" constant="12" id="JoR-VQ-h4V"/>
-                            <constraint firstItem="oXa-LZ-pvj" firstAttribute="top" secondItem="uFH-le-6i7" secondAttribute="top" id="O7c-cP-oFm"/>
+                            <constraint firstItem="uFH-le-6i7" firstAttribute="top" secondItem="lof-Ey-IPR" secondAttribute="top" constant="10" id="JoR-VQ-h4V" userLabel="Date Label.top = top + 12"/>
+                            <constraint firstItem="oXa-LZ-pvj" firstAttribute="centerY" secondItem="lof-Ey-IPR" secondAttribute="centerY" id="O7c-cP-oFm"/>
                             <constraint firstItem="t5J-xk-yXq" firstAttribute="centerY" secondItem="lV7-rK-gas" secondAttribute="centerY" id="Pr0-ss-PCS"/>
                             <constraint firstItem="TpI-i7-PDk" firstAttribute="leading" secondItem="1fL-ql-Hfg" secondAttribute="trailing" id="TU0-OR-OXR"/>
                             <constraint firstAttribute="bottom" secondItem="Drj-gb-CmX" secondAttribute="bottom" id="ZAC-8g-I6v"/>
@@ -123,7 +123,7 @@
                             <constraint firstItem="uFH-le-6i7" firstAttribute="leading" secondItem="oXa-LZ-pvj" secondAttribute="trailing" constant="10" id="iPt-2Y-afY"/>
                             <constraint firstAttribute="trailing" secondItem="t5J-xk-yXq" secondAttribute="trailing" constant="12" id="izN-PH-Mb2"/>
                             <constraint firstItem="1fL-ql-Hfg" firstAttribute="bottom" secondItem="lof-Ey-IPR" secondAttribute="bottom" constant="-6" id="kUL-3d-eNZ"/>
-                            <constraint firstItem="TpI-i7-PDk" firstAttribute="top" secondItem="mhM-ON-FAA" secondAttribute="bottom" constant="6" id="pVN-Cm-KLx"/>
+                            <constraint firstItem="TpI-i7-PDk" firstAttribute="top" secondItem="mhM-ON-FAA" secondAttribute="bottom" constant="3" id="pVN-Cm-KLx"/>
                             <constraint firstItem="1fL-ql-Hfg" firstAttribute="centerY" secondItem="TpI-i7-PDk" secondAttribute="centerY" id="rvc-gd-x6c"/>
                             <constraint firstItem="TpI-i7-PDk" firstAttribute="trailing" secondItem="mhM-ON-FAA" secondAttribute="trailing" id="xkT-Mm-Xn6"/>
                         </constraints>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Fine tune the following items for dynamic type:

- Max number of lines for podcast names and details only when using larger accessibility sizes
- Update spacing for player shelf actions to ensure minimum 72 spacing
- Update spacing for multi-selection actions to ensure minimum 72 spacing
- Ensure that larger grid cells only show on larger sizes of accessibility

| Player Shelf Actions Normal |  Player Shelf Actions Edit  | Multi-select | Multi-select Edit
| - | - | - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-09 at 21 31 40" src="https://github.com/user-attachments/assets/e42cb12d-5ba6-46ee-944c-5a743a03bd3c" />  | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-09 at 21 31 42" src="https://github.com/user-attachments/assets/77fb3b83-74d5-466c-941e-2327a79603fb" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-09 at 21 31 27" src="https://github.com/user-attachments/assets/3893270d-b187-4868-b4e2-57a015b8f0ef" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-09 at 21 31 31" src="https://github.com/user-attachments/assets/22a2c40a-1423-460d-ba9b-91463382bdca" /> |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-09 at 21 39 22" src="https://github.com/user-attachments/assets/2bac591f-de9c-4f8e-9f52-ec52187552c3" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-09 at 21 39 06" src="https://github.com/user-attachments/assets/ef88b0bf-6be0-4eac-afb8-8870fc217de5" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-09 at 21 38 57" src="https://github.com/user-attachments/assets/3386af4b-31ed-40cc-8652-af1800e2f4b8" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-09 at 21 38 45" src="https://github.com/user-attachments/assets/d624da65-cf4d-4969-b8e4-ce474c607eb9" /> |

## To test

1. Start the app
2. Ensure that you have set the default Dynamic Type setting (Large)
3. Open a Podcast
4. Activate multi-select
5. Tap on the ... button
6. Check that rows have the minimum 72 spacing
7. Play an episode
8. Open the full screen player
9. Tap on the ... button
10. Check that rows have the minimum 72 spacing
11. Tap on Edit
12. Check that rows have the minimum 72 spacing
13. Open UpNext
14. Check  that episode titles don't have more than 1 lines

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
