### PR TITLE
Fix an issue with text cut in Pocket Casts +Plus promo in Settings / Appearance

### DIFF
--- a/podcasts/AppearanceViewController.swift
+++ b/podcasts/AppearanceViewController.swift
@@ -79,8 +79,6 @@ class AppearanceViewController: PCViewController, UITableViewDataSource, UITable
         if rowType == .appIcon {
             let metric = UIFontMetrics(forTextStyle: .largeTitle)
             return metric.scaledValue(for: 188)
-        } else if rowType == .plusCallout {
-            return 161
         }
 
         return UITableView.automaticDimension


### PR DESCRIPTION
Fixes PCIOS-598

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

Environment: clean install, no Pocket Casts Plus.

- Open Settings / Appearance
- Scroll to the bottom

## Screenshots

Before 


<img width="340"  alt="Screenshot 2026-04-13 at 5 21 42 PM" src="https://github.com/user-attachments/assets/be8ca0b5-c088-42b4-8db6-d717e8d25d62" />

After

<img width="340"  alt="Screenshot 2026-04-13 at 5 25 40 PM" src="https://github.com/user-attachments/assets/d9e568eb-f107-4ed3-9a77-cff2e9c9c9d2" /> <img width="340"  alt="Screenshot 2026-04-13 at 5 30 11 PM" src="https://github.com/user-attachments/assets/dda37d6a-766a-41eb-b8f7-c14442722ce1" />

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
