### PR TITLE
Fix size and shape of button when using larger accessibility sizes an…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -----
 - Show buffering UI on Full Screen Player [#4051](https://github.com/Automattic/pocket-casts-ios/pull/4051)
 - Ensure that temporary download files are properly deleted from the system [#4052](https://github.com/Automattic/pocket-casts-ios/pull/4052)
+- Fix size and shape of podcast header buttons when using show borders [#4077](https://github.com/Automattic/pocket-casts-ios/pull/4077)
 
 8.7
 -----

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
@@ -76,7 +76,7 @@ struct PodcastHeaderView: View {
                 .clipped()
             PodcastDetailsTabView(delegate: viewModel.delegate)
         }
-        .padding(.horizontal)
+        .padding(.horizontal, 16)
     }
 
     private var podcastCategory: some View {
@@ -106,9 +106,9 @@ struct PodcastHeaderView: View {
     }
 
     @ScaledMetric(relativeTo: .body) private var titleBottomMargin = 16
-    @ScaledMetric(relativeTo: .title2) private var itemMargin = 24
-    @ScaledMetric(relativeTo: .title2) private var iconSize = 24
-    @ScaledMetric(relativeTo: .title2) private var iconRounding = 32
+    @ScaledMetric(relativeTo: .largeTitle) private var itemMargin = 24
+    @ScaledMetric(relativeTo: .largeTitle) private var iconSize = 24
+    @ScaledMetric(relativeTo: .largeTitle) private var iconRounding = 32
 
     private var podcastTitle: some View {
         HStack(spacing: 0) {
@@ -149,7 +149,7 @@ struct PodcastHeaderView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .background(theme.support02)
-                        .tint(theme.primaryUi01)
+                        .foregroundStyle(theme.primaryUi01)
                         .frame(width: iconSize, height: iconSize)
                         .clipShape(Circle())
                         .opacity(viewModel.isSubscribed ? 1 : 0)
@@ -163,6 +163,7 @@ struct PodcastHeaderView: View {
                 .clipped()
 
         }
+        .buttonStyle(.plain)
     }
 
     private var fundingButton: some View {
@@ -185,6 +186,7 @@ struct PodcastHeaderView: View {
             }
         }
         .accessibilityLabel(L10n.funding)
+        .buttonStyle(.plain)
     }
 
     private func fundingImage(width: CGFloat, height: CGFloat, padding: CGFloat) -> some View {
@@ -230,10 +232,12 @@ struct PodcastHeaderView: View {
             Image(imageName)
                 .renderingMode(.template)
                 .resizable()
+                .aspectRatio(contentMode: .fit)
                 .frame(width: iconSize, height: iconSize)
                 .padding(8)
                 .foregroundStyle(theme.primaryIcon03)
         }
+        .buttonStyle(.plain)
         .accessibilityLabel(title)
     }
 


### PR DESCRIPTION
…d and show border

| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-566 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
| Before | After |
| - | - |
| <img width="480" height="1040" alt="IMG_0112" src="https://github.com/user-attachments/assets/d92e0aec-02d1-47d2-8316-91574d9b0d43" /> | <img width="480" height="1040" alt="IMG_0111" src="https://github.com/user-attachments/assets/a6d18cd6-f8c9-453a-91e5-3a8178db2b54" /> |

This PR set the button styles to plain to avoid excessive border width when Border Show is set

## To test

1. Start the app
2. Setup the Dynamic Type to larger accessibility size and enable Show Borders
3. Open a Podcast
4. Check the header buttons fit in screen
5. Check if the Tabs for Episode is also with the correct margin from the left

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
