### PR TITLE
Enable SwiftLint rule: shorthand_optional_binding

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -57,6 +57,9 @@ only_rules:
   # the declaration.
   - opening_brace
 
+  # Prefer shorthand optional binding `if let foo {` over `if let foo = foo {`.
+  - shorthand_optional_binding
+
   # Files should have a single trailing newline.
   - trailing_newline
 

--- a/Modules/Sources/GRDBMacrosPlugin/GRDBRecordMacro.swift
+++ b/Modules/Sources/GRDBMacrosPlugin/GRDBRecordMacro.swift
@@ -68,7 +68,7 @@ public struct GRDBRecordMacro: MemberMacro, ExtensionMacro {
         var members: [DeclSyntax] = []
 
         // 1. Generate databaseTableName if table parameter provided
-        if let tableName = tableName {
+        if let tableName {
             members.append("""
                 \(raw: accessModifier)static let databaseTableName = "\(raw: tableName)"
                 """)

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -773,7 +773,7 @@ class EpisodeDataManager {
         var values = [episode.keepEpisode] as [Any]
 
         fields.append("starredModified")
-        if let starredModified = starredModified {
+        if let starredModified {
             values.append(starredModified)
         } else {
             let starredModifiedValue = starred ? DBUtils.currentUTCTimeInMillis() : 0
@@ -1148,7 +1148,7 @@ class EpisodeDataManager {
         dbQueue.write { db in
             do {
                 var query = "UPDATE \(DataManager.episodeTableName) SET \(fields.joined(separator: " = ?, ")) = ?"
-                if let whereClause = whereClause {
+                if let whereClause {
                     query += " WHERE \(whereClause)"
                 }
                 try db.executeUpdate(query, values: values)

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -139,7 +139,7 @@ class PodcastDataManager {
             do {
                 var values: [Any]?
                 var whereClause = "WHERE p.subscribed = 1"
-                if let inFolderUuid = inFolderUuid {
+                if let inFolderUuid {
                     whereClause += " AND p.folderUuid = ?"
                     values = [inFolderUuid]
                 }
@@ -167,7 +167,7 @@ class PodcastDataManager {
             do {
                 var values: [Any]?
                 var whereClause = "WHERE p.subscribed = 1"
-                if let inFolderUuid = inFolderUuid {
+                if let inFolderUuid {
                     whereClause += " AND p.folderUuid = ?"
                     values = [inFolderUuid]
                 }

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
@@ -53,7 +53,7 @@ class UserEpisodeDataManager {
     func findAll(sortedBy: UploadedSort, limit: Int? = nil, dbQueue: PCDBQueue) -> [UserEpisode] {
         let whereClause = "WHERE uploadStatus != \(UploadStatus.deleteFromCloudPending.rawValue) AND uploadStatus != \(UploadStatus.deleteFromCloudAndLocalPending.rawValue)"
         var limitClause = ""
-        if let limit = limit {
+        if let limit {
             limitClause = " LIMIT \(limit)"
         }
         switch sortedBy {
@@ -74,7 +74,7 @@ class UserEpisodeDataManager {
 
     func findAllDownloaded(sortedBy: UploadedSort, limit: Int? = nil, dbQueue: PCDBQueue) -> [UserEpisode] {
         var limitClause = ""
-        if let limit = limit {
+        if let limit {
             limitClause = " LIMIT \(limit)"
         }
 
@@ -245,13 +245,13 @@ class UserEpisodeDataManager {
         var fields = [String]()
         var values = [Any]()
 
-        if let duration = duration, duration > 0 {
+        if let duration, duration > 0 {
             fields.append("duration")
             values.append(duration)
         }
 
         // this field defaults to non-null 0, which is not a valid playing status so we need to handle this
-        if let playingStatus = playingStatus {
+        if let playingStatus {
             let status = PlayingStatus(rawValue: Int32(playingStatus)) ?? .notPlayed
             let actualStatus = Int(status.rawValue)
             fields.append("playingStatus")
@@ -261,7 +261,7 @@ class UserEpisodeDataManager {
             values.append(PlayingStatus.notPlayed.rawValue)
         }
 
-        if let playedUpTo = playedUpTo, playedUpTo > 0 {
+        if let playedUpTo, playedUpTo > 0 {
             fields.append("playedUpTo")
             values.append(playedUpTo)
         }

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DBUtils.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DBUtils.swift
@@ -1,13 +1,13 @@
 import Foundation
 class DBUtils {
     class func convertDate(value: TimeInterval?) -> Date? {
-        guard let value = value, value > 0 else { return nil }
+        guard let value, value > 0 else { return nil }
 
         return Date(timeIntervalSince1970: value)
     }
 
     class func nullIfNil(value: Any?) -> Any {
-        guard let value = value else { return NSNull() }
+        guard let value else { return NSNull() }
 
         return value
     }

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/BaseEpisode+Encoding.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/BaseEpisode+Encoding.swift
@@ -2,43 +2,43 @@ import Foundation
 
 public extension BaseEpisode {
     func encode(date: Date?) -> String {
-        guard let date = date else { return "" }
+        guard let date else { return "" }
 
         return "\(date.timeIntervalSince1970)"
     }
 
     func decodeInt32FromString(value: String?) -> Int32 {
-        guard let value = value, !value.isEmpty else { return 0 }
+        guard let value, !value.isEmpty else { return 0 }
 
         return Int32(value) ?? 0
     }
 
     func decodeInt64FromString(value: String?) -> Int64 {
-        guard let value = value, !value.isEmpty else { return 0 }
+        guard let value, !value.isEmpty else { return 0 }
 
         return Int64(value) ?? 0
     }
 
     func decodeDateFromString(date: String?) -> Date? {
-        guard let date = date, !date.isEmpty, let doubleVal = Double(date) else { return nil }
+        guard let date, !date.isEmpty, let doubleVal = Double(date) else { return nil }
 
         return Date(timeIntervalSince1970: doubleVal)
     }
 
     func decodeBoolFromString(value: String?) -> Bool {
-        guard let value = value else { return false }
+        guard let value else { return false }
 
         return Bool(value) ?? false
     }
 
     func decodeDoubleFromString(value: String?) -> Double {
-        guard let value = value else { return 0 }
+        guard let value else { return 0 }
 
         return Double(value) ?? 0
     }
 
     func decodeOptionalStringFromString(value: String?) -> String? {
-        guard let value = value, !value.isEmpty else { return nil }
+        guard let value, !value.isEmpty else { return nil }
 
         return value
     }

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -161,7 +161,7 @@ public class Episode: NSObject, BaseEpisode {
     // MARK: - Meta
 
     @objc public func videoPodcast() -> Bool {
-        if let fileType = fileType, fileType.startsWith(string: "video/") {
+        if let fileType, fileType.startsWith(string: "video/") {
             return true
         }
 
@@ -171,7 +171,7 @@ public class Episode: NSObject, BaseEpisode {
     // MARK: - Helpers
 
     public func mayContainChapters() -> Bool {
-        guard let fileType = fileType else { return false }
+        guard let fileType else { return false }
 
         return (fileType.caseInsensitiveCompare("audio/x-m4a") == .orderedSame ||
             fileType.caseInsensitiveCompare("audio/x-m4b") == .orderedSame ||

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -53,7 +53,7 @@ public class EpisodeFilter: NSObject {
     override public init() {}
 
     public func setTitle(_ title: String?, defaultTitle: String) {
-        guard let title = title, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard let title, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             playlistName = defaultTitle
 
             return

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
@@ -142,7 +142,7 @@ public class UserEpisode: NSObject, BaseEpisode {
     }
 
     @objc public func videoPodcast() -> Bool {
-        if let fileType = fileType, fileType.startsWith(string: "video/") {
+        if let fileType, fileType.startsWith(string: "video/") {
             return true
         }
 
@@ -150,7 +150,7 @@ public class UserEpisode: NSObject, BaseEpisode {
     }
 
     public func mayContainChapters() -> Bool {
-        guard let fileType = fileType else { return false }
+        guard let fileType else { return false }
 
         return (fileType.caseInsensitiveCompare("audio/x-m4a") == .orderedSame || fileType.caseInsensitiveCompare("audio/x-m4b") == .orderedSame || fileType.caseInsensitiveCompare("audio/mp3") == .orderedSame || fileType.caseInsensitiveCompare("audio/mpeg") == .orderedSame)
     }

--- a/Modules/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -858,7 +858,7 @@ public class PlaylistQueryBuilder {
         var queryString = "archived = 0 "
         var addedUuid = false
 
-        if let episodeUuidToAdd = episodeUuidToAdd {
+        if let episodeUuidToAdd {
             queryString += "AND ((uuid = '\(episodeUuidToAdd)') OR ("
             addedUuid = true
         } else {

--- a/Modules/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/UpNextListComparator.swift
@@ -16,7 +16,7 @@ public struct UpNextListComparator {
                                lastServerRefresh: Date?,
                                lastWatchDataTime: Date,
                                useConservativeComparison: Bool = true) -> UpNextComparisonResult {
-        guard let phoneEpisodes = phoneEpisodes, !phoneEpisodes.isEmpty else {
+        guard let phoneEpisodes, !phoneEpisodes.isEmpty else {
             if watchEpisodeCount == 0 {
                 return .same
             } else {
@@ -46,7 +46,7 @@ public struct UpNextListComparator {
             }
         }
 
-        guard let lastServerRefresh = lastServerRefresh else {
+        guard let lastServerRefresh else {
             if useConservativeComparison {
                 FileLog.shared.addMessage("WatchSyncManager: No lastServerRefresh timestamp, returning .notEnoughInformation")
                 return .notEnoughInformation

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
@@ -83,7 +83,7 @@ class ApiBaseTask: Operation {
         let requestUrl = ServerHelper.asUrl(url)
         let method = "GET"
         var request = createRequest(url: requestUrl, method: method, token: token)
-        if let customHeaders = customHeaders {
+        if let customHeaders {
             for header in customHeaders {
                 request.setValue(header.value, forHTTPHeaderField: header.key)
             }
@@ -137,7 +137,7 @@ class ApiBaseTask: Operation {
     }
 
     func formatDate(_ date: Date?) -> String {
-        if let date = date {
+        if let date {
             return isoDateFormatter.string(from: date)
         }
 
@@ -152,7 +152,7 @@ class ApiBaseTask: Operation {
         request.addLocalizationHeaders()
         let privateUserAgent = ServerConfig.shared.syncDelegate?.privateUserAgent() ?? ""
         request.setValue(privateUserAgent, forHTTPHeaderField: ServerConstants.HttpHeaders.userAgent)
-        if let token = token {
+        if let token {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         return request

--- a/Modules/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -29,7 +29,7 @@ class TokenHelper {
     func callSecureUrl(request: URLRequest) async throws -> (HTTPURLResponse?, Data?) {
         try await withCheckedThrowingContinuation { continuation in
             performCallSecureUrl(request: request, retryOnUnauthorized: true) { response, data, error in
-                if let error = error {
+                if let error {
                     continuation.resume(throwing: error)
                     return
                 }

--- a/Modules/Sources/PocketCastsServer/Public/API/APIServerHandler+TrialEligibility.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/APIServerHandler+TrialEligibility.swift
@@ -15,7 +15,7 @@ public extension ApiServerHandler {
         }
 
         URLSession.shared.dataTask(with: request) { data, urlResponse, error in
-            guard let data = data, error == nil, urlResponse?.extractStatusCode() == ServerConstants.HttpConstants.ok else {
+            guard let data, error == nil, urlResponse?.extractStatusCode() == ServerConstants.HttpConstants.ok else {
                 completion(nil)
                 return
             }

--- a/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -179,7 +179,7 @@ public extension ApiServerHandler {
     }
 
     class func extractErrorResponse(data: Data?, response: URLResponse?, error: Error? = nil) -> APIError? {
-        if let data = data {
+        if let data {
             do {
                 let errorJson = try JSONDecoder().decode(ErrorResponse.self, from: data)
                 return APIError(rawValue: errorJson.errorMessageId ?? "unknown")

--- a/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -38,7 +38,7 @@ public enum AuthenticationScope: String {
 
 public extension ApiServerHandler {
     func validateLogin(identityToken: String?, scope: AuthenticationScope = .mobile) async throws -> AuthenticationResponse {
-        guard let identityToken = identityToken,
+        guard let identityToken,
               let request = tokenRequest(identityToken: identityToken, scope: scope)
         else {
             FileLog.shared.addMessage("Unable to create protobuffer request to obtain token via Apple SSO")

--- a/Modules/Sources/PocketCastsServer/Public/Cache/CacheServerHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Cache/CacheServerHandler.swift
@@ -37,7 +37,7 @@ public class CacheServerHandler {
         URLSession.shared.dataTask(with: request) { [weak self] data, response, _ in
             guard let strongSelf = self else { return }
 
-            if let data = data, let response = response {
+            if let data, let response {
                 let responseToCache = CachedURLResponse(response: response, data: data)
                 strongSelf.colorsUrlsCache.storeCachedResponse(responseToCache, for: request)
 
@@ -72,7 +72,7 @@ public class CacheServerHandler {
         tokenHelper.callSecureUrl(request: request) { [weak self] response, data, _ in
             guard let strongSelf = self else { return }
 
-            if response?.statusCode == ServerConstants.HttpConstants.ok, let data = data, let podcastInfo = strongSelf.asJson(data: data) {
+            if response?.statusCode == ServerConstants.HttpConstants.ok, let data, let podcastInfo = strongSelf.asJson(data: data) {
                 if let lastModified = response?.allHeaderFields[ServerConstants.HttpHeaders.lastModified] as? String {
                     completion(podcastInfo, lastModified)
                 } else {
@@ -92,7 +92,7 @@ public class CacheServerHandler {
         request.addLocalizationHeaders()
 
         tokenHelper.callSecureUrl(request: request) { response, data, _ in
-            if response?.statusCode == ServerConstants.HttpConstants.ok, let data = data, let url = String(data: data, encoding: .utf8) {
+            if response?.statusCode == ServerConstants.HttpConstants.ok, let data, let url = String(data: data, encoding: .utf8) {
                 completion(url)
 
                 return
@@ -118,7 +118,7 @@ public class CacheServerHandler {
             }
 
             guard let strongSelf = self else { return }
-            if let data = data, let podcastInfo = strongSelf.asJson(data: data) {
+            if let data, let podcastInfo = strongSelf.asJson(data: data) {
                 if let lastModified = response?.allHeaderFields[ServerConstants.HttpHeaders.lastModified] as? String {
                     completion(podcastInfo, lastModified)
                 } else {
@@ -160,7 +160,7 @@ public class CacheServerHandler {
         }
 
         tokenHelper.callSecureUrl(request: request) { response, data, _ in
-            guard response?.statusCode == ServerConstants.HttpConstants.ok, let data = data else {
+            guard response?.statusCode == ServerConstants.HttpConstants.ok, let data else {
                 completion?(nil)
                 return
             }
@@ -181,7 +181,7 @@ public class CacheServerHandler {
     }
 
     private func topLevelValue<T>(data: Data?, name: String, ofType: T.Type) -> T? {
-        guard let data = data else { return nil }
+        guard let data else { return nil }
 
         do {
             let json = try JSONSerialization.jsonObject(with: data, options: [])
@@ -194,7 +194,7 @@ public class CacheServerHandler {
     }
 
     private func asJson(data: Data?) -> [String: Any]? {
-        guard let data = data else { return nil }
+        guard let data else { return nil }
 
         do {
             if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] { return json }

--- a/Modules/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler+Blaze.swift
@@ -33,7 +33,7 @@ extension DiscoverServerHandler {
         let path = ServerConstants.Urls.discover() + "blaze/promotions.json"
         let fetchResult: (BlazePromotion, Bool)? = await withCheckedContinuation { continuation in
             discoverRequest(path: path, type: BlazePromotions.self, authenticated: false) { promotions, useCache in
-                if let promotions = promotions,
+                if let promotions,
                    let promotion = promotions.promotions.first(where: { $0.location == location }) {
                     continuation.resume(returning: (promotion, useCache))
                 } else {

--- a/Modules/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -105,13 +105,13 @@ public class DiscoverServerHandler: DiscoverServerHandling {
     }
 
     public func discoverItem<T>(_ source: String?, authenticated: Bool, type: T.Type) -> AnyPublisher<T, Error> where T: Decodable {
-        guard let source = source else {
+        guard let source else {
             return Fail(error: DiscoverServerError.badRequest).eraseToAnyPublisher()
         }
 
         return Future { [unowned self] promise in
             self.discoverRequest(path: source, type: type, authenticated: authenticated) { discoverList, _ in
-                if let discoverList = discoverList {
+                if let discoverList {
                     promise(.success(discoverList))
                 } else {
                     promise(.failure(DiscoverServerError.unknown))
@@ -211,9 +211,9 @@ public class DiscoverServerHandler: DiscoverServerHandling {
 
         performDiscoverRequest(path: path, authenticated: authenticated) { [weak self] data, response, error, useCache in
             guard
-                let self = self,
-                let data = data,
-                let response = response,
+                let self,
+                let data,
+                let response,
                 error == nil
             else {
                 completion(nil, false)

--- a/Modules/Sources/PocketCastsServer/Public/MetadataUpdater.swift
+++ b/Modules/Sources/PocketCastsServer/Public/MetadataUpdater.swift
@@ -22,7 +22,7 @@ public class MetadataUpdater {
     }
 
     public func updateMetadataFrom(response: HTTPURLResponse?, episode: Episode?) {
-        guard let episode = episode, let response = response else { return }
+        guard let episode, let response else { return }
 
         MetadataTask.updateEpisodeFrom(response: response, episode: episode)
     }

--- a/Modules/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
@@ -120,7 +120,7 @@ public class MainServerHandler {
         }
 
         URLSession.shared.dataTask(with: request) { data, _, error in
-            guard let data = data, error == nil else {
+            guard let data, error == nil else {
                 completion(ImportOpmlResponse.failedResponse())
                 return
             }
@@ -154,7 +154,7 @@ public class MainServerHandler {
         }
 
         URLSession.shared.dataTask(with: request) { data, _, error in
-            guard let data = data, error == nil else {
+            guard let data, error == nil else {
                 completion(ExportPodcastsResponse.failedResponse())
                 return
             }
@@ -185,7 +185,7 @@ public class MainServerHandler {
         }
 
         URLSession.shared.dataTask(with: request) { data, _, error in
-            guard let data = data, error == nil else {
+            guard let data, error == nil else {
                 completion(ShareListResponse.failedResponse())
                 return
             }
@@ -210,8 +210,8 @@ public class MainServerHandler {
         tokenHelper.callSecureUrl(request: request) { response, data, error in
             let statusCode = response?.statusCode ?? 0
 
-            guard statusCode == ServerConstants.HttpConstants.ok, let data = data else {
-                if let error = error {
+            guard statusCode == ServerConstants.HttpConstants.ok, let data else {
+                if let error {
                     FileLog.shared.addMessage("Refresh failed: with error \(error.localizedDescription), status code \(statusCode)")
                 } else {
                     FileLog.shared.addMessage("Refresh failed: response returned no data, status code \(statusCode)")
@@ -338,7 +338,7 @@ public class MainServerHandler {
         }
 
         URLSession.shared.dataTask(with: request) { data, _, error in
-            guard let data = data, error == nil else {
+            guard let data, error == nil else {
                 completion(nil)
                 return
             }

--- a/Modules/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
@@ -56,7 +56,7 @@ class PodcastSearchOperation: Operation {
         var shouldRetry = false
         dispatchGroup.enter()
         URLSession.shared.dataTask(with: request) { data, _, error in
-            guard let data = data, error == nil else {
+            guard let data, error == nil else {
                 shouldRetry = true
                 self.dispatchGroup.leave()
                 return

--- a/Modules/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
@@ -89,7 +89,7 @@ public class RefreshManager {
 
         DispatchQueue.global().async {
             MainServerHandler.shared.refresh(podcasts: podcasts) { [weak self] refreshResponse in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.processPodcastRefreshResponse(refreshResponse) { _ in
                     completion?()
@@ -122,7 +122,7 @@ public class RefreshManager {
             }
 
             MainServerHandler.shared.refresh(podcasts: podcasts) { [weak self] refreshResponse in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.processPodcastRefreshResponse(refreshResponse) { _ in
                     completion?()
@@ -136,7 +136,7 @@ public class RefreshManager {
         DispatchQueue.global().async {
             let podcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
             MainServerHandler.shared.refresh(podcasts: podcasts) { [weak self] refreshResponse in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.processPodcastRefreshResponse(refreshResponse, completion: completion)
             }

--- a/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
@@ -12,7 +12,7 @@ extension ServerPodcastManager {
     ///   - completion: a completion block that receives a `Bool`
     public func updatePodcastIfRequired(podcast: Podcast, addMissingEpisodes: Bool = false, completion: ((Bool) -> Void)?) {
         CacheServerHandler.shared.loadPodcastIfModified(podcast: podcast) { [weak self] podcastInfo, lastModified in
-            if let podcastInfo = podcastInfo {
+            if let podcastInfo {
                 self?.updatePodcast(podcast: podcast, lastModified: lastModified, podcastInfo: podcastInfo, addMissingEpisodes: addMissingEpisodes, completion: {
                     FileLog.shared.addMessage("\(podcast.title ?? "") updated from cache server")
                     completion?(true)

--- a/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -62,7 +62,7 @@ public class ServerPodcastManager: NSObject {
 
     public func addFromUuid(podcastUuid: String, subscribe: Bool, autoDownloads: Int = 0, completion: ((Bool) -> Void)?) {
         CacheServerHandler.shared.loadPodcastInfo(podcastUuid: podcastUuid) { [weak self] podcastInfo, lastModified in
-            if let podcastInfo = podcastInfo {
+            if let podcastInfo {
                 self?.addFromJson(podcastUuid: podcastUuid, lastModified: lastModified, podcastInfo: podcastInfo, subscribe: subscribe, autoDownloads: autoDownloads, completion: completion)
             } else {
                 completion?(false)
@@ -297,7 +297,7 @@ public class ServerPodcastManager: NSObject {
             return nil
         }
 
-        guard let data = data else {
+        guard let data else {
             return nil
         }
 

--- a/Modules/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -242,7 +242,7 @@ public class ServerSettings {
     }
 
     public class func setSyncingEmail(email: String?) {
-        if let email = email {
+        if let email {
             KeychainHelper.save(string: email, key: ServerConstants.Values.syncingEmailKey, accessibility: kSecAttrAccessibleAfterFirstUnlock)
         } else {
             KeychainHelper.removeKey(ServerConstants.Values.syncingEmailKey)

--- a/Modules/Sources/PocketCastsServer/Public/Sharing/SharingServerHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sharing/SharingServerHandler.swift
@@ -91,7 +91,7 @@ public class SharingServerHandler {
         }
 
         URLSession.shared.dataTask(with: request) { data, response, error in
-            guard (response as? HTTPURLResponse)?.statusCode == ServerConstants.HttpConstants.ok, let data = data, error == nil else {
+            guard (response as? HTTPURLResponse)?.statusCode == ServerConstants.HttpConstants.ok, let data, error == nil else {
                 completion(nil)
 
                 return
@@ -108,7 +108,7 @@ public class SharingServerHandler {
 
     public func loadList(listUrl: URL, completion: @escaping (_ podcastList: PodcastList?) -> Void) {
         URLSession.shared.dataTask(with: listUrl) { data, response, error in
-            guard (response as? HTTPURLResponse)?.statusCode == ServerConstants.HttpConstants.ok, let data = data, error == nil else {
+            guard (response as? HTTPURLResponse)?.statusCode == ServerConstants.HttpConstants.ok, let data, error == nil else {
                 completion(nil)
 
                 return

--- a/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -502,7 +502,7 @@ public struct DiscoverEpisode: Decodable {
     public let number: Int?
 
     public var isTrailer: Bool {
-        guard let type = type else { return false }
+        guard let type else { return false }
         return type == "trailer"
     }
 }

--- a/Modules/Sources/PocketCastsServer/Public/StatsManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/StatsManager.swift
@@ -163,7 +163,7 @@ public class StatsManager {
 
     public func loadRemoteStats(completion: ((Bool) -> Void)?) {
         ApiServerHandler.shared.loadStatsRequest { [weak self] remoteStats in
-            guard let strongSelf = self, let remoteStats = remoteStats else { return }
+            guard let strongSelf = self, let remoteStats else { return }
 
             strongSelf.saveTime(remoteStats.silenceRemovalTime, key: ServerConstants.UserDefaults.statsDynamicSpeedSecondsServer)
             strongSelf.saveTime(remoteStats.totalListenTime, key: ServerConstants.UserDefaults.statsListenedToServer)

--- a/Modules/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
@@ -64,7 +64,7 @@ extension BackgroundSyncManager: URLSessionDelegate, URLSessionDownloadDelegate 
     }
 
     public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        if let error = error {
+        if let error {
             FileLog.shared.addMessage("URLSession didCompleteWithError \(error.localizedDescription)")
             return
         }
@@ -107,7 +107,7 @@ extension BackgroundSyncManager: URLSessionDelegate, URLSessionDownloadDelegate 
     // MARK: - Up Next Processing
 
     private func processUpNextSyncData(_ data: Data?) {
-        guard let data = data else { return }
+        guard let data else { return }
 
         syncProcessQueue.addOperation {
             let upNextTask = UpNextSyncTask()
@@ -141,7 +141,7 @@ extension BackgroundSyncManager: URLSessionDelegate, URLSessionDownloadDelegate 
     // MARK: - Refresh Processing
 
     private func processRefreshResponse(data: Data?) {
-        guard let data = data else { return }
+        guard let data else { return }
 
         syncProcessQueue.addOperation {
             let response = ServerHelper.decodeRefreshResponse(from: data)

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncHistoryTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncHistoryTask.swift
@@ -42,7 +42,7 @@ class SyncHistoryTask: ApiBaseTask {
             let (response, httpStatus) = postToServer(url: url, token: token, data: data)
             if httpStatus == ServerConstants.HttpConstants.notModified {
                 DataManager.sharedManager.markAllEpisodePlaybackHistorySynced()
-            } else if let response = response, httpStatus == ServerConstants.HttpConstants.ok {
+            } else if let response, httpStatus == ServerConstants.HttpConstants.ok {
                 process(serverData: response)
             } else {
                 print("SyncHistoryTask Unable to sync with server got status \(httpStatus)")

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -158,7 +158,7 @@ class SyncSettingsTask: ApiBaseTask {
             let data = try settingsRequest.serializedData()
             let (response, httpStatus) = postToServer(url: url, token: token, data: data)
 
-            if let response = response, httpStatus == ServerConstants.HttpConstants.ok {
+            if let response, httpStatus == ServerConstants.HttpConstants.ok {
                 process(serverData: response)
             } else {
                 FileLog.shared.addMessage("SyncSettingsTask Unable to sync with server got status \(httpStatus)")

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -42,13 +42,13 @@ extension SyncTask {
         DataManager.sharedManager.clearAllFolderInformation()
 
         // import any folders first, since that's fast and needs no extra calls
-        if let folders = folders {
+        if let folders {
             for folder in folders {
                 processFolder(folder)
             }
         }
 
-        guard let podcasts = podcasts else { return }
+        guard let podcasts else { return }
 
         totalToImport = podcasts.count
         NotificationCenter.default.post(name: ServerNotifications.syncProgressPodcastCount, object: totalToImport)
@@ -120,7 +120,7 @@ extension SyncTask {
             retrieveEpisodesTask.completion = { episodes in
                 DataManager.sharedManager.save(podcast: localPodcast)
 
-                guard let episodes = episodes else { return }
+                guard let episodes else { return }
 
                 DataManager.sharedManager.saveBulkEpisodeSyncInfo(episodes: DataConverter.convert(syncInfoEpisodes: episodes))
             }

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -76,14 +76,14 @@ class SyncTask: ApiBaseTask {
                 return
             }
 
-            if let folders = folders {
+            if let folders {
                 for folder in folders {
                     FolderHelper.addFolderToDatabase(folder)
                 }
             }
 
             // then update the podcasts with folder info as well as addedDate if required
-            if let podcasts = podcasts {
+            if let podcasts {
                 // If the server returns ALL `sortPosition` as `0`
                 // It means we should keep the local order for them to be synced later
                 let serverReturnsSortPosition: Bool = podcasts.compactMap { $0.sortPosition }.map { Int($0) }.reduce(0, +) > 0
@@ -153,7 +153,7 @@ class SyncTask: ApiBaseTask {
         // next we need their playlists
         let retrievePlaylistsTask = RetrievePlaylistsTask()
         retrievePlaylistsTask.completion = { playlists in
-            guard let playlists = playlists else { return }
+            guard let playlists else { return }
 
             self.processServerPlaylists(playlists)
         }

--- a/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -59,7 +59,7 @@ class UpNextSyncTask: ApiBaseTask {
             if httpStatus == ServerConstants.HttpConstants.notModified {
                 // no changes that we need to process
                 FileLog.shared.addMessage("UpNextSyncTask: Server returned not modified to Up Next sync, no changes required")
-            } else if let response = response, httpStatus == ServerConstants.HttpConstants.ok {
+            } else if let response, httpStatus == ServerConstants.HttpConstants.ok {
                 process(serverData: response, latestActionTime: latestActionTime)
             } else {
                 FileLog.shared.addMessage("UpNextSyncTask: Unable to sync with server got status \(httpStatus)")
@@ -369,7 +369,7 @@ class UpNextSyncTask: ApiBaseTask {
         ServerConfig.shared.playbackDelegate?.queueRefreshList(checkForAutoDownload: true)
 
         ServerConfig.shared.playbackDelegate?.upNextQueueChanged()
-        if let episodePlayingBeforeChanges = episodePlayingBeforeChanges, let currentlyPlaying = ServerConfig.shared.playbackDelegate?.isNowPlayingEpisode(episodeUuid: episodePlayingBeforeChanges.uuid), currentlyPlaying == false {
+        if let episodePlayingBeforeChanges, let currentlyPlaying = ServerConfig.shared.playbackDelegate?.isNowPlayingEpisode(episodeUuid: episodePlayingBeforeChanges.uuid), currentlyPlaying == false {
             // currently playing episode has changed
             ServerConfig.shared.playbackDelegate?.playingEpisodeChangedExternally()
         } else if episodePlayingBeforeChanges == nil, !modifiedList.isEmpty {

--- a/Modules/Sources/PocketCastsServer/Public/URLConnection.swift
+++ b/Modules/Sources/PocketCastsServer/Public/URLConnection.swift
@@ -36,7 +36,7 @@ public class URLConnection {
         }
 
         _ = semaphore.wait(timeout: .distantFuture)
-        if let error = error {
+        if let error {
             throw error
         }
         return (data, response)
@@ -49,7 +49,7 @@ public class URLConnection {
     public func send(request: URLRequest) async throws -> (Data?, URLResponse?) {
         try await withCheckedThrowingContinuation { continuation in
             send(request: request) { data, response, error in
-                if let error = error {
+                if let error {
                     continuation.resume(throwing: error)
                 } else {
                     continuation.resume(returning: (data, response))

--- a/Modules/Sources/PocketCastsServer/Public/URLResponse+HttpHelpers.swift
+++ b/Modules/Sources/PocketCastsServer/Public/URLResponse+HttpHelpers.swift
@@ -16,7 +16,7 @@ extension URLResponse {
 
     // The following directives indicate the response must not be cached.
     var cacheControlNoCache: Bool {
-        guard let cacheControl = cacheControl else {
+        guard let cacheControl else {
             return false
         }
         return cacheControl.contains("no-cache") || cacheControl.contains("no-store") || cacheControl.contains("must-revalidate")
@@ -24,7 +24,7 @@ extension URLResponse {
 
     // The number of seconds from the time of the request the data is refresh.
     var cacheControlMaxAge: Int? {
-        guard let cacheControl = cacheControl else {
+        guard let cacheControl else {
             return nil
         }
         // Split into directives ["public", "max-age=604800", "immutable"]
@@ -60,11 +60,11 @@ extension URLResponse {
             return nil
         }
         // check http header Cache-Control max-age
-        else if let date = date, let maxAge = cacheControlMaxAge, maxAge > 0 {
+        else if let date, let maxAge = cacheControlMaxAge, maxAge > 0 {
             return date.addingTimeInterval(TimeInterval(maxAge))
         }
         // check http header Expires
-        else if let expiresDate = expiresDate {
+        else if let expiresDate {
             return expiresDate
         }
         return nil

--- a/Modules/Sources/PocketCastsServer/Public/Upload/UploadManager+URLSessionDelegate.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Upload/UploadManager+URLSessionDelegate.swift
@@ -88,14 +88,14 @@ extension UploadManager: URLSessionDelegate, URLSessionDataDelegate {
         }
 
         var episode = DataManager.sharedManager.findUserEpisode(uploadTaskId: uploadId)
-        if let episode = episode {
+        if let episode {
             uploadingEpisodesCache[uploadId] = episode
         } else {
             if includeImageTasks {
                 let imageUuid = uploadId.replacingOccurrences(of: imageTaskPrefix, with: "")
 
                 let imageEpisode = DataManager.sharedManager.findUserEpisode(uuid: imageUuid)
-                if let imageEpisode = imageEpisode {
+                if let imageEpisode {
                     episode = imageEpisode
                     uploadingEpisodesCache[uploadId] = episode
                 }

--- a/Modules/Sources/PocketCastsServer/Public/Upload/UploadManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Upload/UploadManager.swift
@@ -138,7 +138,7 @@ public class UploadManager: NSObject {
     }
 
     private func cancelTaskId(_ taskId: String?, episode: UserEpisode, session: URLSession) {
-        guard let taskId = taskId else { return }
+        guard let taskId else { return }
 
         session.getTasksWithCompletionHandler { [weak self] _, uploadTasks, _ in
             if uploadTasks.isEmpty { return }
@@ -209,7 +209,7 @@ public class UploadManager: NSObject {
             DataManager.sharedManager.saveEpisode(uploadStatus: UploadStatus.uploading, episode: episode)
 
             uploadTask.taskDescription = taskId
-            if let taskId = taskId {
+            if let taskId {
                 self.uploadingEpisodesCache[taskId] = episode
             }
             uploadTask.resume()

--- a/Modules/Sources/PocketCastsUtils/Extensions/StringExtension.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/StringExtension.swift
@@ -7,7 +7,7 @@ public extension String {
     }
 
     func startsWith(string: String?) -> Bool {
-        guard let string = string else { return false }
+        guard let string else { return false }
 
         guard let range = range(of: string, options: .caseInsensitive) else { return false }
 

--- a/Modules/Sources/PocketCastsUtils/Extensions/UI/UILabel+Attributed.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/UI/UILabel+Attributed.swift
@@ -3,7 +3,7 @@
 
     public extension UILabel {
         func setLetterSpacing(_ letterSpacing: CGFloat) {
-            guard let text = text else { return }
+            guard let text else { return }
             let attributedString = NSMutableAttributedString(string: text)
             attributedString.addAttribute(NSAttributedString.Key.kern, value: letterSpacing, range: NSRange(location: 0, length: text.count))
             attributedText = attributedString

--- a/Modules/Sources/PocketCastsUtils/Extensions/UI/UIViewExtension.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/UI/UIViewExtension.swift
@@ -3,7 +3,7 @@
 
     public extension UIView {
         func anchorToAllSidesOf(view: UIView?) {
-            guard let view = view else { return }
+            guard let view else { return }
 
             translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
@@ -15,7 +15,7 @@
         }
 
         func anchorToAllSidesOf(view: UIView?, padding: CGFloat) {
-            guard let view = view else { return }
+            guard let view else { return }
 
             translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([

--- a/Modules/Sources/PocketCastsUtils/Formatting/DateFormatHelper.swift
+++ b/Modules/Sources/PocketCastsUtils/Formatting/DateFormatHelper.swift
@@ -80,7 +80,7 @@ public class DateFormatHelper: NSObject {
     // MARK: - Long d MMMM yyyy
 
     public func longLocalizedFormat(_ date: Date?) -> String {
-        guard let date = date else { return "" }
+        guard let date else { return "" }
 
         return fullDateFormatter.string(from: date)
     }
@@ -88,13 +88,13 @@ public class DateFormatHelper: NSObject {
     // MARK: - Short dd MMMM
 
     public func shortLocalizedFormat(_ date: Date?) -> String {
-        guard let date = date else { return "" }
+        guard let date else { return "" }
 
         return shortLocalizedFormatter.string(from: date)
     }
 
     public func aboutPageFormat(_ date: Date?) -> String {
-        guard let date = date else { return "" }
+        guard let date else { return "" }
 
         if !date.isCurrentYear() {
             return fullDateFormatter.string(from: date)
@@ -112,7 +112,7 @@ public class DateFormatHelper: NSObject {
     }()
 
     public func tinyLocalizedFormat(_ date: Date?) -> String {
-        guard let date = date else { return "" }
+        guard let date else { return "" }
 
         if !date.isCurrentYear() {
             return fullDateFormatter.string(from: date)
@@ -143,13 +143,13 @@ public class DateFormatHelper: NSObject {
     }()
 
     public func jsonFormat(_ date: Date?) -> String {
-        guard let date = date else { return "" }
+        guard let date else { return "" }
 
         return jsonDateFormatter.string(from: date)
     }
 
     public func jsonDate(_ string: String?) -> Date? {
-        guard let string = string else { return nil }
+        guard let string else { return nil }
 
         return jsonDateFormatter.date(from: string)
     }
@@ -165,7 +165,7 @@ public class DateFormatHelper: NSObject {
     }()
 
     public func httpDate(_ string: String?) -> Date? {
-        guard let string = string else { return nil }
+        guard let string else { return nil }
 
         return httpDateFormatter.date(from: string)
     }

--- a/Modules/Sources/PocketCastsUtils/General/DateUtil.swift
+++ b/Modules/Sources/PocketCastsUtils/General/DateUtil.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public enum DateUtil {
     public static func hasEnoughTimePassed(since date: Date?, time: TimeInterval) -> Bool {
-        guard let date = date else { return true }
+        guard let date else { return true }
 
         return -date.timeIntervalSinceNow > time
     }

--- a/Modules/Sources/PocketCastsUtils/General/KeychainHelper.swift
+++ b/Modules/Sources/PocketCastsUtils/General/KeychainHelper.swift
@@ -57,7 +57,7 @@ public class KeychainHelper {
         let fullKey = prefix + key
 
         // If the value is nil, delete the item
-        guard let value = value else {
+        guard let value else {
             var query = createQuery()
             query[kSecAttrService as String] = fullKey
             let status = SecItemDelete(query as CFDictionary)

--- a/Modules/Sources/PocketCastsUtils/General/TimedActionHelper.swift
+++ b/Modules/Sources/PocketCastsUtils/General/TimedActionHelper.swift
@@ -17,7 +17,7 @@ public class TimedActionHelper {
     }
 
     public func isTimerValid() -> Bool {
-        guard let timer = timer else {
+        guard let timer else {
             return false
         }
         return timer.isValid

--- a/Modules/Sources/PocketCastsUtils/Logging/TraceManager.swift
+++ b/Modules/Sources/PocketCastsUtils/Logging/TraceManager.swift
@@ -14,7 +14,7 @@ public class TraceManager {
     }
 
     public func endTracing(trace: AnyObject?) {
-        guard let trace = trace else { return }
+        guard let trace else { return }
 
         traceHandler?.endTracing(trace: trace)
     }

--- a/NotificationExtension/NotificationService.swift
+++ b/NotificationExtension/NotificationService.swift
@@ -19,7 +19,7 @@ class NotificationService: UNNotificationServiceExtension {
         self.contentHandler = contentHandler
         bestAttemptContent = (request.content.mutableCopy() as? UNMutableNotificationContent)
 
-        if let bestAttemptContent = bestAttemptContent {
+        if let bestAttemptContent {
             if let podcastUuid = bestAttemptContent.userInfo["podcast_uuid"] as? String, let podcastImageUrl = localUrlFor(podcastUuid: podcastUuid) {
                 do {
                     let attachment = try UNNotificationAttachment(identifier: podcastUuid, url: podcastImageUrl, options: nil)
@@ -32,7 +32,7 @@ class NotificationService: UNNotificationServiceExtension {
     }
 
     override func serviceExtensionTimeWillExpire() {
-        if let contentHandler = contentHandler, let bestAttemptContent = bestAttemptContent {
+        if let contentHandler, let bestAttemptContent {
             contentHandler(bestAttemptContent)
         }
     }

--- a/Pocket Casts Watch App/UI/Episode Lists/Episode List/EpisodeRowViewModel.swift
+++ b/Pocket Casts Watch App/UI/Episode Lists/Episode List/EpisodeRowViewModel.swift
@@ -69,7 +69,7 @@ class EpisodeRowViewModel: EpisodeViewModel, Identifiable {
         informationLabel.append(info)
         accessibilityLabel.append(info)
 
-        if let statusText = statusText {
+        if let statusText {
             accessibilityLabel.append(statusText)
         }
 

--- a/Pocket Casts Watch App/UI/Episode Lists/Podcast Episode List/PodcastEpisodeListViewModel.swift
+++ b/Pocket Casts Watch App/UI/Episode Lists/Podcast Episode List/PodcastEpisodeListViewModel.swift
@@ -5,7 +5,7 @@ import PocketCastsUtils
 
 class PodcastEpisodeListViewModel: ObservableObject {
     static func createEpisodesQuery(forPodcast podcast: Podcast?) -> String {
-        guard let podcast = podcast else { return "" }
+        guard let podcast else { return "" }
 
         let episodeSortOrder = podcast.podcastSortOrder
 

--- a/Pocket Casts Watch App/UI/Episode/Episode Actions/DownloadProgressEpisodeActionView.swift
+++ b/Pocket Casts Watch App/UI/Episode/Episode Actions/DownloadProgressEpisodeActionView.swift
@@ -8,7 +8,7 @@ struct DownloadProgressEpisodeActionView: View {
     }
 
     private func downloadIconForProgress(_ progress: DownloadProgress?) -> String {
-        guard let progress = progress else {
+        guard let progress else {
             return EpisodeAction.pauseDownload.iconName
         }
 

--- a/Pocket Casts Watch App/UI/Episode/EpisodeDetailsViewModel.swift
+++ b/Pocket Casts Watch App/UI/Episode/EpisodeDetailsViewModel.swift
@@ -113,7 +113,7 @@ class EpisodeDetailsViewModel: EpisodeViewModel {
             }
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [unowned self] fetchedEpisode in
-                if let fetchedEpisode = fetchedEpisode {
+                if let fetchedEpisode {
                     self.episode = fetchedEpisode
                 } else {
                     self.shouldDismiss = true

--- a/Pocket Casts Watch App/UI/ExtensionDelegate.swift
+++ b/Pocket Casts Watch App/UI/ExtensionDelegate.swift
@@ -18,7 +18,7 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
 
     private func setupCrashLogging() {
         crashLogging = try? CrashLogging(dataProvider: WatchCrashLoggingDataProvider()).start()
-        if let crashLogging = crashLogging {
+        if let crashLogging {
             ServerConfig.shared.errorLogger = WatchCrashLoggingErrorLogger(crashLogging: crashLogging)
         }
     }
@@ -107,7 +107,7 @@ class ExtensionDelegate: NSObject, WKApplicationDelegate {
         FileLog.shared.addMessage("Scheduling next refresh for 60 minutes time")
         let preferredDate = Date(timeIntervalSinceNow: 60.minutes)
         WKApplication.shared().scheduleBackgroundRefresh(withPreferredDate: preferredDate, userInfo: nil) { error in
-            if let error = error {
+            if let error {
                 FileLog.shared.addMessage("Task scheduling error \(error.localizedDescription)")
             }
         }

--- a/Pocket Casts Watch App/UI/Main Page/SourceInterfaceModel.swift
+++ b/Pocket Casts Watch App/UI/Main Page/SourceInterfaceModel.swift
@@ -84,7 +84,7 @@ class SourceInterfaceModel: ObservableObject {
 
     @objc private func handleStatusChangeFromNotification() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.reload()
         }

--- a/Pocket Casts Watch App/UI/Navigation/NavigationManager.swift
+++ b/Pocket Casts Watch App/UI/Navigation/NavigationManager.swift
@@ -20,7 +20,7 @@ class NavigationManager: ObservableObject {
 
         if interfaceType == .nowPlaying {
             navigateToNowPlaying(source: SourceManager.shared.currentSource(), fromLaunchEvent: true)
-        } else if let interfaceType = interfaceType {
+        } else if let interfaceType {
             navigateTo(interfaceType, context: context)
         }
     }

--- a/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingViewModel.swift
+++ b/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingViewModel.swift
@@ -47,7 +47,7 @@ class NowPlayingViewModel: ObservableObject {
         )
         .map { [unowned self] episode in
             guard
-                let episode = episode,
+                let episode,
                 let title = self.playSource.nowPlayingTitle(forEpisode: episode)
             else {
                 return L10n.loading
@@ -63,7 +63,7 @@ class NowPlayingViewModel: ObservableObject {
         )
         .receive(on: RunLoop.main)
         .sink { [unowned self] episode in
-            guard let episode = episode else { return }
+            guard let episode else { return }
             self.progress = self.playSource.playbackProgress
             self.progressTitle = self.playSource.nowPlayingSubTitle(forEpisode: episode) ?? ""
             self.timeRemaining = self.playSource.nowPlayingTimeRemaining(forEpisode: episode)
@@ -72,7 +72,7 @@ class NowPlayingViewModel: ObservableObject {
 
         playbackChanged
             .map { [unowned self] episode in
-                guard let episode = episode else { return false }
+                guard let episode else { return false }
                 return self.playSource.isPlaying(forEpisode: episode)
             }
             .receive(on: RunLoop.main)
@@ -87,7 +87,7 @@ class NowPlayingViewModel: ObservableObject {
 
         $episode
             .map { [unowned self] episode in
-                guard let episode = episode else { return Color.white }
+                guard let episode else { return Color.white }
                 return self.playSource.nowPlayingTint(forEpisode: episode)
             }
             .receive(on: RunLoop.main)
@@ -126,12 +126,12 @@ class NowPlayingViewModel: ObservableObject {
     }
 
     func playPauseTapped() {
-        guard let episode = episode else { return }
+        guard let episode else { return }
         playSource.playPauseTapped(withEpisode: episode, playlist: nil)
     }
 
     func markPlayed() {
-        guard let episode = episode else { return }
+        guard let episode else { return }
         playSource.markPlayed(episode: episode)
     }
 

--- a/Pocket Casts Watch App/UI/SwiftUI/ItemListContainer.swift
+++ b/Pocket Casts Watch App/UI/SwiftUI/ItemListContainer.swift
@@ -28,7 +28,7 @@ struct ItemListContainer<Content: View>: View {
                 Text(noItemsTitle)
                     .font(.dynamic(size: 16, weight: .medium))
 
-                if let noItemsSubtitle = noItemsSubtitle {
+                if let noItemsSubtitle {
                     Text(noItemsSubtitle)
                         .font(.dynamic(size: 14))
                         .multilineTextAlignment(.center)

--- a/PocketCastsTests/Tests/Analytics/AppLifecyleAnalyticsTests.swift
+++ b/PocketCastsTests/Tests/Analytics/AppLifecyleAnalyticsTests.swift
@@ -275,7 +275,7 @@ class AppLifecycleAnalyticsTests: XCTestCase {
 
             XCTAssertEqual(event, .applicationClosed)
 
-            guard let properties = properties, let time = properties["time_in_app"] as? String else {
+            guard let properties, let time = properties["time_in_app"] as? String else {
                 XCTFail("Properties and time_in_app should not be nil")
                 return
             }

--- a/PocketCastsTests/Tests/Utilities/DownloadManagerRetryTests.swift
+++ b/PocketCastsTests/Tests/Utilities/DownloadManagerRetryTests.swift
@@ -148,7 +148,7 @@ extension DownloadManager {
         }
 
         let episode = dataManager.findBaseEpisode(downloadTaskId: taskDescription)
-        if let episode = episode {
+        if let episode {
             downloadingEpisodesCache[taskDescription] = episode
         }
 

--- a/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateRetryTests.swift
+++ b/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateRetryTests.swift
@@ -27,7 +27,7 @@ final class MediaExporterResourceLoaderDelegateRetryTests: XCTestCase {
         delegate = nil
 
         // Clean up temporary file
-        if let tempFilePath = tempFilePath {
+        if let tempFilePath {
             try? FileManager.default.removeItem(atPath: tempFilePath)
         }
 
@@ -186,7 +186,7 @@ final class MediaExporterResourceLoaderDelegateRetryTests: XCTestCase {
 extension MediaExporterResourceLoaderDelegate {
 
     func retryWithoutUserAgent(originalURL: URL?) {
-        guard let originalURL = originalURL else { return }
+        guard let originalURL else { return }
 
         invalidateAndCancelSession(shouldResetData: false)
 

--- a/PodcastsIntents/ExtendSleepTimerIntentHandler.swift
+++ b/PodcastsIntents/ExtendSleepTimerIntentHandler.swift
@@ -9,7 +9,7 @@ class ExtendSleepTimerIntentHandler: NSObject, SJExtendSleepTimerIntentHandling 
 
         userActivity.isEligibleForSearch = true
         let minutes = intent.minutes
-        if let minutes = minutes {
+        if let minutes {
             userActivity.title = "Extending sleep timer by \(minutes) minutes"
         } else {
             userActivity.title = "Extend sleep timer"

--- a/PodcastsIntents/SleepTimerIntentHandler.swift
+++ b/PodcastsIntents/SleepTimerIntentHandler.swift
@@ -9,7 +9,7 @@ class SleepTimerIntentHandler: NSObject, SJSleepTimerIntentHandling {
 
         userActivity.isEligibleForSearch = true
         let minutes = intent.minutes
-        if let minutes = minutes {
+        if let minutes {
             userActivity.title = "Setting sleep timer to \(minutes) minutes"
         } else {
             userActivity.title = "Setting sleep timer"

--- a/WidgetExtension/Common/ArtworkViews.swift
+++ b/WidgetExtension/Common/ArtworkViews.swift
@@ -20,7 +20,7 @@ struct LargeArtworkView: View {
                     .backwardWidgetAccentable(isAccentedRenderingMode)
             }
 
-            if let imageData = imageData, let uiImage = UIImage(data: imageData) {
+            if let imageData, let uiImage = UIImage(data: imageData) {
                 Image(uiImage: uiImage)
                     .resizable()
                     .backwardWidgetFullColorRenderingMode()
@@ -57,7 +57,7 @@ struct SmallArtworkView: View {
                 .cornerRadius(5)
                 .secondaryShadow()
                 .backwardWidgetAccentable(isAccentedRenderingMode)
-            if let imageData = imageData, let uiImage = UIImage(data: imageData) {
+            if let imageData, let uiImage = UIImage(data: imageData) {
                 Image(uiImage: uiImage)
                     .resizable()
                     .backwardWidgetFullColorRenderingMode()

--- a/WidgetExtension/Data/WidgetEpisode.swift
+++ b/WidgetExtension/Data/WidgetEpisode.swift
@@ -22,7 +22,7 @@ class WidgetEpisode: ObservableObject, Hashable {
 
     // in a widget, you can't load images asynchronously, since the UI is rendered and later displayed, so as weird as it looks, this is how we cache the image data
     func loadImageData() {
-        guard let imageUrl = imageUrl else { return }
+        guard let imageUrl else { return }
 
         imageData = try? Data(contentsOf: imageUrl)
     }
@@ -41,7 +41,7 @@ class WidgetEpisode: ObservableObject, Hashable {
         } else {
             let fileManager = FileManager.default
             let container = fileManager.containerURL(forSecurityApplicationGroupIdentifier: CommonWidgetHelper.appGroupId)
-            if let container = container {
+            if let container {
                 let directoryPath = container.appendingPathComponent("widget_images")
                 let sharedFilePath = directoryPath.appendingPathComponent("\(commonItem.episodeUuid).jpg")
                 if fileManager.fileExists(atPath: sharedFilePath.path) {

--- a/WidgetExtension/Up Next/UpNextLargeWidgetView.swift
+++ b/WidgetExtension/Up Next/UpNextLargeWidgetView.swift
@@ -107,7 +107,7 @@ struct LargeFilterView: View {
                 }
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(alignment: .top) {
-                        if let filterName = filterName {
+                        if let filterName {
                             Text(filterName)
                                 .font(.callout)
                                 .fontWeight(.regular)

--- a/WidgetExtension/Up Next/UpNextMediumWidgetView.swift
+++ b/WidgetExtension/Up Next/UpNextMediumWidgetView.swift
@@ -105,7 +105,7 @@ struct MediumFilterView: View {
                 VStack(alignment: .leading, spacing: 10) {
                     EpisodeView.createCompactWhenNecessaryView(episode: firstEpisode)
                         .frame(minHeight: 42, maxHeight: 56)
-                    if let secondEpisode = secondEpisode {
+                    if let secondEpisode {
                         EpisodeView.createCompactWhenNecessaryView(episode: secondEpisode)
                             .frame(minHeight: 42, maxHeight: 56)
                     } else {

--- a/WidgetExtension/Up Next/UpNextProvider.swift
+++ b/WidgetExtension/Up Next/UpNextProvider.swift
@@ -45,7 +45,7 @@ struct UpNextProvider: TimelineProvider {
     }
 
     private func upNextEntry(episodes: [WidgetEpisode]?, data: WidgetData, imageCountToCache: Int = 0) -> UpNextEntry {
-        if let episodes = episodes, !episodes.isEmpty, imageCountToCache > 0 {
+        if let episodes, !episodes.isEmpty, imageCountToCache > 0 {
             for episode in episodes.prefix(imageCountToCache) {
                 episode.loadImageData()
             }

--- a/podcasts/AboutView.swift
+++ b/podcasts/AboutView.swift
@@ -191,7 +191,7 @@ struct AboutRow: View {
                 Text(mainText)
                     .textStyle(PrimaryText())
                 Spacer()
-                if let secondaryText = secondaryText {
+                if let secondaryText {
                     Text(secondaryText)
                         .textStyle(SecondaryText())
                 }

--- a/podcasts/AccountUpdatedViewController.swift
+++ b/podcasts/AccountUpdatedViewController.swift
@@ -81,7 +81,7 @@ class AccountUpdatedViewController: UIViewController {
     }
 
     @IBAction func closeTapped(_ sender: Any) {
-        if let delegate = delegate {
+        if let delegate {
             delegate.accountUpdatedAcknowledged()
             return
         }

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -90,7 +90,7 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
 
     @objc private func subscriptionStatusChanged() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.updateDisplayedData()
         }

--- a/podcasts/AddCustomViewController.swift
+++ b/podcasts/AddCustomViewController.swift
@@ -261,7 +261,7 @@ class AddCustomViewController: PCViewController, UITextFieldDelegate {
         avFileUtil = AVFileUtil(fileURL: destinationUrl, durationHandler: { duration in
             self.duration = duration
         }, titleHandler: { embeddedName in
-            if let embeddedName = embeddedName {
+            if let embeddedName {
                 self.name = embeddedName
             }
             DispatchQueue.main.async {
@@ -292,7 +292,7 @@ class AddCustomViewController: PCViewController, UITextFieldDelegate {
 
     @objc private func setupUserAccess() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if SubscriptionHelper.hasActiveSubscription() {
                 self.addCustomlock.isHidden = true
@@ -322,7 +322,7 @@ class AddCustomViewController: PCViewController, UITextFieldDelegate {
         Analytics.track(.userFileEditDismissed)
         navigationController?.navigationBar.isHidden = false
         if episodeToEdit == nil {
-            if let destinationUrl = destinationUrl {
+            if let destinationUrl {
                 StorageManager.removeItem(at: destinationUrl)
             }
             dismiss(animated: true, completion: nil)
@@ -339,7 +339,7 @@ class AddCustomViewController: PCViewController, UITextFieldDelegate {
 
         let selectedColor = greyIndexPath.item == 0 ? selectedColorIndex + 1 : selectedColorIndex
 
-        if let episodeToEdit = episodeToEdit {
+        if let episodeToEdit {
             if artworkNeedsUpdating {
                 do {
                     try UserEpisodeManager.updateUserEpisodeImage(uuid: episodeToEdit.uuid, artwork: artwork, completion: {

--- a/podcasts/Analytics/AppLifecyleAnalytics.swift
+++ b/podcasts/Analytics/AppLifecyleAnalytics.swift
@@ -121,7 +121,7 @@ extension AppLifecycleAnalytics {
         }
 
         // If we can't determine which version then default to no version
-        guard let version = version else {
+        guard let version else {
             return nil
         }
 

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -74,7 +74,7 @@ class AnalyticsCoordinator {
     }
 
     var currentAnalyticsSource: AnalyticsSource {
-        if let currentSource = currentSource {
+        if let currentSource {
             self.currentSource = nil
             return currentSource
         }

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -441,7 +441,7 @@ private extension AnalyticsHelper {
             Firebase.Analytics.logEvent(name, parameters: parameters)
 
         if FeatureFlag.firebaseLogging.enabled {
-                if let parameters = parameters {
+                if let parameters {
                     logger.debug("🟢 Tracked: \(name) \(parameters)")
                 } else {
                     logger.debug("🟢 Tracked: \(name)")

--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -86,7 +86,7 @@ extension AppDelegate {
                 }
             }
 
-            if let urlString = urlString, let url = URL(string: urlString) {
+            if let urlString, let url = URL(string: urlString) {
                 JLRoutes.routeURL(url)
             }
         } else if intent is SJOpenFilterIntent {

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -514,10 +514,10 @@ extension AppDelegate {
             }
 
             PodcastManager.shared.importSharedItemFromUrl(path) { item in
-                guard let item = item else {
+                guard let item else {
                     self.hideProgressDialog()
                     FileLog.shared.addMessage("Unable to load shared item \(path)")
-                    if let onErrorOpen = onErrorOpen {
+                    if let onErrorOpen {
                         UIApplication.shared.open(onErrorOpen, options: [:], completionHandler: nil)
                     }
 

--- a/podcasts/AppearanceViewController.swift
+++ b/podcasts/AppearanceViewController.swift
@@ -54,7 +54,7 @@ class AppearanceViewController: PCViewController, UITableViewDataSource, UITable
 
     @objc func subscriptionStatusChanged() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.updateTableAndData()
         }
@@ -167,7 +167,7 @@ class AppearanceViewController: PCViewController, UITableViewDataSource, UITable
 
     func presentThemePicker(selectedTheme: Theme.ThemeType, persistThemeChange: @escaping (Theme.ThemeType) -> Void) {
         let themeSelector = ThemeSelectorView(title: L10n.appearanceThemeSelect, onThemeSelected: { [weak self] theme in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if theme.isPlusOnly, !SubscriptionHelper.hasActiveSubscription() {
                 self.dismiss(animated: true) {

--- a/podcasts/ArchiveHelper.swift
+++ b/podcasts/ArchiveHelper.swift
@@ -26,7 +26,7 @@ class ArchiveHelper {
     }
 
     class func applyAutoArchivingToPodcast(_ podcast: Podcast?) {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         let afterPlayedTime = podcast.isAutoArchiveOverridden ? podcast.autoArchivePlayedAfterTime : Settings.autoArchivePlayedAfter()
         let afterInactiveTime = podcast.isAutoArchiveOverridden ? podcast.autoArchiveInactiveAfterTime : Settings.autoArchiveInactiveAfter()

--- a/podcasts/AudioReadTask.swift
+++ b/podcasts/AudioReadTask.swift
@@ -73,13 +73,13 @@ class AudioReadTask {
 
     func startup() {
         readQueue.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             // there are some Core Audio errors that aren't marked as throws in the Swift code, so they'll crash the app
             // that's why we have an Objective-C try/catch block here to catch them (see https://github.com/shiftyjelly/pocketcasts-ios/issues/1493 for more details)
             do {
                 try SJCommonUtils.catchException { [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
 
                     do {
                         while !self.cancelled.value {
@@ -260,7 +260,7 @@ class AudioReadTask {
         // In order to prevent this issue, we convert a mono buffer to stereo buffer
         // For more info, see: https://github.com/Automattic/pocket-casts-ios/issues/62
         var audioBuffer: BufferedAudio
-        if let audioPCMBuffer = audioPCMBuffer,
+        if let audioPCMBuffer,
            audioPCMBuffer.audioBufferList.pointee.mNumberBuffers == 1,
            let twoChannelsFormat = AVAudioFormat(standardFormatWithSampleRate: audioFile.processingFormat.sampleRate, channels: 2),
            let twoChannnelBuffer = AVAudioPCMBuffer(pcmFormat: twoChannelsFormat, frameCapacity: audioPCMBuffer.frameCapacity) {

--- a/podcasts/AudioUtils.swift
+++ b/podcasts/AudioUtils.swift
@@ -23,7 +23,7 @@ class AudioUtils {
     }
 
     class func performFade(_ fadeOut: Bool, length: vDSP_Length, data: UnsafeMutablePointer<Float32>?) {
-        guard let data = data else { return }
+        guard let data else { return }
 
         var ramp = [Float32](repeating: 0, count: Int(length))
 

--- a/podcasts/BaseEpisode+Formatting.swift
+++ b/podcasts/BaseEpisode+Formatting.swift
@@ -99,7 +99,7 @@ extension BaseEpisode {
 
     func shortDateFor(date: Date?) -> String {
         let noDate = L10n.podcastNoDate
-        guard let date = date, date.timeIntervalSince1970 > 0 else { return noDate }
+        guard let date, date.timeIntervalSince1970 > 0 else { return noDate }
 
         if Calendar.current.isDateInToday(date) {
             return L10n.today

--- a/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkPodcastListViewModel.swift
@@ -27,7 +27,7 @@ class BookmarkPodcastListViewModel: BookmarkListViewModel {
         }
 
         var items: [Bookmark]
-        if let podcast = podcast {
+        if let podcast {
             items = bookmarkManager.bookmarks(for: podcast, sorted: sortOption).includeEpisodes()
         } else {
             items = bookmarkManager.allBookmarks(sorted: sortOption).includeEpisodes().includePodcasts()

--- a/podcasts/BundleImageView.swift
+++ b/podcasts/BundleImageView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class BundleImageView: PodcastImageView {
     func setBundleImageUrl(url: String, size: PodcastThumbnailSize) {
-        guard let imageView = imageView else { return }
+        guard let imageView else { return }
 
         ImageManager.sharedManager.loadBundleImage(imageUrl: url, imageView: imageView, placeholderSize: size)
         adjustForSize(size)

--- a/podcasts/BundlePodcastCell.swift
+++ b/podcasts/BundlePodcastCell.swift
@@ -89,7 +89,7 @@ class BundlePodcastCell: ThemeableCell {
     @IBAction func subscribeTapped(_ sender: AnyObject) {
         subscribeButton.currentlyOn = true
 
-        guard let discoverPodcast = discoverPodcast else { return }
+        guard let discoverPodcast else { return }
 
         if discoverPodcast.iTunesOnly() {
             ServerPodcastManager.shared.subscribeFromItunesId(Int(discoverPodcast.iTunesId!)!, completion: nil)

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
@@ -135,7 +135,7 @@ extension PlusPricingInfoModel.PlusProductPricingInfo {
     fileprivate var formattedMonthlyPrice: String? {
         switch identifier {
         case .yearly, .yearlyReferral, .patronYearly:
-            if let monthlyPrice = monthlyPrice, !monthlyPrice.isEmpty {
+            if let monthlyPrice, !monthlyPrice.isEmpty {
                 return L10n.iapProductMonthlyPricingFormat(monthlyPrice)
             }
             return nil

--- a/podcasts/CarPlay/CarPlaySceneDelegate+Convert.swift
+++ b/podcasts/CarPlay/CarPlaySceneDelegate+Convert.swift
@@ -65,7 +65,7 @@ extension CarPlaySceneDelegate {
         }
 
         item.handler = { [weak self] _, completion in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.upNextTapped(showNowPlaying: true)
             completion()

--- a/podcasts/CarPlay/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlay/CarPlaySceneDelegate.swift
@@ -91,7 +91,7 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
 
     @objc private func handlePlaybackStateChanged() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let nowPlayingTemplate = CPNowPlayingTemplate.shared
             self.updateNowPlayingButtons(template: nowPlayingTemplate)

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -61,11 +61,11 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         var podcastIndexRow = indexPath.row
-        if showPromotion(), let promotion = promotion {
+        if showPromotion(), let promotion {
             if indexPath.row == CategoryPodcastsViewController.promotionRow {
                 let cell = tableView.dequeueReusableCell(withIdentifier: CategoryPodcastsViewController.sponsoredCellId, for: indexPath) as! CategorySponsoredCell
                 var isSubscribed = false
-                if let delegate = delegate {
+                if let delegate {
                     var discoverPodcast = DiscoverPodcast()
                     discoverPodcast.uuid = promotion.podcast_uuid
                     isSubscribed = delegate.isSubscribed(podcast: discoverPodcast)
@@ -87,7 +87,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        guard let delegate = delegate else { return }
+        guard let delegate else { return }
 
         if let cell = tableView.cellForRow(at: indexPath) as? DiscoverPodcastTableCell {
             let podcast = podcasts[indexPath.row]
@@ -96,14 +96,14 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
             let listUuid = "category-\(categoryName.lowercased())-\(region ?? "unknown")"
 
             delegate.show(discoverPodcast: podcast, placeholderImage: cell.podcastImage.image, isFeatured: false, listUuid: listUuid)
-        } else if let cell = tableView.cellForRow(at: indexPath) as? CategorySponsoredCell, let promotion = promotion {
+        } else if let cell = tableView.cellForRow(at: indexPath) as? CategorySponsoredCell, let promotion {
             var podcastInfo = PodcastInfo()
             podcastInfo.title = promotion.title
             podcastInfo.uuid = promotion.podcast_uuid
             let listId = promotion.promotion_uuid
             delegate.show(podcastInfo: podcastInfo, placeholderImage: cell.podcastImage.image, isFeatured: false, listUuid: listId)
 
-            if let listId = listId, let uuid = podcastInfo.uuid {
+            if let listId, let uuid = podcastInfo.uuid {
                 AnalyticsHelper.podcastTappedFromList(listId: listId, podcastUuid: uuid)
             }
         }
@@ -123,7 +123,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     // MARK: - Loading
 
     private func loadPodcasts() {
-        guard let delegate = delegate, let category, let source = delegate.replaceRegionCode(string: category.source) else { return }
+        guard let delegate, let category, let source = delegate.replaceRegionCode(string: category.source) else { return }
         if loadingIndicator.isAnimating || !podcasts.isEmpty { return }
 
         noNetworkView.isHidden = true

--- a/podcasts/CategorySponsoredCell.swift
+++ b/podcasts/CategorySponsoredCell.swift
@@ -85,7 +85,7 @@ class CategorySponsoredCell: ThemeableCell {
     @IBAction func subscribeTapped(_ sender: AnyObject) {
         subscribeButton.currentlyOn = true
 
-        guard let discoverPromotion = discoverPromotion else { return }
+        guard let discoverPromotion else { return }
 
         if let uuid = discoverPromotion.podcast_uuid {
             ServerPodcastManager.shared.subscribe(to: uuid, completion: nil)

--- a/podcasts/CategorySummaryViewController.swift
+++ b/podcasts/CategorySummaryViewController.swift
@@ -45,7 +45,7 @@ class CategorySummaryViewController: UIViewController, UITableViewDataSource, UI
 
         DiscoverServerHandler.shared.discoverCategories(source: source, authenticated: item.authenticated, completion: { [weak self] discoverCategories in
             DispatchQueue.main.async {
-                guard let strongSelf = self, let discoverCategories = discoverCategories else { return }
+                guard let strongSelf = self, let discoverCategories else { return }
 
                 strongSelf.titleLabel.text = item.title?.localized
                 strongSelf.categories = discoverCategories
@@ -73,7 +73,7 @@ class CategorySummaryViewController: UIViewController, UITableViewDataSource, UI
         let category = categories[indexPath.row]
 
         let categoryPodcastsController = CategoryPodcastsViewController(category: category, region: regionCode)
-        if let delegate = delegate {
+        if let delegate {
             categoryPodcastsController.registerDiscoverDelegate(delegate)
             delegate.navController()?.pushViewController(categoryPodcastsController, animated: true)
 

--- a/podcasts/ChangePasswordViewController.swift
+++ b/podcasts/ChangePasswordViewController.swift
@@ -184,7 +184,7 @@ class ChangePasswordViewController: PCViewController, UITextFieldDelegate {
             textFieldToToggle = confirmField
         }
 
-        if let textFieldToToggle = textFieldToToggle {
+        if let textFieldToToggle {
             textFieldToToggle.isSecureTextEntry.toggle()
             if textFieldToToggle.isSecureTextEntry {
                 tappedButton.setImage(UIImage(named: "eye-crossed"), for: .normal)

--- a/podcasts/CheckboxCell.swift
+++ b/podcasts/CheckboxCell.swift
@@ -42,7 +42,7 @@ class CheckboxCell: ThemeableCell {
     }
 
     private func updateButtonColor() {
-        guard let filterColor = filterColor else { return }
+        guard let filterColor else { return }
 
         selectButton.tintColor = ThemeColor.filterInteractive01(filterColor: filterColor)
     }

--- a/podcasts/CollectionSummaryViewController.swift
+++ b/podcasts/CollectionSummaryViewController.swift
@@ -128,7 +128,7 @@ class CollectionSummaryViewController: UIViewController, DiscoverSummaryProtocol
     // MARK: Actions
 
     @objc func showCollection() {
-        guard let delegate = delegate, let item = item else { return }
+        guard let delegate, let item else { return }
 
         if let podcasts = podcastCollection?.podcasts, !podcasts.isEmpty {
             delegate.showExpanded(item: item, podcasts: podcasts, podcastCollection: podcastCollection)

--- a/podcasts/ColorManager.swift
+++ b/podcasts/ColorManager.swift
@@ -43,7 +43,7 @@ class ColorManager {
 
     class func darkThemeTintColorForPodcastUuid(_ uuid: String, completion: @escaping ((UIColor) -> Void)) {
         CacheServerHandler.shared.loadPodcastColors(podcastUuid: uuid, allowCachedVersion: true, completion: { _, _, darkThemeTint in
-            guard let darkThemeTint = darkThemeTint else {
+            guard let darkThemeTint else {
                 completion(ColorManager.sharedManager.defaultDarkTintColor)
 
                 return
@@ -151,7 +151,7 @@ class ColorManager {
             dispatchGroup.enter()
 
             CacheServerHandler.shared.loadPodcastColors(podcastUuid: podcastUuid, allowCachedVersion: false, completion: { backgroundColor, lightThemeTint, darkThemeTint in
-                guard let backgroundColor = backgroundColor, let lightThemeTint = lightThemeTint, let darkThemeTint = darkThemeTint else {
+                guard let backgroundColor, let lightThemeTint, let darkThemeTint else {
                     strongSelf.handleDownloadError(podcastUuid: podcastUuid)
                     dispatchGroup.leave()
 

--- a/podcasts/Common Components/Buttons/UpNextButton.swift
+++ b/podcasts/Common Components/Buttons/UpNextButton.swift
@@ -143,7 +143,7 @@ class UpNextButton: UIButton {
     }
 
     private func isDarkTheme() -> Bool {
-        if let themeOverride = themeOverride {
+        if let themeOverride {
             return themeOverride.isDark
         }
         return Theme.isDarkTheme()

--- a/podcasts/Common Components/ExpandableLabel.swift
+++ b/podcasts/Common Components/ExpandableLabel.swift
@@ -111,7 +111,7 @@ class ExpandableLabel: ThemeableLabel {
 
             return Int(ceil(CGFloat(labelSize.height) / (font.lineHeight * desiredLinedHeightMultiple)))
         } else {
-            guard let text = text else { return 1 }
+            guard let text else { return 1 }
 
             layoutIfNeeded()
 

--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -73,7 +73,7 @@ class MainEpisodeActionView: UIView {
     // MARK: - User Actions
 
     @objc private func buttonTapped() {
-        guard let delegate = delegate else { return }
+        guard let delegate else { return }
 
         if state == .play {
             delegate.playTapped()

--- a/podcasts/Common Components/MultiSelect/MultiSelectFooterView.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectFooterView.swift
@@ -146,7 +146,7 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
     }
 
     @IBAction func moreTapped(_ sender: Any) {
-        guard let delegate = delegate else { return }
+        guard let delegate else { return }
 
         let actions = getActionsFunc()
 
@@ -176,12 +176,12 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
     }
 
     @IBAction func rightActionTapped(_ sender: Any) {
-        guard let delegate = delegate, let rightAction = rightAction else { return }
+        guard let delegate, let rightAction else { return }
         MultiSelectHelper.performAction(rightAction, actionDelegate: delegate, view: rightActionButton)
     }
 
     @IBAction func leftActionTapped(_ sender: Any) {
-        guard let delegate = delegate, let leftAction = leftAction else { return }
+        guard let delegate, let leftAction else { return }
         MultiSelectHelper.performAction(leftAction, actionDelegate: delegate, view: leftActionButton)
     }
 
@@ -209,7 +209,7 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
         let newLeftAction = MultiSelectHelper.invertActionIfRequired(action: actions[0], actionDelegate: actionDelegate)
         if leftAction != newLeftAction {
             leftAction = newLeftAction
-            if let leftAction = leftAction {
+            if let leftAction {
                 leftActionButton.setImage(UIImage(named: leftAction.iconName()), for: .normal)
                 leftActionButton.accessibilityLabel = leftAction.title()
             }
@@ -219,7 +219,7 @@ class MultiSelectFooterView: UIView, MultiSelectActionOrderDelegate {
         if rightAction != newRightAction {
             rightAction = newRightAction
 
-            if let rightAction = rightAction {
+            if let rightAction {
                 rightActionButton.setImage(UIImage(named: rightAction.iconName()), for: .normal)
                 rightActionButton.accessibilityLabel = rightAction.title()
             }

--- a/podcasts/Common Components/PCAlwaysVisibleCastBtn.swift
+++ b/podcasts/Common Components/PCAlwaysVisibleCastBtn.swift
@@ -47,7 +47,7 @@ class PCAlwaysVisibleCastBtn: UIButton {
     }
 
     @objc private func statusDidChange() {
-        guard let imageView = imageView else { return }
+        guard let imageView else { return }
 
         if GoogleCastManager.sharedManager.connecting() {
             if !imageView.isAnimating {

--- a/podcasts/Common Components/PCRefreshControl.swift
+++ b/podcasts/Common Components/PCRefreshControl.swift
@@ -159,7 +159,7 @@ class PCRefreshControl: UIView {
     // MARK: - Table Offset
 
     func offsetToPullDown() {
-        if let scrollView = scrollView {
+        if let scrollView {
             let searchHeight = searchBar != nil ? PCSearchBarController.defaultHeight : 0
             let offset = searchHeight + viewHeight
             scrollView.contentInset = UIEdgeInsets(top: offset, left: scrollView.contentInset.left, bottom: scrollView.contentInset.bottom, right: scrollView.contentInset.right)
@@ -167,7 +167,7 @@ class PCRefreshControl: UIView {
     }
 
     func resetOffset() {
-        guard let scrollView = scrollView else {
+        guard let scrollView else {
             return
         }
 
@@ -281,7 +281,7 @@ class PCRefreshControl: UIView {
 
     func processRefreshCompleted(_ message: String) {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.refreshLabel.text = message
             self.perform(#selector(self.refreshEndTimerFired), with: nil, afterDelay: 1.0)

--- a/podcasts/Common Components/PlusLockedInfoView.swift
+++ b/podcasts/Common Components/PlusLockedInfoView.swift
@@ -97,7 +97,7 @@ class PlusLockedInfoView: ThemeableView {
 
     @IBAction func closeTapped() {
         Analytics.track(.upgradeBannerDismissed, properties: ["source": delegate?.displaySource.rawValue ?? PlusUpgradeViewSource.unknown.rawValue])
-        if let delegate = delegate {
+        if let delegate {
             delegate.closeInfoTapped()
         } else {
             contentView.isHidden = true

--- a/podcasts/Common Components/Podcast Selection/PodcastChooserViewController.swift
+++ b/podcasts/Common Components/Podcast Selection/PodcastChooserViewController.swift
@@ -94,7 +94,7 @@ class PodcastChooserViewController: PCViewController, UITableViewDelegate, UITab
 
         let podcastUuid = allPodcasts[indexPath.row].uuid
         let index = selectedUuids.firstIndex(of: podcastUuid)
-        if let index = index {
+        if let index {
             selectedUuids.remove(at: index)
             Analytics.track(.settingsSelectPodcastsPodcastToggled, properties: ["uuid": podcastUuid, "enabled": false, "source": analyticsSource])
             // to support things like playlist editting that need to know about all/none selected events send a different event when it gets to 0

--- a/podcasts/Common Components/RichExpandableDescriptionView.swift
+++ b/podcasts/Common Components/RichExpandableDescriptionView.swift
@@ -197,7 +197,7 @@ class RichExpandableLabel: WKWebView {
 
     private func updateScrollSize() {
         evaluateJavaScript("document.body.scrollHeight", completionHandler: { [weak self] height, _ in
-            guard let self = self, let cgHeight = height as? CGFloat else { return }
+            guard let self, let cgHeight = height as? CGFloat else { return }
 
             contentHeight = CGFloat(cgHeight).rounded(.up)
             htmlReady = true
@@ -212,7 +212,7 @@ class RichExpandableLabel: WKWebView {
 
     private func updateLinesRequired() {
         evaluateJavaScript("countLines()", completionHandler: { [weak self] lines, error in
-            guard let self = self, let linesRequired = lines as? Double else { return }
+            guard let self, let linesRequired = lines as? Double else { return }
             collapsed = Int(linesRequired.rounded(.up)) > self.maxLines
         })
     }
@@ -225,7 +225,7 @@ class RichExpandableLabel: WKWebView {
 extension RichExpandableLabel: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         evaluateJavaScript("document.readyState", completionHandler: { [weak self] complete, _ in
-            guard let self = self,
+            guard let self,
                   let result = complete as? String,
                   result == "complete" // ensure that the load of HTML is complete and not in another loading state
             else {

--- a/podcasts/Common Components/Search/PCSearchBarController+Animation.swift
+++ b/podcasts/Common Components/Search/PCSearchBarController+Animation.swift
@@ -8,7 +8,7 @@ extension PCSearchBarController {
 
         view.layoutIfNeeded()
         UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
                 self.roundedBgTrailingSpaceParent.isActive = false

--- a/podcasts/Common Components/Search/PCSearchBarController+Scrolling.swift
+++ b/podcasts/Common Components/Search/PCSearchBarController+Scrolling.swift
@@ -9,7 +9,7 @@ extension PCSearchBarController {
     }
 
     func parentScrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard let searchControllerTopConstant = searchControllerTopConstant else { return }
+        guard let searchControllerTopConstant else { return }
 
         let yPos = scrollView.contentOffset.y + (view.superview?.safeAreaInsets.top ?? 0)
 

--- a/podcasts/Common Components/Search/PCSearchBarController+TextFieldDelegate.swift
+++ b/podcasts/Common Components/Search/PCSearchBarController+TextFieldDelegate.swift
@@ -24,7 +24,7 @@ extension PCSearchBarController: UITextFieldDelegate {
     @objc func textFieldDidChange() {
         let searchTerm = searchTextField.text
 
-        if let searchTerm = searchTerm, !searchTerm.isEmpty {
+        if let searchTerm, !searchTerm.isEmpty {
             clearSearchBtn.isHidden = false
             searchDelegate?.searchTermChanged(searchTerm)
             resetSearchTimer()

--- a/podcasts/Common Components/SettingsTableHeader.swift
+++ b/podcasts/Common Components/SettingsTableHeader.swift
@@ -63,7 +63,7 @@ class SettingsTableHeader: ThemeableView {
             self.lockImage = lockImage
         }
 
-        if let rightBtnTitle = rightBtnTitle, let rightBtnSelector = rightBtnSelector, let rightBtnTarget = rightBtnTarget {
+        if let rightBtnTitle, let rightBtnSelector, let rightBtnTarget {
             let rightBtn = ThemeableUIButton()
             rightBtn.setTitle(rightBtnTitle, for: .normal)
             rightBtn.titleLabel?.font = titleLabel.font

--- a/podcasts/Common Components/ShiftyLoadingAlert.swift
+++ b/podcasts/Common Components/ShiftyLoadingAlert.swift
@@ -4,7 +4,7 @@ class ShiftyLoadingAlert {
     private var titleToSet = ""
     var title = "" {
         didSet {
-            if let alertController = alertController {
+            if let alertController {
                 alertController.title = "\(title)\n\n\n"
             }
         }
@@ -12,7 +12,7 @@ class ShiftyLoadingAlert {
 
     var progress = 0 as CGFloat {
         didSet {
-            if let progressIndicator = progressIndicator {
+            if let progressIndicator {
                 progressIndicator.progress = progress
             }
         }
@@ -39,7 +39,7 @@ class ShiftyLoadingAlert {
                 self.progressIndicator?.center = CGPoint(x: parentFrame.width / 2.0, y: (parentFrame.height / 2.0) + 10)
                 self.progressIndicator?.progress = 0.01
 
-                if let completion = completion {
+                if let completion {
                     completion()
                 }
             }
@@ -53,7 +53,7 @@ class ShiftyLoadingAlert {
                 indeterminantIndicator.center = CGPoint(x: parentFrame.width / 2.0, y: (parentFrame.height / 2.0) + 10)
                 indeterminantIndicator.startAnimating()
 
-                if let completion = completion {
+                if let completion {
                     completion()
                 }
             }

--- a/podcasts/Common Components/TinyPageControl.swift
+++ b/podcasts/Common Components/TinyPageControl.swift
@@ -63,7 +63,7 @@ class TinyPageControl: UIControl {
                 }
             }
 
-            if let delegate = delegate {
+            if let delegate {
                 delegate.pageDidChange(currentPage)
             }
         }

--- a/podcasts/Common Components/View Controllers/PCViewController.swift
+++ b/podcasts/Common Components/View Controllers/PCViewController.swift
@@ -60,7 +60,7 @@ class PCViewController: SimpleNotificationsViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if let title = title, !title.isEmpty {
+        if let title, !title.isEmpty {
             setupNavBar(animated: animated)
         }
         refreshRightButtons()
@@ -101,10 +101,10 @@ class PCViewController: SimpleNotificationsViewController {
     @objc func refreshRightButtons() {
         if supportsGoogleCast || !extraRightButtons.isEmpty {
             var buttons = [UIBarButtonItem]()
-            if let customRightBtn = customRightBtn {
+            if let customRightBtn {
                 buttons.append(customRightBtn)
             }
-            if let googleCastBtn = googleCastBtn, supportsGoogleCast {
+            if let googleCastBtn, supportsGoogleCast {
                 buttons.append(googleCastBtn)
             }
             buttons.append(contentsOf: extraRightButtons)

--- a/podcasts/CreateFilterViewController.swift
+++ b/podcasts/CreateFilterViewController.swift
@@ -198,7 +198,7 @@ class CreateFilterViewController: PCViewController, UITextFieldDelegate, UIScrol
     // MARK: - UIScrollViewDelegate
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard let filterNameTextField = filterNameTextField else { return }
+        guard let filterNameTextField else { return }
 
         // dismiss the keyboard on scroll up
         if scrollView.contentOffset.y > 40, filterNameTextField.isFirstResponder {

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -116,7 +116,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
     }
 
     func buffering() -> Bool {
-        guard let player = player else { return false }
+        guard let player else { return false }
 
         if let item = player.currentItem {
             return item.isPlaybackBufferEmpty || !item.isPlaybackLikelyToKeepUp
@@ -589,7 +589,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             guard
                 let referenceToSelf = DefaultPlayer.unretainedDefaultPlayer(for: inRefCon),
                 let tap = referenceToSelf.audioMix?.inputParameters.first?.audioTapProcessor,
-                let ioData = ioData
+                let ioData
             else {
                 return -1
             }
@@ -649,7 +649,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             guard
                 let referenceToSelf = DefaultPlayer.unretainedDefaultPlayer(for: inRefCon),
                 let peakLimiter = referenceToSelf.peakLimiter,
-                let ioData = ioData
+                let ioData
             else {
                 return -1
             }
@@ -700,7 +700,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             // do this on the main thread because timers require run loops
             DispatchQueue.main.async {
                 Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] timer in
-                    guard let self = self else {
+                    guard let self else {
                         timer.invalidate()
                         return
                     }
@@ -779,7 +779,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         }
 
         rateObserver = player?.observe(\.rate) { [weak self] player, _ in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if player.rate == 1 {
                 // there's a bug where playback can be resumed from outside our app, and Apple sets the wrong playback rate, fix that here
@@ -811,7 +811,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
         let nc = NotificationCenter.default
         playToEndObserver = nc.addObserver(forName: NSNotification.Name.AVPlayerItemDidPlayToEndTime, object: nil, queue: nil) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if !FeatureFlag.checkFinishedTimeBeforeShouldKeepPlaying.enabled {
                 self.shouldKeepPlaying = false
@@ -855,7 +855,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         }
 
         playFailedObserver = nc.addObserver(forName: NSNotification.Name.AVPlayerItemFailedToPlayToEndTime, object: nil, queue: nil) { [weak self] notification in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.shouldKeepPlaying = false
 
@@ -865,7 +865,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         }
 
         playStalledObserver = nc.addObserver(forName: NSNotification.Name.AVPlayerItemPlaybackStalled, object: nil, queue: nil) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             FileLog.shared.addMessage("Received notification of playback stall")
             if self.shouldKeepPlaying {
                 FileLog.shared.addMessage("Trying to recover from stall by playing")

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -438,7 +438,7 @@ struct DeveloperMenu_Previews: PreviewProvider {
 extension Bundle {
 
     var identifier: String {
-        guard let infoDictionary = infoDictionary, let identifier = infoDictionary["CFBundleIdentifier"] as? String else {
+        guard let infoDictionary, let identifier = infoDictionary["CFBundleIdentifier"] as? String else {
             return "Cound not load bundle id."
         }
 

--- a/podcasts/DisclosureCell.swift
+++ b/podcasts/DisclosureCell.swift
@@ -54,7 +54,7 @@ class DisclosureCell: ThemeableCell {
     }
 
     func setImage(imageName: String?, tintColor: UIColor? = nil) {
-        if let imageName = imageName {
+        if let imageName {
             cellTextToImageConstraint.isActive = true
             cellTextToMarginConstraint.isActive = false
             cellTextToImageConstraint.priority = .required

--- a/podcasts/DiscoverCollectionHeader.swift
+++ b/podcasts/DiscoverCollectionHeader.swift
@@ -108,7 +108,7 @@ class DiscoverCollectionHeader: UICollectionReusableView {
     }
 
     func populate(podcastCollection: PodcastCollection?) {
-        guard let podcastCollection = podcastCollection else {
+        guard let podcastCollection else {
             headerView.isHidden = true
             return
         }

--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -127,7 +127,7 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
     }
 
     func showExpanded(item: DiscoverItem, episodes: [DiscoverEpisode], podcastCollection: PodcastCollection?) {
-        guard let podcastCollection = podcastCollection else { return }
+        guard let podcastCollection else { return }
 
         if let listId = item.uuid {
             AnalyticsHelper.listShowAllTapped(listId: listId, dateTime: podcastCollection.datetime)

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -225,7 +225,7 @@ extension DiscoverCollectionViewController {
     private func configureDataSource() {
 
         let footerRegistrationCountrySummary = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(elementKind: UICollectionView.elementKindSectionFooter) { [weak self] supplementaryView, elementKind, indexPath in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let countrySummary = CountrySummaryViewController()
             countrySummary.discoverLayout = self.discoverLayout
@@ -279,7 +279,7 @@ extension DiscoverCollectionViewController {
         }
 
         dataSource.supplementaryViewProvider = { [weak self] collectionView, elementKind, indexPath in
-            guard let self = self else { return nil }
+            guard let self else { return nil }
 
             if elementKind == UICollectionView.elementKindSectionFooter {
                 if self.selectedCategory == nil && self.discoverLayout != nil {

--- a/podcasts/DiscoverEpisodeViewModel.swift
+++ b/podcasts/DiscoverEpisodeViewModel.swift
@@ -52,7 +52,7 @@ class DiscoverEpisodeViewModel: ObservableObject {
         $discoverEpisode
             .receive(on: ImmediateScheduler.shared)
             .sink(receiveValue: { [weak self] episode in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.episodeUUID = episode?.uuid
                 self.title = episode?.title ?? ""
                 self.imageUUID = episode?.podcastUuid
@@ -108,7 +108,7 @@ class DiscoverEpisodeViewModel: ObservableObject {
                 if self.playbackManager.isActivelyPlaying(episodeUuid: episodeUuid) {
                     PlaybackActionHelper.pause()
                 } else if let baseEpisode = DataManager.sharedManager.findEpisode(uuid: episodeUuid) {
-                    if let listId = listId {
+                    if let listId {
                         AnalyticsHelper.podcastEpisodePlayedFromList(listId: listId, podcastUuid: podcastUuid)
                     }
                     PlaybackActionHelper.play(episode: baseEpisode, podcastUuid: podcastUuid)
@@ -129,7 +129,7 @@ class DiscoverEpisodeViewModel: ObservableObject {
         DiscoverEpisodeViewModel.loadPodcast(podcastUuid, episodeUuid: episodeUuid)
             .receive(on: RunLoop.main)
             .sink { [weak self] podcast in
-                guard let podcast = podcast else {
+                guard let podcast else {
                     self?.delegate?.failedToLoadEpisode()
                     return
                 }

--- a/podcasts/DiscoverPeekViewController.swift
+++ b/podcasts/DiscoverPeekViewController.swift
@@ -39,7 +39,7 @@ class DiscoverPeekViewController: UIViewController, UICollectionViewDelegate {
     public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
         guard isPeekEnabled == true else { return }
 
-        guard let currentScrollOffset = currentScrollOffset else { return }
+        guard let currentScrollOffset else { return }
         let target = targetContentOffset.pointee
         let currentScrollDistance = target.x - currentScrollOffset.x
         let coefficent = Int(max(-1, min(currentScrollDistance / scrollThreshold, 1)))

--- a/podcasts/DiscoverPodcastTableCell.swift
+++ b/podcasts/DiscoverPodcastTableCell.swift
@@ -108,7 +108,7 @@ class DiscoverPodcastTableCell: ThemeableCell {
     @IBAction func subscribeTapped(_ sender: AnyObject) {
         subscribeButton.currentlyOn = true
 
-        guard let discoverPodcast = discoverPodcast else { return }
+        guard let discoverPodcast else { return }
 
         if discoverPodcast.iTunesOnly() {
             ServerPodcastManager.shared.subscribeFromItunesId(Int(discoverPodcast.iTunesId!)!, completion: nil)

--- a/podcasts/DownloadManager+SessionManagement.swift
+++ b/podcasts/DownloadManager+SessionManagement.swift
@@ -33,7 +33,7 @@ extension DownloadManager {
                     let oldAttempt = self.downloadAttempts.removeValue(forKey: foregroundTask.taskIdentifier)
 
                     let backgroundTask: URLSessionDownloadTask
-                    if let data = data {
+                    if let data {
                         backgroundTask = self.cellularBackgroundSession.downloadTask(withResumeData: data)
                     } else {
                         backgroundTask = self.cellularBackgroundSession.downloadTask(with: request)

--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -276,7 +276,7 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
         }
 
         let episode = dataManager.findBaseEpisode(downloadTaskId: taskDescription)
-        if let episode = episode {
+        if let episode {
             downloadingEpisodesCache[taskDescription] = episode
         }
 

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -301,7 +301,7 @@ class DownloadManager: NSObject, FilePathProtocol {
             }
         } else if let episode = episode as? UserEpisode {
             ApiServerHandler.shared.uploadFilePlayRequest(episode: episode, completion: { [weak self] url in
-                guard let url = url else {
+                guard let url else {
                     self?.dataManager.saveEpisode(downloadStatus: .downloadFailed, downloadError: L10n.downloadErrorTryAgain, downloadTaskId: nil, episode: episode)
                     NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeDownloadStatusChanged, object: episode.uuid)
                     return
@@ -690,7 +690,7 @@ class DownloadManager: NSObject, FilePathProtocol {
     }
 
     private func cancelTaskId(_ taskId: String?, episode: BaseEpisode, session: URLSession) {
-        guard let taskId = taskId else { return }
+        guard let taskId else { return }
 
         session.getTasksWithCompletionHandler { [weak self] _, _, downloadTasks in
             if downloadTasks.isEmpty { return }
@@ -706,7 +706,7 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     private func cancelTask(_ task: URLSessionDownloadTask, for episode: BaseEpisode) {
         task.cancel { [weak self] data in
-            if let data = data, !data.isEmpty, let tempFilePath = self?.tempPathForEpisode(episode) {
+            if let data, !data.isEmpty, let tempFilePath = self?.tempPathForEpisode(episode) {
                 do {
                     try data.write(to: URL(fileURLWithPath: tempFilePath), options: .atomic)
                 } catch {

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -224,7 +224,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
     // MARK: - Notification handler
 
     @objc func podcastUpdated(_ notification: Notification) {
-        guard let podcastChooserController = podcastChooserController else { return }
+        guard let podcastChooserController else { return }
         let allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
         podcastChooserController.selectedUuids = allPodcasts.filter { $0.autoDownloadOn() }.map(\.uuid)
         podcastChooserController.selectedUuidsUpdated = true

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -32,7 +32,7 @@ class DownloadsViewController: PCViewController {
     var isMultiSelectEnabled = false {
         didSet {
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.setupNavBar()
                 self.downloadsTable.beginUpdates()
                 self.downloadsTable.setEditing(self.isMultiSelectEnabled, animated: true)

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -62,7 +62,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     func playing() -> Bool {
         if aboutToPlay.value { return true }
 
-        if let player = player {
+        if let player {
             return player.isPlaying
         }
 
@@ -213,7 +213,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     }
 
     func setPlaybackRate(_ rate: Double) {
-        if let timePitch = timePitch {
+        if let timePitch {
             playbackSpeed = rate
             timePitch.rate = Float(rate)
         }
@@ -246,7 +246,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
             return lastSeekTime
         }
 
-        if let audioFile = audioFile, let curFrame = currentFrame() {
+        if let audioFile, let curFrame = currentFrame() {
             return Double(curFrame) / audioFile.fileFormat.sampleRate
         }
 
@@ -254,7 +254,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     }
 
     private func currentFrame() -> AVAudioFramePosition? {
-        if let audioPlayTask = audioPlayTask {
+        if let audioPlayTask {
             return audioPlayTask.lastFrameRendered()
         }
 
@@ -262,7 +262,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     }
 
     func duration() -> TimeInterval {
-        if let audioFile = audioFile {
+        if let audioFile {
             return (Double(cachedFrameCount) / audioFile.fileFormat.sampleRate)
         }
 
@@ -370,7 +370,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
         audioReadTask?.shutdown()
         audioPlayTask?.shutdown()
 
-        guard let audioFile = audioFile, let player = player, let playBufferManager = playBufferManager else { return }
+        guard let audioFile, let player, let playBufferManager else { return }
         let requiredStartTime = PlaybackManager.shared.requiredStartingPosition()
         audioReadTask = AudioReadTask(trimSilence: effects.trimSilence, audioFile: audioFile, outputFormat: audioFile.processingFormat, bufferManager: playBufferManager, playPositionHint: requiredStartTime, frameCount: cachedFrameCount, useVoiceBoostN: useVoiceBoostN, sampleRate: audioFileSampleRate)
         audioPlayTask = AudioPlayTask(player: player, bufferManager: playBufferManager)
@@ -427,7 +427,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     // MARK: - Audio Units
 
     private func setFloatParameter(_ audioUnit: AudioUnit?, key: AudioUnitParameterID, value: Float) {
-        if let audioUnit = audioUnit {
+        if let audioUnit {
             AudioUnitSetParameter(audioUnit, key, kAudioUnitScope_Global, 0, value, 0)
         }
     }

--- a/podcasts/End of Year/StoryShareableText.swift
+++ b/podcasts/End of Year/StoryShareableText.swift
@@ -124,7 +124,7 @@ class StoryShareableText: UIActivityItemProvider, ShareableMetadataDataSource {
         let listInfo = SharingServerHandler.PodcastShareInfo(title: L10n.eoyStoryTopPodcastsListTitle, description: "", podcasts: podcasts.map { $0.uuid })
         SharingServerHandler.shared.sharePodcastList(listInfo: listInfo) { [weak self] shareUrl in
             DispatchQueue.main.async {
-                if let shareUrl = shareUrl {
+                if let shareUrl {
                     Settings.top5PodcastsListLink = shareUrl
                     self?.podcastListURL = shareUrl
                 }

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -192,7 +192,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     }
 
     private func populate(progressOnly: Bool) {
-        guard let episode = episode else { return }
+        guard let episode else { return }
 
         if !progressOnly {
             setEpisodeTitle(episode: episode)
@@ -324,7 +324,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     }
 
     private func labelForAccessibility(episode: BaseEpisode?) -> String {
-        guard let episode = episode else { return "" }
+        guard let episode else { return "" }
         let heading = dayName.text?.replacingOccurrences(of: "•", with: ",") ?? ""
         let title = episodeTitle.text ?? ""
         let info = episode.accessibilityDisplayableInfo()
@@ -382,7 +382,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     // MARK: - Event Handling
 
     @objc private func updateCellFromGenericEvent() {
-        guard let episode = episode else { return }
+        guard let episode else { return }
 
         updateCell(episodeUuid: episode.uuid)
     }
@@ -402,7 +402,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             populateFrom(episode: newEpisode, tintColor: mainTintColor, playlistUuid: playlistUuid, podcastUuid: podcastUuid)
         } else {
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.populateFrom(episode: newEpisode, tintColor: self.mainTintColor, playlistUuid: self.playlistUuid, podcastUuid: self.podcastUuid)
             }
@@ -432,7 +432,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             populate(progressOnly: true)
         } else {
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.populate(progressOnly: true)
             }
@@ -461,10 +461,10 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     }
 
     func playTapped() {
-        guard let episode = episode else { return }
+        guard let episode else { return }
 
         // if the user tapped play from a featured list, record that. We just want the first play, if they are unpausing it, that's not relevant (hence the last check below)
-        if let podcastUuid = podcastUuid, let listUuid = listUuid, !PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+        if let podcastUuid, let listUuid, !PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
             AnalyticsHelper.podcastEpisodePlayedFromList(listId: listUuid, podcastUuid: podcastUuid)
         }
 
@@ -476,7 +476,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     }
 
     func errorTapped() {
-        guard let episode = episode else { return }
+        guard let episode else { return }
 
         let statusBarStyle = playlistUuid == nil ? UIStatusBarStyle.lightContent : AppTheme.defaultStatusBarStyle()
         if episode.playbackError() {

--- a/podcasts/Episode/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+Actions.swift
@@ -75,7 +75,7 @@ extension EpisodeDetailViewController {
 
     func playPauseEpisode(isPlaying: Bool) {
         if isPlaying {
-            if let timestamp = timestamp {
+            if let timestamp {
                 DataManager.sharedManager.saveEpisode(playedUpTo: timestamp, episode: episode, updateSyncFlag: false)
                 PlaybackManager.shared.seekTo(time: timestamp, startPlaybackAfterSeek: false)
                 updateProgress()
@@ -83,7 +83,7 @@ extension EpisodeDetailViewController {
 
             PlaybackActionHelper.playPause()
         } else {
-            if let timestamp = timestamp {
+            if let timestamp {
                 episode.playingStatus = PlayingStatus.inProgress.rawValue
                 episode.playedUpTo = timestamp
                 DataManager.sharedManager.save(episode: episode)

--- a/podcasts/Episode/EpisodeDetailViewController.swift
+++ b/podcasts/Episode/EpisodeDetailViewController.swift
@@ -375,7 +375,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
             performUpdateDisplayedData(reloadingEpisode: reloadingEpisode)
         } else {
             DispatchQueue.main.sync { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.performUpdateDisplayedData(reloadingEpisode: reloadingEpisode)
             }

--- a/podcasts/EpisodeDateHelper.swift
+++ b/podcasts/EpisodeDateHelper.swift
@@ -51,7 +51,7 @@ struct EpisodeDateHelper {
         }
 
         private static func rowTitle(dateText: String, episode: Episode, indicatorText: String? = nil) -> String {
-            guard let indicatorText = indicatorText else {
+            guard let indicatorText else {
                 if episode.episodeNumber < 1 {
                     return dateText
                 }
@@ -62,7 +62,7 @@ struct EpisodeDateHelper {
         }
 
         private static func setRowTitle(dateText: String, episode: Episode, label: UILabel, tintColor: UIColor?, indicatorText: String? = nil) {
-            guard let indicatorText = indicatorText, let tintColor = tintColor else {
+            guard let indicatorText, let tintColor else {
                 if episode.episodeNumber < 1 {
                     label.text = dateText
 
@@ -105,7 +105,7 @@ struct EpisodeDateHelper {
         }
 
         private static func rowTitle(dateText: String, episode: Episode, indicatorText: String? = nil) -> String {
-            guard let indicatorText = indicatorText else {
+            guard let indicatorText else {
                 if episode.episodeNumber < 1 {
                     return dateText
                 }

--- a/podcasts/EpisodeFileSizeUpdater.swift
+++ b/podcasts/EpisodeFileSizeUpdater.swift
@@ -4,7 +4,7 @@ import PocketCastsDataModel
 
 class EpisodeFileSizeUpdater {
     class func updateEpisodeDuration(episode: BaseEpisode?) {
-        guard let episode = episode else { return }
+        guard let episode else { return }
 
         let fileLocation = episode.pathToDownloadedFile(pathFinder: DownloadManager.shared)
         let url = URL(fileURLWithPath: fileLocation)

--- a/podcasts/EpisodeFilterChipCell.swift
+++ b/podcasts/EpisodeFilterChipCell.swift
@@ -33,7 +33,7 @@ class EpisodeFilterChipCell: ThemeableCollectionCell {
     }
 
     private func updateColors() {
-        guard let filterColor = filterColor else { return }
+        guard let filterColor else { return }
 
         if backgroundIsPrimaryUI01 {
             titleLabel.textColor = isChipEnabled ? ThemeColor.filterInteractive02(filterColor: filterColor) : ThemeColor.filterInteractive06(filterColor: filterColor)

--- a/podcasts/EpisodeListTableViewCell.swift
+++ b/podcasts/EpisodeListTableViewCell.swift
@@ -63,7 +63,7 @@ class EpisodeListTableViewCell: UITableViewCell {
 
         viewModel.$imageUUID
             .sink(receiveValue: { [unowned self] uuid in
-                if let uuid = uuid {
+                if let uuid {
                     self.podcastImage.setPodcast(uuid: uuid, size: .grid)
                 }
             })

--- a/podcasts/ExpandedCollectionViewController+CollectionView.swift
+++ b/podcasts/ExpandedCollectionViewController+CollectionView.swift
@@ -10,7 +10,7 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
         case .grid:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ExpandedCollectionViewController.gridCellId, for: indexPath) as! LargeListCell
             let thisPodcast = podcasts[indexPath.row]
-            if let delegate = delegate {
+            if let delegate {
                 cell.populateFrom(thisPodcast, isSubscribed: delegate.isSubscribed(podcast: thisPodcast))
                 cell.onSubscribe = { [weak self] in
                     if let listId = self?.item.uuid, let podcastUuid = thisPodcast.uuid {
@@ -23,7 +23,7 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
         case .descriptive_list:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ExpandedCollectionViewController.descriptiveCellId, for: indexPath) as! DescriptiveCollectionCell
             let thisPodcast = podcasts[indexPath.row]
-            if let delegate = delegate {
+            if let delegate {
                 cell.populateFrom(thisPodcast, isSubscribed: delegate.isSubscribed(podcast: thisPodcast))
                 cell.onSubscribe = { [weak self] in
                     if let listId = self?.item.uuid, let podcastUuid = thisPodcast.uuid {

--- a/podcasts/ExpandedEpisodeListViewController.swift
+++ b/podcasts/ExpandedEpisodeListViewController.swift
@@ -88,7 +88,7 @@ class ExpandedEpisodeListViewController: PCViewController, UITableViewDelegate, 
         DiscoverEpisodeViewModel.loadPodcast(podcastUuid, episodeUuid: episodeUuid)
             .receive(on: RunLoop.main)
             .sink { [weak self] podcast in
-                guard let podcast = podcast else {
+                guard let podcast else {
                     self?.delegate?.failedToLoadEpisode()
                     return
                 }

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -103,7 +103,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FeaturedSummaryViewController.cellId, for: indexPath) as! FeaturedCollectionViewCell
 
         let podcast = podcasts[indexPath.row]
-        if let delegate = delegate {
+        if let delegate {
             cell.populateFrom(podcast, isSubscribed: delegate.isSubscribed(podcast: podcast), listName: listType, isSponsored: sponsoredPodcasts.contains(podcast))
             cell.featuredView.onSubscribe = { [weak self] in
                 if let listId = self?.listId(for: podcast), let podcastUuid = podcast.uuid {
@@ -124,13 +124,13 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let delegate = delegate else { return }
+        guard let delegate else { return }
 
         let podcast = podcasts[indexPath.row]
         let listId = listId(for: podcast)
         delegate.show(discoverPodcast: podcast, placeholderImage: nil, isFeatured: true, listUuid: listId)
 
-        if let listId = listId, let podcastUuid = podcast.uuid {
+        if let listId, let podcastUuid = podcast.uuid {
             AnalyticsHelper.podcastTappedFromList(listId: listId, podcastUuid: podcastUuid)
         }
     }
@@ -172,7 +172,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
     func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         guard let source = item.source, let title = item.title?.localized else { return }
 
-        if let delegate = delegate {
+        if let delegate {
             listType = delegate.replaceRegionName(string: title)
         }
 
@@ -198,7 +198,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
                 if let source = sponsored.source, let position = sponsored.position {
                     dispatchGroup.enter()
                     DiscoverServerHandler.shared.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
-                        guard let podcastList = podcastList, let discoverPodcast = podcastList.podcasts?.first else { return }
+                        guard let podcastList, let discoverPodcast = podcastList.podcasts?.first else { return }
 
                         sponsoredPodcastsToAdd[position] = discoverPodcast
 

--- a/podcasts/FileTypeUtil.swift
+++ b/podcasts/FileTypeUtil.swift
@@ -3,7 +3,7 @@ import UniformTypeIdentifiers
 
 class FileTypeUtil {
     public class func fileExtension(forType type: String?) -> String {
-        guard let type = type else { return ".mp3" }
+        guard let type else { return ".mp3" }
 
         if type.contains("video/3gpp") { return ".3gp" }
         else if type.contains("video/3gpp2") { return ".3g2" }

--- a/podcasts/FilterChipCollectionView.swift
+++ b/podcasts/FilterChipCollectionView.swift
@@ -53,7 +53,7 @@ class FilterChipCollectionView: UICollectionView, UICollectionViewDelegate, UICo
 
     var lastSelectedIndexPath: IndexPath?
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let filter = filter else { return }
+        guard let filter else { return }
         let chip = FilterChipCollectionView.chipData[indexPath.row]
         if !isChipSelected(chip: chip) {
             deselectItem(at: indexPath, animated: false)
@@ -101,7 +101,7 @@ class FilterChipCollectionView: UICollectionView, UICollectionViewDelegate, UICo
     }
 
     private func titleForChip(chip: ChipType) -> String {
-        guard let filter = filter else { return "" }
+        guard let filter else { return "" }
         var returnedString = ""
         switch chip {
         case .podcast:
@@ -162,7 +162,7 @@ class FilterChipCollectionView: UICollectionView, UICollectionViewDelegate, UICo
     }
 
     private func isChipSelected(chip: ChipType) -> Bool {
-        guard let filter = filter else { return false }
+        guard let filter else { return false }
         var result = false
         switch chip {
         case .podcast:
@@ -195,7 +195,7 @@ class FilterChipCollectionView: UICollectionView, UICollectionViewDelegate, UICo
     }
 
     func saveFilterAndNotify() {
-        guard let filter = filter else { return }
+        guard let filter else { return }
         filter.syncStatus = SyncStatus.notSynced.rawValue
         DataManager.sharedManager.save(playlist: filter)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged, object: filter)
@@ -206,7 +206,7 @@ class FilterChipCollectionView: UICollectionView, UICollectionViewDelegate, UICo
     }
 
     func scrollToLastSelected() {
-        guard let lastSelectedIndexPath = lastSelectedIndexPath else { return }
+        guard let lastSelectedIndexPath else { return }
         scrollToItem(at: lastSelectedIndexPath, at: .left, animated: false)
     }
 

--- a/podcasts/FilterEditOptionsViewController.swift
+++ b/podcasts/FilterEditOptionsViewController.swift
@@ -327,7 +327,7 @@ class FilterEditOptionsViewController: PCViewController, UITableViewDelegate, UI
             title: L10n.delete,
             style: .destructive
         ) { [weak self] _ in
-            guard let self = self else { return }
+            guard let self else { return }
             PlaylistManager.delete(playlist: self.filterToEdit, fireEvent: true)
             self.navigationController?.popToRootViewController(animated: true)
         }

--- a/podcasts/Folders/Create & Edit/Model/FolderModel.swift
+++ b/podcasts/Folders/Create & Edit/Model/FolderModel.swift
@@ -8,7 +8,7 @@ class FolderModel: ObservableObject {
     @Published var folderUuid: String?
     @Published var selectedPodcastUuids: [String] = [] {
         didSet {
-            guard let folderUuid = folderUuid, saveOnChange else { return }
+            guard let folderUuid, saveOnChange else { return }
 
             updateFoldersBasedOnSelection()
 
@@ -19,7 +19,7 @@ class FolderModel: ObservableObject {
 
     @Published var name: String = "" {
         didSet {
-            guard let folderUuid = folderUuid, saveOnChange else { return }
+            guard let folderUuid, saveOnChange else { return }
 
             if let folder = DataManager.sharedManager.findFolder(uuid: folderUuid) {
                 folder.name = nameForFolder()
@@ -35,7 +35,7 @@ class FolderModel: ObservableObject {
         didSet {
             color = color(for: colorInt)
 
-            guard let folderUuid = folderUuid, saveOnChange else { return }
+            guard let folderUuid, saveOnChange else { return }
 
             DataManager.sharedManager.updateFolderColor(folderUuid: folderUuid, color: Int32(colorInt), syncModified: TimeFormatter.currentUTCTimeInMillis())
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.folderChanged, object: folderUuid)
@@ -87,7 +87,7 @@ class FolderModel: ObservableObject {
     }
 
     func deleteFolder() {
-        guard let folderUuid = folderUuid else { return }
+        guard let folderUuid else { return }
 
         DataManager.sharedManager.delete(folderUuid: folderUuid, markAsDeleted: SyncManager.isUserLoggedIn())
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.folderDeleted, object: folderUuid)
@@ -109,7 +109,7 @@ class FolderModel: ObservableObject {
 
     private func updateFoldersBasedOnSelection() {
         var foldersChanged: Set<String> = []
-        if let folderUuid = folderUuid { foldersChanged.insert(folderUuid) }
+        if let folderUuid { foldersChanged.insert(folderUuid) }
 
         // look for other folders that our selected podcasts may have come from, to update their syncModified dates
         for uuid in selectedPodcastUuids {

--- a/podcasts/Folders/Create & Edit/Views/ColorPreviewFolderView.swift
+++ b/podcasts/Folders/Create & Edit/Views/ColorPreviewFolderView.swift
@@ -87,7 +87,7 @@ struct PodcastPreviewImage: View {
                 .frame(width: 40, height: 40)
                 .foregroundColor(.gray)
                 .opacity(0.5)
-            if let podcastUuid = podcastUuid {
+            if let podcastUuid {
                 KFImage(ServerHelper.imageUrl(podcastUuid: podcastUuid, size: 130))
                     .resizable()
                     .frame(width: 40, height: 40)

--- a/podcasts/Folders/FolderViewController.swift
+++ b/podcasts/Folders/FolderViewController.swift
@@ -144,7 +144,7 @@ class FolderViewController: PCViewController, UIGestureRecognizerDelegate {
         optionsPicker.addAction(action: editAction)
 
         let addRemoveAction = OptionAction(label: L10n.folderAddRemovePodcasts, icon: "folder-podcasts") { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.showPodcastSelectionDialog()
 

--- a/podcasts/Folders/FoldersCoordinator.swift
+++ b/podcasts/Folders/FoldersCoordinator.swift
@@ -85,8 +85,8 @@ class FoldersCoordinator: NSObject {
         }
 
         let creatFolderView = CreateFolderView { [weak vc, weak self] folderUuid in
-            guard let self = self else { return }
-            if let folderUuid = folderUuid, let folder = dataManager.findFolder(uuid: folderUuid) {
+            guard let self else { return }
+            if let folderUuid, let folder = dataManager.findFolder(uuid: folderUuid) {
                 vc?.dismiss(animated: true, completion: { [weak self] in
                     self?.navigationManager.navigateTo(NavigationManager.folderPageKey, data: [NavigationManager.folderKey: folder])
                 })

--- a/podcasts/Google Cast/GoogleCastManager.swift
+++ b/podcasts/Google Cast/GoogleCastManager.swift
@@ -288,7 +288,7 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
     // MARK: - GCKRemoteMediaClientListener
 
     func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
-        guard let mediaStatus = mediaStatus else { return }
+        guard let mediaStatus else { return }
         AnalyticsPlaybackHelper.shared.currentSource = .chromecast
 
         if mediaStatus.playerState == .playing {

--- a/podcasts/Google Cast/UI/CastDeviceVolumeView.swift
+++ b/podcasts/Google Cast/UI/CastDeviceVolumeView.swift
@@ -11,7 +11,7 @@ class CastDeviceVolumeView: UIStackView {
         devices = GoogleCastManager.sharedManager.allMultiZoneDevices()
 
         // there's no point in controlling multi-room audio that only has 1 speaker, so check for that here
-        guard let devices = devices, devices.count > 1 else { return }
+        guard let devices, devices.count > 1 else { return }
 
         for (index, device) in devices.enumerated() {
             addDevice(device, index: index)

--- a/podcasts/GridLayout.swift
+++ b/podcasts/GridLayout.swift
@@ -90,7 +90,7 @@ class GridLayout: UICollectionViewLayout, GridLayoutDelegate {
 
     override func prepare() {
         // On rotation, UICollectionView sometimes calls prepare without calling invalidateLayout
-        guard itemAttributesCache.isEmpty, headerAttributesCache.isEmpty, let collectionView = collectionView else { return }
+        guard itemAttributesCache.isEmpty, headerAttributesCache.isEmpty, let collectionView else { return }
 
         let fixedDimension: CGFloat
         if scrollDirection == .vertical {

--- a/podcasts/HorizontaCollectionModel.swift
+++ b/podcasts/HorizontaCollectionModel.swift
@@ -65,7 +65,7 @@ class HorizontalCollectionModel: ObservableObject {
     }
 
     func showCollection() {
-        guard let delegate = delegate, let item = item else { return }
+        guard let delegate, let item else { return }
 
         if let podcasts = podcastCollection?.podcasts, !podcasts.isEmpty {
             delegate.showExpanded(item: item, podcasts: podcasts, podcastCollection: podcastCollection)

--- a/podcasts/ImportExportViewController.swift
+++ b/podcasts/ImportExportViewController.swift
@@ -86,11 +86,11 @@ class ImportExportViewController: PCViewController, UIDocumentInteractionControl
 
         MainServerHandler.shared.exportPodcasts(uuids: uuids) { exportResponse in
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.loadingAlert?.hideAlert(false)
                 self.loadingAlert = nil
 
-                guard let exportResponse = exportResponse, exportResponse.success(), let mapping = exportResponse.result else {
+                guard let exportResponse, exportResponse.success(), let mapping = exportResponse.result else {
                     self.presentError()
                     Analytics.track(.settingsImportExportFailed)
                     return

--- a/podcasts/InAppPurchases/IAPHelper.swift
+++ b/podcasts/InAppPurchases/IAPHelper.swift
@@ -676,7 +676,7 @@ private extension IAPHelper {
         let flow = OnboardingFlow.shared.currentFlow
         properties["flow"] = flow.rawValue
 
-        if let error = error {
+        if let error {
             properties["error_code"] = error.code
         }
 

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -117,7 +117,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: LargeListSummaryViewController.cellId, for: indexPath) as! LargeListCell
         let thisPodcast = podcasts[indexPath.row]
-        if let delegate = delegate {
+        if let delegate {
             cell.populateFrom(thisPodcast, isSubscribed: delegate.isSubscribed(podcast: thisPodcast))
             cell.onSubscribe = { [weak self] in
                 if let listId = self?.item?.uuid, let podcastUuid = thisPodcast.uuid {
@@ -134,7 +134,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let item = item else { return }
+        guard let item else { return }
 
         let podcast = podcasts[indexPath.row]
 
@@ -239,7 +239,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     // MARK: - IBActions
 
     @IBAction func showAllTapped(_ sender: Any) {
-        guard let delegate = delegate, let item = item else { return }
+        guard let delegate, let item else { return }
 
         delegate.showExpanded(item: item, podcasts: podcasts, podcastCollection: nil, datetime: datetime)
     }

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -41,7 +41,7 @@ class ListeningHistoryViewController: PCViewController {
     var isMultiSelectEnabled = false {
         didSet {
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.setupNavBar()
                 self.listeningHistoryTable.beginUpdates()
                 self.listeningHistoryTable.setEditing(self.isMultiSelectEnabled, animated: true)

--- a/podcasts/Lists/HomeGridListItem.swift
+++ b/podcasts/Lists/HomeGridListItem.swift
@@ -28,9 +28,9 @@ class HomeGridListItem: ListItem {
     static let empty = HomeGridListItem(gridItem: nil, badgeType: .off, theme: Theme.sharedTheme.activeTheme)
 
     override var differenceIdentifier: String {
-        if let podcast = podcast {
+        if let podcast {
             return "podcast-\(podcast.uuid)"
-        } else if let folder = folder {
+        } else if let folder {
             return "folder-\(folder.uuid)"
         }
         return "empty"
@@ -47,7 +47,7 @@ class HomeGridListItem: ListItem {
     override func handleIsEqual(_ otherItem: ListItem) -> Bool {
         guard let rhs = otherItem as? HomeGridListItem else { return false }
 
-        if let otherPodcast = rhs.podcast, let podcast = podcast {
+        if let otherPodcast = rhs.podcast, let podcast {
             return differenceIdentifier == rhs.differenceIdentifier &&
                 frozenBadgeCount == rhs.frozenBadgeCount &&
                 badgeType == rhs.badgeType &&
@@ -62,7 +62,7 @@ class HomeGridListItem: ListItem {
                 podcast.boostVolume == otherPodcast.boostVolume &&
                 podcast.trimSilenceAmount == otherPodcast.trimSilenceAmount &&
                 podcast.settings == otherPodcast.settings
-        } else if let otherFolder = rhs.folder, let folder = folder {
+        } else if let otherFolder = rhs.folder, let folder {
             return differenceIdentifier == rhs.differenceIdentifier &&
                 frozenBadgeCount == rhs.frozenBadgeCount &&
                 badgeType == rhs.badgeType &&

--- a/podcasts/Main/NavigationManager.swift
+++ b/podcasts/Main/NavigationManager.swift
@@ -120,7 +120,7 @@ class NavigationManager {
         lastNavData = data
 
         if place == NavigationManager.podcastPageKey {
-            guard let data = data else { return }
+            guard let data else { return }
 
             if let podcast = data[NavigationManager.podcastKey] as? Podcast {
                 mainController?.navigateToPodcast(podcast)
@@ -145,13 +145,13 @@ class NavigationManager {
                 mainController?.navigateTo(podcast: searchResult)
             }
         } else if place == NavigationManager.folderPageKey {
-            guard let data = data else { return }
+            guard let data else { return }
 
             if let folder = data[NavigationManager.folderKey] as? Folder {
                 mainController?.navigateToFolder(folder, popToRootViewController: (data[NavigationManager.popToRootViewController] as? Bool) ?? true)
             }
         } else if place == NavigationManager.episodePageKey {
-            guard let data = data, let uuid = data[NavigationManager.episodeUuidKey] as? String else { return }
+            guard let data, let uuid = data[NavigationManager.episodeUuidKey] as? String else { return }
 
             mainController?.navigateToEpisode(uuid, podcastUuid: data[NavigationManager.podcastKey] as? String, timestamp: data[NavigationManager.episodeTimestamp] as? TimeInterval)
         } else if place == NavigationManager.podcastListPageKey {
@@ -159,7 +159,7 @@ class NavigationManager {
         } else if place == NavigationManager.discoverPageKey {
             navigateToDiscover(data: data, animated: animated)
         } else if place == NavigationManager.filterPageKey {
-            if let data = data, let filterUuid = data[NavigationManager.filterUuidKey] as? String, let filter = DataManager.sharedManager.findPlaylist(uuid: filterUuid) {
+            if let data, let filterUuid = data[NavigationManager.filterUuidKey] as? String, let filter = DataManager.sharedManager.findPlaylist(uuid: filterUuid) {
                 mainController?.navigateToFilter(filter, animated: animated)
             } else {
                 mainController?.navigateToFilter(nil, animated: animated)
@@ -167,7 +167,7 @@ class NavigationManager {
         } else if place == NavigationManager.filterAddKey {
             mainController?.navigateToAddFilter()
         } else if place == NavigationManager.uploadedPageKey {
-            if let data = data, let fileURL = data[NavigationManager.uploadFileKey] as? URL {
+            if let data, let fileURL = data[NavigationManager.uploadFileKey] as? URL {
                 mainController?.navigateToAddCustom(fileURL)
             }
         } else if place == NavigationManager.filesPageKey {
@@ -175,7 +175,7 @@ class NavigationManager {
         } else if place == NavigationManager.subscriptionCancelledAcknowledgePageKey {
             mainController?.showSubscriptionCancelledAcknowledge()
         } else if place == NavigationManager.subscriptionRequiredPageKey {
-            if let data = data, let rootVC = data[NavigationManager.subscriptionUpgradeVCKey] as? UIViewController {
+            if let data, let rootVC = data[NavigationManager.subscriptionUpgradeVCKey] as? UIViewController {
                 let source = (data["source"] as? PlusUpgradeViewSource) ?? .unknown
                 let context = data["context"] as? OnboardingFlow.Context
                 let flow = data["flow"] as? OnboardingFlow.Flow
@@ -188,12 +188,12 @@ class NavigationManager {
         } else if place == NavigationManager.showTermsOfUsePageKey {
             mainController?.showTermsOfUse()
         } else if place == NavigationManager.showWhatsNewPageKey {
-            if let data = data, let whatsNewInfo = data[NavigationManager.whatsNewInfoKey] as? WhatsNewInfo {
+            if let data, let whatsNewInfo = data[NavigationManager.whatsNewInfoKey] as? WhatsNewInfo {
                 mainController?.showWhatsNew(whatsNewInfo: whatsNewInfo)
             }
         } else if place == NavigationManager.settingsAppearanceKey {
             var showThemeSelection = false
-            if let data = data, let showThemeSelectionValue = data[NavigationManager.settingsAppearanceShowThemeKey] as? Bool {
+            if let data, let showThemeSelectionValue = data[NavigationManager.settingsAppearanceShowThemeKey] as? Bool {
                 showThemeSelection = showThemeSelectionValue
             }
             mainController?.showSettingsAppearance(showThemeSelection: showThemeSelection)
@@ -204,21 +204,21 @@ class NavigationManager {
             mainController?.showHeadphoneSettings()
         }
         else if place == NavigationManager.settingsRedeemGuestPassKey {
-            guard let data = data, let url = data[NavigationManager.redeemGuestPassURLKey] as? URL else {
+            guard let data, let url = data[NavigationManager.redeemGuestPassURLKey] as? URL else {
                 return
             }
             mainController?.showRedeemGuestPass(url: url)
         }
         else if place == NavigationManager.showPromotionPageKey {
             var promoCode: String?
-            if let data = data, let promoString = data[NavigationManager.promotionInfoKey] as? String {
+            if let data, let promoString = data[NavigationManager.promotionInfoKey] as? String {
                 promoCode = promoString
             }
             mainController?.showPromotionPage(promoCode: promoCode)
         } else if place == NavigationManager.showPromotionFinishedPageKey {
             mainController?.showPromotionFinishedAcknowledge()
         } else if place == NavigationManager.supporterSignInKey {
-            if let data = data {
+            if let data {
                 if let podcastInfo = data[NavigationManager.supporterPodcastInfo] as? PodcastInfo {
                     mainController?.showSupporterSignIn(podcastInfo: podcastInfo)
                 } else if let bundleUuid = data[NavigationManager.supporterBundleUuid] as? String {
@@ -227,12 +227,12 @@ class NavigationManager {
             }
         } else if place == NavigationManager.supporterBundlePageKey {
             var bundleUuid: String?
-            if let data = data, let uuid = data[NavigationManager.supporterBundleUuid] as? String {
+            if let data, let uuid = data[NavigationManager.supporterBundleUuid] as? String {
                 bundleUuid = uuid
             }
             mainController?.showSupporterBundleDetails(bundleUuid: bundleUuid)
         } else if place == NavigationManager.openUrlInSafariVCKey {
-            if let data = data, let urlString = data[NavigationManager.safariVCUrlKey] as? String {
+            if let data, let urlString = data[NavigationManager.safariVCUrlKey] as? String {
                 mainController?.showInSafariViewController(urlString: urlString)
             }
         } else if place == NavigationManager.endOfYearStories {
@@ -261,7 +261,7 @@ class NavigationManager {
     }
 
     func navigateToDiscover(data: NSDictionary?, animated: Bool) {
-        guard let data = data else {
+        guard let data else {
             mainController?.navigateToDiscover(animated)
             return
         }

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -163,7 +163,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        if let error = error {
+        if let error {
             downloadFailed(with: error)
             return
         }
@@ -308,7 +308,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
     private func fillInContentInformationRequest(_ contentInformationRequest: AVAssetResourceLoadingContentInformationRequest?) {
         // Do we have response from the server?
-        guard let response = response else { return }
+        guard let response else { return }
 
         contentInformationRequest?.contentType = response.mimeType
         contentInformationRequest?.contentLength = response.expectedContentLength
@@ -434,7 +434,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     }
 
     private func retryWithoutUserAgent(originalURL: URL?) {
-        guard let originalURL = originalURL else {
+        guard let originalURL else {
             FileLog.shared.addMessage("MediaExporterResourceLoaderDelegate: Cannot retry without User-Agent - no original URL")
             return
         }

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -78,7 +78,7 @@ extension MediaFileHandle {
         lock.lock()
         defer { lock.unlock() }
 
-        guard let writeHandle = writeHandle else { return }
+        guard let writeHandle else { return }
 
         try writeHandle.seekToEnd()
 
@@ -89,7 +89,7 @@ extension MediaFileHandle {
         lock.lock()
         defer { lock.unlock() }
 
-        guard let writeHandle = writeHandle else { return }
+        guard let writeHandle else { return }
 
         do {
             try writeHandle.synchronize()

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -94,7 +94,7 @@ extension MiniPlayerViewController {
     }
 
     func closeUpNextAndFullPlayer(completion: (() -> Void)? = nil) {
-        if let fullScreenPlayer = fullScreenPlayer {
+        if let fullScreenPlayer {
             _ = fullScreenPlayer.children.map { $0.dismiss(animated: false, completion: nil) }
             closeFullScreenPlayer(completion: {
                 completion?()
@@ -102,7 +102,7 @@ extension MiniPlayerViewController {
             return
         }
 
-        if let upNextViewController = upNextViewController {
+        if let upNextViewController {
             upNextViewController.dismiss(animated: true, completion: nil)
         }
         completion?()

--- a/podcasts/MultipleActionView.swift
+++ b/podcasts/MultipleActionView.swift
@@ -33,7 +33,7 @@ class MultipleActionView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)
 
-        if let icon = icon, let image = UIImage(named: icon)?.tintedImage(ThemeColor.primaryIcon01(for: themeOverride)) {
+        if let icon, let image = UIImage(named: icon)?.tintedImage(ThemeColor.primaryIcon01(for: themeOverride)) {
             let imageView = UIImageView(image: image)
             imageView.translatesAutoresizingMaskIntoConstraints = false
             addSubview(imageView)

--- a/podcasts/NetworkSummaryViewController.swift
+++ b/podcasts/NetworkSummaryViewController.swift
@@ -72,7 +72,7 @@ class NetworkSummaryViewController: DiscoverPeekViewController, DiscoverSummaryP
             preloadedImage = cell.networkImage.image
         }
         let networkViewController = NetworkViewController(network: network, preloadedImage: preloadedImage)
-        if let delegate = delegate {
+        if let delegate {
             networkViewController.registerDiscoverDelegate(delegate)
             delegate.navController()?.pushViewController(networkViewController, animated: true)
         }
@@ -90,7 +90,7 @@ class NetworkSummaryViewController: DiscoverPeekViewController, DiscoverSummaryP
         guard let source = item.source else { return }
 
         DiscoverServerHandler.shared.discoverNetworkList(source: source, authenticated: item.authenticated) { [weak self] podcastNetworks in
-            guard let strongSelf = self, let podcastNetworks = podcastNetworks else { return }
+            guard let strongSelf = self, let podcastNetworks else { return }
 
             strongSelf.networks = podcastNetworks
             DispatchQueue.main.async {

--- a/podcasts/NetworkViewController.swift
+++ b/podcasts/NetworkViewController.swift
@@ -97,7 +97,7 @@ class NetworkViewController: PCViewController, UITableViewDataSource, UITableVie
     @objc private func subscribeRequested(_ notification: Notification) {
         let cell = notification.object as! PodcastGroupCell
         let indexPath = networksTable.indexPath(for: cell)
-        if let indexPath = indexPath, indexPath.row < podcasts?.count ?? 0, let podcastUuid = podcasts?[indexPath.row].uuid {
+        if let indexPath, indexPath.row < podcasts?.count ?? 0, let podcastUuid = podcasts?[indexPath.row].uuid {
             ServerPodcastManager.shared.subscribe(to: podcastUuid, completion: nil)
         }
     }
@@ -130,7 +130,7 @@ class NetworkViewController: PCViewController, UITableViewDataSource, UITableVie
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        if let delegate = delegate, let podcast = podcasts?[indexPath.row] {
+        if let delegate, let podcast = podcasts?[indexPath.row] {
             let cell = tableView.cellForRow(at: indexPath) as! PodcastGroupCell?
             delegate.show(discoverPodcast: podcast, placeholderImage: cell?.podcastImage.image, isFeatured: false, listUuid: nil)
         }
@@ -169,7 +169,7 @@ class NetworkViewController: PCViewController, UITableViewDataSource, UITableVie
 
         loadingIndicator.startAnimating()
         DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: nil) { [weak self] podcastList in
-            guard let strongSelf = self, let podcastList = podcastList else { return }
+            guard let strongSelf = self, let podcastList else { return }
 
             DispatchQueue.main.async {
                 strongSelf.loadingIndicator.stopAnimating()

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -269,7 +269,7 @@ extension ManualPlaylistsChooserViewController: UITableViewDelegate, UITableView
             let playlist = manualPlaylists[indexPath.row]
             let episodeIsInPlaylist = initialSelectedPlaylists.contains(playlist.uuid)
             let onToggleChange: (Bool) -> Void = { [weak self] selected in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 if selected {
                     let maxPlaylistItems = Constants.Limits.maxFilterItems
@@ -285,7 +285,7 @@ extension ManualPlaylistsChooserViewController: UITableViewDelegate, UITableView
             }
             let isSelected = Binding<Bool>(
                 get: { [weak self] in
-                    guard let self = self else { return false }
+                    guard let self else { return false }
                     return self.newSelectedPlaylists.contains(playlist.uuid)
                 },
                 set: { newValue in

--- a/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
@@ -109,7 +109,7 @@ extension PlaylistDetailViewController {
 
     private func reorderEpisodesAction() -> OptionAction {
         OptionAction(label: L10n.playlistManualEpisodesOrderOption, icon: "filter_manual_episode_order") { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.track(.filterRearrangeEpisodesTapped)
             self.showCustomOrderList()
         }
@@ -124,7 +124,7 @@ extension PlaylistDetailViewController {
 
     private func downloadAllOption() -> OptionAction {
         OptionAction(label: L10n.downloadAll, icon: "filter_downloaded") { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.track(.filterDownloadAllTapped)
 
             let downloadableCount = self.downloadableCount(listEpisodes: self.viewModel.episodes)
@@ -180,7 +180,7 @@ extension PlaylistDetailViewController {
 
     private func start(action: ActionType, forAllEpisodes episodes: [ListEpisode]) {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if self.viewModel.episodes.isEmpty { return }
 
@@ -229,7 +229,7 @@ extension PlaylistDetailViewController {
 
     private func unarchiveAllPlaylistEpisodes() {
         Task { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let newData = self.viewModel.episodesDataManager.playlistEpisodes(for: self.viewModel.playlist, shouldShowArchived: true)
             let episodes = newData.map { $0.episode }
             EpisodeManager.bulkUnarchive(episodes: episodes)

--- a/podcasts/New Detail/PlaylistDetailViewController+TableView.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+TableView.swift
@@ -52,7 +52,7 @@ extension PlaylistDetailViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let onToggleChange: (Bool) -> Void = { [weak self] selected in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.track(selected ? .filterShowArchivedTapped : .filterHideArchivedTapped)
             self.viewModel.updateShowArchivedEpisodes(show: selected)
@@ -75,7 +75,7 @@ extension PlaylistDetailViewController: UITableViewDataSource {
             }
             let isSelected = Binding<Bool>(
                 get: { [weak self] in
-                    guard let self = self else { return false }
+                    guard let self else { return false }
                     return self.viewModel.shouldShowArchived
                 },
                 set: { newValue in

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -83,7 +83,7 @@ class PlaylistDetailViewController: FakeNavViewController {
     var isMultiSelectEnabled = false {
         didSet {
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.tableView.beginUpdates()
                 self.tableView.setEditing(self.isMultiSelectEnabled, animated: true)

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel+PlayAll.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel+PlayAll.swift
@@ -8,7 +8,7 @@ extension PlaylistDetailViewModel {
 
     func saveUpNextAndPlay() {
         Task { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let batches = await self.batchedUpNextEpisodes()
             await MainActor.run {
                 self.playAllEpisodes()

--- a/podcasts/NotificationsViewController.swift
+++ b/podcasts/NotificationsViewController.swift
@@ -251,7 +251,7 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
     // MARK: - Notification handler
 
     @objc func podcastUpdated(_ notification: Notification) {
-        guard let podcastChooserController = podcastChooserController else { return }
+        guard let podcastChooserController else { return }
         let allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
         podcastChooserController.selectedUuids = allPodcasts.filter(\.isPushEnabled).map(\.uuid)
         podcastChooserController.selectedUuidsUpdated = true

--- a/podcasts/NowPlayingHelper.swift
+++ b/podcasts/NowPlayingHelper.swift
@@ -113,7 +113,7 @@ class NowPlayingHelper {
 
         nowPlayingClone[MPMediaItemPropertyPlaybackDuration] = NSNumber(value: duration)
         nowPlayingClone[MPNowPlayingInfoPropertyElapsedPlaybackTime] = NSNumber(value: upTo)
-        if let playbackRate = playbackRate {
+        if let playbackRate {
             nowPlayingClone[MPNowPlayingInfoPropertyPlaybackRate] = NSNumber(value: playbackRate)
             nowPlayingClone[MPNowPlayingInfoPropertyDefaultPlaybackRate] = NSNumber(value: playbackRate)
         } else {

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -513,7 +513,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         EpisodeManager.setStarred(!episode.keepEpisode, episode: episode, updateSyncStatus: SyncManager.isUserLoggedIn())
 
-        if let starBtn = starBtn {
+        if let starBtn {
             let starImage = episode.keepEpisode ? UIImage(named: "player_star_filled") : UIImage(named: "player_star_empty")
 
             UIView.transition(with: starBtn, duration: Constants.Animation.defaultAnimationTime, options: .transitionCrossDissolve, animations: {
@@ -541,7 +541,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     private func sharePodcast(source: UIView, podcast: Podcast?) {
-        guard let _ = source.superview, let podcast = podcast else { return }
+        guard let _ = source.superview, let podcast else { return }
 
         SharingModal.show(option: .podcast(podcast), from: analyticsSource, in: self)
     }

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -144,7 +144,7 @@ extension NowPlayingPlayerItemViewController {
     }
 
     private func updateChapterProgress(for chapter: ChapterInfo?, playheadPosition: TimeInterval) {
-        guard let chapter = chapter else {
+        guard let chapter else {
             return
         }
 

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -293,7 +293,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 #if !APPCLIP
         if SubscriptionHelper.shouldDisplayPlayerBannerAd {
             DiscoverServerHandler.shared.blazePromotion(for: .player) { [weak self] promotion, shouldAnimate in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 if shouldAnimate {
                     self.bannerTask = Task { [weak self] in

--- a/podcasts/Onboarding/Import/ImportViewModel.swift
+++ b/podcasts/Onboarding/Import/ImportViewModel.swift
@@ -167,7 +167,7 @@ extension ImportViewModel {
 extension ImportViewModel {
     func importFromURL(_ url: URL, completion: @escaping ((Bool) -> Void)) {
         let task = URLSession.shared.dataTask(with: url) { data, response, error in
-            guard let data = data else {
+            guard let data else {
                 print("Error downloading data: \(error?.localizedDescription ?? "Unknown error")")
                 completion(false)
                 return

--- a/podcasts/Onboarding/InterestButton.swift
+++ b/podcasts/Onboarding/InterestButton.swift
@@ -26,7 +26,7 @@ struct InterestButton: View {
             doAnimationAndAction()
         }) {
             HStack {
-                if let icon = icon, let url = URL(string: icon) {
+                if let icon, let url = URL(string: icon) {
                     ZStack {
                         if isSelected {
                             KFImage(url)

--- a/podcasts/OptionsPicker.swift
+++ b/podcasts/OptionsPicker.swift
@@ -64,7 +64,7 @@ class OptionsPicker {
     }
 
     func controllerDidAnimateOut(optionChosen: Bool) {
-        if let noActionCallback = noActionCallback, !optionChosen {
+        if let noActionCallback, !optionChosen {
             noActionCallback()
         }
 

--- a/podcasts/OptionsPickerRootController.swift
+++ b/podcasts/OptionsPickerRootController.swift
@@ -118,7 +118,7 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         dismissGestureRecognizer.delegate = self
         dismissView.addGestureRecognizer(dismissGestureRecognizer)
 
-        if let title = title {
+        if let title {
             addTitle(title, titleColor: colors.title)
         }
 

--- a/podcasts/PCNavigationController.swift
+++ b/podcasts/PCNavigationController.swift
@@ -10,9 +10,9 @@ class PCNavigationController: UINavigationController, UIGestureRecognizerDelegat
     init(rootViewController: UIViewController, navStyle: ThemeStyle? = nil, titleStyle: ThemeStyle? = nil, iconStyle: ThemeStyle? = nil, themeOverride: Theme.ThemeType? = nil) {
         super.init(rootViewController: rootViewController)
 
-        if let navStyle = navStyle { self.navStyle = navStyle }
-        if let titleStyle = titleStyle { self.titleStyle = titleStyle }
-        if let iconStyle = iconStyle { self.iconStyle = iconStyle }
+        if let navStyle { self.navStyle = navStyle }
+        if let titleStyle { self.titleStyle = titleStyle }
+        if let iconStyle { self.iconStyle = iconStyle }
         self.themeOverride = themeOverride
 
         updateNavColors()
@@ -86,7 +86,7 @@ class PCNavigationController: UINavigationController, UIGestureRecognizerDelegat
     // MARK: - Orientation
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        if let topViewController = topViewController {
+        if let topViewController {
             return topViewController.supportedInterfaceOrientations
         }
 

--- a/podcasts/PlaybackActionHelper.swift
+++ b/podcasts/PlaybackActionHelper.swift
@@ -103,9 +103,9 @@ class PlaybackActionHelper {
             }
         }
 
-        if let playlistUuid = playlistUuid {
+        if let playlistUuid {
             SiriShortcutsManager.shared.donatePlaylistPlayed(playlistUuid: playlistUuid)
-        } else if let podcastUuid = podcastUuid {
+        } else if let podcastUuid {
             SiriShortcutsManager.shared.donatePodcastPlayed(podcastUuid: podcastUuid)
         }
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -113,7 +113,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     // MARK: - API
 
     func isNowPlayingEpisode(episodeUuid: String?) -> Bool {
-        if let episodeUuid = episodeUuid, let playingEpisode = currentEpisode() {
+        if let episodeUuid, let playingEpisode = currentEpisode() {
             return playingEpisode.uuid == episodeUuid
         }
 
@@ -139,13 +139,13 @@ class PlaybackManager: ServerPlaybackDelegate {
     func playing() -> Bool {
         if aboutToPlay.value { return true }
 
-        guard let player = player else { return false }
+        guard let player else { return false }
 
         return player.playing()
     }
 
     func buffering() -> Bool {
-        guard let player = player else { return false }
+        guard let player else { return false }
 
         return player.buffering()
     }
@@ -279,7 +279,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         recordPlaybackPosition(sendToServerImmediately: playing(), fireNotifications: true)
 
-        if let player = player {
+        if let player {
             player.pause()
         }
         updateNowPlayingInfo()
@@ -445,7 +445,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         FileLog.shared.addMessage("seek to \(time) startPlaybackAfterSeek \(startPlaybackAfterSeek)")
 
         let isReadyToPlay = FeatureFlag.playerIsReadyToPlay.enabled ? (player?.isReadyToPlay() == true) : true
-        if let player = player, isReadyToPlay {
+        if let player, isReadyToPlay {
             player.seekTo(time, completion: { [weak self] () in
                 guard let strongSelf = self else { return }
 
@@ -521,7 +521,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     func duration() -> TimeInterval {
         guard let currentEpisode = currentEpisode() else { return 0 }
 
-        if let player = player, !aboutToPlay.value, !buffering() {
+        if let player, !aboutToPlay.value, !buffering() {
             let episodeDuration = currentEpisode.duration
             let playerDuration = player.duration()
             return (playerDuration > 0) ? playerDuration : episodeDuration
@@ -535,7 +535,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         #if APPCLIP
         return false
         #else
-        guard let episode = episode else { return false }
+        guard let episode else { return false }
 
         return queue.contains(episode: episode)
         #endif
@@ -605,7 +605,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             return
         }
 
-        if let episode = episode {
+        if let episode {
             queue.remove(episode: episode, fireNotification: fireNotification)
         }
     }
@@ -706,7 +706,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             haveCalledPlayerLoad = true
         }
 
-        if let player = player {
+        if let player {
             // in order for things like Picture in Picture to work properly, an audio session needs to be activated. If the UI is asking for the internal AVPlayer, then make sure we do this
             activateAudioSession(completion: nil)
             return player.internalPlayerForVideoPlayback()
@@ -746,7 +746,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         shouldDeactivateSession.value = true
         // iOS gets cranky if you try to de-activate a session that's playing audio, and calling pause doesn't immediately cause audio to stop playing, so as a workaround wait a bit then do it
         deactivateTimedActionHelper.startTimer(for: 3.seconds) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let audioSession = AVAudioSession.sharedInstance()
             if !self.shouldDeactivateSession.value { return }
@@ -902,7 +902,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             load(episode: episode, autoPlay: playing(), overrideUpNext: false)
         }
 
-        if let player = player {
+        if let player {
             player.effectsDidChange()
         }
         updateAllNowPlayingData()
@@ -971,7 +971,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         aboutToPlay.value = false
 
         // make sure we load the saved speed for this track
-        if let player = player {
+        if let player {
             player.setPlaybackRate(effects().playbackSpeed)
         }
 
@@ -1316,7 +1316,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     private func playerSwitchRequired() -> Bool {
         let possiblePlayers = supportedPlayers()
-        if let player = player, let firstSupportedPlayer = possiblePlayers.first {
+        if let player, let firstSupportedPlayer = possiblePlayers.first {
             return type(of: player) != firstSupportedPlayer
         }
 
@@ -1390,7 +1390,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         haveCalledPlayerLoad = false
         seekingTo = PlaybackManager.notSeeking
         FileLog.shared.addMessage("cleanupCurrentPlayer permanent? \(permanent)")
-        if let player = player {
+        if let player {
             player.endPlayback(permanent: permanent)
         }
 
@@ -1404,12 +1404,12 @@ class PlaybackManager: ServerPlaybackDelegate {
                 playersToCleanUp.append(player)
             }
             playerCleanupQueue.asyncAfter(deadline: .now() + 5.seconds) { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 let index = self.playersToCleanUp.firstIndex(where: { listPlayer -> Bool in
                     listPlayer == player
                 })
-                if let index = index {
+                if let index {
                     self.playersToCleanUp.remove(at: index)
                 }
 
@@ -1446,7 +1446,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         if FeatureFlag.activateAudioSessionInBackground.enabled {
             // Perform audio session activation on a background queue to avoid blocking the main thread
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                guard let self = self else {
+                guard let self else {
                     completion?(false)
                     return
                 }
@@ -1571,7 +1571,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     @objc private func progressTimerFired() {
-        guard let player = player, let episode = currentEpisode() else { return }
+        guard let player, let episode = currentEpisode() else { return }
 
         StatsManager.shared.addTotalListeningTime(updateTimerInterval)
         if player.playbackRate() > 1 {
@@ -2039,7 +2039,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         command.isEnabled = true
         command.preferredIntervals = [NSNumber(value: intervalAmount)]
 
-        if let handler = handler {
+        if let handler {
             command.addTarget(handler: handler)
         }
     }
@@ -2130,7 +2130,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             }
 
             FileLog.shared.addMessage("PlaybackManager handleAudioInterrupt began reason: \(interruptionReason?.description ?? "unknown")")
-            if let player = player {
+            if let player {
                 wasPlayingBeforeInterruption = player.shouldBePlaying()
                 player.interruptionDidStart()
             }

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -62,7 +62,7 @@ class PlaybackQueue: NSObject {
     }
 
     func removeTopEpisode(fireNotification: Bool) {
-        guard let topEpisode = topEpisode else { return }
+        guard let topEpisode else { return }
 
         FileLog.shared.addMessage("Remove Top Episode \(topEpisode.title ?? "Untitled")")
         remove(episode: topEpisode, fireNotification: fireNotification)
@@ -252,7 +252,7 @@ class PlaybackQueue: NSObject {
     }
 
     func clearUpNextList() {
-        guard let topEpisode = topEpisode else { return }
+        guard let topEpisode else { return }
 
         DataManager.sharedManager.snapshotUpNext()
 
@@ -363,7 +363,7 @@ class PlaybackQueue: NSObject {
         if !Settings.downloadUpNextEpisodes() { return }
 
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             let episodes = self.allEpisodes(includeNowPlaying: !FeatureFlag.streamAndCachePlayingEpisode.enabled)
             for episode in episodes {
                 self.autoDownloadIfRequired(episode: episode)

--- a/podcasts/PlayerCell.swift
+++ b/podcasts/PlayerCell.swift
@@ -118,7 +118,7 @@ class PlayerCell: ThemeableSwipeCell {
     }
 
     private func labelForAccessibility(episode: BaseEpisode?) -> String {
-        guard let episode = episode else { return "" }
+        guard let episode else { return "" }
         let heading = dayName.text?.replacingOccurrences(of: "•", with: ",") ?? ""
         let title = episodeTitle.text ?? ""
         let subtitle = episode.subTitle()

--- a/podcasts/PlayerChapterCell.swift
+++ b/podcasts/PlayerChapterCell.swift
@@ -152,7 +152,7 @@ class PlayerChapterCell: UITableViewCell {
     }
 
     @objc func progressUpdated(animated: Bool = true) {
-        guard let chapter = chapter, chapter == PlaybackManager.shared.currentChapters().visibleChapter else { return }
+        guard let chapter, chapter == PlaybackManager.shared.currentChapters().visibleChapter else { return }
 
         layoutIfNeeded()
 

--- a/podcasts/PlaylistManager.swift
+++ b/podcasts/PlaylistManager.swift
@@ -65,7 +65,7 @@ class PlaylistManager {
     }
 
     class func delete(playlist: EpisodeFilter?, fireEvent: Bool) {
-        guard let playlist = playlist else { return }
+        guard let playlist else { return }
 
         if SyncManager.isUserLoggedIn() {
             playlist.wasDeleted = true

--- a/podcasts/PlaylistSelectionViewController.swift
+++ b/podcasts/PlaylistSelectionViewController.swift
@@ -60,7 +60,7 @@ class PlaylistSelectionViewController: PCViewController, UITableViewDelegate, UI
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let playlist = allPlaylists[indexPath.row]
         let onToggleChange: (Bool) -> Void = { [weak self] selected in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if selected {
                 self.selectedPlaylists.append(playlist.uuid)
@@ -76,7 +76,7 @@ class PlaylistSelectionViewController: PCViewController, UITableViewDelegate, UI
         if FeatureFlag.playlistsRebranding.enabled {
             let isSelected = Binding<Bool>(
                 get: { [weak self] in
-                    guard let self = self else { return false }
+                    guard let self else { return false }
                     return self.selectedPlaylists.contains(playlist.uuid)
                 },
                 set: { newValue in

--- a/podcasts/PlaylistShortcutsViewController.swift
+++ b/podcasts/PlaylistShortcutsViewController.swift
@@ -149,7 +149,7 @@ class PlaylistShortcutsViewController: PCViewController, UITableViewDelegate, UI
             self.enabledShortcuts = []
             self.availableRows = [.playTopEpisode, .playAll, .openPlaylist]
 
-            if let allVoiceShortcuts = allVoiceShortcuts {
+            if let allVoiceShortcuts {
                 for voiceShortcut in allVoiceShortcuts {
                     if let playIntent = voiceShortcut.shortcut.intent as? INPlayMediaIntent {
                         if playIntent.mediaContainer?.identifier == self.playlist.uuid {
@@ -179,7 +179,7 @@ class PlaylistShortcutsViewController: PCViewController, UITableViewDelegate, UI
 
             DispatchQueue.main.async {
                 self.activityIndicator.stopAnimating()
-                if let error = error {
+                if let error {
                     FileLog.shared.addMessage("Failed INVoiceShortcutCenter.getAllVoiceShortcuts with error \(error.localizedDescription)")
                     self.errorView.isHidden = false
                 } else {

--- a/podcasts/PlaylistViewController+TableData.swift
+++ b/podcasts/PlaylistViewController+TableData.swift
@@ -109,7 +109,7 @@ extension PlaylistViewController: UITableViewDelegate, UITableViewDataSource {
             if selectedEpisode.wasDeleted {
                 let episodeUuid = selectedEpisode.uuid
                 let view = ModalMessageViewController.episodeUnavailableAlert { [weak self] in
-                    guard let self = self else { return }
+                    guard let self else { return }
                     DataManager.sharedManager.deleteEpisodes([episodeUuid], from: self.filter)
                     self.refreshEpisodes(animated: true)
                 }

--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -82,7 +82,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
     var isMultiSelectEnabled = false {
         didSet {
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 self.setupNavBar()
                 self.tableView.beginUpdates()
@@ -327,7 +327,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
         }
 
         let playAllAction = OptionAction(label: L10n.playAll, icon: "filter_play") { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             Analytics.track(.filterOptionsModalOptionTapped, properties: ["option": "play_all"])
             let playableEpisodeCount = min(ServerSettings.autoAddToUpNextLimit(), self.episodes.count)
@@ -337,7 +337,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
         }
 
         let downloadAllAction = OptionAction(label: L10n.downloadAll, icon: "filter_downloaded") { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             Analytics.track(.filterOptionsModalOptionTapped, properties: ["option": "download_all"])
 
             let downloadableCount = self.downloadableCount(listEpisodes: self.episodes)
@@ -509,7 +509,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
 
     func archiveAll(startingAt: Episode) {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if self.episodes.isEmpty { return }
 
@@ -529,7 +529,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
 
     func downloadAll() {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if self.episodes.isEmpty { return }
 
@@ -539,7 +539,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
 
     func queueAll() {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if self.episodes.isEmpty { return }
             self.queueItems(allEpisodes: self.episodes)

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -305,7 +305,7 @@ extension PlaylistsViewController {
             sourceView: cell.artworkImageSource,
             sourceRect: cell.artworkImageSource.bounds
         )
-        guard let tip = tip else { return }
+        guard let tip else { return }
         newFilterTip = tip
 
         //TODO: Add analytics

--- a/podcasts/PodcastChapterParser.swift
+++ b/podcasts/PodcastChapterParser.swift
@@ -128,7 +128,7 @@ class PodcastChapterParser {
 
     private func isValidUrl(_ urlStr: String?) -> Bool {
         // first check can we actually make a URL out of this string and does it have a scheme?
-        guard let urlStr = urlStr, let url = URL(string: urlStr), let scheme = url.scheme else { return false }
+        guard let urlStr, let url = URL(string: urlStr), let scheme = url.scheme else { return false }
 
         // next see if the scheme is http or https, we don't support any others
         return scheme.caseInsensitiveCompare("http") == .orderedSame || scheme.caseInsensitiveCompare("https") == .orderedSame

--- a/podcasts/PodcastHeaderListViewController.swift
+++ b/podcasts/PodcastHeaderListViewController.swift
@@ -120,7 +120,7 @@ class PodcastHeaderListViewController: PCViewController, UITableViewDataSource, 
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        if let delegate = delegate {
+        if let delegate {
             let podcast = podcasts[indexPath.row]
             delegate.show(discoverPodcast: podcast, placeholderImage: nil, isFeatured: false, listUuid: nil)
         }

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -18,7 +18,7 @@ class PodcastImageView: UIView {
     }
 
     func setPodcast(uuid: String, size: PodcastThumbnailSize) {
-        guard let imageView = imageView else { return }
+        guard let imageView else { return }
         imageView.removeConstraints(imageView.constraints)
         imageView.anchorToAllSidesOf(view: self)
         ImageManager.sharedManager.loadImage(podcastUuid: uuid, imageView: imageView, size: size, showPlaceHolder: true)
@@ -31,14 +31,14 @@ class PodcastImageView: UIView {
     }
 
     func setUserEpisode(uuid: String, size: PodcastThumbnailSize) {
-        guard let imageView = imageView else { return }
+        guard let imageView else { return }
 
         ImageManager.sharedManager.loadUserEpisodeImage(uuid: uuid, imageView: imageView, size: size, completionHandler: nil)
         adjustForSize(size)
     }
 
     func setBaseEpisode(episode: BaseEpisode, size: PodcastThumbnailSize) {
-        guard let imageView = imageView else { return }
+        guard let imageView else { return }
 
         ImageManager.sharedManager.loadImage(episode: episode, imageView: imageView, size: size)
         adjustForSize(size)
@@ -83,7 +83,7 @@ class PodcastImageView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        guard let shadowView = shadowView else { return }
+        guard let shadowView else { return }
 
         // the code below updates the shadow path when the view changes size. Two things to note:
         // 1. You can't not set a path. It's good for performance but also because shadowView is transparent it won't draw a shadow unless you tell it where
@@ -91,7 +91,7 @@ class PodcastImageView: UIView {
         if let animation = layer.animation(forKey: "position") {
             CATransaction.begin()
             CATransaction.setCompletionBlock { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 shadowView.layer.shadowPath = UIBezierPath(rect: self.bounds).cgPath
             }
@@ -118,7 +118,7 @@ class PodcastImageView: UIView {
         backgroundColor = UIColor.clear
 
         shadowView = UIView(frame: bounds)
-        if let shadowView = shadowView {
+        if let shadowView {
             shadowView.backgroundColor = UIColor.clear
             shadowView.clipsToBounds = false
 
@@ -127,7 +127,7 @@ class PodcastImageView: UIView {
         }
 
         imageView = UIImageView(frame: bounds)
-        if let imageView = imageView {
+        if let imageView {
             imageView.backgroundColor = UIColor.clear
             imageView.clipsToBounds = true
             imageView.contentMode = .scaleAspectFill

--- a/podcasts/Podcasts/All Podcasts/Cells/PodcastGridCell.swift
+++ b/podcasts/Podcasts/All Podcasts/Cells/PodcastGridCell.swift
@@ -75,7 +75,7 @@ class PodcastGridCell: UICollectionViewCell {
     }
 
     private func setImage() {
-        guard let podcastUuid = podcastUuid else { return }
+        guard let podcastUuid else { return }
 
         ImageManager.sharedManager.loadImage(podcastUuid: podcastUuid, imageView: podcastImage, size: .grid, showPlaceHolder: false)
     }

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController+CollectionView.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController+CollectionView.swift
@@ -185,7 +185,7 @@ extension PodcastListViewController: UICollectionViewDelegate, UICollectionViewD
             // Remove existing subviews
             headerView.subviews.forEach { $0.removeFromSuperview() }
 
-            if let bannerAdModel = bannerAdModel {
+            if let bannerAdModel {
                 let bannerAdView = bannerAdView(bannerAdModel: bannerAdModel)
                 let hostingController = PCHostingController(rootView: bannerAdView)
                 hostingController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -154,7 +154,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
 
     @objc private func subscriptionStatusDidChange() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.updateNavigationButtons()
             self.loadBannerAd()
@@ -166,7 +166,7 @@ class PodcastListViewController: PCViewController, UIGestureRecognizerDelegate, 
 
         if SubscriptionHelper.shouldDisplayBannerAd {
             DiscoverServerHandler.shared.blazePromotion(for: .podcastList) { [weak self] promotion, shouldAnimate in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 if shouldAnimate {
                     self.bannerTask = Task { [weak self] in

--- a/podcasts/Podcasts/Helpers/GridHelper.swift
+++ b/podcasts/Podcasts/Helpers/GridHelper.swift
@@ -111,7 +111,7 @@ class GridHelper {
         movingIndexPath = collectionView.indexPathForItem(at: location)
 
         if gesture.state == .began {
-            if let movingIndexPath = movingIndexPath {
+            if let movingIndexPath {
                 collectionView.beginInteractiveMovementForItem(at: movingIndexPath)
                 animatePickingUpCell(pickedUpCell(collectionView: collectionView))
             }
@@ -136,7 +136,7 @@ class GridHelper {
     }
 
     private func animatePickingUpCell(_ cell: UICollectionViewCell?) {
-        guard let cell = cell else { return }
+        guard let cell else { return }
 
         UIView.animate(withDuration: 0.1, delay: 0, options: [.allowUserInteraction, .beginFromCurrentState], animations: {
             cell.alpha = GridHelper.moveAlpha
@@ -145,7 +145,7 @@ class GridHelper {
     }
 
     private func animatePuttingDownCell(_ cell: UICollectionViewCell?) {
-        guard let cell = cell else { return }
+        guard let cell else { return }
 
         UIView.animate(withDuration: 0.1, delay: 0, options: [.allowUserInteraction, .beginFromCurrentState], animations: {
             cell.alpha = 1

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderCell.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderCell.swift
@@ -40,7 +40,7 @@ class PodcastHeaderCell: UITableViewCell {
                     .setupDefaultEnvironment()
                     .ignoresSafeArea()//Needs to be done in order to allow expansion of the view to navigation area when scrolling up
             } contentSizeUpdated: { [weak self] size in
-                guard let self = self else { return }
+                guard let self else { return }
                 calculatedHeight = size.height
                 if firstTime {
                     firstTime = false

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderModel.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderModel.swift
@@ -112,7 +112,7 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
     }
 
     func subscribeButtonTapped() {
-        guard let delegate = delegate else { return }
+        guard let delegate else { return }
 
         if podcast.isSubscribed() || isSubscribed {
             delegate.unsubscribe()

--- a/podcasts/Podcasts/Podcast Page/EpisodeListSearchController+Search.swift
+++ b/podcasts/Podcasts/Podcast Page/EpisodeListSearchController+Search.swift
@@ -23,7 +23,7 @@ extension EpisodeListSearchController: UITextFieldDelegate {
     func handleTextFieldDidChange() {
         let searchTerm = searchTextField.text
 
-        if let searchTerm = searchTerm, !searchTerm.isEmpty {
+        if let searchTerm, !searchTerm.isEmpty {
             clearSearchBtn.isHidden = false
             resetSearchTimer()
         } else {

--- a/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
+++ b/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
@@ -134,7 +134,7 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
         if delegate.shouldDisplayPodcastFeedReloadButton() {
             let reloadPodcastFeedAction = OptionAction(label: L10n.podcastFeedReloadButton, icon: "stats_skipping") { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.podcastDelegate?.reloadPodcastFeed(source: .menu)
             }
             optionPicker.addAction(action: reloadPodcastFeedAction)
@@ -232,13 +232,13 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
     }
 
     private func performUnarchiveAll() {
-        guard let podcastDelegate = podcastDelegate else { return }
+        guard let podcastDelegate else { return }
 
         podcastDelegate.unarchiveAllTapped()
     }
 
     private func confirmArchiveAll(episodeCount: Int, playedOnly: Bool) {
-        guard let podcastDelegate = podcastDelegate else { return }
+        guard let podcastDelegate else { return }
 
         let archiveAllConfirm = OptionsPicker(title: nil)
         let archiveAllAction = OptionAction(label: episodeCount == 1 ? L10n.podcastArchiveEpisodeCountSingular : L10n.podcastArchiveEpisodesCountPluralFormat(episodeCount.localized()), icon: nil, action: {

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastArchiveViewController+Table.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastArchiveViewController+Table.swift
@@ -149,7 +149,7 @@ extension PodcastArchiveViewController: UITableViewDataSource, UITableViewDelega
     private func addEpisodeLimitAction(limit: Int32, to: OptionsPicker) {
         let selectedSetting = podcast.autoArchiveEpisodeLimitCount
         let action = OptionAction(label: stringForLimit(limit), selected: selectedSetting == limit) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.podcast.autoArchiveEpisodeLimitCount = limit
             DataManager.sharedManager.saveAutoArchiveLimit(podcast: self.podcast, limit: limit)
@@ -166,7 +166,7 @@ extension PodcastArchiveViewController: UITableViewDataSource, UITableViewDelega
     private func addArchivePlayedAction(time: TimeInterval, to: OptionsPicker) {
         let selectedSetting = podcast.autoArchivePlayedAfterTime
         let action = OptionAction(label: ArchiveHelper.archiveTimeToText(time), selected: selectedSetting == time) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.podcast.autoArchivePlayedAfterTime = time
             DataManager.sharedManager.save(podcast: self.podcast)
@@ -184,7 +184,7 @@ extension PodcastArchiveViewController: UITableViewDataSource, UITableViewDelega
     private func addArchiveInactiveAction(time: TimeInterval, to: OptionsPicker) {
         let selectedSetting = podcast.autoArchiveInactiveAfterTime
         let action = OptionAction(label: ArchiveHelper.archiveTimeToText(time), selected: selectedSetting == time) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.podcast.autoArchiveInactiveAfterTime = time
             DataManager.sharedManager.save(podcast: self.podcast)

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController+Table.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController+Table.swift
@@ -135,7 +135,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
     private func addTrimLevelAction(level: TrimSilenceAmount, to: OptionsPicker) {
         let selectedAmount = TrimSilenceAmount(rawValue: Int32(podcast.trimSilenceAmount)) ?? .low
         let action = OptionAction(label: level.description, selected: selectedAmount == level) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if FeatureFlag.newSettingsStorage.enabled {
                 self.podcast.settings.trimSilence = TrimSilence(amount: level)

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController+Table.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController+Table.swift
@@ -246,7 +246,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
             playlistSelectionViewController.allPlaylists = playlistsPodcastCanAppearIn()
             playlistSelectionViewController.selectedPlaylists = playlistUuidsPodcastAppearsIn()
             playlistSelectionViewController.playlistSelected = { [weak self] playlist in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 playlist.addPodcast(podcastUuid: self.podcast.uuid)
                 DataManager.sharedManager.save(playlist: playlist)
@@ -255,7 +255,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
                 Analytics.track(.filterUpdated, properties: ["group": "podcasts", "source": "podcast_settings"])
             }
             playlistSelectionViewController.playlistUnselected = { [weak self] playlist in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 playlist.removePodcast(podcastUuid: self.podcast.uuid)
                 DataManager.sharedManager.save(playlist: playlist)

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController+NetworkLoad.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController+NetworkLoad.swift
@@ -23,7 +23,7 @@ extension PodcastViewController {
     }
 
     func checkIfPodcastNeedsUpdating() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
         let addMissingEpisodes = Settings.addMissingEpisodes
         ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast, addMissingEpisodes: addMissingEpisodes) { [weak self] updated in
             if updated {
@@ -33,7 +33,7 @@ extension PodcastViewController {
     }
 
     private func processPodcastAdded(added: Bool, uuid: String?) {
-        guard let uuid = uuid, let podcast = DataManager.sharedManager.findPodcast(uuid: uuid, includeUnsubscribed: true) else {
+        guard let uuid, let podcast = DataManager.sharedManager.findPodcast(uuid: uuid, includeUnsubscribed: true) else {
             loadingEnded(successfully: false)
 
             return

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController+Search.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController+Search.swift
@@ -3,7 +3,7 @@ import PocketCastsServer
 
 extension PodcastViewController {
     func performEpisodeSearch(query: String) {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         let search = CacheServerHandler.EpisodeSearchQuery(podcastUuid: podcast.uuid, searchTerm: query)
         CacheServerHandler.shared.searchEpisodesInPodcast(search: search) { [weak self] results in
@@ -16,7 +16,7 @@ extension PodcastViewController {
     func showSearchResults(_ result: CacheServerHandler.EpisodeSearchResult?) {
         searchController?.searchDidComplete()
 
-        guard let podcast = podcast, let result = result else { return }
+        guard let podcast, let result else { return }
 
         uuidsThatMatchSearch.removeAll()
 

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController+Swipe.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController+Swipe.swift
@@ -46,7 +46,7 @@ extension PodcastViewController: SwipeTableViewCellDelegate, SwipeHandler {
     }
 
     func actionPerformed(willBeRemoved: Bool) {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         loadLocalEpisodes(podcast: podcast, animated: true)
     }

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController+TableData.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController+TableData.swift
@@ -195,7 +195,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
                 let cell = podcastHeaderCell
                 return cell
             } else {
-                guard let bookmarkViewModel = bookmarkViewModel else {
+                guard let bookmarkViewModel else {
                     return UITableViewCell()
                 }
                 let cell = tableView.dequeueReusableCell(withIdentifier: BookmarksHostingCell.reuseIdentifier, for: indexPath) as! BookmarksHostingCell
@@ -317,7 +317,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
                 tableView.deselectRow(at: indexPath, animated: true)
 
                 if indexPath.section == PodcastViewController.allEpisodesSection {
-                    guard let podcast = podcast, let episode = episodeAtIndexPath(indexPath) else { return }
+                    guard let podcast, let episode = episodeAtIndexPath(indexPath) else { return }
 
                     if searchController?.searchBarActive() == true {
                         hideSearchKeyboard()
@@ -397,7 +397,7 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
             let image = UIImage(systemName: "mic")?.withConfiguration(UIImage.SymbolConfiguration(weight: .bold))
             let headerView = YouMightLikeSectionHeaderView(image: image, title: L10n.podcastPodrollHeader)
             headerView.onTapped = { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 BottomSheetSwiftUIWrapper.present(
                     PodrollInformationModalView(onDismiss: { [weak self] in
                         self?.presentedViewController?.dismiss(animated: true, completion: nil)

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -367,7 +367,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     private func setupBookmarkViewModel() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         let sortOption = Settings.podcastBookmarksSort
         let viewModel = BookmarkPodcastListViewModel(podcast: podcast,
@@ -472,7 +472,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         }
 
         // if it's a local podcast, refresh it when the view appears, eg: when you tab back to it
-        if let podcast = podcast, podcast.isSubscribed(), hasAppearedAlready {
+        if let podcast, podcast.isSubscribed(), hasAppearedAlready {
             refreshEpisodes()
         }
 
@@ -601,7 +601,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     @objc private func refreshEpisodes() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         loadLocalEpisodes(podcast: podcast, animated: true)
     }
@@ -611,7 +611,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     @objc private func shareTapped(_ sender: UIButton) {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         let sourceRect = sender.superview!.convert(sender.frame, to: view)
         SharingHelper.shared.shareLinkTo(podcast: podcast, fromController: self, fromSource: analyticsSource, sourceRect: sourceRect, sourceView: view)
@@ -619,7 +619,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     private func loadPodcastInfo() {
-        if let podcast = podcast {
+        if let podcast {
             if podcast.isSubscribed() {
                 loadLocalEpisodes(podcast: podcast, animated: false)
                 checkIfPodcastNeedsUpdating()
@@ -648,7 +648,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     func loadLocalEpisodes(podcast: Podcast, animated: Bool) {
         let uuidsToFilter = (searchController?.searchInProgress() ?? false) ? uuidsThatMatchSearch : nil
         let refreshOperation = PodcastEpisodesRefreshOperation(podcast: podcast, uuidsToFilter: uuidsToFilter) { [weak self] newData in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.navTitle = podcast.title
 
@@ -739,7 +739,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     // MARK: - PodcastActionsDelegate
 
     func refreshArtwork() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         let optionsPicker = OptionsPicker(title: nil)
         let refreshAction = OptionAction(label: L10n.podcastRefreshArtwork, icon: nil) {
@@ -778,7 +778,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     private func performUnsubscribe() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         PodcastManager.shared.unsubscribe(podcast: podcast)
         navigationController?.popViewController(animated: true)
@@ -786,7 +786,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func subscribe() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         podcast.subscribed = 1
         podcast.syncStatus = SyncStatus.notSynced.rawValue
@@ -842,19 +842,19 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func episodeCount() -> Int {
-        guard let podcast = podcast else { return 0 }
+        guard let podcast else { return 0 }
 
         return DataManager.sharedManager.count(query: "SELECT COUNT(*) FROM \(DataManager.episodeTableName) WHERE podcast_id == ?", values: [podcast.id])
     }
 
     func archivedEpisodeCount() -> Int {
-        guard let podcast = podcast else { return 0 }
+        guard let podcast else { return 0 }
 
         return DataManager.sharedManager.count(query: "SELECT COUNT(*) FROM \(DataManager.episodeTableName) WHERE podcast_id == ? AND archived = 1", values: [podcast.id])
     }
 
     func settingsTapped() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         let settingsController = PodcastSettingsViewController(podcast: podcast)
         settingsController.episodes = episodeInfo
@@ -876,7 +876,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             navigationController?.pushViewController(signinPage, animated: true)
             return
         }
-        guard let podcast = podcast, let bundle = SubscriptionHelper.bundleSubscriptionForPodcast(podcastUuid: podcast.uuid) else { return }
+        guard let podcast, let bundle = SubscriptionHelper.bundleSubscriptionForPodcast(podcastUuid: podcast.uuid) else { return }
         let subscriptionController = SupporterPodcastViewController(bundleSubscription: bundle)
         navigationController?.pushViewController(subscriptionController, animated: true)
     }
@@ -900,7 +900,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             return
         }
 
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         if let currentFolder = podcast.folderUuid, !currentFolder.isEmpty {
             // podcast is already in a folder, present the options for removing/moving it
@@ -950,7 +950,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func clearSearch() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         uuidsThatMatchSearch.removeAll()
         loadLocalEpisodes(podcast: podcast, animated: true)
@@ -959,7 +959,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func toggleShowArchived() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         podcast.shouldShowArchived = !podcast.shouldShowArchived
         DataManager.sharedManager.save(podcast: podcast)
@@ -977,7 +977,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func unarchiveAllTapped() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         DispatchQueue.global().async {
             DataManager.sharedManager.markAllUnarchivedForPodcast(id: podcast.id)
@@ -994,7 +994,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     func archiveAll(playedOnly: Bool = false) {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         DispatchQueue.global().async { [weak self] in
             guard let allObjects = self?.episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
@@ -1021,7 +1021,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     func downloadAllTapped() {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self, let allObjects = self.episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
+            guard let self, let allObjects = self.episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
 
             let episodes = allObjects.compactMap { ($0 as? ListEpisode)?.episode }
             AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
@@ -1119,7 +1119,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     func downloadSeasonTapped(season: Int) {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let listEpisodesForSeason = episodesForSeason(season)
             let episodes = listEpisodesForSeason.map { $0.episode }
@@ -1162,7 +1162,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     func queueAllTapped() {
         DispatchQueue.global().async { [weak self] in
-            guard let self = self, let allObjects = self.episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
+            guard let self, let allObjects = self.episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
             self.queueItems(allObjects: allObjects)
         }
     }
@@ -1297,7 +1297,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     private func showPodcastFolderMoveOptions(currentFolderUuid: String) {
-        guard let podcast = podcast, let folder = DataManager.sharedManager.findFolder(uuid: currentFolderUuid) else { return }
+        guard let podcast, let folder = DataManager.sharedManager.findFolder(uuid: currentFolderUuid) else { return }
 
         let optionsPicker = OptionsPicker(title: folder.name.localizedUppercase)
         let removeAction = OptionAction(label: L10n.folderRemoveFrom.localizedCapitalized, icon: "folder-remove") {
@@ -1315,7 +1315,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         optionsPicker.addAction(action: removeAction)
 
         let changeFolderAction = OptionAction(label: L10n.folderChange.localizedCapitalized, icon: "folder-arrow") { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.showFolderPickerDialog()
 
@@ -1333,7 +1333,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     private func showFolderPickerDialog() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         let model = ChoosePodcastFolderModel(pickingFor: podcast.uuid, currentFolder: podcast.folderUuid)
         let chooseFolderView = ChoosePodcastFolderView(model: model) { [weak self] _ in
@@ -1559,7 +1559,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     // MARK: - Long press actions
 
     func archiveAll(startingAt: Episode) {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         DispatchQueue.global().async { [weak self] in
             guard let allObjects = self?.episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
@@ -1602,7 +1602,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
     @MainActor
     func loadRecommendations() async {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         isLoadingRecommendations.send(true)
         updateEmptyStateVisibility()
@@ -1647,7 +1647,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         currentViewModeSubject.send(mode)
         switch mode {
         case .episodes:
-            if let podcast = podcast {
+            if let podcast {
                 loadLocalEpisodes(podcast: podcast, animated: true)
             }
         case .youMightLike:

--- a/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.swift
+++ b/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.swift
@@ -141,7 +141,7 @@ class IncomingShareListViewController: PCViewController, UITableViewDelegate, UI
 
         SharingServerHandler.shared.loadList(listUrl: url) { podcastList in
             DispatchQueue.main.async {
-                guard let podcastList = podcastList else {
+                guard let podcastList else {
                     self.handleLoadFailed()
 
                     return

--- a/podcasts/Podcasts/Share Podcast List/SharePublishViewController.swift
+++ b/podcasts/Podcasts/Share Podcast List/SharePublishViewController.swift
@@ -118,7 +118,7 @@ class SharePublishViewController: PCViewController, UICollectionViewDelegate, UI
         let listInfo = SharingServerHandler.PodcastShareInfo(title: title, description: listDescription.text, podcasts: shareUuids)
         SharingServerHandler.shared.sharePodcastList(listInfo: listInfo) { shareUrl in
             DispatchQueue.main.async {
-                guard let shareUrl = shareUrl else {
+                guard let shareUrl else {
                     self.sharingDidFail()
 
                     return

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -248,7 +248,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
     @objc private func refreshComplete() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.refreshControl?.endRefreshing(true)
             self.isRefreshAnimating = false
@@ -258,7 +258,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
     @objc private func handleDataChangedNotification() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.updateDisplayedData()
         }

--- a/podcasts/PromotionViewController.swift
+++ b/podcasts/PromotionViewController.swift
@@ -234,7 +234,7 @@ class PromotionViewController: UIViewController, SyncSigninDelegate, AccountUpda
     }
 
     private func redeemCode() { // called for signed in users only
-        guard let promoCode = promoCode else {
+        guard let promoCode else {
             promoStatus = .codeInvalid
             return
         }

--- a/podcasts/RegionCancellingScrollView.swift
+++ b/podcasts/RegionCancellingScrollView.swift
@@ -5,7 +5,7 @@ class RegionCancellingScrollView: UIScrollView, UIGestureRecognizerDelegate {
     var regionsToCancelIn: CGRect?
 
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        guard let regionsToCancelIn = regionsToCancelIn else { return true }
+        guard let regionsToCancelIn else { return true }
 
         // cancel all gesture recognisers for the area we've agreed not to touch
         let location = touch.location(in: self)

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -374,7 +374,7 @@ class Settings: NSObject {
     }
 
     private class func convertRegion(userRegion: String?, discoverLayout: DiscoverLayout) -> String {
-        guard let userRegion = userRegion else { return discoverLayout.defaultRegionCode }
+        guard let userRegion else { return discoverLayout.defaultRegionCode }
 
         if let _ = discoverLayout.regions?[userRegion.lowercased()] {
             return userRegion

--- a/podcasts/SettingsOptionsViewController.swift
+++ b/podcasts/SettingsOptionsViewController.swift
@@ -85,7 +85,7 @@ class SettingsOptionsViewController: UIViewController, UITableViewDataSource, UI
     }
 
     private func saveChanges() {
-        if let settingsKey = settingsKey {
+        if let settingsKey {
             UserDefaults.standard.set(selectedItem, forKey: settingsKey)
         } else {
             itemSelected?(selectedItem)

--- a/podcasts/SharedItemImporter.swift
+++ b/podcasts/SharedItemImporter.swift
@@ -20,7 +20,7 @@ class SharedItemImporter: Operation {
         autoreleasepool {
             dispatchGroup.enter()
             MainServerHandler.shared.lookupShareLink(sharePath: urlToImport) { [weak self] listResponse in
-                guard let listResponse = listResponse, listResponse.success() else {
+                guard let listResponse, listResponse.success() else {
                     self?.sendResponse()
                     return
                 }

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -22,7 +22,7 @@ class SharingHelper: NSObject {
         guard let sharingUrl = URL(string: ServerConstants.Urls.pocketcastsDotCom) else { return }
 
         activityController = UIActivityViewController(activityItems: [L10n.appShareText, sharingUrl], applicationActivities: nil)
-        guard let activityController = activityController else { return }
+        guard let activityController else { return }
 
         activityController.completionWithItemsHandler = nil
 
@@ -46,7 +46,7 @@ class SharingHelper: NSObject {
         activityController = UIActivityViewController(activityItems: [URL(string: url)!], applicationActivities: nil)
         activityController?.completionWithItemsHandler = nil
 
-        guard let activityController = activityController else { return }
+        guard let activityController else { return }
 
         fromController.present(activityController, animated: true) {
             completionHandler?()

--- a/podcasts/ShowNotesFormatterUtils.swift
+++ b/podcasts/ShowNotesFormatterUtils.swift
@@ -13,7 +13,7 @@ class ShowNotesFormatterUtils {
             var aTagPlaceholderMap = [String: String]()
 
             aTagRegex.enumerateMatches(in: outString, options: [], range: NSMakeRange(0, outString.count)) { match, _, _ in
-                if let match = match, let rangeOfMatch = Range(match.range, in: outString) {
+                if let match, let rangeOfMatch = Range(match.range, in: outString) {
                     let link = String(outString[rangeOfMatch])
                     let placeholderCount = aTagPlaceholderMap.count
                     let linkPlaceholder = "!PC_A_TAG_PLACEHOLDER_\(placeholderCount)!"

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -146,7 +146,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
     private func loadShowNotes() {
         if downloadingShowNotes { return }
 
-        guard let episode = episode else { return }
+        guard let episode else { return }
 
         loadingIndicator.startAnimating()
 
@@ -170,14 +170,14 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
     }
 
     private func displayShowNotes(_ showNotes: String?, shouldResetScrollOffset: Bool = true) {
-        guard let episode = episode else { return }
+        guard let episode else { return }
 
         DispatchQueue.main.async { [weak self] in
             guard let strongSelf = self else { return }
 
             strongSelf.loadingIndicator.stopAnimating()
             let tintColor = strongSelf.linkTintColor()
-            if let showNotes = showNotes {
+            if let showNotes {
                 let isCurrentEpisode = PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid)
                 let formattedNotes = ShowNotesFormatter.format(showNotes: showNotes, tintColor: tintColor, convertTimesToLinks: isCurrentEpisode, bgColor: nil, textColor: ThemeColor.playerContrast01())
                 strongSelf.showNotesWebView.loadHTMLString(formattedNotes, baseURL: URL(fileURLWithPath: Bundle.main.bundlePath))
@@ -239,7 +239,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         showNotesWebView.evaluateJavaScript("document.readyState", completionHandler: { [weak self] complete, _ in
-            guard let self = self,
+            guard let self,
                   let result = complete as? String,
                   result == "complete" // ensure that the load of HTML is complete and not in another loading state
             else {

--- a/podcasts/SimpleActionView.swift
+++ b/podcasts/SimpleActionView.swift
@@ -133,7 +133,7 @@ class SimpleActionView: UIView {
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         UIView.animate(withDuration: 0.2) { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.backgroundColor = ThemeColor.primaryUi01Active(for: self.themeOverride)
         }
@@ -159,7 +159,7 @@ class SimpleActionView: UIView {
         action.action()
 
         if action.onOffAction {
-            guard let onOffSwitch = onOffSwitch else { return }
+            guard let onOffSwitch else { return }
 
             onOffSwitch.isOn = !onOffSwitch.isOn
         } else {

--- a/podcasts/SingleEpisodeViewController.swift
+++ b/podcasts/SingleEpisodeViewController.swift
@@ -65,7 +65,7 @@ class SingleEpisodeViewController: UIViewController {
         viewModel.$imageUUID
             .receive(on: RunLoop.main)
             .sink(receiveValue: { [unowned self] uuid in
-                if let uuid = uuid {
+                if let uuid {
                     self.podcastImage.setPodcast(uuid: uuid, size: .grid)
                 }
             })

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -100,7 +100,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
     // MARK: Populate UI
 
     func populate() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         if let title = podcast.title?.localized {
             podcastTitle?.text = title
@@ -141,7 +141,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
     // MARK: Actions
 
     @IBAction func subscribeTapped(_ sender: Any) {
-        guard !subscribeButton.currentlyOn, let podcast = podcast else { return }
+        guard !subscribeButton.currentlyOn, let podcast else { return }
 
         subscribeButton.currentlyOn = true
 
@@ -154,7 +154,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
     }
 
     @objc func showPodcast() {
-        guard let podcast = podcast else { return }
+        guard let podcast else { return }
 
         delegate?.show(discoverPodcast: podcast, placeholderImage: nil, isFeatured: true, listUuid: item?.uuid)
 

--- a/podcasts/SiriSettingsViewController.swift
+++ b/podcasts/SiriSettingsViewController.swift
@@ -209,7 +209,7 @@ class SiriSettingsViewController: PCViewController, UITableViewDelegate, UITable
                     self.activityIndicator.stopAnimating()
                     self.errorView.isHidden = false
                 }
-                if let error = error {
+                if let error {
                     FileLog.shared.addMessage("Failed INVoiceShortcutCenter.getAllVoiceShortcuts with error \(error.localizedDescription)")
                 }
             }
@@ -248,7 +248,7 @@ class SiriSettingsViewController: PCViewController, UITableViewDelegate, UITable
     // MARK: INUIAddVoiceShortcutViewController
 
     func addVoiceShortcutViewController(_ controller: INUIAddVoiceShortcutViewController, didFinishWith voiceShortcut: INVoiceShortcut?, error: Error?) {
-        if let voiceShortcut = voiceShortcut {
+        if let voiceShortcut {
             enabledShortcuts.append(voiceShortcut)
             if let index = suggestedShortcuts.firstIndex(of: voiceShortcut.shortcut) {
                 suggestedShortcuts.remove(at: index)

--- a/podcasts/SiriShortcutsManager.swift
+++ b/podcasts/SiriShortcutsManager.swift
@@ -73,7 +73,7 @@ class SiriShortcutsManager: CustomObserver {
                     }
                 }
             }
-            if let error = error {
+            if let error {
                 FileLog.shared.addMessage("Failed INVoiceShortcutCenter.getAllVoiceShortcuts with error \(error.localizedDescription)")
             }
             completion(nil)

--- a/podcasts/SleepTimerViewController.swift
+++ b/podcasts/SleepTimerViewController.swift
@@ -390,7 +390,7 @@ class SleepTimerViewController: SimpleNotificationsViewController {
 class MultiLineButton: ThemeableUIButton {
 
     override var intrinsicContentSize: CGSize {
-        guard let titleLabel = titleLabel else {
+        guard let titleLabel else {
             return super.intrinsicContentSize
         }
 

--- a/podcasts/SmallPagedListSummaryViewController.swift
+++ b/podcasts/SmallPagedListSummaryViewController.swift
@@ -136,7 +136,7 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SmallPagedListSummaryViewController.cellId, for: indexPath) as! SmallListCell
         let thisPodcast = podcasts[indexPath.row]
-        if let delegate = delegate {
+        if let delegate {
             cell.populateFrom(thisPodcast, isSubscribed: delegate.isSubscribed(podcast: thisPodcast))
             cell.onSubscribe = { [weak self] in
                 if let listId = self?.item?.uuid, let podcastUuid = thisPodcast.uuid {
@@ -149,7 +149,7 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
     }
 
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let item = item else { return }
+        guard let item else { return }
 
         let podcast = podcasts[indexPath.item]
 
@@ -243,7 +243,7 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
     }
 
     @IBAction func showAllClicked(_ sender: Any) {
-        guard let delegate = delegate, let item = item else { return }
+        guard let delegate, let item else { return }
 
         delegate.showExpanded(item: item, podcasts: podcasts, podcastCollection: nil)
     }

--- a/podcasts/Sonos/SonosLinkController.swift
+++ b/podcasts/Sonos/SonosLinkController.swift
@@ -84,7 +84,7 @@ private extension SonosLinkController {
             let token = await ApiServerHandler.shared.exchangeSonosToken()
 
             DispatchQueue.main.async { [weak self] in
-                guard let token = token else {
+                guard let token else {
                     self?.updateConnectButtonTitle(L10n.retry.localizedUppercase)
                     SJUIUtils.showAlert(title: L10n.sonosConnectionFailedTitle, message: L10n.sonosConnectionFailedAccountLink, from: self)
                     return

--- a/podcasts/StarredViewController.swift
+++ b/podcasts/StarredViewController.swift
@@ -29,7 +29,7 @@ class StarredViewController: PCViewController {
     var isMultiSelectEnabled: Bool = false {
         didSet {
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.setupNavBar()
                 self.starredTable.beginUpdates()
                 self.starredTable.setEditing(self.isMultiSelectEnabled, animated: true)
@@ -89,7 +89,7 @@ class StarredViewController: PCViewController {
         loadingIndicator.startAnimating()
         refreshQueue.addOperation {
             ApiServerHandler.shared.retrieveStarred { episodes in
-                guard let episodes = episodes else {
+                guard let episodes else {
                     DispatchQueue.main.sync {
                         self.loadingIndicator.stopAnimating()
                     }

--- a/podcasts/SupporterContributionsViewController.swift
+++ b/podcasts/SupporterContributionsViewController.swift
@@ -169,7 +169,7 @@ class SupporterContributionsViewController: PCViewController, UITableViewDelegat
             let bundleUrl = ServerHelper.bundleUrl(bundleUuid: bundle.bundleUuid)
             DiscoverServerHandler.shared.discoverPodcastCollection(source: bundleUrl.absoluteString, authenticated: nil, completion: { podcastCollection in
 
-                guard let podcastCollection = podcastCollection else { return }
+                guard let podcastCollection else { return }
                 self.bundleInfo[bundle.bundleUuid] = podcastCollection
                 DispatchQueue.main.async {
                     self.tableView.reloadData()

--- a/podcasts/SupporterGratitudeViewController.swift
+++ b/podcasts/SupporterGratitudeViewController.swift
@@ -47,7 +47,7 @@ class SupporterGratitudeViewController: PCViewController, SyncSigninDelegate {
             heartView.setDefaultGreen()
             updatePodcastHeartColors(uuid: uuid)
         }
-        if let bundleUuid = bundleUuid {
+        if let bundleUuid {
             loadBundleCollection(uuid: bundleUuid)
             heartView.setDefaultGreen()
         }
@@ -78,7 +78,7 @@ class SupporterGratitudeViewController: PCViewController, SyncSigninDelegate {
 
     private func updatePodcastHeartColors(uuid: String) {
         CacheServerHandler.shared.loadPodcastColors(podcastUuid: uuid, allowCachedVersion: false, completion: { _, lightThemeTint, darkThemeTint in
-            guard let lightThemeTint = lightThemeTint, let darkThemeTint = darkThemeTint else { return }
+            guard let lightThemeTint, let darkThemeTint else { return }
             DispatchQueue.main.sync { () in
                 self.heartView.setGradientColors(light: UIColor(hex: lightThemeTint), dark: UIColor(hex: darkThemeTint))
             }
@@ -88,7 +88,7 @@ class SupporterGratitudeViewController: PCViewController, SyncSigninDelegate {
     private func loadBundleCollection(uuid: String) {
         let bundleUrl = ServerHelper.bundleUrl(bundleUuid: uuid)
         DiscoverServerHandler.shared.discoverPodcastCollection(source: bundleUrl.absoluteString, authenticated: nil, completion: { podcastCollection in
-            guard let podcastCollection = podcastCollection else { return }
+            guard let podcastCollection else { return }
 
             DispatchQueue.main.async {
                 if let bundleTitle = podcastCollection.author {

--- a/podcasts/SupporterPodcastViewController.swift
+++ b/podcasts/SupporterPodcastViewController.swift
@@ -115,7 +115,7 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
         populateHeader()
         tableView.tableHeaderView = headerView
 
-        if let firstPodcastSubscription = firstPodcastSubscription, firstPodcastSubscription.autoRenewing, firstPodcastSubscription.platformIsWeb() {
+        if let firstPodcastSubscription, firstPodcastSubscription.autoRenewing, firstPodcastSubscription.platformIsWeb() {
             tableView.tableFooterView = footerView
         }
 
@@ -144,7 +144,7 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
         var sections = [TableSection]()
         if isSingleBundleSubscription() {
             sections.append(.manageSubscription)
-        } else if !isSingleBundleSubscription(), let firstPodcastSubscription = firstPodcastSubscription, firstPodcastSubscription.autoRenewing, firstPodcastSubscription.platformIsWeb() {
+        } else if !isSingleBundleSubscription(), let firstPodcastSubscription, firstPodcastSubscription.autoRenewing, firstPodcastSubscription.platformIsWeb() {
             sections.append(.manageSubscription)
         }
 
@@ -156,7 +156,7 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
     }
 
     private func rows(_ section: TableSection) -> [TableRow] {
-        guard let firstPodcastSubscription = firstPodcastSubscription else {
+        guard let firstPodcastSubscription else {
             return [TableRow]()
         }
 
@@ -263,7 +263,7 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
         switch section {
         case .bundlePodcasts:
             let headerFrame = CGRect(x: 0, y: 0, width: 0, height: 54)
-            if let firstPodcastSubscription = firstPodcastSubscription, !firstPodcastSubscription.isExpired() {
+            if let firstPodcastSubscription, !firstPodcastSubscription.isExpired() {
                 let podcastCount = bundleSubscription.podcasts.count.localized()
                 let subscribedPodcastCount = bundleSubscription.podcasts.filter { DataManager.sharedManager.findPodcast(uuid: $0.uuid) != nil }.count.localized()
                 let title = L10n.paidPodcastBundledSubscriptions(subscribedPodcastCount, podcastCount)
@@ -320,7 +320,7 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
         progressAlert = ShiftyLoadingAlert(title: L10n.canceling)
         progressAlert?.showAlert(self, hasProgress: false, completion: nil)
         ApiServerHandler.shared.cancelPaidPodcastSubcription(bundleUuid: firstPodcastSubscription.bundleUuid) { [weak self] success in
-            guard let self = self else { return }
+            guard let self else { return }
 
             DispatchQueue.main.async {
                 self.progressAlert?.hideAlert(true)
@@ -491,7 +491,7 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
     private func loadBundleCollection(uuid: String) {
         let bundleUrl = ServerHelper.bundleUrl(bundleUuid: uuid)
         DiscoverServerHandler.shared.discoverPodcastCollection(source: bundleUrl.absoluteString, authenticated: nil, completion: { podcastCollection in
-            guard let podcastCollection = podcastCollection else { return }
+            guard let podcastCollection else { return }
             self.bundleCollection = podcastCollection
             DispatchQueue.main.async {
                 self.populateHeader()

--- a/podcasts/Syncing/SyncSigninViewController.swift
+++ b/podcasts/Syncing/SyncSigninViewController.swift
@@ -168,10 +168,10 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
     }
 
     @objc private func syncUpToChanged(_ notification: Notification) {
-        guard let progressAlert = progressAlert, let number = notification.object as? NSNumber else { return }
+        guard let progressAlert, let number = notification.object as? NSNumber else { return }
 
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let upTo = number.intValue
             if self.totalPodcastsToImport > 0 {
@@ -185,7 +185,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
     }
 
     @objc private func podcastsImported() {
-        guard let progressAlert = progressAlert else { return }
+        guard let progressAlert else { return }
 
         DispatchQueue.main.async {
             progressAlert.title = L10n.syncInProgress
@@ -194,7 +194,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
 
     @objc private func syncCompleted() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.progressAlert?.hideAlert(false)
             self.progressAlert = nil

--- a/podcasts/Theme/Themable Views/ThemeableImageView.swift
+++ b/podcasts/Theme/Themable Views/ThemeableImageView.swift
@@ -40,7 +40,7 @@ class ThemeableImageView: UIImageView {
     private func updateImage() {
         if let imageName = imageNameFunc {
             image = UIImage(named: imageName())
-        } else if let imageStyle = imageStyle, let currentImage = image {
+        } else if let imageStyle, let currentImage = image {
             image = currentImage.tintedImage(AppTheme.colorForStyle(imageStyle))
         }
     }

--- a/podcasts/Theme/Themable Views/ThemeableTextField.swift
+++ b/podcasts/Theme/Themable Views/ThemeableTextField.swift
@@ -47,7 +47,7 @@ class ThemeableTextField: UITextField {
 
     private func updateColor() {
         textColor = AppTheme.colorForStyle(textStyle)
-        if let placeholder = placeholder {
+        if let placeholder {
             attributedPlaceholder = NSAttributedString(string: placeholder, attributes: [NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(placeholderStyle).withAlphaComponent(0.5)])
         }
         if let background = backgroundStyle {

--- a/podcasts/Theme/Theme Specific Components/LenticularViewController.swift
+++ b/podcasts/Theme/Theme Specific Components/LenticularViewController.swift
@@ -8,7 +8,7 @@ class LenticularViewController: UIViewController {
 
         view.isUserInteractionEnabled = false
         overlayView = LenticularOverlayView(frame: view.bounds)
-        if let overlayView = overlayView {
+        if let overlayView {
             overlayView.backgroundColor = UIColor.clear
 
             view.addSubview(overlayView)

--- a/podcasts/ThemeableAccessibilityCollectionView.swift
+++ b/podcasts/ThemeableAccessibilityCollectionView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class ThemeableAccessibilityCollectionView: ThemeableCollectionView {
     override func accessibilityElementCount() -> Int {
-        guard let dataSource = dataSource else {
+        guard let dataSource else {
             return 0
         }
 

--- a/podcasts/TimeSlider.swift
+++ b/podcasts/TimeSlider.swift
@@ -119,7 +119,7 @@ class TimeSlider: UIView {
                 }
                 recalculatePositionRects(true)
 
-                if let delegate = delegate {
+                if let delegate {
                     delegate.sliderDidBeginSliding()
                 }
             }
@@ -132,7 +132,7 @@ class TimeSlider: UIView {
             if shouldPopupOnDrag { timeLayer().popupScale = 0 }
             recalculatePositionRects(true)
 
-            if let delegate = delegate {
+            if let delegate {
                 delegate.sliderDidEndSliding()
             }
         }
@@ -144,7 +144,7 @@ class TimeSlider: UIView {
             if shouldPopupOnDrag { timeLayer().popupScale = 0 }
             recalculatePositionRects(true)
 
-            if let delegate = delegate {
+            if let delegate {
                 delegate.sliderDidSlide(to: currentTime)
                 delegate.sliderDidEndSliding()
             }
@@ -168,7 +168,7 @@ class TimeSlider: UIView {
 
             timeLayer().popupValue = TimeFormatter.shared.playTimeFormat(time: currentTime) as NSString
             recalculatePositionRects(false)
-            if let delegate = delegate {
+            if let delegate {
                 delegate.sliderDidProvisionallySlide(to: currentTime)
             }
         }

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -313,7 +313,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     }
 
     @objc private func shareEpisode() {
-        guard let transcript = transcript else { return }
+        guard let transcript else { return }
 
         let transcriptText = transcript.attributedText.string
         let activityViewController = UIActivityViewController(activityItems: [transcriptText], applicationActivities: nil)
@@ -622,7 +622,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             return
         }
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             if FeatureFlag.generatedTranscripts.enabled,
                transcriptManager?.hasGeneratedTranscripts == true {
                 self.stackView.alpha = 1.0

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -98,7 +98,7 @@ class UpNextNowPlayingCell: ThemeableCell {
         let duration: Double
         let currentTime: TimeInterval
 
-        if let episode = episode {
+        if let episode {
             duration = episode.duration
             currentTime = PlaybackManager.shared.currentTime()
         }
@@ -178,7 +178,7 @@ class UpNextNowPlayingCell: ThemeableCell {
         defer {
             setNeedsUpdateConstraints()
         }
-        guard let episode = episode else {
+        guard let episode else {
             downloadingIndicator.isHidden = true
             downloadedIndicator.isHidden = true
             return

--- a/podcasts/UpNextViewController+Swipe.swift
+++ b/podcasts/UpNextViewController+Swipe.swift
@@ -12,7 +12,7 @@ extension UpNextViewController: SwipeTableViewCellDelegate {
         switch orientation {
         case .left:
             let moveToTopAction = SwipeAction(style: .default, title: nil) { [weak self] _, indexPath in
-                guard let self = self, let episode = PlaybackManager.shared.queue.episodeAt(index: indexPath.row) else { return }
+                guard let self, let episode = PlaybackManager.shared.queue.episodeAt(index: indexPath.row) else { return }
 
                 Analytics.track(.episodeSwipeActionPerformed, properties: ["action": "up_next_move_up", "source": "up_next"])
 
@@ -24,7 +24,7 @@ extension UpNextViewController: SwipeTableViewCellDelegate {
             moveToTopAction.accessibilityLabel = L10n.moveToTop
             moveToTopAction.hidesWhenSelected = true
             let moveToBottomAction = SwipeAction(style: .default, title: nil) { [weak self] _, indexPath in
-                guard let self = self, let episode = PlaybackManager.shared.queue.episodeAt(index: indexPath.row) else { return }
+                guard let self, let episode = PlaybackManager.shared.queue.episodeAt(index: indexPath.row) else { return }
 
                 let queueCount = PlaybackManager.shared.queue.upNextCount()
                 PlaybackManager.shared.queue.move(episode: episode, to: queueCount - 1, fireNotification: false)
@@ -38,7 +38,7 @@ extension UpNextViewController: SwipeTableViewCellDelegate {
             return [moveToTopAction, moveToBottomAction]
         case .right:
             let deleteAction = SwipeAction(style: .destructive, title: nil) { [weak self] _, indexPath in
-                guard let self = self, let episode = PlaybackManager.shared.queue.episodeAt(index: indexPath.row) else { return }
+                guard let self, let episode = PlaybackManager.shared.queue.episodeAt(index: indexPath.row) else { return }
 
                 self.changedViaSwipeToRemove = true
                 PlaybackManager.shared.removeIfPlayingOrQueued(episode: episode, fireNotification: true, userInitiated: true)

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -32,7 +32,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             let didChange = oldValue != isMultiSelectEnabled
 
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.updateNavBarButtons()
                 contentInseter.isMultiSelectEnabled = isMultiSelectEnabled
                 if !self.isMultiSelectEnabled {
@@ -300,7 +300,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     @objc private func subscriptionStatusDidChange() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             if FeatureFlag.upNextShuffle.enabled {
                 // Update UI
                 FileLog.shared.addMessage("UpNext subscriptionStatusDidChange: user has active subscription: \(SubscriptionHelper.hasActiveSubscription()) and is logged in: \(SyncManager.isUserLoggedIn())")

--- a/podcasts/UploadedSettingsViewController.swift
+++ b/podcasts/UploadedSettingsViewController.swift
@@ -34,7 +34,7 @@ class UploadedSettingsViewController: PCViewController, UITableViewDelegate, UIT
 
     @objc func subscriptionStatusChanged() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.settingsTable.reloadData()
         }

--- a/podcasts/UploadedStorageHeaderView.swift
+++ b/podcasts/UploadedStorageHeaderView.swift
@@ -71,7 +71,7 @@ class UploadedStorageHeaderView: UIView {
     }
 
     @objc private func headerTapped() {
-        if let controllerForPresenting = controllerForPresenting {
+        if let controllerForPresenting {
             NavigationManager.sharedManager.showUpsellView(from: controllerForPresenting, source: .files)
         }
     }

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -61,7 +61,7 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
     var isMultiSelectEnabled = false {
         didSet {
             DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.setupNavBar()
                 self.uploadsTable.beginUpdates()
                 self.uploadsTable.setEditing(self.isMultiSelectEnabled, animated: true)
@@ -141,7 +141,7 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
         reloadAllFiles()
         addUIObservers()
 
-        if let fileURL = fileURL {
+        if let fileURL {
             let addCustomVC = AddCustomViewController(fileUrl: fileURL)
 
             present(SJUIUtils.popupNavController(for: addCustomVC), animated: true, completion: nil)
@@ -228,7 +228,7 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
 
     @objc private func handleReloadFromNotification() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.reloadLocalFiles()
         }

--- a/podcasts/UrlHelper.swift
+++ b/podcasts/UrlHelper.swift
@@ -2,13 +2,13 @@ import Foundation
 
 struct URLHelper {
     static func isValidScheme(_ scheme: String?) -> Bool {
-        guard let scheme = scheme else { return false }
+        guard let scheme else { return false }
 
         return ((scheme.caseInsensitiveCompare("http") == .orderedSame) || (scheme.caseInsensitiveCompare("https") == .orderedSame))
     }
 
     static func isMailtoScheme(_ scheme: String?) -> Bool {
-        guard let scheme = scheme else { return false }
+        guard let scheme else { return false }
 
         return scheme.caseInsensitiveCompare("mailto") == .orderedSame
     }

--- a/podcasts/UserEpisodeDetailViewController.swift
+++ b/podcasts/UserEpisodeDetailViewController.swift
@@ -191,7 +191,7 @@ class UserEpisodeDetailViewController: UIViewController {
 
     @objc private func updateFromNotification() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             let oldEpisode = self.episode
 
@@ -270,7 +270,7 @@ class UserEpisodeDetailViewController: UIViewController {
         guard UploadManager.shared.progressManager.hasProgressForUserEpisode(episode.uuid) else { return }
 
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             if !self.episode.uploading() {
                 self.reloadEpisode()
@@ -320,7 +320,7 @@ class UserEpisodeDetailViewController: UIViewController {
     private var isAnimatingOut = false
     func animateIn() {
         window = SceneHelper.newMainScreenWindow()
-        guard let window = window else { return }
+        guard let window else { return }
 
         window.rootViewController = self
         window.windowLevel = UIWindow.Level.alert
@@ -329,7 +329,7 @@ class UserEpisodeDetailViewController: UIViewController {
         containerViewBottomConstraint.constant = -containerHeight()
         view.layoutIfNeeded()
         UIView.animate(withDuration: Constants.Animation.bottomCardAnimationTime, delay: 0, options: .curveEaseOut, animations: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.containerViewBottomConstraint.constant = 0
             self.greyBackgroundView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
@@ -346,7 +346,7 @@ class UserEpisodeDetailViewController: UIViewController {
         isAnimatingOut = true
         view?.layoutIfNeeded()
         UIView.animate(withDuration: Constants.Animation.bottomCardAnimationTime, animations: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.greyBackgroundView.backgroundColor = UIColor.clear
             self.containerViewBottomConstraint.constant = -self.containerHeight()
@@ -363,13 +363,13 @@ class UserEpisodeDetailViewController: UIViewController {
         errorContainerView.isHidden = false
 
         UIView.animate(withDuration: Constants.Animation.defaultAnimationTime / 2, animations: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.containerViewHeight.constant = UserEpisodeDetailViewController.containerHeightWithError
             self.view.layoutIfNeeded()
         }) { [weak self] _ in
             self?.containerViewHeight.constant = UserEpisodeDetailViewController.containerHeightWithError
             UIView.animate(withDuration: Constants.Animation.defaultAnimationTime / 2, animations: { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.errorContainerView.alpha = 1
             }) { [weak self] _ in
                 self?.errorContainerView.alpha = 1
@@ -381,12 +381,12 @@ class UserEpisodeDetailViewController: UIViewController {
     func animateOutError() {
         errorContainerView.alpha = 1
         UIView.animate(withDuration: Constants.Animation.defaultAnimationTime / 2, animations: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
             self.errorContainerView.alpha = 0
         }) { [weak self] _ in
 
             UIView.animate(withDuration: Constants.Animation.defaultAnimationTime / 2, animations: { [weak self] in
-                guard let self = self else { return }
+                guard let self else { return }
                 self.containerViewHeight.constant = UserEpisodeDetailViewController.containerHeightWithoutError
                 self.view.layoutIfNeeded()
 

--- a/podcasts/UserEpisodeManager.swift
+++ b/podcasts/UserEpisodeManager.swift
@@ -16,7 +16,7 @@ struct UserEpisodeManager {
             episode.uuid = uuid
             episode.sizeInBytes = Int64(fileSize)
             episode.episodeStatus = DownloadStatus.downloaded.rawValue
-            if let artwork = artwork {
+            if let artwork {
                 episode.imageColor = 0
                 do {
                     let filePath = episode.urlForImage()
@@ -80,7 +80,7 @@ struct UserEpisodeManager {
         NotificationCenter.default.post(name: ServerNotifications.userEpisodeUploadStatusChanged, object: episode.uuid)
 
         ApiServerHandler.shared.uploadFileDelete(episode: episode, completion: { success in
-            guard let success = success, success else { return }
+            guard let success, success else { return }
             DataManager.sharedManager.saveEpisode(uploadStatus: .notUploaded, episode: episode)
             NotificationCenter.default.post(name: ServerNotifications.userEpisodeUploadStatusChanged, object: episode.uuid)
             UserEpisodeManager.updateUserEpisodes()
@@ -116,7 +116,7 @@ struct UserEpisodeManager {
         }
 
         ApiServerHandler.shared.uploadFileDelete(episode: userEpisode, completion: { success in
-            guard let success = success else { return }
+            guard let success else { return }
             if success {
                 DataManager.sharedManager.saveEpisode(uploadStatus: .notUploaded, episode: userEpisode)
                 UserEpisodeManager.deleteFromDevice(userEpisode: userEpisode, removeFromPlaybackQueue: false)
@@ -200,7 +200,7 @@ struct UserEpisodeManager {
                     }
 
                     let filePath = episode.urlForImage()
-                    if let artwork = artwork {
+                    if let artwork {
                         do {
                             try artwork.jpegData(compressionQuality: 1)?.write(to: filePath)
                             episode.imageModified = TimeFormatter.currentUTCTimeInMillis()

--- a/podcasts/Utilities/BlurEffectView.swift
+++ b/podcasts/Utilities/BlurEffectView.swift
@@ -15,7 +15,7 @@ class BlurEffectView: UIVisualEffectView {
     }
 
     override func didMoveToSuperview() {
-        guard let superview = superview else { return }
+        guard let superview else { return }
         backgroundColor = .clear
         frame = superview.bounds //Or setup constraints instead
         setupBlur()

--- a/podcasts/Utilities/NotificationsHelper.swift
+++ b/podcasts/Utilities/NotificationsHelper.swift
@@ -137,7 +137,7 @@ class NotificationsHelper: NSObject, UNUserNotificationCenterDelegate {
         if downloadEpisodeActionId == response.actionIdentifier {
             AnalyticsHelper.downloadFromNotification()
             findEpisode(episodeUuid: episodeUuid) { episode in
-                if let episode = episode {
+                if let episode {
                     DownloadManager.shared.addToQueue(episodeUuid: episode.uuid)
                 }
 
@@ -148,7 +148,7 @@ class NotificationsHelper: NSObject, UNUserNotificationCenterDelegate {
             AnalyticsHelper.addToUpNextFromNotification(playFirst: playFirst)
 
             findEpisode(episodeUuid: episodeUuid) { episode in
-                if let episode = episode {
+                if let episode {
                     PlaybackManager.shared.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: playFirst, userInitiated: true)
                 }
 
@@ -157,7 +157,7 @@ class NotificationsHelper: NSObject, UNUserNotificationCenterDelegate {
         } else if playNowActionid == response.actionIdentifier {
             AnalyticsHelper.playNowFromNotification()
             findEpisode(episodeUuid: episodeUuid) { episode in
-                if let episode = episode {
+                if let episode {
                     PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
                 }
 
@@ -175,7 +175,7 @@ class NotificationsHelper: NSObject, UNUserNotificationCenterDelegate {
         } else {
             // none of the actions where 3D Touched, the user just wants to open this episode if there is one
             findEpisode(episodeUuid: episodeUuid) { [weak self] episode in
-                guard let self = self else { return }
+                guard let self else { return }
 
                 if let episode = episode as? Episode, let podcast = DataManager.sharedManager.findPodcast(uuid: episode.podcastUuid) {
                     self.appDelegate()?.openEpisode(episode.uuid, from: podcast)

--- a/podcasts/Utilities/SwiftUI/Confetti.swift
+++ b/podcasts/Utilities/SwiftUI/Confetti.swift
@@ -195,7 +195,7 @@ extension ConfettiView {
 
         let confettiView = Self()
 
-        if let frame = frame {
+        if let frame {
             confettiView.frame = frame
         }
 

--- a/podcasts/Utilities/UIViewController+ContentUnavailableConfiguration.swift
+++ b/podcasts/Utilities/UIViewController+ContentUnavailableConfiguration.swift
@@ -11,7 +11,7 @@ extension UIViewController {
         pc_contentUnavailableView?.removeFromSuperview()
         pc_contentUnavailableView = nil
 
-        guard let configuration = configuration else { return }
+        guard let configuration else { return }
 
         let configView = configuration.makeContentView()
         configView.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/VideoPlayerView.swift
+++ b/podcasts/VideoPlayerView.swift
@@ -39,7 +39,7 @@ class VideoPlayerView: UIView {
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         guard keyPath == "videoRect", playerLayer.videoRect.size != CGSize.zero else { return }
 
-        if let videoSizeKnown = videoSizeKnown, player != nil {
+        if let videoSizeKnown, player != nil {
             videoSizeKnown(playerLayer.videoRect.size)
         }
     }

--- a/podcasts/VideoViewController.swift
+++ b/podcasts/VideoViewController.swift
@@ -217,7 +217,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     // MARK: - Picture In Picture
 
     @IBAction func pictureInPictureTapped(_ sender: Any) {
-        guard let pipController = pipController else { return }
+        guard let pipController else { return }
 
         if pipController.isPictureInPictureActive {
             pipController.stopPictureInPicture()
@@ -227,7 +227,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     }
 
     private func setupPictureInPicturePlayback() {
-        if let videoPlayerView = videoPlayerView, AVPictureInPictureController.isPictureInPictureSupported() {
+        if let videoPlayerView, AVPictureInPictureController.isPictureInPictureSupported() {
             pipController = AVPictureInPictureController(playerLayer: videoPlayerView.playerLayer)
             pipController?.delegate = self
             pipButton.isHidden = false
@@ -237,7 +237,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     }
 
     private func teardownPictureInPicturePlayback() {
-        if let pipController = pipController {
+        if let pipController {
             pipController.delegate = nil
         }
 

--- a/podcasts/Watch Communication/WatchManager.swift
+++ b/podcasts/Watch Communication/WatchManager.swift
@@ -43,7 +43,7 @@ class WatchManager: NSObject, WCSessionDelegate {
         guard WCSession.isSupported() else { return }
 
         sessionQueue.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             // Prevent multiple setup calls
             guard !self.isSettingUp else { return }

--- a/podcasts/WatchNowPlayingHelper.swift
+++ b/podcasts/WatchNowPlayingHelper.swift
@@ -68,7 +68,7 @@ class WatchNowPlayingHelper {
 
         nowPlayingClone[MPMediaItemPropertyPlaybackDuration] = NSNumber(value: duration)
         nowPlayingClone[MPNowPlayingInfoPropertyElapsedPlaybackTime] = NSNumber(value: upTo)
-        if let playbackRate = playbackRate {
+        if let playbackRate {
             nowPlayingClone[MPNowPlayingInfoPropertyPlaybackRate] = NSNumber(value: playbackRate)
             nowPlayingClone[MPNowPlayingInfoPropertyDefaultPlaybackRate] = NSNumber(value: playbackRate)
         } else {

--- a/podcasts/WatchSettingsViewController.swift
+++ b/podcasts/WatchSettingsViewController.swift
@@ -38,7 +38,7 @@ class WatchSettingsViewController: PCViewController, UITableViewDelegate, UITabl
 
     @objc func subscriptionStatusChanged() {
         DispatchQueue.main.async { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
             self.settingsTable.reloadData()
         }

--- a/podcasts/WhatsNewLinkButton.swift
+++ b/podcasts/WhatsNewLinkButton.swift
@@ -29,13 +29,13 @@ class WhatsNewLinkButton: ThemeableRoundedButton {
     }
 
     @objc private func openLink() {
-        guard let url = url else { return }
+        guard let url else { return }
 
         NavigationManager.sharedManager.navigateTo(NavigationManager.openUrlInSafariVCKey, data: [NavigationManager.safariVCUrlKey: url.absoluteString])
     }
 
     @objc private func navigateTo() {
-        guard let navigationKey = navigationKey else { return }
+        guard let navigationKey else { return }
         delegate?.closeWhatsNew()
         NavigationManager.sharedManager.navigateTo(navigationKey, data: nil)
     }

--- a/podcasts/Zendesk/FileLog+FileUpload.swift
+++ b/podcasts/Zendesk/FileLog+FileUpload.swift
@@ -71,7 +71,7 @@ extension FileLog: EventLoggingDelegate {
     public func encryptedWatchLogUUID() -> AnyPublisher<String, Never> {
         watchLogFileForUpload()
             .tryMap { [unowned self] filePath in
-                guard let filePath = filePath else {
+                guard let filePath else {
                     return Self.noWearableLogsAvailable
                 }
 


### PR DESCRIPTION
## What

Enables the SwiftLint [`shorthand_optional_binding`](https://realm.github.io/SwiftLint/shorthand_optional_binding.html) rule, which flags `if let foo = foo` / `guard let foo = foo` patterns in favour of the shorthand `if let foo` / `guard let foo` available since Swift 5.7.

## Details

- Auto-fixed violations: 570 (across 256 files)
- Manual (agentic) fixes: 0
- Violations left for human review: 0

Verification on the worktree:

- `make format` produced 0 remaining `shorthand_optional_binding` violations.
- `make build_staging` succeeded.

## Context

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint), progressively enabling SwiftLint rules across Automattic's iOS repositories one rule at a time.
