### PR TITLE
Handle truncated protobuf responses

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
@@ -16,7 +16,7 @@ extension BackgroundSyncManager: URLSessionDelegate, URLSessionDownloadDelegate 
         // Verify the download completed fully by comparing received bytes to Content-Length.
         // A truncated download can produce valid-but-incomplete protobuf that silently drops fields.
         if FeatureFlag.detectTruncatedBackgroundSyncDownloads.enabled {
-            let expectedLength = downloadTask.response?.expectedContentLength ?? -1
+            let expectedLength = downloadTask.response?.expectedContentLength ?? BackgroundSyncManager.unknownContentLength
             if let receivedData = data, !BackgroundSyncManager.isDownloadComplete(receivedBytes: receivedData.count, expectedContentLength: expectedLength) {
                 FileLog.shared.addMessage("Background sync data truncated for task \(downloadTask.taskDescription ?? "unknown"): received \(receivedData.count) bytes, expected \(expectedLength)")
                 data = nil

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
@@ -13,6 +13,16 @@ extension BackgroundSyncManager: URLSessionDelegate, URLSessionDownloadDelegate 
             FileLog.shared.addMessage("Failed to load background sync data: \(error.localizedDescription)")
         }
 
+        // Verify the download completed fully by comparing received bytes to Content-Length.
+        // A truncated download can produce valid-but-incomplete protobuf that silently drops fields.
+        if FeatureFlag.detectTruncatedBackgroundSyncDownloads.enabled {
+            let expectedLength = downloadTask.response?.expectedContentLength ?? -1
+            if let receivedData = data, !BackgroundSyncManager.isDownloadComplete(receivedBytes: receivedData.count, expectedContentLength: expectedLength) {
+                FileLog.shared.addMessage("Background sync data truncated for task \(downloadTask.taskDescription ?? "unknown"): received \(receivedData.count) bytes, expected \(expectedLength)")
+                data = nil
+            }
+        }
+
         if downloadTask.taskDescription == refreshTaskId {
             processRefreshResponse(data: data)
             haveProcessedRefresh = true

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager.swift
@@ -109,6 +109,19 @@ public class BackgroundSyncManager: NSObject {
         return task
     }
 
+    /// Returns `true` if the download is complete (received bytes match expected),
+    /// or if the expected length is unknown (Content-Length not set / chunked transfer).
+    /// Returns `false` if the received byte count doesn't match the expected Content-Length,
+    /// indicating the download was truncated.
+    static func isDownloadComplete(receivedBytes: Int, expectedContentLength: Int64) -> Bool {
+        guard expectedContentLength != -1 else {
+            // Unknown content length (chunked transfer encoding) — can't verify
+            return true
+        }
+
+        return Int64(receivedBytes) == expectedContentLength
+    }
+
     private func createUrlSession(identifier: String) -> URLSession {
         let config = URLSessionConfiguration.background(withIdentifier: identifier)
         let session = URLSession(configuration: config, delegate: self, delegateQueue: nil)

--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager.swift
@@ -112,9 +112,12 @@ public class BackgroundSyncManager: NSObject {
     /// Returns `true` if the download is complete (received bytes match expected),
     /// or if the expected length is unknown (Content-Length not set / chunked transfer).
     /// Returns `false` if the received byte count doesn't match the expected Content-Length,
-    /// indicating the download was truncated.
+    /// indicating the download was truncated or corrupt.
+    /// Value returned by `URLResponse.expectedContentLength` when the length is unknown.
+    static let unknownContentLength: Int64 = -1
+
     static func isDownloadComplete(receivedBytes: Int, expectedContentLength: Int64) -> Bool {
-        guard expectedContentLength != -1 else {
+        guard expectedContentLength != unknownContentLength else {
             // Unknown content length (chunked transfer encoding) — can't verify
             return true
         }

--- a/Modules/Server/Tests/PocketCastsServerTests/BackgroundSyncManagerTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/BackgroundSyncManagerTests.swift
@@ -1,0 +1,52 @@
+@testable import PocketCastsServer
+import XCTest
+
+final class BackgroundSyncManagerTests: XCTestCase {
+
+    // MARK: - Download completeness check
+
+    func testCompleteDownloadReturnsTrue() {
+        XCTAssertTrue(
+            BackgroundSyncManager.isDownloadComplete(receivedBytes: 1024, expectedContentLength: 1024),
+            "Download with matching byte count should be considered complete"
+        )
+    }
+
+    func testTruncatedDownloadReturnsFalse() {
+        XCTAssertFalse(
+            BackgroundSyncManager.isDownloadComplete(receivedBytes: 512, expectedContentLength: 1024),
+            "Download with fewer bytes than expected should be considered truncated"
+        )
+    }
+
+    func testUnknownContentLengthReturnsTrue() {
+        // -1 means Content-Length was not set (chunked transfer encoding)
+        XCTAssertTrue(
+            BackgroundSyncManager.isDownloadComplete(receivedBytes: 512, expectedContentLength: -1),
+            "Unknown content length should be treated as complete (can't verify)"
+        )
+    }
+
+    func testZeroBytesWithExpectedContentReturnsFalse() {
+        XCTAssertFalse(
+            BackgroundSyncManager.isDownloadComplete(receivedBytes: 0, expectedContentLength: 100),
+            "Zero bytes received when content was expected should be truncated"
+        )
+    }
+
+    func testEmptyResponseMatchingExpectedReturnsTrue() {
+        // Server genuinely returned 0 bytes with Content-Length: 0
+        XCTAssertTrue(
+            BackgroundSyncManager.isDownloadComplete(receivedBytes: 0, expectedContentLength: 0),
+            "Empty response matching Content-Length: 0 should be considered complete"
+        )
+    }
+
+    func testExtraBytesReturnsFalse() {
+        // More bytes than expected — also suspicious
+        XCTAssertFalse(
+            BackgroundSyncManager.isDownloadComplete(receivedBytes: 2048, expectedContentLength: 1024),
+            "More bytes than expected should be considered incomplete/corrupt"
+        )
+    }
+}

--- a/Modules/Server/Tests/PocketCastsServerTests/BackgroundSyncManagerTests.swift
+++ b/Modules/Server/Tests/PocketCastsServerTests/BackgroundSyncManagerTests.swift
@@ -20,9 +20,8 @@ final class BackgroundSyncManagerTests: XCTestCase {
     }
 
     func testUnknownContentLengthReturnsTrue() {
-        // -1 means Content-Length was not set (chunked transfer encoding)
         XCTAssertTrue(
-            BackgroundSyncManager.isDownloadComplete(receivedBytes: 512, expectedContentLength: -1),
+            BackgroundSyncManager.isDownloadComplete(receivedBytes: 512, expectedContentLength: BackgroundSyncManager.unknownContentLength),
             "Unknown content length should be treated as complete (can't verify)"
         )
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -298,6 +298,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Ensure that tmp files are removed when no longer needed
     case cleanUpTmpFiles
 
+    /// Detect truncated background sync downloads by comparing received bytes to Content-Length
+    case detectTruncatedBackgroundSyncDownloads
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -499,6 +502,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .unlimitedWatchUpNextSync:
             true
         case .cleanUpTmpFiles:
+            true
+        case .detectTruncatedBackgroundSyncDownloads:
             true
         }
     }


### PR DESCRIPTION
| 📘 Part of: [Watch + Up Next Sync](https://linear.app/a8c/project/ios-watch-up-next-sync-3f36270786fd) |
|:---:|

There are indications [from our Up Next Sentry logging](https://a8c.sentry.io/issues/7308322687/?environment=appStore&project=4503921846583296&query=is%3Aunresolved%20issue.category%3A%5Berror%2Coutage%5D&referrer=issue-stream) that users are receiving truncated protobuf responses. Theoretically, this could lead to "empty" Up Next responses where the response truncated is _exactly_ between the `serverModified` date and the list of episodes.

The changes here verify that we received the full response by checking the content-length header and verifying the byte count we received.

Two things limit the scope of these changes:
* The `detectTruncatedBackgroundSyncDownloads` Feature Flag
* The Watch App is the only one using `BackgroundSyncManager.performBackgroundRefresh`

## To test

This is difficult to test because Watch ↔ iPhone syncing doesn't work well in the simulators and I cannot figure out how to proxy the watch connection to rewrite the response.

Overall, this can be smoke tested by running the Watch app in Watch mode for a while and making sure new episodes are synced.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
