### PR TITLE
Fix layout positioning on Sleep Timer

### DIFF
--- a/podcasts/SleepTimerViewController.xib
+++ b/podcasts/SleepTimerViewController.xib
@@ -177,7 +177,7 @@
                                 <constraint firstItem="UQK-q4-qBY" firstAttribute="leading" secondItem="NpZ-qP-qnr" secondAttribute="leading" constant="20" id="lpg-MM-g46"/>
                             </constraints>
                         </view>
-                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HO2-dO-eLB">
+                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HO2-dO-eLB">
                             <rect key="frame" x="0.0" y="68" width="408" height="432"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="DJb-Yj-WkR">
@@ -332,10 +332,11 @@
                                 </stackView>
                             </subviews>
                             <constraints>
-                                <constraint firstItem="DJb-Yj-WkR" firstAttribute="trailing" secondItem="dMa-B9-sF2" secondAttribute="trailing" constant="-20" id="4v0-Yg-Pb2"/>
+                                <constraint firstItem="DJb-Yj-WkR" firstAttribute="trailing" secondItem="JGY-oo-rAo" secondAttribute="trailing" constant="-20" id="4v0-Yg-Pb2"/>
                                 <constraint firstItem="JGY-oo-rAo" firstAttribute="bottom" secondItem="DJb-Yj-WkR" secondAttribute="bottom" id="FM2-nI-WCq"/>
                                 <constraint firstItem="DJb-Yj-WkR" firstAttribute="top" secondItem="JGY-oo-rAo" secondAttribute="top" id="Z2h-dC-exa"/>
-                                <constraint firstItem="DJb-Yj-WkR" firstAttribute="leading" secondItem="dMa-B9-sF2" secondAttribute="leading" constant="20" id="uou-NG-XfL"/>
+                                <constraint firstItem="DJb-Yj-WkR" firstAttribute="width" secondItem="dMa-B9-sF2" secondAttribute="width" constant="-40" id="ofF-rQ-ZN6"/>
+                                <constraint firstItem="DJb-Yj-WkR" firstAttribute="leading" secondItem="JGY-oo-rAo" secondAttribute="leading" constant="20" id="uou-NG-XfL"/>
                             </constraints>
                             <viewLayoutGuide key="contentLayoutGuide" id="JGY-oo-rAo"/>
                             <viewLayoutGuide key="frameLayoutGuide" id="dMa-B9-sF2"/>

--- a/podcasts/SleepTimerViewController.xib
+++ b/podcasts/SleepTimerViewController.xib
@@ -177,7 +177,7 @@
                                 <constraint firstItem="UQK-q4-qBY" firstAttribute="leading" secondItem="NpZ-qP-qnr" secondAttribute="leading" constant="20" id="lpg-MM-g46"/>
                             </constraints>
                         </view>
-                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HO2-dO-eLB">
+                        <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" bouncesZoom="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HO2-dO-eLB">
                             <rect key="frame" x="0.0" y="68" width="408" height="432"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="DJb-Yj-WkR">
@@ -332,10 +332,10 @@
                                 </stackView>
                             </subviews>
                             <constraints>
-                                <constraint firstItem="DJb-Yj-WkR" firstAttribute="trailing" secondItem="JGY-oo-rAo" secondAttribute="trailing" constant="20" id="4v0-Yg-Pb2"/>
+                                <constraint firstItem="DJb-Yj-WkR" firstAttribute="trailing" secondItem="dMa-B9-sF2" secondAttribute="trailing" constant="-20" id="4v0-Yg-Pb2"/>
                                 <constraint firstItem="JGY-oo-rAo" firstAttribute="bottom" secondItem="DJb-Yj-WkR" secondAttribute="bottom" id="FM2-nI-WCq"/>
                                 <constraint firstItem="DJb-Yj-WkR" firstAttribute="top" secondItem="JGY-oo-rAo" secondAttribute="top" id="Z2h-dC-exa"/>
-                                <constraint firstItem="DJb-Yj-WkR" firstAttribute="leading" secondItem="JGY-oo-rAo" secondAttribute="leading" constant="20" id="uou-NG-XfL"/>
+                                <constraint firstItem="DJb-Yj-WkR" firstAttribute="leading" secondItem="dMa-B9-sF2" secondAttribute="leading" constant="20" id="uou-NG-XfL"/>
                             </constraints>
                             <viewLayoutGuide key="contentLayoutGuide" id="JGY-oo-rAo"/>
                             <viewLayoutGuide key="frameLayoutGuide" id="dMa-B9-sF2"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-590](https://linear.app/a8c/issue/PCIOS-590/sleep-timer-plusminus-buttons-missing-due-to-text-size) <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Fix Sleep timer -/+ buttons going out of screen on Display Zoom -> Larger Text

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-04 at 10 18 15" src="https://github.com/user-attachments/assets/c4cbff4a-825c-4275-b906-928099d1a828" /> |  <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-04 at 10 16 09" src="https://github.com/user-attachments/assets/611380c7-a976-4ace-931f-c16de55924e2" /> | 


## To test

1. Activate Display Zoom -> Larger Text on your test device. Settings -> Display  Zoom -> Larger Text
2. Start the app
3. Play an episode
4. Open the full screen player
5. Tap on Sleep Timer
6. Check if layout is correct and specifically if the + - buttons are not scrolling out of screen

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
