### PR TITLE
Enable SwiftLint rule: duplicate_imports

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -30,6 +30,9 @@ only_rules:
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 
+  # Imports should not be duplicated.
+  - duplicate_imports
+
   # Prefer checking `isEmpty` over comparing `count` to zero.
   - empty_count
 

--- a/Modules/Tests/PocketCastsDependencyInjectionTests/DependencyInjectionTests.swift
+++ b/Modules/Tests/PocketCastsDependencyInjectionTests/DependencyInjectionTests.swift
@@ -1,7 +1,5 @@
 import XCTest
 import PocketCastsDependencyInjection
-@testable import PocketCastsDependencyInjection
-
 final class DependencyInjectionTests: XCTestCase {
     @Dependency(container: TestDependencyContainer.current, \.mockSingleton)
     var mockSingleton: MockSingleton

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -3,8 +3,6 @@ import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
 import UIKit
-import SwiftUI
-
 class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
     private let episodesDataManager = EpisodesDataManager()
     private var cancellables = Set<AnyCancellable>()


### PR DESCRIPTION
## What the rule does

Flags files that import the same module more than once.

## Changes

- Added `duplicate_imports` to `only_rules` in `.swiftlint.yml` (alphabetical order).
- **Auto-fixed violations:** 2
- **Manual fixes:** 0
- **Left for human review:** 0

### Fixed files

- `Modules/Tests/PocketCastsDependencyInjectionTests/DependencyInjectionTests.swift` — removed redundant `@testable import PocketCastsDependencyInjection` that duplicated a plain import on the line above.
- `podcasts/UploadedViewController.swift` — removed a duplicate `import SwiftUI`.

## Campaign

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint) — progressively enabling more SwiftLint rules one rule and one PR at a time.