### PR TITLE
Fix Protobuf serializedData deprecation warnings

### DIFF
--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangeEmailTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangeEmailTask.swift
@@ -35,7 +35,7 @@ class ChangeEmailTask: ApiBaseTask {
             }
 
             do {
-                let result = try Api_UserChangeResponse(serializedData: responseData)
+                let result = try Api_UserChangeResponse(serializedBytes: responseData)
                 completion?(result.success.value)
                 FileLog.shared.addMessage("API change email response \(result)")
             } catch {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangePasswordTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangePasswordTask.swift
@@ -35,7 +35,7 @@ class ChangePasswordTask: ApiBaseTask {
             }
 
             do {
-                let result = try Api_UserChangeResponse(serializedData: responseData)
+                let result = try Api_UserChangeResponse(serializedBytes: responseData)
                 completion?(result.success.value)
                 FileLog.shared.addMessage("API change password response \(result)")
             } catch {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/DeleteAccountTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/DeleteAccountTask.swift
@@ -20,7 +20,7 @@ class DeleteAccountTask: ApiBaseTask {
                 return
             }
 
-            let changeResponse = try Api_UserChangeResponse(serializedData: responseData)
+            let changeResponse = try Api_UserChangeResponse(serializedBytes: responseData)
             let success = changeResponse.success.value
             let message = changeResponse.message
 

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/PurchaseReceiptTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/PurchaseReceiptTask.swift
@@ -40,7 +40,7 @@ class PurchaseReceiptTask: ApiBaseTask {
                 return
             }
             do {
-                let status = try Api_SubscriptionsStatusResponse(serializedData: responseData)
+                let status = try Api_SubscriptionsStatusResponse(serializedBytes: responseData)
                 SubscriptionHelper.setSubscriptionPaid(Int(status.paid))
                 SubscriptionHelper.setSubscriptionPlatform(Int(status.platform))
                 SubscriptionHelper.setSubscriptionExpiryDate(status.expiryDate.timeIntervalSince1970)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RecommendEpisodesTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RecommendEpisodesTask.swift
@@ -22,7 +22,7 @@ class RecommendEpisodesTask: ApiBaseTask {
             }
 
             do {
-                if let topEpisode = try Api_EpisodesResponse(serializedData: responseData).episodes.first {
+                if let topEpisode = try Api_EpisodesResponse(serializedBytes: responseData).episodes.first {
                     let episode = Episode()
                     episode.uuid = topEpisode.uuid
                     episode.podcastUuid = topEpisode.podcastUuid

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RedeemPromoCodeTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RedeemPromoCodeTask.swift
@@ -29,7 +29,7 @@ class RedeemPromoCodeTask: ApiBaseTask {
 
             do {
                 if httpStatus == ServerConstants.HttpConstants.ok {
-                    let promotion = try Api_Promotion(serializedData: responseData)
+                    let promotion = try Api_Promotion(serializedBytes: responseData)
                     completion?(httpStatus, promotion.description_p, nil)
                     FileLog.shared.addMessage("Redeem promo code response \n \(httpStatus)")
                 } else if let json = try JSONSerialization.jsonObject(with: responseData, options: []) as? [String: String], let errorMessageId = json["errorMessageId"] {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralGetCodeTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralGetCodeTask.swift
@@ -23,7 +23,7 @@ class ReferralGetCodeTask: ApiBaseTask, @unchecked Sendable {
                 completion?(nil)
                 return
             }
-            let apiCode = try Api_ReferralCode(serializedData: responseData)
+            let apiCode = try Api_ReferralCode(serializedBytes: responseData)
             completion?(ReferralCode(code: apiCode.code, url: apiCode.url))
         } catch {
             FileLog.shared.addMessage("Failed to parse  Api_GetRererralCodeRequest \(error.localizedDescription)")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralValidateTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralValidateTask.swift
@@ -42,7 +42,7 @@ class ReferralValidateTask: ApiBaseTask, @unchecked Sendable {
                 completion?(nil)
                 return
             }
-            let validationResponse = try Api_ReferralValidationResponse(serializedData: responseData)
+            let validationResponse = try Api_ReferralValidationResponse(serializedBytes: responseData)
             let details = try? JSONDecoder().decode(ReferralOfferDetail.self, from: validationResponse.details.data(using: .utf8)!)
             completion?(ReferralValidate(offer: validationResponse.offer, platform: Int(validationResponse.platform), details: details))
         } catch {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveBookmarksTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveBookmarksTask.swift
@@ -34,7 +34,7 @@ class RetrieveBookmarksTask: ApiBaseTask {
 
     private func parse(response: Data) {
         do {
-            let bookmarksResponse = try Api_BookmarksResponse(serializedData: response)
+            let bookmarksResponse = try Api_BookmarksResponse(serializedBytes: response)
             onBookmarksRetrieved(bookmarksResponse.bookmarks.nilIfEmpty())
         } catch {
             failed("Decoding BookmarksResponse failed \(error.localizedDescription)")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
@@ -28,7 +28,7 @@ class RetrieveCustomFilesTask: ApiBaseTask {
             }
 
             do {
-                let serverResponse = try Files_FileListResponse(serializedData: responseData)
+                let serverResponse = try Files_FileListResponse(serializedBytes: responseData)
                 #if !os(watchOS) // WatchOS doesn't handle the 10GB user File limits
                     ServerSettings.setCustomStorageUserLimit(Int(serverResponse.account.totalSize))
                     ServerSettings.setCustomStorageUsed(Int(serverResponse.account.usedSize))

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveEpisodesTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveEpisodesTask.swift
@@ -39,7 +39,7 @@ class RetrieveEpisodesTask: ApiBaseTask {
             }
 
             do {
-                let syncEpisodes = try Api_SyncEpisodesResponse(serializedData: responseData).episodes
+                let syncEpisodes = try Api_SyncEpisodesResponse(serializedBytes: responseData).episodes
 
                 for syncEpisode in syncEpisodes {
                     let convertedEpisode = convertFromProto(syncEpisode)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUploadStatus.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUploadStatus.swift
@@ -33,7 +33,7 @@ class RetrieveFileUploadStatusTask: ApiBaseTask {
             }
 
             do {
-                let serverResponse = try Files_SuccessResponse(serializedData: responseData)
+                let serverResponse = try Files_SuccessResponse(serializedBytes: responseData)
                 FileLog.shared.addMessage("RetrieveFileUploadStatusTask  - server returned upload success =\(serverResponse.self)")
                 if serverResponse.success {
                     DataManager.sharedManager.saveEpisode(uploadStatus: .uploaded, episode: episode)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUsageTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUsageTask.swift
@@ -26,7 +26,7 @@ class RetrieveFileUsageTask: ApiBaseTask {
             }
 
             do {
-                let serverResponse = try Files_AccountUsage(serializedData: responseData)
+                let serverResponse = try Files_AccountUsage(serializedBytes: responseData)
 
                 ServerSettings.setCustomStorageUserLimit(Int(serverResponse.totalSize))
                 ServerSettings.setCustomStorageUsed(Int(serverResponse.usedSize))

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveLastSyncDateTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveLastSyncDateTask.swift
@@ -21,7 +21,7 @@ class RetrieveLastSyncDateTask: ApiBaseTask {
             }
 
             do {
-                let lasySyncAt = try Api_UserLastSyncAtResponse(serializedData: responseData).lastSyncAt
+                let lasySyncAt = try Api_UserLastSyncAtResponse(serializedBytes: responseData).lastSyncAt
 
                 completion?(lasySyncAt)
             } catch {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePlaylistsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePlaylistsTask.swift
@@ -23,7 +23,7 @@ class RetrievePlaylistsTask: ApiBaseTask {
             }
 
             do {
-                let serverPlaylists = try Api_UserPlaylistListResponse(serializedData: responseData).playlists
+                let serverPlaylists = try Api_UserPlaylistListResponse(serializedBytes: responseData).playlists
                 if serverPlaylists.isEmpty {
                     completion?(nil)
 

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePodcastsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePodcastsTask.swift
@@ -24,7 +24,7 @@ class RetrievePodcastsTask: ApiBaseTask {
             }
 
             do {
-                let response = try Api_UserPodcastListResponse(serializedData: responseData)
+                let response = try Api_UserPodcastListResponse(serializedBytes: responseData)
 
                 var podcasts = [PodcastSyncInfo]()
                 for serverPodcast in response.podcasts {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveRatingsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveRatingsTask.swift
@@ -27,7 +27,7 @@ class RetrieveRatingsTask: ApiBaseTask, @unchecked Sendable {
                 return
             }
 
-            let serverRatings = try Api_PodcastRatingsResponse(serializedData: responseData).podcastRatings
+            let serverRatings = try Api_PodcastRatingsResponse(serializedBytes: responseData).podcastRatings
             if serverRatings.isEmpty {
                 success = true
                 completion?(convertedRatings)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStarredTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStarredTask.swift
@@ -30,7 +30,7 @@ class RetrieveStarredTask: ApiBaseTask {
             }
 
             do {
-                let serverEpisodes = try Api_StarredEpisodesResponse(serializedData: responseData).episodes
+                let serverEpisodes = try Api_StarredEpisodesResponse(serializedBytes: responseData).episodes
                 if serverEpisodes.isEmpty {
                     completion?(convertedEpisodes)
 

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStatsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStatsTask.swift
@@ -31,7 +31,7 @@ class RetrieveStatsTask: ApiBaseTask {
             }
 
             do {
-                let result = try Api_StatsResponse(serializedData: responseData)
+                let result = try Api_StatsResponse(serializedBytes: responseData)
 
                 let remoteStats = RemoteStats(silenceRemovalTime: result.timeSilenceRemoval,
                                               totalListenTime: result.timeListened,

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
@@ -17,7 +17,7 @@ class SubscriptionStatusTask: ApiBaseTask {
                 return
             }
             do {
-                let status = try Api_SubscriptionsStatusResponse(serializedData: responseData)
+                let status = try Api_SubscriptionsStatusResponse(serializedBytes: responseData)
                 let originalSubscriptionStatus = SubscriptionHelper.hasActiveSubscription()
                 SubscriptionHelper.setSubscriptionPaid(Int(status.paid))
                 SubscriptionHelper.setSubscriptionPlatform(Int(status.platform))

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFilePlayRequestTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFilePlayRequestTask.swift
@@ -25,7 +25,7 @@ class UploadFilePlayRequestTask: ApiBaseTask {
             }
 
             do {
-                let playResponse = try Files_FilePlayResponse(serializedData: responseData)
+                let playResponse = try Files_FilePlayResponse(serializedBytes: responseData)
                 guard httpStatus?.statusCode == ServerConstants.HttpConstants.ok else {
                     FileLog.shared.addMessage("Upload file play request failed \(httpStatus?.statusCode ?? -1) with message: \(playResponse.textFormatString())")
                     completion?(nil)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFileRequestTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFileRequestTask.swift
@@ -34,7 +34,7 @@ class UploadFileRequestTask: ApiBaseTask {
             }
 
             do {
-                let uploadResponse = try Files_FileUploadResponse(serializedData: responseData)
+                let uploadResponse = try Files_FileUploadResponse(serializedBytes: responseData)
                 FileLog.shared.addMessage("Upload request response \(uploadResponse)")
                 completion?(URL(string: uploadResponse.url))
                 return

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadImageRequestTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadImageRequestTask.swift
@@ -47,7 +47,7 @@ class UploadImageRequestTask: ApiBaseTask {
             }
 
             do {
-                let uploadResponse = try Files_ImageUploadResponse(serializedData: responseData)
+                let uploadResponse = try Files_ImageUploadResponse(serializedBytes: responseData)
                 FileLog.shared.addMessage("Upload image request response \(uploadResponse)")
                 completion?(URL(string: uploadResponse.url))
                 return

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UserPodcastRatingTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UserPodcastRatingTask.swift
@@ -72,7 +72,7 @@ class UserPodcastRatingGetTask: ApiBaseTask {
             }
 
             do {
-                let result = try Api_PodcastRating(serializedData: responseData)
+                let result = try Api_PodcastRating(serializedBytes: responseData)
                 let userRating = UserPodcastRating(podcastRating: result.podcastRating,
                                                    podcastUuid: result.podcastUuid,
                                                    modifiedAt: result.modifiedAt.date)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/WinbackOfferTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/WinbackOfferTask.swift
@@ -25,7 +25,7 @@ class WinbackOfferTask: ApiBaseTask, @unchecked Sendable {
                 completion?(nil)
                 return
             }
-            let validationResponse = try Api_WinbackResponse(serializedData: responseData)
+            let validationResponse = try Api_WinbackResponse(serializedBytes: responseData)
             let details = try? JSONDecoder().decode(ReferralOfferDetail.self, from: validationResponse.details.data(using: .utf8)!)
             let winbackOffer = WinbackOfferInfo(
                 offer: validationResponse.offer,

--- a/Modules/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -176,7 +176,7 @@ class TokenHelper {
             }
 
             if httpResponse.statusCode == ServerConstants.HttpConstants.ok {
-                let userLoginResponse = try Api_UserLoginResponse(serializedData: validData)
+                let userLoginResponse = try Api_UserLoginResponse(serializedBytes: validData)
                 return AuthenticationResponse(from: userLoginResponse)
             }
 

--- a/Modules/Sources/PocketCastsServer/Public/API/APIServerHandler+TrialEligibility.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/APIServerHandler+TrialEligibility.swift
@@ -20,7 +20,7 @@ public extension ApiServerHandler {
                 return
             }
 
-            let eligible = (try? Api_CheckEligibleResponse(serializedData: data))?.eligible
+            let eligible = (try? Api_CheckEligibleResponse(serializedBytes: data))?.eligible
 
             completion(eligible)
         }.resume()

--- a/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -47,7 +47,7 @@ public extension ApiServerHandler {
                 }
 
                 do {
-                    let response = try Api_UserChangeResponse(serializedData: responseData)
+                    let response = try Api_UserChangeResponse(serializedBytes: responseData)
                     completion(response.success.value, nil)
                 } catch {
                     completion(false, nil)
@@ -83,7 +83,7 @@ public extension ApiServerHandler {
                 }
 
                 do {
-                    let response = try Api_RegisterResponse(serializedData: responseData)
+                    let response = try Api_RegisterResponse(serializedBytes: responseData)
                     completion(response.success.value, response.uuid, nil)
                 } catch {
                     completion(false, nil, nil)
@@ -122,7 +122,7 @@ public extension ApiServerHandler {
                 }
 
                 do {
-                    let response = try Api_UserLoginResponse(serializedData: responseData)
+                    let response = try Api_UserLoginResponse(serializedBytes: responseData)
                     completion(response.token, response.uuid, nil)
                 } catch {
                     FileLog.shared.addMessage("Error occurred while trying to unpack token request \(error.localizedDescription)")
@@ -159,10 +159,10 @@ public extension ApiServerHandler {
 
                 do {
                     if usingRefreshToken {
-                        let response = try Api_TokenLoginResponse(serializedData: responseData)
+                        let response = try Api_TokenLoginResponse(serializedBytes: responseData)
                         continuation.resume(returning: AuthenticationResponse(from: response))
                     } else {
-                        let userLoginResponse = try Api_UserLoginResponse(serializedData: responseData)
+                        let userLoginResponse = try Api_UserLoginResponse(serializedBytes: responseData)
                         continuation.resume(returning: AuthenticationResponse(from: userLoginResponse))
                     }
                 } catch {

--- a/Modules/Sources/PocketCastsServer/Public/API/ValidatePromoCodeHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/ValidatePromoCodeHandler.swift
@@ -27,7 +27,7 @@ public class ValidatePromoCodeTask {
                 print("Server response is \(httpResponse.statusCode)")
                 if httpResponse.statusCode == ServerConstants.HttpConstants.ok {
                     do {
-                        let promotion = try Api_Promotion(serializedData: responseData)
+                        let promotion = try Api_Promotion(serializedBytes: responseData)
                         completion(true, promotion.description_p, nil)
 
                         FileLog.shared.addMessage("Validate promo code response \n \(httpResponse.statusCode)")

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncHistoryTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncHistoryTask.swift
@@ -54,7 +54,7 @@ class SyncHistoryTask: ApiBaseTask {
 
     private func process(serverData: Data) {
         do {
-            let response = try Api_HistoryResponse(serializedData: serverData)
+            let response = try Api_HistoryResponse(serializedBytes: serverData)
 
             // on watchOS, we don't show history, so we also don't process server changes we only want to push changes up, not down
             #if !os(watchOS)

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -170,7 +170,7 @@ class SyncSettingsTask: ApiBaseTask {
 
     private func process(serverData: Data) {
         do {
-            let settings = try Api_NamedSettingsResponse(serializedData: serverData)
+            let settings = try Api_NamedSettingsResponse(serializedBytes: serverData)
 
             if FeatureFlag.settingsSync.enabled {
                 appSettings.settings.update(with: settings)

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -218,7 +218,7 @@ class SyncTask: ApiBaseTask {
                 await dataManager.bookmarks.markAllBookmarksAsSynced()
             }
 
-            let response = try Api_SyncUpdateResponse(serializedData: responseData)
+            let response = try Api_SyncUpdateResponse(serializedBytes: responseData)
             processServerData(response: response)
 
             StatsManager.shared.setSyncStatus(.synced)

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -71,7 +71,7 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
 
     private func compareNumberOfEpisodes(serverData: Data) {
         do {
-            let response = try Api_YearHistoryResponse(serializedData: serverData)
+            let response = try Api_YearHistoryResponse(serializedBytes: serverData)
 
             let localNumberOfEpisodes = DataManager.sharedManager.numberOfEpisodes(year: Int(yearToSync))
 
@@ -88,7 +88,7 @@ class SyncYearListeningHistoryTask: ApiBaseTask {
 
     private func syncMissingEpisodes(serverData: Data) {
         do {
-            let response = try Api_YearHistoryResponse(serializedData: serverData)
+            let response = try Api_YearHistoryResponse(serializedBytes: serverData)
 
             // on watchOS, we don't show history, so we also don't process server changes we only want to push changes up, not down
             #if !os(watchOS)

--- a/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -166,7 +166,7 @@ class UpNextSyncTask: ApiBaseTask {
         defer { objc_sync_exit(UpNextSyncTask.processDataLock) }
 
         do {
-            let response = try Api_UpNextResponse(serializedData: serverData)
+            let response = try Api_UpNextResponse(serializedBytes: serverData)
             applyServerChanges(episodes: response.episodes)
 
             // save the server last modified so we can send it back next time. For legacy compatibility this is stored as a string

--- a/Modules/Tests/PocketCastsServerTests/SyncSettingsTaskTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/SyncSettingsTaskTests.swift
@@ -34,7 +34,7 @@ class SyncSettingsTaskTests: XCTestCase {
         let task = SyncSettingsTask(appSettings: store, urlConnection: URLConnection { urlRequest in
 
             let data = try XCTUnwrap(urlRequest.httpBody, "Request body should exist")
-            let request = try Api_NamedSettingsRequest(serializedData: data)
+            let request = try Api_NamedSettingsRequest(serializedBytes: data)
 
             XCTAssertTrue(request.changedSettings.openLinks.hasValue, "Change value should be included")
             XCTAssertEqual(request.changedSettings.openLinks.modifiedAt.timeIntervalSinceReferenceDate, changedDate.timeIntervalSinceReferenceDate, accuracy: 0.01, "Modified at should be around the time the value was updated")


### PR DESCRIPTION
A simple but high-impact change as at eliminates 40 warnings.

The underlying implementation is identical. The only thing that changes is that it now goes through the `SwiftProtobufContiguousBytes` init.


```swift
    @inlinable
    public init<Bytes: SwiftProtobufContiguousBytes>(
        serializedBytes bytes: Bytes,
        extensions: (any ExtensionMap)? = nil,
        partial: Bool = false,
        options: BinaryDecodingOptions = BinaryDecodingOptions()
    ) throws {
        self.init()
        try merge(serializedBytes: bytes, extensions: extensions, partial: partial, options: options)
    }



    @inlinable
    @available(*, deprecated, renamed: "init(serializedBytes:extensions:partial:options:)")
    public init(
        serializedData data: Data,
        extensions: (any ExtensionMap)? = nil,
        partial: Bool = false,
        options: BinaryDecodingOptions = BinaryDecodingOptions()
    ) throws {
        self.init()
        try merge(serializedBytes: data, extensions: extensions, partial: partial, options: options)
    }
```

## To test

Smoke test that on clean install the app fetches your content successfully. If it works in one place, it works everywhere else.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
