### PR TITLE
Enable SwiftLint rule: empty_string

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -32,7 +32,7 @@ only_rules:
   # Prefer checking `isEmpty` over comparing `count` to zero.
   - empty_count
 
-  # Prefer `""` over String().
+  # Prefer `.isEmpty` over comparing to an empty string literal.
   - empty_string
 
   # Arguments can be omitted when matching enums with associated types if they

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -32,6 +32,9 @@ only_rules:
   # Prefer checking `isEmpty` over comparing `count` to zero.
   - empty_count
 
+  # Prefer `""` over String().
+  - empty_string
+
   # Arguments can be omitted when matching enums with associated types if they
   # are not used.
   - empty_enum_arguments

--- a/podcasts/DownloadedFilesViewController.swift
+++ b/podcasts/DownloadedFilesViewController.swift
@@ -68,7 +68,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
                 cell.selectButton.addTarget(self, action: #selector(DownloadedFilesViewController.unplayedToggled(_:)), for: .touchUpInside)
 
                 let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: Int64(unplayedSize))
-                cell.subtitleLabel.text = sizeAsStr == "" ? SizeFormatter.shared.placeholder : sizeAsStr
+                cell.subtitleLabel.text = sizeAsStr.isEmpty ? SizeFormatter.shared.placeholder : sizeAsStr
             case 1:
                 cell.titleLabel.text = L10n.inProgress
                 cell.setSelectedState(deleteInProgress)
@@ -76,7 +76,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
                 cell.selectButton.addTarget(self, action: #selector(DownloadedFilesViewController.inProgressToggled(_:)), for: .touchUpInside)
 
                 let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: Int64(inProgressSize))
-                cell.subtitleLabel.text = sizeAsStr == "" ? SizeFormatter.shared.placeholder : sizeAsStr
+                cell.subtitleLabel.text = sizeAsStr.isEmpty ? SizeFormatter.shared.placeholder : sizeAsStr
             case 2:
                 cell.titleLabel.text = L10n.statusPlayed
                 cell.setSelectedState(deletePlayed)
@@ -84,7 +84,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
                 cell.selectButton.addTarget(self, action: #selector(DownloadedFilesViewController.playedToggled(_:)), for: .touchUpInside)
 
                 let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: Int64(playedSize))
-                cell.subtitleLabel.text = sizeAsStr == "" ? SizeFormatter.shared.placeholder : sizeAsStr
+                cell.subtitleLabel.text = sizeAsStr.isEmpty ? SizeFormatter.shared.placeholder : sizeAsStr
             default:
                 break
             }
@@ -104,7 +104,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
 
             let total = totalDeleteSize()
             let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: Int64(total))
-            cell.statValue.text = sizeAsStr == "" ? SizeFormatter.shared.placeholder : sizeAsStr
+            cell.statValue.text = sizeAsStr.isEmpty ? SizeFormatter.shared.placeholder : sizeAsStr
             return cell
         case 3:
             let cell = tableView.dequeueReusableCell(withIdentifier: buttonCellId, for: indexPath) as! DestructiveButtonCell

--- a/podcasts/Episode/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+Actions.swift
@@ -130,8 +130,8 @@ extension EpisodeDetailViewController {
             downloadBtn.accessibilityLabel = L10n.cancelDownload
         } else {
             downloadBtn.setImage(UIImage(named: "episode-download"), for: .normal)
-            let sizeAsStr = episode.sizeInBytes == 0 ? "" : SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
-            downloadBtn.setTitle(sizeAsStr == "" ? L10n.download : sizeAsStr, for: .normal)
+            let sizeAsStr = episode.sizeInBytes == 0 ? nil : SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
+            downloadBtn.setTitle(sizeAsStr ?? L10n.download, for: .normal)
             downloadBtn.accessibilityLabel = L10n.download
         }
 

--- a/podcasts/Episode/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+Actions.swift
@@ -131,7 +131,13 @@ extension EpisodeDetailViewController {
         } else {
             downloadBtn.setImage(UIImage(named: "episode-download"), for: .normal)
             let sizeAsStr = episode.sizeInBytes == 0 ? nil : SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
-            downloadBtn.setTitle(sizeAsStr ?? L10n.download, for: .normal)
+            let downloadTitle: String
+            if let sizeAsStr, !sizeAsStr.isEmpty {
+                downloadTitle = sizeAsStr
+            } else {
+                downloadTitle = L10n.download
+            }
+            downloadBtn.setTitle(downloadTitle, for: .normal)
             downloadBtn.accessibilityLabel = L10n.download
         }
 

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -154,7 +154,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
             if let showNotes = try? await ShowInfoCoordinator.shared.loadShowNotes(podcastUuid: episode.parentIdentifier(), episodeUuid: episode.uuid) {
                 self?.downloadingShowNotes = false
 
-                let shouldResetScrollOffset = lastEpisodeUuidRendered != episode.uuid && lastEpisodeUuidRendered != ""
+                let shouldResetScrollOffset = lastEpisodeUuidRendered != episode.uuid && !lastEpisodeUuidRendered.isEmpty
                 self?.displayShowNotes(showNotes, shouldResetScrollOffset: shouldResetScrollOffset)
 
                 // if we get back the no show notes available message, make sure next update we try again

--- a/podcasts/StorageAndDataUseViewController.swift
+++ b/podcasts/StorageAndDataUseViewController.swift
@@ -59,7 +59,7 @@ class StorageAndDataUseViewController: PCViewController, UITableViewDelegate, UI
 
             let fileSize = EpisodeManager.downloadSizeOfAllEpisodes()
             let sizeAsStr = SizeFormatter.shared.noDecimalFormat(bytes: Int64(fileSize))
-            cell.cellSecondaryLabel.text = sizeAsStr == "" ? SizeFormatter.shared.placeholder : sizeAsStr
+            cell.cellSecondaryLabel.text = sizeAsStr.isEmpty ? SizeFormatter.shared.placeholder : sizeAsStr
 
             return cell
         } else {


### PR DESCRIPTION
## Summary
Enables SwiftLint's empty_string rule, which prefers .isEmpty over comparing strings to an empty string literal.

## Changes
- Auto-fixed violations: 0
- Agentic fixes: 7
- Violations left for human review: 0
- Part of the Orchard SwiftLint rollout campaign

## Verification
- make lint
- make build_staging
- make test_staging
