### PR TITLE
Revert "Fix playback resuming unexpectedly after phone calls (#4102)"

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -38,7 +38,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     private var player: PlaybackProtocol?
 
     private var switchingToDifferentUpNextEpisode = false
-    private let interruptInProgress = AtomicBool()
+    private var interruptInProgress = false
 
     private var wasPlayingBeforeInterruption = false
     private let aboutToPlay = AtomicBool()
@@ -1781,14 +1781,6 @@ class PlaybackManager: ServerPlaybackDelegate {
         commandCenter.playCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
             guard let strongSelf = self, let _ = strongSelf.currentEpisode() else { return .noActionableNowPlayingItem }
 
-            // Don't start playback during an active audio interruption (e.g. phone call).
-            // Bluetooth devices like Garmin watches with mic/speaker trigger route changes
-            // during calls, which cause iOS to send spurious playCommand events.
-            if strongSelf.interruptInProgress.value {
-                FileLog.shared.addMessage("Remote control: playCommand, ignored because an audio interruption is in progress")
-                return .success
-            }
-
             strongSelf.analyticsPlaybackHelper.currentSource = strongSelf.commandCenterSource
 
             if Settings.legacyBluetoothModeEnabled() {
@@ -1810,10 +1802,8 @@ class PlaybackManager: ServerPlaybackDelegate {
                             return .commandFailed
                         }
                     }
-                    // For non-legacy Bluetooth and when not playing over AirPlay, treat playCommand
-                    // as a play/pause toggle to preserve compatibility with accessories that send
-                    // playCommand as a toggle (play while paused, play again to pause).
-                    FileLog.shared.addMessage("Remote control: playCommand, treating as play/pause toggle")
+                    // we hook play up to play/pause because that's how some headphones/car stereos do it instead of sending distinct play/pause events
+                    FileLog.shared.addMessage("Remote control: playCommand, treating as playPause")
                     strongSelf.playPause()
                 }
             }
@@ -2112,7 +2102,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         let interruptionType = userInfo[AVAudioSessionInterruptionTypeKey] as! NSNumber
         let interruptionReason = userInfo[AVAudioSessionInterruptionReasonKey] as? UInt
         if interruptionType.uintValue == AVAudioSession.InterruptionType.ended.rawValue {
-            interruptInProgress.value = false
+            interruptInProgress = false
             let interruptionOption = userInfo[AVAudioSessionInterruptionOptionKey] as! NSNumber
             FileLog.shared.addMessage("PlaybackManager handleAudioInterrupt ended, should attempt to restart audio: \(interruptionOption) reason: \(interruptionReason?.description ?? "unknown")")
             if interruptionOption.uintValue == AVAudioSession.InterruptionOptions.shouldResume.rawValue, wasPlayingBeforeInterruption {
@@ -2130,13 +2120,13 @@ class PlaybackManager: ServerPlaybackDelegate {
             // we run into any issues
             if #available(iOS 17, watchOS 10, *), FeatureFlag.ignoreRouteDisconnectedInterruption.enabled {
                 if interruptionReason != AVAudioSession.InterruptionReason.routeDisconnected.rawValue {
-                    interruptInProgress.value = true
+                    interruptInProgress = true
                 }
             } else {
                 // We do not get the InterruptionReason.routeDisconnected notification on older versions, so
                 // no need to perform the same check for older versions.
                 // Also, will default to the old behaviour if the feature flag is disabled on newer versions.
-                interruptInProgress.value = true
+                interruptInProgress = true
             }
 
             FileLog.shared.addMessage("PlaybackManager handleAudioInterrupt began reason: \(interruptionReason?.description ?? "unknown")")
@@ -2296,7 +2286,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     // MARK: - Interruptions
 
     func interruptionInProgress() -> Bool {
-        interruptInProgress.value
+        interruptInProgress
     }
 
     // MARK: - Private helpers


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR reverts the changes done here: https://github.com/Automattic/pocket-casts-ios/pull/4102

## To test

1. Pair a Bluetooth device with mic/speaker 
2. Open Pocket Casts with an episode loaded but **paused**
3. Receive a phone call → silence it or let it ring to voicemail
4. Verify playback does **not** resume when the call ends
5. Verify normal play/pause from lock screen, headphones, and Control Center still works

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
