### PR TITLE
Add NS_NOESCAPE to SJCommonUtils.catchException

### DIFF
--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -408,9 +408,9 @@ class PlaylistDetailViewController: FakeNavViewController {
 
         if animated, contentChanged {
             do {
-                try SJCommonUtils.catchException { [weak self] in
-                    self?.tableView.reload(using: data, with: .fade) { [weak self] newData in
-                        self?.viewModel.update(data: newData) {
+                try SJCommonUtils.catchException {
+                    tableView.reload(using: data, with: .fade) { newData in
+                        viewModel.update(data: newData) { [weak self] in
                             self?.reloadRefreshControlColor()
                         }
                     }

--- a/podcasts/SJCommonUtils.h
+++ b/podcasts/SJCommonUtils.h
@@ -10,6 +10,6 @@
 + (void)setDontBackupFlag:(NSURL * _Nonnull)url;
 + (void)removeDontBackupFlag:(NSURL * _Nonnull)url;
 
-+ (BOOL)catchException:(void(^_Nullable)(void))tryBlock error:(__autoreleasing NSError  * _Nullable * _Nullable)error;
++ (BOOL)catchException:(NS_NOESCAPE void(^_Nullable)(void))tryBlock error:(__autoreleasing NSError  * _Nullable * _Nullable)error;
 
 @end

--- a/podcasts/SJCommonUtils.m
+++ b/podcasts/SJCommonUtils.m
@@ -43,13 +43,15 @@
     return fileSize;
 }
 
-+ (BOOL)catchException:(void(^)(void))tryBlock error:(__autoreleasing NSError **)error {
++ (BOOL)catchException:(NS_NOESCAPE void(^)(void))tryBlock error:(__autoreleasing NSError **)error {
     @try {
         tryBlock();
         return YES;
     }
     @catch (NSException *exception) {
-        *error = [[NSError alloc] initWithDomain:exception.name code:0 userInfo:exception.userInfo];
+        if (error) {
+            *error = [[NSError alloc] initWithDomain:exception.name code:0 userInfo:exception.userInfo];
+        }
         return NO;
     }
 }


### PR DESCRIPTION
Fixes a minor inconvenience I noticed when working on `PlaylistDetailViewController` – the closure is now non-escaping. In addition, I fixed an `error` dereferencing that could lead to a crash if the pointer was ever null.

## To test

n/a

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
