### PR TITLE
Fix release-toolkit metadata source update

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -920,7 +920,7 @@ platform :ios do
       },
       app_store_keywords: {
         path: File.join(source_metadata_folder, 'keywords.txt'),
-        comment: 'translators: Comma seperated Keywords used for Search Engine Optimization in the Apple App Store. Limit to 100 characters including spaces and commas!'
+        comment: 'translators: Comma separated Keywords used for Search Engine Optimization in the Apple App Store. Limit to 100 characters including spaces and commas!'
       }
     }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -906,7 +906,7 @@ platform :ios do
   #
   lane :update_app_store_strings do
     source_metadata_folder = File.join(APP_STORE_METADATA_FOLDER, 'default')
-    version = get_version_number(xcodeproj: XCODE_PROJECT_PATH, target: 'podcasts')
+    version = release_version_current
 
     files = {
       whats_new: File.join(source_metadata_folder, 'release_notes.txt'),

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -912,16 +912,16 @@ platform :ios do
       whats_new: File.join(source_metadata_folder, 'release_notes.txt'),
       app_store_subtitle: {
         path: File.join(source_metadata_folder, 'subtitle.txt'),
-        comment: 'translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!',
+        comment: 'translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!'
       },
       app_store_desc: {
         path: File.join(source_metadata_folder, 'description.txt'),
-        comment: 'translators: Multi-paragraph text used to display in the Apple App Store.',
+        comment: 'translators: Multi-paragraph text used to display in the Apple App Store.'
       },
       app_store_keywords: {
         path: File.join(source_metadata_folder, 'keywords.txt'),
-        comment: 'translators: Comma seperated Keywords used for Search Engine Optimization in the Apple App Store. Limit to 100 characters including spaces and commas!',
-      },
+        comment: 'translators: Comma seperated Keywords used for Search Engine Optimization in the Apple App Store. Limit to 100 characters including spaces and commas!'
+      }
     }
 
     gp_update_metadata_source(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -910,15 +910,25 @@ platform :ios do
 
     files = {
       whats_new: File.join(source_metadata_folder, 'release_notes.txt'),
-      app_store_subtitle: File.join(source_metadata_folder, 'subtitle.txt'),
-      app_store_desc: File.join(source_metadata_folder, 'description.txt'),
-      app_store_keywords: File.join(source_metadata_folder, 'keywords.txt')
+      app_store_subtitle: {
+        path: File.join(source_metadata_folder, 'subtitle.txt'),
+        comment: 'translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!',
+      },
+      app_store_desc: {
+        path: File.join(source_metadata_folder, 'description.txt'),
+        comment: 'translators: Multi-paragraph text used to display in the Apple App Store.',
+      },
+      app_store_keywords: {
+        path: File.join(source_metadata_folder, 'keywords.txt'),
+        comment: 'translators: Comma seperated Keywords used for Search Engine Optimization in the Apple App Store. Limit to 100 characters including spaces and commas!',
+      },
     }
 
-    ios_update_metadata_source(
+    gp_update_metadata_source(
       po_file_path: File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'AppStoreStrings.po'),
       source_files: files,
-      release_version: version
+      release_version: version,
+      commit_changes: true
     )
   end
 


### PR DESCRIPTION
Following up to https://github.com/Automattic/pocket-casts-ios/pull/4099, where we had to update release-toolkit.

This updates the `update_app_store_strings` Fastlane lane to match the latest release-toolkit API. This isn't called directly by automation, but the lane as it currently is, is broken.

The lane now calls `gp_update_metadata_source`, passes structured metadata entries for subtitle, description, and keywords with translator comments, and keeps `commit_changes: true` so generated source updates are still committed automatically.

## To test

1. Run `bundle exec fastlane ios update_app_store_strings`.
2. Confirm the lane completes without calling the removed `ios_update_metadata_source` helper.
3. Confirm `fastlane/AppStoreStrings.po` is updated from the metadata source files in `fastlane/metadata/default/`.
4. If the metadata source changes, confirm the lane creates the expected commit for the updated `.po` file.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
