### PR TITLE
Only use ContextUpdateDebouncer if we are running in the foreground

### DIFF
--- a/Pocket Casts Watch App/UI/WatchSyncManager.swift
+++ b/Pocket Casts Watch App/UI/WatchSyncManager.swift
@@ -80,10 +80,13 @@ class WatchSyncManager {
     }
 
     @objc func handleContextUpdate() {
-        if FeatureFlag.watchUpNextSyncFix.enabled {
+        if FeatureFlag.watchUpNextSyncFix.enabled,
+           WKApplication.shared().applicationState != .background {
             // Debounce context updates to allow watch to fully process phone's changes
             // before deciding whether to sync. This prevents the watch from sending
             // stale Up Next data that could overwrite recent phone changes.
+            // Only debounce in foreground — in background, the system's execution window
+            // is tied to setTaskCompletedWithSnapshot, so we must process immediately.
             contextUpdateDebouncer.call()
         } else {
             processContextUpdate()


### PR DESCRIPTION
| 📘 Part of: [Watch + Up Next Sync](https://linear.app/a8c/project/ios-watch-up-next-sync-3f36270786fd) |
|:---:|

A [Sentry error](https://a8c.sentry.io/issues/7323762277/?project=4503921846583296&query=is%3Aunresolved&referrer=issue-stream) is being logged for invalid URL sessions which may be caused by this debouncer running after we have reported the task is completed.

This change simply checks whether we are running in the background before debouncing. When running in the background we would now use the same code path from before the debouncer was added.

## To test

* Install Apple Watch app
* Run the app and make episode changes to test background sync

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
