### PR TITLE
Fix smart playlist not refreshing when clearing search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 8.11
 -----
 - Fix an issue with Playlist not reloading after archiving entries during empty search [#4136](https://github.com/Automattic/pocket-casts-ios/pull/4136)
+- Fix smart playlist not refreshing when clearing search field [#4138](https://github.com/Automattic/pocket-casts-ios/pull/4138)
 
 8.10
 -----

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -366,6 +366,7 @@ extension PlaylistDetailViewModel {
             model: .episodes,
             elements: tempEpisodes
         )
+        reloadEpisodeList()
     }
 
     func endSearch() {


### PR DESCRIPTION
Fixes PCIOS-599 by adding a missing `reload` call – seems as simple as that. This change requires the [previous fix](https://github.com/Automattic/pocket-casts-ios/pull/4136) as it relies on `reloadEpisodeList()` to trigger a `refreshOperation` with empty search field.

## To test

Follow the steps from the original issue.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
