### PR TITLE
Update episode cell error states

### DIFF
--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -116,7 +116,7 @@ class MainEpisodeActionView: UIView {
         let isPlaying = (isCurrent && PlaybackManager.shared.playing())
         let googleCastConnected = GoogleCastManager.sharedManager.connected()
         let primaryRowActionIsDownload = Settings.primaryRowAction() == .download
-        if googleCastConnected || isCurrent {
+        if googleCastConnected, isCurrent {
             state = isPlaying ? .pause : .play
         } else if episode.played() {
             state = episode.downloaded(pathFinder: DownloadManager.shared) ? .playedPlay : .playedDownload

--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -116,7 +116,7 @@ class MainEpisodeActionView: UIView {
         let isPlaying = (isCurrent && PlaybackManager.shared.playing())
         let googleCastConnected = GoogleCastManager.sharedManager.connected()
         let primaryRowActionIsDownload = Settings.primaryRowAction() == .download
-        if googleCastConnected, isCurrent {
+        if googleCastConnected {
             state = isPlaying ? .pause : .play
         } else if episode.played() {
             state = episode.downloaded(pathFinder: DownloadManager.shared) ? .playedPlay : .playedDownload

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -223,7 +223,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             if !hideStatus {
                 let statusImage: UIImage?
                 if episode.downloadFailed() || uploadFailed || episode.playbackError() {
-                    statusImage = UIImage(named: "list_downloadfailed")
+                    statusImage = UIImage(named: "profile-alert")
                 } else if episode.downloaded(pathFinder: DownloadManager.shared) {
                     statusImage = UIImage(named: "list_downloaded")
                 } else {

--- a/podcasts/Lists/ListEpisode.swift
+++ b/podcasts/Lists/ListEpisode.swift
@@ -32,6 +32,7 @@ class ListEpisode: ListItem {
             episode.playedUpTo == rhs.episode.playedUpTo &&
             episode.duration == rhs.episode.duration &&
             episode.archived == rhs.episode.archived &&
+            episode.playbackErrorDetails == rhs.episode.playbackErrorDetails &&
             episode.keepEpisode == rhs.episode.keepEpisode &&
             episode.sizeInBytes == rhs.episode.sizeInBytes &&
             tintColor == rhs.tintColor &&


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-586](https://linear.app/a8c/issue/PCIOS-586/change-the-episode-row-error-icon-to-match-android) <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Update the error icon of episode cells to use alert, and the current play button of episode immediately updates the state to retry when error happens.

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-06 at 14 58 58" src="https://github.com/user-attachments/assets/9a9a5c0c-03b7-4609-a0cc-d77377b26f63" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-06 at 15 02 46" src="https://github.com/user-attachments/assets/ee7d9df5-e364-4f28-9cf1-410897289c0e" /> |

## To test

1. Start the app
2. Ensure that you have `displayErrorsOnPlayer` FF On
3. Add the [Test Podcast](https://pca.st/private/25cc6130-0a1b-013f-b6fa-0affe8d08c2d) to your account
4. Open the Test Podcast
5. Try to play episode 1
7. Check that you see an error banner showing on the bottom that says: "Episode not available"
9. Check that the error icon on the episode cell now shows the triangle alert icon
10. Check that play icon on the episode updates to the retry icon immediately

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
