### PR TITLE
Disable watch crash explicit logging

### DIFF
--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -307,7 +307,7 @@ public enum FeatureFlag: String, CaseIterable {
     /// Track network data usage per episode/connection type in the NetworkDataUsage table
     case trackNetworkDataUsage
 
-    /// If enabled we send critical watch crash logs to Sentry
+    /// If enabled, send watch-related error and crash logs to Sentry
     case watchSentryCrashLog
 
     public var enabled: Bool {

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -307,6 +307,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Track network data usage per episode/connection type in the NetworkDataUsage table
     case trackNetworkDataUsage
 
+    /// If enabled we send critical watch crash logs to Sentry
+    case watchSentryCrashLog
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -515,6 +518,8 @@ public enum FeatureFlag: String, CaseIterable {
 			true
         case .trackNetworkDataUsage:
             true
+        case .watchSentryCrashLog:
+            false
         }
     }
 

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -308,7 +308,7 @@ public enum FeatureFlag: String, CaseIterable {
     case trackNetworkDataUsage
 
     /// If enabled, send watch-related error and crash logs to Sentry
-    case watchSentryCrashLog
+    case watchSentryLogs
 
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
@@ -518,7 +518,7 @@ public enum FeatureFlag: String, CaseIterable {
 			true
         case .trackNetworkDataUsage:
             true
-        case .watchSentryCrashLog:
+        case .watchSentryLogs:
             false
         }
     }

--- a/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Utils/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -307,7 +307,8 @@ public enum FeatureFlag: String, CaseIterable {
     /// Track network data usage per episode/connection type in the NetworkDataUsage table
     case trackNetworkDataUsage
 
-    /// If enabled, send watch-related error and crash logs to Sentry
+    /// If enabled, send explicit watch-related error logs to Sentry.
+    /// This does not control automatic crash reporting.
     case watchSentryLogs
 
     public var enabled: Bool {

--- a/Pocket Casts Watch App/UI/ExtensionDelegate.swift
+++ b/Pocket Casts Watch App/UI/ExtensionDelegate.swift
@@ -143,6 +143,8 @@ private struct WatchCrashLoggingErrorLogger: ErrorLogger {
     let crashLogging: CrashLogging
 
     func log(error: Error, context: [String: String]?) {
-        crashLogging.logError(error, tags: context ?? [:], level: .warning)
+        if FeatureFlag.watchSentryCrashLog.enabled {
+            crashLogging.logError(error, tags: context ?? [:], level: .warning)
+        }
     }
 }

--- a/Pocket Casts Watch App/UI/ExtensionDelegate.swift
+++ b/Pocket Casts Watch App/UI/ExtensionDelegate.swift
@@ -143,7 +143,7 @@ private struct WatchCrashLoggingErrorLogger: ErrorLogger {
     let crashLogging: CrashLogging
 
     func log(error: Error, context: [String: String]?) {
-        if FeatureFlag.watchSentryCrashLog.enabled {
+        if FeatureFlag.watchSentryLogs.enabled {
             crashLogging.logError(error, tags: context ?? [:], level: .warning)
         }
     }

--- a/Pocket Casts Watch App/UI/ExtensionDelegate.swift
+++ b/Pocket Casts Watch App/UI/ExtensionDelegate.swift
@@ -143,8 +143,6 @@ private struct WatchCrashLoggingErrorLogger: ErrorLogger {
     let crashLogging: CrashLogging
 
     func log(error: Error, context: [String: String]?) {
-        if FeatureFlag.watchSentryLogs.enabled {
-            crashLogging.logError(error, tags: context ?? [:], level: .warning)
-        }
+        FileLog.shared.addMessage("Watch Crash Logger: \(error.localizedDescription). Context: \(context?.debugDescription ?? "")")
     }
 }

--- a/podcasts/Watch Communication/WatchManager.swift
+++ b/podcasts/Watch Communication/WatchManager.swift
@@ -639,23 +639,10 @@ class WatchManager: NSObject, WCSessionDelegate {
         return nsError.domain == WCErrorDomain && nsError.code == WCError.Code.payloadTooLarge.rawValue
     }
 
-    /// Logs a Sentry error and FileLog message if the WatchConnectivity error is due to payload being too large.
+    /// Logs a FileLog message if the WatchConnectivity error is due to payload being too large.
     /// This helps track when synced data exceeds WatchConnectivity's size limits.
     private func logPayloadTooLargeError(method: String, upNextCount: Int) {
         FileLog.shared.addMessage("WatchManager: Payload too large for \(method). Up Next count: \(upNextCount)")
-        if FeatureFlag.watchSentryLogs.enabled {
-            let watchError = WatchSyncError.sendMessageFailed(underlyingError: WCError(.payloadTooLarge))
-            CrashLoggingAdapter.sharedManager?.crashLogging?.logError(
-                watchError,
-                tags: [
-                    "source": "watch_sync",
-                    "method": method,
-                    "error_code": "payloadTooLarge",
-                    "up_next_count": "\(upNextCount)"
-                ],
-                level: .warning // This is a critical error but we fall back to the limited Up Next sync so it should be recoverable
-            )
-        }
     }
 
     // MARK: - Encoding

--- a/podcasts/Watch Communication/WatchManager.swift
+++ b/podcasts/Watch Communication/WatchManager.swift
@@ -643,18 +643,19 @@ class WatchManager: NSObject, WCSessionDelegate {
     /// This helps track when synced data exceeds WatchConnectivity's size limits.
     private func logPayloadTooLargeError(method: String, upNextCount: Int) {
         FileLog.shared.addMessage("WatchManager: Payload too large for \(method). Up Next count: \(upNextCount)")
-
-        let watchError = WatchSyncError.sendMessageFailed(underlyingError: WCError(.payloadTooLarge))
-        CrashLoggingAdapter.sharedManager?.crashLogging?.logError(
-            watchError,
-            tags: [
-                "source": "watch_sync",
-                "method": method,
-                "error_code": "payloadTooLarge",
-                "up_next_count": "\(upNextCount)"
-            ],
-            level: .warning // This is a critical error but we fall back to the limited Up Next sync so it should be recoverable
-        )
+        if FeatureFlag.watchSentryCrashLog.enabled {
+            let watchError = WatchSyncError.sendMessageFailed(underlyingError: WCError(.payloadTooLarge))
+            CrashLoggingAdapter.sharedManager?.crashLogging?.logError(
+                watchError,
+                tags: [
+                    "source": "watch_sync",
+                    "method": method,
+                    "error_code": "payloadTooLarge",
+                    "up_next_count": "\(upNextCount)"
+                ],
+                level: .warning // This is a critical error but we fall back to the limited Up Next sync so it should be recoverable
+            )
+        }
     }
 
     // MARK: - Encoding

--- a/podcasts/Watch Communication/WatchManager.swift
+++ b/podcasts/Watch Communication/WatchManager.swift
@@ -643,7 +643,7 @@ class WatchManager: NSObject, WCSessionDelegate {
     /// This helps track when synced data exceeds WatchConnectivity's size limits.
     private func logPayloadTooLargeError(method: String, upNextCount: Int) {
         FileLog.shared.addMessage("WatchManager: Payload too large for \(method). Up Next count: \(upNextCount)")
-        if FeatureFlag.watchSentryCrashLog.enabled {
+        if FeatureFlag.watchSentryLogs.enabled {
             let watchError = WatchSyncError.sendMessageFailed(underlyingError: WCError(.payloadTooLarge))
             CrashLoggingAdapter.sharedManager?.crashLogging?.logError(
                 watchError,


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR disables explicit crash logging on watch sync to avoid flood of warning logs on Sentry.
This is done with a FeatureFlag so we can be sure we are not hiding other real logs crashes coming from the watch or sync errors.

## To test

1. Start the watch app on the simulator or device
2. Smoke test the behaviour of app 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.