### PR TITLE
Update proto buffer script output path

### DIFF
--- a/scripts/update_proto.sh
+++ b/scripts/update_proto.sh
@@ -20,5 +20,5 @@ else
     echo "Brew is not installed. Make sure protoc + protoc-gen-swift is installed."
 fi
 
-protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/api.proto
-protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/files.proto
+protoc --swift_out=./Modules/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/api.proto
+protoc --swift_out=./Modules/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/files.proto


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

The latest changes made on project structure because of modularization changed the project modules folders.
This PR updates path to the Server Module code so that the script can generate at the correct place

## To test

1. Try to run the protobuf scripts running: `make update_proto API_PATH={API_PATH}`
2. Replace the  {API_PATH} with the full path to a local copy of the `pocket-casts-sync-api` project and then  `/api/modules/protobuf/src/main/proto` folder. EX: `make update_proto API_PATH=../pocket-casts-sync-api/api/modules/protobuf/src/main/proto`
3. Check if all runs correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.