### PR TITLE
POC-499: 0.1 Add `syncedTranscripts` feature flag

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -125,6 +125,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the generated transcript
     case generatedTranscripts
 
+    /// Enable synced transcripts with playback timing
+    case syncedTranscripts
+
     /// Encourage Account Creation
     case encourageAccountCreation
 
@@ -397,6 +400,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .generatedTranscripts:
             true
+        case .syncedTranscripts:
+            false
         case .libroFm:
             false
         case .encourageAccountCreation:


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/POC-499/01-add-syncedtranscripts-feature-flag

## Summary
Add a new `syncedTranscripts` feature flag to gate the upcoming synced transcripts functionality. When off, the transcript view uses raw playback time (existing non-synced behavior).

## Changes
- Added `syncedTranscripts` case to `FeatureFlag` enum, placed next to `generatedTranscripts`
- Set default value to `false` (feature is off until later tasks are implemented)

## Verification
- **Lint**: PASS — `make format` completed cleanly
- **Tests**: PASS — `make build_staging` succeeded (build includes SwiftLint)
- **Diff review**: PASS — only 5 lines added to a single file, no unintended changes
- **Secret scan**: PASS — no secrets in diff

## Confidence
**HIGH** — Straightforward single-case addition following existing patterns. Build passes.

---
This PR was created autonomously by linear-solver.
Triage complexity: simple | [Linear issue](https://linear.app/a8c/issue/POC-499/01-add-syncedtranscripts-feature-flag)