### PR TITLE
Fix discover category list

### DIFF
--- a/PocketCastsTests/Tests/Discover/CategoryPodcastsViewControllerTests.swift
+++ b/PocketCastsTests/Tests/Discover/CategoryPodcastsViewControllerTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import podcasts
+@testable import PocketCastsServer
+
+final class CategoryPodcastsViewControllerTests: XCTestCase {
+
+    // MARK: - Bug Reproduction: PCIOS-561
+    // Top 5 podcasts are being repeated on Category pages
+    //
+    // When viewing a category page, the "Most Popular" carousel shows the top 5 podcasts.
+    // The list below should start at #6, but currently shows all podcasts including the top 5.
+    //
+    // Root cause: CategoryPodcastsViewController doesn't use summaryItemCount from the
+    // DiscoverItem to skip podcasts already shown in the carousel.
+
+    func testCategoryListItemShouldIncludeSummaryItemCountToSkipCarouselPodcasts() {
+        // Given: A category with a "Most Popular" section showing 5 items
+        var category = DiscoverCategory(id: 1, name: "Technology")
+        category.source = "https://example.com/tech"
+        let popularItemsCount = 5
+
+        // When: Creating a category list item for the full podcast list
+        // The item should specify how many podcasts to skip (those already in the carousel)
+        let categoryListItem = DiscoverItem(
+            id: "category-\(category.id ?? 0)",
+            title: category.name,
+            type: "category_podcast_list",
+            summaryItemCount: popularItemsCount, // This is what the fix should add
+            source: category.source,
+            regions: ["us"],
+            categoryID: category.id
+        )
+
+        // Then: The item should have summaryItemCount set to skip the carousel podcasts
+        XCTAssertEqual(
+            categoryListItem.summaryItemCount,
+            popularItemsCount,
+            "Category list item should have summaryItemCount to indicate how many podcasts to skip"
+        )
+    }
+
+    func testCategoryPodcastsViewControllerInitializesWithZeroSkipCount() {
+        // Given/When: A CategoryPodcastsViewController initialized with default skipCount
+        let viewController = CategoryPodcastsViewController(region: "us")
+
+        // Then: skipCount should be 0 by default
+        XCTAssertEqual(
+            viewController.currentSkipCount,
+            0,
+            "CategoryPodcastsViewController should initialize with skipCount of 0"
+        )
+    }
+
+    func testCategoryPodcastsViewControllerCanBeInitializedWithCustomSkipCount() {
+        // Given/When: A CategoryPodcastsViewController initialized with a custom skipCount
+        let viewController = CategoryPodcastsViewController(region: "us", skipCount: 5)
+
+        // Then: skipCount should match the provided value
+        XCTAssertEqual(
+            viewController.currentSkipCount,
+            5,
+            "CategoryPodcastsViewController should use the provided skipCount"
+        )
+    }
+
+    func testCategoryPodcastsViewControllerUpdatesSkipCountFromItem() {
+        // Given: A CategoryPodcastsViewController with default skipCount
+        let viewController = CategoryPodcastsViewController(region: "us")
+        XCTAssertEqual(viewController.currentSkipCount, 0, "Initial skipCount should be 0")
+
+        // And: A DiscoverItem with summaryItemCount indicating podcasts to skip
+        let item = DiscoverItem(
+            id: "category-1",
+            title: "Technology",
+            type: "category_podcast_list",
+            summaryItemCount: 5, // Skip first 5 podcasts (already shown in carousel)
+            source: "https://example.com/tech",
+            regions: ["us"],
+            categoryID: 1
+        )
+
+        var category = DiscoverCategory(id: 1, name: "Technology")
+        category.source = "https://example.com/tech"
+
+        // When: updateSkipCount is called with the item
+        // (This method will be added as part of the fix)
+        viewController.updateSkipCount(from: item)
+
+        // Then: skipCount should be updated from item.summaryItemCount
+        // This test will FAIL until the fix is implemented
+        XCTAssertEqual(
+            viewController.currentSkipCount,
+            5,
+            "CategoryPodcastsViewController should update skipCount from item.summaryItemCount"
+        )
+    }
+
+    func testCategoryPodcastsViewControllerKeepsZeroSkipCountWhenItemHasNoSummaryItemCount() {
+        // Given: A CategoryPodcastsViewController with default skipCount
+        let viewController = CategoryPodcastsViewController(region: "us")
+
+        // And: A DiscoverItem WITHOUT summaryItemCount
+        let item = DiscoverItem(
+            id: "category-1",
+            title: "Technology",
+            type: "category_podcast_list",
+            source: "https://example.com/tech",
+            regions: ["us"],
+            categoryID: 1
+        )
+
+        // When: updateSkipCount is called with the item
+        viewController.updateSkipCount(from: item)
+
+        // Then: skipCount should remain 0
+        XCTAssertEqual(
+            viewController.currentSkipCount,
+            0,
+            "CategoryPodcastsViewController should keep skipCount at 0 when item has no summaryItemCount"
+        )
+    }
+}

--- a/PocketCastsTests/Tests/Discover/CategoryPodcastsViewControllerTests.swift
+++ b/PocketCastsTests/Tests/Discover/CategoryPodcastsViewControllerTests.swift
@@ -4,40 +4,9 @@ import XCTest
 
 final class CategoryPodcastsViewControllerTests: XCTestCase {
 
-    // MARK: - Bug Reproduction: PCIOS-561
-    // Top 5 podcasts are being repeated on Category pages
-    //
-    // When viewing a category page, the "Most Popular" carousel shows the top 5 podcasts.
-    // The list below should start at #6, but currently shows all podcasts including the top 5.
-    //
-    // Root cause: CategoryPodcastsViewController doesn't use summaryItemCount from the
-    // DiscoverItem to skip podcasts already shown in the carousel.
-
-    func testCategoryListItemShouldIncludeSummaryItemCountToSkipCarouselPodcasts() {
-        // Given: A category with a "Most Popular" section showing 5 items
-        var category = DiscoverCategory(id: 1, name: "Technology")
-        category.source = "https://example.com/tech"
-        let popularItemsCount = 5
-
-        // When: Creating a category list item for the full podcast list
-        // The item should specify how many podcasts to skip (those already in the carousel)
-        let categoryListItem = DiscoverItem(
-            id: "category-\(category.id ?? 0)",
-            title: category.name,
-            type: "category_podcast_list",
-            summaryItemCount: popularItemsCount, // This is what the fix should add
-            source: category.source,
-            regions: ["us"],
-            categoryID: category.id
-        )
-
-        // Then: The item should have summaryItemCount set to skip the carousel podcasts
-        XCTAssertEqual(
-            categoryListItem.summaryItemCount,
-            popularItemsCount,
-            "Category list item should have summaryItemCount to indicate how many podcasts to skip"
-        )
-    }
+    // MARK: - Bug Fix: PCIOS-561
+    // Top 5 podcasts were being repeated on Category pages.
+    // The fix uses summaryItemCount from DiscoverItem to skip podcasts already shown in the carousel.
 
     func testCategoryPodcastsViewControllerInitializesWithZeroSkipCount() {
         // Given/When: A CategoryPodcastsViewController initialized with default skipCount
@@ -45,7 +14,7 @@ final class CategoryPodcastsViewControllerTests: XCTestCase {
 
         // Then: skipCount should be 0 by default
         XCTAssertEqual(
-            viewController.currentSkipCount,
+            viewController.skipCount,
             0,
             "CategoryPodcastsViewController should initialize with skipCount of 0"
         )
@@ -57,7 +26,7 @@ final class CategoryPodcastsViewControllerTests: XCTestCase {
 
         // Then: skipCount should match the provided value
         XCTAssertEqual(
-            viewController.currentSkipCount,
+            viewController.skipCount,
             5,
             "CategoryPodcastsViewController should use the provided skipCount"
         )
@@ -66,7 +35,7 @@ final class CategoryPodcastsViewControllerTests: XCTestCase {
     func testCategoryPodcastsViewControllerUpdatesSkipCountFromItem() {
         // Given: A CategoryPodcastsViewController with default skipCount
         let viewController = CategoryPodcastsViewController(region: "us")
-        XCTAssertEqual(viewController.currentSkipCount, 0, "Initial skipCount should be 0")
+        XCTAssertEqual(viewController.skipCount, 0, "Initial skipCount should be 0")
 
         // And: A DiscoverItem with summaryItemCount indicating podcasts to skip
         let item = DiscoverItem(
@@ -79,17 +48,12 @@ final class CategoryPodcastsViewControllerTests: XCTestCase {
             categoryID: 1
         )
 
-        var category = DiscoverCategory(id: 1, name: "Technology")
-        category.source = "https://example.com/tech"
-
         // When: updateSkipCount is called with the item
-        // (This method will be added as part of the fix)
         viewController.updateSkipCount(from: item)
 
         // Then: skipCount should be updated from item.summaryItemCount
-        // This test will FAIL until the fix is implemented
         XCTAssertEqual(
-            viewController.currentSkipCount,
+            viewController.skipCount,
             5,
             "CategoryPodcastsViewController should update skipCount from item.summaryItemCount"
         )
@@ -114,7 +78,7 @@ final class CategoryPodcastsViewControllerTests: XCTestCase {
 
         // Then: skipCount should remain 0
         XCTAssertEqual(
-            viewController.currentSkipCount,
+            viewController.skipCount,
             0,
             "CategoryPodcastsViewController should keep skipCount at 0 when item has no summaryItemCount"
         )

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -168,7 +168,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     /// Updates the skipCount from the item's summaryItemCount.
     /// This is used to skip podcasts already shown in the "Most Popular" carousel.
     func updateSkipCount(from item: DiscoverItem) {
-        skipCount = item.summaryItemCount ?? 0
+        skipCount = max(0, item.summaryItemCount ?? 0)
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -27,8 +27,13 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
             title = category?.name?.localized
         }
     }
-    private var skipCount: Int
+    private(set) var skipCount: Int
     private var podcasts = [DiscoverPodcast]()
+
+    /// Exposes skipCount for testing purposes
+    var currentSkipCount: Int {
+        skipCount
+    }
     private var promotion: DiscoverCategoryPromotion?
     fileprivate var region: String?
 
@@ -160,6 +165,12 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
         self.delegate = delegate
     }
 
+    /// Updates the skipCount from the item's summaryItemCount.
+    /// This is used to skip podcasts already shown in the "Most Popular" carousel.
+    func updateSkipCount(from item: DiscoverItem) {
+        skipCount = item.summaryItemCount ?? 0
+    }
+
     override var preferredStatusBarStyle: UIStatusBarStyle {
         AppTheme.defaultStatusBarStyle()
     }
@@ -178,8 +189,11 @@ extension CategoryPodcastsViewController: DiscoverSummaryProtocol {
         }
         self.region = region
 
+        // Update skipCount from item to skip podcasts already shown in the carousel
+        updateSkipCount(from: item)
+
         podcasts = []
-        podcastsTable.reloadData()
+        podcastsTable?.reloadData()
         loadPodcasts()
     }
 }

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -29,11 +29,6 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     }
     private(set) var skipCount: Int
     private var podcasts = [DiscoverPodcast]()
-
-    /// Exposes skipCount for testing purposes
-    var currentSkipCount: Int {
-        skipCount
-    }
     private var promotion: DiscoverCategoryPromotion?
     fileprivate var region: String?
 

--- a/podcasts/DiscoverCollectionViewController+Categories.swift
+++ b/podcasts/DiscoverCollectionViewController+Categories.swift
@@ -60,7 +60,8 @@ extension DiscoverCollectionViewController {
         var newLayout = layout
         newLayout.layout?.insert(item, at: layout.layout?.startIndex.advanced(by: 1) ?? 0)
 
-        let categoryListItem = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, type: "category_podcast_list", source: category.source, regions: regions, categoryID: category.id)
+        // Use the summaryItemCount from the "Most Popular" item to skip those podcasts in the full list
+        let categoryListItem = DiscoverItem(id: "category-\(category.id ?? 0)", title: category.name, type: "category_podcast_list", summaryItemCount: item.summaryItemCount, source: category.source, regions: regions, categoryID: category.id)
         newLayout.layout?.append(categoryListItem)
 
         return newLayout


### PR DESCRIPTION
Fixes [PCIOS-561](https://linear.app/a8c/issue/PCIOS-561/top-5-podcasts-are-being-repeated-on-category-pages)

| Before | After |
|--|--|
| <img width="300" alt="Simulator Screenshot - iPhone 15 - 2026-03-12 at 15 20 10" src="https://github.com/user-attachments/assets/ba49f9fd-8ad7-4902-83f3-3f22c10e4941" /> | <img width="300" alt="Simulator Screenshot - iPhone 15 - 2026-03-12 at 15 32 40" src="https://github.com/user-attachments/assets/32b9e83b-00dd-4a86-838c-30077efb9acc" /> |


## To test

* Visit a category in the Discover tab
* ✅ Verify that the carousel podcasts are not shown in the list below

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
