### PR TITLE
Add input/output files to L10n build phase to skip redundant runs

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -6554,18 +6554,20 @@
 		};
 		462F3AA2274EB4C3005FEB1F /* L10n */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"$(SRCROOT)/podcasts/en.lproj/Localizable.strings",
+				"$(SRCROOT)/swiftgen.yml",
 			);
 			name = L10n;
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(SRCROOT)/podcasts/Strings+Generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
A small build time optimization. It currently takes 1.5s on my machine for every incremental build.

<img width="603" height="151" alt="Screenshot 2026-04-14 at 12 31 53 PM" src="https://github.com/user-attachments/assets/cc4a5ced-4ead-4813-99d9-9a2ecdacde38" />


## To test

- Change something in `Localizable.strings` for English
- Build `pocketcasts`
- Verify that `String+Generated.swift` is updated

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
