### PR TITLE
Ensure podcast settings cell for UpNext show selected values

### DIFF
--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -78,7 +78,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastSettingsViewController.disclosureCellId, for: indexPath) as! DisclosureCell
             cell.cellLabel.text = L10n.settingsQueuePosition
             cell.setImage(imageName: nil)
-
+            cell.showSecondaryLabel = true
             let upNextOrder = podcast.autoAddToUpNextSetting()?.rawValue
             cell.cellSecondaryLabel.text = (upNextOrder == AutoAddToUpNextSetting.addLast.rawValue) ? L10n.bottom : L10n.top
 
@@ -87,7 +87,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastSettingsViewController.disclosureCellId, for: indexPath) as! DisclosureCell
             cell.cellLabel.text = L10n.settingsGlobalSettings
             cell.setImage(imageName: nil)
-
+            cell.showSecondaryLabel = true
             cell.cellSecondaryLabel.text = L10n.settingsEpisodeLimitFormat(ServerSettings.autoAddToUpNextLimit().localized())
 
             return cell

--- a/podcasts/PodcastSettingsViewController+Table.swift
+++ b/podcasts/PodcastSettingsViewController+Table.swift
@@ -320,13 +320,14 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
 
     private func showAutoAddPositionSettings() {
         let positionPicker = OptionsPicker(title: L10n.autoAdd.localizedUppercase)
+        let currentSetting = podcast.autoAddToUpNextSetting()
 
-        let topAction = OptionAction(label: L10n.top, icon: nil) {
+        let topAction = OptionAction(label: L10n.top, icon: nil, selected: currentSetting == .addFirst) {
             self.setUpNext(.addFirst)
         }
         positionPicker.addAction(action: topAction)
 
-        let bottomAction = OptionAction(label: L10n.bottom, icon: nil) {
+        let bottomAction = OptionAction(label: L10n.bottom, icon: nil, selected: currentSetting == .addLast) {
             self.setUpNext(.addLast)
         }
         positionPicker.addAction(action: bottomAction)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Small fix to ensure that the UpNext adding options are show in Podcast Settings
<img width="320"  alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-13 at 10 19 19" src="https://github.com/user-attachments/assets/02c1bef9-d6c1-4f05-b8f1-15560371159c" />

## To test

1. Start the app
2. Open a Podcast you follow
3. Open podcast settings
4. Enable Add to Up Next
5. Check that you can see the current values for Position in Queue  and Global settings

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
