### PR TITLE
POC-530: Change how we fetch the reference fingerprint

### DIFF
--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -74,12 +74,6 @@ final class FingerprintTimingManager: NSObject {
     func setup() {
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(handleTrackChanged),
-            name: Constants.Notifications.playbackTrackChanged,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
             selector: #selector(handlePlaybackProgress),
             name: Constants.Notifications.playbackProgress,
             object: nil
@@ -88,6 +82,16 @@ final class FingerprintTimingManager: NSObject {
     }
 
     // MARK: - Public API
+
+    func prepareForCurrentEpisode() {
+        let episode = PlaybackManager.shared.currentEpisode()
+
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.resetState()
+            self.prepareForEpisode(episode)
+        }
+    }
 
     func referenceTime(forPlaybackTime playbackTime: Double) -> Double? {
         dispatchPrecondition(condition: .notOnQueue(queue))
@@ -126,16 +130,6 @@ final class FingerprintTimingManager: NSObject {
     #endif
 
     // MARK: - Notification Handlers
-
-    @objc private func handleTrackChanged() {
-        let episode = PlaybackManager.shared.currentEpisode()
-
-        queue.async { [weak self] in
-            guard let self else { return }
-            self.resetState()
-            self.prepareForEpisode(episode)
-        }
-    }
 
     @objc private func handlePlaybackProgress() {
         let playbackTime = PlaybackManager.shared.currentTime()

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -446,6 +446,9 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         loadTranscript()
         addObservers()
         (transcriptView as UIScrollView).delegate = self
+        if FeatureFlag.syncedTranscripts.enabled, !showFromEpisode {
+            FingerprintTimingManager.shared.prepareForCurrentEpisode()
+        }
         #if DEBUG
         let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
             self?.debugOverlay?.update()
@@ -737,7 +740,14 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
         if FeatureFlag.syncedTranscripts.enabled {
             addCustomObserver(Constants.Notifications.playbackProgress, selector: #selector(updateTranscriptPosition))
+            if !showFromEpisode {
+                addCustomObserver(Constants.Notifications.playbackTrackChanged, selector: #selector(prepareFingerprintForCurrentEpisode))
+            }
         }
+    }
+
+    @objc private func prepareFingerprintForCurrentEpisode() {
+        FingerprintTimingManager.shared.prepareForCurrentEpisode()
     }
 
     @objc private func updateTranscriptPosition() {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -498,6 +498,9 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         resetKmp()
         resetSearch()
         loadTranscript()
+        if FeatureFlag.syncedTranscripts.enabled {
+            FingerprintTimingManager.shared.prepareForCurrentEpisode()
+        }
     }
 
     @objc private func closeTapped() {
@@ -740,14 +743,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
         if FeatureFlag.syncedTranscripts.enabled {
             addCustomObserver(Constants.Notifications.playbackProgress, selector: #selector(updateTranscriptPosition))
-            if !showFromEpisode {
-                addCustomObserver(Constants.Notifications.playbackTrackChanged, selector: #selector(prepareFingerprintForCurrentEpisode))
-            }
         }
-    }
-
-    @objc private func prepareFingerprintForCurrentEpisode() {
-        FingerprintTimingManager.shared.prepareForCurrentEpisode()
     }
 
     @objc private func updateTranscriptPosition() {


### PR DESCRIPTION
| 📘 Part of: POC-530 |
|:---:|

Follow-up — the previous PR merged without this commit.

Rework the trigger for fetching the server-provided reference fingerprint. Previously the fetch was wired to the `playbackTrackChanged` notification, which meant it never ran when an episode was already playing at app launch — opening the transcript produced no fetch and no log output. It also did work for episodes whose transcript was never opened.

The fetch now runs lazily from the transcript view:

- `FingerprintTimingManager.setup()` no longer observes `playbackTrackChanged`.
- A public `prepareForCurrentEpisode()` replaces the old notification handler and is called from `TranscriptViewController.willBeAddedToPlayer()` (gated on `FeatureFlag.syncedTranscripts` and non-episode context).
- `TranscriptViewController` also observes `playbackTrackChanged` itself so auto-advance / skip while the transcript is visible re-preps for the new episode.

Net behavior: no fingerprint work happens unless the user actually opens the transcript tab. In-flight fetches are cancelled on track change via the existing `resetState()` / `fetchTask.cancel()` path.

## To test

1. Enable `Feature Flag → Synced Transcripts` in the debug menu.
2. Launch the app with playback already restored for an episode, open the transcript tab, and confirm the FileLog shows:
   - `FingerprintTimingManager: fetching reference from server for <uuid>`
   - `FingerprintReferenceRetriever: reference fetched for <uuid> (<N> bytes)`
   - `FingerprintTimingManager: saved reference to disk for <uuid>`
3. Without opening the transcript tab, play an episode and confirm no `FingerprintReferenceRetriever:` logs appear — the fetch path is lazy.
4. With the transcript tab open, skip to the next episode and confirm a new fetch kicks off for the new episode.
5. Reopen the same episode after a cold launch → cache hit (no fetch log); the `.ref.fp.json` sits next to the episode audio in `Documents/podcasts_non_backed_up/`.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.