### PR TITLE
Fix Update divider spacing of cell

### DIFF
--- a/podcasts/PlayerCell.xib
+++ b/podcasts/PlayerCell.xib
@@ -84,7 +84,7 @@
                         </subviews>
                     </stackView>
                     <view alpha="0.20000000000000001" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SPL-EK-QpB" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="75" width="320" height="1"/>
+                        <rect key="frame" x="0.0" y="79" width="320" height="1"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="Yg3-Y0-GSr"/>
@@ -109,7 +109,7 @@
                     <constraint firstAttribute="trailing" secondItem="vxd-V8-but" secondAttribute="trailing" constant="8" id="dsp-Ea-A98"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="wE1-9S-69I" secondAttribute="trailing" constant="8" id="eja-el-zCZ"/>
                     <constraint firstItem="oRM-hc-IES" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottom" constant="-14" id="gys-zy-Lhp"/>
-                    <constraint firstItem="SPL-EK-QpB" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottom" constant="-4" id="ixX-SD-QBc"/>
+                    <constraint firstItem="SPL-EK-QpB" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottom" id="ixX-SD-QBc"/>
                     <constraint firstItem="wE1-9S-69I" firstAttribute="top" secondItem="vxd-V8-but" secondAttribute="bottom" constant="2" id="tXG-hc-RAK"/>
                 </constraints>
             </tableViewCellContentView>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Update spacing on divider

| Before | After |
| - | - |
|  <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-06 at 16 35 11" src="https://github.com/user-attachments/assets/cbff7029-caf9-4b08-95d6-197f3b417386" /> |<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-06 at 16 31 19" src="https://github.com/user-attachments/assets/8b3cce8d-64d7-48e8-9d77-6bed15c40566" /> |

## To test

- Open the app
- Add some episodes to UpNext
- Open the UpNext tab
- Swipe to right or left
- Check if the swipe icons align correctly with top and bottom of cell

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
