### PR TITLE
Change logging level for up next sync

### DIFF
--- a/podcasts/WatchManager.swift
+++ b/podcasts/WatchManager.swift
@@ -653,7 +653,7 @@ class WatchManager: NSObject, WCSessionDelegate {
                 "error_code": "payloadTooLarge",
                 "up_next_count": "\(upNextCount)"
             ],
-            level: .error
+            level: .warning // This is a critical error but we fall back to the limited Up Next sync so it should be recoverable
         )
     }
 


### PR DESCRIPTION
Changes the Sentry logging level from `error` to `warning` for `payloadTooLarge` errors. We can still see them in Sentry but they don't need to clutter up our error logging. [This Sentry event](https://a8c.sentry.io/issues/7306474311/events/d20e1661ba1a49e9b817a12850dfd35e/?project=4503921846583296&referrer=previous-event) shows some of the reports so far.

## To test

We have other warning events that are going through so it shouldn't break anything. If you want, you can manually trigger this code path and verify the event occurs in Sentry.

Otherwise, 🟢 CI

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
