### PR TITLE
Ensure that max height fits all text

### DIFF
--- a/podcasts/HorizontalCollectionList.swift
+++ b/podcasts/HorizontalCollectionList.swift
@@ -26,6 +26,7 @@ struct HorizontalCollectionList: View {
             Text(model.type)
                 .foregroundStyle(theme.primaryText01)
                 .font(size: 22, style: .title, weight: .bold)
+                .lineLimit(2)
             Spacer()
             Button() {
                 model.showCollection()
@@ -119,7 +120,7 @@ struct HorizontalCollectionList: View {
                 model.subscribePodcast(podcast)
             }
         }
-        .frame(maxHeight: (adjustedRowHeight - 8.0) / 2.0)
+        .frame(height: (adjustedRowHeight - 8.0) / 2.0)
         .onTapGesture {
             model.showPodcast(podcast)
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Fix clipping text on Network Highlight when Display Zoom is on

| Before  | After |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-19 at 22 35 12" src="https://github.com/user-attachments/assets/483beed9-8c56-4a74-9d6e-92487c67b638" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-19 at 22 38 15" src="https://github.com/user-attachments/assets/be50e1b1-03a2-4fbc-830b-f2aca39bd6d4" /> |

## To test

1. Enable Display Zoom on the device
2. Set the text for larger accessibility sizes
3. Open the app
4. Open Discovery
5. Scroll for a Network hightlight cell like the above
6. Check that all the text overly on the poster shows inside the poster image
7. Smoke test on the regular display zoom and accessibility sizes to see if all is correct

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
