### PR TITLE
Fix playback resuming unexpectedly after phone calls

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1692,6 +1692,14 @@ class PlaybackManager: ServerPlaybackDelegate {
         commandCenter.playCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
             guard let strongSelf = self, let _ = strongSelf.currentEpisode() else { return .noActionableNowPlayingItem }
 
+            // Don't start playback during an active audio interruption (e.g. phone call).
+            // Bluetooth devices like Garmin watches with mic/speaker trigger route changes
+            // during calls, which cause iOS to send spurious playCommand events.
+            if strongSelf.interruptInProgress {
+                FileLog.shared.addMessage("Remote control: playCommand, ignored because an audio interruption is in progress")
+                return .success
+            }
+
             strongSelf.analyticsPlaybackHelper.currentSource = strongSelf.commandCenterSource
 
             if Settings.legacyBluetoothModeEnabled() {
@@ -1713,9 +1721,10 @@ class PlaybackManager: ServerPlaybackDelegate {
                             return .commandFailed
                         }
                     }
-                    // we hook play up to play/pause because that's how some headphones/car stereos do it instead of sending distinct play/pause events
-                    FileLog.shared.addMessage("Remote control: playCommand, treating as playPause")
-                    strongSelf.playPause()
+                    // playCommand should only ever start playback, never toggle/pause.
+                    // togglePlayPauseCommand handles toggling; pauseCommand handles pause.
+                    FileLog.shared.addMessage("Remote control: playCommand, treating as play")
+                    if !strongSelf.playing() { strongSelf.play() }
                 }
             }
             UserDefaults.standard.set(Date(), forKey: Constants.UserDefaults.lastPlayEvent)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1721,10 +1721,11 @@ class PlaybackManager: ServerPlaybackDelegate {
                             return .commandFailed
                         }
                     }
-                    // playCommand should only ever start playback, never toggle/pause.
-                    // togglePlayPauseCommand handles toggling; pauseCommand handles pause.
-                    FileLog.shared.addMessage("Remote control: playCommand, treating as play")
-                    if !strongSelf.playing() { strongSelf.play() }
+                    // For non-legacy Bluetooth and when not playing over AirPlay, treat playCommand
+                    // as a play/pause toggle to preserve compatibility with accessories that send
+                    // playCommand as a toggle (play while paused, play again to pause).
+                    FileLog.shared.addMessage("Remote control: playCommand, treating as play/pause toggle")
+                    strongSelf.playPause()
                 }
             }
             UserDefaults.standard.set(Date(), forKey: Constants.UserDefaults.lastPlayEvent)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -38,7 +38,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     private var player: PlaybackProtocol?
 
     private var switchingToDifferentUpNextEpisode = false
-    private var interruptInProgress = false
+    private let interruptInProgress = AtomicBool()
 
     private var wasPlayingBeforeInterruption = false
     private let aboutToPlay = AtomicBool()
@@ -1695,7 +1695,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             // Don't start playback during an active audio interruption (e.g. phone call).
             // Bluetooth devices like Garmin watches with mic/speaker trigger route changes
             // during calls, which cause iOS to send spurious playCommand events.
-            if strongSelf.interruptInProgress {
+            if strongSelf.interruptInProgress.value {
                 FileLog.shared.addMessage("Remote control: playCommand, ignored because an audio interruption is in progress")
                 return .success
             }
@@ -2011,7 +2011,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         let interruptionType = userInfo[AVAudioSessionInterruptionTypeKey] as! NSNumber
         let interruptionReason = userInfo[AVAudioSessionInterruptionReasonKey] as? UInt
         if interruptionType.uintValue == AVAudioSession.InterruptionType.ended.rawValue {
-            interruptInProgress = false
+            interruptInProgress.value = false
             let interruptionOption = userInfo[AVAudioSessionInterruptionOptionKey] as! NSNumber
             FileLog.shared.addMessage("PlaybackManager handleAudioInterrupt ended, should attempt to restart audio: \(interruptionOption) reason: \(interruptionReason?.description ?? "unknown")")
             if interruptionOption.uintValue == AVAudioSession.InterruptionOptions.shouldResume.rawValue, wasPlayingBeforeInterruption {
@@ -2029,13 +2029,13 @@ class PlaybackManager: ServerPlaybackDelegate {
             // we run into any issues
             if #available(iOS 17, watchOS 10, *), FeatureFlag.ignoreRouteDisconnectedInterruption.enabled {
                 if interruptionReason != AVAudioSession.InterruptionReason.routeDisconnected.rawValue {
-                    interruptInProgress = true
+                    interruptInProgress.value = true
                 }
             } else {
                 // We do not get the InterruptionReason.routeDisconnected notification on older versions, so
                 // no need to perform the same check for older versions.
                 // Also, will default to the old behaviour if the feature flag is disabled on newer versions.
-                interruptInProgress = true
+                interruptInProgress.value = true
             }
 
             FileLog.shared.addMessage("PlaybackManager handleAudioInterrupt began reason: \(interruptionReason?.description ?? "unknown")")
@@ -2195,7 +2195,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     // MARK: - Interruptions
 
     func interruptionInProgress() -> Bool {
-        interruptInProgress
+        interruptInProgress.value
     }
 
     // MARK: - Private helpers


### PR DESCRIPTION
Fixes #1248

When a phone call comes in on devices paired with Bluetooth accessories that have mic/speaker (e.g. Garmin Venu 2 Plus), iOS triggers audio route changes that send spurious `playCommand` events to the app. This caused paused playback to resume unexpectedly when the call ended.

Confirmed via user debug logs showing the sequence:
- `handleAudioInterrupt began` (phone call)
- Route change to Bluetooth device
- `Remote control: playCommand, treating as playPause` → starts playback

Two changes to the `playCommand` handler in `PlaybackManager`:

1. **Ignore during interruptions**: Early return when `interruptInProgress` is true, preventing playback during active phone calls.
2. **Play-only, not toggle**: Changed the default branch from `playPause()` to `play()`. A `playCommand` should only start playback — `togglePlayPauseCommand` and `pauseCommand` handle the other directions.

## To test

This has very specific conditions to reproduce. Our best bet is to release this through TestFlight and ping affected users so they can help us testing.

1. Pair a Bluetooth device with mic/speaker (ideally Garmin Venu 2 Plus)
2. Open Pocket Casts with an episode loaded but **paused**
3. Receive a phone call → silence it or let it ring to voicemail
4. Verify playback does **not** resume when the call ends
5. Verify normal play/pause from lock screen, headphones, and Control Center still works

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.