### PR TITLE
Adjust size of image on collection

### DIFF
--- a/podcasts/HorizontalCollectionList.swift
+++ b/podcasts/HorizontalCollectionList.swift
@@ -13,12 +13,18 @@ struct HorizontalCollectionList: View {
 
     @ScaledMetric(relativeTo: .largeTitle) var scaledRowHeight = CGFloat(210)
 
+    @ScaledMetric(relativeTo: .largeTitle) var scaledRowWidth = CGFloat(180)
+
     var adjustedHeight: CGFloat {
         return max(323, scaledHeight)
     }
 
     var adjustedRowHeight: CGFloat {
         return min(320, max(210, scaledRowHeight))
+    }
+
+    var adjustedRowWidth: CGFloat {
+        return min(320, max(180, scaledRowWidth))
     }
 
     var header: some View {
@@ -53,7 +59,7 @@ struct HorizontalCollectionList: View {
                     Color.gray
                 }
             }
-            .frame(width: adjustedRowHeight, height: adjustedRowHeight)
+            .frame(width: adjustedRowWidth, height: adjustedRowHeight)
             VStack() {
                 Spacer()
                 Text(model.title)
@@ -72,7 +78,7 @@ struct HorizontalCollectionList: View {
                 Spacer().frame(height: 4)
             }
             .foregroundColor(.clear)
-            .frame(width: adjustedRowHeight, height: adjustedRowHeight / 2)
+            .frame(width: adjustedRowWidth, height: adjustedRowHeight / 2)
             .background(
                 LinearGradient(
                     stops: [
@@ -85,7 +91,7 @@ struct HorizontalCollectionList: View {
             )
         }
         .cornerRadius(4)
-        .frame(width: adjustedRowHeight, height: adjustedRowHeight)
+        .frame(width: adjustedRowWidth, height: adjustedRowHeight)
         .padding(.leading, 16)
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-585 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
| Before | After |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-31 at 14 34 26" src="https://github.com/user-attachments/assets/cbd3d535-343f-49dc-a9f5-52252dee941c" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-31 at 14 27 10" src="https://github.com/user-attachments/assets/2ed237f6-73ad-479d-82de-a99b7b76bca3" /> |

## To test

1. Star the app
2. Open Discovery
3. Scroll to a Feature List
4. Check that the poster image is taller  ( 210 height x 180 width) in the Default Text Size

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
