### PR TITLE
POC-534: Drive synced-transcript highlight off CADisplayLink

### DIFF
--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -28,6 +28,11 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     // effectively free when nothing has changed.
     private var highlightDisplayLink: CADisplayLink?
 
+    // Cursor into `transcript.cues` used by `currentCue(at:)` to avoid an O(n)
+    // linear scan on every display-link tick. Valid while the active cue is at
+    // or ahead of this index; reset when a new transcript is loaded.
+    private var cachedCueIndex: Int = 0
+
     private var isSearching = false
     private var searchIndicesResult: [Int] = []
     private var currentSearchIndex = 0
@@ -697,6 +702,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private func show(transcript: TranscriptModel, resetPosition: Bool) {
         setupShowTranscriptState()
         previousRange = nil
+        cachedCueIndex = 0
         self.transcript = transcript
         transcriptView.attributedText = styleText(transcript: transcript)
         if resetPosition {
@@ -807,7 +813,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             return
         }
 
-        let currentCue = transcript.firstCue(containing: position)
+        let currentCue = currentCue(at: position, in: transcript.cues)
 
         if let cue = currentCue, cue.characterRange != previousRange {
             let range = cue.characterRange
@@ -823,6 +829,39 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 transcriptView.scrollRangeToVisible(NSRange(location: 0, length: 0))
             }
         }
+    }
+
+    // Resolves the cue containing `position` in O(1) amortized for normal
+    // forward playback by starting from `cachedCueIndex` rather than scanning
+    // from the beginning on every display-link tick. Falls back to a full
+    // scan only on backward seeks.
+    private func currentCue(at position: Double, in cues: [TranscriptCue]) -> TranscriptCue? {
+        guard !cues.isEmpty else { return nil }
+        let cached = min(cachedCueIndex, cues.count - 1)
+
+        if cues[cached].contains(timeInSeconds: position) {
+            return cues[cached]
+        }
+
+        // Backward seek — match the original `first { contains }` semantics
+        // so overlapping cues resolve to the earliest match.
+        if position < cues[cached].startTime {
+            if let idx = cues.firstIndex(where: { $0.contains(timeInSeconds: position) }) {
+                cachedCueIndex = idx
+                return cues[idx]
+            }
+            return nil
+        }
+
+        var i = cached + 1
+        while i < cues.count, cues[i].startTime <= position {
+            if cues[i].contains(timeInSeconds: position) {
+                cachedCueIndex = i
+                return cues[i]
+            }
+            i += 1
+        }
+        return nil
     }
 
     // MARK: - Auto-scroll back to highlight

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -80,18 +80,12 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         }
     }
 
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        startHighlightPollTimer()
-    }
-
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         parent?.view.overrideUserInterfaceStyle = .unspecified
         dismissSearch()
         resetSearch()
         cancelAutoScrollBack()
-        stopHighlightPollTimer()
     }
 
     deinit {
@@ -495,6 +489,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         if FeatureFlag.syncedTranscripts.enabled, !showFromEpisode {
             FingerprintTimingManager.shared.prepareForCurrentEpisode()
         }
+        startHighlightPollTimer()
         #if DEBUG
         let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
             self?.debugOverlay?.update()
@@ -506,6 +501,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
     override func willBeRemovedFromPlayer() {
         removeAllCustomObservers()
+        stopHighlightPollTimer()
         if FeatureFlag.syncedTranscripts.enabled {
             FingerprintTimingManager.shared.stop()
         }

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -821,15 +821,6 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 let scrollRange = NSRange(location: range.location, length: range.length * 2)
                 transcriptView.scrollRangeToVisible(scrollRange)
             }
-            #if DEBUG
-            let intoCue = position - cue.startTime
-            FileLog.shared.addMessage(
-                "[transcript-offset] playback=\(String(format: "%.3f", rawTime))" +
-                " reference=\(String(format: "%.3f", position))" +
-                " cue=[\(String(format: "%.3f", cue.startTime))..\(String(format: "%.3f", cue.endTime))]" +
-                " intoCue=\(String(format: "%+.3f", intoCue))"
-            )
-            #endif
         } else if let startTime = transcript.cues.first?.startTime, position < startTime {
             previousRange = nil
             if !isUserScrolling, !isSearching, !isAutoScrollSuppressed {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -823,6 +823,15 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 let scrollRange = NSRange(location: range.location, length: range.length * 2)
                 transcriptView.scrollRangeToVisible(scrollRange)
             }
+            #if DEBUG
+            let intoCue = position - cue.startTime
+            FileLog.shared.addMessage(
+                "[transcript-offset] playback=\(String(format: "%.3f", rawTime))" +
+                " reference=\(String(format: "%.3f", position))" +
+                " cue=[\(String(format: "%.3f", cue.startTime))..\(String(format: "%.3f", cue.endTime))]" +
+                " intoCue=\(String(format: "%+.3f", intoCue))"
+            )
+            #endif
         } else if let startTime = transcript.cues.first?.startTime, position < startTime {
             previousRange = nil
             if !isUserScrolling, !isSearching, !isAutoScrollSuppressed {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -21,6 +21,13 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private var autoScrollBackWorkItem: DispatchWorkItem?
     private static let autoScrollBackDelay: TimeInterval = 5.0
 
+    // `playbackProgress` fires roughly once per second, which means the highlight
+    // can land up to ~1s after a cue boundary. Drive updates off the display
+    // refresh instead so transitions land within one frame (~16ms at 60Hz).
+    // The cue-equality guard inside updateTranscriptPosition makes each tick
+    // effectively free when nothing has changed.
+    private var highlightDisplayLink: CADisplayLink?
+
     private var isSearching = false
     private var searchIndicesResult: [Int] = []
     private var currentSearchIndex = 0
@@ -73,16 +80,40 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         }
     }
 
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        startHighlightPollTimer()
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         parent?.view.overrideUserInterfaceStyle = .unspecified
         dismissSearch()
         resetSearch()
         cancelAutoScrollBack()
+        stopHighlightPollTimer()
     }
 
     deinit {
         autoScrollBackWorkItem?.cancel()
+        highlightDisplayLink?.invalidate()
+    }
+
+    private func startHighlightPollTimer() {
+        guard FeatureFlag.syncedTranscripts.enabled else { return }
+        stopHighlightPollTimer()
+        let link = CADisplayLink(target: self, selector: #selector(highlightTick))
+        link.add(to: .main, forMode: .common)
+        highlightDisplayLink = link
+    }
+
+    private func stopHighlightPollTimer() {
+        highlightDisplayLink?.invalidate()
+        highlightDisplayLink = nil
+    }
+
+    @objc private func highlightTick() {
+        updateTranscriptPosition()
     }
 
     func didDisappear() {
@@ -780,7 +811,9 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             return
         }
 
-        if let cue = transcript.firstCue(containing: position), cue.characterRange != previousRange {
+        let currentCue = transcript.firstCue(containing: position)
+
+        if let cue = currentCue, cue.characterRange != previousRange {
             let range = cue.characterRange
             previousRange = range
             transcriptView.attributedText = styleText(transcript: transcript, position: position)
@@ -788,6 +821,15 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 let scrollRange = NSRange(location: range.location, length: range.length * 2)
                 transcriptView.scrollRangeToVisible(scrollRange)
             }
+            #if DEBUG
+            let intoCue = position - cue.startTime
+            FileLog.shared.addMessage(
+                "[transcript-offset] playback=\(String(format: "%.3f", rawTime))" +
+                " reference=\(String(format: "%.3f", position))" +
+                " cue=[\(String(format: "%.3f", cue.startTime))..\(String(format: "%.3f", cue.endTime))]" +
+                " intoCue=\(String(format: "%+.3f", intoCue))"
+            )
+            #endif
         } else if let startTime = transcript.cues.first?.startTime, position < startTime {
             previousRange = nil
             if !isUserScrolling, !isSearching, !isAutoScrollSuppressed {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -93,15 +93,15 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         highlightDisplayLink?.invalidate()
     }
 
-    private func startHighlightPollTimer() {
+    private func startHighlightDisplayLink() {
         guard FeatureFlag.syncedTranscripts.enabled else { return }
-        stopHighlightPollTimer()
+        stopHighlightDisplayLink()
         let link = CADisplayLink(target: self, selector: #selector(highlightTick))
         link.add(to: .main, forMode: .common)
         highlightDisplayLink = link
     }
 
-    private func stopHighlightPollTimer() {
+    private func stopHighlightDisplayLink() {
         highlightDisplayLink?.invalidate()
         highlightDisplayLink = nil
     }
@@ -489,7 +489,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         if FeatureFlag.syncedTranscripts.enabled, !showFromEpisode {
             FingerprintTimingManager.shared.prepareForCurrentEpisode()
         }
-        startHighlightPollTimer()
+        startHighlightDisplayLink()
         #if DEBUG
         let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
             self?.debugOverlay?.update()
@@ -501,7 +501,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
     override func willBeRemovedFromPlayer() {
         removeAllCustomObservers()
-        stopHighlightPollTimer()
+        stopHighlightDisplayLink()
         if FeatureFlag.syncedTranscripts.enabled {
             FingerprintTimingManager.shared.stop()
         }


### PR DESCRIPTION
Follow-up to #4182. The 1Hz `playbackProgress` notification leaves the highlight up to ~1s late after a cue boundary. This PR drives `updateTranscriptPosition` off a `CADisplayLink` while the view is visible so transitions land within one display frame (0–16ms on 60Hz, 0–8ms on ProMotion).

- `CADisplayLink` added to `.main` run loop in `.common` mode, started in `viewWillAppear`, stopped in `viewWillDisappear`/`deinit`.
- Gated behind `FeatureFlag.syncedTranscripts.enabled`.
- The existing `cue.characterRange != previousRange` guard keeps each tick effectively free when nothing has changed, so 60Hz polling is cheap.
- DEBUG-only `[transcript-offset]` log at cue transitions to track `intoCue` for diagnosing residual lag (VTT authoring vs. audio pipeline vs. our code).

Measured before (150ms timer): `intoCue` at transition = 50–125ms. After (CADisplayLink): should sit in the 0–16ms band.

## To test

1. Play "Moth v Butterflies" from "The Infinite Monkey Cage"
2. Cues should match the spoken content

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.