### PR TITLE
Ensure stall observer is removed

### DIFF
--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -860,7 +860,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             PlaybackManager.shared.playbackDidFail(error: .playbackError(logMessage: errorMessage, isLocalFile: isPlayingLocalFile))
         }
 
-        _ = nc.addObserver(forName: NSNotification.Name.AVPlayerItemPlaybackStalled, object: nil, queue: nil) { [weak self] _ in
+        playStalledObserver = nc.addObserver(forName: NSNotification.Name.AVPlayerItemPlaybackStalled, object: nil, queue: nil) { [weak self] _ in
             guard let self = self else { return }
 
             if self.shouldKeepPlaying {

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -862,8 +862,9 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
         playStalledObserver = nc.addObserver(forName: NSNotification.Name.AVPlayerItemPlaybackStalled, object: nil, queue: nil) { [weak self] _ in
             guard let self = self else { return }
-
+            FileLog.shared.addMessage("Received notification of playback stall")
             if self.shouldKeepPlaying {
+                FileLog.shared.addMessage("Trying to recover from stall by playing")
                 self.play(completion: nil)
             }
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

This resulted from the investigation on the resume playback when stalls happened. Claude was reporting that the observer was being removed because we were not storing it. But in reality it’s the other way around it’s being kept around because the notification observer was retaining it and we were never removing it.

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR ensures that stall removal is correctly removed on cleanup and adds some logging to stall removal actions

The Stall observer was not being removed on clean so it stayed dormant on the notification. The guard for weak self was protecting of crashes and retain cycle but better do the clean up operation correctly by storing the observer and removing on clean up
 
## To test

1. Start the app
2. Play an episode
3. Pause the episode
4. Play another episode ( if you want you can add a breakpoint on DefaultPlayer->cleanUpPlayer-> line 887 to see if removal happens
5. If you want to check the logging, activate the Network Link Conditioner and use the `Very Bad Network` setting to cause stall on playback of an episode
6. Check if logs show up

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
