### PR TITLE
Avoid duplicate stream request when one is already ongoing

### DIFF
--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -367,8 +367,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
         var newItem: AVPlayerItem = playbackItem
         #if !os(watchOS) && !APPCLIP
-        if episode.autoDownloadStatus == AutoDownloadStatus.playerDownloadedForStreaming.rawValue || episode.autoDownloadStatus == AutoDownloadStatus.autoDownloaded.rawValue,
-           let customDelegate = downloadAndStreamEpisodes[episode.uuid] {
+        if let customDelegate = downloadAndStreamEpisodes[episode.uuid] {
             // We are already downloading this episode for streaming
             FileLog.shared.addMessage("DownloadManager stream and download: skipping because we are already exporting: \(episode.uuid)")
             let customURL = URL(string: "custom-\(urlAsset.url.absoluteString)")!


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR avoids a scenario where a duplicate stream download request is made when an existing one is still running.


https://github.com/user-attachments/assets/012dc42b-c8a0-4a1b-835d-42f5973e29e5


## To test

1. Start the app
2. Open a podcast with long episodes. For example [Tim Ferris Show](https://pca.st/podcast/046f9e00-a81a-0131-c656-723c91aeae46)
3. Select some episodes by long press and select to download
4. While they are downloading tap on play on one of them ( notice the current progress going back to zero, this is expected)
5. Them play on another episode
6. Tap on play on first episode you tapped play
7. Notice that now the progress shouldn't return to zero. ( You also should see another message in the console saying: `DownloadManager stream and download: skipping because we are already exporting:`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
