### PR TITLE
Update addressable to 2.9.0 (CVE-2026-35611)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     ast (2.4.2)
@@ -306,7 +306,7 @@ GEM
     progress_bar (1.3.4)
       highline (>= 1.6)
       options (~> 2.3.0)
-    public_suffix (7.0.0)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.1)
@@ -397,4 +397,4 @@ DEPENDENCIES
   watchbuild
 
 BUNDLED WITH
-   2.4.13
+   2.6.8


### PR DESCRIPTION
Fixes AINFRA-2264

## Summary
- Bumps `addressable` gem from vulnerable version to 2.9.0
- Fixes CVE-2026-35611 (GHSA-h27x-rffw-24p4) — high severity ReDoS in Addressable templates
- Vulnerable range: `>= 2.3.0, < 2.9.0`

## Test plan
- [ ] CI passes
- [ ] No changes to app behavior (transitive dependency only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)