### PR TITLE
Remove v7Run lastTabOpened update

### DIFF
--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -51,10 +51,6 @@ extension AppDelegate {
             defaults.set(true, forKey: Constants.UserDefaults.cleanupPlayed)
         }
 
-        performUpdateIfRequired(updateKey: "v7Run") {
-            defaults.set(2, forKey: Constants.UserDefaults.lastTabOpened)
-        }
-
         performUpdateIfRequired(updateKey: "v7bRun") {
             Settings.setAutoDownloadMobileDataAllowed(false)
         }


### PR DESCRIPTION
Fixes a bug with the selected tab after onboarding.

When the app launches, `MainTabBarController.viewDidAppear` is called with the following code switching tabs:

```swift
// if this key was never set lets default to Discovery or Podcast depending of podcasts followed
if UserDefaults.standard.object(forKey: Constants.UserDefaults.lastTabOpened) == nil {
    selectedIndex = DataManager.sharedManager.podcastCount() > 0 ? Tab.podcasts.rawValue: Tab.discover.rawValue
}
```

This is called AGAIN after Onboarding completes. Because `lastTabOpened` was being set to that default value, this code was skipped.

The downside here is that `MainTabBarController.viewDidAppear` is called BEFORE onboarding begins as well as after.

## To test

### Discover Tab
* On a fresh install
* Go through onboarding and don't follow any podcasts
* ✅ Ensure the Discover tab is shown

### Podcasts tab
* Reinstall
* Go through onboarding and follow podcasts
* ✅ Ensure the Podcasts tab is shown

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
