### PR TITLE
POC-507: 0.9 Debug overlay, DEBUG-only

### DIFF
--- a/podcasts/Fingerprint/FingerprintDebugOverlay.swift
+++ b/podcasts/Fingerprint/FingerprintDebugOverlay.swift
@@ -21,7 +21,11 @@ class FingerprintDebugOverlay: UIView {
 
     func update() {
         entries = FingerprintTimingManager.shared.debugMappingSnapshot()
-        totalDuration = FingerprintTimingManager.shared.totalDuration ?? 0
+        // Fingerprint generation may not have started yet (no context → nil duration).
+        // Fall back to the episode's duration so the playback cursor and tap-to-seek
+        // work regardless of fingerprint state.
+        let fingerprintDuration = FingerprintTimingManager.shared.totalDuration ?? 0
+        totalDuration = fingerprintDuration > 0 ? fingerprintDuration : PlaybackManager.shared.duration()
         playbackPosition = PlaybackManager.shared.currentTime()
         setNeedsDisplay()
     }

--- a/podcasts/Fingerprint/FingerprintDebugOverlay.swift
+++ b/podcasts/Fingerprint/FingerprintDebugOverlay.swift
@@ -1,0 +1,65 @@
+#if DEBUG
+import UIKit
+
+class FingerprintDebugOverlay: UIView {
+
+    private var entries: [FingerprintTimingManager.TimeMappingEntry] = []
+    private var totalDuration: Double = 0
+    private var playbackPosition: Double = 0
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .black
+        layer.cornerRadius = 4
+        clipsToBounds = true
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap(_:))))
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update() {
+        entries = FingerprintTimingManager.shared.debugMappingSnapshot()
+        totalDuration = FingerprintTimingManager.shared.totalDuration ?? 0
+        playbackPosition = PlaybackManager.shared.currentTime()
+        setNeedsDisplay()
+    }
+
+    @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
+        guard totalDuration > 0 else { return }
+        let x = gesture.location(in: self).x
+        let time = Double(x / bounds.width) * totalDuration
+        PlaybackManager.shared.seekTo(time: max(0, time))
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard totalDuration > 0 else { return }
+
+        let ctx = UIGraphicsGetCurrentContext()
+
+        for entry in entries {
+            let x = CGFloat(entry.playbackTime / totalDuration) * rect.width
+            let segmentWidth = max(CGFloat(2.0 / totalDuration) * rect.width, 2)
+
+            let color: UIColor
+            if entry.score >= FingerprintConstants.debugOverlayHighScoreThreshold {
+                color = .systemGreen
+            } else if entry.score >= FingerprintConstants.debugOverlayMediumScoreThreshold {
+                color = .systemOrange
+            } else {
+                color = .systemRed
+            }
+
+            ctx?.setFillColor(color.cgColor)
+            ctx?.fill(CGRect(x: x, y: 0, width: segmentWidth, height: rect.height))
+        }
+
+        if playbackPosition > 0 {
+            let px = CGFloat(playbackPosition / totalDuration) * rect.width
+            ctx?.setFillColor(UIColor.white.cgColor)
+            ctx?.fill(CGRect(x: px - 1, y: 0, width: 2, height: rect.height))
+        }
+    }
+}
+#endif

--- a/podcasts/Fingerprint/FingerprintDebugOverlay.swift
+++ b/podcasts/Fingerprint/FingerprintDebugOverlay.swift
@@ -31,10 +31,10 @@ class FingerprintDebugOverlay: UIView {
     }
 
     @objc private func handleTap(_ gesture: UITapGestureRecognizer) {
-        guard totalDuration > 0 else { return }
+        guard totalDuration > 0, bounds.width > 0 else { return }
         let x = gesture.location(in: self).x
         let time = Double(x / bounds.width) * totalDuration
-        PlaybackManager.shared.seekTo(time: max(0, time))
+        PlaybackManager.shared.seekTo(time: min(max(0, time), totalDuration))
     }
 
     override func draw(_ rect: CGRect) {

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -38,6 +38,13 @@ final class FingerprintTimingManager: NSObject {
     struct TimeMappingEntry {
         let playbackTime: Double
         let referenceTime: Double
+        let score: Float
+
+        init(playbackTime: Double, referenceTime: Double, score: Float = 0) {
+            self.playbackTime = playbackTime
+            self.referenceTime = referenceTime
+            self.score = score
+        }
     }
 
     // MARK: - Private State
@@ -104,6 +111,18 @@ final class FingerprintTimingManager: NSObject {
             )
         }
     }
+
+    #if DEBUG
+    var totalDuration: Double? {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+        return queue.sync { context?.duration }
+    }
+
+    func debugMappingSnapshot() -> [TimeMappingEntry] {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+        return queue.sync { playbackToReference }
+    }
+    #endif
 
     // MARK: - Notification Handlers
 
@@ -389,7 +408,8 @@ final class FingerprintTimingManager: NSObject {
 
             insertMapping(TimeMappingEntry(
                 playbackTime: batchStartTime + Double(window.timestampMs) / 1000.0,
-                referenceTime: Double(best.timestamp)
+                referenceTime: Double(best.timestamp),
+                score: best.score
             ))
             inserted += 1
         }

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -23,6 +23,11 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
     private var transcriptManager: TranscriptManager?
 
+    #if DEBUG
+    private var debugOverlay: FingerprintDebugOverlay?
+    private var debugTimer: Timer?
+    #endif
+
     private var transcriptViewTopConstraint: NSLayoutConstraint?
     private var topGradientTopConstraint: NSLayoutConstraint?
     private var topGradientHeightConstraint: NSLayoutConstraint?
@@ -170,6 +175,24 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         )
 
         view.addSubview(hiddenTextView)
+
+        #if DEBUG
+        let overlay = FingerprintDebugOverlay()
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(overlay)
+        NSLayoutConstraint.activate([
+            overlay.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            overlay.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            overlay.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8),
+            overlay.heightAnchor.constraint(equalToConstant: 12)
+        ])
+        debugOverlay = overlay
+        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak overlay] _ in
+            overlay?.update()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        debugTimer = timer
+        #endif
 
         stackView.addArrangedSubview(closeButton)
         stackView.addArrangedSubview(UIView())
@@ -432,6 +455,10 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
     override func willBeRemovedFromPlayer() {
         removeAllCustomObservers()
+        #if DEBUG
+        debugTimer?.invalidate()
+        debugTimer = nil
+        #endif
     }
 
     override func themeDidChange() {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -187,11 +187,6 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             overlay.heightAnchor.constraint(equalToConstant: 12)
         ])
         debugOverlay = overlay
-        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak overlay] _ in
-            overlay?.update()
-        }
-        RunLoop.main.add(timer, forMode: .common)
-        debugTimer = timer
         #endif
 
         stackView.addArrangedSubview(closeButton)
@@ -451,6 +446,13 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         loadTranscript()
         addObservers()
         (transcriptView as UIScrollView).delegate = self
+        #if DEBUG
+        let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
+            self?.debugOverlay?.update()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        debugTimer = timer
+        #endif
     }
 
     override func willBeRemovedFromPlayer() {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/POC-507/09-debug-overlay-debug-only

## Summary
Add a DEBUG-only fingerprint confidence overlay that visualizes matching quality across the episode timeline as a horizontal color-coded bar with a playhead indicator.

## Changes
- Added `score` property to `FingerprintTimingManager.TimeMappingEntry` (with default value of 0 to preserve backward compatibility with tests)
- Added `debugMappingSnapshot()` and `totalDuration` to `FingerprintTimingManager` (behind `#if DEBUG`)
- Created `podcasts/Fingerprint/FingerprintDebugOverlay.swift` — a `UIView` that draws green/orange/red segments based on `FingerprintConstants` thresholds, a white playhead line, and supports tap-to-seek

## Verification
- **Lint**: PASS — `make format` applied, no issues
- **Tests**: PASS — all `FingerprintTimingManagerTests` pass
- **Diff review**: PASS — minimal changes, no unintended modifications, no secrets
- **Secret scan**: PASS — no credentials in diff

## Confidence
**HIGH** — Matches the reference implementation from `poc/transcripts-ai-enablement` while using `FingerprintConstants` thresholds instead of hardcoded values, and all existing tests pass.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/POC-507/09-debug-overlay-debug-only)