### PR TITLE
Fix calculation of max buffered time

### DIFF
--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -129,14 +129,16 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         guard let loadedTimeRanges = player?.currentItem?.loadedTimeRanges else { return 0 }
 
         let upTo = currentTime()
+        var maxTime: TimeInterval = 0
         for range in loadedTimeRanges {
             let rangeBuferred = range.timeRangeValue
-            if (CMTimeGetSeconds(rangeBuferred.start) + CMTimeGetSeconds(rangeBuferred.duration)) > upTo {
-                return CMTimeGetSeconds(rangeBuferred.duration)
+            let rangeMaxTime = CMTimeGetSeconds(rangeBuferred.start) + CMTimeGetSeconds(rangeBuferred.duration)
+            if rangeMaxTime > upTo, rangeMaxTime > maxTime {
+                maxTime = rangeMaxTime
             }
         }
 
-        return 0
+        return maxTime
     }
 
     func play(completion: (() -> Void)? = nil) {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Updates the calculation of the loaded ranges to take in account the maximum range loaded and not only the first range that is larger than the the current play position


## To test

1. Open an podcast with a longer episode that is not downloaded
2. Tap play on the episode
3. Watch the loading bar on the progress indicator on the mini-player and see if buffering bar updates correctly
4. Check if playing continues correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
