### PR TITLE
Watch Stop playing a sound on play.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 8.10
 -----
-
+- Watch Stop playing a sound on play. [#4118](https://github.com/Automattic/pocket-casts-ios/pull/4118)
 
 8.9
 -----

--- a/Pocket Casts Watch App/UI/Episode/EpisodeView.swift
+++ b/Pocket Casts Watch App/UI/Episode/EpisodeView.swift
@@ -67,7 +67,7 @@ struct EpisodeView: View {
 
     private var playPauseButton: some View {
         Button {
-            WKInterfaceDevice.current().play(viewModel.isPlaying ? .click : .start)
+            WKInterfaceDevice.current().play(.click)
             viewModel.playPauseTapped()
         } label: {
             Image(viewModel.isPlaying ? "episodepause" : "episodeplay", bundle: Bundle.watchAssets)

--- a/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingControls.swift
+++ b/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingControls.swift
@@ -78,7 +78,7 @@ struct NowPlayingControls: View {
 
     private var playPauseButton: some View {
         Button {
-            WKInterfaceDevice.current().play(viewModel.isPlaying ? .click : .start)
+            WKInterfaceDevice.current().play(.click)
             viewModel.playPauseTapped()
         } label: {
             Image(viewModel.isPlaying ? "pause" : "play")


### PR DESCRIPTION
Fixes [PCIOS-582](https://linear.app/a8c/issue/PCIOS-582/apple-watch-chime-on-play#comment-e01c3dca) <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Change play action to only do .click when pressing play/pause

## To test

1. Start the watch app on a real watch device
2. Open an episode
3. Tap on play, check that no sound is played, you only feel an haptic effect
4. Open the now playing screen
5. Tap on pause. Check if you felt an  haptic effect
6. Tap on play. Check if you felt an  haptic effect

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
