### PR TITLE
Fix DownloadManager sessions racing conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 8.9
 -----
-
+- Fix DownloadManager sessions racing conditions [#4080](https://github.com/Automattic/pocket-casts-ios/pull/4080)
 
 8.8
 -----

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -88,6 +88,12 @@ class DownloadManager: NSObject, FilePathProtocol {
          }()
     #endif
 
+    private func setupSessions() {
+        let _ = wifiOnlyBackgroundSession
+        let _ = cellularBackgroundSession
+        let _ = cellularForegroundSession
+    }
+
     lazy var wifiOnlyBackgroundSession: URLSession = {
         var config = URLSessionConfiguration.background(withIdentifier: "au.com.shiftyjelly.PCBackgroundSession")
         if FeatureFlag.useCellularNetworkApis.enabled {
@@ -155,6 +161,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         self.dataManager = dataManager
         super.init()
 
+        setupSessions()
         // setup the temp download folder, in caches where iOS can purge it if need be
         let paths = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true)
         if let cachePath = paths.first as NSString? {

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -88,10 +88,14 @@ class DownloadManager: NSObject, FilePathProtocol {
          }()
     #endif
 
+    /// Eagerly initializes all URLSessions to avoid race conditions.
+    /// Swift lazy properties are not thread-safe: if multiple threads access an
+    /// uninitialized lazy var concurrently, the initializer can run more than once.
+    /// Calling this from `init()` guarantees single-threaded first access.
     private func setupSessions() {
-        let _ = wifiOnlyBackgroundSession
-        let _ = cellularBackgroundSession
-        let _ = cellularForegroundSession
+        _ = wifiOnlyBackgroundSession
+        _ = cellularBackgroundSession
+        _ = cellularForegroundSession
     }
 
     lazy var wifiOnlyBackgroundSession: URLSession = {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Ensure lazy sessions are created on init so that no racing condition happen to avoid racing conditions on creation.

Related issues: https://a8c.sentry.io/issues/6791357208/?project=4503921846583296&query=is%3Aunresolved&referrer=issue-stream&sort=freq

## To test

1. Start the app
2. Start different downloads for episode
3. Check downloads work correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
