### PR TITLE
POC-501: 0.3 Define `FingerprintConstants`

### DIFF
--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+enum FingerprintConstants {
+    /// Seconds of playback jump that triggers a re-fingerprint from the current position.
+    static let restartDeltaSeconds: Double = 10
+
+    /// Seconds of margin beyond the mapped range before triggering a restart.
+    static let playbackRangeMarginSeconds: Double = 30
+
+    /// Minimum match score to accept a fingerprint match result.
+    static let matchScoreThreshold: Float = 0.5
+
+    /// Number of fingerprint windows processed per batch.
+    static let batchSize: Int = 50
+
+    /// Seconds between polls when waiting for the streaming buffer to grow.
+    static let bufferGrowPollCadenceSeconds: TimeInterval = 1.0
+
+    /// Score at or above which the debug overlay shows green (high confidence).
+    static let debugOverlayHighScoreThreshold: Float = 0.85
+
+    /// Score at or above which the debug overlay shows orange (medium confidence).
+    static let debugOverlayMediumScoreThreshold: Float = 0.7
+
+    /// Minimum number of mapping entries before the timing manager transitions to `.active`.
+    static let minimumCoverageForActive: Int = 2
+}


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/POC-501/03-define-fingerprintconstants

## Summary
Adds `FingerprintConstants.swift` — a single enum containing all tuning constants for the fingerprint timing system, extracted from the POC branch (`poc/transcripts-ai-enablement`).

## Changes
- New file `podcasts/Fingerprint/FingerprintConstants.swift` with constants for:
  - `restartDeltaSeconds` (10) — playback jump threshold for re-fingerprinting
  - `playbackRangeMarginSeconds` (30) — margin beyond mapped range before restart
  - `matchScoreThreshold` (0.5) — minimum score to accept a match
  - `batchSize` (50) — fingerprint windows per processing batch
  - `bufferGrowPollCadenceSeconds` (1.0) — poll interval for streaming buffer
  - `debugOverlayHighScoreThreshold` (0.85) — green threshold in debug overlay
  - `debugOverlayMediumScoreThreshold` (0.7) — orange threshold in debug overlay
  - `minimumCoverageForActive` (2) — mapping entries needed for active state

## Verification
- **Lint**: PASS — `make format` clean
- **Tests**: PASS — `make build_staging` succeeded (no new tests needed for a constants-only file)
- **Diff review**: PASS — single new file, no unintended changes
- **Secret scan**: PASS — no credentials in diff

## Confidence
**HIGH** — Straightforward constants file with values copied directly from the POC. All values verified against the POC source.

---
This PR was created autonomously by linear-solver.
Triage complexity: simple | [Linear issue](https://linear.app/a8c/issue/POC-501/03-define-fingerprintconstants)