### PR TITLE
Ensure that we only send data back when the response object is available

### DIFF
--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -268,6 +268,9 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
         // Filter out the unfullfilled requests
         let requestsFulfilled: Set<AVAssetResourceLoadingRequest> = pendingRequests.filter {
+            guard response != nil else {
+                return false
+            }
             fillInContentInformationRequest($0.contentInformationRequest)
             guard haveEnoughDataToFulfillRequest($0.dataRequest!) else { return false }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-558 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR updates the streaming media loader to ensure that the `contentInformationRequest` when requested is properly filled with existing response data. 
The previous code could run into data race scenario that a `response` was not ready when `contentInformationRequest` was being filled,  but then filling media data that was already written to memory or disk and incorrectly fulfil the request as mark it as `finishLoading` without filling the correct data and making the AVPlayer to fail with bad media data.

## To test

1. Start the app using a real device
2. Select some episodes and start downloading them
3. Tap on play on one of those episodes that is downloading.
4. Check if playback happens correctly

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
