### PR TITLE
Remove files that are on tmp that are older than 1 week

### DIFF
--- a/PocketCastsTests/Tests/Utilities/EpisodeManagerTests.swift
+++ b/PocketCastsTests/Tests/Utilities/EpisodeManagerTests.swift
@@ -140,4 +140,68 @@ final class EpisodeManagerTests: DBTestCase {
         // Then: Should return nil since no token available
         XCTAssertNil(url, "Should return nil when no sync token available for user episode")
     }
+
+    // MARK: - cleanUpTmpFolder Tests
+
+    func testCleanUpTmpFolderRemovesFilesOlderThanOneWeek() throws {
+      // Given: A tmp directory with an old file (> 1 week)
+      let tmpDir = NSTemporaryDirectory() + UUID().uuidString
+      try FileManager.default.createDirectory(atPath: tmpDir, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(atPath: tmpDir) }
+
+      let oldFilePath = (tmpDir as NSString).appendingPathComponent("old_episode.mp3")
+      FileManager.default.createFile(atPath: oldFilePath, contents: Data("old".utf8))
+
+      let eightDaysAgo = Date.now.addingTimeInterval(-8.days)
+      try FileManager.default.setAttributes([.modificationDate: eightDaysAgo], ofItemAtPath: oldFilePath)
+
+      // When
+      EpisodeManager.cleanUpTmpFolder(folderPath: tmpDir)
+
+      // Then: File should be deleted
+      XCTAssertFalse(FileManager.default.fileExists(atPath: oldFilePath), "File older than 1 week should be removed")
+    }
+
+    func testCleanUpTmpFolderKeepsFilesNewerThanOneWeek() throws {
+      // Given: A tmp directory with a recent file (< 1 week)
+      let tmpDir = NSTemporaryDirectory() + UUID().uuidString
+      try FileManager.default.createDirectory(atPath: tmpDir, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(atPath: tmpDir) }
+
+      let recentFilePath = (tmpDir as NSString).appendingPathComponent("recent_episode.mp3")
+      FileManager.default.createFile(atPath: recentFilePath, contents: Data("recent".utf8))
+
+      let threeDaysAgo = Date.now.addingTimeInterval(-3.days)
+      try FileManager.default.setAttributes([.modificationDate: threeDaysAgo], ofItemAtPath: recentFilePath)
+
+      // When
+      EpisodeManager.cleanUpTmpFolder(folderPath: tmpDir)
+
+      // Then: File should still exist
+      XCTAssertTrue(FileManager.default.fileExists(atPath: recentFilePath), "File newer than 1 week should be kept")
+    }
+
+    func testCleanUpTmpFolderMixedAgesDeletesOnlyOldFiles() throws {
+      // Given: A tmp directory with both old and recent files
+      let tmpDir = NSTemporaryDirectory() + UUID().uuidString
+      try FileManager.default.createDirectory(atPath: tmpDir, withIntermediateDirectories: true)
+      defer { try? FileManager.default.removeItem(atPath: tmpDir) }
+
+      let oldFilePath = (tmpDir as NSString).appendingPathComponent("old.mp3")
+      let recentFilePath = (tmpDir as NSString).appendingPathComponent("recent.mp3")
+      FileManager.default.createFile(atPath: oldFilePath, contents: Data("old".utf8))
+      FileManager.default.createFile(atPath: recentFilePath, contents: Data("recent".utf8))
+
+      try FileManager.default.setAttributes([.modificationDate: Date.now.addingTimeInterval(-10.days)], ofItemAtPath:
+    oldFilePath)
+      try FileManager.default.setAttributes([.modificationDate: Date.now.addingTimeInterval(-1.days)], ofItemAtPath:
+    recentFilePath)
+
+      // When
+      EpisodeManager.cleanUpTmpFolder(folderPath: tmpDir)
+
+      // Then
+      XCTAssertFalse(FileManager.default.fileExists(atPath: oldFilePath), "Old file should be removed")
+      XCTAssertTrue(FileManager.default.fileExists(atPath: recentFilePath), "Recent file should be kept")
+    }
 }

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -385,9 +385,9 @@ class EpisodeManager: NSObject {
         }
     }
 
-    class func cleanUpTmpFolder() {
+    class func cleanUpTmpFolder(folderPath: String = DownloadManager.shared.tempDownloadFolder) {
         let fileManager = FileManager.default
-        let tmpPath = DownloadManager.shared.tempDownloadFolder
+        let tmpPath = folderPath
         guard let folderEnum = fileManager.enumerator(atPath: tmpPath) else {
             return
         }

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -395,7 +395,7 @@ class EpisodeManager: NSObject {
         while let tmpFile = folderEnum.nextObject() as? String {
             let fullFilePath = (tmpPath as NSString).appendingPathComponent(tmpFile)
             guard let attributes = try? fileManager.attributesOfItem(atPath: fullFilePath),
-                  let date = attributes[.creationDate] as? Date,
+                  let date = attributes[.modificationDate] as? Date,
                   Date.now.timeIntervalSince(date) > 1.week
             else {
                 continue

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -380,19 +380,12 @@ class EpisodeManager: NSObject {
         }
 
         if FeatureFlag.cleanUpTmpFiles.enabled {
-            // Remove any files in the temporary folder that were not part of the above, that should be orphan files
-            let filePaths = Set(episodes.map { DownloadManager.shared.tempPathForEpisode($0) })
-            // Also protect actively downloading episodes
-            let downloadingEpisodes = DataManager.sharedManager.findEpisodesWhere(
-                customWhere: "episodeStatus == \(DownloadStatus.downloading.rawValue) OR episodeStatus == \(DownloadStatus.queued.rawValue) OR (autoDownloadStatus == \(AutoDownloadStatus.playerDownloadedForStreaming.rawValue) && episodeStatus != \(DownloadStatus.downloaded))",
-                arguments: nil
-            )
-            let allExceptions = filePaths.union(downloadingEpisodes.map { DownloadManager.shared.tempPathForEpisode($0) })
-            cleanUpTmpFolder(exceptions: allExceptions)
+            // Remove any lingering files in the temporary folder that were not removed above, those should be orphan files
+            cleanUpTmpFolder()
         }
     }
 
-    class func cleanUpTmpFolder(exceptions: Set<String>) {
+    class func cleanUpTmpFolder() {
         let fileManager = FileManager.default
         let tmpPath = DownloadManager.shared.tempDownloadFolder
         guard let folderEnum = fileManager.enumerator(atPath: tmpPath) else {
@@ -401,9 +394,11 @@ class EpisodeManager: NSObject {
         FileLog.shared.addMessage("Episode Manager: Starting removing the temporary orphan files")
         while let tmpFile = folderEnum.nextObject() as? String {
             let fullFilePath = (tmpPath as NSString).appendingPathComponent(tmpFile)
-            if exceptions.contains(fullFilePath) {
+            guard let date = try? fileManager.attributesOfItem(atPath: fullFilePath).fileCreationDate,
+               Date.now.timeIntervalSince(date) > 1.week else {
                 continue
             }
+
             FileLog.shared.addMessage("Episode Manager: Removing the following orphan file \(tmpFile)")
             StorageManager.removeItem(at: URL(fileURLWithPath: fullFilePath))
         }

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -394,8 +394,10 @@ class EpisodeManager: NSObject {
         FileLog.shared.addMessage("Episode Manager: Starting removing the temporary orphan files")
         while let tmpFile = folderEnum.nextObject() as? String {
             let fullFilePath = (tmpPath as NSString).appendingPathComponent(tmpFile)
-            guard let date = try? fileManager.attributesOfItem(atPath: fullFilePath).fileCreationDate,
-               Date.now.timeIntervalSince(date) > 1.week else {
+            guard let attributes = try? fileManager.attributesOfItem(atPath: fullFilePath),
+                  let date = attributes[.creationDate] as? Date,
+                  Date.now.timeIntervalSince(date) > 1.week
+            else {
                 continue
             }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR changes the method to clean up tmp files by using the modification date instead of trying to find exceptions on episodes.
The rational is that a file existing on the tmp folder should only exist there while it's being downloaded/streamed, then when finished it should be moved/copied out of the tmp folder.
If a file is there more than a week it means that the downloaded/stream was interrupted in flight and the file is orphaned

## To test

1. Start the app
2. Start playing an episode and/or multiple downloads
3. Pull to Refresh on Profile
4. Check that not any of ongoing downloads/streaming is affected

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
