### PR TITLE
POC-530: 1.0 Fetch server-provided fingerprint reference

### DIFF
--- a/podcasts/Fingerprint/FingerprintReferenceRetriever.swift
+++ b/podcasts/Fingerprint/FingerprintReferenceRetriever.swift
@@ -41,7 +41,16 @@ actor FingerprintReferenceRetriever {
             try Task.checkCancellation()
             if attempt > 0 {
                 let delay = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
-                try? await Task.sleep(nanoseconds: delay)
+                do {
+                    try await Task.sleep(nanoseconds: delay)
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    FileLog.shared.addMessage(
+                        "FingerprintReferenceRetriever: retry delay failed for \(episodeUuid) — \(error.localizedDescription)"
+                    )
+                    return nil
+                }
             }
 
             do {

--- a/podcasts/Fingerprint/FingerprintReferenceRetriever.swift
+++ b/podcasts/Fingerprint/FingerprintReferenceRetriever.swift
@@ -1,0 +1,169 @@
+import Compression
+import Foundation
+import PocketCastsServer
+import PocketCastsUtils
+
+actor FingerprintReferenceRetriever {
+
+    static let shared = FingerprintReferenceRetriever()
+
+    private var inFlightRequests: [String: Task<Data?, Never>] = [:]
+    private static let maxRetries = 3
+
+    func fetchReferenceData(podcastUuid: String, episodeUuid: String) async -> Data? {
+        let key = "\(podcastUuid)/\(episodeUuid)"
+
+        if let existing = inFlightRequests[key] {
+            return await existing.value
+        }
+
+        let task = Task<Data?, Never> {
+            await performFetch(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+        }
+
+        inFlightRequests[key] = task
+        let result = await task.value
+        inFlightRequests[key] = nil
+        return result
+    }
+
+    private func performFetch(podcastUuid: String, episodeUuid: String) async -> Data? {
+        let urlString = "\(ServerConstants.Urls.generatedTranscripts)\(podcastUuid)/\(episodeUuid)-fingerprints.json.gz"
+        guard let url = URL(string: urlString) else {
+            FileLog.shared.addMessage("FingerprintReferenceRetriever: invalid URL for \(episodeUuid)")
+            return nil
+        }
+
+        for attempt in 0..<Self.maxRetries {
+            if attempt > 0 {
+                let delay = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
+                try? await Task.sleep(nanoseconds: delay)
+            }
+
+            do {
+                let (data, response) = try await URLSession.shared.data(from: url)
+                let statusCode = response.extractStatusCode()
+
+                if statusCode == ServerConstants.HttpConstants.notFound {
+                    FileLog.shared.addMessage("FingerprintReferenceRetriever: no reference for \(episodeUuid) (404)")
+                    return nil
+                }
+
+                guard statusCode == ServerConstants.HttpConstants.ok else {
+                    if statusCode >= ServerConstants.HttpConstants.serverError {
+                        FileLog.shared.addMessage(
+                            "FingerprintReferenceRetriever: server error \(statusCode) for \(episodeUuid), "
+                                + "attempt \(attempt + 1)/\(Self.maxRetries)"
+                        )
+                        continue
+                    }
+                    FileLog.shared.addMessage(
+                        "FingerprintReferenceRetriever: unexpected status \(statusCode) for \(episodeUuid)"
+                    )
+                    return nil
+                }
+
+                guard let jsonData = Self.decompressGzipIfNeeded(data) else {
+                    FileLog.shared.addMessage("FingerprintReferenceRetriever: decompression failed for \(episodeUuid)")
+                    return nil
+                }
+
+                FileLog.shared.addMessage(
+                    "FingerprintReferenceRetriever: reference fetched for \(episodeUuid) (\(jsonData.count) bytes)"
+                )
+                return jsonData
+            } catch {
+                if Self.isTransientError(error) {
+                    FileLog.shared.addMessage(
+                        "FingerprintReferenceRetriever: transient error for \(episodeUuid), "
+                            + "attempt \(attempt + 1)/\(Self.maxRetries) — \(error.localizedDescription)"
+                    )
+                    continue
+                }
+                FileLog.shared.addMessage(
+                    "FingerprintReferenceRetriever: fetch failed for \(episodeUuid) — \(error.localizedDescription)"
+                )
+                return nil
+            }
+        }
+
+        FileLog.shared.addMessage("FingerprintReferenceRetriever: exhausted retries for \(episodeUuid)")
+        return nil
+    }
+
+    // MARK: - Gzip Decompression
+
+    static func decompressGzipIfNeeded(_ data: Data) -> Data? {
+        guard data.count >= 2 else { return data }
+
+        if data[data.startIndex] == 0x1f, data[data.startIndex + 1] == 0x8b {
+            return decompressGzip(data)
+        }
+
+        return data
+    }
+
+    private static func decompressGzip(_ data: Data) -> Data? {
+        guard data.count >= 10 else { return nil }
+
+        var offset = 10
+        let flags = data[data.startIndex + 3]
+
+        if flags & 0x04 != 0 {
+            guard data.count > offset + 2 else { return nil }
+            let extraLen = Int(data[data.startIndex + offset])
+                | (Int(data[data.startIndex + offset + 1]) << 8)
+            offset += 2 + extraLen
+        }
+        if flags & 0x08 != 0 {
+            while offset < data.count, data[data.startIndex + offset] != 0 { offset += 1 }
+            offset += 1
+        }
+        if flags & 0x10 != 0 {
+            while offset < data.count, data[data.startIndex + offset] != 0 { offset += 1 }
+            offset += 1
+        }
+        if flags & 0x02 != 0 { offset += 2 }
+
+        guard data.count > offset + 8 else { return nil }
+
+        let isizeOffset = data.startIndex + data.count - 4
+        let isize = Int(data[isizeOffset])
+            | (Int(data[isizeOffset + 1]) << 8)
+            | (Int(data[isizeOffset + 2]) << 16)
+            | (Int(data[isizeOffset + 3]) << 24)
+
+        let compressedSlice = data[(data.startIndex + offset)..<(data.startIndex + data.count - 8)]
+        let bufferSize = min(max(isize, compressedSlice.count * 4), 50_000_000)
+        guard bufferSize > 0 else { return nil }
+
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+
+        let decompressedSize = compressedSlice.withUnsafeBytes { rawBuffer -> Int in
+            guard let baseAddress = rawBuffer.baseAddress else { return 0 }
+            return compression_decode_buffer(
+                buffer,
+                bufferSize,
+                baseAddress.assumingMemoryBound(to: UInt8.self),
+                compressedSlice.count,
+                nil,
+                COMPRESSION_ZLIB
+            )
+        }
+
+        guard decompressedSize > 0 else { return nil }
+        return Data(bytes: buffer, count: decompressedSize)
+    }
+
+    private static func isTransientError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain else { return false }
+        return [
+            NSURLErrorTimedOut,
+            NSURLErrorNetworkConnectionLost,
+            NSURLErrorNotConnectedToInternet,
+            NSURLErrorCannotConnectToHost,
+        ].contains(nsError.code)
+    }
+}

--- a/podcasts/Fingerprint/FingerprintReferenceRetriever.swift
+++ b/podcasts/Fingerprint/FingerprintReferenceRetriever.swift
@@ -7,27 +7,30 @@ actor FingerprintReferenceRetriever {
 
     static let shared = FingerprintReferenceRetriever()
 
-    private var inFlightRequests: [String: Task<Data?, Never>] = [:]
+    private var inFlightRequests: [String: Task<Data?, any Error>] = [:]
     private static let maxRetries = 3
 
     func fetchReferenceData(podcastUuid: String, episodeUuid: String) async -> Data? {
         let key = "\(podcastUuid)/\(episodeUuid)"
 
         if let existing = inFlightRequests[key] {
-            return await existing.value
+            return try? await existing.value
         }
 
-        let task = Task<Data?, Never> {
-            await performFetch(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+        let task = Task<Data?, any Error> {
+            try await performFetch(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
         }
 
         inFlightRequests[key] = task
-        let result = await task.value
-        inFlightRequests[key] = nil
-        return result
+        defer { inFlightRequests[key] = nil }
+        return await withTaskCancellationHandler {
+            try? await task.value
+        } onCancel: {
+            task.cancel()
+        }
     }
 
-    private func performFetch(podcastUuid: String, episodeUuid: String) async -> Data? {
+    private func performFetch(podcastUuid: String, episodeUuid: String) async throws -> Data? {
         let urlString = "\(ServerConstants.Urls.generatedTranscripts)\(podcastUuid)/\(episodeUuid)-fingerprints.json.gz"
         guard let url = URL(string: urlString) else {
             FileLog.shared.addMessage("FingerprintReferenceRetriever: invalid URL for \(episodeUuid)")
@@ -35,6 +38,7 @@ actor FingerprintReferenceRetriever {
         }
 
         for attempt in 0..<Self.maxRetries {
+            try Task.checkCancellation()
             if attempt > 0 {
                 let delay = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
                 try? await Task.sleep(nanoseconds: delay)
@@ -72,6 +76,8 @@ actor FingerprintReferenceRetriever {
                     "FingerprintReferenceRetriever: reference fetched for \(episodeUuid) (\(jsonData.count) bytes)"
                 )
                 return jsonData
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 if Self.isTransientError(error) {
                     FileLog.shared.addMessage(

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -171,6 +171,11 @@ final class FingerprintTimingManager: NSObject {
     private func prepareForEpisode(_ episode: BaseEpisode?) {
         updateState(.idle)
 
+        guard FeatureFlag.syncedTranscripts.enabled else {
+            updateState(.unavailable)
+            return
+        }
+
         guard let episode else {
             updateState(.unavailable)
             return
@@ -178,11 +183,40 @@ final class FingerprintTimingManager: NSObject {
 
         let uuid = episode.uuid
 
-        guard let reference = loadReference(for: episode) else {
-            updateState(.unavailable)
-            FileLog.shared.addMessage("FingerprintTimingManager: no reference fingerprint for \(uuid)")
+        if let reference = loadReference(for: episode) {
+            configureForReference(reference, episode: episode)
             return
         }
+
+        updateState(.preparing)
+        FileLog.shared.addMessage("FingerprintTimingManager: fetching reference from server for \(uuid)")
+
+        let flag = cancellationFlag
+        Task { [weak self] in
+            guard !flag.isCancelled else { return }
+
+            let data = await FingerprintReferenceRetriever.shared.fetchReferenceData(
+                podcastUuid: episode.parentIdentifier(),
+                episodeUuid: uuid
+            )
+
+            self?.queue.async { [weak self] in
+                guard let self, !flag.isCancelled else { return }
+
+                guard let data, let reference = ReferenceFingerprint.decode(from: data) else {
+                    self.updateState(.unavailable)
+                    FileLog.shared.addMessage("FingerprintTimingManager: no reference available for \(uuid)")
+                    return
+                }
+
+                self.saveReferenceData(data, for: episode)
+                self.configureForReference(reference, episode: episode)
+            }
+        }
+    }
+
+    private func configureForReference(_ reference: ReferenceFingerprint, episode: BaseEpisode) {
+        let uuid = episode.uuid
 
         guard let audioFileURL = resolveAudioFileURL(for: episode) else {
             updateState(.unavailable)
@@ -484,10 +518,24 @@ final class FingerprintTimingManager: NSObject {
     // MARK: - Helpers
 
     private func loadReference(for episode: BaseEpisode) -> ReferenceFingerprint? {
-        let audioPath = DownloadManager.shared.pathForEpisode(episode)
-        let fpPath = (audioPath as NSString).deletingPathExtension + ".fp.json"
-        guard let data = FileManager.default.contents(atPath: fpPath) else { return nil }
+        let path = referencePath(for: episode)
+        guard let data = FileManager.default.contents(atPath: path) else { return nil }
         return ReferenceFingerprint.decode(from: data)
+    }
+
+    private func referencePath(for episode: BaseEpisode) -> String {
+        let audioPath = DownloadManager.shared.pathForEpisode(episode)
+        return (audioPath as NSString).deletingPathExtension + ".ref.fp.json"
+    }
+
+    private func saveReferenceData(_ data: Data, for episode: BaseEpisode) {
+        let path = referencePath(for: episode)
+        do {
+            try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+            FileLog.shared.addMessage("FingerprintTimingManager: saved reference to disk for \(episode.uuid)")
+        } catch {
+            FileLog.shared.addMessage("FingerprintTimingManager: failed to save reference — \(error.localizedDescription)")
+        }
     }
 
     private func resolveAudioFileURL(for episode: BaseEpisode) -> URL? {

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -56,6 +56,7 @@ final class FingerprintTimingManager: NSObject {
     )
     private var context: GenerationContext?
     private var cancellationFlag = CancellationFlag()
+    private var fetchTask: Task<Void, Never>?
     private var playbackToReference: [TimeMappingEntry] = []
     private var referenceToPlayback: [TimeMappingEntry] = []
     private var lastPlaybackTime: Double = -1
@@ -150,6 +151,8 @@ final class FingerprintTimingManager: NSObject {
     // MARK: - State Management
 
     private func resetState() {
+        fetchTask?.cancel()
+        fetchTask = nil
         cancellationFlag.cancel()
         cancellationFlag = CancellationFlag()
         context = nil
@@ -192,7 +195,7 @@ final class FingerprintTimingManager: NSObject {
         FileLog.shared.addMessage("FingerprintTimingManager: fetching reference from server for \(uuid)")
 
         let flag = cancellationFlag
-        Task { [weak self] in
+        fetchTask = Task { [weak self] in
             guard !flag.isCancelled else { return }
 
             let data = await FingerprintReferenceRetriever.shared.fetchReferenceData(


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/POC-530/10-fetch-server-provided-fingerprint-reference

## Summary
- Adds `FingerprintReferenceRetriever` actor that fetches gzip-compressed fingerprint references from `shownotes.pocketcasts.{com,net}/generated_transcripts/{podcastUUID}/{episodeUUID}-fingerprints.json.gz`
- Updates `FingerprintTimingManager` to check the `syncedTranscripts` feature flag, try a local `.ref.fp.json` disk cache first, then fall back to async server fetch with retry/backoff
- Handles HTTP 404 gracefully (no error surfaced, sync disabled for that episode), retries on 5xx/transient network errors with exponential backoff (up to 3 attempts)
- Decompresses gzip responses using the Compression framework (raw DEFLATE via `COMPRESSION_ZLIB` after stripping the gzip header), with auto-detection to handle cases where URLSession already decompressed the response
- Persists decoded reference JSON to `.ref.fp.json` alongside the audio file so replays skip re-fetching

## Changes
- **`podcasts/Fingerprint/FingerprintReferenceRetriever.swift`** (NEW) — Actor with request deduplication, gzip decompression, retry logic, and transient error detection
- **`podcasts/Fingerprint/FingerprintTimingManager.swift`** — Refactored `prepareForEpisode` to gate on feature flag, check disk cache, and fetch asynchronously; extracted `configureForReference` method; updated persistence path from `.fp.json` to `.ref.fp.json`

## Verification
- **Lint**: PASS
- **Tests**: PASS — all 11 FingerprintTimingManagerTests pass
- **Diff review**: PASS — confirmed no unintended changes, no secrets
- **Build**: PASS — `make build_staging` succeeds

## Confidence
**MEDIUM** — The networking, retry, and state management logic is straightforward and follows existing patterns (TranscriptsDataRetriever, ShowInfoDataRetriever). The gzip decompression uses the Compression framework with gzip header parsing, which handles standard gzip format correctly but hasn't been tested against the actual server response. The feature is gated behind the `syncedTranscripts` flag (currently disabled), so there's no risk to existing functionality.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/POC-530/10-fetch-server-provided-fingerprint-reference)