### PR TITLE
Update episode not available error message on banner

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -2892,19 +2892,19 @@
 			);
 			target = 4694FA5F2799C80300E9CF70 /* Screenshot Automation */;
 		};
-		FF609D032F8909CD00B409BC /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				"String+SentenceCase.swift",
-			);
-			target = BDD301631EFB9356004A9972 /* Pocket Casts Watch App */;
-		};
-		FF609D042F8909CD00B409BC /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		FF60EC562F890CF400B409BC /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				"String+SentenceCase.swift",
 			);
 			target = F5D5F7782CEBE769001F492D /* Pocket Casts App Clip */;
+		};
+		FF60EC582F890D1F00B409BC /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"String+SentenceCase.swift",
+			);
+			target = BDD301631EFB9356004A9972 /* Pocket Casts Watch App */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -2945,7 +2945,7 @@
 		3F7479452F555197004C7FF6 /* ABTest */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3F74794E2F555197004C7FF6 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ABTest; sourceTree = "<group>"; };
 		3F7479522F55519F004C7FF6 /* Unlockable */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3F74795C2F55519F004C7FF6 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Unlockable; sourceTree = "<group>"; };
 		3F7479C32F5551AA004C7FF6 /* Analytics */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3F7479EC2F5551AA004C7FF6 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 3F7479ED2F5551AA004C7FF6 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Analytics; sourceTree = "<group>"; };
-		3F747A532F5553A1004C7FF6 /* Extensions */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Extensions; sourceTree = "<group>"; };
+		3F747A532F5553A1004C7FF6 /* Extensions */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (FF60EC582F890D1F00B409BC /* PBXFileSystemSynchronizedBuildFileExceptionSet */, FF60EC562F890CF400B409BC /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Extensions; sourceTree = "<group>"; };
 		3F747A542F5598A2004C7FF6 /* Playback */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Playback; sourceTree = "<group>"; };
 		3F747A5A2F559925004C7FF6 /* Notifications */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Notifications; sourceTree = "<group>"; };
 		3FDAD4E72F46D75100CC3259 /* NotificationContent */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3FDAD4EC2F46D75100CC3259 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = NotificationContent; sourceTree = "<group>"; };

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -2892,6 +2892,20 @@
 			);
 			target = 4694FA5F2799C80300E9CF70 /* Screenshot Automation */;
 		};
+		FF609D032F8909CD00B409BC /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"String+SentenceCase.swift",
+			);
+			target = BDD301631EFB9356004A9972 /* Pocket Casts Watch App */;
+		};
+		FF609D042F8909CD00B409BC /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"String+SentenceCase.swift",
+			);
+			target = F5D5F7782CEBE769001F492D /* Pocket Casts App Clip */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -67,15 +67,10 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         label.textAlignment = .center
         label.numberOfLines = 1
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontForContentSizeCategory = false
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.5
         return label
-    }()
-
-    private let errorChevron: UIImageView = {
-        let view = UIImageView(image: UIImage(named: "chevron-small-right"))
-        view.tintColor = AppTheme.mainTextColor()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
     }()
 
     // MARK: - State
@@ -1028,7 +1023,6 @@ extension MainTabBarController {
     private func setupErrorBanner() {
         view.addSubview(errorBanner)
         errorBanner.addSubview(errorLabel)
-        errorBanner.addSubview(errorChevron)
 
         let bottomSpacing = errorBanner.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         bottomSpacing.priority = .defaultLow
@@ -1047,17 +1041,10 @@ extension MainTabBarController {
 
             // Error label
             errorLabel.leadingAnchor.constraint(greaterThanOrEqualTo: errorBanner.leadingAnchor, constant: 16),
-            errorLabel.trailingAnchor.constraint(lessThanOrEqualTo: errorBanner.trailingAnchor, constant: -40),
+            errorLabel.trailingAnchor.constraint(lessThanOrEqualTo: errorBanner.trailingAnchor, constant: -16),
             errorLabel.centerXAnchor.constraint(equalTo: errorBanner.centerXAnchor),
             errorLabel.topAnchor.constraint(equalTo: errorBanner.topAnchor, constant: 0),
             errorLabel.bottomAnchor.constraint(equalTo: errorBanner.bottomAnchor, constant: 0),
-
-            // Error Action button
-            errorChevron.leadingAnchor.constraint(equalTo: errorLabel.trailingAnchor, constant: 8),
-            errorChevron.trailingAnchor.constraint(lessThanOrEqualTo: errorBanner.trailingAnchor, constant: -16),
-            errorChevron.centerYAnchor.constraint(equalTo: errorLabel.centerYAnchor),
-            errorChevron.widthAnchor.constraint(equalToConstant: 24),
-            errorChevron.heightAnchor.constraint(equalToConstant: 24),
         ])
     }
 
@@ -1087,8 +1074,7 @@ extension MainTabBarController {
             // do not track this if the full screen player is visible
             AnalyticsPlaybackHelper.shared.playbackErrorShown(playerSource: .miniPlayer)
         }
-        errorLabel.text = error.shortUserMessage
-        errorChevron.isHidden = error.userAction == nil
+        errorLabel.attributedText = error.shortUserAttributedMessage(mainColor: AppTheme.mainTextColor(), interactiveColor: ThemeColor.primaryInteractive01())
         errorBanner.isUserInteractionEnabled = error.userAction != nil
         errorBanner.layoutIfNeeded()
         errorBanner.isHidden = false
@@ -1147,6 +1133,5 @@ extension MainTabBarController {
     private func updateErrorColor() {
         errorBanner.backgroundColor = AppTheme.tabBarBackgroundColor()
         errorLabel.textColor = AppTheme.mainTextColor()
-        errorChevron.tintColor = AppTheme.mainTextColor()
     }
 }

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -199,7 +199,7 @@ extension NowPlayingPlayerItemViewController {
     func showError(_ error: PlaybackManager.PlaybackError, dismissAfter seconds: TimeInterval?) {
         AnalyticsPlaybackHelper.shared.playbackErrorShown(playerSource: .fullPlayer)
         // Move error container in view
-        errorLabel.attributedText = error.shortUserAttributedMessage(mainColor: ThemeColor.playerContrast02(), interactiveColor: ThemeColor.playerContrast03())
+        errorLabel.attributedText = error.shortUserAttributedMessage(mainColor: ThemeColor.playerContrast02(), interactiveColor: ThemeColor.primaryInteractive01())
         errorContainer.layoutIfNeeded()
         errorBottomSpacing.constant = 0
         playerBottomSpacing.constant = 16

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -199,8 +199,7 @@ extension NowPlayingPlayerItemViewController {
     func showError(_ error: PlaybackManager.PlaybackError, dismissAfter seconds: TimeInterval?) {
         AnalyticsPlaybackHelper.shared.playbackErrorShown(playerSource: .fullPlayer)
         // Move error container in view
-        errorLabel.text = error.shortUserMessage
-        errorChevron.isHidden = error.userAction == nil
+        errorLabel.attributedText = error.shortUserAttributedMessage(mainColor: ThemeColor.playerContrast02(), interactiveColor: ThemeColor.playerContrast03())
         errorContainer.layoutIfNeeded()
         errorBottomSpacing.constant = 0
         playerBottomSpacing.constant = 16

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -202,15 +202,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     @IBOutlet weak var errorLabel: ThemeableLabel! {
         didSet {
             errorLabel.font = .font(ofSize: 14, weight: .medium, scalingWith: .subheadline)
-            errorLabel.adjustsFontForContentSizeCategory = true
             errorLabel.style = .playerContrast02
-        }
-    }
-
-    @IBOutlet weak var errorChevron: UIImageView! {
-        didSet {
-            errorChevron.isHidden = true
-            errorChevron.tintColor = ThemeColor.playerContrast02()
         }
     }
 

--- a/podcasts/NowPlayingPlayerItemViewController.xib
+++ b/podcasts/NowPlayingPlayerItemViewController.xib
@@ -384,7 +384,7 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Owh-jf-YTg" userLabel="ErrorContainer" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="896" width="414" height="48"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="96b-yr-mZE" userLabel="ErrorMessage" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="YES" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="96b-yr-mZE" userLabel="ErrorMessage" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                             <rect key="frame" x="16" y="8" width="382" height="32"/>
                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>

--- a/podcasts/NowPlayingPlayerItemViewController.xib
+++ b/podcasts/NowPlayingPlayerItemViewController.xib
@@ -21,7 +21,6 @@
                 <outlet property="episodeInfoView" destination="MLe-7y-U6n" id="0K2-Ws-I3X"/>
                 <outlet property="episodeName" destination="ool-HF-az4" id="87D-Nv-oIM"/>
                 <outlet property="errorBottomSpacing" destination="ckZ-tn-s0v" id="T3H-oG-x6y"/>
-                <outlet property="errorChevron" destination="Flg-T9-xTd" id="dZl-q1-AiG"/>
                 <outlet property="errorContainer" destination="Owh-jf-YTg" id="TJt-lH-W8r"/>
                 <outlet property="errorLabel" destination="96b-yr-mZE" id="PeX-yT-KUQ"/>
                 <outlet property="fillView" destination="sbN-fi-Mv7" id="AN8-6l-tnT"/>
@@ -385,33 +384,21 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Owh-jf-YTg" userLabel="ErrorContainer" customClass="ThemeableView" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="896" width="414" height="48"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="96b-yr-mZE" userLabel="ErrorMessage" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
-                            <rect key="frame" x="207" y="8" width="0.0" height="32"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="96b-yr-mZE" userLabel="ErrorMessage" customClass="ThemeableLabel" customModule="Pocket_Casts_App_Clip" customModuleProvider="target">
+                            <rect key="frame" x="16" y="8" width="382" height="32"/>
                             <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron-small-right" translatesAutoresizingMaskIntoConstraints="NO" id="Flg-T9-xTd">
-                            <rect key="frame" x="207" y="12" width="24" height="24"/>
-                            <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="24" id="8fQ-5d-DA3"/>
-                                <constraint firstAttribute="width" constant="24" id="iqy-9m-PhI"/>
-                            </constraints>
-                        </imageView>
                     </subviews>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.070000000000000007" colorSpace="custom" customColorSpace="calibratedRGB"/>
                     <constraints>
-                        <constraint firstItem="Flg-T9-xTd" firstAttribute="leading" secondItem="96b-yr-mZE" secondAttribute="trailing" id="B1m-Dh-DE4"/>
-                        <constraint firstItem="Flg-T9-xTd" firstAttribute="centerY" secondItem="96b-yr-mZE" secondAttribute="centerY" id="Cgg-YW-Kl3"/>
-                        <constraint firstItem="96b-yr-mZE" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="Owh-jf-YTg" secondAttribute="trailing" constant="-32" id="CkS-yR-wqI"/>
+                        <constraint firstItem="96b-yr-mZE" firstAttribute="trailing" secondItem="Owh-jf-YTg" secondAttribute="trailing" constant="-16" id="CkS-yR-wqI"/>
                         <constraint firstItem="96b-yr-mZE" firstAttribute="top" secondItem="Owh-jf-YTg" secondAttribute="top" constant="8" id="Tha-E8-VUo"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Flg-T9-xTd" secondAttribute="trailing" constant="8" id="Uw0-CV-tco"/>
                         <constraint firstAttribute="bottom" secondItem="96b-yr-mZE" secondAttribute="bottom" constant="8" id="bf9-Jd-CIf"/>
-                        <constraint firstAttribute="height" constant="48" id="eT2-Qf-DyX" userLabel="height ≥ 48"/>
-                        <constraint firstItem="96b-yr-mZE" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Owh-jf-YTg" secondAttribute="leading" constant="32" id="i4h-zQ-7M7"/>
-                        <constraint firstItem="96b-yr-mZE" firstAttribute="centerX" secondItem="Owh-jf-YTg" secondAttribute="centerX" id="ww8-J4-Sug"/>
+                        <constraint firstAttribute="height" constant="48" id="eT2-Qf-DyX"/>
+                        <constraint firstItem="96b-yr-mZE" firstAttribute="leading" secondItem="Owh-jf-YTg" secondAttribute="leading" constant="16" id="i4h-zQ-7M7"/>
                     </constraints>
                 </view>
             </subviews>
@@ -443,6 +430,5 @@
         <image name="chapter-link-white" width="24" height="24"/>
         <image name="chapter-skipbackwards" width="30" height="30"/>
         <image name="chapter-skipforward" width="30" height="30"/>
-        <image name="chevron-small-right" width="24" height="24"/>
     </resources>
 </document>

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1017,7 +1017,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         func shortUserAttributedMessage(mainColor: UIColor, interactiveColor: UIColor) -> NSAttributedString {
             let baseText = self.shortUserMessage
-            let learnMore = L10n.learnMore
+            let learnMore: String = String(L10n.learnMore).sentenceCased
             let attributedString = NSMutableAttributedString(string: baseText, attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .medium)])
             if self.userAction != nil {
                 attributedString.append(NSAttributedString(string: " ", attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .medium)]))

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1015,6 +1015,17 @@ class PlaybackManager: ServerPlaybackDelegate {
             }
         }
 
+        func shortUserAttributedMessage(mainColor: UIColor, interactiveColor: UIColor) -> NSAttributedString {
+            let baseText = self.shortUserMessage
+            let learnMore = L10n.learnMore
+            let attributedString = NSMutableAttributedString(string: baseText, attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .regular)])
+            if self.userAction != nil {
+                attributedString.append(NSAttributedString(string: " ", attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .regular)]))
+                attributedString.append(NSAttributedString(string: learnMore, attributes: [.foregroundColor: interactiveColor, .font: UIFont.systemFont(ofSize: 14, weight: .bold)]))
+            }
+            return attributedString
+        }
+
         var userAction: URL? {
             switch self {
             case .episodeNotAvailable(let errorCode, _):

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1018,10 +1018,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         func shortUserAttributedMessage(mainColor: UIColor, interactiveColor: UIColor) -> NSAttributedString {
             let baseText = self.shortUserMessage
             let learnMore = L10n.learnMore
-            let attributedString = NSMutableAttributedString(string: baseText, attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .regular)])
+            let attributedString = NSMutableAttributedString(string: baseText, attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .medium)])
             if self.userAction != nil {
-                attributedString.append(NSAttributedString(string: " ", attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .regular)]))
-                attributedString.append(NSAttributedString(string: learnMore, attributes: [.foregroundColor: interactiveColor, .font: UIFont.systemFont(ofSize: 14, weight: .bold)]))
+                attributedString.append(NSAttributedString(string: " ", attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .medium)]))
+                attributedString.append(NSAttributedString(string: learnMore, attributes: [.foregroundColor: interactiveColor, .font: UIFont.systemFont(ofSize: 14, weight: .medium)]))
             }
             return attributedString
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2399,7 +2399,7 @@ internal enum L10n {
   /// Generic error used when playback fails but the episode has a downloaded file. Warns the user that playback is failing because the associated file likely has been corrupted.
   internal static var playerErrorCorruptedFile: String { return L10n.tr("Localizable", "player_error_corrupted_file", fallback: "The episode might be corrupted, but you can try to play it again.") }
   /// Generic error used when playback fails because we are unable to access the episode file.
-  internal static var playerErrorEpisodeNotAvailable: String { return L10n.tr("Localizable", "player_error_episode_not_available", fallback: "Episode not available") }
+  internal static var playerErrorEpisodeNotAvailable: String { return L10n.tr("Localizable", "player_error_episode_not_available", fallback: "Episode not available.") }
   /// Generic error used when playback fails while streaming. Asks the user to verify their internet connection.
   internal static var playerErrorInternetConnection: String { return L10n.tr("Localizable", "player_error_internet_connection", fallback: "Check your Internet connection and try again.") }
   /// Generic error used when no internet connection is available.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2399,7 +2399,7 @@ internal enum L10n {
   /// Generic error used when playback fails but the episode has a downloaded file. Warns the user that playback is failing because the associated file likely has been corrupted.
   internal static var playerErrorCorruptedFile: String { return L10n.tr("Localizable", "player_error_corrupted_file", fallback: "The episode might be corrupted, but you can try to play it again.") }
   /// Generic error used when playback fails because we are unable to access the episode file.
-  internal static var playerErrorEpisodeNotAvailable: String { return L10n.tr("Localizable", "player_error_episode_not_available", fallback: "Episode not available.") }
+  internal static var playerErrorEpisodeNotAvailable: String { return L10n.tr("Localizable", "player_error_episode_not_available", fallback: "This episode can't be played.") }
   /// Generic error used when playback fails while streaming. Asks the user to verify their internet connection.
   internal static var playerErrorInternetConnection: String { return L10n.tr("Localizable", "player_error_internet_connection", fallback: "Check your Internet connection and try again.") }
   /// Generic error used when no internet connection is available.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5861,7 +5861,7 @@
 "files_not_uploaded" = "No files uploaded";
 
 /* Generic error used when playback fails because we are unable to access the episode file. */
-"player_error_episode_not_available" = "Episode not available";
+"player_error_episode_not_available" = "Episode not available.";
 
 /* Generic error used when no internet connection is available. */
 "player_error_short_no_connection" = "You’re offline";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5861,7 +5861,7 @@
 "files_not_uploaded" = "No files uploaded";
 
 /* Generic error used when playback fails because we are unable to access the episode file. */
-"player_error_episode_not_available" = "Episode not available.";
+"player_error_episode_not_available" = "This episode can't be played.";
 
 /* Generic error used when no internet connection is available. */
 "player_error_short_no_connection" = "You’re offline";


### PR DESCRIPTION
Fixes [PCIOS-596](https://linear.app/a8c/issue/PCIOS-596/update-error-label-from-episode-not-available) <!-- issue number, if applicable -->

| 1 | 2 | 3 | 4 |
| - | - | - | - |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-10 at 11 37 39" src="https://github.com/user-attachments/assets/94077fca-5a3b-4edd-a569-49e62577c8f8" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-10 at 11 37 35" src="https://github.com/user-attachments/assets/1538ce0e-17bd-4349-96c1-113bf39444be" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-10 at 11 37 26" src="https://github.com/user-attachments/assets/bc301d63-8b44-4ffe-aa73-69152f9935b2" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-10 at 11 37 22" src="https://github.com/user-attachments/assets/d376ce6c-16b0-4d77-baa7-dfb3a4b12994" /> |

Changed the message from `Episode not available` to `This episode can't be played. Learn more`
Removed chevron and used Learn More instead

## To test

1. Start the app
2. Ensure that you have `displayErrorsOnPlayer` FF On
3. Add the [Test Podcast](https://pca.st/private/25cc6130-0a1b-013f-b6fa-0affe8d08c2d) to your account
4. Open the Test Podcast
5. Try to play episode 1
7.  Check that you see an error banner showing on the bottom that says: "This episode can't be played. Learn more"

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
