### PR TITLE
POC-532: Drift filter to stop spurious fingerprint jump-arounds

### DIFF
--- a/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
@@ -139,6 +139,114 @@ final class FingerprintTimingManagerTests: XCTestCase {
         XCTAssertEqual(result, 45.0, accuracy: 0.001)
     }
 
+    // MARK: - Drift filter
+
+    func testDriftFilterSequentialStreamInsertsAllInOrder() throws {
+        let manager = FingerprintTimingManager()
+        // Seven sequential candidates (rate 1), well under the 5 s tolerance.
+        let stream = (0..<7).map { i in Entry(playbackTime: Double(i) * 2, referenceTime: Double(i) * 2) }
+
+        manager.stubMatches(stream)
+
+        // All seven should be committed in order, queryable across the range.
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 0)), 0, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 12)), 12, accuracy: 0.001)
+    }
+
+    func testDriftFilterDropsLoneOutlier() throws {
+        let manager = FingerprintTimingManager()
+        // Three sequential (bootstrap), one outlier, three more sequential.
+        let stream: [Entry] = [
+            Entry(playbackTime: 0, referenceTime: 0),
+            Entry(playbackTime: 2, referenceTime: 2),
+            Entry(playbackTime: 4, referenceTime: 4),
+            Entry(playbackTime: 6, referenceTime: 500), // lone outlier
+            Entry(playbackTime: 8, referenceTime: 8),   // back on trend
+            Entry(playbackTime: 10, referenceTime: 10),
+            Entry(playbackTime: 12, referenceTime: 12),
+        ]
+
+        manager.stubMatches(stream)
+
+        // The outlier at playback=6 should have been dropped, not interpolated.
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 4)), 4, accuracy: 0.001)
+        // A query right where the outlier was should interpolate between 4 and 8 → 6,
+        // not land near 500.
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 6)), 6, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 12)), 12, accuracy: 0.001)
+    }
+
+    func testDriftFilterConfirmsRealJump() throws {
+        let manager = FingerprintTimingManager()
+        // Three sequential, then a 90 s transcript-only ad break jump.
+        let stream: [Entry] = [
+            Entry(playbackTime: 0, referenceTime: 0),
+            Entry(playbackTime: 2, referenceTime: 2),
+            Entry(playbackTime: 4, referenceTime: 4),
+            Entry(playbackTime: 6, referenceTime: 96),  // jump — pending
+            Entry(playbackTime: 8, referenceTime: 98),  // confirms the jump
+            Entry(playbackTime: 10, referenceTime: 100),
+        ]
+
+        manager.stubMatches(stream)
+
+        // Pre-jump region intact.
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 4)), 4, accuracy: 0.001)
+        // Post-jump region also committed.
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 8)), 98, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 10)), 100, accuracy: 0.001)
+    }
+
+    func testDriftFilterRejectsJumpAroundNoise() throws {
+        let manager = FingerprintTimingManager()
+        // Three sequential, then four candidates all over the place, none consistent
+        // with each other or with the trusted anchor.
+        let stream: [Entry] = [
+            Entry(playbackTime: 0, referenceTime: 0),
+            Entry(playbackTime: 2, referenceTime: 2),
+            Entry(playbackTime: 4, referenceTime: 4),
+            Entry(playbackTime: 6, referenceTime: 500),
+            Entry(playbackTime: 8, referenceTime: 150),
+            Entry(playbackTime: 10, referenceTime: 800),
+            Entry(playbackTime: 12, referenceTime: 220),
+        ]
+
+        manager.stubMatches(stream)
+
+        // The three bootstrap entries are the only things in the mapping; none of
+        // the noise lands. Had any of the noise been accepted, queries in that
+        // region would snap to the bogus reference value (e.g. 500 / 150 / 800).
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 2)), 2, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 6)), 6, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 10)), 10, accuracy: 0.001)
+    }
+
+    func testDriftFilterBootstrapRollsForwardPastEarlyJump() throws {
+        let manager = FingerprintTimingManager()
+        // First two candidates would form a consistent pair, but the third breaks
+        // rate 1. The window rolls forward until a consistent trio arrives.
+        let stream: [Entry] = [
+            Entry(playbackTime: 0, referenceTime: 0),
+            Entry(playbackTime: 2, referenceTime: 2),
+            Entry(playbackTime: 4, referenceTime: 400),  // breaks the trio
+            Entry(playbackTime: 6, referenceTime: 402),
+            Entry(playbackTime: 8, referenceTime: 404),  // now (4, 400) / (6, 402) / (8, 404) form a rate-1 trio
+        ]
+
+        manager.stubMatches(stream)
+
+        // The first two candidates (0→0, 2→2) must NOT be in the mapping — if
+        // they had been committed, a query at playback=4 would be 3-ish
+        // (midway between (2,2) and the next anchor). Instead the trio
+        // (4,400)/(6,402)/(8,404) is the only committed region, so
+        // playback=4 pins to 400.
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 4)), 400, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 6)), 402, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 8)), 404, accuracy: 0.001)
+    }
+
+    // MARK: - Static interpolate helper: math correctness
+
     func testInterpolateReturnsExactValueAtBoundary() throws {
         let entries = [
             Entry(playbackTime: 0.0, referenceTime: 100.0),

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -48,4 +48,21 @@ enum FingerprintConstants {
     /// Number of consecutive rate-≈1 candidates required to establish the first
     /// trusted anchor before we have one to project from.
     static let driftBootstrapCount: Int = 3
+
+    /// Minimum matcher score for a match to even reach the drift filter. This is
+    /// stricter than `matchScoreThreshold` on purpose: `matchScoreThreshold` is
+    /// the matcher's minimum-confidence floor, this is the filter's "is this
+    /// actually a good enough match to build a mapping on" bar. Set high enough
+    /// that low-confidence hits in non-matching audio (ads, music beds, intros
+    /// not in the transcript) don't feed the filter.
+    static let driftAnchorScoreThreshold: Float = 0.75
+
+    /// Minimum score gap between the top-1 and top-2 matcher candidates for a
+    /// window. Real audio matches have a unique winner — top-1 scores much
+    /// higher than top-2 because only one region of the reference truly lines
+    /// up. Spurious matches from non-matching audio score similarly against
+    /// several nearby reference windows (weak evidence smeared across the
+    /// reference), so the gap is small. Rejecting those avoids admitting
+    /// correlated false positives produced by overlapping query windows.
+    static let driftScoreDominanceGap: Float = 0.15
 }

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -49,20 +49,19 @@ enum FingerprintConstants {
     /// trusted anchor before we have one to project from.
     static let driftBootstrapCount: Int = 3
 
-    /// Minimum matcher score for a match to even reach the drift filter. This is
-    /// stricter than `matchScoreThreshold` on purpose: `matchScoreThreshold` is
-    /// the matcher's minimum-confidence floor, this is the filter's "is this
-    /// actually a good enough match to build a mapping on" bar. Set high enough
-    /// that low-confidence hits in non-matching audio (ads, music beds, intros
-    /// not in the transcript) don't feed the filter.
-    static let driftAnchorScoreThreshold: Float = 0.75
+    /// Minimum matcher score for a match to even reach the drift filter. Stricter
+    /// than `matchScoreThreshold` on purpose: that one is the matcher's minimum-
+    /// confidence floor; this is the filter's "is this actually good enough to
+    /// build a mapping on" bar. Kept just above the red/orange boundary on the
+    /// debug overlay so solid-orange matches (which do come from real content)
+    /// still get in, while the red noise does not.
+    static let driftAnchorScoreThreshold: Float = 0.65
 
     /// Minimum score gap between the top-1 and top-2 matcher candidates for a
-    /// window. Real audio matches have a unique winner — top-1 scores much
-    /// higher than top-2 because only one region of the reference truly lines
-    /// up. Spurious matches from non-matching audio score similarly against
-    /// several nearby reference windows (weak evidence smeared across the
-    /// reference), so the gap is small. Rejecting those avoids admitting
-    /// correlated false positives produced by overlapping query windows.
-    static let driftScoreDominanceGap: Float = 0.15
+    /// window. Real matches tend to have a clear winner; correlated false
+    /// positives from non-matching audio score similarly against several nearby
+    /// reference windows, so the gap is small. Small value here — we just want
+    /// to reject near-ties, not demand a huge dominance (which would kill real
+    /// matches whose nearby reference windows also score decently).
+    static let driftScoreDominanceGap: Float = 0.05
 }

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -37,4 +37,15 @@ enum FingerprintConstants {
 
     /// Minimum number of mapping entries before the timing manager transitions to `.active`.
     static let minimumCoverageForActive: Int = 2
+
+    /// Residual tolerance, in seconds, on the rate-≈1 drift filter. This is **not**
+    /// a jump size cap — a jump of any magnitude is accepted as long as the next
+    /// candidate projects from the jump position at rate 1 within this tolerance.
+    /// What this rejects is "candidate sits off any recent rate-1 line", i.e.
+    /// jump-around noise.
+    static let driftToleranceSeconds: Double = 5
+
+    /// Number of consecutive rate-≈1 candidates required to establish the first
+    /// trusted anchor before we have one to project from.
+    static let driftBootstrapCount: Int = 3
 }

--- a/podcasts/Fingerprint/FingerprintDebugOverlay.swift
+++ b/podcasts/Fingerprint/FingerprintDebugOverlay.swift
@@ -4,6 +4,7 @@ import UIKit
 class FingerprintDebugOverlay: UIView {
 
     private var entries: [FingerprintTimingManager.TimeMappingEntry] = []
+    private var rejections: [FingerprintTimingManager.TimeMappingEntry] = []
     private var totalDuration: Double = 0
     private var playbackPosition: Double = 0
 
@@ -39,6 +40,7 @@ class FingerprintDebugOverlay: UIView {
 
     func update() {
         entries = FingerprintTimingManager.shared.debugMappingSnapshot()
+        rejections = FingerprintTimingManager.shared.debugRejectionsSnapshot()
         // Fingerprint generation may not have started yet (no context → nil duration).
         // Fall back to the episode's duration so the playback cursor and tap-to-seek
         // work regardless of fingerprint state.
@@ -65,6 +67,18 @@ class FingerprintDebugOverlay: UIView {
         // as the full-file walk fills coverage in.
         ctx?.setFillColor(UIColor.darkGray.withAlphaComponent(0.5).cgColor)
         ctx?.fill(rect)
+
+        // Rejected-candidate ticks at half-height on the bottom — "matcher fired
+        // here but the drift filter dropped it as noise". Drawn underneath the
+        // accepted-match bars so any accepted segment visually covers its slot.
+        let tickHeight = rect.height / 2
+        let tickY = rect.height - tickHeight
+        for entry in rejections {
+            let x = CGFloat(entry.playbackTime / totalDuration) * rect.width
+            let tickWidth = max(CGFloat(1.0 / totalDuration) * rect.width, 1.5)
+            ctx?.setFillColor(UIColor.systemPurple.withAlphaComponent(0.75).cgColor)
+            ctx?.fill(CGRect(x: x, y: tickY, width: tickWidth, height: tickHeight))
+        }
 
         for entry in entries {
             let x = CGFloat(entry.playbackTime / totalDuration) * rect.width

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -597,9 +597,15 @@ final class FingerprintTimingManager: NSObject {
         }
 
         #if DEBUG
+        // `inserted` is the mapping count committed during this call, not a
+        // ratio to windows processed — the drift filter holds candidates in a
+        // pool across batches and can flush several at once on confirmation, so
+        // `inserted` may exceed `windows.count` (or be zero while the pool is
+        // still accumulating). Report them as independent quantities.
         let avgNonZero = nonZeroScoreCount > 0 ? scoreSum / Float(nonZeroScoreCount) : 0
         FileLog.shared.addMessage(
-            "FingerprintTimingManager: matched \(inserted)/\(windows.count) windows "
+            "FingerprintTimingManager: processed \(windows.count) windows, "
+                + "committed \(inserted) mappings "
                 + "(coverage: \(coverage), bestScore: \(String(format: "%.3f", bestScoreOverall)), "
                 + "nonZero: \(nonZeroScoreCount), avgNonZero: \(String(format: "%.3f", avgNonZero)))"
         )

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -535,27 +535,48 @@ final class FingerprintTimingManager: NSObject {
         var scoreSum: Float = 0
 
         for window in windows {
+            // Pull top-2 so we can check how dominant the winner is — ambiguous
+            // wins (top-1 barely beats top-2) are the hallmark of correlated
+            // false positives from non-matching audio.
             let matches = ctx.matcher.findTopMatches(
                 queryHashes: window.hashes,
-                maxResults: 1
+                maxResults: 2
             )
-            if let best = matches.first {
-                if best.score > 0 {
-                    nonZeroScoreCount += 1
-                    scoreSum += best.score
-                }
-                if best.score > bestScoreOverall { bestScoreOverall = best.score }
+            guard let best = matches.first else { continue }
 
-                if best.score >= FingerprintConstants.matchScoreThreshold {
-                    let absolutePlaybackTime = startOffset + Double(window.timestampMs) / 1000.0
-                    let candidate = TimeMappingEntry(
-                        playbackTime: absolutePlaybackTime,
-                        referenceTime: Double(best.timestamp),
-                        score: best.score
-                    )
-                    inserted += consider(candidate: candidate)
-                }
+            if best.score > 0 {
+                nonZeroScoreCount += 1
+                scoreSum += best.score
             }
+            if best.score > bestScoreOverall { bestScoreOverall = best.score }
+            guard best.score >= FingerprintConstants.matchScoreThreshold else { continue }
+
+            let absolutePlaybackTime = startOffset + Double(window.timestampMs) / 1000.0
+            let candidate = TimeMappingEntry(
+                playbackTime: absolutePlaybackTime,
+                referenceTime: Double(best.timestamp),
+                score: best.score
+            )
+
+            // Pre-filter gates. Low-score and ambiguous matches are recorded as
+            // rejections so the debug overlay can visualize "matcher fired but
+            // we didn't trust it" distinctly from "matcher never fired here".
+            if best.score < FingerprintConstants.driftAnchorScoreThreshold {
+                recordRejection(candidate, reason: "low score \(String(format: "%.2f", best.score))")
+                continue
+            }
+            let runnerUpScore = matches.dropFirst().first?.score ?? 0
+            let dominance = best.score - runnerUpScore
+            if dominance < FingerprintConstants.driftScoreDominanceGap {
+                recordRejection(
+                    candidate,
+                    reason: "ambiguous top-1 vs top-2 "
+                        + "(\(String(format: "%.2f", best.score)) vs \(String(format: "%.2f", runnerUpScore)))"
+                )
+                continue
+            }
+
+            inserted += consider(candidate: candidate)
         }
 
         let coverage = playbackToReference.count

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -60,6 +60,15 @@ final class FingerprintTimingManager: NSObject {
     private var referenceToPlayback: [TimeMappingEntry] = []
     private var lastProgressPosition: Double = -1
 
+    // Drift-filter state — see `consider(candidate:)`.
+    private var filterLastTrusted: TimeMappingEntry?
+    private var filterCandidatePool: [TimeMappingEntry] = []
+
+    #if DEBUG
+    private static let debugRejectionCap = 500
+    private var debugRejections: [TimeMappingEntry] = []
+    #endif
+
     // MARK: - Init
 
     override init() {
@@ -171,7 +180,9 @@ final class FingerprintTimingManager: NSObject {
 
     /// Cancel the in-flight stream and start a new one anchored at `position`.
     /// Existing mappings are kept — they're still valid, we just refocus
-    /// coverage growth around the listener's new position.
+    /// coverage growth around the listener's new position. Filter state is
+    /// reset because the new stream's first matches live in a region that has
+    /// no rate relationship to the old trusted anchor.
     private func restart(from position: Double, context ctx: GenerationContext) {
         cancellationFlag.cancel()
         cancellationFlag = CancellationFlag()
@@ -184,6 +195,7 @@ final class FingerprintTimingManager: NSObject {
             isCancelled: { flag.isCancelled }
         )
         context = newContext
+        resetFilterState()
         startStream(context: newContext, fromPosition: position)
     }
 
@@ -221,6 +233,14 @@ final class FingerprintTimingManager: NSObject {
         dispatchPrecondition(condition: .notOnQueue(queue))
         return queue.sync { playbackToReference }
     }
+
+    /// Candidates that reached the drift filter but were rejected. The debug
+    /// overlay uses this to distinguish "matcher never fired here" from
+    /// "matcher fired but everything was filtered out as noise".
+    func debugRejectionsSnapshot() -> [TimeMappingEntry] {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+        return queue.sync { debugRejections }
+    }
     #endif
 
     // MARK: - State Management
@@ -234,6 +254,15 @@ final class FingerprintTimingManager: NSObject {
         playbackToReference.removeAll()
         referenceToPlayback.removeAll()
         lastProgressPosition = -1
+        resetFilterState()
+        #if DEBUG
+        debugRejections.removeAll()
+        #endif
+    }
+
+    private func resetFilterState() {
+        filterLastTrusted = nil
+        filterCandidatePool.removeAll()
     }
 
     private func updateState(_ newState: State) {
@@ -519,12 +548,12 @@ final class FingerprintTimingManager: NSObject {
 
                 if best.score >= FingerprintConstants.matchScoreThreshold {
                     let absolutePlaybackTime = startOffset + Double(window.timestampMs) / 1000.0
-                    insertMapping(TimeMappingEntry(
+                    let candidate = TimeMappingEntry(
                         playbackTime: absolutePlaybackTime,
                         referenceTime: Double(best.timestamp),
                         score: best.score
-                    ))
-                    inserted += 1
+                    )
+                    inserted += consider(candidate: candidate)
                 }
             }
         }
@@ -542,12 +571,126 @@ final class FingerprintTimingManager: NSObject {
         )
     }
 
+    // MARK: - Drift Filter
+
+    /// Routes a score-passing candidate through the drift filter. Returns the
+    /// number of entries actually inserted into the mapping arrays this call.
+    ///
+    /// Invariant the filter enforces:
+    /// **no anchor — bootstrap or post-jump — is admitted until we've seen
+    /// `driftBootstrapCount` consecutive rate-≈1 candidates in a row.**
+    ///
+    /// - Fast path: candidate is in-trend with `filterLastTrusted` → commit
+    ///   immediately, flush any pooled candidates as rejections (a prior jump
+    ///   attempt that didn't pan out turned out to be noise).
+    /// - Slow path: candidate goes into `filterCandidatePool`. Once the pool's
+    ///   tail is `driftBootstrapCount` consecutive consistent entries, commit
+    ///   them all and drop anything before as rejections. Otherwise evict the
+    ///   oldest and keep rolling.
+    ///
+    /// This is the same rule for the initial bootstrap (no `lastTrusted` yet)
+    /// and for post-trusted jumps, so a single lucky pair can never admit an
+    /// anchor — what the user was seeing as "jump-arounds" in the debug UI.
+    @discardableResult
+    private func consider(candidate: TimeMappingEntry) -> Int {
+        if let trusted = filterLastTrusted, Self.isInTrend(candidate, relativeTo: trusted) {
+            // Sequential continuation. Anything that had collected in the pool
+            // was a jump attempt that never stabilized — reject it.
+            flushPoolAsRejected(reason: "returned to trend")
+            insertMapping(candidate)
+            filterLastTrusted = candidate
+            return 1
+        }
+
+        filterCandidatePool.append(candidate)
+        let n = FingerprintConstants.driftBootstrapCount
+
+        guard filterCandidatePool.count >= n else { return 0 }
+
+        let recent = Array(filterCandidatePool.suffix(n))
+        if Self.formsConsistentSequence(recent) {
+            // Confirmed new anchor. Anything older in the pool is noise.
+            let keepStart = filterCandidatePool.count - n
+            if keepStart > 0 {
+                for entry in filterCandidatePool.prefix(keepStart) {
+                    recordRejection(entry, reason: "pool evicted by confirmed anchor")
+                }
+            }
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: drift filter confirmed anchor "
+                    + "at playback \(String(format: "%.1f", recent.first!.playbackTime))s → "
+                    + "\(String(format: "%.1f", recent.last!.playbackTime))s "
+                    + "(\(n) consistent)"
+            )
+            for entry in recent {
+                insertMapping(entry)
+            }
+            filterLastTrusted = recent.last
+            filterCandidatePool.removeAll()
+            return n
+        }
+
+        // Not consistent yet — evict oldest and keep waiting for the window to
+        // roll onto a consistent stretch.
+        let evicted = filterCandidatePool.removeFirst()
+        recordRejection(evicted, reason: "pool evicted, no consistent run")
+        return 0
+    }
+
+    private func flushPoolAsRejected(reason: String) {
+        for entry in filterCandidatePool {
+            recordRejection(entry, reason: reason)
+        }
+        filterCandidatePool.removeAll()
+    }
+
+    /// Two entries are in-trend when `Δreference ≈ Δplayback` (rate ≈ 1),
+    /// within `driftToleranceSeconds` of residual slack.
+    private static func isInTrend(_ candidate: TimeMappingEntry, relativeTo anchor: TimeMappingEntry) -> Bool {
+        let deltaPlayback = candidate.playbackTime - anchor.playbackTime
+        let deltaReference = candidate.referenceTime - anchor.referenceTime
+        return abs(deltaReference - deltaPlayback) <= FingerprintConstants.driftToleranceSeconds
+    }
+
+    private static func formsConsistentSequence(_ entries: [TimeMappingEntry]) -> Bool {
+        guard entries.count >= 2 else { return true }
+        for i in 1..<entries.count where !isInTrend(entries[i], relativeTo: entries[i - 1]) {
+            return false
+        }
+        return true
+    }
+
+    private func recordRejection(_ entry: TimeMappingEntry, reason: String) {
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: drift filter dropped \(reason) "
+                + "at playback \(String(format: "%.1f", entry.playbackTime))s "
+                + "(matched reference \(String(format: "%.1f", entry.referenceTime))s)"
+        )
+        #if DEBUG
+        debugRejections.append(entry)
+        if debugRejections.count > Self.debugRejectionCap {
+            debugRejections.removeFirst(debugRejections.count - Self.debugRejectionCap)
+        }
+        #endif
+    }
+
     // MARK: - Time Mapping
 
     /// Test seam: inserts a mapping on the manager's serial queue so queries are
     /// consistent with production insertions that happen from within `processMatches`.
     func insert(mapping: TimeMappingEntry) {
         queue.sync { insertMapping(mapping) }
+    }
+
+    /// Test seam: routes a sequence of candidates through the drift filter
+    /// synchronously on the manager's serial queue, the way `processMatches`
+    /// does in production.
+    func stubMatches(_ entries: [TimeMappingEntry]) {
+        queue.sync {
+            for entry in entries {
+                _ = consider(candidate: entry)
+            }
+        }
     }
 
     private func insertMapping(_ entry: TimeMappingEntry) {

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -153,9 +153,11 @@ final class FingerprintTimingManager: NSObject {
         if lastProgressPosition >= 0 {
             let delta = abs(playbackTime - lastProgressPosition)
             if delta > FingerprintConstants.restartDeltaSeconds {
+                #if DEBUG
                 FileLog.shared.addMessage(
                     "FingerprintTimingManager: playback jumped \(String(format: "%.1f", delta))s — restarting from \(String(format: "%.1f", playbackTime))s"
                 )
+                #endif
                 restart(from: playbackTime, context: ctx)
                 lastProgressPosition = playbackTime
                 return
@@ -164,9 +166,11 @@ final class FingerprintTimingManager: NSObject {
         lastProgressPosition = playbackTime
 
         if isWithinMappedRange(playbackTime) { return }
+        #if DEBUG
         FileLog.shared.addMessage(
             "FingerprintTimingManager: playback at \(String(format: "%.1f", playbackTime))s outside mapped range — restarting"
         )
+        #endif
         restart(from: playbackTime, context: ctx)
     }
 
@@ -403,12 +407,16 @@ final class FingerprintTimingManager: NSObject {
             guard let self else { return }
             do {
                 try self.streamFingerprint(context: ctx, startingAt: aligned)
+                #if DEBUG
                 FileLog.shared.addMessage(
                     "FingerprintTimingManager: streaming fingerprint completed (started at \(String(format: "%.1f", aligned))s)"
                 )
+                #endif
                 self.finishIfStillPreparing(terminalState: .unavailable, context: ctx)
             } catch StreamError.cancelled {
+                #if DEBUG
                 FileLog.shared.addMessage("FingerprintTimingManager: streaming fingerprint cancelled")
+                #endif
                 // State will be reset by whatever cancelled us (restart / stop / new episode).
             } catch {
                 FileLog.shared.addMessage(
@@ -530,9 +538,11 @@ final class FingerprintTimingManager: NSObject {
         context ctx: GenerationContext
     ) {
         var inserted = 0
+        #if DEBUG
         var bestScoreOverall: Float = 0
         var nonZeroScoreCount = 0
         var scoreSum: Float = 0
+        #endif
 
         for window in windows {
             // Pull top-2 so we can check how dominant the winner is — ambiguous
@@ -544,11 +554,13 @@ final class FingerprintTimingManager: NSObject {
             )
             guard let best = matches.first else { continue }
 
+            #if DEBUG
             if best.score > 0 {
                 nonZeroScoreCount += 1
                 scoreSum += best.score
             }
             if best.score > bestScoreOverall { bestScoreOverall = best.score }
+            #endif
             guard best.score >= FingerprintConstants.matchScoreThreshold else { continue }
 
             let absolutePlaybackTime = startOffset + Double(window.timestampMs) / 1000.0
@@ -584,12 +596,14 @@ final class FingerprintTimingManager: NSObject {
             updateState(.active(coverage: coverage))
         }
 
+        #if DEBUG
         let avgNonZero = nonZeroScoreCount > 0 ? scoreSum / Float(nonZeroScoreCount) : 0
         FileLog.shared.addMessage(
             "FingerprintTimingManager: matched \(inserted)/\(windows.count) windows "
                 + "(coverage: \(coverage), bestScore: \(String(format: "%.3f", bestScoreOverall)), "
                 + "nonZero: \(nonZeroScoreCount), avgNonZero: \(String(format: "%.3f", avgNonZero)))"
         )
+        #endif
     }
 
     // MARK: - Drift Filter
@@ -637,12 +651,14 @@ final class FingerprintTimingManager: NSObject {
                     recordRejection(entry, reason: "pool evicted by confirmed anchor")
                 }
             }
+            #if DEBUG
             FileLog.shared.addMessage(
                 "FingerprintTimingManager: drift filter confirmed anchor "
                     + "at playback \(String(format: "%.1f", recent.first!.playbackTime))s → "
                     + "\(String(format: "%.1f", recent.last!.playbackTime))s "
                     + "(\(n) consistent)"
             )
+            #endif
             for entry in recent {
                 insertMapping(entry)
             }
@@ -682,12 +698,12 @@ final class FingerprintTimingManager: NSObject {
     }
 
     private func recordRejection(_ entry: TimeMappingEntry, reason: String) {
+        #if DEBUG
         FileLog.shared.addMessage(
             "FingerprintTimingManager: drift filter dropped \(reason) "
                 + "at playback \(String(format: "%.1f", entry.playbackTime))s "
                 + "(matched reference \(String(format: "%.1f", entry.referenceTime))s)"
         )
-        #if DEBUG
         debugRejections.append(entry)
         if debugRejections.count > Self.debugRejectionCap {
             debugRejections.removeFirst(debugRejections.count - Self.debugRejectionCap)

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -750,17 +750,21 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     }
 
     @objc private func updateTranscriptPosition() {
+        guard let transcript else { return }
+
+        // Only highlight when the fingerprint flow has an actual mapping for this
+        // playback time. Without that, falling back to raw playback time would
+        // highlight arbitrary VTT lines during ads and other non-matching audio.
         let rawTime = playbackManager.currentTime()
-        let position: TimeInterval
-        if case .active = FingerprintTimingManager.shared.state,
-           let referenceTime = FingerprintTimingManager.shared.referenceTime(forPlaybackTime: rawTime) {
-            position = referenceTime
-        } else {
-            position = rawTime
-        }
-        guard let transcript else {
+        guard case .active = FingerprintTimingManager.shared.state,
+              let position = FingerprintTimingManager.shared.referenceTime(forPlaybackTime: rawTime) else {
+            if previousRange != nil {
+                previousRange = nil
+                transcriptView.attributedText = styleText(transcript: transcript)
+            }
             return
         }
+
         if let cue = transcript.firstCue(containing: position), cue.characterRange != previousRange {
             let range = cue.characterRange
             previousRange = range


### PR DESCRIPTION
| 📘 Part of: #POC-532 | Stacks on: #4176 |
|:---:|:---:|

Stacks on top of #4176. Target is intentionally `poc-531/sync-transcripts-downloaded-files`.

## Problem

`FingerprintTimingManager.processMatches` accepted every match with score ≥ `matchScoreThreshold` and fed it straight into the playback↔reference mapping. In practice the matcher produces occasional spurious top-1 hits — windows whose hashes coincidentally resemble a far-away region of the reference. Each bogus match lands in the sorted mapping and, via interpolation, yanks reference time around for every query nearby, producing visible mis-highlights. In the debug overlay this shows up as "jump-around" regions where colored bars dance around without a coherent trend.

About the shape of real matches:

1. **Most of the time**: sequential — Δreference/Δplayback ≈ 1.
2. **Occasionally**: a single legitimate jump (transcript has content the audio doesn't, e.g. a 90s ad slot in the transcript). After the jump, rate returns to ≈1.
3. **Never**: multiple jumps within a small window. Jump-arounds mean the audio in that region isn't actually in the reference — those matches are noise.

## Approach

A small state machine between "score passed" and `insertMapping`. One invariant:

> No anchor — bootstrap or post-jump — is admitted until we've seen **`driftBootstrapCount` (3) consecutive rate-≈1 candidates in a row**.

- **Fast path**: candidate is in-trend with `lastTrusted` → commit immediately, flush the pool as rejections (any prior jump attempt that didn't stabilize was noise).
- **Slow path**: candidate goes into a pool. Once the pool's tail is 3 consistent entries, commit them and drop anything before as rejections. Otherwise evict the oldest and keep rolling.

Same rule for initial bootstrap and for post-trusted jumps, so a single lucky pair can never admit an anchor — what was showing as jump-arounds before. Legitimate ad-break jumps (30s–1m30s+) are still accepted because the audio continues coherently after the jump, producing the 3 consistent matches needed to confirm the new anchor.

### Filter reset points

Filter state is cleared in both:

- `resetState()` — switching episodes.
- `restart(from:context:)` — user seek. New stream region has no rate relationship to the old `lastTrusted`, so a fresh bootstrap is needed. Existing mapping entries from the old region stay (still valid there).

### Debug overlay

Rejected candidates were invisible before — a bare region could mean "matcher fired here but got filtered out" or "matcher never fired here". The overlay now draws rejections as half-height purple ticks under the existing full-height green/orange/red accepted-match bars, so the three cases are visually distinct.

<img width="400" alt="Simulator Screenshot - iPhone 17 - 2026-04-23 at 13 26 03" src="https://github.com/user-attachments/assets/0b56a855-bdf0-4dc3-9968-9a19d2041ad9" />


### Constants

```
driftToleranceSeconds: Double = 5    // residual slack on rate-1 projection. NOT a jump size cap.
driftBootstrapCount: Int = 3         // consecutive consistent candidates required.
```

The tolerance is often misread as a jump-size ceiling. It isn't — a 90s ad-break jump works fine: the jump candidate becomes the head of a new pool, and the next two rate-1 candidates from the new region confirm the whole trio. The tolerance just bounds how far any single candidate can sit off a rate-1 projection from *some* recent anchor (trusted or pool-internal).

## To test

1. `make build_staging`
2. `make test_staging ONLY_TESTING=PocketCastsTests/FingerprintTimingManagerTests` — 5 new cases cover sequential, lone outlier, real jump, jump-around noise, and bootstrap rolling past an early inconsistency.
3. Manual: open the transcript on a downloaded episode that previously showed jump-around mis-highlights. The debug overlay should now show purple rejection ticks in those regions (matcher fired but drift filter dropped the output) rather than random-looking colored bars.
4. Manual: play through a transcript-only ad break (30s – 1m30s). Highlighting should resume on the right side of the ad within a few windows; the overlay should show accepted bars on both sides of the break.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.