### PR TITLE
Install protobuf packages if missing in update_proto

### DIFF
--- a/scripts/update_proto.sh
+++ b/scripts/update_proto.sh
@@ -16,7 +16,9 @@ fi
 if command -v brew &> /dev/null; then
     for pkg in protobuf swift-protobuf; do
         if brew list --formula "$pkg" &> /dev/null; then
-            brew upgrade "$pkg"
+            # Upgrades are best-effort: a transient Homebrew failure shouldn't
+            # block proto generation when the installed version already works.
+            brew upgrade "$pkg" || echo "Warning: failed to upgrade $pkg; continuing with the installed version."
         else
             brew install "$pkg"
         fi
@@ -25,5 +27,12 @@ else
     echo "Brew is not installed. Make sure protoc + protoc-gen-swift is installed."
 fi
 
-protoc --swift_out=./Modules/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/api.proto
-protoc --swift_out=./Modules/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/files.proto
+for tool in protoc protoc-gen-swift; do
+    if ! command -v "$tool" &> /dev/null; then
+        echo "Error: $tool is not installed or not on PATH. Install protobuf and swift-protobuf and try again."
+        exit 1
+    fi
+done
+
+protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/api.proto
+protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/files.proto

--- a/scripts/update_proto.sh
+++ b/scripts/update_proto.sh
@@ -34,5 +34,6 @@ for tool in protoc protoc-gen-swift; do
     fi
 done
 
-protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/api.proto
-protoc --swift_out=./Modules/Server/Sources/PocketCastsServer/Private/Protobuffer --proto_path=$API_BASE_FOLDER/ $API_BASE_FOLDER/files.proto
+PROTO_OUT=./Modules/Sources/PocketCastsServer/Private/Protobuffer
+protoc --swift_out="$PROTO_OUT" --proto_path="$API_BASE_FOLDER" "$API_BASE_FOLDER/api.proto"
+protoc --swift_out="$PROTO_OUT" --proto_path="$API_BASE_FOLDER" "$API_BASE_FOLDER/files.proto"

--- a/scripts/update_proto.sh
+++ b/scripts/update_proto.sh
@@ -14,8 +14,13 @@ then
 fi
 
 if command -v brew &> /dev/null; then
-    brew upgrade protobuf
-    brew upgrade swift-protobuf
+    for pkg in protobuf swift-protobuf; do
+        if brew list --formula "$pkg" &> /dev/null; then
+            brew upgrade "$pkg"
+        else
+            brew install "$pkg"
+        fi
+    done
 else
     echo "Brew is not installed. Make sure protoc + protoc-gen-swift is installed."
 fi


### PR DESCRIPTION
When I tried to test #4121 , I got an error about `swift-protobuf` not being installed. The README (and AGENTS) document that the tool needs to be installed via `brew`, but I didn't read any because this is a repo I've had on my machine for a while, so I missed that information. 

This PR updates the protobuf generator script to install the required tools via `brew` if they are not available.

I think it's a neat improvement, but not a mandatory one. After all, installing the tool is a one-off on a new dev machine, I could live with it staying the way it is if you think the added complexity in the script is not worth the trade.