### PR TITLE
Update Fingerprint package for TestFlight build

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9077ebfa0969207b23f521a34cb30d603bb748fe74e8ba62e0d54fe8f0de0d7d",
+  "originHash" : "d7e1ddc81980c84ec3a7f03d7a441ff9806fca62c89971fb3e926c11a103816f",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -223,7 +223,7 @@
       "location" : "https://github.com/Automattic/pocket-casts-ios-fingerprint",
       "state" : {
         "branch" : "trunk",
-        "revision" : "ca130afdbe21e1e5a207cf12246668ba40127a30"
+        "revision" : "b696bd9a4a495604532b1b7a484ab140c144eccc"
       }
     },
     {


### PR DESCRIPTION
Fixes PCIOS-

Updates the `pocket-casts-ios-fingerprint` package revision (from `ca130af` to `b696bd9`) to fix the TestFlight build for the 8.11 release.

## To test

1. Check out this branch.
2. Run \`make build_staging\` and confirm the build succeeds.
3. Verify CI / TestFlight archive completes without the previous fingerprint-related failure.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to \`CHANGELOG.md\` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.