### PR TITLE
Improve Heatmap implementation

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -307,6 +307,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Track network data usage per episode/connection type in the NetworkDataUsage table
     case trackNetworkDataUsage
 
+    /// Show the listening activity heatmap on the Stats screen
+    case statsHeatmap
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -515,6 +518,8 @@ public enum FeatureFlag: String, CaseIterable {
 			true
         case .trackNetworkDataUsage:
             true
+        case .statsHeatmap:
+            false
         }
     }
 

--- a/PocketCastsTests/Mocks/DataManagerMock.swift
+++ b/PocketCastsTests/Mocks/DataManagerMock.swift
@@ -5,6 +5,7 @@ import Foundation
 class DataManagerMock: DataManager {
     var podcastsToReturn: [Podcast] = []
     var episodesToReturn: [Episode] = []
+    var dailyListeningTimeToReturn: [String: Double] = [:]
 
     override func findEpisodesWhere(customWhere: String, arguments: [Any]?) -> [Episode] {
         return episodesToReturn
@@ -12,5 +13,9 @@ class DataManagerMock: DataManager {
 
     override func allPodcasts(includeUnsubscribed: Bool, reloadFromDatabase: Bool = false) -> [Podcast] {
         return podcastsToReturn
+    }
+
+    override func dailyListeningTime(forLast days: Int = 365) -> [String: Double] {
+        return dailyListeningTimeToReturn
     }
 }

--- a/PocketCastsTests/Tests/Profile/ListeningHeatmapViewModelTests.swift
+++ b/PocketCastsTests/Tests/Profile/ListeningHeatmapViewModelTests.swift
@@ -135,7 +135,7 @@ final class ListeningHeatmapViewModelTests: XCTestCase {
         dataManager: DataManager = DataManagerMock(),
         today: Date
     ) -> ListeningHeatmapViewModel {
-        ListeningHeatmapViewModel(dataManager: dataManager, calendar: enUSCalendar, now: today)
+        ListeningHeatmapViewModel(dataManager: dataManager, calendar: enUSCalendar, now: { today })
     }
 
     private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {

--- a/PocketCastsTests/Tests/Profile/ListeningHeatmapViewModelTests.swift
+++ b/PocketCastsTests/Tests/Profile/ListeningHeatmapViewModelTests.swift
@@ -34,13 +34,11 @@ final class ListeningHeatmapViewModelTests: XCTestCase {
     }
 
     func testBuildWeeks_enUS_gridSpansOneFullYear() {
-        // today = Monday 2026-04-20. Start of grid: Sunday 2025-04-20 (the week containing
-        // today - 364 days = Monday 2025-04-21). That's 366 days = 53 columns.
         let viewModel = makeViewModel(today: date(2026, 4, 20))
 
         let weeks = viewModel.buildWeeks(from: [:])
 
-        XCTAssertEqual(weeks.count, 53)
+        XCTAssertEqual(weeks.count, 105)
         XCTAssertEqual(weeks.dropLast().allSatisfy { $0.count == 7 }, true)
         XCTAssertEqual(weeks.last?.count, 2) // Sun + Mon
     }
@@ -94,8 +92,7 @@ final class ListeningHeatmapViewModelTests: XCTestCase {
 
         waitForLoad(viewModel)
 
-        XCTAssertFalse(viewModel.hasData)
-        XCTAssertEqual(viewModel.weeks.count, 53)
+        XCTAssertEqual(viewModel.weeks.count, 105)
         XCTAssertTrue(viewModel.weeks.flatMap { $0 }.allSatisfy { $0.intensity == 0 })
     }
 
@@ -114,7 +111,6 @@ final class ListeningHeatmapViewModelTests: XCTestCase {
 
         waitForLoad(viewModel)
 
-        XCTAssertTrue(viewModel.hasData)
         let bySeconds = Dictionary(uniqueKeysWithValues: viewModel.weeks
             .flatMap { $0 }
             .filter { $0.seconds > 0 }

--- a/PocketCastsTests/Tests/Profile/ListeningHeatmapViewModelTests.swift
+++ b/PocketCastsTests/Tests/Profile/ListeningHeatmapViewModelTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+import Combine
+
+@testable import PocketCastsDataModel
+@testable import podcasts
+
+final class ListeningHeatmapViewModelTests: XCTestCase {
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    // MARK: - Week alignment (English locale)
+
+    func testBuildWeeks_enUS_firstDayIsSunday() throws {
+        let viewModel = makeViewModel(today: date(2026, 4, 20))
+
+        let weeks = viewModel.buildWeeks(from: [:])
+
+        let firstDay = try XCTUnwrap(weeks.first?.first).date
+        XCTAssertEqual(enUSCalendar.component(.weekday, from: firstDay), 1, "First column day should be Sunday in en_US")
+    }
+
+    func testBuildWeeks_enUS_lastDayIsToday() throws {
+        let today = date(2026, 4, 20)
+        let viewModel = makeViewModel(today: today)
+
+        let weeks = viewModel.buildWeeks(from: [:])
+
+        let lastDay = try XCTUnwrap(weeks.last?.last).date
+        XCTAssertEqual(lastDay, enUSCalendar.startOfDay(for: today))
+    }
+
+    func testBuildWeeks_enUS_gridSpansOneFullYear() {
+        // today = Monday 2026-04-20. Start of grid: Sunday 2025-04-20 (the week containing
+        // today - 364 days = Monday 2025-04-21). That's 366 days = 53 columns.
+        let viewModel = makeViewModel(today: date(2026, 4, 20))
+
+        let weeks = viewModel.buildWeeks(from: [:])
+
+        XCTAssertEqual(weeks.count, 53)
+        XCTAssertEqual(weeks.dropLast().allSatisfy { $0.count == 7 }, true)
+        XCTAssertEqual(weeks.last?.count, 2) // Sun + Mon
+    }
+
+    // MARK: - Data mapping
+
+    func testBuildWeeks_emptyData_allIntensityZero() {
+        let viewModel = makeViewModel(today: date(2026, 4, 20))
+
+        let weeks = viewModel.buildWeeks(from: [:])
+
+        XCTAssertTrue(weeks.flatMap { $0 }.allSatisfy { $0.intensity == 0 })
+    }
+
+    func testBuildWeeks_intensityAssignsLevels1Through4() {
+        let today = date(2026, 4, 20)
+        let viewModel = makeViewModel(today: today)
+
+        // 8 sorted values: [10, 20, 40, 50, 60, 70, 80, 100].
+        // thresholds: sorted[2]=40, sorted[4]=60, sorted[6]=80.
+        // Expected: 10→1, 50→2, 70→3, 100→4.
+        let data: [String: Double] = [
+            "2026-04-01": 10,
+            "2026-04-02": 20,
+            "2026-04-03": 40,
+            "2026-04-04": 50,
+            "2026-04-05": 60,
+            "2026-04-06": 70,
+            "2026-04-07": 80,
+            "2026-04-08": 100
+        ]
+
+        let weeks = viewModel.buildWeeks(from: data)
+        let bySeconds = Dictionary(uniqueKeysWithValues: weeks
+            .flatMap { $0 }
+            .filter { $0.seconds > 0 }
+            .map { ($0.seconds, $0.intensity) })
+
+        XCTAssertEqual(bySeconds[10], 1)
+        XCTAssertEqual(bySeconds[50], 2)
+        XCTAssertEqual(bySeconds[70], 3)
+        XCTAssertEqual(bySeconds[100], 4)
+    }
+
+    // MARK: - load() end-to-end with injected DataManager
+
+    func testLoad_emptyData_setsHasDataFalseAndAllIntensityZero() {
+        let dataManagerMock = DataManagerMock()
+        dataManagerMock.dailyListeningTimeToReturn = [:]
+        let viewModel = makeViewModel(dataManager: dataManagerMock, today: date(2026, 4, 20))
+
+        waitForLoad(viewModel)
+
+        XCTAssertFalse(viewModel.hasData)
+        XCTAssertEqual(viewModel.weeks.count, 53)
+        XCTAssertTrue(viewModel.weeks.flatMap { $0 }.allSatisfy { $0.intensity == 0 })
+    }
+
+    func testLoad_withData_computesIntensitiesFromQuartiles() {
+        let dataManagerMock = DataManagerMock()
+        // 4 sorted values: [100, 300, 600, 1200].
+        // thresholds: sorted[1]=300, sorted[2]=600, sorted[3]=1200.
+        // Expected: 100→1, 300→1, 600→2, 1200→3.
+        dataManagerMock.dailyListeningTimeToReturn = [
+            "2026-04-10": 100,
+            "2026-04-11": 300,
+            "2026-04-12": 600,
+            "2026-04-13": 1200
+        ]
+        let viewModel = makeViewModel(dataManager: dataManagerMock, today: date(2026, 4, 20))
+
+        waitForLoad(viewModel)
+
+        XCTAssertTrue(viewModel.hasData)
+        let bySeconds = Dictionary(uniqueKeysWithValues: viewModel.weeks
+            .flatMap { $0 }
+            .filter { $0.seconds > 0 }
+            .map { ($0.seconds, $0.intensity) })
+        XCTAssertEqual(bySeconds[100], 1)
+        XCTAssertEqual(bySeconds[300], 1)
+        XCTAssertEqual(bySeconds[600], 2)
+        XCTAssertEqual(bySeconds[1200], 3)
+    }
+
+    // MARK: - Helpers
+
+    private lazy var enUSCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = Locale(identifier: "en_US")
+        calendar.firstWeekday = 1 // Sunday
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }()
+
+    private func makeViewModel(
+        dataManager: DataManager = DataManagerMock(),
+        today: Date
+    ) -> ListeningHeatmapViewModel {
+        ListeningHeatmapViewModel(dataManager: dataManager, calendar: enUSCalendar, now: today)
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        enUSCalendar.date(from: DateComponents(year: year, month: month, day: day))!
+    }
+
+    private func formattedKey(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = enUSCalendar.timeZone
+        return formatter.string(from: date)
+    }
+
+    private func waitForLoad(_ viewModel: ListeningHeatmapViewModel) {
+        let expectation = XCTestExpectation(description: "weeks published")
+        viewModel.$weeks
+            .dropFirst()
+            .sink { _ in expectation.fulfill() }
+            .store(in: &cancellables)
+        viewModel.load()
+        wait(for: [expectation], timeout: 2.0)
+    }
+}

--- a/PocketCastsTests/Tests/Profile/ListeningHeatmapViewModelTests.swift
+++ b/PocketCastsTests/Tests/Profile/ListeningHeatmapViewModelTests.swift
@@ -50,7 +50,7 @@ final class ListeningHeatmapViewModelTests: XCTestCase {
 
         let weeks = viewModel.buildWeeks(from: [:])
 
-        XCTAssertTrue(weeks.flatMap { $0 }.allSatisfy { $0.intensity == 0 })
+        XCTAssertTrue(weeks.flatMap { $0 }.allSatisfy { $0.intensity == .none })
     }
 
     func testBuildWeeks_intensityAssignsLevels1Through4() {
@@ -77,10 +77,10 @@ final class ListeningHeatmapViewModelTests: XCTestCase {
             .filter { $0.seconds > 0 }
             .map { ($0.seconds, $0.intensity) })
 
-        XCTAssertEqual(bySeconds[10], 1)
-        XCTAssertEqual(bySeconds[50], 2)
-        XCTAssertEqual(bySeconds[70], 3)
-        XCTAssertEqual(bySeconds[100], 4)
+        XCTAssertEqual(bySeconds[10], .minimal)
+        XCTAssertEqual(bySeconds[50], .light)
+        XCTAssertEqual(bySeconds[70], .moderate)
+        XCTAssertEqual(bySeconds[100], .heavy)
     }
 
     // MARK: - load() end-to-end with injected DataManager
@@ -93,7 +93,7 @@ final class ListeningHeatmapViewModelTests: XCTestCase {
         waitForLoad(viewModel)
 
         XCTAssertEqual(viewModel.weeks.count, 105)
-        XCTAssertTrue(viewModel.weeks.flatMap { $0 }.allSatisfy { $0.intensity == 0 })
+        XCTAssertTrue(viewModel.weeks.flatMap { $0 }.allSatisfy { $0.intensity == .none })
     }
 
     func testLoad_withData_computesIntensitiesFromQuartiles() {
@@ -115,10 +115,10 @@ final class ListeningHeatmapViewModelTests: XCTestCase {
             .flatMap { $0 }
             .filter { $0.seconds > 0 }
             .map { ($0.seconds, $0.intensity) })
-        XCTAssertEqual(bySeconds[100], 1)
-        XCTAssertEqual(bySeconds[300], 1)
-        XCTAssertEqual(bySeconds[600], 2)
-        XCTAssertEqual(bySeconds[1200], 3)
+        XCTAssertEqual(bySeconds[100], .minimal)
+        XCTAssertEqual(bySeconds[300], .minimal)
+        XCTAssertEqual(bySeconds[600], .light)
+        XCTAssertEqual(bySeconds[1200], .moderate)
     }
 
     // MARK: - Helpers

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -490,6 +490,8 @@
 		9AF646952E5E081600627836 /* PlaylistDetailViewController+TableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF646942E5E081400627836 /* PlaylistDetailViewController+TableView.swift */; };
 		9AF646972E5E0BB800627836 /* PlaylistDetailViewController+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AF646962E5E0BB700627836 /* PlaylistDetailViewController+Search.swift */; };
 		9E2A72C35884B71C45856DFA /* VoiceBoostN.c in Sources */ = {isa = PBXBuildFile; fileRef = 14DD11DB5830A48ACE6928B2 /* VoiceBoostN.c */; };
+		AA1B2C3D4E5F607100HEAT01 /* ListeningHeatmapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F607100HEAT03 /* ListeningHeatmapView.swift */; };
+		AA1B2C3D4E5F607100HEAT02 /* ListeningHeatmapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F607100HEAT04 /* ListeningHeatmapViewModel.swift */; };
 		B7E0F1A52D4A1B5600123456 /* ProfileRefreshButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E0F1A42D4A1B5600123456 /* ProfileRefreshButton.swift */; };
 		BD00CB2B24BD20CD00A10257 /* TimeStepperCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD00CB2924BD20CD00A10257 /* TimeStepperCell.swift */; };
 		BD00CB2C24BD20CD00A10257 /* TimeStepperCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD00CB2A24BD20CD00A10257 /* TimeStepperCell.xib */; };
@@ -1055,8 +1057,6 @@
 		C713D4F42A04C90500A78468 /* ProfileDataViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D4EC2A04C90400A78468 /* ProfileDataViewModel.swift */; };
 		C713D4F52A04C90500A78468 /* ProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D4ED2A04C90400A78468 /* ProfileImage.swift */; };
 		C713D4F62A04C90500A78468 /* AccountHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D4EE2A04C90400A78468 /* AccountHeaderView.swift */; };
-		AA1B2C3D4E5F607100HEAT01 /* ListeningHeatmapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F607100HEAT03 /* ListeningHeatmapView.swift */; };
-		AA1B2C3D4E5F607100HEAT02 /* ListeningHeatmapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F607100HEAT04 /* ListeningHeatmapViewModel.swift */; };
 		C713D4F72A04C90500A78468 /* ProfileHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D4EF2A04C90400A78468 /* ProfileHeaderView.swift */; };
 		C713D4F82A04C90500A78468 /* ProfileHeaderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D4F02A04C90400A78468 /* ProfileHeaderViewModel.swift */; };
 		C713D4F92A04C90500A78468 /* SubscriptionProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D4F12A04C90500A78468 /* SubscriptionProfileImage.swift */; };
@@ -1998,6 +1998,8 @@
 		9AF646922E5DEB1300627836 /* PlaylistDetailViewController+MultiSelect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaylistDetailViewController+MultiSelect.swift"; sourceTree = "<group>"; };
 		9AF646942E5E081400627836 /* PlaylistDetailViewController+TableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaylistDetailViewController+TableView.swift"; sourceTree = "<group>"; };
 		9AF646962E5E0BB700627836 /* PlaylistDetailViewController+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaylistDetailViewController+Search.swift"; sourceTree = "<group>"; };
+		AA1B2C3D4E5F607100HEAT03 /* ListeningHeatmapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningHeatmapView.swift; sourceTree = "<group>"; };
+		AA1B2C3D4E5F607100HEAT04 /* ListeningHeatmapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningHeatmapViewModel.swift; sourceTree = "<group>"; };
 		B7E0F1A42D4A1B5600123456 /* ProfileRefreshButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRefreshButton.swift; sourceTree = "<group>"; };
 		BD00CB2924BD20CD00A10257 /* TimeStepperCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeStepperCell.swift; sourceTree = "<group>"; };
 		BD00CB2A24BD20CD00A10257 /* TimeStepperCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TimeStepperCell.xib; sourceTree = "<group>"; };
@@ -2559,8 +2561,6 @@
 		C713D4EC2A04C90400A78468 /* ProfileDataViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileDataViewModel.swift; sourceTree = "<group>"; };
 		C713D4ED2A04C90400A78468 /* ProfileImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileImage.swift; sourceTree = "<group>"; };
 		C713D4EE2A04C90400A78468 /* AccountHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountHeaderView.swift; sourceTree = "<group>"; };
-		AA1B2C3D4E5F607100HEAT03 /* ListeningHeatmapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningHeatmapView.swift; sourceTree = "<group>"; };
-		AA1B2C3D4E5F607100HEAT04 /* ListeningHeatmapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningHeatmapViewModel.swift; sourceTree = "<group>"; };
 		C713D4EF2A04C90400A78468 /* ProfileHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileHeaderView.swift; sourceTree = "<group>"; };
 		C713D4F02A04C90400A78468 /* ProfileHeaderViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileHeaderViewModel.swift; sourceTree = "<group>"; };
 		C713D4F12A04C90500A78468 /* SubscriptionProfileImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SubscriptionProfileImage.swift; sourceTree = "<group>"; };

--- a/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/podcasts.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7ac3040d6bdf3d89c67d3028b8e38e284d6ab33f07e31ce561379daa78f060ad",
+  "originHash" : "abd7e3ee8e43115731d3c622076d4f577dc28209e01b97ec9eca85a01d828d87",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
-        "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
-        "version" : "7.10.0"
+        "revision" : "a5a1be26b4513dc7ec360eb56bc08a345bac6649",
+        "version" : "7.5.0"
       }
     },
     {

--- a/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
@@ -5,6 +5,7 @@ import PocketCastsServer
 struct AccountHeaderView: View {
     @EnvironmentObject var theme: Theme
     @ObservedObject var viewModel: AccountHeaderViewModel
+
     @State private var showingChampion = false
 
     var body: some View {

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
@@ -64,13 +64,18 @@ struct ListeningHeatmapView: View {
 
     // MARK: - Day Labels
 
-    private let dayLabelWidth: CGFloat = 18
+    private let dayLabelWidth: CGFloat = 24
 
     private var dayLabels: some View {
-        VStack(spacing: cellSpacing) {
-            ForEach(0..<7, id: \.self) { dayIndex in
-                if dayIndex == 1 || dayIndex == 3 || dayIndex == 5 {
-                    Text(dayAbbreviation(dayIndex))
+        let calendar = Calendar.current
+        let symbols = calendar.shortWeekdaySymbols
+        // Label every other row starting from firstWeekday (rows 0, 2, 4, 6).
+        let labeledRows: Set<Int> = [0, 2, 4, 6]
+        return VStack(spacing: cellSpacing) {
+            ForEach(0..<7, id: \.self) { rowIndex in
+                if labeledRows.contains(rowIndex) {
+                    let symbolIndex = (calendar.firstWeekday - 1 + rowIndex) % 7
+                    Text(symbols[symbolIndex])
                         .font(size: 10, style: .caption2, weight: .regular)
                         .foregroundColor(theme.primaryText02)
                         .frame(width: dayLabelWidth, height: cellSize, alignment: .trailing)
@@ -131,11 +136,6 @@ struct ListeningHeatmapView: View {
         case 4: return theme.primaryInteractive01
         default: return theme.primaryUi05.opacity(0.3)
         }
-    }
-
-    private func dayAbbreviation(_ index: Int) -> String {
-        let symbols = Calendar.current.veryShortWeekdaySymbols
-        return symbols[index]
     }
 
     private struct MonthPosition {

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
@@ -116,7 +116,7 @@ struct ListeningHeatmapView: View {
             Text(L10n.statsListeningActivityLegendLess)
                 .font(size: 10, style: .caption2, weight: .regular)
                 .foregroundColor(theme.primaryText02)
-            ForEach(0..<5, id: \.self) { level in
+            ForEach(HeatmapIntensity.allCases, id: \.self) { level in
                 RoundedRectangle(cornerRadius: 2)
                     .fill(colorForIntensity(level))
                     .frame(width: cellSize, height: cellSize)
@@ -129,14 +129,13 @@ struct ListeningHeatmapView: View {
 
     // MARK: - Helpers
 
-    private func colorForIntensity(_ level: Int) -> Color {
+    private func colorForIntensity(_ level: HeatmapIntensity) -> Color {
         switch level {
-        case 0: return theme.primaryUi05.opacity(0.3)
-        case 1: return theme.primaryInteractive01.opacity(0.3)
-        case 2: return theme.primaryInteractive01.opacity(0.5)
-        case 3: return theme.primaryInteractive01.opacity(0.75)
-        case 4: return theme.primaryInteractive01
-        default: return theme.primaryUi05.opacity(0.3)
+        case .none: return theme.primaryUi05.opacity(0.3)
+        case .minimal: return theme.primaryInteractive01.opacity(0.3)
+        case .light: return theme.primaryInteractive01.opacity(0.5)
+        case .moderate: return theme.primaryInteractive01.opacity(0.75)
+        case .heavy: return theme.primaryInteractive01
         }
     }
 

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
@@ -6,12 +6,12 @@ struct ListeningHeatmapView: View {
     @ObservedObject var viewModel: ListeningHeatmapViewModel
 
     private let calendar = Calendar.current
-    private let cellSize: CGFloat = 12
-    private let cellSpacing: CGFloat = 3
-    private let dayLabelWidth: CGFloat = 24
+    @ScaledMetric(relativeTo: .caption2) private var cellSize: CGFloat = 12
+    @ScaledMetric(relativeTo: .caption2) private var cellSpacing: CGFloat = 3
+    @ScaledMetric(relativeTo: .caption2) private var dayLabelWidth: CGFloat = 28
+    @ScaledMetric(relativeTo: .caption2) private var monthLabelHeight: CGFloat = 14
     private let gridLeadingPadding: CGFloat = 4
     private let gridTrailingPadding: CGFloat = 8
-    private let monthLabelHeight: CGFloat = 14
     private let monthLabelBottomPadding: CGFloat = 4
 
     private var columnWidth: CGFloat { cellSize + cellSpacing }
@@ -25,6 +25,7 @@ struct ListeningHeatmapView: View {
         }
         .padding(.vertical, 12)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .dynamicTypeSize(...DynamicTypeSize.xxLarge)
     }
 
     private var heatmapGrid: some View {

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
@@ -5,15 +5,16 @@ struct ListeningHeatmapView: View {
     @EnvironmentObject private var theme: Theme
     @ObservedObject var viewModel: ListeningHeatmapViewModel
 
-    private let calendar = Calendar.current
-    @ScaledMetric(relativeTo: .caption2) private var cellSize: CGFloat = 12
-    @ScaledMetric(relativeTo: .caption2) private var cellSpacing: CGFloat = 3
+    @ScaledMetric private var cellSize: CGFloat = 12
+    @ScaledMetric private var cellSpacing: CGFloat = 3
     @ScaledMetric(relativeTo: .caption2) private var dayLabelWidth: CGFloat = 28
     @ScaledMetric(relativeTo: .caption2) private var monthLabelHeight: CGFloat = 14
+
     private let gridLeadingPadding: CGFloat = 4
     private let gridTrailingPadding: CGFloat = 8
     private let monthLabelBottomPadding: CGFloat = 4
 
+    private var calendar: Calendar { viewModel.calendar }
     private var columnWidth: CGFloat { cellSize + cellSpacing }
 
     var body: some View {
@@ -25,7 +26,6 @@ struct ListeningHeatmapView: View {
         }
         .padding(.vertical, 12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .dynamicTypeSize(...DynamicTypeSize.xxLarge)
     }
 
     private var heatmapGrid: some View {
@@ -160,4 +160,14 @@ struct ListeningHeatmapView: View {
 
         return positions
     }
+}
+
+// MARK: - Previews
+#Preview {
+    VStack {
+        ListeningHeatmapView(viewModel: .init())
+        Spacer()
+    }
+    .setupDefaultEnvironment()
+    .dynamicTypeSize(DynamicTypeSize.medium...DynamicTypeSize.accessibility2)
 }

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
@@ -102,7 +102,7 @@ struct ListeningHeatmapView: View {
     private var legendRow: some View {
         HStack(spacing: 4) {
             Spacer()
-            Text(L10n.less)
+            Text(L10n.statsListeningActivityLegendLess)
                 .font(size: 10, style: .caption2, weight: .regular)
                 .foregroundColor(theme.primaryText02)
             ForEach(0..<5, id: \.self) { level in
@@ -110,7 +110,7 @@ struct ListeningHeatmapView: View {
                     .fill(colorForIntensity(level))
                     .frame(width: cellSize, height: cellSize)
             }
-            Text(L10n.more)
+            Text(L10n.statsListeningActivityLegendMore)
                 .font(size: 10, style: .caption2, weight: .regular)
                 .foregroundColor(theme.primaryText02)
         }

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
@@ -24,7 +24,7 @@ struct ListeningHeatmapView: View {
             legendRow
                 .padding(.horizontal, gridTrailingPadding)
         }
-        .padding(.vertical, 12)
+        .padding(.vertical, 16)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
@@ -85,7 +85,7 @@ struct ListeningHeatmapView: View {
                 if rowIndex % 2 == 0 {
                     let symbolIndex = (calendar.firstWeekday - 1 + rowIndex) % 7
                     Text(symbols[symbolIndex])
-                        .font(size: 10, style: .caption2, weight: .regular)
+                        .font(size: 10, style: .caption2, weight: .medium)
                         .foregroundColor(theme.primaryText02)
                         .frame(width: dayLabelWidth, height: cellSize, alignment: .trailing)
                 } else {
@@ -103,7 +103,7 @@ struct ListeningHeatmapView: View {
 
             ForEach(monthPositions, id: \.weekIndex) { position in
                 Text(position.label)
-                    .font(size: 10, style: .caption2, weight: .regular)
+                    .font(size: 10, style: .caption2, weight: .medium)
                     .foregroundColor(theme.primaryText02)
                     .offset(x: CGFloat(position.weekIndex) * columnWidth)
             }

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
@@ -22,7 +22,7 @@ struct ListeningHeatmapView: View {
             heatmapGrid
 
             legendRow
-                .padding(.horizontal, 16)
+                .padding(.horizontal, gridTrailingPadding)
         }
         .padding(.vertical, 12)
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
@@ -53,6 +53,16 @@ struct ListeningHeatmapView: View {
             .padding(.trailing, gridTrailingPadding)
         }
         .frame(height: gridHeight)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        let count = viewModel.weeks.reduce(0) { partial, week in
+            partial + week.reduce(0) { $0 + ($1.seconds > 0 ? 1 : 0) }
+        }
+        let formatted = NumberFormatter.localizedString(from: NSNumber(value: count), number: .decimal)
+        return L10n.statsListeningActivityAccessibilityLabel(formatted)
     }
 
     private var gridHeight: CGFloat {

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
@@ -17,21 +17,19 @@ struct ListeningHeatmapView: View {
     private var columnWidth: CGFloat { cellSize + cellSpacing }
 
     var body: some View {
-        if viewModel.hasData {
-            VStack(alignment: .leading, spacing: 8) {
-                Text(L10n.listeningActivity)
-                    .font(size: 14, style: .subheadline, weight: .semibold)
-                    .foregroundColor(theme.primaryText01)
-                    .padding(.horizontal, 16)
+        VStack(alignment: .leading, spacing: 8) {
+            Text(L10n.listeningActivity)
+                .font(size: 14, style: .subheadline, weight: .semibold)
+                .foregroundColor(theme.primaryText01)
+                .padding(.horizontal, 16)
 
-                heatmapGrid
+            heatmapGrid
 
-                legendRow
-                    .padding(.horizontal, 16)
-            }
-            .padding(.vertical, 12)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            legendRow
+                .padding(.horizontal, 16)
         }
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var heatmapGrid: some View {

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
@@ -10,7 +10,7 @@ struct ListeningHeatmapView: View {
     private let cellSpacing: CGFloat = 3
     private let dayLabelWidth: CGFloat = 24
     private let gridLeadingPadding: CGFloat = 4
-    private let gridTrailingPadding: CGFloat = 16
+    private let gridTrailingPadding: CGFloat = 8
     private let monthLabelHeight: CGFloat = 14
     private let monthLabelBottomPadding: CGFloat = 4
 
@@ -18,11 +18,6 @@ struct ListeningHeatmapView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(L10n.listeningActivity)
-                .font(size: 14, style: .subheadline, weight: .semibold)
-                .foregroundColor(theme.primaryText01)
-                .padding(.horizontal, 16)
-
             heatmapGrid
 
             legendRow

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapView.swift
@@ -5,8 +5,16 @@ struct ListeningHeatmapView: View {
     @EnvironmentObject private var theme: Theme
     @ObservedObject var viewModel: ListeningHeatmapViewModel
 
+    private let calendar = Calendar.current
     private let cellSize: CGFloat = 12
     private let cellSpacing: CGFloat = 3
+    private let dayLabelWidth: CGFloat = 24
+    private let gridLeadingPadding: CGFloat = 4
+    private let gridTrailingPadding: CGFloat = 16
+    private let monthLabelHeight: CGFloat = 14
+    private let monthLabelBottomPadding: CGFloat = 4
+
+    private var columnWidth: CGFloat { cellSize + cellSpacing }
 
     var body: some View {
         if viewModel.hasData {
@@ -26,54 +34,51 @@ struct ListeningHeatmapView: View {
         }
     }
 
-    // MARK: - Heatmap Grid
-
     private var heatmapGrid: some View {
-        ScrollViewReader { proxy in
-            ScrollView(.horizontal, showsIndicators: false) {
-                VStack(alignment: .leading, spacing: 0) {
-                    monthLabels
-                        .padding(.leading, dayLabelWidth + cellSpacing)
-                        .padding(.bottom, 4)
+        GeometryReader { geometry in
+            let visibleWeeks = computeVisibleWeeks(availableWidth: geometry.size.width)
+            VStack(alignment: .leading, spacing: 0) {
+                monthLabels(weeks: visibleWeeks)
+                    .padding(.leading, dayLabelWidth + cellSpacing)
+                    .padding(.bottom, monthLabelBottomPadding)
 
-                    HStack(alignment: .top, spacing: cellSpacing) {
-                        dayLabels
+                HStack(alignment: .top, spacing: cellSpacing) {
+                    dayLabels
 
-                        ForEach(Array(viewModel.weeks.enumerated()), id: \.offset) { weekIndex, week in
-                            VStack(spacing: cellSpacing) {
-                                ForEach(week) { day in
-                                    RoundedRectangle(cornerRadius: 2)
-                                        .fill(colorForIntensity(day.intensity))
-                                        .frame(width: cellSize, height: cellSize)
-                                }
+                    ForEach(visibleWeeks.indices, id: \.self) { weekIndex in
+                        VStack(spacing: cellSpacing) {
+                            ForEach(visibleWeeks[weekIndex]) { day in
+                                RoundedRectangle(cornerRadius: 2)
+                                    .fill(colorForIntensity(day.intensity))
+                                    .frame(width: cellSize, height: cellSize)
                             }
-                            .id(weekIndex)
                         }
                     }
                 }
-                .padding(.leading, 4)
-                .padding(.trailing, 16)
             }
-            .onAppear {
-                if !viewModel.weeks.isEmpty {
-                    proxy.scrollTo(viewModel.weeks.count - 1, anchor: .trailing)
-                }
-            }
+            .padding(.leading, gridLeadingPadding)
+            .padding(.trailing, gridTrailingPadding)
         }
+        .frame(height: gridHeight)
     }
 
-    // MARK: - Day Labels
+    private var gridHeight: CGFloat {
+        7 * cellSize + 6 * cellSpacing + monthLabelHeight + monthLabelBottomPadding
+    }
 
-    private let dayLabelWidth: CGFloat = 24
+    private func computeVisibleWeeks(availableWidth: CGFloat) -> [[HeatmapDay]] {
+        guard availableWidth > 0 else { return [] }
+        let usable = availableWidth - dayLabelWidth - cellSpacing - gridLeadingPadding - gridTrailingPadding
+        let maxVisible = max(0, Int((usable + cellSpacing) / columnWidth))
+        guard maxVisible > 0 else { return [] }
+        return Array(viewModel.weeks.suffix(maxVisible))
+    }
 
     private var dayLabels: some View {
-        let calendar = Calendar.current
         let symbols = calendar.shortWeekdaySymbols
-        // Label every other row starting from firstWeekday (rows 0, 2, 4, 6).
-        let labeledRows: Set<Int> = [0, 2, 4, 6]
         return VStack(spacing: cellSpacing) {
             ForEach(0..<7, id: \.self) { rowIndex in
-                if labeledRows.contains(rowIndex) {
+                if rowIndex % 2 == 0 {
                     let symbolIndex = (calendar.firstWeekday - 1 + rowIndex) % 7
                     Text(symbols[symbolIndex])
                         .font(size: 10, style: .caption2, weight: .regular)
@@ -87,15 +92,10 @@ struct ListeningHeatmapView: View {
         }
     }
 
-    // MARK: - Month Labels
-
-    private var monthLabels: some View {
-        let calendar = Calendar.current
-        let monthPositions = computeMonthPositions(calendar: calendar)
-        let columnWidth = cellSize + cellSpacing
-
+    private func monthLabels(weeks: [[HeatmapDay]]) -> some View {
+        let monthPositions = computeMonthPositions(weeks: weeks)
         return ZStack(alignment: .leading) {
-            Color.clear.frame(height: 14)
+            Color.clear.frame(height: monthLabelHeight)
 
             ForEach(monthPositions, id: \.weekIndex) { position in
                 Text(position.label)
@@ -105,8 +105,6 @@ struct ListeningHeatmapView: View {
             }
         }
     }
-
-    // MARK: - Legend
 
     private var legendRow: some View {
         HStack(spacing: 4) {
@@ -143,11 +141,11 @@ struct ListeningHeatmapView: View {
         let label: String
     }
 
-    private func computeMonthPositions(calendar: Calendar) -> [MonthPosition] {
+    private func computeMonthPositions(weeks: [[HeatmapDay]]) -> [MonthPosition] {
         var positions: [MonthPosition] = []
         let shortMonths = calendar.shortMonthSymbols
 
-        for (weekIndex, week) in viewModel.weeks.enumerated() {
+        for (weekIndex, week) in weeks.enumerated() {
             guard let firstDay = week.first else { continue }
             let day = calendar.component(.day, from: firstDay.date)
             if day <= 7 {

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
@@ -12,18 +12,34 @@ class ListeningHeatmapViewModel: ObservableObject {
     @Published var weeks: [[HeatmapDay]] = []
     @Published var hasData = false
 
-    private static let dateFormatter: DateFormatter = {
+    private let dataManager: DataManager
+    private let calendar: Calendar
+    private let now: Date
+    private let dateFormatter: DateFormatter
+
+    private let daysOfHistory = 365
+
+    init(
+        dataManager: DataManager = DataManager.sharedManager,
+        calendar: Calendar = .current,
+        now: Date = Date()
+    ) {
+        self.dataManager = dataManager
+        self.calendar = calendar
+        self.now = now
+
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        return formatter
-    }()
+        formatter.timeZone = calendar.timeZone
+        self.dateFormatter = formatter
+    }
 
     func load() {
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let self else { return }
 
-            let rawData = DataManager.sharedManager.dailyListeningTime(forLast: 365)
+            let rawData = self.dataManager.dailyListeningTime(forLast: self.daysOfHistory)
             let weeks = self.buildWeeks(from: rawData)
             let hasData = rawData.values.contains(where: { $0 > 0 })
 
@@ -34,35 +50,34 @@ class ListeningHeatmapViewModel: ObservableObject {
         }
     }
 
-    private func buildWeeks(from data: [String: Double]) -> [[HeatmapDay]] {
-        let calendar = Calendar.current
-        let today = calendar.startOfDay(for: Date())
+    func buildWeeks(from data: [String: Double]) -> [[HeatmapDay]] {
+        let today = calendar.startOfDay(for: now)
 
-        // Find the Sunday that starts the week containing the day 364 days ago
-        let startDay = calendar.date(byAdding: .day, value: -364, to: today)!
-        let weekday = calendar.component(.weekday, from: startDay)
-        // weekday: 1 = Sunday. We want to align to Sunday.
-        let startSunday = calendar.date(byAdding: .day, value: -(weekday - 1), to: startDay)!
+        // Align to the start of the week (locale-aware) containing the oldest day in the window.
+        let startDay = calendar.date(byAdding: .day, value: -(daysOfHistory - 1), to: today)!
+        let startOfWeek = calendar.dateInterval(of: .weekOfYear, for: startDay)!.start
 
-        // Build all days from startSunday to today
-        var allDays: [HeatmapDay] = []
-        var current = startSunday
+        var rawDays: [(date: Date, seconds: Double)] = []
+        var current = startOfWeek
         while current <= today {
-            let key = Self.dateFormatter.string(from: current)
-            let seconds = data[key] ?? 0
-            allDays.append(HeatmapDay(id: current, date: current, seconds: seconds, intensity: 0))
+            let key = dateFormatter.string(from: current)
+            rawDays.append((current, data[key] ?? 0))
             current = calendar.date(byAdding: .day, value: 1, to: current)!
         }
 
         // Compute intensity quartiles from non-zero days
-        let nonZeroValues = allDays.compactMap { $0.seconds > 0 ? $0.seconds : nil }.sorted()
+        let nonZeroValues = rawDays.compactMap { $0.seconds > 0 ? $0.seconds : nil }.sorted()
         let thresholds = quartileThresholds(from: nonZeroValues)
 
-        for i in allDays.indices {
-            allDays[i].intensity = intensityLevel(for: allDays[i].seconds, thresholds: thresholds)
+        let allDays = rawDays.map { day in
+            HeatmapDay(
+                date: day.date,
+                seconds: day.seconds,
+                intensity: intensityLevel(for: day.seconds, thresholds: thresholds)
+            )
         }
 
-        // Group into weeks (columns of 7 days, Sunday-Saturday)
+        // Group into weeks (columns of 7 days, aligned to calendar.firstWeekday).
         var weeks: [[HeatmapDay]] = []
         var week: [HeatmapDay] = []
         for day in allDays {

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
@@ -9,7 +9,7 @@ struct HeatmapDay: Identifiable {
     let intensity: Int // 0-4
 }
 
-class ListeningHeatmapViewModel: ObservableObject {
+final class ListeningHeatmapViewModel: ObservableObject {
     @Published var weeks: [[HeatmapDay]] = []
     @Published var hasData = false
 

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
@@ -61,7 +61,6 @@ final class ListeningHeatmapViewModel: ObservableObject {
         guard let startDay = calendar.date(byAdding: .day, value: -(daysOfHistory - 1), to: today),
               let startOfWeek = calendar.dateInterval(of: .weekOfYear, for: startDay)?.start else {
             assertionFailure("ListeningHeatmapViewModel: failed to compute heatmap date range")
-            FileLog.shared.addMessage("ListeningHeatmapViewModel: failed to compute heatmap date range")
             return []
         }
 
@@ -72,7 +71,6 @@ final class ListeningHeatmapViewModel: ObservableObject {
             rawDays.append((current, data[key] ?? 0))
             guard let next = calendar.date(byAdding: .day, value: 1, to: current) else {
                 assertionFailure("ListeningHeatmapViewModel: failed to advance date by one day")
-                FileLog.shared.addMessage("ListeningHeatmapViewModel: failed to advance date by one day")
                 return []
             }
             current = next

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
@@ -2,10 +2,10 @@ import Foundation
 import PocketCastsDataModel
 
 struct HeatmapDay: Identifiable {
-    let id: Date
+    var id: Date { date }
     let date: Date
     let seconds: Double
-    var intensity: Int // 0-4
+    let intensity: Int // 0-4
 }
 
 class ListeningHeatmapViewModel: ObservableObject {

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
@@ -12,6 +12,7 @@ struct HeatmapDay: Identifiable {
 final class ListeningHeatmapViewModel: ObservableObject {
     @Published private(set) var weeks: [[HeatmapDay]] = []
 
+    private var isLoading = false
     private let dataManager: DataManager
     private let calendar: Calendar
     private let now: Date
@@ -38,14 +39,16 @@ final class ListeningHeatmapViewModel: ObservableObject {
     }
 
     func load() {
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            guard let self else { return }
+        guard !isLoading else { return }
+        isLoading = true
 
+        DispatchQueue.global(qos: .userInitiated).async {
             let rawData = self.dataManager.dailyListeningTime(forLast: self.daysOfHistory)
             let weeks = self.buildWeeks(from: rawData)
 
             DispatchQueue.main.async {
                 self.weeks = weeks
+                self.isLoading = false
             }
         }
     }

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
@@ -16,7 +16,7 @@ final class ListeningHeatmapViewModel: ObservableObject {
 
     private var isLoading = false
     private let dataManager: DataManager
-    private let now: Date
+    private let now: () -> Date
     private let dateFormatter: DateFormatter
 
     // Make sure we have enough to cover the largest iPad screen
@@ -25,7 +25,7 @@ final class ListeningHeatmapViewModel: ObservableObject {
     init(
         dataManager: DataManager = DataManager.sharedManager,
         calendar: Calendar = .current,
-        now: Date = Date()
+        now: @escaping () -> Date = { Date() }
     ) {
         self.dataManager = dataManager
         self.calendar = calendar
@@ -56,7 +56,7 @@ final class ListeningHeatmapViewModel: ObservableObject {
     }
 
     func buildWeeks(from data: [String: Double]) -> [[HeatmapDay]] {
-        let today = calendar.startOfDay(for: now)
+        let today = calendar.startOfDay(for: now())
 
         // Align to the start of the week (locale-aware) containing the oldest day in the window.
         guard let startDay = calendar.date(byAdding: .day, value: -(daysOfHistory - 1), to: today),

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
@@ -2,11 +2,19 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsUtils
 
+enum HeatmapIntensity: CaseIterable {
+    case none
+    case minimal
+    case light
+    case moderate
+    case heavy
+}
+
 struct HeatmapDay: Identifiable {
     var id: Date { date }
     let date: Date
     let seconds: Double
-    let intensity: Int // 0-4
+    let intensity: HeatmapIntensity
 }
 
 final class ListeningHeatmapViewModel: ObservableObject {
@@ -116,12 +124,12 @@ final class ListeningHeatmapViewModel: ObservableObject {
         ]
     }
 
-    private func intensityLevel(for seconds: Double, thresholds: [Double]) -> Int {
-        guard seconds > 0 else { return 0 }
-        guard thresholds.count == 3 else { return 1 }
-        if seconds <= thresholds[0] { return 1 }
-        if seconds <= thresholds[1] { return 2 }
-        if seconds <= thresholds[2] { return 3 }
-        return 4
+    private func intensityLevel(for seconds: Double, thresholds: [Double]) -> HeatmapIntensity {
+        guard seconds > 0 else { return .none }
+        guard thresholds.count == 3 else { return .minimal }
+        if seconds <= thresholds[0] { return .minimal }
+        if seconds <= thresholds[1] { return .light }
+        if seconds <= thresholds[2] { return .moderate }
+        return .heavy
     }
 }

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
@@ -12,9 +12,10 @@ struct HeatmapDay: Identifiable {
 final class ListeningHeatmapViewModel: ObservableObject {
     @Published private(set) var weeks: [[HeatmapDay]] = []
 
+    let calendar: Calendar
+
     private var isLoading = false
     private let dataManager: DataManager
-    private let calendar: Calendar
     private let now: Date
     private let dateFormatter: DateFormatter
 

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
@@ -19,7 +19,8 @@ final class ListeningHeatmapViewModel: ObservableObject {
     private let now: Date
     private let dateFormatter: DateFormatter
 
-    private let daysOfHistory = 365
+    // Make sure we have enough to cover the largest iPad screen
+    private let daysOfHistory = 2 * 365
 
     init(
         dataManager: DataManager = DataManager.sharedManager,

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
@@ -10,8 +10,7 @@ struct HeatmapDay: Identifiable {
 }
 
 final class ListeningHeatmapViewModel: ObservableObject {
-    @Published var weeks: [[HeatmapDay]] = []
-    @Published var hasData = false
+    @Published private(set) var weeks: [[HeatmapDay]] = []
 
     private let dataManager: DataManager
     private let calendar: Calendar
@@ -34,6 +33,8 @@ final class ListeningHeatmapViewModel: ObservableObject {
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = calendar.timeZone
         self.dateFormatter = formatter
+
+        self.weeks = buildWeeks(from: [:])
     }
 
     func load() {
@@ -42,11 +43,9 @@ final class ListeningHeatmapViewModel: ObservableObject {
 
             let rawData = self.dataManager.dailyListeningTime(forLast: self.daysOfHistory)
             let weeks = self.buildWeeks(from: rawData)
-            let hasData = rawData.values.contains(where: { $0 > 0 })
 
             DispatchQueue.main.async {
                 self.weeks = weeks
-                self.hasData = hasData
             }
         }
     }

--- a/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
+++ b/podcasts/Profile - SwiftUI/Account/ListeningHeatmapViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsDataModel
+import PocketCastsUtils
 
 struct HeatmapDay: Identifiable {
     var id: Date { date }
@@ -54,15 +55,24 @@ class ListeningHeatmapViewModel: ObservableObject {
         let today = calendar.startOfDay(for: now)
 
         // Align to the start of the week (locale-aware) containing the oldest day in the window.
-        let startDay = calendar.date(byAdding: .day, value: -(daysOfHistory - 1), to: today)!
-        let startOfWeek = calendar.dateInterval(of: .weekOfYear, for: startDay)!.start
+        guard let startDay = calendar.date(byAdding: .day, value: -(daysOfHistory - 1), to: today),
+              let startOfWeek = calendar.dateInterval(of: .weekOfYear, for: startDay)?.start else {
+            assertionFailure("ListeningHeatmapViewModel: failed to compute heatmap date range")
+            FileLog.shared.addMessage("ListeningHeatmapViewModel: failed to compute heatmap date range")
+            return []
+        }
 
         var rawDays: [(date: Date, seconds: Double)] = []
         var current = startOfWeek
         while current <= today {
             let key = dateFormatter.string(from: current)
             rawDays.append((current, data[key] ?? 0))
-            current = calendar.date(byAdding: .day, value: 1, to: current)!
+            guard let next = calendar.date(byAdding: .day, value: 1, to: current) else {
+                assertionFailure("ListeningHeatmapViewModel: failed to advance date by one day")
+                FileLog.shared.addMessage("ListeningHeatmapViewModel: failed to advance date by one day")
+                return []
+            }
+            current = next
         }
 
         // Compute intensity quartiles from non-zero days

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -121,6 +121,7 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
             cell.contentConfiguration = UIHostingConfiguration {
                 ListeningHeatmapView(viewModel: heatmapViewModel)
                     .environmentObject(Theme.sharedTheme)
+                    .dynamicTypeSize(DynamicTypeSize.medium...DynamicTypeSize.accessibility2)
             }
             .margins(.all, 0)
             return cell

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -12,6 +12,23 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
     private enum LoadingStatus { case loading, loaded, failed }
     private var loadingState = LoadingStatus.loading
 
+    private enum StatsSection {
+        case header
+        case heatmap
+        case timeSavedBreakdown
+        case timeSavedTotal
+    }
+
+    private var sections: [StatsSection] {
+        guard loadingState == .loaded else { return [.header] }
+        var sections: [StatsSection] = [.header]
+        if FeatureFlag.statsHeatmap.enabled {
+            sections.append(.heatmap)
+        }
+        sections.append(contentsOf: [.timeSavedBreakdown, .timeSavedTotal])
+        return sections
+    }
+
     private var localOnly = !SyncManager.isUserLoggedIn()
 
     let playbackTimeHelper = PlaybackTimeHelper()
@@ -36,7 +53,9 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        heatmapViewModel.load()
+        if FeatureFlag.statsHeatmap.enabled {
+            heatmapViewModel.load()
+        }
         loadStats()
     }
 
@@ -45,35 +64,30 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
         Analytics.track(.statsDismissed)
     }
 
-    // MARK: - Sections
-    // Section 0: Header (total listening time)
-    // Section 1: Heatmap (listening activity graph)
-    // Section 2: Time Saved breakdown
-    // Section 3: Time Saved total
-
     func numberOfSections(in tableView: UITableView) -> Int {
-        loadingState == LoadingStatus.loaded ? 4 : 1
+        sections.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if section == 0 || section == 1 || section == 3 {
+        switch sections[section] {
+        case .header, .heatmap, .timeSavedTotal:
             return 1
+        case .timeSavedBreakdown:
+            return 4
         }
-
-        return 4
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerFrame = CGRect(x: 0, y: 0, width: 0, height: Constants.Values.tableSectionHeaderHeight)
 
-        if section == 1 {
+        switch sections[section] {
+        case .heatmap:
             return SettingsTableHeader(frame: headerFrame, title: L10n.statsListeningActivitySectionTitle)
-        }
-        if section == 2 {
+        case .timeSavedBreakdown:
             return SettingsTableHeader(frame: headerFrame, title: L10n.statsTimeSaved)
+        case .header, .timeSavedTotal:
+            return nil
         }
-
-        return nil
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -81,14 +95,17 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        if section == 0 {
+        switch sections[section] {
+        case .header:
             return UITableView.automaticDimension
+        default:
+            return 18
         }
-        return 18
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.section == 0 {
+        switch sections[indexPath.section] {
+        case .header:
             let castCell = tableView.dequeueReusableCell(withIdentifier: statsHeaderCellId, for: indexPath) as! StatsTopCell
             if loadingState == LoadingStatus.failed {
                 castCell.loadingIndicator.stopAnimating()
@@ -114,8 +131,7 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
                 castCell.accessibilityLabel = L10n.statsAccessibilityListenHistoryFormat(castCell.timeLabel.text ?? "", castCell.descriptionLabel.text ?? "")
             }
             return castCell
-        }
-        if indexPath.section == 1 {
+        case .heatmap:
             let cell = tableView.dequeueReusableCell(withIdentifier: heatmapCellId, for: indexPath)
             cell.contentConfiguration = UIHostingConfiguration {
                 ListeningHeatmapView(viewModel: heatmapViewModel)
@@ -124,8 +140,7 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
             }
             .margins(.all, 0)
             return cell
-        }
-        if indexPath.section == 2 {
+        case .timeSavedBreakdown:
             let castCell = tableView.dequeueReusableCell(withIdentifier: statsCellId, for: indexPath) as! StatsCell
             castCell.showIcon()
             if indexPath.row == 0 {
@@ -147,13 +162,14 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
             }
             castCell.statValue.style = .primaryText01
             return castCell
+        case .timeSavedTotal:
+            let castCell = tableView.dequeueReusableCell(withIdentifier: statsCellId, for: indexPath) as! StatsCell
+            castCell.statName.text = L10n.statsTotal
+            castCell.statValue.text = formatStat(skippedStat() + variableSpeedStat() + silenceRemovedStat() + autoSkipStat())
+            castCell.statValue.style = .support01
+            castCell.hideIcon()
+            return castCell
         }
-        let castCell = tableView.dequeueReusableCell(withIdentifier: statsCellId, for: indexPath) as! StatsCell
-        castCell.statName.text = L10n.statsTotal
-        castCell.statValue.text = formatStat(skippedStat() + variableSpeedStat() + silenceRemovedStat() + autoSkipStat())
-        castCell.statValue.style = .support01
-        castCell.hideIcon()
-        return castCell
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -161,14 +177,14 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        if indexPath.section == 0 {
+        switch sections[indexPath.section] {
+        case .header:
             return 200
-        }
-        if indexPath.section == 1 {
+        case .heatmap:
             return 180
+        case .timeSavedBreakdown, .timeSavedTotal:
+            return 44
         }
-
-        return 44
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -67,6 +67,9 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let headerFrame = CGRect(x: 0, y: 0, width: 0, height: Constants.Values.tableSectionHeaderHeight)
 
+        if section == 1 {
+            return SettingsTableHeader(frame: headerFrame, title: L10n.listeningActivity)
+        }
         if section == 2 {
             return SettingsTableHeader(frame: headerFrame, title: L10n.statsTimeSaved)
         }
@@ -116,7 +119,6 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
         if indexPath.section == 1 {
             let cell = tableView.dequeueReusableCell(withIdentifier: heatmapCellId, for: indexPath)
             cell.selectionStyle = .none
-            cell.backgroundColor = .clear
             cell.contentConfiguration = UIHostingConfiguration {
                 ListeningHeatmapView(viewModel: heatmapViewModel)
                     .environmentObject(Theme.sharedTheme)

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -67,7 +67,7 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
         let headerFrame = CGRect(x: 0, y: 0, width: 0, height: Constants.Values.tableSectionHeaderHeight)
 
         if section == 1 {
-            return SettingsTableHeader(frame: headerFrame, title: L10n.listeningActivity)
+            return SettingsTableHeader(frame: headerFrame, title: L10n.statsListeningActivitySectionTitle)
         }
         if section == 2 {
             return SettingsTableHeader(frame: headerFrame, title: L10n.statsTimeSaved)

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -21,7 +21,7 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
         didSet {
             statsTable.register(UINib(nibName: "StatsCell", bundle: nil), forCellReuseIdentifier: statsCellId)
             statsTable.register(UINib(nibName: "StatsTopCell", bundle: nil), forCellReuseIdentifier: statsHeaderCellId)
-            statsTable.register(UITableViewCell.self, forCellReuseIdentifier: heatmapCellId)
+            statsTable.register(UINib(nibName: "StatsCell", bundle: nil), forCellReuseIdentifier: heatmapCellId)
             statsTable.contentInset = UIEdgeInsets(top: -35, left: 0, bottom: Constants.Values.miniPlayerOffset, right: 0)
         }
     }
@@ -117,7 +117,6 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
         }
         if indexPath.section == 1 {
             let cell = tableView.dequeueReusableCell(withIdentifier: heatmapCellId, for: indexPath)
-            cell.selectionStyle = .none
             cell.contentConfiguration = UIHostingConfiguration {
                 ListeningHeatmapView(viewModel: heatmapViewModel)
                     .environmentObject(Theme.sharedTheme)

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -31,13 +31,12 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
 
         title = L10n.settingsStats
         Analytics.track(.statsShown)
-
-        heatmapViewModel.load()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        heatmapViewModel.load()
         loadStats()
     }
 

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -115,27 +115,13 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
         }
         if indexPath.section == 1 {
             let cell = tableView.dequeueReusableCell(withIdentifier: heatmapCellId, for: indexPath)
-            cell.contentView.subviews.forEach { $0.removeFromSuperview() }
             cell.selectionStyle = .none
             cell.backgroundColor = .clear
-
-            let heatmapView = ListeningHeatmapView(viewModel: heatmapViewModel)
-                .environmentObject(Theme.sharedTheme)
-            let hostingController = UIHostingController(rootView: heatmapView)
-            hostingController.view.backgroundColor = .clear
-            hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-
-            addChild(hostingController)
-            cell.contentView.addSubview(hostingController.view)
-            hostingController.didMove(toParent: self)
-
-            NSLayoutConstraint.activate([
-                hostingController.view.topAnchor.constraint(equalTo: cell.contentView.topAnchor),
-                hostingController.view.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
-                hostingController.view.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
-                hostingController.view.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor)
-            ])
-
+            cell.contentConfiguration = UIHostingConfiguration {
+                ListeningHeatmapView(viewModel: heatmapViewModel)
+                    .environmentObject(Theme.sharedTheme)
+            }
+            .margins(.all, 0)
             return cell
         }
         if indexPath.section == 2 {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -1710,10 +1710,6 @@ internal enum L10n {
   internal static var learnAboutRatings: String { return L10n.tr("Localizable", "learn_about_ratings", fallback: "Learn about ratings") }
   /// Text for a button where you learn more about a feature
   internal static var learnMore: String { return L10n.tr("Localizable", "learn_more", fallback: "Learn More") }
-  /// Label for the low end of the heatmap legend
-  internal static var less: String { return L10n.tr("Localizable", "less", fallback: "Less") }
-  /// Title for the listening activity heatmap on the account screen
-  internal static var listeningActivity: String { return L10n.tr("Localizable", "listening_activity", fallback: "Listening Activity") }
   /// A common string used throughout the app. Often refers to the Listening History screen.
   internal static var listeningHistory: String { return L10n.tr("Localizable", "listening_history", fallback: "Listening History") }
   /// Title for action to remove episode from listening history
@@ -1768,8 +1764,6 @@ internal enum L10n {
   internal static var month: String { return L10n.tr("Localizable", "month", fallback: "month") }
   /// Basic string used to callout payment intervals like yearly vs monthly
   internal static var monthly: String { return L10n.tr("Localizable", "monthly", fallback: "Monthly") }
-  /// Label for the high end of the heatmap legend
-  internal static var more: String { return L10n.tr("Localizable", "more", fallback: "More") }
   /// A title used to a show a list of the most popular podcasts in a category.
   internal static var mostPopular: String { return L10n.tr("Localizable", "most_popular", fallback: "Most Popular") }
   /// A title used to a show a list of the most popular podcasts in a category with the provided name of that category.
@@ -4059,6 +4053,12 @@ internal enum L10n {
   internal static var statsListenHistoryLoading: String { return L10n.tr("Localizable", "stats_listen_history_loading", fallback: "You’ve listened for") }
   /// Header for the cell displaying the time for how long they've listened to Pocket Casts.
   internal static var statsListenHistoryNoDate: String { return L10n.tr("Localizable", "stats_listen_history_no_date", fallback: "You’ve listened for") }
+  /// Label for the low end of the heatmap legend
+  internal static var statsListeningActivityLegendLess: String { return L10n.tr("Localizable", "stats_listening_activity_legend_less", fallback: "Less") }
+  /// Label for the high end of the heatmap legend
+  internal static var statsListeningActivityLegendMore: String { return L10n.tr("Localizable", "stats_listening_activity_legend_more", fallback: "More") }
+  /// Title for the listening activity heatmap on the account screen
+  internal static var statsListeningActivitySectionTitle: String { return L10n.tr("Localizable", "stats_listening_activity_section_title", fallback: "Listening Activity") }
   /// Row header that displays the amount of time saved from the Skip forward feature.
   internal static var statsSkipping: String { return L10n.tr("Localizable", "stats_skipping", fallback: "Skipping") }
   /// Section header that breaks down how much listening time has been saved across a variety of features.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4053,6 +4053,10 @@ internal enum L10n {
   internal static var statsListenHistoryLoading: String { return L10n.tr("Localizable", "stats_listen_history_loading", fallback: "You’ve listened for") }
   /// Header for the cell displaying the time for how long they've listened to Pocket Casts.
   internal static var statsListenHistoryNoDate: String { return L10n.tr("Localizable", "stats_listen_history_no_date", fallback: "You’ve listened for") }
+  /// VoiceOver label for the listening activity heatmap. '%1$@' is a placeholder for the number of days with listening activity out of the last 365.
+  internal static func statsListeningActivityAccessibilityLabel(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "stats_listening_activity_accessibility_label", String(describing: p1), fallback: "Listening activity heatmap. Days listened: %1$@ of 365.")
+  }
   /// Label for the low end of the heatmap legend
   internal static var statsListeningActivityLegendLess: String { return L10n.tr("Localizable", "stats_listening_activity_legend_less", fallback: "Less") }
   /// Label for the high end of the heatmap legend

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1223,13 +1223,13 @@
 "keycommand_play_pause" = "Play/Pause";
 
 /* Title for the listening activity heatmap on the account screen */
-"listening_activity" = "Listening Activity";
+"stats_listening_activity_section_title" = "Listening Activity";
 
 /* Label for the low end of the heatmap legend */
-"less" = "Less";
+"stats_listening_activity_legend_less" = "Less";
 
 /* Label for the high end of the heatmap legend */
-"more" = "More";
+"stats_listening_activity_legend_more" = "More";
 
 /* A common string used throughout the app. Often refers to the Listening History screen. */
 "listening_history" = "Listening History";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1231,6 +1231,9 @@
 /* Label for the high end of the heatmap legend */
 "stats_listening_activity_legend_more" = "More";
 
+/* VoiceOver label for the listening activity heatmap. '%1$@' is a placeholder for the number of days with listening activity out of the last 365. */
+"stats_listening_activity_accessibility_label" = "Listening activity heatmap. Days listened: %1$@ of 365.";
+
 /* A common string used throughout the app. Often refers to the Listening History screen. */
 "listening_history" = "Listening History";
 


### PR DESCRIPTION
- Show empty data when loading and if there is no listening history (previously was showing empty view
- Add accessibility support: voice-over, dynamic type
- Move `load` to `viewWillAppear` so it reloads as you enter the screen
- Make the grid layout dynamic so it always covers the available width
- Update localizable strings to use namespacing for keys
- Revert unrelated `Package.swift` change
- Switch to `UIHostingConfiguration` to avoid orphaned `UIHostingController` accumulating on cell reuse
- A couple of other minor changes

## To test

- Verify that the "Heatmap" shows your listening history

> [!WARNING]  
> The current algorithm used in `dailyListeningTime` has a major issue. I'm considering hiding this feature under a FF for now until there is a resolution. In addition, I still need to verify if it correctly handles the timezones.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

## Screenshots

<img width="350" alt="Screenshot 2026-04-20 at 3 47 31 PM" src="https://github.com/user-attachments/assets/65def3b6-1d47-4d13-bb45-7a563294e017" />
<img width="350" alt="Screenshot 2026-04-20 at 3 47 33 PM" src="https://github.com/user-attachments/assets/10b464c1-a414-4bc1-8568-3a9dac5b6555" />
<img width="350"  alt="Screenshot 2026-04-20 at 3 47 49 PM" src="https://github.com/user-attachments/assets/b2ca7298-7bf5-4c7e-a158-178fd1ce8032" />
<img width="350"  alt="Screenshot 2026-04-20 at 4 51 01 PM" src="https://github.com/user-attachments/assets/2b1d8fc7-bc66-4487-8525-cd34671e49e2" />

### iPad

<img width="1320" height="999" alt="Screenshot 2026-04-20 at 4 03 53 PM" src="https://github.com/user-attachments/assets/e8691630-7575-485c-a2df-d96bb8478883" />
<img width="946" height="1373" alt="Screenshot 2026-04-20 at 4 03 56 PM" src="https://github.com/user-attachments/assets/0c286f0c-dc37-49be-98e6-016d86075b39" />

### Dynamic Type

<img width="1661" height="1122" alt="Screenshot 2026-04-20 at 3 45 52 PM" src="https://github.com/user-attachments/assets/7a79a812-499e-4ff1-b064-d24408174583" />
