### PR TITLE
Fix animations in Playlist Details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Fix an issue with Playlist not reloading after archiving entries during empty search [#4136](https://github.com/Automattic/pocket-casts-ios/pull/4136)
 - Fix smart playlist not refreshing when clearing search field [#4138](https://github.com/Automattic/pocket-casts-ios/pull/4138)
+- Fix animations in Playlist Details when the episode list is updated [#4174](https://github.com/Automattic/pocket-casts-ios/pull/4174)
 
 8.10
 -----

--- a/podcasts/New Detail/PlaylistDetailViewController+TableView.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+TableView.swift
@@ -44,7 +44,7 @@ extension PlaylistDetailViewController: UITableViewDataSource {
     }
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return viewModel.numberOfSection
+        return viewModel.dataSource.count
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -409,7 +409,7 @@ class PlaylistDetailViewController: FakeNavViewController {
         if animated, contentChanged {
             do {
                 try SJCommonUtils.catchException {
-                    tableView.reload(using: data, with: .fade) { newData in
+                    tableView.reload(using: data, with: .automatic) { newData in
                         viewModel.update(data: newData) { [weak self] in
                             self?.reloadRefreshControlColor()
                         }

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -42,10 +42,6 @@ class PlaylistDetailViewModel: ObservableObject {
         dataManager.podcastCount() > 0
     }
 
-    var numberOfSection: Int {
-        isManualPlaylist ? 3 : 2
-    }
-
     var isPlaylistFull: Bool {
 #if DEBUG
         playlistEpisodesCount >= Settings.debugPlaylistsLimit
@@ -91,6 +87,7 @@ class PlaylistDetailViewModel: ObservableObject {
         self.episodesDataManager = episodesDataManager
         self.onChange = onChange
         self.onButtonTapped = onButtonTapped
+        self.dataSource = makeSections(episodes: [])
     }
 
     func update(data: DataSourceValue, then block: (() -> Void)? = nil) {
@@ -148,7 +145,7 @@ class PlaylistDetailViewModel: ObservableObject {
                     self?.playlistName = reloadedPlaylist.playlistName
                 }
             }
-            reloadEpisodeList(animated: false)
+            reloadEpisodeList(animated: true)
         }
     }
 
@@ -168,15 +165,14 @@ class PlaylistDetailViewModel: ObservableObject {
             guard let self else { return }
             DispatchQueue.main.async {
                 self.archivedEpisodesCount = archivedEpisodeCount
-                if self.firstTimeLoading {
-                    self.firstTimeLoading.toggle()
-                }
+                let isFirstReload = self.firstTimeLoading
+                self.firstTimeLoading = false
                 let changeSetTuple = self.buildChangeSet(source: self.episodes, newData: newData)
                 let contentHasChanged = changeSetTuple.0
                 if contentHasChanged {
                     self.dataManager.updatePlaylistUpdateDate(for: self.playlist)
                 }
-                self.onChange(changeSetTuple.1, animated, contentHasChanged)
+                self.onChange(changeSetTuple.1, animated && !isFirstReload, contentHasChanged)
             }
         }
         operationQueue.addOperation(refreshOperation)
@@ -231,19 +227,26 @@ class PlaylistDetailViewModel: ObservableObject {
         newData: [ListEpisode]
     ) -> (Bool, StagedChangeset<DataSourceValue>) {
         let oldSections = dataSource
-        var newSections: [ArraySection<Section, ListItem>] = []
+        let contentChanged = !source.isContentEqual(to: newData)
+        let effectiveEpisodes = contentChanged ? newData : episodes
+        let newSections = makeSections(episodes: effectiveEpisodes)
 
-        // Header section (always included)
-        newSections.append(
-            ArraySection(
-                model: .header,
-                elements: [PlaylistHeaderViewCellPlaceholder()]
-            )
+        let changeset = StagedChangeset(
+            source: oldSections,
+            target: newSections
         )
 
-        // Archive section (only for manual playlists)
+        let contentHasChanged = !newSections.isContentEqual(to: oldSections) || contentChanged
+        return (contentHasChanged, changeset)
+    }
+
+    private func makeSections(episodes: [ListEpisode]) -> DataSourceValue {
+        var sections: DataSourceValue = [
+            ArraySection(model: .header, elements: [PlaylistHeaderViewCellPlaceholder()])
+        ]
+
         if isManualPlaylist {
-            newSections.append(
+            sections.append(
                 ArraySection(
                     model: .archive,
                     elements: [
@@ -256,13 +259,8 @@ class PlaylistDetailViewModel: ObservableObject {
             )
         }
 
-        // Episodes section (always included: it shows placeholder in case of empty episodes)
-        let contentChanged = !source.isContentEqual(to: newData)
-        let effectiveEpisodes = contentChanged ? newData : episodes
-
         let episodeElements: [ListItem]
-
-        if newData.isEmpty {
+        if episodes.isEmpty {
             if isSearching {
                 episodeElements = [NoSearchResultsPlaceholder()]
             } else if isManualPlaylist, !shouldShowArchived {
@@ -278,23 +276,11 @@ class PlaylistDetailViewModel: ObservableObject {
                 episodeElements = []
             }
         } else {
-            episodeElements = effectiveEpisodes
+            episodeElements = episodes
         }
 
-        newSections.append(
-            ArraySection(
-                model: .episodes,
-                elements: episodeElements
-            )
-        )
-
-        let changeset = StagedChangeset(
-            source: oldSections,
-            target: newSections
-        )
-
-        let contentHasChanged = !newSections.isContentEqual(to: oldSections) || contentChanged
-        return (contentHasChanged, changeset)
+        sections.append(ArraySection(model: .episodes, elements: episodeElements))
+        return sections
     }
 
     private func loadImagesURLs(episodes: [ListEpisode], includingEpisodeArtwork: Bool = false) async throws -> [PlaylistArtworkView.ImageItem] {


### PR DESCRIPTION
I'm working on fixing the animations in the swipe actions. In order to do that and make it sensible to the user, you first need to fix animations in the list. This is what this PR is about. The foundation with `StagedChangeset` is already there but is used a bit incorrectly.

**What changed**
  - `numberOfSections(in:)` now reads from `viewModel.dataSource.count` instead of a hardcoded `numberOfSection` (removed).
  - `PlaylistDetailViewModel` seeds `dataSource` at init with the real initial shape (header + archive-if-manual + empty episodes). This prevents incorrect diff being created on the first reload.
  - Extracted `makeSections(episodes:)` so the init seed and `buildChangeSet` build sections through one code path.
  - First reload after init is forced non-animated; subsequent reloads animate as before.

**Why**

The table view's section count (2 or 3) disagreed with `dataSource ([])`, so the first `StagedChangeset` tried to insert sections UIKit already reported as present. That threw `NSInternalInconsistencyException`, which `SJCommonUtils.catchException` silently swallowed and fell back to `reloadData()` - masking the bug and losing the fade animation. Seeding the data source removes the mismatch; unifying section construction keeps the initial state and all future diffs in sync; skipping animation on the first reload avoids the header/archive rows visibly popping in on open.

**Future Changes**

The animations on manual reload currently still appear a bit off. I plan to slightly refactor `reloadPlaylistAndEpisodes` and `reloadEpisodeList` to add a bit of throttling. The similar mechanism will also be used in the future to temporary disable reloads when the swipe menu is shown and re-enable later.

## To test

- Open a Smart Playlsit
- Make a change on a different device
- Refresh on the first device
- Verify that animations are performed

## Recording

Before (no animations)

https://github.com/user-attachments/assets/3f542731-ace9-40f0-bb90-f924b52e5726

After (automatic animations; will be improved with debounce and delay in the future PRs)

https://github.com/user-attachments/assets/689fc10f-c18b-434f-abe8-16bc18e64dde


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
