### PR TITLE
POC-531: Highlight transcripts based on fingerprint for downloaded files

### DIFF
--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -119,8 +119,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
 
-        FingerprintTimingManager.shared.setup()
-
         badgeHelper.setup()
         WatchManager.shared.setup()
         shortcutManager.listenForShortcutChanges()

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -73,8 +73,17 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         if FeatureFlag.generatedTranscripts.enabled {
             let externalTranscripts = metadata?.transcripts ?? []
             var pocketCastsTranscripts: [Episode.Metadata.Transcript] = []
-            if let episode = dataManager.findEpisode(uuid: episodeUuid),
-               let hasTranscript = episode.hasGeneratedTranscript {
+
+            #if DEBUG
+            let forceGeneratedTranscript = FeatureFlag.syncedTranscripts.enabled
+            #else
+            let forceGeneratedTranscript = false
+            #endif
+
+            if forceGeneratedTranscript {
+                pocketCastsTranscripts = [buildGeneratedTranscript(podcastUuid: podcastUuid, episodeUuid: episodeUuid)]
+            } else if let episode = dataManager.findEpisode(uuid: episodeUuid),
+                      let hasTranscript = episode.hasGeneratedTranscript {
                 if hasTranscript {
                     let transcript = buildGeneratedTranscript(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
                     pocketCastsTranscripts = [transcript]

--- a/podcasts/Episode+Transcript.swift
+++ b/podcasts/Episode+Transcript.swift
@@ -1,18 +1,35 @@
 import PocketCastsDataModel
+import PocketCastsUtils
 
 extension Episode {
     func checkTranscriptAvailability() {
         Task.init {
-            if let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier(), episodeUuid: uuid) {
-                let transcriptsAvailable = !metadata.transcripts.isEmpty
-                let hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
-                let userInfo = [
-                    "episodeUuid": uuid,
-                    "isAvailable": transcriptsAvailable,
-                    "hasGeneratedTranscripts": hasGeneratedTranscripts
-                ]
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeTranscriptAvailabilityChanged, userInfo: userInfo)
+            let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier(), episodeUuid: uuid)
+
+            let transcriptsAvailable: Bool
+            let hasGeneratedTranscripts: Bool
+
+            #if DEBUG
+            if FeatureFlag.syncedTranscripts.enabled {
+                transcriptsAvailable = true
+                hasGeneratedTranscripts = metadata?.hasGeneratedTranscripts ?? false
+            } else {
+                guard let metadata else { return }
+                transcriptsAvailable = !metadata.transcripts.isEmpty
+                hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
             }
+            #else
+            guard let metadata else { return }
+            transcriptsAvailable = !metadata.transcripts.isEmpty
+            hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
+            #endif
+
+            let userInfo: [AnyHashable: Any] = [
+                "episodeUuid": uuid,
+                "isAvailable": transcriptsAvailable,
+                "hasGeneratedTranscripts": hasGeneratedTranscripts
+            ]
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeTranscriptAvailabilityChanged, userInfo: userInfo)
         }
     }
 }

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -2,9 +2,12 @@ import Foundation
 
 enum FingerprintConstants {
     /// Seconds of playback jump that triggers a re-fingerprint from the current position.
+    /// Reserved for future streaming support — unused on the downloaded-files path, which
+    /// fingerprints the whole file upfront.
     static let restartDeltaSeconds: Double = 10
 
     /// Seconds of margin beyond the mapped range before triggering a restart.
+    /// Reserved for future streaming support — unused on the downloaded-files path.
     static let playbackRangeMarginSeconds: Double = 30
 
     /// Minimum match score to accept a fingerprint match result.
@@ -16,10 +19,8 @@ enum FingerprintConstants {
     /// Interval between windowed fingerprints produced during live matching, in milliseconds.
     static let windowIntervalMs: UInt32 = 2000
 
-    /// Number of seconds of audio fingerprinted per batch.
-    static let batchDurationSeconds: Double = 60
-
     /// Seconds between polls when waiting for the streaming buffer to grow.
+    /// Reserved for future streaming support — unused on the downloaded-files path.
     static let bufferGrowPollCadenceSeconds: TimeInterval = 1.0
 
     /// Score at or above which the debug overlay shows green (high confidence).

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -1,13 +1,14 @@
 import Foundation
 
 enum FingerprintConstants {
-    /// Seconds of playback jump that triggers a re-fingerprint from the current position.
-    /// Reserved for future streaming support — unused on the downloaded-files path, which
-    /// fingerprints the whole file upfront.
+    /// If consecutive playback-progress notifications differ by more than this,
+    /// treat it as a seek/skip and restart fingerprint generation at the new position
+    /// so coverage stays close to what the listener is hearing.
     static let restartDeltaSeconds: Double = 10
 
-    /// Seconds of margin beyond the mapped range before triggering a restart.
-    /// Reserved for future streaming support — unused on the downloaded-files path.
+    /// When playback drifts further than this beyond the already-mapped range,
+    /// restart fingerprint generation from the new position. Also acts as the
+    /// slack window around the mapped range before we consider playback "outside".
     static let playbackRangeMarginSeconds: Double = 30
 
     /// Minimum match score to accept a fingerprint match result.
@@ -24,7 +25,8 @@ enum FingerprintConstants {
     static let streamChunkSeconds: Double = 5
 
     /// Seconds between polls when waiting for the streaming buffer to grow.
-    /// Reserved for future streaming support — unused on the downloaded-files path.
+    /// Reserved for future streaming support — not yet referenced, but the hook
+    /// lives here so the knob is discoverable when we pick that path up.
     static let bufferGrowPollCadenceSeconds: TimeInterval = 1.0
 
     /// Score at or above which the debug overlay shows green (high confidence).

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -19,6 +19,10 @@ enum FingerprintConstants {
     /// Interval between windowed fingerprints produced during live matching, in milliseconds.
     static let windowIntervalMs: UInt32 = 2000
 
+    /// Seconds of decoded PCM read per AVAudioFile chunk during streaming
+    /// fingerprint generation. Smaller = more responsive UI, larger = less per-call overhead.
+    static let streamChunkSeconds: Double = 5
+
     /// Seconds between polls when waiting for the streaming buffer to grow.
     /// Reserved for future streaming support — unused on the downloaded-files path.
     static let bufferGrowPollCadenceSeconds: TimeInterval = 1.0

--- a/podcasts/Fingerprint/FingerprintDebugOverlay.swift
+++ b/podcasts/Fingerprint/FingerprintDebugOverlay.swift
@@ -7,12 +7,30 @@ class FingerprintDebugOverlay: UIView {
     private var totalDuration: Double = 0
     private var playbackPosition: Double = 0
 
+    private let statusLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 9, weight: .semibold)
+        label.textColor = .white
+        // swiftlint:disable:next inverse_text_alignment
+        label.textAlignment = .right
+        label.shadowColor = .black
+        label.shadowOffset = CGSize(width: 0, height: 1)
+        label.isUserInteractionEnabled = false
+        return label
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         backgroundColor = .black
         layer.cornerRadius = 4
         clipsToBounds = true
         addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleTap(_:))))
+        addSubview(statusLabel)
+        NSLayoutConstraint.activate([
+            statusLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
+            statusLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
     }
 
     required init?(coder: NSCoder) {
@@ -27,6 +45,7 @@ class FingerprintDebugOverlay: UIView {
         let fingerprintDuration = FingerprintTimingManager.shared.totalDuration ?? 0
         totalDuration = fingerprintDuration > 0 ? fingerprintDuration : PlaybackManager.shared.duration()
         playbackPosition = PlaybackManager.shared.currentTime()
+        statusLabel.text = describe(state: FingerprintTimingManager.shared.state)
         setNeedsDisplay()
     }
 
@@ -41,6 +60,11 @@ class FingerprintDebugOverlay: UIView {
         guard totalDuration > 0 else { return }
 
         let ctx = UIGraphicsGetCurrentContext()
+
+        // Backdrop spanning the whole timeline so processed-vs-remaining is visible
+        // as the full-file walk fills coverage in.
+        ctx?.setFillColor(UIColor.darkGray.withAlphaComponent(0.5).cgColor)
+        ctx?.fill(rect)
 
         for entry in entries {
             let x = CGFloat(entry.playbackTime / totalDuration) * rect.width
@@ -63,6 +87,16 @@ class FingerprintDebugOverlay: UIView {
             let px = CGFloat(playbackPosition / totalDuration) * rect.width
             ctx?.setFillColor(UIColor.white.cgColor)
             ctx?.fill(CGRect(x: px - 1, y: 0, width: 2, height: rect.height))
+        }
+    }
+
+    private func describe(state: FingerprintTimingManager.State) -> String {
+        switch state {
+        case .idle: return "idle"
+        case .preparing: return "preparing"
+        case .active(let coverage): return "active (\(coverage))"
+        case .failed: return "failed"
+        case .unavailable: return "unavailable"
         }
     }
 }

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import Fingerprint
 import PocketCastsDataModel
@@ -30,7 +31,6 @@ final class FingerprintTimingManager: NSObject {
         let audioFileURL: URL
         let duration: Double
         let matcher: CheckpointMatcher
-        let fingerprinter: Fingerprinter
         let isCancelled: () -> Bool
     }
 
@@ -236,7 +236,6 @@ final class FingerprintTimingManager: NSObject {
             audioFileURL: audioFileURL,
             duration: duration,
             matcher: matcher,
-            fingerprinter: Fingerprinter(),
             isCancelled: { flag.isCancelled }
         )
         context = newContext
@@ -249,69 +248,92 @@ final class FingerprintTimingManager: NSObject {
         processAllBatches(context: newContext)
     }
 
-    // MARK: - Full-File Processing
+    // MARK: - Streaming Fingerprint Processing
 
-    /// Fingerprint the whole downloaded file in one pass. We can't byte-slice and feed
-    /// arbitrary chunks to the fingerprinter — the codec needs a real container/header
-    /// to detect format, which only exists at file start. Memory-mapping the file keeps
-    /// peak resident memory bounded.
+    /// Stream-decode the downloaded file with `AVAudioFile`, push PCM into the
+    /// streaming fingerprinter chunk-by-chunk, and match each batch of windows
+    /// as soon as it's emitted. This populates the playback↔reference mapping
+    /// progressively so highlighting/tap-to-seek become usable well before the
+    /// whole file has been processed.
     private func processAllBatches(context ctx: GenerationContext) {
         generationQueue.async { [weak self] in
             guard let self else { return }
-            let result = Self.fingerprintWholeFile(
-                fileURL: ctx.audioFileURL,
-                fingerprinter: ctx.fingerprinter,
-                isCancelled: ctx.isCancelled
-            )
-
-            self.queue.async { [weak self] in
-                guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
-
-                switch result {
-                case .success(let windows):
-                    self.processMatches(windows: windows, context: ctx)
-                    FileLog.shared.addMessage(
-                        "FingerprintTimingManager: full-file processing completed (\(windows.count) windows)"
-                    )
-                case .failure(let error):
-                    FileLog.shared.addMessage(
-                        "FingerprintTimingManager: full-file processing failed — \(error)"
-                    )
-                }
+            do {
+                try self.streamFingerprint(context: ctx)
+                FileLog.shared.addMessage("FingerprintTimingManager: streaming fingerprint completed")
+            } catch StreamError.cancelled {
+                FileLog.shared.addMessage("FingerprintTimingManager: streaming fingerprint cancelled")
+            } catch {
+                FileLog.shared.addMessage(
+                    "FingerprintTimingManager: streaming fingerprint failed — \(error.localizedDescription)"
+                )
             }
         }
     }
 
-    private static func fingerprintWholeFile(
-        fileURL: URL,
-        fingerprinter: Fingerprinter,
-        isCancelled: () -> Bool
-    ) -> Result<[WindowedFingerprint], Error> {
-        if isCancelled() { return .failure(BatchError.cancelled) }
+    private func streamFingerprint(context ctx: GenerationContext) throws {
+        let audioFile = try AVAudioFile(forReading: ctx.audioFileURL)
+        let format = audioFile.processingFormat
+        let sampleRate = UInt32(format.sampleRate)
+        let channels = UInt16(format.channelCount)
 
-        let data: Data
-        do {
-            data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
-        } catch {
-            return .failure(error)
+        let streamer = StreamingWindowedFingerprinter(
+            sampleRate: sampleRate,
+            channels: channels,
+            windowDurationMs: FingerprintConstants.windowDurationMs,
+            windowIntervalMs: FingerprintConstants.windowIntervalMs
+        )
+
+        let chunkFrames = AVAudioFrameCount(format.sampleRate * FingerprintConstants.streamChunkSeconds)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
+            throw StreamError.bufferAllocationFailed
         }
 
-        if isCancelled() { return .failure(BatchError.cancelled) }
+        while true {
+            if ctx.isCancelled() { throw StreamError.cancelled }
+            try audioFile.read(into: buffer, frameCount: chunkFrames)
+            if buffer.frameLength == 0 { break }
 
-        do {
-            let windows = try fingerprinter.fingerprintDataWindowed(
-                data: data,
-                windowDurationMs: FingerprintConstants.windowDurationMs,
-                windowIntervalMs: FingerprintConstants.windowIntervalMs
-            )
-            return .success(windows)
-        } catch {
-            return .failure(error)
+            let interleaved = Self.interleavedSamples(from: buffer)
+            let windows = streamer.pushSamplesF32(samples: interleaved, channels: channels)
+            if !windows.isEmpty {
+                dispatchProcessMatches(windows: windows, context: ctx)
+            }
+        }
+
+        if ctx.isCancelled() { throw StreamError.cancelled }
+        let tail = streamer.flush()
+        if !tail.isEmpty {
+            dispatchProcessMatches(windows: tail, context: ctx)
         }
     }
 
-    private enum BatchError: Error {
+    private func dispatchProcessMatches(windows: [WindowedFingerprint], context ctx: GenerationContext) {
+        queue.async { [weak self] in
+            guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
+            self.processMatches(windows: windows, context: ctx)
+        }
+    }
+
+    private static func interleavedSamples(from buffer: AVAudioPCMBuffer) -> [Float] {
+        let frameCount = Int(buffer.frameLength)
+        let channelCount = Int(buffer.format.channelCount)
+        guard frameCount > 0, channelCount > 0,
+              let channelData = buffer.floatChannelData else { return [] }
+
+        var result = [Float](repeating: 0, count: frameCount * channelCount)
+        for ch in 0..<channelCount {
+            let src = channelData[ch]
+            for frame in 0..<frameCount {
+                result[frame * channelCount + ch] = src[frame]
+            }
+        }
+        return result
+    }
+
+    private enum StreamError: Error {
         case cancelled
+        case bufferAllocationFailed
     }
 
     private func processMatches(

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -58,6 +58,7 @@ final class FingerprintTimingManager: NSObject {
     private var fetchTask: Task<Void, Never>?
     private var playbackToReference: [TimeMappingEntry] = []
     private var referenceToPlayback: [TimeMappingEntry] = []
+    private var lastProgressPosition: Double = -1
 
     // MARK: - Init
 
@@ -67,6 +68,12 @@ final class FingerprintTimingManager: NSObject {
             self,
             selector: #selector(handleEpisodeDownloaded(_:)),
             name: Constants.Notifications.episodeDownloaded,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handlePlaybackProgress),
+            name: Constants.Notifications.playbackProgress,
             object: nil
         )
     }
@@ -99,6 +106,68 @@ final class FingerprintTimingManager: NSObject {
             )
             self.prepareForCurrentEpisode()
         }
+    }
+
+    /// Re-anchor fingerprint generation to wherever the listener is now: if playback
+    /// jumps suddenly (seek/skip), or drifts beyond the mapped range, restart the
+    /// stream from the new position so coverage stays close to what's playing.
+    @objc private func handlePlaybackProgress() {
+        let playbackTime = PlaybackManager.shared.currentTime()
+        guard playbackTime >= 0 else { return }
+
+        let episodeUuid = PlaybackManager.shared.currentEpisode()?.uuid
+        queue.async { [weak self] in
+            self?.processProgress(playbackTime: playbackTime, episodeUuid: episodeUuid)
+        }
+    }
+
+    private func processProgress(playbackTime: Double, episodeUuid: String?) {
+        guard let ctx = context, ctx.episodeUuid == episodeUuid else { return }
+
+        if lastProgressPosition >= 0 {
+            let delta = abs(playbackTime - lastProgressPosition)
+            if delta > FingerprintConstants.restartDeltaSeconds {
+                FileLog.shared.addMessage(
+                    "FingerprintTimingManager: playback jumped \(String(format: "%.1f", delta))s — restarting from \(String(format: "%.1f", playbackTime))s"
+                )
+                restart(from: playbackTime, context: ctx)
+                lastProgressPosition = playbackTime
+                return
+            }
+        }
+        lastProgressPosition = playbackTime
+
+        if isWithinMappedRange(playbackTime) { return }
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: playback at \(String(format: "%.1f", playbackTime))s outside mapped range — restarting"
+        )
+        restart(from: playbackTime, context: ctx)
+    }
+
+    private func isWithinMappedRange(_ playbackTime: Double) -> Bool {
+        guard let first = playbackToReference.first,
+              let last = playbackToReference.last else { return false }
+        let margin = FingerprintConstants.playbackRangeMarginSeconds
+        return playbackTime >= first.playbackTime - margin
+            && playbackTime <= last.playbackTime + margin
+    }
+
+    /// Cancel the in-flight stream and start a new one anchored at `position`.
+    /// Existing mappings are kept — they're still valid, we just refocus
+    /// coverage growth around the listener's new position.
+    private func restart(from position: Double, context ctx: GenerationContext) {
+        cancellationFlag.cancel()
+        cancellationFlag = CancellationFlag()
+        let flag = cancellationFlag
+        let newContext = GenerationContext(
+            episodeUuid: ctx.episodeUuid,
+            audioFileURL: ctx.audioFileURL,
+            duration: ctx.duration,
+            matcher: ctx.matcher,
+            isCancelled: { flag.isCancelled }
+        )
+        context = newContext
+        startStream(context: newContext, fromPosition: position)
     }
 
     func referenceTime(forPlaybackTime playbackTime: Double) -> Double? {
@@ -147,6 +216,7 @@ final class FingerprintTimingManager: NSObject {
         context = nil
         playbackToReference.removeAll()
         referenceToPlayback.removeAll()
+        lastProgressPosition = -1
     }
 
     private func updateState(_ newState: State) {
@@ -269,22 +339,27 @@ final class FingerprintTimingManager: NSObject {
             "FingerprintTimingManager: preparing for \(uuid) (\(libraryCheckpoints.count) checkpoints)"
         )
 
-        processAllBatches(context: newContext)
+        let startPosition = PlaybackManager.shared.currentTime()
+        startStream(context: newContext, fromPosition: startPosition)
     }
 
     // MARK: - Streaming Fingerprint Processing
 
     /// Stream-decode the downloaded file with `AVAudioFile`, push PCM into the
     /// streaming fingerprinter chunk-by-chunk, and match each batch of windows
-    /// as soon as it's emitted. This populates the playback↔reference mapping
-    /// progressively so highlighting/tap-to-seek become usable well before the
-    /// whole file has been processed.
-    private func processAllBatches(context ctx: GenerationContext) {
+    /// as soon as it's emitted. We start near the current playback position
+    /// (snapped to a 2s grid so window timestamps line up with the reference
+    /// checkpoints), so highlighting becomes usable for what the listener is
+    /// actually hearing — without waiting for the entire file to be processed.
+    private func startStream(context ctx: GenerationContext, fromPosition position: Double) {
+        let aligned = Self.alignToWindowGrid(position)
         generationQueue.async { [weak self] in
             guard let self else { return }
             do {
-                try self.streamFingerprint(context: ctx)
-                FileLog.shared.addMessage("FingerprintTimingManager: streaming fingerprint completed")
+                try self.streamFingerprint(context: ctx, startingAt: aligned)
+                FileLog.shared.addMessage(
+                    "FingerprintTimingManager: streaming fingerprint completed (started at \(String(format: "%.1f", aligned))s)"
+                )
             } catch StreamError.cancelled {
                 FileLog.shared.addMessage("FingerprintTimingManager: streaming fingerprint cancelled")
             } catch {
@@ -295,11 +370,27 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
-    private func streamFingerprint(context ctx: GenerationContext) throws {
+    /// Snap a playback time to the window-interval grid so that the windows we
+    /// emit align with the reference checkpoint timestamps. The reference is
+    /// produced with the same `windowIntervalMs` stride starting at 0, so any
+    /// off-grid start would yield windows whose audio content is shifted
+    /// relative to the reference and would fail to match.
+    private static func alignToWindowGrid(_ time: Double) -> Double {
+        let stride = Double(FingerprintConstants.windowIntervalMs) / 1000.0
+        guard stride > 0 else { return max(0, time) }
+        return max(0, floor(time / stride) * stride)
+    }
+
+    private func streamFingerprint(context ctx: GenerationContext, startingAt startSeconds: Double) throws {
         let audioFile = try AVAudioFile(forReading: ctx.audioFileURL)
         let format = audioFile.processingFormat
         let sampleRate = UInt32(format.sampleRate)
         let channels = UInt16(format.channelCount)
+
+        let startFrame = AVAudioFramePosition(startSeconds * format.sampleRate)
+        if startFrame > 0, startFrame < audioFile.length {
+            audioFile.framePosition = startFrame
+        }
 
         let streamer = StreamingWindowedFingerprinter(
             sampleRate: sampleRate,
@@ -321,21 +412,25 @@ final class FingerprintTimingManager: NSObject {
             let interleaved = Self.interleavedSamples(from: buffer)
             let windows = streamer.pushSamplesF32(samples: interleaved, channels: channels)
             if !windows.isEmpty {
-                dispatchProcessMatches(windows: windows, context: ctx)
+                dispatchProcessMatches(windows: windows, startOffset: startSeconds, context: ctx)
             }
         }
 
         if ctx.isCancelled() { throw StreamError.cancelled }
         let tail = streamer.flush()
         if !tail.isEmpty {
-            dispatchProcessMatches(windows: tail, context: ctx)
+            dispatchProcessMatches(windows: tail, startOffset: startSeconds, context: ctx)
         }
     }
 
-    private func dispatchProcessMatches(windows: [WindowedFingerprint], context ctx: GenerationContext) {
+    private func dispatchProcessMatches(
+        windows: [WindowedFingerprint],
+        startOffset: Double,
+        context ctx: GenerationContext
+    ) {
         queue.async { [weak self] in
             guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
-            self.processMatches(windows: windows, context: ctx)
+            self.processMatches(windows: windows, startOffset: startOffset, context: ctx)
         }
     }
 
@@ -362,6 +457,7 @@ final class FingerprintTimingManager: NSObject {
 
     private func processMatches(
         windows: [WindowedFingerprint],
+        startOffset: Double,
         context ctx: GenerationContext
     ) {
         var inserted = 0
@@ -382,8 +478,9 @@ final class FingerprintTimingManager: NSObject {
                 if best.score > bestScoreOverall { bestScoreOverall = best.score }
 
                 if best.score >= FingerprintConstants.matchScoreThreshold {
+                    let absolutePlaybackTime = startOffset + Double(window.timestampMs) / 1000.0
                     insertMapping(TimeMappingEntry(
-                        playbackTime: Double(window.timestampMs) / 1000.0,
+                        playbackTime: absolutePlaybackTime,
                         referenceTime: Double(best.timestamp),
                         score: best.score
                     ))

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -90,6 +90,19 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
+    /// Cancel any in-flight reference fetch and streaming fingerprint work, discard
+    /// the current context and mappings, and return to `.idle`. Called when the
+    /// transcript view is torn down so we don't keep burning CPU/memory on audio
+    /// the listener is no longer looking at.
+    func stop() {
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.resetState()
+            self.updateState(.idle)
+            FileLog.shared.addMessage("FingerprintTimingManager: stopped")
+        }
+    }
+
     /// When an episode download completes while the transcript flow has already requested
     /// preparation, retry. If we previously gave up because no local file existed, or were
     /// processing a partial streaming buffer, we now have a complete file to fingerprint.

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -28,7 +28,6 @@ final class FingerprintTimingManager: NSObject {
     private struct GenerationContext {
         let episodeUuid: String
         let audioFileURL: URL
-        let fileSize: UInt64
         let duration: Double
         let matcher: CheckpointMatcher
         let fingerprinter: Fingerprinter
@@ -59,26 +58,11 @@ final class FingerprintTimingManager: NSObject {
     private var fetchTask: Task<Void, Never>?
     private var playbackToReference: [TimeMappingEntry] = []
     private var referenceToPlayback: [TimeMappingEntry] = []
-    private var lastPlaybackTime: Double = -1
-    private var lastProcessedBatchIndex: Int = -1
-    private var isProcessingBatch = false
 
     // MARK: - Init
 
     override init() {
         super.init()
-    }
-
-    // MARK: - Lifecycle
-
-    func setup() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handlePlaybackProgress),
-            name: Constants.Notifications.playbackProgress,
-            object: nil
-        )
-        FileLog.shared.addMessage("FingerprintTimingManager: setup complete")
     }
 
     // MARK: - Public API
@@ -129,19 +113,6 @@ final class FingerprintTimingManager: NSObject {
     }
     #endif
 
-    // MARK: - Notification Handlers
-
-    @objc private func handlePlaybackProgress() {
-        let playbackTime = PlaybackManager.shared.currentTime()
-        guard playbackTime >= 0 else { return }
-
-        let episodeUuid = PlaybackManager.shared.currentEpisode()?.uuid
-
-        queue.async { [weak self] in
-            self?.processProgress(playbackTime: playbackTime, episodeUuid: episodeUuid)
-        }
-    }
-
     // MARK: - State Management
 
     private func resetState() {
@@ -152,9 +123,6 @@ final class FingerprintTimingManager: NSObject {
         context = nil
         playbackToReference.removeAll()
         referenceToPlayback.removeAll()
-        lastPlaybackTime = -1
-        lastProcessedBatchIndex = -1
-        isProcessingBatch = false
     }
 
     private func updateState(_ newState: State) {
@@ -217,29 +185,36 @@ final class FingerprintTimingManager: NSObject {
 
         guard let audioFileURL = resolveAudioFileURL(for: episode) else {
             updateState(.unavailable)
-            FileLog.shared.addMessage("FingerprintTimingManager: no audio file for \(uuid)")
-            return
-        }
-
-        let fileSize: UInt64
-        do {
-            let attrs = try FileManager.default.attributesOfItem(atPath: audioFileURL.path)
-            fileSize = attrs[.size] as? UInt64 ?? 0
-        } catch {
-            updateState(.failed(error))
-            FileLog.shared.addMessage("FingerprintTimingManager: cannot read file attributes — \(error.localizedDescription)")
+            FileLog.shared.addMessage("FingerprintTimingManager: episode \(uuid) is not downloaded — skipping fingerprinting")
             return
         }
 
         let duration = episode.duration
-        guard fileSize > 0, duration > 0 else {
+        guard duration > 0 else {
             updateState(.unavailable)
             return
         }
 
         let matcher = CheckpointMatcher()
         let duration_s = reference.checkpointDurationSeconds
+        let rawCheckpointCount = reference.checkpoints.count
         let libraryCheckpoints = reference.libraryCheckpoints()
+
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: reference for \(uuid) — "
+                + "totalDuration=\(reference.totalDuration)s, "
+                + "checkpointInterval=\(reference.checkpointInterval), "
+                + "checkpointDuration=\(reference.checkpointDuration)s, "
+                + "timestampQuantum=\(reference.timestampQuantum), "
+                + "raw=\(rawCheckpointCount), decoded=\(libraryCheckpoints.count)"
+        )
+        if let first = libraryCheckpoints.first, let last = libraryCheckpoints.last {
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: checkpoint timestamps span "
+                    + "\(String(format: "%.1f", first.timestampSeconds))s..\(String(format: "%.1f", last.timestampSeconds))s "
+                    + "(audio duration \(String(format: "%.1f", duration))s)"
+            )
+        }
 
         guard !libraryCheckpoints.isEmpty else {
             updateState(.unavailable)
@@ -259,7 +234,6 @@ final class FingerprintTimingManager: NSObject {
         let newContext = GenerationContext(
             episodeUuid: uuid,
             audioFileURL: audioFileURL,
-            fileSize: fileSize,
             duration: duration,
             matcher: matcher,
             fingerprinter: Fingerprinter(),
@@ -271,135 +245,53 @@ final class FingerprintTimingManager: NSObject {
         FileLog.shared.addMessage(
             "FingerprintTimingManager: preparing for \(uuid) (\(libraryCheckpoints.count) checkpoints)"
         )
+
+        processAllBatches(context: newContext)
     }
 
-    // MARK: - Progress Processing
+    // MARK: - Full-File Processing
 
-    private func processProgress(playbackTime: Double, episodeUuid: String?) {
-        guard let ctx = context, ctx.episodeUuid == episodeUuid else { return }
-
-        if lastPlaybackTime >= 0 {
-            let delta = abs(playbackTime - lastPlaybackTime)
-            if delta > FingerprintConstants.restartDeltaSeconds {
-                FileLog.shared.addMessage(
-                    "FingerprintTimingManager: jump detected (\(String(format: "%.1f", delta))s), restarting"
-                )
-                restartFromCurrentPosition(playbackTime: playbackTime)
-                return
-            }
-        }
-        lastPlaybackTime = playbackTime
-
-        if isWithinMappedRange(playbackTime) { return }
-        guard !isProcessingBatch else { return }
-
-        let batchDur = FingerprintConstants.batchDurationSeconds
-        guard batchDur > 0 else { return }
-        let batchIndex = Int(playbackTime / batchDur)
-        guard batchIndex != lastProcessedBatchIndex else { return }
-
-        lastProcessedBatchIndex = batchIndex
-        isProcessingBatch = true
-
-        generateAndMatchBatch(batchIndex: batchIndex, context: ctx)
-    }
-
-    private func restartFromCurrentPosition(playbackTime: Double) {
-        cancellationFlag.cancel()
-        cancellationFlag = CancellationFlag()
-        if let existingCtx = context {
-            let flag = cancellationFlag
-            context = GenerationContext(
-                episodeUuid: existingCtx.episodeUuid,
-                audioFileURL: existingCtx.audioFileURL,
-                fileSize: existingCtx.fileSize,
-                duration: existingCtx.duration,
-                matcher: existingCtx.matcher,
-                fingerprinter: existingCtx.fingerprinter,
-                isCancelled: { flag.isCancelled }
-            )
-        }
-        playbackToReference.removeAll()
-        referenceToPlayback.removeAll()
-        lastProcessedBatchIndex = -1
-        isProcessingBatch = false
-        lastPlaybackTime = playbackTime
-        updateState(.preparing)
-    }
-
-    private func isWithinMappedRange(_ playbackTime: Double) -> Bool {
-        guard let first = playbackToReference.first,
-              let last = playbackToReference.last else {
-            return false
-        }
-        let margin = FingerprintConstants.playbackRangeMarginSeconds
-        return playbackTime >= first.playbackTime - margin
-            && playbackTime <= last.playbackTime + margin
-    }
-
-    // MARK: - Batch Generation & Matching
-
-    private func generateAndMatchBatch(batchIndex: Int, context ctx: GenerationContext) {
-        let batchDur = FingerprintConstants.batchDurationSeconds
-        let startTime = Double(batchIndex) * batchDur
-        let endTime = min(startTime + batchDur, ctx.duration)
-
-        let bytesPerSecond = Double(ctx.fileSize) / ctx.duration
-        let startByte = UInt64(max(0, startTime * bytesPerSecond))
-        let endByte = min(UInt64(endTime * bytesPerSecond), ctx.fileSize)
-
-        guard startByte < endByte else {
-            isProcessingBatch = false
-            return
-        }
-
+    /// Fingerprint the whole downloaded file in one pass. We can't byte-slice and feed
+    /// arbitrary chunks to the fingerprinter — the codec needs a real container/header
+    /// to detect format, which only exists at file start. Memory-mapping the file keeps
+    /// peak resident memory bounded.
+    private func processAllBatches(context ctx: GenerationContext) {
         generationQueue.async { [weak self] in
             guard let self else { return }
-            let result = Self.fingerprintBatch(
+            let result = Self.fingerprintWholeFile(
                 fileURL: ctx.audioFileURL,
-                byteRange: startByte..<endByte,
                 fingerprinter: ctx.fingerprinter,
                 isCancelled: ctx.isCancelled
             )
 
-            self.queue.async {
-                defer { self.isProcessingBatch = false }
-                guard self.context?.episodeUuid == ctx.episodeUuid else { return }
+            self.queue.async { [weak self] in
+                guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
 
                 switch result {
                 case .success(let windows):
-                    self.processMatches(
-                        windows: windows,
-                        batchStartTime: startTime,
-                        context: ctx
+                    self.processMatches(windows: windows, context: ctx)
+                    FileLog.shared.addMessage(
+                        "FingerprintTimingManager: full-file processing completed (\(windows.count) windows)"
                     )
                 case .failure(let error):
                     FileLog.shared.addMessage(
-                        "FingerprintTimingManager: batch \(batchIndex) failed — \(error)"
+                        "FingerprintTimingManager: full-file processing failed — \(error)"
                     )
                 }
             }
         }
     }
 
-    private static func fingerprintBatch(
+    private static func fingerprintWholeFile(
         fileURL: URL,
-        byteRange: Range<UInt64>,
         fingerprinter: Fingerprinter,
         isCancelled: () -> Bool
     ) -> Result<[WindowedFingerprint], Error> {
         if isCancelled() { return .failure(BatchError.cancelled) }
 
-        let slice: Data
+        let data: Data
         do {
-            let fileHandle = try FileHandle(forReadingFrom: fileURL)
-            defer { try? fileHandle.close() }
-            try fileHandle.seek(toOffset: byteRange.lowerBound)
-            let length = Int(byteRange.upperBound - byteRange.lowerBound)
-            guard let data = try fileHandle.read(upToCount: length), data.count == length else {
-                return .failure(BatchError.invalidByteRange)
-            }
-            slice = data
+            data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
         } catch {
             return .failure(error)
         }
@@ -408,7 +300,7 @@ final class FingerprintTimingManager: NSObject {
 
         do {
             let windows = try fingerprinter.fingerprintDataWindowed(
-                data: slice,
+                data: data,
                 windowDurationMs: FingerprintConstants.windowDurationMs,
                 windowIntervalMs: FingerprintConstants.windowIntervalMs
             )
@@ -420,29 +312,38 @@ final class FingerprintTimingManager: NSObject {
 
     private enum BatchError: Error {
         case cancelled
-        case invalidByteRange
     }
 
     private func processMatches(
         windows: [WindowedFingerprint],
-        batchStartTime: Double,
         context ctx: GenerationContext
     ) {
         var inserted = 0
+        var bestScoreOverall: Float = 0
+        var nonZeroScoreCount = 0
+        var scoreSum: Float = 0
+
         for window in windows {
             let matches = ctx.matcher.findTopMatches(
                 queryHashes: window.hashes,
                 maxResults: 1
             )
-            guard let best = matches.first,
-                  best.score >= FingerprintConstants.matchScoreThreshold else { continue }
+            if let best = matches.first {
+                if best.score > 0 {
+                    nonZeroScoreCount += 1
+                    scoreSum += best.score
+                }
+                if best.score > bestScoreOverall { bestScoreOverall = best.score }
 
-            insertMapping(TimeMappingEntry(
-                playbackTime: batchStartTime + Double(window.timestampMs) / 1000.0,
-                referenceTime: Double(best.timestamp),
-                score: best.score
-            ))
-            inserted += 1
+                if best.score >= FingerprintConstants.matchScoreThreshold {
+                    insertMapping(TimeMappingEntry(
+                        playbackTime: Double(window.timestampMs) / 1000.0,
+                        referenceTime: Double(best.timestamp),
+                        score: best.score
+                    ))
+                    inserted += 1
+                }
+            }
         }
 
         let coverage = playbackToReference.count
@@ -450,9 +351,11 @@ final class FingerprintTimingManager: NSObject {
             updateState(.active(coverage: coverage))
         }
 
+        let avgNonZero = nonZeroScoreCount > 0 ? scoreSum / Float(nonZeroScoreCount) : 0
         FileLog.shared.addMessage(
-            "FingerprintTimingManager: batch at \(String(format: "%.1f", batchStartTime))s "
-                + "matched \(inserted)/\(windows.count) windows (coverage: \(coverage))"
+            "FingerprintTimingManager: matched \(inserted)/\(windows.count) windows "
+                + "(coverage: \(coverage), bestScore: \(String(format: "%.3f", bestScoreOverall)), "
+                + "nonZero: \(nonZeroScoreCount), avgNonZero: \(String(format: "%.3f", avgNonZero)))"
         )
     }
 
@@ -535,18 +438,12 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
+    /// Downloaded-only: the full-file processing path requires the complete audio file on disk.
+    /// Streaming-buffer support is intentionally out of scope for POC-531.
     private func resolveAudioFileURL(for episode: BaseEpisode) -> URL? {
         let downloadPath = DownloadManager.shared.pathForEpisode(episode)
-        if FileManager.default.fileExists(atPath: downloadPath) {
-            return URL(fileURLWithPath: downloadPath)
-        }
-
-        let streamingPath = DownloadManager.shared.streamingBufferPathForEpisode(episode)
-        if FileManager.default.fileExists(atPath: streamingPath) {
-            return URL(fileURLWithPath: streamingPath)
-        }
-
-        return nil
+        guard FileManager.default.fileExists(atPath: downloadPath) else { return nil }
+        return URL(fileURLWithPath: downloadPath)
     }
 }
 

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -377,12 +377,29 @@ final class FingerprintTimingManager: NSObject {
                 FileLog.shared.addMessage(
                     "FingerprintTimingManager: streaming fingerprint completed (started at \(String(format: "%.1f", aligned))s)"
                 )
+                self.finishIfStillPreparing(terminalState: .unavailable, context: ctx)
             } catch StreamError.cancelled {
                 FileLog.shared.addMessage("FingerprintTimingManager: streaming fingerprint cancelled")
+                // State will be reset by whatever cancelled us (restart / stop / new episode).
             } catch {
                 FileLog.shared.addMessage(
                     "FingerprintTimingManager: streaming fingerprint failed — \(error.localizedDescription)"
                 )
+                self.finishIfStillPreparing(terminalState: .failed(error), context: ctx)
+            }
+        }
+    }
+
+    /// Only override state if the stream for `ctx` is still the current one AND we
+    /// haven't already reached `.active` — otherwise a late completion for an
+    /// abandoned context would clobber a healthy state.
+    private func finishIfStillPreparing(terminalState: State, context ctx: GenerationContext) {
+        queue.async { [weak self] in
+            guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                if case .active = self.state { return }
+                self.state = terminalState
             }
         }
     }

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -63,6 +63,12 @@ final class FingerprintTimingManager: NSObject {
 
     override init() {
         super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleEpisodeDownloaded(_:)),
+            name: Constants.Notifications.episodeDownloaded,
+            object: nil
+        )
     }
 
     // MARK: - Public API
@@ -74,6 +80,24 @@ final class FingerprintTimingManager: NSObject {
             guard let self else { return }
             self.resetState()
             self.prepareForEpisode(episode)
+        }
+    }
+
+    /// When an episode download completes while the transcript flow has already requested
+    /// preparation, retry. If we previously gave up because no local file existed, or were
+    /// processing a partial streaming buffer, we now have a complete file to fingerprint.
+    @objc private func handleEpisodeDownloaded(_ notification: Notification) {
+        guard let downloadedUuid = notification.object as? String,
+              let currentUuid = PlaybackManager.shared.currentEpisode()?.uuid,
+              currentUuid == downloadedUuid else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if case .active = self.state { return }
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: episode \(downloadedUuid) finished downloading — re-preparing"
+            )
+            self.prepareForCurrentEpisode()
         }
     }
 
@@ -185,7 +209,7 @@ final class FingerprintTimingManager: NSObject {
 
         guard let audioFileURL = resolveAudioFileURL(for: episode) else {
             updateState(.unavailable)
-            FileLog.shared.addMessage("FingerprintTimingManager: episode \(uuid) is not downloaded — skipping fingerprinting")
+            FileLog.shared.addMessage("FingerprintTimingManager: no local audio file for \(uuid) — skipping fingerprinting")
             return
         }
 
@@ -460,12 +484,20 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
-    /// Downloaded-only: the full-file processing path requires the complete audio file on disk.
-    /// Streaming-buffer support is intentionally out of scope for POC-531.
+    /// Resolves the local audio file for an episode. Pocket Casts always writes a
+    /// local copy — either at the downloaded path (explicit download) or at the
+    /// streaming-buffer path (auto-cached during streaming). Either is a complete
+    /// file that AVAudioFile can decode.
     private func resolveAudioFileURL(for episode: BaseEpisode) -> URL? {
         let downloadPath = DownloadManager.shared.pathForEpisode(episode)
-        guard FileManager.default.fileExists(atPath: downloadPath) else { return nil }
-        return URL(fileURLWithPath: downloadPath)
+        if FileManager.default.fileExists(atPath: downloadPath) {
+            return URL(fileURLWithPath: downloadPath)
+        }
+        let streamingPath = DownloadManager.shared.streamingBufferPathForEpisode(episode)
+        if FileManager.default.fileExists(atPath: streamingPath) {
+            return URL(fileURLWithPath: streamingPath)
+        }
+        return nil
     }
 }
 

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -416,7 +416,13 @@ final class FingerprintTimingManager: NSObject {
     }
 
     private func streamFingerprint(context ctx: GenerationContext, startingAt startSeconds: Double) throws {
-        let audioFile = try AVAudioFile(forReading: ctx.audioFileURL)
+        // Force the reader to hand us non-interleaved Float32 PCM so
+        // `buffer.floatChannelData` is never nil regardless of the on-disk format.
+        let audioFile = try AVAudioFile(
+            forReading: ctx.audioFileURL,
+            commonFormat: .pcmFormatFloat32,
+            interleaved: false
+        )
         let format = audioFile.processingFormat
         let sampleRate = UInt32(format.sampleRate)
         let channels = UInt16(format.channelCount)

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -78,6 +78,10 @@ final class FingerprintTimingManager: NSObject {
         )
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     // MARK: - Public API
 
     func prepareForCurrentEpisode() {

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -621,10 +621,12 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
-    /// Resolves the local audio file for an episode. Pocket Casts always writes a
-    /// local copy — either at the downloaded path (explicit download) or at the
-    /// streaming-buffer path (auto-cached during streaming). Either is a complete
-    /// file that AVAudioFile can decode.
+    /// Resolves the local audio file for an episode. The downloaded path is always
+    /// a complete file. The streaming-buffer path may still be growing — `AVAudioFile`
+    /// only sees the bytes present at open time, so we'll fingerprint up to that point
+    /// and stop; the rest of the buffer (if it fills in later) is not picked up. Full
+    /// streaming support would need file-growth tracking, which is out of scope for
+    /// this PR (see `bufferGrowPollCadenceSeconds` in `FingerprintConstants`).
     private func resolveAudioFileURL(for episode: BaseEpisode) -> URL? {
         let downloadPath = DownloadManager.shared.pathForEpisode(episode)
         if FileManager.default.fileExists(atPath: downloadPath) {

--- a/podcasts/Fingerprint/ReferenceFingerprint.swift
+++ b/podcasts/Fingerprint/ReferenceFingerprint.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Fingerprint
 import PocketCastsUtils
 
 struct ReferenceFingerprint: Decodable {
@@ -55,6 +54,11 @@ struct ReferenceFingerprint: Decodable {
     }
 
     /// Decode every v2 checkpoint into the library's `(timestamp, hashes)` shape.
+    ///
+    /// The `data` payload in compact-v2 is the raw little-endian byte packing of
+    /// `[UInt32]` hashes (not the `fingerprintFromBytes` framed format), and
+    /// `timestampQuantum` is the number of seconds per delta unit (so the resulting
+    /// timestamp is `accumulated * quantum` seconds — no /1000 conversion).
     /// Returns an empty array if none of the checkpoints parse.
     func libraryCheckpoints() -> [LibraryCheckpoint] {
         var accumulated = 0
@@ -64,9 +68,14 @@ struct ReferenceFingerprint: Decodable {
         for checkpoint in checkpoints {
             accumulated += checkpoint.delta
             guard let payload = Data(base64Encoded: checkpoint.data) else { continue }
-            guard let decoded = fingerprintFromBytes(data: payload) else { continue }
-            let timestamp = Float(Double(accumulated) * Double(timestampQuantum) / 1000.0)
-            result.append(LibraryCheckpoint(timestampSeconds: timestamp, hashes: decoded.hashes))
+            guard payload.count % 4 == 0 else { continue }
+            let hashes = payload.withUnsafeBytes { rawBuffer -> [UInt32] in
+                let count = rawBuffer.count / 4
+                let typed = rawBuffer.bindMemory(to: UInt32.self)
+                return (0..<count).map { UInt32(littleEndian: typed[$0]) }
+            }
+            let timestamp = Float(accumulated) * Float(timestampQuantum)
+            result.append(LibraryCheckpoint(timestampSeconds: timestamp, hashes: hashes))
         }
         return result
     }

--- a/podcasts/Fingerprint/ReferenceFingerprint.swift
+++ b/podcasts/Fingerprint/ReferenceFingerprint.swift
@@ -69,10 +69,20 @@ struct ReferenceFingerprint: Decodable {
             accumulated += checkpoint.delta
             guard let payload = Data(base64Encoded: checkpoint.data) else { continue }
             guard payload.count % 4 == 0 else { continue }
-            let hashes = payload.withUnsafeBytes { rawBuffer -> [UInt32] in
-                let count = rawBuffer.count / 4
-                let typed = rawBuffer.bindMemory(to: UInt32.self)
-                return (0..<count).map { UInt32(littleEndian: typed[$0]) }
+            // Decode as little-endian UInt32s via byte-shift arithmetic — `Data`'s
+            // underlying storage isn't guaranteed to be 4-byte aligned, so directly
+            // binding/reinterpreting as `UInt32` can trap on misaligned access.
+            let count = payload.count / 4
+            var hashes = [UInt32](repeating: 0, count: count)
+            payload.withUnsafeBytes { rawBuffer in
+                guard let base = rawBuffer.baseAddress else { return }
+                for i in 0..<count {
+                    let b0 = UInt32(base.load(fromByteOffset: i * 4, as: UInt8.self))
+                    let b1 = UInt32(base.load(fromByteOffset: i * 4 + 1, as: UInt8.self))
+                    let b2 = UInt32(base.load(fromByteOffset: i * 4 + 2, as: UInt8.self))
+                    let b3 = UInt32(base.load(fromByteOffset: i * 4 + 3, as: UInt8.self))
+                    hashes[i] = b0 | (b1 << 8) | (b2 << 16) | (b3 << 24)
+                }
             }
             let timestamp = Float(accumulated) * Float(timestampQuantum)
             result.append(LibraryCheckpoint(timestampSeconds: timestamp, hashes: hashes))

--- a/podcasts/TranscriptManager.swift
+++ b/podcasts/TranscriptManager.swift
@@ -78,11 +78,13 @@ class TranscriptManager {
             throw TranscriptError.failedToLoad
         }
 
-        let crumb = Breadcrumb()
-        crumb.level = SentryLevel.info
-        crumb.category = "transcript"
-        crumb.message = "Transcript file \(transcriptURL)"
-        SentrySDK.addBreadcrumb(crumb)
+        await MainActor.run {
+            let crumb = Breadcrumb()
+            crumb.level = SentryLevel.info
+            crumb.category = "transcript"
+            crumb.message = "Transcript file \(transcriptURL)"
+            SentrySDK.addBreadcrumb(crumb)
+        }
 
         guard let model = TranscriptModel.makeModel(from: transcriptText, format: transcriptFormat) else {
             throw TranscriptError.failedToParse

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -184,7 +184,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             overlay.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
             overlay.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
             overlay.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -8),
-            overlay.heightAnchor.constraint(equalToConstant: 12)
+            overlay.heightAnchor.constraint(equalToConstant: 16)
         ])
         debugOverlay = overlay
         #endif

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -460,6 +460,9 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
     override func willBeRemovedFromPlayer() {
         removeAllCustomObservers()
+        if FeatureFlag.syncedTranscripts.enabled {
+            FingerprintTimingManager.shared.stop()
+        }
         #if DEBUG
         debugTimer?.invalidate()
         debugTimer = nil


### PR DESCRIPTION
| 📘 Part of: #POC-531 |
|:---:|

Wires fingerprint-based transcript highlighting end-to-end for **downloaded** episodes, building on top of the reference-fingerprint plumbing landed by POC-530.

## What's in

**Progressive fingerprinting anchored to playback**

- `FingerprintTimingManager` now decodes the local audio file through `AVAudioFile` and feeds PCM chunk-by-chunk into `StreamingWindowedFingerprinter`. Matches are inserted into the playback↔reference mapping as each chunk is processed, so highlighting and tap-to-seek become usable well before the whole file is done.
- Fingerprint generation starts at the current playback position (snapped to the 2s window grid so hashes line up with the reference checkpoints), not at byte 0. On a big seek or when playback drifts outside the mapped range, it cancels the in-flight stream and restarts from the new position. This keeps coverage close to what the listener is actually hearing.

**Reference-format fix**

- `ReferenceFingerprint.libraryCheckpoints()` was decoding the server's `fingerprint-compact-v2` payloads with the wrong framing (`fingerprintFromBytes` expects a length-prefixed blob, but compact-v2 stores raw packed `u32` LE hashes) and using the wrong timestamp scale (`/1000` assumes ms-per-unit, but the format uses seconds-per-unit). Both fixed; we now decode all checkpoints and place them on the correct absolute timeline.

**Lifecycle**

- Re-runs preparation when `episodeDownloaded` fires for the current episode, so a transcript that was opened mid-download picks up the complete file as soon as it lands.
- `stop()` is called from `TranscriptViewController.willBeRemovedFromPlayer` — leaving the transcript tears down the in-flight reference fetch, cancels the streaming pipeline, clears mappings, and returns to `.idle`.

**Scope note: streaming**

- Scope for this PR is **downloaded** episodes. `resolveAudioFileURL` does fall back to the streaming-buffer path if a file already exists there (covers the case where the user played through previously and the cache is complete), but there's no file-growth tracking or post-stream re-prep — if the buffer is still being written when we open it, `AVAudioFile` only sees what's on disk at that moment and we won't pick up the rest. The three streaming-oriented constants (`restartDeltaSeconds`, `playbackRangeMarginSeconds`, `bufferGrowPollCadenceSeconds`) are kept and annotated as reserved for a future streaming path.

**Debug UI**

- The DEBUG overlay gains a grey timeline backdrop so coverage progress is visible as it fills in, plus a small status label showing `idle / preparing / active(N) / failed / unavailable`.

**Cleanup**

- Unused byte-range batching removed. `batchDurationSeconds` dropped (no longer used).
- Sentry `addBreadcrumb` call in `TranscriptManager.loadTranscript` moved to the main actor to avoid a Main Thread Checker warning.

## To test

1. Enable the `syncedTranscripts` feature flag in a staging build.
2. Find a podcast episode that has a server-side fingerprint reference.
3. **Downloaded path:** download the episode, open it, open the Transcript tab.
   - Tail the file log: expect `preparing for <uuid>`, then `matched X/Y windows (coverage: N)` lines as PCM chunks flow through.
   - The DEBUG overlay at the bottom of the transcript fills left-to-right with green/orange segments; the status label transitions `preparing → active(coverage: N)`.
   - Before playback starts, tap a cue near the fingerprinted region — playback should seek to the right point.
   - Press play. The active cue highlights and auto-scrolls. Seek backwards a long way and confirm coverage refocuses around the new position.
4. **Mid-download path:** open the transcript while an episode is still downloading (expect `unavailable` initially), then let the download finish. The manager should re-prepare and highlighting kicks in.
5. **Exit cleanup:** while fingerprinting is in flight, close the transcript screen. Log should show `FingerprintTimingManager: stopped` and no further `matched …` lines for that episode.
6. Run the unit tests: `make test_staging ONLY_TESTING=PocketCastsTests/FingerprintTimingManagerTests`.

> ⚠️ Includes commit `1c1f1301c DEBUG: assume generated transcripts always` to force the server/feature gate during staging testing. Revert before merge once the server side is ready.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.