### PR TITLE
Implement animation that matchs mini player

### DIFF
--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -81,6 +81,7 @@ extension NowPlayingPlayerItemViewController {
 
         let highlightColor = PlayerColorHelper.playerHighlightColor01(for: .dark)
         timeSlider.leftColor = highlightColor
+        timeSlider.animationColor = PlayerColorHelper.playerHighlightColor01(for: .dark).withAlphaComponent(0.2)
         timeSlider.circleColor = buttonColor
         timeSlider.rightColor = ThemeColor.playerContrast06()
         timeSlider.popupColor = ThemeColor.playerContrast06()

--- a/podcasts/TimeSlider.swift
+++ b/podcasts/TimeSlider.swift
@@ -22,7 +22,7 @@ class TimeSlider: UIView {
         }
     }
 
-    var animationColor = UIColor.white {
+    var animationColor = UIColor.white.withAlphaComponent(0.4) {
         didSet {
             timeLayer().animationColor = animationColor.cgColor
         }

--- a/podcasts/TimeSlider.swift
+++ b/podcasts/TimeSlider.swift
@@ -22,7 +22,7 @@ class TimeSlider: UIView {
         }
     }
 
-    var animationColor = UIColor.white.withAlphaComponent(0.4) {
+    var animationColor = UIColor.white.withAlphaComponent(0.2) {
         didSet {
             timeLayer().animationColor = animationColor.cgColor
         }

--- a/podcasts/TimeSliderLayer.swift
+++ b/podcasts/TimeSliderLayer.swift
@@ -85,7 +85,9 @@ class TimeSliderLayer: CALayer {
         //draw animation line
         if shouldAnimate {
             let clippedRect = progressAnimationRect.intersection(CGRect(x: leftHalfRect.origin.x, y: leftHalfRect.origin.y, width: leftHalfRect.width + rightHalfRect.width, height: leftHalfRect.height))
-            drawRoundedLine(rect: clippedRect, color: animationColor, context: ctx)
+            if !clippedRect.isNull {
+                drawRoundedLine(rect: clippedRect, color: animationColor, context: ctx)
+            }
         }
 
         // draw the left line
@@ -166,10 +168,9 @@ class TimeSliderLayer: CALayer {
 
         let duration: CFTimeInterval = 1.0
         let animationLineWidth = animationLineWidth()
-
-        progressAnimationRect = CGRect(x: leftHalfRect.origin.x + leftHalfRect.size.width, y: leftHalfRect.origin.y, width: animationLineWidth, height: rightHalfRect.size.height)
-
         let progressStartX = leftHalfRect.origin.x
+
+        progressAnimationRect = CGRect(x: progressStartX - animationLineWidth, y: leftHalfRect.origin.y, width: animationLineWidth, height: rightHalfRect.size.height)
 
         let moveAnimation = CAKeyframeAnimation(keyPath: "progressAnimationRect.origin.x")
         moveAnimation.values = [

--- a/podcasts/TimeSliderLayer.swift
+++ b/podcasts/TimeSliderLayer.swift
@@ -81,6 +81,13 @@ class TimeSliderLayer: CALayer {
         defer {
             UIGraphicsPopContext()
         }
+
+        //draw animation line
+        if shouldAnimate {
+            let clippedRect = progressAnimationRect.intersection(CGRect(x: leftHalfRect.origin.x, y: leftHalfRect.origin.y, width: leftHalfRect.width + rightHalfRect.width, height: leftHalfRect.height))
+            drawRoundedLine(rect: clippedRect, color: animationColor, context: ctx)
+        }
+
         // draw the left line
         ctx.setFillColor(leftColor)
         ctx.setStrokeColor(leftColor)
@@ -92,10 +99,6 @@ class TimeSliderLayer: CALayer {
         ctx.setStrokeColor(rightColor)
         let rightPath = UIBezierPath(roundedRect: rightHalfRect, cornerRadius: 2)
         rightPath.fill()
-
-        if shouldAnimate {
-            drawRoundedLine(rect: progressAnimationRect, color: animationColor, context: ctx)
-        }
 
         // draw the knob
         ctx.addEllipse(in: knobRect)
@@ -161,44 +164,34 @@ class TimeSliderLayer: CALayer {
 
         animating = true
 
-        let duration: CFTimeInterval = 0.75
-        let progressStartX = rightHalfRect.origin.x
+        let duration: CFTimeInterval = 1.0
         let animationLineWidth = animationLineWidth()
 
-        // Initialize the model rect to match the first keyframe (start X and minimal width)
-        progressAnimationRect = CGRect(
-            x: progressStartX,
-            y: leftHalfRect.origin.y,
-            width: 1,
-            height: leftHalfRect.size.height
-        )
+        progressAnimationRect = CGRect(x: leftHalfRect.origin.x + leftHalfRect.size.width, y: leftHalfRect.origin.y, width: animationLineWidth, height: rightHalfRect.size.height)
+
+        let progressStartX = leftHalfRect.origin.x
+
+        let moveAnimation = CAKeyframeAnimation(keyPath: "progressAnimationRect.origin.x")
+        moveAnimation.values = [
+            progressStartX - animationLineWidth,
+            progressStartX,
+            rightHalfRect.origin.x + rightHalfRect.size.width + animationLineWidth
+        ]
+        moveAnimation.keyTimes = [0, 0.3, 1]
+        moveAnimation.duration = duration
 
         let growAnimation = CAKeyframeAnimation(keyPath: "progressAnimationRect.size.width")
         growAnimation.values = [
-            1,
-            animationLineWidth / 4,
             animationLineWidth / 2,
-            animationLineWidth / 4 * 3,
-            animationLineWidth
+            animationLineWidth,
+            1
         ]
-        growAnimation.keyTimes = [0, 0.25, 0.5, 0.75, 1]
+        growAnimation.keyTimes = [0, 0.5, 1]
         growAnimation.duration = duration
 
-        let colorAnimation = CAKeyframeAnimation(keyPath: "animationColor")
-        colorAnimation.values = [
-            animationColor.copy(alpha: 0.5)!,
-            animationColor.copy(alpha: 0.4)!,
-            animationColor.copy(alpha: 0.3)!,
-            animationColor.copy(alpha: 0.2)!,
-            animationColor.copy(alpha: 0.1)!
-        ]
-        colorAnimation.keyTimes = [0, 0.25, 0.5, 0.75, 1]
-        colorAnimation.duration = duration
-
         let animationGroup = CAAnimationGroup()
-        animationGroup.animations = [growAnimation, colorAnimation]
+        animationGroup.animations = [moveAnimation, growAnimation]
         animationGroup.duration = duration
-
         animationGroup.repeatCount = .greatestFiniteMagnitude
 
         add(animationGroup, forKey: Self.animationKey)
@@ -213,7 +206,7 @@ class TimeSliderLayer: CALayer {
     }
 
     private func animationLineWidth() -> CGFloat {
-        rightHalfRect.size.width
+        (leftHalfRect.size.width + rightHalfRect.size.width) / 3
     }
 
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Updates the animation on the full screen player to match the one in the mini-player

https://github.com/user-attachments/assets/471665b6-2c58-4723-85bc-9d0c7757013c


## To test

1. Start the app
2. Open a podcast
3. Disable Internet connection
4. Tap Play on an episode
5. Open the full screen player
6. Check that the buffering animation matches the above.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
