### PR TITLE
Fix AirPlay route change bug

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1968,7 +1968,18 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         let reason = changeReason.uintValue
         if let currEpisode = currentEpisode(), playingOverAirplay() && playerSwitchRequired() {
-            let autoPlay = FeatureFlag.dontAutoplayOnRouteChange.enabled ? false : true
+            let wasPlaying = player?.shouldBePlaying() ?? false
+            let autoPlay: Bool
+            if FeatureFlag.dontAutoplayOnRouteChange.enabled {
+                // When flag is enabled: only autoplay if we were already playing
+                autoPlay = wasPlaying
+                if autoPlay {
+                    FileLog.shared.addMessage("PlaybackManager: Route change with active playback, preserving autoPlay=true")
+                }
+            } else {
+                // When flag is disabled: always autoplay (original behavior)
+                autoPlay = true
+            }
             load(episode: currEpisode, autoPlay: autoPlay, overrideUpNext: false)
         } else if reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue {
             player?.routeDidChange(shouldPause: true)


### PR DESCRIPTION
Fixes [PCIOS-553](https://linear.app/a8c/issue/PCIOS-553/audio-stops-after-1-second-when-switching-playback-to-homepod-via-in)

I [added](https://github.com/Automattic/pocket-casts-ios/pull/3864) the `dontAutoplayOnRouteChange` Feature Flag with a change to the autoplay behavior when switching routes to avoid issues I noticed where triggering Airplay would autoplay without the episode currently playing. However, that change disabled all autoplay which a player switch was required (Trim Silence). This now checks whether the player should play, which was the intended behavior.

I've disabled the `dontAutoplayOnRouteChange` Feature Flag for now but it can be re-enabled with 8.8 after this change.

## To test

* Play an episode with Trim Silence enabled
* Airplay to a speaker
* Ensure playback continues without needing to be restarted in the app 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
