### PR TITLE
Update cleanup logic

### DIFF
--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -456,7 +456,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             }
             if exportStatus.error == nil {
                 FileLog.shared.addMessage("DownloadManager stream and download: end downloading \(episode.uuid) successfully")
-                processEpisode(episode, downloadedFile: outputURL, reportedContentType: exportStatus.reportedType, copyFile: true)                
+                processEpisode(episode, downloadedFile: outputURL, reportedContentType: exportStatus.reportedType, copyFile: true)
             } else {
                 FileLog.shared.addMessage("DownloadManager stream and download: failed downloading \(episode.uuid) -> \(exportStatus.error?.localizedDescription ?? "")")
                 wasDownloadingBefore = episode.downloading()

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -457,6 +457,9 @@ class DownloadManager: NSObject, FilePathProtocol {
             if exportStatus.error == nil {
                 FileLog.shared.addMessage("DownloadManager stream and download: end downloading \(episode.uuid) successfully")
                 processEpisode(episode, downloadedFile: outputURL, reportedContentType: exportStatus.reportedType, copyFile: true)
+                // The tmp file is intentionally left in place here. The OS reclaims files in the system
+                // tmp directory under memory pressure, and DownloadedFilesViewController.performDelete()
+                // cleans up orphans older than 1 week on the next user-triggered cleanup.
             } else {
                 FileLog.shared.addMessage("DownloadManager stream and download: failed downloading \(episode.uuid) -> \(exportStatus.error?.localizedDescription ?? "")")
                 wasDownloadingBefore = episode.downloading()

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -456,11 +456,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             }
             if exportStatus.error == nil {
                 FileLog.shared.addMessage("DownloadManager stream and download: end downloading \(episode.uuid) successfully")
-                processEpisode(episode, downloadedFile: outputURL, reportedContentType: exportStatus.reportedType, copyFile: true)
-                if FeatureFlag.cleanUpTmpFiles.enabled {
-                    // Now that the file is downloaded and copied we can mark it for deletion on release
-                    customLoaderDelegate.deleteFileOnRelease = true
-                }
+                processEpisode(episode, downloadedFile: outputURL, reportedContentType: exportStatus.reportedType, copyFile: true)                
             } else {
                 FileLog.shared.addMessage("DownloadManager stream and download: failed downloading \(episode.uuid) -> \(exportStatus.error?.localizedDescription ?? "")")
                 wasDownloadingBefore = episode.downloading()

--- a/podcasts/DownloadedFilesViewController.swift
+++ b/podcasts/DownloadedFilesViewController.swift
@@ -175,11 +175,11 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
 
         Analytics.track(.downloadsCleanUpCompleted, properties: ["unplayed": deleteUnplayed, "in_progress": deleteInProgress, "played": deletePlayed, "include_starred": includeStarred])
 
-        let unplayedSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(unplayedSize))
-        let inProgressSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(inProgressSize))
-        let playedSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(playedSize))
-        let tmpFilesSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(tmpFilesSize))
-        FileLog.shared.addMessage("[DownloadFilesViewController] space being used:\n - Unplayed: \(unplayedSize)\n - InProgress: \(inProgressSize)\n - Played: \(playedSize)\n - Temporary: \(tmpFilesSize)")
+        let formattedUnplayedSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(unplayedSize))
+        let formattedInProgressSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(inProgressSize))
+        let formattedPlayedSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(playedSize))
+        let formattedTmpFilesSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(tmpFilesSize))
+        FileLog.shared.addMessage("[DownloadFilesViewController] space being used:\n - Unplayed: \(formattedUnplayedSize)\n - InProgress: \(formattedInProgressSize)\n - Played: \(formattedPlayedSize)\n - Temporary: \(formattedTmpFilesSize)")
 
         DispatchQueue.global(qos: .default).async { () in
             EpisodeManager.deleteAllDownloadedFiles(unplayed: self.deleteUnplayed, inProgress: self.deleteInProgress, played: self.deletePlayed, includeStarred: self.includeStarred)
@@ -201,7 +201,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
         unplayedSize = EpisodeManager.downloadSizeOfUnplayedEpisodes(includeStarred: includeStarred)
         inProgressSize = EpisodeManager.downloadSizeOfInProgressEpisodes(includeStarred: includeStarred)
         playedSize = EpisodeManager.downloadSizeOfPlayedEpisodes(includeStarred: includeStarred)
-        tmpFilesSize = EpisodeManager.tmpFolderSize()
+        tmpFilesSize = FeatureFlag.cleanUpTmpFiles.enabled ? EpisodeManager.tmpFolderSize() : 0
 
         DispatchQueue.main.async { () in
             self.settingsTable.reloadData()

--- a/podcasts/DownloadedFilesViewController.swift
+++ b/podcasts/DownloadedFilesViewController.swift
@@ -176,7 +176,10 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
 
         DispatchQueue.global(qos: .default).async { () in
             EpisodeManager.deleteAllDownloadedFiles(unplayed: self.deleteUnplayed, inProgress: self.deleteInProgress, played: self.deletePlayed, includeStarred: self.includeStarred)
-
+            if FeatureFlag.cleanUpTmpFiles.enabled {
+                // Remove any lingering files in the temporary folder that were not removed above, those should be orphan files
+                EpisodeManager.cleanUpTmpFolder()
+            }
             self.performRefresh()
         }
     }

--- a/podcasts/DownloadedFilesViewController.swift
+++ b/podcasts/DownloadedFilesViewController.swift
@@ -174,6 +174,11 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
 
         Analytics.track(.downloadsCleanUpCompleted, properties: ["unplayed": deleteUnplayed, "in_progress": deleteInProgress, "played": deletePlayed, "include_starred": includeStarred])
 
+        let unplayedSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(unplayedSize))
+        let inProgressSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(inProgressSize))
+        let playedSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(playedSize))
+        FileLog.shared.addMessage("[DownloadFilesViewController] space being used:\n - Unplaye: \(unplayedSize)\n - InProgress: \(inProgressSize)\n - Played: \(playedSize)")
+
         DispatchQueue.global(qos: .default).async { () in
             EpisodeManager.deleteAllDownloadedFiles(unplayed: self.deleteUnplayed, inProgress: self.deleteInProgress, played: self.deletePlayed, includeStarred: self.includeStarred)
             if FeatureFlag.cleanUpTmpFiles.enabled {

--- a/podcasts/DownloadedFilesViewController.swift
+++ b/podcasts/DownloadedFilesViewController.swift
@@ -15,6 +15,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
     private var unplayedSize = 0 as UInt64
     private var playedSize = 0 as UInt64
     private var inProgressSize = 0 as UInt64
+    private var tmpFilesSize = 0 as UInt64
 
     @IBOutlet var settingsTable: UITableView! {
         didSet {
@@ -177,7 +178,8 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
         let unplayedSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(unplayedSize))
         let inProgressSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(inProgressSize))
         let playedSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(playedSize))
-        FileLog.shared.addMessage("[DownloadFilesViewController] space being used:\n - Unplaye: \(unplayedSize)\n - InProgress: \(inProgressSize)\n - Played: \(playedSize)")
+        let tmpFilesSize = SizeFormatter.shared.noDecimalFormat(bytes: Int64(tmpFilesSize))
+        FileLog.shared.addMessage("[DownloadFilesViewController] space being used:\n - Unplayed: \(unplayedSize)\n - InProgress: \(inProgressSize)\n - Played: \(playedSize)\n - Temporary: \(tmpFilesSize)")
 
         DispatchQueue.global(qos: .default).async { () in
             EpisodeManager.deleteAllDownloadedFiles(unplayed: self.deleteUnplayed, inProgress: self.deleteInProgress, played: self.deletePlayed, includeStarred: self.includeStarred)
@@ -199,6 +201,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
         unplayedSize = EpisodeManager.downloadSizeOfUnplayedEpisodes(includeStarred: includeStarred)
         inProgressSize = EpisodeManager.downloadSizeOfInProgressEpisodes(includeStarred: includeStarred)
         playedSize = EpisodeManager.downloadSizeOfPlayedEpisodes(includeStarred: includeStarred)
+        tmpFilesSize = EpisodeManager.tmpFolderSize()
 
         DispatchQueue.main.async { () in
             self.settingsTable.reloadData()

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -387,6 +387,7 @@ class EpisodeManager: NSObject {
             return
         }
         FileLog.shared.addMessage("Episode Manager: Starting removing the temporary orphan files")
+        var totalFilesSize: UInt64 = 0
         while let tmpFile = folderEnum.nextObject() as? String {
             let fullFilePath = (tmpPath as NSString).appendingPathComponent(tmpFile)
             guard let attributes = try? fileManager.attributesOfItem(atPath: fullFilePath),
@@ -395,11 +396,12 @@ class EpisodeManager: NSObject {
             else {
                 continue
             }
-
+            totalFilesSize += attributes[.size] as? UInt64 ?? 0
             FileLog.shared.addMessage("Episode Manager: Removing the following orphan file \(tmpFile)")
             StorageManager.removeItem(at: URL(fileURLWithPath: fullFilePath))
         }
-        FileLog.shared.addMessage("Episode Manager: Ending removing the temporary orphan files")
+        let formatFileSizes = SizeFormatter.shared.noDecimalFormat(bytes: Int64(totalFilesSize))
+        FileLog.shared.addMessage("Episode Manager: Ending removing the temporary orphan files. Removed \(formatFileSizes)")
     }
 
     class func urlForEpisode(_ episode: BaseEpisode, streamingOnly: Bool = false) -> URL? {

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -378,11 +378,6 @@ class EpisodeManager: NSObject {
                 deleteDownloadedFiles(episode: episode)
             }
         }
-
-        if FeatureFlag.cleanUpTmpFiles.enabled {
-            // Remove any lingering files in the temporary folder that were not removed above, those should be orphan files
-            cleanUpTmpFolder()
-        }
     }
 
     class func cleanUpTmpFolder(folderPath: String = DownloadManager.shared.tempDownloadFolder) {

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -380,23 +380,27 @@ class EpisodeManager: NSObject {
         }
     }
 
-    class func cleanUpTmpFolder(folderPath: String = DownloadManager.shared.tempDownloadFolder) {
+    private class func enumerateTmpFolder(folderPath: String, _ body: (String, [FileAttributeKey: Any]) -> Void) {
         let fileManager = FileManager.default
-        let tmpPath = folderPath
-        guard let folderEnum = fileManager.enumerator(atPath: tmpPath) else {
-            return
+        guard let folderEnum = fileManager.enumerator(atPath: folderPath) else { return }
+        while let tmpFile = folderEnum.nextObject() as? String {
+            let fullFilePath = (folderPath as NSString).appendingPathComponent(tmpFile)
+            guard let attributes = try? fileManager.attributesOfItem(atPath: fullFilePath) else { continue }
+            body(tmpFile, attributes)
         }
+    }
+
+    class func cleanUpTmpFolder(folderPath: String = DownloadManager.shared.tempDownloadFolder) {
         FileLog.shared.addMessage("Episode Manager: Starting removing the temporary orphan files")
         var totalFilesSize: UInt64 = 0
-        while let tmpFile = folderEnum.nextObject() as? String {
-            let fullFilePath = (tmpPath as NSString).appendingPathComponent(tmpFile)
-            guard let attributes = try? fileManager.attributesOfItem(atPath: fullFilePath),
-                  let date = attributes[.modificationDate] as? Date,
+        enumerateTmpFolder(folderPath: folderPath) { tmpFile, attributes in
+            guard let date = attributes[.modificationDate] as? Date,
                   Date.now.timeIntervalSince(date) > 1.week
             else {
-                continue
+                return
             }
             totalFilesSize += attributes[.size] as? UInt64 ?? 0
+            let fullFilePath = (folderPath as NSString).appendingPathComponent(tmpFile)
             FileLog.shared.addMessage("Episode Manager: Removing the following orphan file \(tmpFile)")
             StorageManager.removeItem(at: URL(fileURLWithPath: fullFilePath))
         }
@@ -405,17 +409,8 @@ class EpisodeManager: NSObject {
     }
 
     class func tmpFolderSize(folderPath: String = DownloadManager.shared.tempDownloadFolder) -> UInt64 {
-        let fileManager = FileManager.default
-        let tmpPath = folderPath
-        guard let folderEnum = fileManager.enumerator(atPath: tmpPath) else {
-            return 0
-        }
         var totalFilesSize: UInt64 = 0
-        while let tmpFile = folderEnum.nextObject() as? String {
-            let fullFilePath = (tmpPath as NSString).appendingPathComponent(tmpFile)
-            guard let attributes = try? fileManager.attributesOfItem(atPath: fullFilePath) else {
-                continue
-            }
+        enumerateTmpFolder(folderPath: folderPath) { _, attributes in
             totalFilesSize += attributes[.size] as? UInt64 ?? 0
         }
         return totalFilesSize

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -404,6 +404,23 @@ class EpisodeManager: NSObject {
         FileLog.shared.addMessage("Episode Manager: Ending removing the temporary orphan files. Removed \(formatFileSizes)")
     }
 
+    class func tmpFolderSize(folderPath: String = DownloadManager.shared.tempDownloadFolder) -> UInt64 {
+        let fileManager = FileManager.default
+        let tmpPath = folderPath
+        guard let folderEnum = fileManager.enumerator(atPath: tmpPath) else {
+            return 0
+        }
+        var totalFilesSize: UInt64 = 0
+        while let tmpFile = folderEnum.nextObject() as? String {
+            let fullFilePath = (tmpPath as NSString).appendingPathComponent(tmpFile)
+            guard let attributes = try? fileManager.attributesOfItem(atPath: fullFilePath) else {
+                continue
+            }
+            totalFilesSize += attributes[.size] as? UInt64 ?? 0
+        }
+        return totalFilesSize
+    }
+
     class func urlForEpisode(_ episode: BaseEpisode, streamingOnly: Bool = false) -> URL? {
         if !streamingOnly {
             // For local playback, prefer downloaded files


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the cleanup code for temporary files to be done during the removal of other files.
The temporary files should be removed by the system, but this change allows the removal of temporary files when the user 
tries to claim space for other episode downloads.

This also adds logging of the disk space being used so when users complain about disk usage we can an idea of the space being used by all episode files when looking at the logs.

## To test

1. Start the app
2. Open Profile -> Downloads
3. Tap on the ... button on the top right
4. Tap on Cleanup
5. Check the logs

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
