### PR TITLE
Cellular Data Usage: Download status fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 8.9
 -----
 - Fix DownloadManager sessions racing conditions [#4080](https://github.com/Automattic/pocket-casts-ios/pull/4080)
-- Ensure that auto-downloads only use cellular if explicitly allowed [#4071](https://github.com/Automattic/pocket-casts-ios/pull/4071)
+- Ensure that downloads, including auto-downloads and manual/bulk downloads, only use cellular if explicitly allowed [#4071](https://github.com/Automattic/pocket-casts-ios/pull/4071)
 
 8.8
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 8.9
 -----
 - Fix DownloadManager sessions racing conditions [#4080](https://github.com/Automattic/pocket-casts-ios/pull/4080)
+- Ensure that auto-downloads only use cellular if explicitly allowed [#4071](https://github.com/Automattic/pocket-casts-ios/pull/4071)
 
 8.8
 -----

--- a/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
+++ b/Modules/DataModel/Sources/PocketCastsDataModel/Public/Enums.swift
@@ -20,7 +20,7 @@ public enum UploadedSort: Int32, CaseIterable, Codable {
 }
 
 public enum AutoDownloadStatus: Int32 {
-    case notSpecified = 0, userDeletedFile = 1, userCancelledDownload = 2, autoDownloaded = 3, playerDownloadedForStreaming = 4
+    case notSpecified = 0, userDeletedFile = 1, userCancelledDownload = 2, autoDownloaded = 3, playerDownloadedForStreaming = 4, userApprovedCellular = 5
 }
 
 public enum DownloadStatus: Int32 {

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -304,6 +304,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Track network data usage per episode/connection type in the NetworkDataUsage table
     case trackNetworkDataUsage
 
+    /// Fix cellular downloads to track user-approved cellular status explicitly
+    case cellularDownloadStatusFix
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -509,6 +512,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .detectTruncatedBackgroundSyncDownloads:
 			true
         case .trackNetworkDataUsage:
+			true
+        case .cellularDownloadStatusFix:
             true
         }
     }

--- a/PocketCastsTests/Tests/Utilities/DownloadManagerCellularSessionTests.swift
+++ b/PocketCastsTests/Tests/Utilities/DownloadManagerCellularSessionTests.swift
@@ -13,11 +13,11 @@ final class DownloadManagerCellularSessionTests: DBTestCase {
     override func setUp() {
         super.setUp()
         originalCellularDownloadStatusFix = FeatureFlag.cellularDownloadStatusFix.enabled
-        try? FeatureFlagOverrideStore().override(FeatureFlag.cellularDownloadStatusFix, withValue: true)
+        XCTAssertNoThrow(try FeatureFlagOverrideStore().override(FeatureFlag.cellularDownloadStatusFix, withValue: true))
     }
 
     override func tearDown() {
-        try? FeatureFlagOverrideStore().override(FeatureFlag.cellularDownloadStatusFix, withValue: originalCellularDownloadStatusFix)
+        XCTAssertNoThrow(try FeatureFlagOverrideStore().override(FeatureFlag.cellularDownloadStatusFix, withValue: originalCellularDownloadStatusFix))
         cleanupDownloadManager()
         super.tearDown()
     }

--- a/PocketCastsTests/Tests/Utilities/DownloadManagerCellularSessionTests.swift
+++ b/PocketCastsTests/Tests/Utilities/DownloadManagerCellularSessionTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import podcasts
 import PocketCastsDataModel
+import PocketCastsUtils
 
 /// Tests for the TOCTOU fix in DownloadManager session selection.
 /// Verifies that session selection is based on explicit user approval status,
@@ -11,12 +12,12 @@ final class DownloadManagerCellularSessionTests: DBTestCase {
 
     override func setUp() {
         super.setUp()
-        originalCellularDownloadStatusFix = FeatureFlag.cellularDownloadStatusFix
-        FeatureFlag.cellularDownloadStatusFix = true
+        originalCellularDownloadStatusFix = FeatureFlag.cellularDownloadStatusFix.enabled
+        try? FeatureFlagOverrideStore().override(FeatureFlag.cellularDownloadStatusFix, withValue: true)
     }
 
     override func tearDown() {
-        FeatureFlag.cellularDownloadStatusFix = originalCellularDownloadStatusFix
+        try? FeatureFlagOverrideStore().override(FeatureFlag.cellularDownloadStatusFix, withValue: originalCellularDownloadStatusFix)
         cleanupDownloadManager()
         super.tearDown()
     }

--- a/PocketCastsTests/Tests/Utilities/DownloadManagerCellularSessionTests.swift
+++ b/PocketCastsTests/Tests/Utilities/DownloadManagerCellularSessionTests.swift
@@ -1,0 +1,209 @@
+import XCTest
+@testable import podcasts
+import PocketCastsDataModel
+
+/// Tests for the TOCTOU fix in DownloadManager session selection.
+/// Verifies that session selection is based on explicit user approval status,
+/// not runtime network state checks.
+final class DownloadManagerCellularSessionTests: DBTestCase {
+
+    override func tearDown() {
+        super.tearDown()
+        cleanupDownloadManager()
+    }
+
+    // MARK: - Session Selection Based on AutoDownloadStatus
+
+    /// Verifies that `.userApprovedCellular` status results in cellular session usage,
+    /// regardless of current network state.
+    func testUserApprovedCellularStatusUsesCellularSession() async throws {
+        // Given: An episode with userApprovedCellular status
+        let testEpisode = createTestEpisode()
+
+        // When: Performing download with userApprovedCellular status
+        await downloadManager.performDownload(
+            episode: testEpisode,
+            url: testEpisode.downloadUrl ?? "",
+            previousDownloadFailed: false,
+            fireNotification: false,
+            autoDownloadStatus: .userApprovedCellular,
+            retryWithoutUserAgent: false
+        )
+
+        // Then: Task should be in cellular session
+        let cellularTasks = await downloadManager.cellularBackgroundSession.allTasks
+        let wifiTasks = await downloadManager.wifiOnlyBackgroundSession.allTasks
+
+        let taskInCellular = cellularTasks.contains { $0.taskDescription == testEpisode.uuid }
+        let taskInWifi = wifiTasks.contains { $0.taskDescription == testEpisode.uuid }
+
+        XCTAssertTrue(taskInCellular, "Task with userApprovedCellular should be in cellular session")
+        XCTAssertFalse(taskInWifi, "Task with userApprovedCellular should NOT be in wifi-only session")
+
+        // Cleanup
+        dataManager.delete(episodeUuid: testEpisode.uuid)
+    }
+
+    /// Verifies that `.notSpecified` status with mobile data disallowed results in
+    /// Wi-Fi-only session usage.
+    func testNotSpecifiedStatusUsesWifiOnlySessionWhenMobileDataDisallowed() async throws {
+        // Given: Mobile data is disallowed and an episode with notSpecified status
+        let originalSetting = Settings.mobileDataAllowed()
+        Settings.setMobileDataAllowed(false)
+        defer { Settings.setMobileDataAllowed(originalSetting) }
+
+        let testEpisode = createTestEpisode()
+
+        // When: Performing download with notSpecified status
+        await downloadManager.performDownload(
+            episode: testEpisode,
+            url: testEpisode.downloadUrl ?? "",
+            previousDownloadFailed: false,
+            fireNotification: false,
+            autoDownloadStatus: .notSpecified,
+            retryWithoutUserAgent: false
+        )
+
+        // Then: Task should be in wifi-only session
+        let cellularTasks = await downloadManager.cellularBackgroundSession.allTasks
+        let wifiTasks = await downloadManager.wifiOnlyBackgroundSession.allTasks
+
+        let taskInCellular = cellularTasks.contains { $0.taskDescription == testEpisode.uuid }
+        let taskInWifi = wifiTasks.contains { $0.taskDescription == testEpisode.uuid }
+
+        XCTAssertFalse(taskInCellular, "Task with notSpecified (mobile data disallowed) should NOT be in cellular session")
+        XCTAssertTrue(taskInWifi, "Task with notSpecified (mobile data disallowed) should be in wifi-only session")
+
+        // Cleanup
+        dataManager.delete(episodeUuid: testEpisode.uuid)
+    }
+
+    /// Verifies that `.notSpecified` status with mobile data allowed results in
+    /// cellular session usage (per user settings).
+    func testNotSpecifiedStatusUsesCellularSessionWhenMobileDataAllowed() async throws {
+        // Given: Mobile data is allowed and an episode with notSpecified status
+        let originalSetting = Settings.mobileDataAllowed()
+        Settings.setMobileDataAllowed(true)
+        defer { Settings.setMobileDataAllowed(originalSetting) }
+
+        let testEpisode = createTestEpisode()
+
+        // When: Performing download with notSpecified status
+        await downloadManager.performDownload(
+            episode: testEpisode,
+            url: testEpisode.downloadUrl ?? "",
+            previousDownloadFailed: false,
+            fireNotification: false,
+            autoDownloadStatus: .notSpecified,
+            retryWithoutUserAgent: false
+        )
+
+        // Then: Task should be in cellular session (because settings allow it)
+        let cellularTasks = await downloadManager.cellularBackgroundSession.allTasks
+        let wifiTasks = await downloadManager.wifiOnlyBackgroundSession.allTasks
+
+        let taskInCellular = cellularTasks.contains { $0.taskDescription == testEpisode.uuid }
+        let taskInWifi = wifiTasks.contains { $0.taskDescription == testEpisode.uuid }
+
+        XCTAssertTrue(taskInCellular, "Task with notSpecified (mobile data allowed) should be in cellular session")
+        XCTAssertFalse(taskInWifi, "Task with notSpecified (mobile data allowed) should NOT be in wifi-only session")
+
+        // Cleanup
+        dataManager.delete(episodeUuid: testEpisode.uuid)
+    }
+
+    /// Verifies that `.autoDownloaded` status respects auto-download mobile data setting.
+    func testAutoDownloadedStatusUsesWifiOnlySessionWhenAutoDownloadMobileDataDisallowed() async throws {
+        // Given: Auto-download mobile data is disallowed
+        let originalSetting = Settings.autoDownloadMobileDataAllowed()
+        Settings.setAutoDownloadMobileDataAllowed(false)
+        defer { Settings.setAutoDownloadMobileDataAllowed(originalSetting) }
+
+        let testEpisode = createTestEpisode()
+
+        // When: Performing download with autoDownloaded status
+        await downloadManager.performDownload(
+            episode: testEpisode,
+            url: testEpisode.downloadUrl ?? "",
+            previousDownloadFailed: false,
+            fireNotification: false,
+            autoDownloadStatus: .autoDownloaded,
+            retryWithoutUserAgent: false
+        )
+
+        // Then: Task should be in wifi-only session
+        let cellularTasks = await downloadManager.cellularBackgroundSession.allTasks
+        let wifiTasks = await downloadManager.wifiOnlyBackgroundSession.allTasks
+
+        let taskInCellular = cellularTasks.contains { $0.taskDescription == testEpisode.uuid }
+        let taskInWifi = wifiTasks.contains { $0.taskDescription == testEpisode.uuid }
+
+        XCTAssertFalse(taskInCellular, "Task with autoDownloaded (auto mobile data disallowed) should NOT be in cellular session")
+        XCTAssertTrue(taskInWifi, "Task with autoDownloaded (auto mobile data disallowed) should be in wifi-only session")
+
+        // Cleanup
+        dataManager.delete(episodeUuid: testEpisode.uuid)
+    }
+
+    // MARK: - Regression Tests
+
+    /// Regression test: Ensures that notSpecified status does NOT implicitly approve
+    /// cellular downloads based on current network state.
+    /// This was the original TOCTOU bug.
+    func testNotSpecifiedStatusDoesNotImplicitlyApproveCellular() async throws {
+        // Given: Mobile data is disallowed (user preference)
+        let originalSetting = Settings.mobileDataAllowed()
+        Settings.setMobileDataAllowed(false)
+        defer { Settings.setMobileDataAllowed(originalSetting) }
+
+        let testEpisode = createTestEpisode()
+
+        // When: Performing download with notSpecified status
+        // (Simulating: user queued on Wi-Fi, but network changed to cellular before download started)
+        await downloadManager.performDownload(
+            episode: testEpisode,
+            url: testEpisode.downloadUrl ?? "",
+            previousDownloadFailed: false,
+            fireNotification: false,
+            autoDownloadStatus: .notSpecified,
+            retryWithoutUserAgent: false
+        )
+
+        // Then: Task should be in wifi-only session, NOT cellular
+        // (The fix ensures we don't assume cellular approval from network state)
+        let cellularTasks = await downloadManager.cellularBackgroundSession.allTasks
+        let taskInCellular = cellularTasks.contains { $0.taskDescription == testEpisode.uuid }
+
+        XCTAssertFalse(taskInCellular, "notSpecified status should NOT result in cellular session when mobile data is disallowed - this would be the TOCTOU bug")
+
+        // Cleanup
+        dataManager.delete(episodeUuid: testEpisode.uuid)
+    }
+
+    // MARK: - Helpers
+
+    private func createTestEpisode() -> Episode {
+        let testEpisode = Episode()
+        testEpisode.uuid = "test-cellular-\(UUID().uuidString)"
+        testEpisode.podcastUuid = podcast.uuid
+        testEpisode.podcast_id = podcast.id
+        testEpisode.downloadUrl = "https://example.com/episode.mp3"
+        testEpisode.autoDownloadStatus = AutoDownloadStatus.notSpecified.rawValue
+        testEpisode.addedDate = Date()
+        dataManager.save(episode: testEpisode)
+        return testEpisode
+    }
+
+    private func cleanupDownloadManager() {
+        let semaphore = DispatchSemaphore(value: 0)
+
+        Task {
+            await downloadManager.cancelAllTasks()
+            downloadManager.clearDownloadAttempts()
+            downloadManager.clearEpisodeCache()
+            semaphore.signal()
+        }
+
+        _ = semaphore.wait(timeout: .now() + 5)
+    }
+}

--- a/PocketCastsTests/Tests/Utilities/DownloadManagerCellularSessionTests.swift
+++ b/PocketCastsTests/Tests/Utilities/DownloadManagerCellularSessionTests.swift
@@ -7,9 +7,18 @@ import PocketCastsDataModel
 /// not runtime network state checks.
 final class DownloadManagerCellularSessionTests: DBTestCase {
 
+    private var originalCellularDownloadStatusFix: Bool!
+
+    override func setUp() {
+        super.setUp()
+        originalCellularDownloadStatusFix = FeatureFlag.cellularDownloadStatusFix
+        FeatureFlag.cellularDownloadStatusFix = true
+    }
+
     override func tearDown() {
-        super.tearDown()
+        FeatureFlag.cellularDownloadStatusFix = originalCellularDownloadStatusFix
         cleanupDownloadManager()
+        super.tearDown()
     }
 
     // MARK: - Session Selection Based on AutoDownloadStatus

--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -286,8 +286,11 @@ extension MainEpisodeActionView {
             let waitingColor = AppTheme.waitingForWifiColor()
             waitingColor.setFill()
 
+            let startingY = circleCenter.y - (Self.circleRadius / 2)
+            let startingX = circleCenter.x - (Self.circleRadius / 2)
+
             // draw the WiFi symbol
-            let translation = CGAffineTransform(translationX: 14 - rightPadding, y: 15 + (bottomPadding / 2.0))
+            let translation = CGAffineTransform(translationX: startingX - rightPadding, y: startingY + (bottomPadding / 2.0))
 
             let curve1 = UIBezierPath()
             curve1.move(to: CGPoint(x: 7.78, y: 0))

--- a/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
@@ -221,25 +221,33 @@ class MultiSelectHelper {
             return
         }
 
-        let downloadText = L10n.downloadCountPrompt(selectedEpisodes.count).localizedUppercase
-        let downloadAction = OptionAction(label: downloadText, icon: nil) { () in
-            MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
-            actionDelegate.multiSelectActionCompleted()
-        }
-
         let confirmPicker = OptionsPicker(title: nil)
         var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
 
         if NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
+            let downloadText = L10n.downloadCountPrompt(selectedEpisodes.count).localizedUppercase
+            let downloadAction = OptionAction(label: downloadText, icon: nil) { () in
+                // User is on Wi-Fi, no cellular approval needed
+                MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate, userApprovedCellular: false)
+                actionDelegate.multiSelectActionCompleted()
+            }
+
             if downloadableCount < 5 {
                 let status = L10n.multiSelectDownloadingEpisodesFormat(selectedEpisodes.count.localized())
                 actionDelegate.multiSelectActionBegan(status: status)
-                MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
+                MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate, userApprovedCellular: false)
                 return
             } else {
                 confirmPicker.addDescriptiveActions(title: L10n.download, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
             }
         } else {
+            let downloadText = L10n.downloadCountPrompt(selectedEpisodes.count).localizedUppercase
+            let downloadAction = OptionAction(label: downloadText, icon: nil) { () in
+                // User explicitly approved cellular download
+                MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate, userApprovedCellular: true)
+                actionDelegate.multiSelectActionCompleted()
+            }
+
             let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
                 let status = L10n.multiSelectQueuingEpisodesFormat(selectedEpisodes.count.localized())
                 actionDelegate.multiSelectActionBegan(status: status)
@@ -257,11 +265,17 @@ class MultiSelectHelper {
         confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())
     }
 
-    private class func downloadEpisodes(_ episodes: [BaseEpisode], actionDelegate: MultiSelectActionDelegate) {
+    private class func downloadEpisodes(_ episodes: [BaseEpisode], actionDelegate: MultiSelectActionDelegate, userApprovedCellular: Bool) {
+        let status: AutoDownloadStatus
+        if FeatureFlag.cellularDownloadStatusFix.enabled {
+            status = userApprovedCellular ? .userApprovedCellular : .notSpecified
+        } else {
+            status = .notSpecified
+        }
         DispatchQueue.global().async {
             var queuedEpisodes = 0
             for episode in episodes {
-                DownloadManager.shared.addToQueue(episodeUuid: episode.uuid, fireNotification: true, autoDownloadStatus: .notSpecified)
+                DownloadManager.shared.addToQueue(episodeUuid: episode.uuid, fireNotification: true, autoDownloadStatus: status)
                 queuedEpisodes += 1
                 if queuedEpisodes == Constants.Limits.maxBulkDownloads {
                     return

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -542,7 +542,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         let mobileDataAllowed = autoDownloadStatus == .autoDownloaded ? Settings.autoDownloadMobileDataAllowed() : Settings.mobileDataAllowed()
         let useCellularSession: Bool
         if FeatureFlag.cellularDownloadStatusFix.enabled {
-            // Allow cellular downloads if mobile data is allowed by settings OR if the user explicitly approved cellular download at queue time
+            // Allow cellular downloads if mobile data is allowed by settings, if the user explicitly approved cellular download at queue time, or for episodes downloaded by the player for streaming
             useCellularSession = mobileDataAllowed || autoDownloadStatus == .userApprovedCellular || autoDownloadStatus == .playerDownloadedForStreaming
         } else {
             // allow cellular downloads if not on WiFi and not auto downloaded, because it means the user said yes to a confirmation prompt

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -540,7 +540,14 @@ class DownloadManager: NSObject, FilePathProtocol {
 
         let tempFilePath = tempPathForEpisode(episode)
         let mobileDataAllowed = autoDownloadStatus == .autoDownloaded ? Settings.autoDownloadMobileDataAllowed() : Settings.mobileDataAllowed()
-        let useCellularSession = (mobileDataAllowed || (!NetworkUtils.shared.isConnectedToUnexpensiveConnection() && autoDownloadStatus != .autoDownloaded)) // allow cellular downloads if not on WiFi and not auto downloaded, because it means the user said yes to a confirmation prompt
+        let useCellularSession: Bool
+        if FeatureFlag.cellularDownloadStatusFix.enabled {
+            // Allow cellular downloads if mobile data is allowed by settings OR if the user explicitly approved cellular download at queue time
+            useCellularSession = mobileDataAllowed || autoDownloadStatus == .userApprovedCellular
+        } else {
+            // allow cellular downloads if not on WiFi and not auto downloaded, because it means the user said yes to a confirmation prompt
+            useCellularSession = (mobileDataAllowed || (!NetworkUtils.shared.isConnectedToUnexpensiveConnection() && autoDownloadStatus != .autoDownloaded))
+        }
 
         #if os(watchOS)
             let sessionToUse = await WKApplication.shared().applicationState == .background ? cellularBackgroundSession : cellularForegroundSession

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -779,7 +779,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         let queuedEpisodes = dataManager.findEpisodesWhere(customWhere: "episodeStatus == ?", arguments: [DownloadStatus.queued.rawValue])
         queuedEpisodes.forEach { episode in
             Task {
-                addToQueue(episodeUuid: episode.uuid)
+                addToQueue(episodeUuid: episode.uuid, fireNotification: false, autoDownloadStatus: AutoDownloadStatus(rawValue: episode.autoDownloadStatus) ?? .notSpecified)
             }
         }
     }

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -543,7 +543,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         let useCellularSession: Bool
         if FeatureFlag.cellularDownloadStatusFix.enabled {
             // Allow cellular downloads if mobile data is allowed by settings OR if the user explicitly approved cellular download at queue time
-            useCellularSession = mobileDataAllowed || autoDownloadStatus == .userApprovedCellular
+            useCellularSession = mobileDataAllowed || autoDownloadStatus == .userApprovedCellular || autoDownloadStatus == .playerDownloadedForStreaming
         } else {
             // allow cellular downloads if not on WiFi and not auto downloaded, because it means the user said yes to a confirmation prompt
             useCellularSession = (mobileDataAllowed || (!NetworkUtils.shared.isConnectedToUnexpensiveConnection() && autoDownloadStatus != .autoDownloaded))

--- a/podcasts/DownloadsViewController+Table.swift
+++ b/podcasts/DownloadsViewController+Table.swift
@@ -97,11 +97,17 @@ extension DownloadsViewController: UITableViewDelegate, UITableViewDataSource {
             if episode.downloadFailed() {
                 let optionsPicker = OptionsPicker(title: nil)
                 let retryAction = OptionAction(label: L10n.retry, icon: nil, action: {
-                    NetworkUtils.shared.downloadEpisodeRequested(autoDownloadStatus: .notSpecified, { later in
+                    NetworkUtils.shared.downloadEpisodeRequested(autoDownloadStatus: .notSpecified, { later, approvedCellular in
                         if later {
                             DownloadManager.shared.queueForLaterDownload(episodeUuid: episode.uuid, fireNotification: true, autoDownloadStatus: .notSpecified)
                         } else {
-                            DownloadManager.shared.addToQueue(episodeUuid: episode.uuid)
+                            let status: AutoDownloadStatus
+                            if FeatureFlag.cellularDownloadStatusFix.enabled {
+                                status = approvedCellular ? .userApprovedCellular : .notSpecified
+                            } else {
+                                status = .notSpecified
+                            }
+                            DownloadManager.shared.addToQueue(episodeUuid: episode.uuid, fireNotification: true, autoDownloadStatus: status)
                         }
                     }, disallowed: nil)
                 })

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -291,13 +291,19 @@ class DownloadsViewController: PCViewController {
     }
 
     private func retryAllFailed() {
-        NetworkUtils.shared.downloadEpisodeRequested(autoDownloadStatus: .notSpecified, { later in
+        NetworkUtils.shared.downloadEpisodeRequested(autoDownloadStatus: .notSpecified, { later, approvedCellular in
             let failedList = self.failedEpisodes()
+            let status: AutoDownloadStatus
+            if FeatureFlag.cellularDownloadStatusFix.enabled {
+                status = approvedCellular ? .userApprovedCellular : .notSpecified
+            } else {
+                status = .notSpecified
+            }
             for episode in failedList {
                 if later {
                     DownloadManager.shared.queueForLaterDownload(episodeUuid: episode.uuid, fireNotification: false, autoDownloadStatus: .notSpecified)
                 } else {
-                    DownloadManager.shared.addToQueue(episodeUuid: episode.uuid, fireNotification: false, autoDownloadStatus: .notSpecified)
+                    DownloadManager.shared.addToQueue(episodeUuid: episode.uuid, fireNotification: false, autoDownloadStatus: status)
                 }
             }
 

--- a/podcasts/Extensions/NetworkUtils+Helpers.swift
+++ b/podcasts/Extensions/NetworkUtils+Helpers.swift
@@ -4,21 +4,28 @@ import PocketCastsServer
 import PocketCastsUtils
 
 extension NetworkUtils {
-    func downloadEpisodeRequested(autoDownloadStatus: AutoDownloadStatus, _ allowed: ((_ later: Bool) -> Void)?, disallowed: (() -> Void)?) {
+    /// Requests permission to download an episode, potentially showing a prompt if on cellular.
+    /// - Parameters:
+    ///   - autoDownloadStatus: The auto-download status of the episode
+    ///   - allowed: Callback invoked when download is allowed.
+    ///     - `later`: true if user chose "Queue for Later", false if "Download Now" or no prompt needed
+    ///     - `approvedCellular`: true if user explicitly approved cellular download in the prompt
+    ///   - disallowed: Callback invoked when user dismisses without choosing an option
+    func downloadEpisodeRequested(autoDownloadStatus: AutoDownloadStatus, _ allowed: ((_ later: Bool, _ approvedCellular: Bool) -> Void)?, disallowed: (() -> Void)?) {
         let mobileDataAllowed = autoDownloadStatus == .autoDownloaded ? Settings.autoDownloadMobileDataAllowed() : Settings.mobileDataAllowed()
 
         if mobileDataAllowed || isConnectedToUnexpensiveConnection() {
-            allowed?(false)
+            allowed?(false, false)
 
             return
         }
 
         let optionsPicker = OptionsPicker(title: nil)
         let downloadAction = OptionAction(label: L10n.podcastDownloadNow, icon: nil) {
-            allowed?(false)
+            allowed?(false, true) // User explicitly approved cellular download
         }
         let laterAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-            allowed?(true)
+            allowed?(true, false)
         }
         laterAction.outline = true
 

--- a/podcasts/ListeningHistoryViewController+Table.swift
+++ b/podcasts/ListeningHistoryViewController+Table.swift
@@ -95,11 +95,17 @@ extension ListeningHistoryViewController: UITableViewDelegate, UITableViewDataSo
             if episode.downloadFailed() {
                 let optionsPicker = OptionsPicker(title: nil)
                 let retryAction = OptionAction(label: L10n.retry, icon: nil, action: {
-                    NetworkUtils.shared.downloadEpisodeRequested(autoDownloadStatus: .notSpecified, { later in
+                    NetworkUtils.shared.downloadEpisodeRequested(autoDownloadStatus: .notSpecified, { later, approvedCellular in
                         if later {
                             DownloadManager.shared.queueForLaterDownload(episodeUuid: episode.uuid, fireNotification: true, autoDownloadStatus: .notSpecified)
                         } else {
-                            DownloadManager.shared.addToQueue(episodeUuid: episode.uuid)
+                            let status: AutoDownloadStatus
+                            if FeatureFlag.cellularDownloadStatusFix.enabled {
+                                status = approvedCellular ? .userApprovedCellular : .notSpecified
+                            } else {
+                                status = .notSpecified
+                            }
+                            DownloadManager.shared.addToQueue(episodeUuid: episode.uuid, fireNotification: true, autoDownloadStatus: status)
                         }
                     }, disallowed: nil)
                 })

--- a/podcasts/PlaybackActionHelper.swift
+++ b/podcasts/PlaybackActionHelper.swift
@@ -36,11 +36,17 @@ class PlaybackActionHelper {
     class func download(episodeUuid: String) {
         AnalyticsEpisodeHelper.shared.downloaded(episodeUUID: episodeUuid)
 
-        NetworkUtils.shared.downloadEpisodeRequested(autoDownloadStatus: .notSpecified, { later in
+        NetworkUtils.shared.downloadEpisodeRequested(autoDownloadStatus: .notSpecified, { later, approvedCellular in
             if later {
                 DownloadManager.shared.queueForLaterDownload(episodeUuid: episodeUuid, fireNotification: true, autoDownloadStatus: .notSpecified)
             } else {
-                DownloadManager.shared.addToQueue(episodeUuid: episodeUuid)
+                let status: AutoDownloadStatus
+                if FeatureFlag.cellularDownloadStatusFix.enabled {
+                    status = approvedCellular ? .userApprovedCellular : .notSpecified
+                } else {
+                    status = .notSpecified
+                }
+                DownloadManager.shared.addToQueue(episodeUuid: episodeUuid, fireNotification: true, autoDownloadStatus: status)
             }
         }, disallowed: nil)
     }
@@ -52,11 +58,17 @@ class PlaybackActionHelper {
     }
 
     class func overrideWaitingForWifi(episodeUuid: String, autoDownloadStatus: AutoDownloadStatus) {
-        NetworkUtils.shared.downloadEpisodeRequested(autoDownloadStatus: autoDownloadStatus, { later in
+        NetworkUtils.shared.downloadEpisodeRequested(autoDownloadStatus: autoDownloadStatus, { later, approvedCellular in
             if later {
                 DownloadManager.shared.queueForLaterDownload(episodeUuid: episodeUuid, fireNotification: true, autoDownloadStatus: autoDownloadStatus)
             } else {
-                DownloadManager.shared.addToQueue(episodeUuid: episodeUuid)
+                let status: AutoDownloadStatus
+                if FeatureFlag.cellularDownloadStatusFix.enabled {
+                    status = approvedCellular ? .userApprovedCellular : autoDownloadStatus
+                } else {
+                    status = autoDownloadStatus
+                }
+                DownloadManager.shared.addToQueue(episodeUuid: episodeUuid, fireNotification: true, autoDownloadStatus: status)
             }
         }, disallowed: nil)
     }

--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -345,14 +345,15 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
             let actualDownloadCount = downloadLimitExceeded ? Constants.Limits.maxBulkDownloads : downloadableCount
             if actualDownloadCount == 0 { return }
             let downloadText = L10n.downloadCountPrompt(actualDownloadCount)
+            let isOnExpensiveConnection = !NetworkUtils.shared.isConnectedToUnexpensiveConnection()
             let downloadAction = OptionAction(label: downloadText, icon: nil) { [weak self] in
-                self?.downloadAll()
+                self?.downloadAll(userApprovedCellular: isOnExpensiveConnection)
             }
 
             let confirmPicker = OptionsPicker(title: nil)
             var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
 
-            if NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
+            if !isOnExpensiveConnection {
                 confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
             } else {
                 downloadAction.destructive = true
@@ -527,13 +528,13 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
         }
     }
 
-    func downloadAll() {
+    func downloadAll(userApprovedCellular: Bool = false) {
         DispatchQueue.global().async { [weak self] in
             guard let self = self else { return }
 
             if self.episodes.count == 0 { return }
 
-            self.downloadItems(allEpisodes: self.episodes)
+            self.downloadItems(allEpisodes: self.episodes, userApprovedCellular: userApprovedCellular)
         }
     }
 
@@ -562,14 +563,20 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
         }
     }
 
-    func downloadItems(allEpisodes: [ListEpisode]) {
+    func downloadItems(allEpisodes: [ListEpisode], userApprovedCellular: Bool = false) {
+        let status: AutoDownloadStatus
+        if FeatureFlag.cellularDownloadStatusFix.enabled {
+            status = userApprovedCellular ? .userApprovedCellular : .notSpecified
+        } else {
+            status = .notSpecified
+        }
         var queuedEpisodes = 0
         for listEpisode in allEpisodes {
             if listEpisode.episode.downloading() || listEpisode.episode.downloaded(pathFinder: DownloadManager.shared) || listEpisode.episode.queued() {
                 continue
             }
 
-            DownloadManager.shared.addToQueue(episodeUuid: listEpisode.episode.uuid, fireNotification: true, autoDownloadStatus: .notSpecified)
+            DownloadManager.shared.addToQueue(episodeUuid: listEpisode.episode.uuid, fireNotification: true, autoDownloadStatus: status)
             queuedEpisodes += 1
             if queuedEpisodes == Constants.Limits.maxBulkDownloads {
                 return

--- a/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
+++ b/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
@@ -170,14 +170,15 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
             let actualDownloadCount = downloadLimitExceeded ? Constants.Limits.maxBulkDownloads : downloadableCount
             if actualDownloadCount == 0 { return }
             let downloadText = L10n.downloadCountPrompt(actualDownloadCount)
+            let isOnExpensiveConnection = !NetworkUtils.shared.isConnectedToUnexpensiveConnection()
             let downloadAction = OptionAction(label: downloadText, icon: nil) { () in
-                delegate.downloadAllTapped()
+                delegate.downloadAllTapped(userApprovedCellular: isOnExpensiveConnection)
             }
 
             let confirmPicker = OptionsPicker(title: nil)
             var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
 
-            if NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
+            if !isOnExpensiveConnection {
                 confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
             } else {
                 downloadAction.destructive = true

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -50,7 +50,7 @@ protocol PodcastActionsDelegate: AnyObject {
     func showingArchived() -> Bool
     func archiveAllTapped(playedOnly: Bool)
     func unarchiveAllTapped()
-    func downloadAllTapped()
+    func downloadAllTapped(userApprovedCellular: Bool)
     func queueAllTapped()
     func downloadableEpisodeCount(items: [ListItem]?) -> Int
 
@@ -1019,7 +1019,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         }
     }
 
-    func downloadAllTapped() {
+    func downloadAllTapped(userApprovedCellular: Bool) {
         DispatchQueue.global().async { [weak self] in
             guard let self = self, let allObjects = self.episodeInfo[safe: 1]?.elements, allObjects.count > 0 else { return }
 
@@ -1027,7 +1027,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
             AnalyticsEpisodeHelper.shared.bulkDownloadEpisodes(episodes: episodes)
 
-            self.downloadItems(allObjects: allObjects)
+            self.downloadItems(allObjects: allObjects, userApprovedCellular: userApprovedCellular)
         }
     }
 
@@ -1143,7 +1143,13 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         EpisodeManager.bulkUnarchive(episodes: episodes)
     }
 
-    func downloadItems(allObjects: [ListItem]) {
+    func downloadItems(allObjects: [ListItem], userApprovedCellular: Bool = false) {
+        let status: AutoDownloadStatus
+        if FeatureFlag.cellularDownloadStatusFix.enabled {
+            status = userApprovedCellular ? .userApprovedCellular : .notSpecified
+        } else {
+            status = .notSpecified
+        }
         var queuedEpisodes = 0
         for object in allObjects {
             guard let listEpisode = object as? ListEpisode else { continue }
@@ -1152,7 +1158,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
                 continue
             }
 
-            DownloadManager.shared.addToQueue(episodeUuid: listEpisode.episode.uuid, fireNotification: true, autoDownloadStatus: .notSpecified)
+            DownloadManager.shared.addToQueue(episodeUuid: listEpisode.episode.uuid, fireNotification: true, autoDownloadStatus: status)
             queuedEpisodes += 1
             if queuedEpisodes == Constants.Limits.maxBulkDownloads {
                 return


### PR DESCRIPTION
Fixes cellular downloads by explicitly tracking when a user approves cellular download via the prompt, rather than inferring it from network state at download time.

Previously, the app inferred cellular approval by checking `!isConnectedToUnexpensiveConnection()` at download time. This was unreliable because:
  - Network state could change between when the user approved and when the download started
  - The check couldn't distinguish between "user approved cellular" vs "auto-download on cellular"

* Added [cellularDownloadStatusFix](https://github.com/Automattic/pocket-casts-ios/blob/bjtitus/cellular-download-status-fixes/Modules/Utils/Sources/PocketCastsUtils/Feature%20Flags/FeatureFlag.swift#L302) flag to control the new cellular download behavior.

The theoretical pattern goes like this:
  1. User taps download while on WiFi, `autoDownloadStatus = .notSpecified`
  2. Network switches to cellular before `performDownload` runs
  3. `!onWifi` is now true, and status is `.notSpecified` (not `.autoDownloaded`)
  4. `useCellularSession = true` download uses cellular even though the user never approved it

**NOTE** This is a change in behavior and it may make sense for queued episodes to continue to download over cellular once the user has initiated the download.

## To test

* Begin a bunch of downloads on wifi manually
* Switch to cellular while episodes are still downloading
* Queued episodes should not begin downloading AFTER switching to cellular (this was the bug before where we had not prompted the user to use cellular but queued episodes would)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
