### PR TITLE
Enable SwiftLint rule: joined_default_parameter

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -46,6 +46,10 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
+  # When calling the `joined` method on an array of strings, omit an
+  # explicit empty-string separator since that is the default.
+  - joined_default_parameter
+
   # MARK comment should be in valid format.
   - mark
 

--- a/podcasts/Extensions/String+SanitizedFileName.swift
+++ b/podcasts/Extensions/String+SanitizedFileName.swift
@@ -8,6 +8,6 @@ extension String {
 
         return self
             .components(separatedBy: invalidCharacters)
-            .joined(separator: "")
+            .joined()
     }
 }

--- a/podcasts/Folders/FoldersCoordinator.swift
+++ b/podcasts/Folders/FoldersCoordinator.swift
@@ -165,7 +165,7 @@ class FoldersCoordinator: NSObject {
 
     private var currentPodcastsHash: String {
         let uuids = dataManager.allPodcastsOrderedByAddedDate().map { $0.uuid }.sorted()
-        let md5 = String(uuids.joined()).md5
+        let md5 = uuids.joined().md5
         return md5
     }
 

--- a/podcasts/Folders/FoldersCoordinator.swift
+++ b/podcasts/Folders/FoldersCoordinator.swift
@@ -165,7 +165,7 @@ class FoldersCoordinator: NSObject {
 
     private var currentPodcastsHash: String {
         let uuids = dataManager.allPodcastsOrderedByAddedDate().map { $0.uuid }.sorted()
-        let md5 = String(uuids.joined(separator: "")).md5
+        let md5 = String(uuids.joined()).md5
         return md5
     }
 


### PR DESCRIPTION
## What

Enables the SwiftLint [`joined_default_parameter`](https://realm.github.io/SwiftLint/joined_default_parameter.html) rule, which flags calls to `joined(separator:)` that pass the default empty-string separator and should just use `joined()`.

## Details

- Auto-fixed violations: 2
- Manual (agentic) fixes: 0
- Violations left for human review: 0

Auto-fixed call sites:

- `podcasts/Extensions/String+SanitizedFileName.swift`
- `podcasts/Folders/FoldersCoordinator.swift`

## Context

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint), progressively enabling SwiftLint rules across Automattic's iOS repositories one rule at a time.