### PR TITLE
Enable SwiftLint rule: prefer_zero_over_explicit_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -53,6 +53,9 @@ only_rules:
   # the declaration.
   - opening_brace
 
+  # Prefer `0` over explicit `Int(0)` / `CGFloat(0)` etc.
+  - prefer_zero_over_explicit_init
+
   # Files should have a single trailing newline.
   - trailing_newline
 

--- a/Modules/Sources/PocketCastsUtils/Extensions/UI/GradientView.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/UI/GradientView.swift
@@ -43,7 +43,7 @@ public class GradientView: UIView {
         ]
 
         gradientLayer.locations = [0, 1]
-        gradientLayer.startPoint = CGPoint(x: 0, y: 0)
+        gradientLayer.startPoint = CGPoint.zero
         gradientLayer.endPoint = CGPoint(x: 0, y: 1)
         gradientLayer.frame = bounds
         layer.addSublayer(gradientLayer)

--- a/podcasts/ChangeEmailViewController.swift
+++ b/podcasts/ChangeEmailViewController.swift
@@ -291,7 +291,7 @@ class ChangeEmailViewController: PCViewController, UITextFieldDelegate {
     }
 
     @objc func keyboardWillHide(notification: NSNotification) {
-        scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        scrollView.contentInset = UIEdgeInsets.zero
         var animationDuration = 0.3
         if let keyboardDuration = (notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double) {
             animationDuration = keyboardDuration

--- a/podcasts/ChangePasswordViewController.swift
+++ b/podcasts/ChangePasswordViewController.swift
@@ -330,7 +330,7 @@ class ChangePasswordViewController: PCViewController, UITextFieldDelegate {
     }
 
     @objc func keyboardWillHide(notification: NSNotification) {
-        scrollView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        scrollView.contentInset = UIEdgeInsets.zero
         var animationDuration = 0.3
         if let keyboardDuration = (notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double) {
             animationDuration = keyboardDuration

--- a/podcasts/GridLayout.swift
+++ b/podcasts/GridLayout.swift
@@ -34,7 +34,7 @@ extension GridLayoutDelegate {
     }
 
     func sizeForItem(inCollectionView collectionView: UICollectionView, withLayout layout: UICollectionViewLayout, atIndexPath indexPath: IndexPath) -> CGSize {
-        CGSize(width: 0, height: 0)
+        CGSize.zero
     }
 }
 

--- a/podcasts/PlayerContainerViewController+Update.swift
+++ b/podcasts/PlayerContainerViewController+Update.swift
@@ -37,7 +37,7 @@ extension PlayerContainerViewController {
             return
         }
 
-        mainScrollView.setContentOffset(CGPoint(x: 0, y: 0), animated: false)
+        mainScrollView.setContentOffset(CGPoint.zero, animated: false)
         tabsView.currentTab = 0
         showNotesItem.removeFromParent()
         showNotesItem.view.removeFromSuperview()

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -104,7 +104,7 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
         }
     }
 
-    var initialTouchPoint = CGPoint(x: 0, y: 0)
+    var initialTouchPoint = CGPoint.zero
 
     var showingChapters = false
     var showingNotes = false

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -220,7 +220,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
     @objc private func checkForScrollTap(_ notification: Notification) {
         if let index = notification.object as? Int, index == tabBarItem.tag, profileTable.contentOffset.y > 0 {
-            profileTable.setContentOffset(CGPoint(x: 0, y: 0), animated: true)
+            profileTable.setContentOffset(CGPoint.zero, animated: true)
         }
     }
 

--- a/podcasts/VideoViewController.swift
+++ b/podcasts/VideoViewController.swift
@@ -359,7 +359,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     // The closeOverlay and controlOverlay are anchored to the safe area
     // when we move the view the overlays flicker
     // To prevent this, anchor to the view instead of the safe area
-    var initialTouchPoint = CGPoint(x: 0, y: 0)
+    var initialTouchPoint = CGPoint.zero
 
     private static let pullDownThreshold: CGFloat = 100
 


### PR DESCRIPTION
## What

Enables the [`prefer_zero_over_explicit_init`](https://realm.github.io/SwiftLint/prefer_zero_over_explicit_init.html) SwiftLint rule, which flags explicit zero-valued initializers (e.g. `CGPoint(x: 0, y: 0)`, `CGRect(x: 0, y: 0, width: 0, height: 0)`) and suggests the shorter `.zero` constant.

## Changes

- `.swiftlint.yml`: added `prefer_zero_over_explicit_init` to `only_rules` (alphabetical).
- 8 Swift files auto-fixed by `make format`.
- No manual fixes required.

## Campaign

Part of the [Orchard](https://github.com/Automattic/orchard-swiftlint) SwiftLint rollout campaign: enabling more rules across Automattic iOS repositories one rule and one PR at a time.

## Testing

The rewrite is type-preserving (`.zero` evaluates to the same literal value as the explicit form), so local build verification is deferred to CI — matching the precedent set by the `toggle_bool` step on this repo.