### PR TITLE
POC-539: Streaming fingerprint support for synced transcripts

### DIFF
--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -24,10 +24,20 @@ enum FingerprintConstants {
     /// fingerprint generation. Smaller = more responsive UI, larger = less per-call overhead.
     static let streamChunkSeconds: Double = 5
 
-    /// Seconds between polls when waiting for the streaming buffer to grow.
-    /// Reserved for future streaming support — not yet referenced, but the hook
-    /// lives here so the knob is discoverable when we pick that path up.
+    /// Seconds between polls when waiting for the streaming buffer to grow
+    /// while fingerprinting a not-yet-downloaded episode.
     static let bufferGrowPollCadenceSeconds: TimeInterval = 1.0
+
+    /// Give up the streaming grow-loop after this many consecutive seconds
+    /// without new bytes — listener likely paused or the network stalled.
+    /// A later `handlePlaybackProgress` restart will pick us back up.
+    static let bufferGrowMaxStallSeconds: TimeInterval = 60
+
+    /// Trailing audio the grow-loop refuses to read, in seconds. The last sliver
+    /// of a growing file can be a partial MP3 frame that decodes to noise —
+    /// waiting until the file has grown past it keeps false-positive
+    /// fingerprint matches out of the mapping.
+    static let bufferGrowTrailingMarginSeconds: Double = 1.0
 
     /// Minimum number of mapping entries before the timing manager transitions to `.active`.
     static let minimumCoverageForActive: Int = 2

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -241,28 +241,6 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
-    /// Strict-range variant of `playbackTime(forReferenceTime:)`. Returns `nil`
-    /// when `referenceTime` falls outside the already-mapped range instead of
-    /// extrapolating with an identity offset. Use this for tap-to-seek where a
-    /// wrong guess would land the listener in the wrong place.
-    func playbackTimeIfCovered(forReferenceTime referenceTime: Double) -> Double? {
-        dispatchPrecondition(condition: .notOnQueue(queue))
-        return queue.sync {
-            guard let first = referenceToPlayback.first,
-                  let last = referenceToPlayback.last,
-                  referenceTime >= first.referenceTime,
-                  referenceTime <= last.referenceTime else {
-                return nil
-            }
-            return Self.interpolate(
-                time: referenceTime,
-                in: referenceToPlayback,
-                keyPath: \.referenceTime,
-                valuePath: \.playbackTime
-            )
-        }
-    }
-
     #if DEBUG
     var totalDuration: Double? {
         dispatchPrecondition(condition: .notOnQueue(queue))

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -29,6 +29,10 @@ final class FingerprintTimingManager: NSObject {
     private struct GenerationContext {
         let episodeUuid: String
         let audioFileURL: URL
+        /// True when `audioFileURL` points at a streaming buffer that may still be
+        /// growing. The fingerprint loop polls for new bytes instead of quitting
+        /// at EOF.
+        let isStreaming: Bool
         let duration: Double
         let matcher: CheckpointMatcher
         let isCancelled: () -> Bool
@@ -166,6 +170,15 @@ final class FingerprintTimingManager: NSObject {
         lastProgressPosition = playbackTime
 
         if isWithinMappedRange(playbackTime) { return }
+
+        // If we haven't produced any anchors yet, the current stream is still
+        // building the first window around the listener's initial position —
+        // restarting every progress tick (which happens each second while the
+        // map is empty) cancels that in-flight work before it can finish. The
+        // delta-based branch above still catches real seeks. Once we have
+        // coverage the drift-restart resumes as before.
+        if playbackToReference.isEmpty { return }
+
         #if DEBUG
         FileLog.shared.addMessage(
             "FingerprintTimingManager: playback at \(String(format: "%.1f", playbackTime))s outside mapped range — restarting"
@@ -194,6 +207,7 @@ final class FingerprintTimingManager: NSObject {
         let newContext = GenerationContext(
             episodeUuid: ctx.episodeUuid,
             audioFileURL: ctx.audioFileURL,
+            isStreaming: ctx.isStreaming,
             duration: ctx.duration,
             matcher: ctx.matcher,
             isCancelled: { flag.isCancelled }
@@ -219,6 +233,28 @@ final class FingerprintTimingManager: NSObject {
         dispatchPrecondition(condition: .notOnQueue(queue))
         return queue.sync {
             Self.interpolate(
+                time: referenceTime,
+                in: referenceToPlayback,
+                keyPath: \.referenceTime,
+                valuePath: \.playbackTime
+            )
+        }
+    }
+
+    /// Strict-range variant of `playbackTime(forReferenceTime:)`. Returns `nil`
+    /// when `referenceTime` falls outside the already-mapped range instead of
+    /// extrapolating with an identity offset. Use this for tap-to-seek where a
+    /// wrong guess would land the listener in the wrong place.
+    func playbackTimeIfCovered(forReferenceTime referenceTime: Double) -> Double? {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+        return queue.sync {
+            guard let first = referenceToPlayback.first,
+                  let last = referenceToPlayback.last,
+                  referenceTime >= first.referenceTime,
+                  referenceTime <= last.referenceTime else {
+                return nil
+            }
+            return Self.interpolate(
                 time: referenceTime,
                 in: referenceToPlayback,
                 keyPath: \.referenceTime,
@@ -327,10 +363,16 @@ final class FingerprintTimingManager: NSObject {
     private func configureForReference(_ reference: ReferenceFingerprint, episode: BaseEpisode) {
         let uuid = episode.uuid
 
-        guard let audioFileURL = resolveAudioFileURL(for: episode) else {
-            updateState(.unavailable)
-            FileLog.shared.addMessage("FingerprintTimingManager: no local audio file for \(uuid) — skipping fingerprinting")
-            return
+        let source = resolveAudioSource(for: episode)
+        let audioFileURL: URL
+        let isStreaming: Bool
+        switch source {
+        case .downloaded(let url):
+            audioFileURL = url
+            isStreaming = false
+        case .streaming(let url):
+            audioFileURL = url
+            isStreaming = true
         }
 
         let duration = episode.duration
@@ -378,6 +420,7 @@ final class FingerprintTimingManager: NSObject {
         let newContext = GenerationContext(
             episodeUuid: uuid,
             audioFileURL: audioFileURL,
+            isStreaming: isStreaming,
             duration: duration,
             matcher: matcher,
             isCancelled: { flag.isCancelled }
@@ -406,7 +449,11 @@ final class FingerprintTimingManager: NSObject {
         generationQueue.async { [weak self] in
             guard let self else { return }
             do {
-                try self.streamFingerprint(context: ctx, startingAt: aligned)
+                if ctx.isStreaming {
+                    try self.streamFingerprintGrowing(context: ctx, startingAt: aligned)
+                } else {
+                    try self.streamFingerprint(context: ctx, startingAt: aligned)
+                }
                 #if DEBUG
                 FileLog.shared.addMessage(
                     "FingerprintTimingManager: streaming fingerprint completed (started at \(String(format: "%.1f", aligned))s)"
@@ -497,6 +544,177 @@ final class FingerprintTimingManager: NSObject {
         let tail = streamer.flush()
         if !tail.isEmpty {
             dispatchProcessMatches(windows: tail, startOffset: startSeconds, context: ctx)
+        }
+    }
+
+    /// Streaming-buffer variant of `streamFingerprint`. Same pipeline, but the
+    /// file may not exist yet when we start, and grows while we read — so we
+    /// reopen `AVAudioFile` each pass to refresh its length, seek to where we
+    /// left off, and consume whatever new frames are available. Exits when the
+    /// buffer has been stalled for `bufferGrowMaxStallSeconds` or the context
+    /// is cancelled; a later `handlePlaybackProgress` restart will pick up
+    /// again if the listener keeps playing.
+    private func streamFingerprintGrowing(context ctx: GenerationContext, startingAt startSeconds: Double) throws {
+        let pollCadence = FingerprintConstants.bufferGrowPollCadenceSeconds
+        let maxStallSeconds = FingerprintConstants.bufferGrowMaxStallSeconds
+        let trailingMarginSeconds = FingerprintConstants.bufferGrowTrailingMarginSeconds
+
+        var streamer: StreamingWindowedFingerprinter?
+        var format: AVAudioFormat?
+        var buffer: AVAudioPCMBuffer?
+        var chunkFrames: AVAudioFrameCount = 0
+        var lastProcessedFrame: AVAudioFramePosition = 0
+        var stallAccumSeconds: Double = 0
+        var announcedFileAppeared = false
+        var totalFramesRead: AVAudioFramePosition = 0
+        var windowsEmitted = 0
+
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: streaming grow-loop starting at \(String(format: "%.1f", startSeconds))s "
+                + "(buffer path: \(ctx.audioFileURL.lastPathComponent))"
+        )
+
+        while true {
+            if ctx.isCancelled() { throw StreamError.cancelled }
+
+            guard FileManager.default.fileExists(atPath: ctx.audioFileURL.path) else {
+                // Streaming buffer not created yet — AVPlayer will write it
+                // once it actually begins fetching bytes.
+                stallAccumSeconds += pollCadence
+                if stallAccumSeconds >= maxStallSeconds { break }
+                try sleepWithCancellation(seconds: pollCadence, context: ctx)
+                continue
+            }
+
+            let audioFile: AVAudioFile
+            do {
+                audioFile = try AVAudioFile(
+                    forReading: ctx.audioFileURL,
+                    commonFormat: .pcmFormatFloat32,
+                    interleaved: false
+                )
+            } catch {
+                // Partial frame at the tail can make `AVAudioFile` refuse to
+                // open momentarily — wait and retry.
+                stallAccumSeconds += pollCadence
+                if stallAccumSeconds >= maxStallSeconds { break }
+                try sleepWithCancellation(seconds: pollCadence, context: ctx)
+                continue
+            }
+
+            if !announcedFileAppeared {
+                announcedFileAppeared = true
+                FileLog.shared.addMessage(
+                    "FingerprintTimingManager: streaming buffer opened "
+                        + "(length \(audioFile.length) frames @ \(Int(audioFile.processingFormat.sampleRate))Hz, "
+                        + "\(audioFile.processingFormat.channelCount)ch)"
+                )
+            }
+
+            if streamer == nil {
+                let fmt = audioFile.processingFormat
+                let desiredStartFrame = max(0, AVAudioFramePosition(startSeconds * fmt.sampleRate))
+
+                // The streaming buffer on disk is sequential from byte 0, so the
+                // local file's frame `N` maps to audio timeline `N / sampleRate`.
+                // If the buffer hasn't grown to `startSeconds` yet, reading from
+                // the current tail and tagging those windows as `startSeconds +
+                // windowTimestamp` would attribute them to the wrong reference
+                // time — matches would fail. Wait until the file covers the
+                // target position, then anchor `lastProcessedFrame` exactly there.
+                guard audioFile.length >= desiredStartFrame else {
+                    stallAccumSeconds += pollCadence
+                    if stallAccumSeconds >= maxStallSeconds { break }
+                    try sleepWithCancellation(seconds: pollCadence, context: ctx)
+                    continue
+                }
+
+                format = fmt
+                streamer = StreamingWindowedFingerprinter(
+                    sampleRate: UInt32(fmt.sampleRate),
+                    channels: UInt16(fmt.channelCount),
+                    windowDurationMs: FingerprintConstants.windowDurationMs,
+                    windowIntervalMs: FingerprintConstants.windowIntervalMs
+                )
+                chunkFrames = AVAudioFrameCount(fmt.sampleRate * FingerprintConstants.streamChunkSeconds)
+                guard let b = AVAudioPCMBuffer(pcmFormat: fmt, frameCapacity: chunkFrames) else {
+                    throw StreamError.bufferAllocationFailed
+                }
+                buffer = b
+                lastProcessedFrame = desiredStartFrame
+            }
+
+            guard let fmt = format, let str = streamer, let buf = buffer else { break }
+
+            let trailingMarginFrames = AVAudioFramePosition(trailingMarginSeconds * fmt.sampleRate)
+            let safeEnd = audioFile.length - trailingMarginFrames
+
+            guard lastProcessedFrame < safeEnd else {
+                stallAccumSeconds += pollCadence
+                if stallAccumSeconds >= maxStallSeconds { break }
+                try sleepWithCancellation(seconds: pollCadence, context: ctx)
+                continue
+            }
+
+            audioFile.framePosition = lastProcessedFrame
+            let framesAvailable = AVAudioFrameCount(safeEnd - lastProcessedFrame)
+            let framesToRead = min(framesAvailable, chunkFrames)
+
+            do {
+                try audioFile.read(into: buf, frameCount: framesToRead)
+            } catch {
+                stallAccumSeconds += pollCadence
+                if stallAccumSeconds >= maxStallSeconds { break }
+                try sleepWithCancellation(seconds: pollCadence, context: ctx)
+                continue
+            }
+
+            if buf.frameLength == 0 {
+                stallAccumSeconds += pollCadence
+                if stallAccumSeconds >= maxStallSeconds { break }
+                try sleepWithCancellation(seconds: pollCadence, context: ctx)
+                continue
+            }
+
+            stallAccumSeconds = 0
+            let framesJustRead = audioFile.framePosition - lastProcessedFrame
+            lastProcessedFrame = audioFile.framePosition
+            totalFramesRead += framesJustRead
+
+            let interleaved = Self.interleavedSamples(from: buf)
+            let windows = str.pushSamplesF32(samples: interleaved, channels: UInt16(fmt.channelCount))
+            if !windows.isEmpty {
+                windowsEmitted += windows.count
+                dispatchProcessMatches(windows: windows, startOffset: startSeconds, context: ctx)
+            }
+        }
+
+        if ctx.isCancelled() { throw StreamError.cancelled }
+        if let str = streamer {
+            let tail = str.flush()
+            if !tail.isEmpty {
+                windowsEmitted += tail.count
+                dispatchProcessMatches(windows: tail, startOffset: startSeconds, context: ctx)
+            }
+        }
+
+        let readSeconds = (format.map { Double(totalFramesRead) / $0.sampleRate }) ?? 0
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: streaming grow-loop ending — "
+                + "read \(String(format: "%.1f", readSeconds))s of audio, "
+                + "emitted \(windowsEmitted) windows, "
+                + "stall accum \(String(format: "%.1f", stallAccumSeconds))s"
+        )
+    }
+
+    /// Sleep on the generation queue in small slices so cancellation is
+    /// observed within at most one slice.
+    private func sleepWithCancellation(seconds: TimeInterval, context ctx: GenerationContext) throws {
+        let sliceSeconds: TimeInterval = 0.2
+        let slices = max(1, Int(ceil(seconds / sliceSeconds)))
+        for _ in 0..<slices {
+            if ctx.isCancelled() { throw StreamError.cancelled }
+            Thread.sleep(forTimeInterval: sliceSeconds)
         }
     }
 
@@ -807,22 +1025,37 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
-    /// Resolves the local audio file for an episode. The downloaded path is always
-    /// a complete file. The streaming-buffer path may still be growing — `AVAudioFile`
-    /// only sees the bytes present at open time, so we'll fingerprint up to that point
-    /// and stop; the rest of the buffer (if it fills in later) is not picked up. Full
-    /// streaming support would need file-growth tracking, which is out of scope for
-    /// this PR (see `bufferGrowPollCadenceSeconds` in `FingerprintConstants`).
-    private func resolveAudioFileURL(for episode: BaseEpisode) -> URL? {
+    /// Which local file backs the fingerprint loop for this episode.
+    ///
+    /// - `.downloaded` is a complete file — the existing read-to-EOF loop handles it.
+    /// - `.streaming` points at the AVPlayer-written buffer, which may be absent at
+    ///   call time or still growing. The grow-loop waits for it to appear and
+    ///   polls for new bytes.
+    private enum AudioSource {
+        case downloaded(URL)
+        case streaming(URL)
+    }
+
+    private func resolveAudioSource(for episode: BaseEpisode) -> AudioSource {
         let downloadPath = DownloadManager.shared.pathForEpisode(episode)
         if FileManager.default.fileExists(atPath: downloadPath) {
-            return URL(fileURLWithPath: downloadPath)
+            return .downloaded(URL(fileURLWithPath: downloadPath))
         }
+        // Two different streaming systems write to different locations:
+        // `MediaExporterResourceLoaderDelegate` (stream-and-cache, default on)
+        // writes to `tempPathForEpisode`, while the legacy URLSession path writes
+        // to `streamingBufferPathForEpisode`. Prefer whichever file already
+        // exists; otherwise pick the one the active feature flag selects.
+        let tempPath = DownloadManager.shared.tempPathForEpisode(episode)
         let streamingPath = DownloadManager.shared.streamingBufferPathForEpisode(episode)
-        if FileManager.default.fileExists(atPath: streamingPath) {
-            return URL(fileURLWithPath: streamingPath)
+        if FileManager.default.fileExists(atPath: tempPath) {
+            return .streaming(URL(fileURLWithPath: tempPath))
         }
-        return nil
+        if FileManager.default.fileExists(atPath: streamingPath) {
+            return .streaming(URL(fileURLWithPath: streamingPath))
+        }
+        let preferred = FeatureFlag.streamAndCachePlayingEpisode.enabled ? tempPath : streamingPath
+        return .streaming(URL(fileURLWithPath: preferred))
     }
 }
 

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -686,13 +686,17 @@ final class FingerprintTimingManager: NSObject {
     }
 
     /// Sleep on the generation queue in small slices so cancellation is
-    /// observed within at most one slice.
+    /// observed within at most one slice. Tracks remaining time rather than
+    /// ceiling-rounding the slice count so we don't oversleep the requested
+    /// duration by up to one slice (e.g. 0.21s → 0.4s).
     private func sleepWithCancellation(seconds: TimeInterval, context ctx: GenerationContext) throws {
         let sliceSeconds: TimeInterval = 0.2
-        let slices = max(1, Int(ceil(seconds / sliceSeconds)))
-        for _ in 0..<slices {
+        var remaining = max(0, seconds)
+        while remaining > 0 {
             if ctx.isCancelled() { throw StreamError.cancelled }
-            Thread.sleep(forTimeInterval: sliceSeconds)
+            let sleepDuration = min(sliceSeconds, remaining)
+            Thread.sleep(forTimeInterval: sleepDuration)
+            remaining -= sleepDuration
         }
     }
 

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -1041,7 +1041,17 @@ final class FingerprintTimingManager: NSObject {
         if FileManager.default.fileExists(atPath: downloadPath) {
             return .downloaded(URL(fileURLWithPath: downloadPath))
         }
-        // Two different streaming systems write to different locations:
+        // A stream-downloaded episode keeps a complete file at the streaming
+        // buffer path. It isn't growing, so route it through the one-shot
+        // fingerprint path instead of the grow-loop — same path trunk took.
+        if let episode = episode as? Episode,
+           episode.streamDownloaded(pathFinder: DownloadManager.shared) {
+            let streamingPath = DownloadManager.shared.streamingBufferPathForEpisode(episode)
+            if FileManager.default.fileExists(atPath: streamingPath) {
+                return .downloaded(URL(fileURLWithPath: streamingPath))
+            }
+        }
+        // Active streaming: the file is either absent or still growing.
         // `MediaExporterResourceLoaderDelegate` (stream-and-cache, default on)
         // writes to `tempPathForEpisode`, while the legacy URLSession path writes
         // to `streamingBufferPathForEpisode`. Prefer whichever file already

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4235,7 +4235,7 @@ internal enum L10n {
   internal static func transcriptErrorNotSupported(_ p1: Any) -> String {
     return L10n.tr("Localizable", "transcript_error_not_supported", String(describing: p1), fallback: "Sorry, but this transcript format is not supported: %1$@")
   }
-  /// Toast shown when the user taps inside the transcript of a streaming (not-yet-downloaded) episode. Tap-to-seek requires a fully downloaded file.
+  /// Toast shown when the user taps inside the transcript but the fingerprint mapping has no anchors yet, so we can't resolve an accurate seek target.
   internal static var transcriptTapToSeekStreamingUnavailable: String { return L10n.tr("Localizable", "transcript_tap_to_seek_streaming_unavailable", fallback: "Tap to seek not available while streaming") }
   /// Label indicating that the trial period for the subscription or promotion has ended.
   internal static var trialFinished: String { return L10n.tr("Localizable", "trial_finished", fallback: "Trial Finished") }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4236,7 +4236,7 @@ internal enum L10n {
     return L10n.tr("Localizable", "transcript_error_not_supported", String(describing: p1), fallback: "Sorry, but this transcript format is not supported: %1$@")
   }
   /// Toast shown when the user taps inside the transcript but the fingerprint mapping has no anchors yet, so we can't resolve an accurate seek target.
-  internal static var transcriptTapToSeekStreamingUnavailable: String { return L10n.tr("Localizable", "transcript_tap_to_seek_streaming_unavailable", fallback: "Tap to seek not available while streaming") }
+  internal static var transcriptTapToSeekStreamingUnavailable: String { return L10n.tr("Localizable", "transcript_tap_to_seek_streaming_unavailable", fallback: "Download the episode to tap to seek") }
   /// Label indicating that the trial period for the subscription or promotion has ended.
   internal static var trialFinished: String { return L10n.tr("Localizable", "trial_finished", fallback: "Trial Finished") }
   /// The Trim Silence feature, removes silence from podcasts to make them shorter.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4235,6 +4235,8 @@ internal enum L10n {
   internal static func transcriptErrorNotSupported(_ p1: Any) -> String {
     return L10n.tr("Localizable", "transcript_error_not_supported", String(describing: p1), fallback: "Sorry, but this transcript format is not supported: %1$@")
   }
+  /// Toast shown when the user taps inside the transcript of a streaming (not-yet-downloaded) episode. Tap-to-seek requires a fully downloaded file.
+  internal static var transcriptTapToSeekStreamingUnavailable: String { return L10n.tr("Localizable", "transcript_tap_to_seek_streaming_unavailable", fallback: "Tap to seek not available while streaming") }
   /// Label indicating that the trial period for the subscription or promotion has ended.
   internal static var trialFinished: String { return L10n.tr("Localizable", "trial_finished", fallback: "Trial Finished") }
   /// The Trim Silence feature, removes silence from podcasts to make them shorter.

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -930,9 +930,21 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         }
         let referenceTime = cue.startTime + fraction * (cue.endTime - cue.startTime)
 
+        let coveredPlaybackTime = FingerprintTimingManager.shared.playbackTimeIfCovered(forReferenceTime: referenceTime)
+
+        if coveredPlaybackTime == nil,
+           FeatureFlag.syncedTranscripts.enabled,
+           let episode = PlaybackManager.shared.currentEpisode(),
+           !episode.downloaded(pathFinder: DownloadManager.shared) {
+            Toast.show(L10n.transcriptTapToSeekStreamingUnavailable)
+            return
+        }
+
         let seekTime: TimeInterval
-        if let playbackTime = FingerprintTimingManager.shared.playbackTime(forReferenceTime: referenceTime) {
-            seekTime = playbackTime
+        if let coveredPlaybackTime {
+            seekTime = coveredPlaybackTime
+        } else if let extrapolated = FingerprintTimingManager.shared.playbackTime(forReferenceTime: referenceTime) {
+            seekTime = extrapolated
         } else {
             seekTime = referenceTime
         }

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -930,23 +930,9 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         }
         let referenceTime = cue.startTime + fraction * (cue.endTime - cue.startTime)
 
-        let coveredPlaybackTime = FingerprintTimingManager.shared.playbackTimeIfCovered(forReferenceTime: referenceTime)
-
-        if coveredPlaybackTime == nil,
-           FeatureFlag.syncedTranscripts.enabled,
-           let episode = PlaybackManager.shared.currentEpisode(),
-           !episode.downloaded(pathFinder: DownloadManager.shared) {
+        guard let seekTime = FingerprintTimingManager.shared.playbackTime(forReferenceTime: referenceTime) else {
             Toast.show(L10n.transcriptTapToSeekStreamingUnavailable)
             return
-        }
-
-        let seekTime: TimeInterval
-        if let coveredPlaybackTime {
-            seekTime = coveredPlaybackTime
-        } else if let extrapolated = FingerprintTimingManager.shared.playbackTime(forReferenceTime: referenceTime) {
-            seekTime = extrapolated
-        } else {
-            seekTime = referenceTime
         }
 
         playbackManager.seekTo(time: seekTime)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4670,6 +4670,9 @@
 /* Transcript error message when transcript is empty*/
 "transcript_error_empty" = "Sorry, but it looks this transcript is empty";
 
+/* Toast shown when the user taps inside the transcript of a streaming (not-yet-downloaded) episode. Tap-to-seek requires a fully downloaded file. */
+"transcript_tap_to_seek_streaming_unavailable" = "Tap to seek not available while streaming";
+
 /* Title of the Transcript excerpt in Episode detail */
 "view_transcript" = "View Transcript";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4670,7 +4670,7 @@
 /* Transcript error message when transcript is empty*/
 "transcript_error_empty" = "Sorry, but it looks this transcript is empty";
 
-/* Toast shown when the user taps inside the transcript of a streaming (not-yet-downloaded) episode. Tap-to-seek requires a fully downloaded file. */
+/* Toast shown when the user taps inside the transcript but the fingerprint mapping has no anchors yet, so we can't resolve an accurate seek target. */
 "transcript_tap_to_seek_streaming_unavailable" = "Tap to seek not available while streaming";
 
 /* Title of the Transcript excerpt in Episode detail */

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4671,7 +4671,7 @@
 "transcript_error_empty" = "Sorry, but it looks this transcript is empty";
 
 /* Toast shown when the user taps inside the transcript but the fingerprint mapping has no anchors yet, so we can't resolve an accurate seek target. */
-"transcript_tap_to_seek_streaming_unavailable" = "Tap to seek not available while streaming";
+"transcript_tap_to_seek_streaming_unavailable" = "Download the episode to tap to seek";
 
 /* Title of the Transcript excerpt in Episode detail */
 "view_transcript" = "View Transcript";


### PR DESCRIPTION
| 📘 Part of: POC-539 |
|:---:|

## Summary

Synced transcripts previously only fingerprinted **downloaded** episodes — the one-shot reader opened the local file, read to EOF, and stopped. For an episode the listener is streaming, the on-disk buffer is still growing as AVPlayer writes it, so fingerprinting never produced anchors and highlighting never turned on.

This PR adds a streaming fingerprint path that treats the buffer as a growing file:

- **Grow-loop** (`streamFingerprintGrowing`): reopens `AVAudioFile` each pass to pick up new bytes, seeks to where it left off, feeds PCM through the existing `StreamingWindowedFingerprinter` pipeline, and bails after `bufferGrowMaxStallSeconds` of no new bytes (a later playback-progress tick will restart it).
- **Routing** (`resolveAudioSource`): `.downloaded` for episodes with a complete local file (`pathForEpisode` or the completed stream-download at `streamingBufferPathForEpisode`) → unchanged one-shot path. `.streaming` for anything currently growing (`tempPathForEpisode` from stream-and-cache, or the legacy streaming buffer) → new grow-loop.
- **Start-position alignment** fix: the grow-loop waits until the on-disk file has reached `startSeconds * sampleRate` before initialising the streamer, then anchors at exactly that frame — so window timestamps line up with reference checkpoints. (Clamping `lastProcessedFrame` down to `audioFile.length` when the file was behind playback would have misattributed windows and produced all-red matches.)
- **`processProgress` guard**: if `playbackToReference` is empty, skip the drift-restart. The grow-loop gets progress ticks every second while still building its first window; without this, each tick would cancel the in-flight work before any anchor landed.
- **Tap-to-seek toast**: when the fingerprint mapping has no anchors yet and `playbackTime(forReferenceTime:)` returns nil (typical in the first few seconds of any new playback, especially streaming), show `"Tap to seek not available while streaming"` instead of falling back to identity `referenceTime`.

All gated by the existing `FeatureFlag.syncedTranscripts`. The tap handler only installs its gesture recogniser when the flag is on, and `prepareForEpisode` bails early when it's off, so the streaming grow-loop never runs with the flag disabled.

## To test

You can use Network Link Conditioner to simulate slow connectivity.

1. Enable `FeatureFlag.syncedTranscripts` (Beta menu or debug overrides).
2. Run the app in `StagingDebug` (I recommend running fresh to avoid picking up buffered files)
3. Login with a Plus account
5. Pick a podcast episode with a synced transcript that is **not** downloaded.
6. Start playback.
7. Within a few seconds of playback, the transcript highlight should start tracking. `FileLog` will show `"streaming grow-loop starting at …s"` and later `"streaming buffer opened …"`.
8. Tap a transcript cue *before* the mapping has produced any anchor (immediately after starting playback) → toast `"Tap to seek not available while streaming"` appears; no seek happens.
9. After a few more seconds, tap a cue → seek fires to the fingerprinted playback time.
10. Regression check: fully download the same episode, restart playback, confirm highlighting and tap-to-seek behave exactly as on `trunk`.
11. Flag off: confirm the transcript loads normally and the tap gesture does nothing

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.