### PR TITLE
Fix some Xcode warnings

### DIFF
--- a/Modules/Sources/EndOfYear/ShareableMetadataProvider.swift
+++ b/Modules/Sources/EndOfYear/ShareableMetadataProvider.swift
@@ -14,7 +14,7 @@ public protocol ShareableMetadataDataSource: AnyObject {
     var hashtags: [String] { get }
 }
 
-public class ShareableMetadataProvider: UIActivityItemProvider {
+public class ShareableMetadataProvider: UIActivityItemProvider, @unchecked Sendable {
     public weak var dataSource: ShareableMetadataDataSource?
 
     public init() {

--- a/Modules/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
@@ -423,8 +423,8 @@ public class MainServerHandler {
     private func jsonWithStandardParams(uniqueId: String) -> [String: Any] {
         var json: [String: Any] = [:]
         let locale = Locale.current
-        json["l"] = locale.languageCode
-        json["c"] = locale.regionCode
+        json["l"] = locale.language.languageCode?.identifier
+        json["c"] = locale.region?.identifier
 
         #if os(watchOS)
             json["m"] = WKInterfaceDevice.current().systemVersion
@@ -442,8 +442,8 @@ public class MainServerHandler {
 
     private func addStandardParams(baseRequest: inout BaseRequest, uniqueId: String) {
         let locale = Locale.current
-        baseRequest.l = locale.languageCode
-        baseRequest.c = locale.regionCode
+        baseRequest.l = locale.language.languageCode?.identifier
+        baseRequest.c = locale.region?.identifier
 
         #if os(watchOS)
             baseRequest.m = WKInterfaceDevice.current().systemVersion

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -351,7 +351,7 @@ class AnalyticsHelper {
             }
 
             let price = product.price
-            let currency = product.priceLocale.currencyCode ?? ""
+            let currency = product.priceLocale.currency?.identifier ?? ""
             let name = product.localizedTitle
 
             let item: [String: Any] = [

--- a/podcasts/DownloadManager+Logging.swift
+++ b/podcasts/DownloadManager+Logging.swift
@@ -69,7 +69,7 @@ extension DownloadManager {
     }
 }
 
-extension tls_ciphersuite_t: CustomDebugStringConvertible {
+extension tls_ciphersuite_t: @retroactive CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {
         case .RSA_WITH_3DES_EDE_CBC_SHA:

--- a/podcasts/Onboarding/Import/ImportViewModel.swift
+++ b/podcasts/Onboarding/Import/ImportViewModel.swift
@@ -71,8 +71,7 @@ class ImportViewModel: OnboardingModel {
         var isSourceAvailable: Bool {
             #if targetEnvironment(simulator)
             return true
-            #endif
-
+            #else
             // Always available - Others and opml from url are always available
             // Note: Even if Apple podcasts has been uninstalled by the user, the system will always report
             // that it's installed.
@@ -85,6 +84,7 @@ class ImportViewModel: OnboardingModel {
             }
 
             return UIApplication.shared.canOpenURL(url)
+            #endif
         }
 
         var hideButton: Bool {

--- a/podcasts/PlaylistRefreshOperation.swift
+++ b/podcasts/PlaylistRefreshOperation.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsUtils
 
-class PlaylistRefreshOperation: Operation {
+class PlaylistRefreshOperation: Operation, @unchecked Sendable {
     private let episodesDataManager: EpisodesDataManager
     private let playlist: EpisodeFilter
     private let completion: ([ListEpisode]) -> Void

--- a/podcasts/Podcasts/Podcast Page/PodcastEpisodesRefreshOperation.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastEpisodesRefreshOperation.swift
@@ -2,7 +2,7 @@ import DifferenceKit
 import Foundation
 import PocketCastsDataModel
 
-class PodcastEpisodesRefreshOperation: Operation {
+class PodcastEpisodesRefreshOperation: Operation, @unchecked Sendable {
     private let episodesDataManager: EpisodesDataManager
     private let podcast: Podcast
     private let uuidsToFilter: [String]?

--- a/podcasts/SharedItemImporter.swift
+++ b/podcasts/SharedItemImporter.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PocketCastsServer
 
-class SharedItemImporter: Operation {
+class SharedItemImporter: Operation, @unchecked Sendable {
     private var urlToImport: String
     private var completion: (IncomingShareItem?) -> Void
 


### PR DESCRIPTION
Automatically fixed some more Xcode warnings:

```
  Batch 1 — deprecated Locale/unreachable code
  - podcasts/Onboarding/Import/ImportViewModel.swift:79 — wrapped post-simulator branch in #else (fixes "code after return
  will never be executed")
  - Modules/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift:426-427, 445-446 — locale.languageCode →
  locale.language.languageCode?.identifier; locale.regionCode → locale.region?.identifier (4 call sites)
  - podcasts/AnalyticsHelper.swift:354 — priceLocale.currencyCode → priceLocale.currency?.identifier

  Batch 2 — @retroactive + Sendable restatements
  - podcasts/DownloadManager+Logging.swift:72 — extension tls_ciphersuite_t: CustomDebugStringConvertible → extension
  tls_ciphersuite_t: @retroactive CustomDebugStringConvertible
  - podcasts/Podcasts/Podcast Page/PodcastEpisodesRefreshOperation.swift:5 — added , @unchecked Sendable
  - podcasts/PlaylistRefreshOperation.swift:5 — added , @unchecked Sendable
  - podcasts/SharedItemImporter.swift:4 — added , @unchecked Sendable
  - Modules/Sources/EndOfYear/ShareableMetadataProvider.swift:17 — added , @unchecked Sendable

  All changes are mechanical renames or single-keyword annotations — no behavioral change. The larger ApiBaseTask subclass
  cohort (~35 more Sendable-restatement warnings in PocketCastsServer) is still open as a thematic follow-up.
```

## To test

n/a

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
