### PR TITLE
Ensure wifi-icon stays centered

### DIFF
--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -290,7 +290,7 @@ extension MainEpisodeActionView {
             let startingX = circleCenter.x - (Self.circleRadius / 2)
 
             // draw the WiFi symbol
-            let translation = CGAffineTransform(translationX: startingX - rightPadding, y: startingY + (bottomPadding / 2.0))
+            let translation = CGAffineTransform(translationX: startingX, y: startingY)
 
             let curve1 = UIBezierPath()
             curve1.move(to: CGPoint(x: 7.78, y: 0))

--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -286,8 +286,11 @@ extension MainEpisodeActionView {
             let waitingColor = AppTheme.waitingForWifiColor()
             waitingColor.setFill()
 
+            let startingY = circleCenter.y - (Self.circleRadius / 2)
+            let startingX = circleCenter.x - (Self.circleRadius / 2)
+
             // draw the WiFi symbol
-            let translation = CGAffineTransform(translationX: 14 - rightPadding, y: 15 + (bottomPadding / 2.0))
+            let translation = CGAffineTransform(translationX: startingX - rightPadding, y: startingY + (bottomPadding / 2.0))
 
             let curve1 = UIBezierPath()
             curve1.move(to: CGPoint(x: 7.78, y: 0))

--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -286,11 +286,12 @@ extension MainEpisodeActionView {
             let waitingColor = AppTheme.waitingForWifiColor()
             waitingColor.setFill()
 
-            let startingY = circleCenter.y - (Self.circleRadius / 2)
-            let startingX = circleCenter.x - (Self.circleRadius / 2)
+            let startingY = circleCenter.y - (Self.circleRadius * enlargementScale / 3)
+            let startingX = circleCenter.x - ((Self.circleRadius + 1) * enlargementScale / 2)
 
             // draw the WiFi symbol
             let translation = CGAffineTransform(translationX: startingX, y: startingY)
+            let scale = CGAffineTransform(scaleX: enlargementScale, y: enlargementScale)
 
             let curve1 = UIBezierPath()
             curve1.move(to: CGPoint(x: 7.78, y: 0))
@@ -301,6 +302,7 @@ extension MainEpisodeActionView {
             curve1.addLine(to: CGPoint(x: 15.56, y: 3.22))
             curve1.addCurve(to: CGPoint(x: 7.78, y: 0), controlPoint1: CGPoint(x: 13.57, y: 1.23), controlPoint2: CGPoint(x: 10.82, y: 0))
             curve1.close()
+            curve1.apply(scale)
             curve1.apply(translation)
             curve1.fill()
 
@@ -313,6 +315,7 @@ extension MainEpisodeActionView {
             curve2.addCurve(to: CGPoint(x: 7.78, y: 4), controlPoint1: CGPoint(x: 11.46, y: 4.78), controlPoint2: CGPoint(x: 9.71, y: 4))
             curve2.addCurve(to: CGPoint(x: 2.83, y: 6.05), controlPoint1: CGPoint(x: 5.85, y: 4), controlPoint2: CGPoint(x: 4.1, y: 4.78))
             curve2.close()
+            curve2.apply(scale)
             curve2.apply(translation)
             curve2.fill()
 
@@ -327,6 +330,7 @@ extension MainEpisodeActionView {
             dot.addCurve(to: CGPoint(x: 7.78, y: 8), controlPoint1: CGPoint(x: 9.36, y: 8.34), controlPoint2: CGPoint(x: 8.61, y: 8))
             dot.addCurve(to: CGPoint(x: 5.66, y: 8.88), controlPoint1: CGPoint(x: 6.95, y: 8), controlPoint2: CGPoint(x: 6.2, y: 8.34))
             dot.close()
+            dot.apply(scale)
             dot.apply(translation)
             dot.fill()
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Ensure that icon for pending upload on waiting for wifi shows correctly

| Before | After |
| - | - |
| <img width="660" height="1434" alt="IMG_1454" src="https://github.com/user-attachments/assets/59ce2ae1-90b0-4ebe-92ce-a2a349e83cdc" /> | <img width="660" height="1434" alt="IMG_1457" src="https://github.com/user-attachments/assets/525d636b-286b-4fa9-b4ed-a67b6e495842" /> |

## To test

1. Start the app
2. Choose a larger dynamic type on settings (
3. Go to Profile -> Settings -> Auto Downloads
4. Ensure that Only on Unmetered Wifi is Off
5. Disable Wifi on the device ( keep celular connection on)
6. Open a Podcast
7. Activate multi-select by long pressing on episodes
8. Select 1 episode
9. Tap on Download
10. Choose Queue for later
11. Go to Profile -> Settings -> Downloads
12. Check that wait for wifi icon has the wifi symbol correctly centered

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
