### PR TITLE
Fix landscape mode of player

### DIFF
--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -178,7 +178,7 @@ extension NowPlayingPlayerItemViewController {
     }
 
     var isErrorVisible: Bool {
-        return errorBottomSpacing.priority == UILayoutPriority.required
+        return errorBottomSpacing.constant == 0
     }
 
     @objc func updateError() {
@@ -202,7 +202,7 @@ extension NowPlayingPlayerItemViewController {
         errorLabel.text = error.shortUserMessage
         errorChevron.isHidden = error.userAction == nil
         errorContainer.layoutIfNeeded()
-        errorBottomSpacing.priority = UILayoutPriority.required
+        errorBottomSpacing.constant = 0
         playerBottomSpacing.constant = 16
         UIView.animate(withDuration: 0.3,
                        delay: 0,
@@ -221,7 +221,7 @@ extension NowPlayingPlayerItemViewController {
 
     func hideError() {
         // Move error out
-        errorBottomSpacing.priority = UILayoutPriority.defaultLow
+        errorBottomSpacing.constant = -48
         playerBottomSpacing.constant = 30
         UIView.animate(withDuration: 0.3,
                        delay: 0,

--- a/podcasts/NowPlayingPlayerItemViewController.xib
+++ b/podcasts/NowPlayingPlayerItemViewController.xib
@@ -425,12 +425,11 @@
                 <constraint firstItem="auM-3f-elA" firstAttribute="centerX" secondItem="dXr-Zd-0wP" secondAttribute="centerX" id="3QC-yl-rk2"/>
                 <constraint firstAttribute="trailing" secondItem="WxQ-7h-0WZ" secondAttribute="trailing" id="4fc-om-1OZ"/>
                 <constraint firstItem="auM-3f-elA" firstAttribute="centerY" secondItem="dXr-Zd-0wP" secondAttribute="centerY" id="P1f-xu-Ze5"/>
-                <constraint firstAttribute="bottom" secondItem="Owh-jf-YTg" secondAttribute="bottom" priority="250" id="ckZ-tn-s0v"/>
+                <constraint firstAttribute="bottom" secondItem="Owh-jf-YTg" secondAttribute="bottom" constant="-48" id="ckZ-tn-s0v"/>
                 <constraint firstItem="sam-0S-73x" firstAttribute="top" secondItem="dXr-Zd-0wP" secondAttribute="top" constant="10" id="fQK-oh-rpi"/>
                 <constraint firstItem="WxQ-7h-0WZ" firstAttribute="top" secondItem="Dsl-xJ-ho3" secondAttribute="top" constant="8" id="hS4-XE-bck"/>
                 <constraint firstAttribute="trailing" secondItem="Owh-jf-YTg" secondAttribute="trailing" id="jYr-cs-wkb"/>
                 <constraint firstItem="Owh-jf-YTg" firstAttribute="leading" secondItem="Dsl-xJ-ho3" secondAttribute="leading" id="ktT-yI-jhC"/>
-                <constraint firstItem="Owh-jf-YTg" firstAttribute="top" secondItem="Dsl-xJ-ho3" secondAttribute="bottom" priority="750" id="mNk-ir-3tT"/>
                 <constraint firstItem="WxQ-7h-0WZ" firstAttribute="leading" secondItem="Dsl-xJ-ho3" secondAttribute="leading" id="wSN-3z-fOR"/>
                 <constraint firstItem="auM-3f-elA" firstAttribute="height" secondItem="dXr-Zd-0wP" secondAttribute="height" id="ycO-kv-OEO"/>
                 <constraint firstItem="Owh-jf-YTg" firstAttribute="top" secondItem="WxQ-7h-0WZ" secondAttribute="bottom" constant="30" id="zFk-ce-kom"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-584 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Fix player layout on iPad landscape with error views.

## To test

1. Start the app on an iPad Landscape mode
2. Start playing an episode
3. Open the player full screen
4. Check if layout is showing correctly
5. change to portrait mode
6. Check if it shows correctly
7. Add the [Test Podcast](https://pca.st/private/25cc6130-0a1b-013f-b6fa-0affe8d08c2d) to your account
8. Open the Test Podcast
9. Try to play episodes 1
10. Check in the full screen player if the error banner shows correctly on Landscape and portrait

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
