### PR TITLE
Fix Now Playing showing podcast author instead of podcast title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Fix an issue with Playlist not reloading after archiving entries during empty search [#4136](https://github.com/Automattic/pocket-casts-ios/pull/4136)
 - Fix smart playlist not refreshing when clearing search field [#4138](https://github.com/Automattic/pocket-casts-ios/pull/4138)
+- Fix Now Playing showing podcast author instead of podcast title [#4168](https://github.com/Automattic/pocket-casts-ios/pull/4168)
 
 8.10
 -----

--- a/podcasts/NowPlayingHelper.swift
+++ b/podcasts/NowPlayingHelper.swift
@@ -82,10 +82,9 @@ class NowPlayingHelper {
         if let episode = episode as? Episode, let parentPodcast = episode.parentPodcast() {
             // some car stereo's do weird things with the % character, so here we replace it with pct to work around those bugs
             let safeCharacterPodcastTitle = parentPodcast.title?.replacingOccurrences(of: "%", with: "pct") ?? "Pocket Casts"
-            let safeCharacterPodcastAuthor = parentPodcast.author?.replacingOccurrences(of: "%", with: "pct") ?? "Pocket Casts"
 
-            nowPlayingInfo[MPMediaItemPropertyArtist] = safeCharacterPodcastAuthor as NSString
-            nowPlayingInfo[MPMediaItemPropertyComposer] = safeCharacterPodcastAuthor as NSString
+            nowPlayingInfo[MPMediaItemPropertyArtist] = safeCharacterPodcastTitle as NSString
+            nowPlayingInfo[MPMediaItemPropertyComposer] = safeCharacterPodcastTitle as NSString
 
             // we purposely show the date here instead, but as with the above there's a car stereo bug we need to work around as well where we don't show the word "Wednesday" in the artist field
             // because on some car stereos that have embedded image databases, this comes up with a really grotesque image (more info: https://github.com/shiftyjelly/pocketcasts-ios/issues/3874)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-608.

"Apple Podcasts" does the same thing (shows podcast title).

## To test

- Follow steps form the ticket

## Screenshots 


<img width="360"  alt="IMG_7086" src="https://github.com/user-attachments/assets/25eaf31d-7511-4ff9-831b-2c04285b61f2" />



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
