### PR TITLE
Add additional details to serverSyncFailed error

### DIFF
--- a/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Server/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -52,6 +52,8 @@ class UpNextSyncTask: ApiBaseTask {
         defer { TraceManager.shared.endTracing(trace: trace) }
 
         let (syncRequest, latestActionTime) = createUpNextSyncRequest()
+        let changeCount = syncRequest.upNext.changes.count
+        let syncReason = SyncManager.syncReason?.rawValue ?? "unknown"
         let url = ServerConstants.Urls.api() + "up_next/sync"
         do {
             let data = try syncRequest.serializedData()
@@ -62,9 +64,18 @@ class UpNextSyncTask: ApiBaseTask {
             } else if let response = response, httpStatus == ServerConstants.HttpConstants.ok {
                 process(serverData: response, latestActionTime: latestActionTime)
             } else {
-                FileLog.shared.addMessage("UpNextSyncTask: Unable to sync with server got status \(httpStatus)")
+                let responseBody = response.flatMap { String(data: $0, encoding: .utf8) }
+                let truncatedBody = responseBody.map { String($0.prefix(500)) } ?? "nil"
+                FileLog.shared.addMessage("UpNextSyncTask: Unable to sync with server got status \(httpStatus), response: \(truncatedBody)")
                 let syncError = UpNextSyncError.serverSyncFailed(httpStatus: httpStatus)
-                ServerConfig.shared.errorLogger?.log(error: syncError, context: ["source": "upnext_sync", "httpStatus": "\(httpStatus)"])
+                ServerConfig.shared.errorLogger?.log(error: syncError, context: [
+                    "source": "upnext_sync",
+                    "httpStatus": "\(httpStatus)",
+                    "changeCount": "\(changeCount)",
+                    "requestBytes": "\(data.count)",
+                    "syncReason": syncReason,
+                    "responseBody": truncatedBody
+                ])
             }
         } catch {
             FileLog.shared.addMessage("UpNextSyncTask: had issues encoding protobuf \(error.localizedDescription)")


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Includes additional details in the `serverSyncFailed` Sentry error to help diagnose what's causing 500s. There are a surprising number of these on watchOS and most are probably network connection errors.

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
