### PR TITLE
Fix an issue with Playlist not reloading after archiving entries during empty search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 8.11
 -----
-
+- Fix an issue with Playlist not reloading after archiving entries during empty search [#4136](https://github.com/Automattic/pocket-casts-ios/pull/4136)
 
 8.10
 -----

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -135,7 +135,7 @@ class PlaylistDetailViewModel: ObservableObject {
     }
 
     func reloadPlaylistAndEpisodes() {
-        if isSearching {
+        if isSearching, !searchTerm.isEmpty {
             searchEpisodes(for: searchTerm)
             return
         }
@@ -153,7 +153,7 @@ class PlaylistDetailViewModel: ObservableObject {
     }
 
     func reloadEpisodeList(animated: Bool = true) {
-        if isSearching {
+        if isSearching, !searchTerm.isEmpty {
             searchEpisodes(for: searchTerm)
             return
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes part of https://linear.app/a8c/issue/PCIOS-599/smart-playlist-display-old-cached-info-even-after-list-has-changed#comment-c5f13c02.

**Root cause**: When a user enters search mode in a playlist but hasn't typed a search term yet, isSearching is true while searchTerm is empty. Performing a swipe action (e.g., archive) calls reloadEpisodeList(), which short-circuited to searchEpisodes(for: searchTerm). Since searchEpisodes returns early when the search term is empty, the episode list was never reloaded, leaving the cell stuck in the expanded swipe action state.

## To test

 1. Open a smart playlist (e.g., "New Releases")
  2. Tap the search icon to enter search mode, but don't type anything
  3. Swipe to archive an episode
  4. Verify the cell disappears from the list (instead of staying stuck with the gray archive action)
  5. Repeat steps 2-4 but type a search term first — verify archive still works correctly during active search
  6. Enter search mode, type a term, archive an episode from results, then clear the search text — verify the archived episode doesn't reappear


## Recordings

Before (tapping, but nothing visually happening)

https://github.com/user-attachments/assets/d6c1a791-a3c3-4242-8b84-1bffc30e3b5d


After (the animations a bit choppy, but it now works)

https://github.com/user-attachments/assets/ad4c1048-5af0-4a7a-a98e-0567aac42c50

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
