### PR TITLE
Update playback error banner message to more generic string

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1010,8 +1010,8 @@ class PlaybackManager: ServerPlaybackDelegate {
                 return L10n.playerErrorCorruptedFile
             case .chromecastError:
                 return L10n.chromecastError
-            case .playbackError(_, let isLocalFile):
-                return isLocalFile ? L10n.playerErrorCorruptedFile : L10n.playerErrorInternetConnection
+            case .playbackError:
+                return L10n.playerErrorShortPlaybackError
             }
         }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2404,6 +2404,8 @@ internal enum L10n {
   internal static var playerErrorInternetConnection: String { return L10n.tr("Localizable", "player_error_internet_connection", fallback: "Check your Internet connection and try again.") }
   /// Generic error used when no internet connection is available.
   internal static var playerErrorShortNoConnection: String { return L10n.tr("Localizable", "player_error_short_no_connection", fallback: "You’re offline") }
+  /// Generic error used when playback fails.
+  internal static var playerErrorShortPlaybackError: String { return L10n.tr("Localizable", "player_error_short_playback_error", fallback: "Playback failed, please try again") }
   /// Accessibility label for the player control that fast-forwards the current playback position by a customizable time.
   internal static var playerIncrementTime: String { return L10n.tr("Localizable", "player_increment_time", fallback: "Increment time") }
   /// Confirmation prompt for marking an episode as played.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5865,3 +5865,6 @@
 
 /* Generic error used when no internet connection is available. */
 "player_error_short_no_connection" = "You’re offline";
+
+/* Generic error used when playback fails. */
+"player_error_short_playback_error" = "Playback failed, please try again";


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

This PR just updates the playback error to a shorter more generic message.
Discussed [here](https://a8c.slack.com/archives/C0AJ0GPFYLF/p1776766685943309)

## To test

1. Start the app on the simulator
2. Ensure that you have `displayErrorsOnPlayer` FF On
3. Add the [Test Podcast](https://pca.st/private/25cc6130-0a1b-013f-b6fa-0affe8d08c2d) to your account
4. Open the Test Podcast
5. Try to play episode 5 ( timeout)
7.  Check that you see an error banner showing on the bottom that says: "Playback failed, please try again"

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
