### PR TITLE
Improved streaming IO handling

### DIFF
--- a/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateErrorHandlingTests.swift
+++ b/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateErrorHandlingTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+import AVFoundation
+@testable import podcasts
+
+final class MediaExporterResourceLoaderDelegateErrorHandlingTests: XCTestCase {
+
+    var tempFilePath: String!
+
+    override func setUp() {
+        super.setUp()
+        tempFilePath = (NSTemporaryDirectory() as NSString).appendingPathComponent(UUID().uuidString + "_delegate_error_test.media")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: tempFilePath)
+        tempFilePath = nil
+        super.tearDown()
+    }
+
+    // MARK: - Failure callback propagation
+
+    func testCallback_receivesFailedStatus_whenURLSessionCompletesWithError() {
+        let expectation = XCTestExpectation(description: "Callback receives .failed")
+        var capturedStatus: MediaExporterResourceLoaderDelegate.FileExportStatus?
+
+        let delegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { status, _, _, _ in
+            capturedStatus = status
+            expectation.fulfill()
+        }
+
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        delegate.urlSession(.shared, task: MockURLSessionTask(), didCompleteWithError: error)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        guard case .failed(let receivedError) = capturedStatus else {
+            XCTFail("Expected .failed status, got \(String(describing: capturedStatus))")
+            return
+        }
+        XCTAssertEqual((receivedError as NSError).code, NSURLErrorNotConnectedToInternet)
+    }
+
+    func testCallback_receivesFailedStatus_whenFileHandleUnableToOpenFile() {
+        let expectation = XCTestExpectation(description: "Callback receives .failed on file error")
+        var capturedStatus: MediaExporterResourceLoaderDelegate.FileExportStatus?
+
+        let delegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { status, _, _, _ in
+            capturedStatus = status
+            expectation.fulfill()
+        }
+
+        let fileError = MediaFileHandleError.unableToOpenFile
+        delegate.urlSession(.shared, task: MockURLSessionTask(), didCompleteWithError: fileError)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        guard case .failed(let receivedError) = capturedStatus else {
+            XCTFail("Expected .failed status, got \(String(describing: capturedStatus))")
+            return
+        }
+        XCTAssertEqual(receivedError as? MediaFileHandleError, .unableToOpenFile)
+    }
+
+    func testCallback_receivesFailedStatus_whenReadPastEndOfFile() {
+        let expectation = XCTestExpectation(description: "Callback receives .failed on end-of-file read")
+        var capturedStatus: MediaExporterResourceLoaderDelegate.FileExportStatus?
+
+        let delegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { status, _, _, _ in
+            capturedStatus = status
+            expectation.fulfill()
+        }
+
+        let eofError = MediaFileHandleError.tryToReadAfterEndOfFile
+        delegate.urlSession(.shared, task: MockURLSessionTask(), didCompleteWithError: eofError)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        guard case .failed(let receivedError) = capturedStatus else {
+            XCTFail("Expected .failed status, got \(String(describing: capturedStatus))")
+            return
+        }
+        XCTAssertEqual(receivedError as? MediaFileHandleError, .tryToReadAfterEndOfFile)
+    }
+
+    func testCallback_isNotCalledWithFailed_whenSessionCompletesSuccessfully() {
+        // A successful completion with no buffered data and no response verification error
+        // should call the callback with .completed, not .failed.
+        let expectation = XCTestExpectation(description: "Callback receives .completed")
+        var capturedStatus: MediaExporterResourceLoaderDelegate.FileExportStatus?
+
+        let delegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { status, _, _, _ in
+            if case .completed = status {
+                capturedStatus = status
+                expectation.fulfill()
+            }
+        }
+
+        let previousMinimumExpectedFileSize = MediaExporterItemConfiguration.minimumExpectedFileSize
+        defer { MediaExporterItemConfiguration.minimumExpectedFileSize = previousMinimumExpectedFileSize }
+        MediaExporterItemConfiguration.minimumExpectedFileSize = 0
+
+        delegate.urlSession(.shared, task: MockURLSessionTask(), didCompleteWithError: nil)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        guard case .completed = capturedStatus else {
+            XCTFail("Expected .completed status, got \(String(describing: capturedStatus))")
+            return
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private class MockURLSessionTask: URLSessionTask {
+    override var originalRequest: URLRequest? { nil }
+}

--- a/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateErrorHandlingTests.swift
+++ b/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateErrorHandlingTests.swift
@@ -82,27 +82,6 @@ final class MediaExporterResourceLoaderDelegateErrorHandlingTests: XCTestCase {
         XCTAssertEqual(receivedError as? MediaFileHandleError, .tryToReadAfterEndOfFile)
     }
 
-    func testCallback_receivesFailedStatus_whenDownloadCompleteAndReadOffsetIsAtEOF() {
-        let expectation = XCTestExpectation(description: "Callback receives .failed when read is requested at EOF")
-        var capturedStatus: MediaExporterResourceLoaderDelegate.FileExportStatus?
-
-        let delegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { status, _, _, _ in
-            capturedStatus = status
-            expectation.fulfill()
-        }
-
-        delegate.setIsDownloadComplete(true)
-        delegate.validateReadOffsetAndHandleError(0)
-
-        wait(for: [expectation], timeout: 1.0)
-
-        guard case .failed(let receivedError) = capturedStatus else {
-            XCTFail("Expected .failed status, got \(String(describing: capturedStatus))")
-            return
-        }
-        XCTAssertEqual(receivedError as? MediaFileHandleError, .tryToReadAfterEndOfFile)
-    }
-
     func testCallback_isNotCalledWithFailed_whenSessionCompletesSuccessfully() {
         // A successful completion with no buffered data and no response verification error
         // should call the callback with .completed, not .failed.

--- a/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateErrorHandlingTests.swift
+++ b/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateErrorHandlingTests.swift
@@ -70,7 +70,7 @@ final class MediaExporterResourceLoaderDelegateErrorHandlingTests: XCTestCase {
             expectation.fulfill()
         }
 
-        let eofError = MediaFileHandleError.tryToReadAfterEndOfFile
+        let eofError = MediaFileHandleError.readAfterEndOfFile
         delegate.urlSession(.shared, task: MockURLSessionTask(), didCompleteWithError: eofError)
 
         wait(for: [expectation], timeout: 1.0)
@@ -79,7 +79,7 @@ final class MediaExporterResourceLoaderDelegateErrorHandlingTests: XCTestCase {
             XCTFail("Expected .failed status, got \(String(describing: capturedStatus))")
             return
         }
-        XCTAssertEqual(receivedError as? MediaFileHandleError, .tryToReadAfterEndOfFile)
+        XCTAssertEqual(receivedError as? MediaFileHandleError, .readAfterEndOfFile)
     }
 
     func testCallback_isNotCalledWithFailed_whenSessionCompletesSuccessfully() {

--- a/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateErrorHandlingTests.swift
+++ b/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateErrorHandlingTests.swift
@@ -82,6 +82,27 @@ final class MediaExporterResourceLoaderDelegateErrorHandlingTests: XCTestCase {
         XCTAssertEqual(receivedError as? MediaFileHandleError, .tryToReadAfterEndOfFile)
     }
 
+    func testCallback_receivesFailedStatus_whenDownloadCompleteAndReadOffsetIsAtEOF() {
+        let expectation = XCTestExpectation(description: "Callback receives .failed when read is requested at EOF")
+        var capturedStatus: MediaExporterResourceLoaderDelegate.FileExportStatus?
+
+        let delegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { status, _, _, _ in
+            capturedStatus = status
+            expectation.fulfill()
+        }
+
+        delegate.setIsDownloadComplete(true)
+        delegate.validateReadOffsetAndHandleError(0)
+
+        wait(for: [expectation], timeout: 1.0)
+
+        guard case .failed(let receivedError) = capturedStatus else {
+            XCTFail("Expected .failed status, got \(String(describing: capturedStatus))")
+            return
+        }
+        XCTAssertEqual(receivedError as? MediaFileHandleError, .tryToReadAfterEndOfFile)
+    }
+
     func testCallback_isNotCalledWithFailed_whenSessionCompletesSuccessfully() {
         // A successful completion with no buffered data and no response verification error
         // should call the callback with .completed, not .failed.

--- a/PocketCastsTests/Tests/Utilities/MediaFileHandleTests.swift
+++ b/PocketCastsTests/Tests/Utilities/MediaFileHandleTests.swift
@@ -20,14 +20,14 @@ final class MediaFileHandleTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - throwableFileSize
+    // MARK: - fileSize
 
-    func testThrowableFileSize_returnsZeroForNewFile() throws {
+    func testFileSize_returnsZeroForNewFile() throws {
         let size = try sut.fileSize()
         XCTAssertEqual(size, 0)
     }
 
-    func testThrowableFileSize_returnsCorrectSizeAfterWrite() throws {
+    func testFileSize_returnsCorrectSizeAfterWrite() throws {
         let data = Data(repeating: 0xAB, count: 1024)
         try sut.append(data: data)
         sut.synchronize()
@@ -36,7 +36,7 @@ final class MediaFileHandleTests: XCTestCase {
         XCTAssertEqual(size, 1024)
     }
 
-    func testThrowableFileSize_throwsWhenFileIsDeleted() throws {
+    func testFileSize_throwsWhenFileIsDeleted() throws {
         try FileManager.default.removeItem(atPath: tempFilePath)
 
         XCTAssertThrowsError(try sut.fileSize(), "throwableFileSize should throw when the file no longer exists")

--- a/PocketCastsTests/Tests/Utilities/MediaFileHandleTests.swift
+++ b/PocketCastsTests/Tests/Utilities/MediaFileHandleTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import podcasts
+
+final class MediaFileHandleTests: XCTestCase {
+
+    var tempFilePath: String!
+    var sut: MediaFileHandle!
+
+    override func setUp() {
+        super.setUp()
+        tempFilePath = (NSTemporaryDirectory() as NSString).appendingPathComponent(UUID().uuidString + "_test.media")
+        sut = MediaFileHandle(filePath: tempFilePath)
+    }
+
+    override func tearDown() {
+        sut.close()
+        sut = nil
+        try? FileManager.default.removeItem(atPath: tempFilePath)
+        tempFilePath = nil
+        super.tearDown()
+    }
+
+    // MARK: - throwableFileSize
+
+    func testThrowableFileSize_returnsZeroForNewFile() throws {
+        let size = try sut.throwableFileSize()
+        XCTAssertEqual(size, 0)
+    }
+
+    func testThrowableFileSize_returnsCorrectSizeAfterWrite() throws {
+        let data = Data(repeating: 0xAB, count: 1024)
+        try sut.append(data: data)
+        sut.synchronize()
+
+        let size = try sut.throwableFileSize()
+        XCTAssertEqual(size, 1024)
+    }
+
+    func testThrowableFileSize_throwsWhenFileIsDeleted() throws {
+        try FileManager.default.removeItem(atPath: tempFilePath)
+
+        XCTAssertThrowsError(try sut.throwableFileSize(), "throwableFileSize should throw when the file no longer exists")
+    }
+
+    // MARK: - readData
+
+    func testReadData_returnsCorrectDataFromFile() throws {
+        let original = Data("hello podcast".utf8)
+        try sut.append(data: original)
+        sut.synchronize()
+
+        let read = try sut.readData(withOffset: 0, forLength: original.count)
+        XCTAssertEqual(read, original)
+    }
+
+    func testReadData_returnsCorrectDataWithOffset() throws {
+        let original = Data("abcdefghij".utf8)
+        try sut.append(data: original)
+        sut.synchronize()
+
+        let read = try sut.readData(withOffset: 5, forLength: 3)
+        XCTAssertEqual(read, Data("fgh".utf8))
+    }
+
+    func testReadData_throwsUnableToOpenFile_afterHandleIsClosed() {
+        sut.close()
+
+        XCTAssertThrowsError(try sut.readData(withOffset: 0, forLength: 10)) { error in
+            XCTAssertEqual(error as? MediaFileHandleError, .unableToOpenFile,
+                           "Expected .unableToOpenFile when file handle has been closed")
+        }
+    }
+
+    func testReadData_throwsUnableToOpenFile_whenFileDeletedBeforeFirstAccess() throws {
+        // readHandle is a lazy var — it's only initialized on the first access.
+        // Deleting the file before that first access means FileHandle(forReadingAtPath:)
+        // returns nil, so readData should throw .unableToOpenFile.
+        let path = (NSTemporaryDirectory() as NSString).appendingPathComponent(UUID().uuidString + "_lazy.media")
+        let handle = MediaFileHandle(filePath: path)
+        defer { try? FileManager.default.removeItem(atPath: path) }
+
+        try FileManager.default.removeItem(atPath: path)
+
+        XCTAssertThrowsError(try handle.readData(withOffset: 0, forLength: 10)) { error in
+            XCTAssertEqual(error as? MediaFileHandleError, .unableToOpenFile,
+                           "Expected .unableToOpenFile when underlying file is gone before first read")
+        }
+    }
+}

--- a/PocketCastsTests/Tests/Utilities/MediaFileHandleTests.swift
+++ b/PocketCastsTests/Tests/Utilities/MediaFileHandleTests.swift
@@ -39,7 +39,7 @@ final class MediaFileHandleTests: XCTestCase {
     func testFileSize_throwsWhenFileIsDeleted() throws {
         try FileManager.default.removeItem(atPath: tempFilePath)
 
-        XCTAssertThrowsError(try sut.fileSize(), "throwableFileSize should throw when the file no longer exists")
+        XCTAssertThrowsError(try sut.fileSize(), "fileSize should throw when the file no longer exists")
     }
 
     // MARK: - readData

--- a/PocketCastsTests/Tests/Utilities/MediaFileHandleTests.swift
+++ b/PocketCastsTests/Tests/Utilities/MediaFileHandleTests.swift
@@ -23,7 +23,7 @@ final class MediaFileHandleTests: XCTestCase {
     // MARK: - throwableFileSize
 
     func testThrowableFileSize_returnsZeroForNewFile() throws {
-        let size = try sut.throwableFileSize()
+        let size = try sut.fileSize()
         XCTAssertEqual(size, 0)
     }
 
@@ -32,14 +32,14 @@ final class MediaFileHandleTests: XCTestCase {
         try sut.append(data: data)
         sut.synchronize()
 
-        let size = try sut.throwableFileSize()
+        let size = try sut.fileSize()
         XCTAssertEqual(size, 1024)
     }
 
     func testThrowableFileSize_throwsWhenFileIsDeleted() throws {
         try FileManager.default.removeItem(atPath: tempFilePath)
 
-        XCTAssertThrowsError(try sut.throwableFileSize(), "throwableFileSize should throw when the file no longer exists")
+        XCTAssertThrowsError(try sut.fileSize(), "throwableFileSize should throw when the file no longer exists")
     }
 
     // MARK: - readData

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1306,7 +1306,6 @@
 		FF9CBAF22EC9293000989151 /* playback2025_listening_time_numbers.json in Resources */ = {isa = PBXBuildFile; fileRef = FF9CBAF12EC9293000989151 /* playback2025_listening_time_numbers.json */; };
 		FF9ED3552C86010F00B6E630 /* TipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9ED3542C86010F00B6E630 /* TipView.swift */; };
 		FFB74B0F2E993A8C00F16857 /* end_of_year_2025_intro.json in Resources */ = {isa = PBXBuildFile; fileRef = FFB74B0D2E993A8C00F16857 /* end_of_year_2025_intro.json */; };
-		FFBCADEB2E6578F900EA8287 /* WrappingHStack in Frameworks */ = {isa = PBXBuildFile; productRef = FFBCADEA2E6578F900EA8287 /* WrappingHStack */; };
 		FFE067392F86ADD000437ACC /* TranscriptFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF54BCA82C5A2F3900A342E5 /* TranscriptFormat.swift */; };
 		FFEE599C2EB378B300D4B145 /* Humane-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = FFEE599B2EB378B300D4B145 /* Humane-SemiBold.otf */; };
 		FFEE59C32EB37F4300D4B145 /* playback2025_listening_time.json in Resources */ = {isa = PBXBuildFile; fileRef = FFEE59C22EB37F4300D4B145 /* playback2025_listening_time.json */; };

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1306,6 +1306,7 @@
 		FF9CBAF22EC9293000989151 /* playback2025_listening_time_numbers.json in Resources */ = {isa = PBXBuildFile; fileRef = FF9CBAF12EC9293000989151 /* playback2025_listening_time_numbers.json */; };
 		FF9ED3552C86010F00B6E630 /* TipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9ED3542C86010F00B6E630 /* TipView.swift */; };
 		FFB74B0F2E993A8C00F16857 /* end_of_year_2025_intro.json in Resources */ = {isa = PBXBuildFile; fileRef = FFB74B0D2E993A8C00F16857 /* end_of_year_2025_intro.json */; };
+		FFBCADEB2E6578F900EA8287 /* WrappingHStack in Frameworks */ = {isa = PBXBuildFile; productRef = FFBCADEA2E6578F900EA8287 /* WrappingHStack */; };
 		FFE067392F86ADD000437ACC /* TranscriptFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF54BCA82C5A2F3900A342E5 /* TranscriptFormat.swift */; };
 		FFEE599C2EB378B300D4B145 /* Humane-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = FFEE599B2EB378B300D4B145 /* Humane-SemiBold.otf */; };
 		FFEE59C32EB37F4300D4B145 /* playback2025_listening_time.json in Resources */ = {isa = PBXBuildFile; fileRef = FFEE59C22EB37F4300D4B145 /* playback2025_listening_time.json */; };

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -367,9 +367,8 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     }
 
     private func downloadComplete() {
-        processPendingRequests()
-
         isDownloadComplete = true
+        processPendingRequests()
         let contentType = self.response?.mimeType
         let fileSize = self.fileHandle.safeFileSize
         callbackQueue.async { [weak self] in

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -265,25 +265,24 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     private func processPendingRequests() {
         lock.lock()
         defer { lock.unlock() }
-
+        var requestsFulfilled: Set<AVAssetResourceLoadingRequest> = []
         do {
-            // Filter out the unfulfilled requests
-            let requestsFulfilled: Set<AVAssetResourceLoadingRequest> = try pendingRequests.filter {
-                guard response != nil else {
-                    return false
-                }
-                fillInContentInformationRequest($0.contentInformationRequest)
-                guard let dataRequest = $0.dataRequest, try haveEnoughDataToFulfillRequest(dataRequest) else {
-                    return false
-                }
-
-                $0.finishLoading()
-                return true
+            guard response != nil else {
+                return
             }
 
+            for request in pendingRequests {
+                fillInContentInformationRequest(request.contentInformationRequest)
+                if let dataRequest = request.dataRequest, try haveEnoughDataToFulfillRequest(dataRequest) {
+                    request.finishLoading()
+                    requestsFulfilled.insert(request)
+                }
+            }
             // Remove fulfilled requests from pending requests
             requestsFulfilled.forEach { pendingRequests.remove($0) }
         } catch {
+            // Remove fulfilled requests from pending requests
+            requestsFulfilled.forEach { pendingRequests.remove($0) }
             downloadFailed(with: error, notify: true)
         }
     }

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -273,7 +273,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
                     return false
                 }
                 fillInContentInformationRequest($0.contentInformationRequest)
-                guard try haveEnoughDataToFulfillRequest($0.dataRequest!) else {
+                guard let dataRequest = $0.dataRequest, try haveEnoughDataToFulfillRequest(dataRequest) else {
                     return false
                 }
 

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -284,7 +284,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             // Remove fulfilled requests from pending requests
             requestsFulfilled.forEach { pendingRequests.remove($0) }
         } catch {
-            downloadFailed(with: error)
+            downloadFailed(with: NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotOpenFile, userInfo: [NSLocalizedDescriptionKey: "Failed reading data. Reason: \(error.localizedDescription)"]))
         }
     }
 
@@ -351,7 +351,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             bufferData = Data()
         } catch {
             FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: failed to write data to file: \(error)")
-            invalidateAndCancelSession()
+            invalidateAndCancelSession(error: NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotWriteToFile, userInfo: [NSLocalizedDescriptionKey: "Failed writing data. Reason: \(error.localizedDescription)"]))
         }
     }
 

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -325,14 +325,10 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let bytesToRespond = min(bytesCached - currentOffset, requestedLength, readDataLimit)
 
         // Read data from disk and pass it to the dataRequest
-        do {
-            guard let data = try fileHandle.readData(withOffset: currentOffset, forLength: bytesToRespond) else {
-                throw MediaFileHandleError.tryToReadAfterEndOfFile
-            }
-            dataRequest.respond(with: data)
-        } catch {
-            throw error
+        guard let data = try fileHandle.readData(withOffset: currentOffset, forLength: bytesToRespond) else {
+            throw MediaFileHandleError.readAfterEndOfFile
         }
+        dataRequest.respond(with: data)
 
         return dataRequest.currentOffset >= requestedLength + requestedOffset
     }
@@ -340,7 +336,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     private func validateCurrentOffset(_ currentOffset: Int, bytesCached: Int) throws {
         if isDownloadComplete, currentOffset >= bytesCached {
             FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: try to read a position after the end of a file")
-            throw MediaFileHandleError.tryToReadAfterEndOfFile
+            throw MediaFileHandleError.readAfterEndOfFile
         }
     }
 

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -267,7 +267,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         defer { lock.unlock() }
 
         do {
-            // Filter out the unfullfilled requests
+            // Filter out the unfulfilled requests
             let requestsFulfilled: Set<AVAssetResourceLoadingRequest> = try pendingRequests.filter {
                 guard response != nil else {
                     return false

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -144,7 +144,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let contentType = response?.mimeType
         callbackQueue.async { [weak self] in
             guard let self else { return }
-            self.callback?(.downloading, contentType, Int64(self.fileHandle.fileSize), dataTask.countOfBytesExpectedToReceive)
+            self.callback?(.downloading, contentType, Int64(self.fileHandle.safeFileSize), dataTask.countOfBytesExpectedToReceive)
         }
     }
 
@@ -301,7 +301,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let requestedOffset = Int(dataRequest.requestedOffset)
         let requestedLength = dataRequest.requestedLength
         let currentOffset = Int(dataRequest.currentOffset)
-        let bytesCached = try fileHandle.throwableFileSize()
+        let bytesCached = try fileHandle.fileSize()
 
         if isDownloadComplete, currentOffset >= bytesCached {
             FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: try to read a position after the end of a file")
@@ -366,8 +366,9 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
         isDownloadComplete = true
         let contentType = self.response?.mimeType
-        callbackQueue.async {
-            self.callback?(.completed, contentType, Int64(self.fileHandle.fileSize), Int64(self.fileHandle.fileSize))
+        let fileSize = self.fileHandle.safeFileSize
+        callbackQueue.async { [weak self] in
+            self?.callback?(.completed, contentType, Int64(fileSize), Int64(fileSize))
         }
     }
 
@@ -377,13 +378,13 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let shouldVerifyDownloadedFileSize = MediaExporterItemConfiguration.shouldVerifyDownloadedFileSize
         let minimumExpectedFileSize = MediaExporterItemConfiguration.minimumExpectedFileSize
         var error: NSError?
-
+        let fileSize = fileHandle.safeFileSize
         if response.statusCode >= 400 {
             error = errorFromStatusCode(response.statusCode)
-        } else if shouldVerifyDownloadedFileSize && response.expectedContentLength != -1 && response.expectedContentLength != fileHandle.fileSize {
-            error = NSError(domain: NSURLErrorDomain, code: NSURLErrorResourceUnavailable, userInfo: [NSLocalizedDescriptionKey: "Failed downloading asset. Reason: wrong file size, expected: \(response.expectedContentLength), actual: \(fileHandle.fileSize)."])
-        } else if minimumExpectedFileSize > 0 && minimumExpectedFileSize > fileHandle.fileSize {
-            error = NSError(domain: NSURLErrorDomain, code: NSURLErrorZeroByteResource, userInfo: [NSLocalizedDescriptionKey: "Failed downloading asset. Reason: file size \(fileHandle.fileSize) is smaller than minimumExpectedFileSize"])
+        } else if shouldVerifyDownloadedFileSize && response.expectedContentLength != -1 && response.expectedContentLength != fileSize {
+            error = NSError(domain: NSURLErrorDomain, code: NSURLErrorResourceUnavailable, userInfo: [NSLocalizedDescriptionKey: "Failed downloading asset. Reason: wrong file size, expected: \(response.expectedContentLength), actual: \(fileSize)."])
+        } else if minimumExpectedFileSize > 0 && minimumExpectedFileSize > fileSize {
+            error = NSError(domain: NSURLErrorDomain, code: NSURLErrorZeroByteResource, userInfo: [NSLocalizedDescriptionKey: "Failed downloading asset. Reason: file size \(fileSize) is smaller than minimumExpectedFileSize"])
         }
 
         return error

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -317,8 +317,14 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let bytesToRespond = min(bytesCached - currentOffset, requestedLength, readDataLimit)
 
         // Read data from disk and pass it to the dataRequest
-        guard let data = fileHandle.readData(withOffset: currentOffset, forLength: bytesToRespond) else { return false }
-        dataRequest.respond(with: data)
+        do {
+            guard let data = try fileHandle.readData(withOffset: currentOffset, forLength: bytesToRespond) else {                
+                return false
+            }
+            dataRequest.respond(with: data)
+        } catch {
+            downloadFailed(with: error)
+        }
 
         return dataRequest.currentOffset >= requestedLength + requestedOffset
     }

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -270,21 +270,27 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             guard response != nil else {
                 return
             }
-
-            for request in pendingRequests {
-                fillInContentInformationRequest(request.contentInformationRequest)
-                if let dataRequest = request.dataRequest, try haveEnoughDataToFulfillRequest(dataRequest) {
-                    request.finishLoading()
-                    requestsFulfilled.insert(request)
+            for loadingRequest in pendingRequests {
+                fillInContentInformationRequest(loadingRequest.contentInformationRequest)
+                if let dataRequest = loadingRequest.dataRequest, try haveEnoughDataToFulfillRequest(dataRequest) {
+                    loadingRequest.finishLoading()
+                    requestsFulfilled.insert(loadingRequest)
+                } else if loadingRequest.dataRequest == nil {
+                    loadingRequest.finishLoading()
+                    requestsFulfilled.insert(loadingRequest)
                 }
             }
-            // Remove fulfilled requests from pending requests
-            requestsFulfilled.forEach { pendingRequests.remove($0) }
+            removeFullfilledRequests(requestsFulfilled)
         } catch {
-            // Remove fulfilled requests from pending requests
-            requestsFulfilled.forEach { pendingRequests.remove($0) }
+            removeFullfilledRequests(requestsFulfilled)
             downloadFailed(with: error, notify: true)
         }
+    }
+
+    private func removeFullfilledRequests(_ requestsFulfilled: Set<AVAssetResourceLoadingRequest>) {
+        var updatedPendingRequests = pendingRequests
+        updatedPendingRequests.subtract(requestsFulfilled)
+        pendingRequests = updatedPendingRequests
     }
 
     private func fillInContentInformationRequest(_ contentInformationRequest: AVAssetResourceLoadingContentInformationRequest?) {

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -303,7 +303,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let currentOffset = Int(dataRequest.currentOffset)
         var bytesCached = try fileHandle.throwableFileSize()
 
-        if isDownloadComplete, currentOffset >= fileHandle.fileSize {
+        if isDownloadComplete, currentOffset >= bytesCached {
             FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: try to read a position after the end of a file")
             throw MediaFileHandleError.tryToReadAfterEndOfFile
         }

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -301,7 +301,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let requestedOffset = Int(dataRequest.requestedOffset)
         let requestedLength = dataRequest.requestedLength
         let currentOffset = Int(dataRequest.currentOffset)
-        var bytesCached = try fileHandle.throwableFileSize()
+        let bytesCached = try fileHandle.throwableFileSize()
 
         if isDownloadComplete, currentOffset >= bytesCached {
             FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: try to read a position after the end of a file")

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -447,19 +447,5 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         invalidateAndCancelSession(shouldResetData: false)
     }
 
-#if DEBUG
-    func setIsDownloadComplete(_ value: Bool) {
-        isDownloadComplete = value
-    }
-
-    func validateReadOffsetAndHandleError(_ currentOffset: Int) {
-        do {
-            let bytesCached = try fileHandle.fileSize()
-            try validateCurrentOffset(currentOffset, bytesCached: bytesCached)
-        } catch {
-            downloadFailed(with: error)
-        }
-    }
-#endif
 }
 #endif

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -284,7 +284,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             // Remove fulfilled requests from pending requests
             requestsFulfilled.forEach { pendingRequests.remove($0) }
         } catch {
-            downloadFailed(with: NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotOpenFile, userInfo: [NSLocalizedDescriptionKey: "Failed reading data. Reason: \(error.localizedDescription)"]))
+            downloadFailed(with: error, notify: true)
         }
     }
 
@@ -351,7 +351,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             bufferData = Data()
         } catch {
             FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: failed to write data to file: \(error)")
-            invalidateAndCancelSession(error: NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotWriteToFile, userInfo: [NSLocalizedDescriptionKey: "Failed writing data. Reason: \(error.localizedDescription)"]))
+            downloadFailed(with: error, notify: true)
         }
     }
 
@@ -429,8 +429,11 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         startDataRequest(with: originalURL, retryWithoutUserAgent: true)
     }
 
-    private func downloadFailed(with error: Error) {
+    private func downloadFailed(with error: Error, notify: Bool = false) {
         FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: Download failed with error: \(error)")
+        if notify {
+            NotificationCenter.default.post(name: AVPlayerItem.failedToPlayToEndTimeNotification, object: nil, userInfo: [AVPlayerItemFailedToPlayToEndTimeErrorKey: error])
+        }
         invalidateAndCancelSession(error: error)
         let contentType = self.response?.mimeType
         callbackQueue.async { [weak self] in

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -330,7 +330,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         // Read data from disk and pass it to the dataRequest
         do {
             guard let data = try fileHandle.readData(withOffset: currentOffset, forLength: bytesToRespond) else {
-                return false
+                throw MediaFileHandleError.tryToReadAfterEndOfFile
             }
             dataRequest.respond(with: data)
         } catch {

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -301,12 +301,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let requestedOffset = Int(dataRequest.requestedOffset)
         let requestedLength = dataRequest.requestedLength
         let currentOffset = Int(dataRequest.currentOffset)
-        var bytesCached = 0
-        do {
-            bytesCached = try fileHandle.throwableFileSize()
-        } catch {
-            throw error
-        }
+        var bytesCached = try fileHandle.throwableFileSize()
 
         if isDownloadComplete, currentOffset >= fileHandle.fileSize {
             FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: try to read a position after the end of a file")

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -303,10 +303,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let currentOffset = Int(dataRequest.currentOffset)
         let bytesCached = try fileHandle.fileSize()
 
-        if isDownloadComplete, currentOffset >= bytesCached {
-            FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: try to read a position after the end of a file")
-            throw MediaFileHandleError.tryToReadAfterEndOfFile
-        }
+        try validateCurrentOffset(currentOffset, bytesCached: bytesCached)
 
         // Is there enough data cached to fulfill the request?
         guard bytesCached > currentOffset else {
@@ -338,6 +335,13 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         }
 
         return dataRequest.currentOffset >= requestedLength + requestedOffset
+    }
+
+    private func validateCurrentOffset(_ currentOffset: Int, bytesCached: Int) throws {
+        if isDownloadComplete, currentOffset >= bytesCached {
+            FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: try to read a position after the end of a file")
+            throw MediaFileHandleError.tryToReadAfterEndOfFile
+        }
     }
 
     private func writeBufferDataToFileIfNeeded() {
@@ -442,5 +446,20 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     @objc private func handleAppWillTerminate() {
         invalidateAndCancelSession(shouldResetData: false)
     }
+
+#if DEBUG
+    func setIsDownloadComplete(_ value: Bool) {
+        isDownloadComplete = value
+    }
+
+    func validateReadOffsetAndHandleError(_ currentOffset: Int) {
+        do {
+            let bytesCached = try fileHandle.fileSize()
+            try validateCurrentOffset(currentOffset, bytesCached: bytesCached)
+        } catch {
+            downloadFailed(with: error)
+        }
+    }
+#endif
 }
 #endif

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -300,6 +300,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             bytesCached = try fileHandle.throwableFileSize()
         } catch {
             downloadFailed(with: error)
+            return false
         }
 
         // Is there enough data cached to fulfill the request?

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -280,14 +280,14 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
                     requestsFulfilled.insert(loadingRequest)
                 }
             }
-            removeFullfilledRequests(requestsFulfilled)
+            removeFulfilledRequests(requestsFulfilled)
         } catch {
-            removeFullfilledRequests(requestsFulfilled)
+            removeFulfilledRequests(requestsFulfilled)
             downloadFailed(with: error, notify: true)
         }
     }
 
-    private func removeFullfilledRequests(_ requestsFulfilled: Set<AVAssetResourceLoadingRequest>) {
+    private func removeFulfilledRequests(_ requestsFulfilled: Set<AVAssetResourceLoadingRequest>) {
         var updatedPendingRequests = pendingRequests
         updatedPendingRequests.subtract(requestsFulfilled)
         pendingRequests = updatedPendingRequests

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -295,7 +295,12 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         let requestedOffset = Int(dataRequest.requestedOffset)
         let requestedLength = dataRequest.requestedLength
         let currentOffset = Int(dataRequest.currentOffset)
-        let bytesCached = fileHandle.fileSize
+        var bytesCached = 0
+        do {
+            bytesCached = try fileHandle.throwableFileSize()
+        } catch {
+            downloadFailed(with: error)
+        }
 
         // Is there enough data cached to fulfill the request?
         guard bytesCached > currentOffset else {

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -266,20 +266,26 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         lock.lock()
         defer { lock.unlock() }
 
-        // Filter out the unfullfilled requests
-        let requestsFulfilled: Set<AVAssetResourceLoadingRequest> = pendingRequests.filter {
-            guard response != nil else {
-                return false
+        do {
+            // Filter out the unfullfilled requests
+            let requestsFulfilled: Set<AVAssetResourceLoadingRequest> = try pendingRequests.filter {
+                guard response != nil else {
+                    return false
+                }
+                fillInContentInformationRequest($0.contentInformationRequest)
+                guard try haveEnoughDataToFulfillRequest($0.dataRequest!) else {
+                    return false
+                }
+
+                $0.finishLoading()
+                return true
             }
-            fillInContentInformationRequest($0.contentInformationRequest)
-            guard haveEnoughDataToFulfillRequest($0.dataRequest!) else { return false }
 
-            $0.finishLoading()
-            return true
+            // Remove fulfilled requests from pending requests
+            requestsFulfilled.forEach { pendingRequests.remove($0) }
+        } catch {
+            downloadFailed(with: error)
         }
-
-        // Remove fulfilled requests from pending requests
-        requestsFulfilled.forEach { pendingRequests.remove($0) }
     }
 
     private func fillInContentInformationRequest(_ contentInformationRequest: AVAssetResourceLoadingContentInformationRequest?) {
@@ -291,7 +297,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         contentInformationRequest?.isByteRangeAccessSupported = true
     }
 
-    private func haveEnoughDataToFulfillRequest(_ dataRequest: AVAssetResourceLoadingDataRequest) -> Bool {
+    private func haveEnoughDataToFulfillRequest(_ dataRequest: AVAssetResourceLoadingDataRequest) throws -> Bool {
         let requestedOffset = Int(dataRequest.requestedOffset)
         let requestedLength = dataRequest.requestedLength
         let currentOffset = Int(dataRequest.currentOffset)
@@ -299,8 +305,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         do {
             bytesCached = try fileHandle.throwableFileSize()
         } catch {
-            downloadFailed(with: error)
-            return false
+            throw error
         }
 
         // Is there enough data cached to fulfill the request?
@@ -333,7 +338,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             }
             dataRequest.respond(with: data)
         } catch {
-            downloadFailed(with: error)
+            throw error
         }
 
         return dataRequest.currentOffset >= requestedLength + requestedOffset

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -308,6 +308,11 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
             throw error
         }
 
+        if isDownloadComplete, currentOffset >= fileHandle.fileSize {
+            FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: try to read a position after the end of a file")
+            throw MediaFileHandleError.tryToReadAfterEndOfFile
+        }
+
         // Is there enough data cached to fulfill the request?
         guard bytesCached > currentOffset else {
             if FeatureFlag.streamAndDownloadReadFromMemoryBuffer.enabled, currentOffset < bufferData.count + bytesCached {
@@ -330,10 +335,6 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
         // Read data from disk and pass it to the dataRequest
         do {
             guard let data = try fileHandle.readData(withOffset: currentOffset, forLength: bytesToRespond) else {
-                if isDownloadComplete, currentOffset >= fileHandle.fileSize {
-                    FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: try to read a position after the end of a file")
-                    downloadFailed(with: MediaFileHandleError.tryToReadAfterEndOfFile)
-                }
                 return false
             }
             dataRequest.respond(with: data)

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -318,7 +318,11 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
         // Read data from disk and pass it to the dataRequest
         do {
-            guard let data = try fileHandle.readData(withOffset: currentOffset, forLength: bytesToRespond) else {                
+            guard let data = try fileHandle.readData(withOffset: currentOffset, forLength: bytesToRespond) else {
+                if isDownloadComplete, currentOffset >= fileHandle.fileSize {
+                    FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: try to read a position after the end of a file")
+                    downloadFailed(with: MediaFileHandleError.tryToReadAfterEndOfFile)
+                }
                 return false
             }
             dataRequest.respond(with: data)

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -3,6 +3,7 @@ import PocketCastsUtils
 
 enum MediaFileHandleError: Error {
     case unableToOpenFile
+    case tryToReadAfterEndOfFile
 }
 
 /// File handle for local file operations.

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -1,6 +1,10 @@
 import Foundation
 import PocketCastsUtils
 
+enum MediaFileHandleError: Error {
+    case unableToOpenFile
+}
+
 /// File handle for local file operations.
 final class MediaFileHandle {
     private let filePath: String
@@ -43,27 +47,27 @@ extension MediaFileHandle {
         return attributes?[.size] as? Int ?? 0
     }
 
-    func readData(withOffset offset: Int, forLength length: Int) -> Data? {
+    func readData(withOffset offset: Int, forLength length: Int) throws -> Data? {
         lock.lock()
         defer { lock.unlock() }
 
         guard let readHandle else {
             FileLog.shared.addMessage("MediaFileHandle: File [\(filePath)] read handle is nil")
-            return nil
+            throw MediaFileHandleError.unableToOpenFile
         }
 
         do {
             try readHandle.seek(toOffset: UInt64(offset))
         } catch {
             FileLog.shared.addMessage("MediaFileHandle: File [\(filePath)] seek error: \(error)")
-            return nil
+            throw error
         }
 
         do {
             return try readHandle.read(upToCount: length)
         } catch {
             FileLog.shared.addMessage("MediaFileHandle: File [\(filePath)] read error: \(error)")
-            return nil
+            throw error
         }
     }
 

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -48,6 +48,16 @@ extension MediaFileHandle {
         return attributes?[.size] as? Int ?? 0
     }
 
+    func throwableFileSize() throws -> Int {
+        do {
+            let attributes = try FileManager.default.attributesOfItem(atPath: filePath)
+            return attributes[.size] as? Int ?? 0
+        } catch {
+            FileLog.shared.addMessage("MediaFileHandle: Read File size of [\(filePath)] error: \(error)")
+            throw error
+        }
+    }
+
     func readData(withOffset offset: Int, forLength length: Int) throws -> Data? {
         lock.lock()
         defer { lock.unlock() }

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -39,7 +39,7 @@ extension MediaFileHandle {
     func fileSize() throws -> Int {
         do {
             let attributes = try FileManager.default.attributesOfItem(atPath: filePath)
-            return attributes[.size] as? Int ?? 0
+            return (attributes[.size] as? NSNumber)?.intValue ?? 0
         } catch {
             FileLog.shared.addMessage("MediaFileHandle: Failed to read file size of [\(filePath)] error: \(error)")
             throw error

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PocketCastsUtils
 
-enum MediaFileHandleError: Error {
+enum MediaFileHandleError: Error, Equatable {
     case unableToOpenFile
     case tryToReadAfterEndOfFile
 }

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -44,18 +44,18 @@ extension MediaFileHandle {
         return nil
     }
 
-    var fileSize: Int {
-        return (try? throwableFileSize()) ?? 0
-    }
-
-    func throwableFileSize() throws -> Int {
+    func fileSize() throws -> Int {
         do {
             let attributes = try FileManager.default.attributesOfItem(atPath: filePath)
             return attributes[.size] as? Int ?? 0
         } catch {
-            FileLog.shared.addMessage("MediaFileHandle: Read File size of [\(filePath)] error: \(error)")
+            FileLog.shared.addMessage("MediaFileHandle: Failed to read file size of [\(filePath)] error: \(error)")
             throw error
         }
+    }
+
+    var safeFileSize: Int {
+        return (try? fileSize()) ?? 0
     }
 
     func readData(withOffset offset: Int, forLength length: Int) throws -> Data? {

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -35,14 +35,6 @@ final class MediaFileHandle {
 // MARK: Internal methods
 
 extension MediaFileHandle {
-    var attributes: [FileAttributeKey: Any]? {
-        do {
-            return try FileManager.default.attributesOfItem(atPath: filePath)
-        } catch let error as NSError {
-            FileLog.shared.addMessage("MediaFileHandle: File [\(filePath)] attribute error: \(error)")
-        }
-        return nil
-    }
 
     func fileSize() throws -> Int {
         do {

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 
 enum MediaFileHandleError: Error, Equatable {
     case unableToOpenFile
-    case tryToReadAfterEndOfFile
+    case readAfterEndOfFile
 }
 
 /// File handle for local file operations.

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -45,7 +45,7 @@ extension MediaFileHandle {
     }
 
     var fileSize: Int {
-        return attributes?[.size] as? Int ?? 0
+        return (try? throwableFileSize()) ?? 0
     }
 
     func throwableFileSize() throws -> Int {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

This PR improves the handling of exceptions on the read/write handle on the media exporter.
This avoids scenarios where the media handle fails IO but the streaming delegate continues to try read/write bytes without reporting an error to the user.

## To test

1. Start the app
2. Play episodes
3. Check if they are playing correctly
4. If you want to do a more advanced test, try to delete/corrupt the tmp file being saved by opening the simulator disk location and corrupting/deleting the file while the streaming is happening and check if the error shows up cleanly.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
