### PR TITLE
Fix smart rules cell height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.11
 -----
+- Fix smart rules too small cell height [#4171](https://github.com/Automattic/pocket-casts-ios/pull/4171)
 - Fix an issue with Playlist not reloading after archiving entries during empty search [#4136](https://github.com/Automattic/pocket-casts-ios/pull/4136)
 - Fix smart playlist not refreshing when clearing search field [#4138](https://github.com/Automattic/pocket-casts-ios/pull/4138)
 

--- a/podcasts/New Creation/New Preview/Rules/SmartPlaylistRuleRowView.swift
+++ b/podcasts/New Creation/New Preview/Rules/SmartPlaylistRuleRowView.swift
@@ -53,7 +53,7 @@ struct SmartPlaylistRuleRowView: View {
                     .padding(.trailing, 8.0)
             }
             .padding(.leading, 16.0)
-            .padding(.vertical, 8.0)
+            .padding(.vertical, 12.0)
             .contentShape(Rectangle())
             .onTapGesture {
                 action(rule)


### PR DESCRIPTION
I couldn't find any related reports, but the current rules are way-way too small. It's really hard to tap. I noticed while working on a related issue. I suggest we fix it.

Before / After

<img width="360"  alt="Screenshot 2026-04-22 at 4 37 31 PM" src="https://github.com/user-attachments/assets/b40664c6-c727-487f-90c0-b1fc09c0dc28" />
<img width="360"  alt="Screenshot 2026-04-22 at 4 36 59 PM" src="https://github.com/user-attachments/assets/8d65600b-7d3b-485d-82b3-775df2ea187f" />

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
