### PR TITLE
Ensure that offline error is only shown when we are actually offine.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 -----
 - Support new transcripts generated episode field [#4116](https://github.com/Automattic/pocket-casts-ios/pull/4116)
 - Watch Stop playing a sound on play. [#4118](https://github.com/Automattic/pocket-casts-ios/pull/4118)
+- Update when offline error message shows on error banner [#4135](https://github.com/Automattic/pocket-casts-ios/pull/4135)
 
 8.9
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 -----
 - Support new transcripts generated episode field [#4116](https://github.com/Automattic/pocket-casts-ios/pull/4116)
 - Watch Stop playing a sound on play. [#4118](https://github.com/Automattic/pocket-casts-ios/pull/4118)
-- Update when offline error message shows on error banner [#4135](https://github.com/Automattic/pocket-casts-ios/pull/4135)
+- Update when the offline error message is shown on the error banner [#4135](https://github.com/Automattic/pocket-casts-ios/pull/4135)
 
 8.9
 -----

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -292,11 +292,16 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             }
         }
         let logMessage = "AVPlayerItemStatusFailed on currentItem: \(playerErrorMessage) - \(playerItemErrorMessage)"
-        var error: PlaybackManager.PlaybackError = .internetConnection(logMessage: logMessage)
+        var error: PlaybackManager.PlaybackError = .playbackError(logMessage: logMessage, isLocalFile: isPlayingLocalFile)
         if let playerNSError,
-           playerNSError.domain == NSURLErrorDomain,
-           PlaybackManager.PlaybackError.knownURLErrors.contains(playerNSError.code) {
-            error = .episodeNotAvailable(errorCode: playerNSError.code, logMessage: logMessage)
+           playerNSError.domain == NSURLErrorDomain {
+            if PlaybackManager.PlaybackError.knownURLErrors.contains(playerNSError.code) {
+                error = .episodeNotAvailable(errorCode: playerNSError.code, logMessage: logMessage)
+            } else if playerNSError.code == NSURLErrorNotConnectedToInternet {
+                error = .internetConnection(logMessage: logMessage)
+            } else {
+                error = .episodeNotAvailable(errorCode: NSURLErrorUnknown, logMessage: logMessage)
+            }
         }
         PlaybackManager.shared.playbackDidFail(error: error)
 

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -300,7 +300,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             } else if playerNSError.code == NSURLErrorNotConnectedToInternet {
                 error = .internetConnection(logMessage: logMessage)
             } else {
-                error = .episodeNotAvailable(errorCode: NSURLErrorUnknown, logMessage: logMessage)
+                error = .episodeNotAvailable(errorCode: playerNSError.code, logMessage: logMessage)
             }
         }
         PlaybackManager.shared.playbackDidFail(error: error)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1011,7 +1011,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             case .chromecastError:
                 return L10n.chromecastError
             case .playbackError(_, let isLocalFile):
-                return isLocalFile ? L10n.playerErrorCorruptedFile : L10n.playerErrorShortNoConnection
+                return isLocalFile ? L10n.playerErrorCorruptedFile : L10n.playerErrorInternetConnection
             }
         }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
For other states if it's an NSURLDomainError we assume a generic episode error and if another type of error a streaming/playback issue

## To test

1. Start the app on a real device
2. Ensure that you have `displayErrorsOnPlayer` FF On
3. Add the [Test Podcast](https://pca.st/private/25cc6130-0a1b-013f-b6fa-0affe8d08c2d) to your account
4. Open the Test Podcast
5. Try to play episode 1
7.  Check that you see an error banner showing on the bottom that says: "This episode can't be played. Learn more"
8. Turn the internet off on the device.
9. Try to play episode 1
10. Check that you see the error banner showing the message: "You're offline"
11. Turn the internet on again
12. Try to play episode 1, check if you see the error banner with the message: `"This episode can't be played. Learn more"

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
