### PR TITLE
Liquid Glass: Mini Player – first iteration

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -348,6 +348,7 @@
 		8B87C47C29F0129A00257B96 /* EpisodeArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87C47B29F0129A00257B96 /* EpisodeArtwork.swift */; };
 		8B907F182AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B907F172AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift */; };
 		8B907F1A2AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B907F192AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift */; };
+		FF26A9924A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */; };
 		8B9D233F2C41B1BE004CD57D /* TranscriptShelfButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9D233E2C41B1BE004CD57D /* TranscriptShelfButton.swift */; };
 		8B9DEFD62906D1CE00075EAB /* EndOfYear.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8B9DEFD52906D1CE00075EAB /* EndOfYear.xcassets */; };
 		8BA55A1528CA8FEB002BECC5 /* PrivacySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */; };
@@ -1843,6 +1844,7 @@
 		8B87C47B29F0129A00257B96 /* EpisodeArtwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeArtwork.swift; sourceTree = "<group>"; };
 		8B907F172AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MiniPlayerViewController+TransitionDelegate.swift"; sourceTree = "<group>"; };
 		8B907F192AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerToFullPlayerAnimator.swift; sourceTree = "<group>"; };
+		FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassPlayerAnimator.swift; sourceTree = "<group>"; };
 		8B9D233E2C41B1BE004CD57D /* TranscriptShelfButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptShelfButton.swift; sourceTree = "<group>"; };
 		8B9DEFD52906D1CE00075EAB /* EndOfYear.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = EndOfYear.xcassets; sourceTree = "<group>"; };
 		8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsViewController.swift; sourceTree = "<group>"; };
@@ -4733,6 +4735,7 @@
 				BD1F977B1FD7894C00F89CCD /* MiniPlayerShadowView.swift */,
 				FF4E93112BDBF0D800F370AA /* MiniPlayerGradientView.swift */,
 				8B907F192AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift */,
+				FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */,
 			);
 			name = "Mini Player";
 			sourceTree = "<group>";
@@ -7157,6 +7160,7 @@
 				409C792F222397BA00386495 /* UserEpisodeActionCell.swift in Sources */,
 				BD03DF8C1CACDB75005A127E /* ButtonCell.swift in Sources */,
 				8B907F1A2AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift in Sources */,
+				FF26A9924A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift in Sources */,
 				4085299F247C9682007FE8AA /* SupporterContributionsViewController.swift in Sources */,
 				BDB165E0208078D5007B57CD /* DownloadManager+URLSessionDelegate.swift in Sources */,
 				C713D4F62A04C90500A78468 /* AccountHeaderView.swift in Sources */,

--- a/podcasts/LiquidGlassPlayerAnimator.swift
+++ b/podcasts/LiquidGlassPlayerAnimator.swift
@@ -26,7 +26,7 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
         // Dismiss: scale duration with gesture velocity so slow flicks get a
         // longer settle (no rushed feel) while fast flicks finish quickly and
         // keep up with the user's intent.
-        return 0.45 - min(0.25, dismissVelocity / 8000)
+        return 0.33 - min(0.15, dismissVelocity / 8000)
     }
 
     private var isPresenting: Bool {
@@ -116,11 +116,14 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
 
         let miniPlayerView = fromViewController.view
         let restingTransform: CGAffineTransform = .identity
-        // Negative y: mini player drops in from above on dismiss (mimicking the
-        // full player's downward exit), and lifts upward as it's covered on
-        // present (mimicking the full player's upward entry).
-        let collapsedTransform = CGAffineTransform(translationX: 0, y: -20).scaledBy(x: 0.92, y: 0.92)
-        miniPlayerView?.transform = isPresenting ? restingTransform : collapsedTransform
+        // Present-end: mini player lifts upward and shrinks slightly as it's
+        // covered, mimicking the full player's upward entry.
+        let coveredTransform = CGAffineTransform(translationX: 0, y: -20).scaledBy(x: 0.92, y: 0.92)
+        // Dismiss-start: mini player begins expanded and offset upward, then
+        // springs back to rest — as if absorbing the full player zooming back
+        // into it. Paired with a bouncy spring so it settles with overshoot.
+        let absorbingTransform = CGAffineTransform(translationX: 0, y: -36).scaledBy(x: 1.12, y: 1.12)
+        miniPlayerView?.transform = isPresenting ? restingTransform : absorbingTransform
 
         animate(withDuration: duration) { [self] in
             playerView.frame = self.isPresenting ? onScreenFrame : offScreenFrame
@@ -134,7 +137,11 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
             playerView.alpha = self.isPresenting ? 1 : 0.33
             artwork?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkFrame
             artwork?.layer.cornerRadius = self.isPresenting ? self.fullPlayerArtwork.layer.cornerRadius : (self.miniPlayerArtwork.imageView?.layer.cornerRadius ?? 0)
-            miniPlayerView?.transform = self.isPresenting ? collapsedTransform : restingTransform
+            // Present-only here — dismiss runs the mini player on a separate
+            // bouncier spring below.
+            if self.isPresenting {
+                miniPlayerView?.transform = coveredTransform
+            }
         } completion: { _ in
             self.fullPlayerArtwork.layer.opacity = !self.isVideoPodcast ? 1 : 0
             self.miniPlayerArtwork.layer.opacity = 1
@@ -146,22 +153,36 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
             playerView.alpha = 1
             transitionContext.completeTransition(true)
         }
+
+        // Dismiss only: bouncy absorb spring on the mini player itself, so it
+        // visibly settles after the full player "collapses" into it.
+        if !isPresenting {
+            animateMiniPlayerAbsorb {
+                miniPlayerView?.transform = restingTransform
+            }
+        }
     }
 
-    /// Spring shape modeled on Apple Music / Podcasts: present has a small
-    /// lively settle, non-interactive dismiss is critically damped so it falls
-    /// cleanly to rest with no overshoot. Interactive dismiss loosens the
-    /// damping a touch so the gesture feels lively. Dismiss carries gesture
-    /// momentum via initialVelocity; present starts from rest.
+    private func animateMiniPlayerAbsorb(animations: @escaping () -> Void) {
+        // Higher damping + longer duration trades a sharp wobble for a softer
+        // settle — still a visible overshoot, but it eases out instead of
+        // bouncing.
+        let timingParameters = UISpringTimingParameters(
+            dampingRatio: 0.6,
+            initialVelocity: CGVector(dx: 0, dy: springVelocity)
+        )
+        let animator = UIViewPropertyAnimator(duration: duration * 1.75, timingParameters: timingParameters)
+        animator.addAnimations(animations)
+        animator.startAnimation()
+    }
+
+    /// Critically damped spring (no overshoot) used for the main present and
+    /// dismiss move. On dismiss, initialVelocity carries the gesture's
+    /// momentum into the animation so it doesn't lurch when the user lets go;
+    /// on present we start from rest. The mini player's absorb on dismiss uses
+    /// a separate bouncier spring — see `animateMiniPlayerAbsorb`.
     private func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
-        let dampingRatio: CGFloat
-        if isPresenting {
-            dampingRatio = 1.0
-        } else if dismissVelocity > 0 {
-            dampingRatio = 0.78
-        } else {
-            dampingRatio = 0.88
-        }
+        let dampingRatio: CGFloat = 1.0
         let velocity = isPresenting ? CGVector.zero : CGVector(dx: 0, dy: springVelocity)
         let timingParameters = UISpringTimingParameters(dampingRatio: dampingRatio, initialVelocity: velocity)
         let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timingParameters)

--- a/podcasts/LiquidGlassPlayerAnimator.swift
+++ b/podcasts/LiquidGlassPlayerAnimator.swift
@@ -84,17 +84,6 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
         }
         playerView.alpha = 1
 
-        // Scrim: dim what's behind the player while it travels. Match the
-        // initial alpha to how much of the player is off-screen so an
-        // interactive dismiss in progress doesn't pop the dim in at full
-        // strength.
-        let scrim = UIView(frame: containerView.bounds)
-        scrim.backgroundColor = .black
-        scrim.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        let offscreenProgress = max(0, min(1, playerView.frame.origin.y / containerView.frame.height))
-        scrim.alpha = 0.3 * (1 - offscreenProgress)
-        containerView.insertSubview(scrim, belowSubview: playerView)
-
         // Compute the artwork frame in window coords. On present, this is the
         // target on-screen position — the player is currently offscreen by
         // containerView.frame.height, so back that out. On dismiss, this is
@@ -142,8 +131,7 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
             // Subtle fade on dismiss (not all the way to 0) so the seam where
             // the morphing artwork hands back to the mini player is masked
             // without making the player feel like it's vanishing.
-            playerView.alpha = self.isPresenting ? 1 : 0.25
-            scrim.alpha = self.isPresenting ? 0.3 : 0
+            playerView.alpha = self.isPresenting ? 1 : 0.33
             artwork?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkFrame
             artwork?.layer.cornerRadius = self.isPresenting ? self.fullPlayerArtwork.layer.cornerRadius : (self.miniPlayerArtwork.imageView?.layer.cornerRadius ?? 0)
             miniPlayerView?.transform = self.isPresenting ? collapsedTransform : restingTransform
@@ -154,7 +142,6 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
                 miniPlayerView?.transform = .identity
             }
             artwork?.removeFromSuperview()
-            scrim.removeFromSuperview()
             playerView.transform = .identity
             playerView.alpha = 1
             transitionContext.completeTransition(true)
@@ -162,11 +149,19 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
     }
 
     /// Spring shape modeled on Apple Music / Podcasts: present has a small
-    /// lively settle, dismiss is critically damped so it falls cleanly to
-    /// rest with no overshoot. Dismiss carries gesture momentum via
-    /// initialVelocity; present starts from rest.
+    /// lively settle, non-interactive dismiss is critically damped so it falls
+    /// cleanly to rest with no overshoot. Interactive dismiss loosens the
+    /// damping a touch so the gesture feels lively. Dismiss carries gesture
+    /// momentum via initialVelocity; present starts from rest.
     private func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
-        let dampingRatio: CGFloat = isPresenting ? 1.0 : 0.88
+        let dampingRatio: CGFloat
+        if isPresenting {
+            dampingRatio = 1.0
+        } else if dismissVelocity > 0 {
+            dampingRatio = 0.78
+        } else {
+            dampingRatio = 0.88
+        }
         let velocity = isPresenting ? CGVector.zero : CGVector(dx: 0, dy: springVelocity)
         let timingParameters = UISpringTimingParameters(dampingRatio: dampingRatio, initialVelocity: velocity)
         let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timingParameters)

--- a/podcasts/LiquidGlassPlayerAnimator.swift
+++ b/podcasts/LiquidGlassPlayerAnimator.swift
@@ -21,12 +21,12 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
 
     private var duration: TimeInterval {
         if isPresenting {
-            return 0.45
+            return 0.55
         }
         // Dismiss: scale duration with gesture velocity so slow flicks get a
         // longer settle (no rushed feel) while fast flicks finish quickly and
         // keep up with the user's intent.
-        return 0.33 - min(0.15, dismissVelocity / 8000)
+        return 0.45 - min(0.15, dismissVelocity / 8000)
     }
 
     private var isPresenting: Bool {

--- a/podcasts/LiquidGlassPlayerAnimator.swift
+++ b/podcasts/LiquidGlassPlayerAnimator.swift
@@ -20,10 +20,13 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
     }()
 
     private var duration: TimeInterval {
-        guard !isPresenting || dismissVelocity != 0 else {
-            return 0.3
+        if isPresenting {
+            return 0.45
         }
-        return 0.2
+        // Dismiss: scale duration with gesture velocity so slow flicks get a
+        // longer settle (no rushed feel) while fast flicks finish quickly and
+        // keep up with the user's intent.
+        return 0.45 - min(0.25, dismissVelocity / 8000)
     }
 
     private var isPresenting: Bool {
@@ -79,6 +82,18 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
             playerView.setNeedsLayout()
             playerView.layoutIfNeeded()
         }
+        playerView.alpha = 1
+
+        // Scrim: dim what's behind the player while it travels. Match the
+        // initial alpha to how much of the player is off-screen so an
+        // interactive dismiss in progress doesn't pop the dim in at full
+        // strength.
+        let scrim = UIView(frame: containerView.bounds)
+        scrim.backgroundColor = .black
+        scrim.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        let offscreenProgress = max(0, min(1, playerView.frame.origin.y / containerView.frame.height))
+        scrim.alpha = 0.3 * (1 - offscreenProgress)
+        containerView.insertSubview(scrim, belowSubview: playerView)
 
         // Compute the artwork frame in window coords. On present, this is the
         // target on-screen position — the player is currently offscreen by
@@ -89,7 +104,11 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
         if isPresenting {
             fullPlayerArtworkFrame.origin.y -= containerView.frame.height
         }
-        let miniPlayerArtworkFrame = miniPlayerArtwork.superview?.convert(miniPlayerArtwork.frame, to: nil) ?? .zero
+        // Use the presentation layer so the source frame reflects the
+        // interactive UIGlassEffect press/zoom that's in flight at tap time —
+        // the model frame would start the morph from the un-zoomed position.
+        let miniPlayerArtworkLayer = miniPlayerArtwork.layer.presentation() ?? miniPlayerArtwork.layer
+        let miniPlayerArtworkFrame = miniPlayerArtworkLayer.convert(miniPlayerArtwork.bounds, to: nil)
 
         var artwork: UIImageView?
         if !isVideoPodcast, fullPlayerArtwork.image != nil {
@@ -116,39 +135,40 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
 
         animate(withDuration: duration) { [self] in
             playerView.frame = self.isPresenting ? onScreenFrame : offScreenFrame
+            // Slight scale-down on dismiss adds an Apple Music-like "lift away"
+            // feel; on present we settle back to identity in case anything left
+            // a residual transform from a previous dismiss.
+            playerView.transform = self.isPresenting ? .identity : CGAffineTransform(scaleX: 0.97, y: 0.97)
+            // Subtle fade on dismiss (not all the way to 0) so the seam where
+            // the morphing artwork hands back to the mini player is masked
+            // without making the player feel like it's vanishing.
+            playerView.alpha = self.isPresenting ? 1 : 0.25
+            scrim.alpha = self.isPresenting ? 0.3 : 0
             artwork?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkFrame
             artwork?.layer.cornerRadius = self.isPresenting ? self.fullPlayerArtwork.layer.cornerRadius : (self.miniPlayerArtwork.imageView?.layer.cornerRadius ?? 0)
+            miniPlayerView?.transform = self.isPresenting ? collapsedTransform : restingTransform
         } completion: { _ in
             self.fullPlayerArtwork.layer.opacity = !self.isVideoPodcast ? 1 : 0
             self.miniPlayerArtwork.layer.opacity = 1
-            artwork?.removeFromSuperview()
-            transitionContext.completeTransition(true)
-        }
-
-        // Mini player bounce: own spring with low damping so the overshoot reads,
-        // and a small delay on dismiss so the bounce isn't hidden behind the
-        // descending full player. On present, completion forces back to identity
-        // because the mini player is fully covered by then.
-        UIView.animate(withDuration: 0.5,
-                       delay: isPresenting ? 0 : 0.08,
-                       usingSpringWithDamping: 0.7,
-                       initialSpringVelocity: 0,
-                       options: [.allowUserInteraction, .beginFromCurrentState]) {
-            miniPlayerView?.transform = self.isPresenting ? collapsedTransform : restingTransform
-        } completion: { _ in
             if self.isPresenting {
                 miniPlayerView?.transform = .identity
             }
+            artwork?.removeFromSuperview()
+            scrim.removeFromSuperview()
+            playerView.transform = .identity
+            playerView.alpha = 1
+            transitionContext.completeTransition(true)
         }
     }
 
-    /// Spring physics matching the legacy animator: dismiss carries gesture
-    /// momentum via initialVelocity; present starts from rest.
+    /// Spring shape modeled on Apple Music / Podcasts: present has a small
+    /// lively settle, dismiss is critically damped so it falls cleanly to
+    /// rest with no overshoot. Dismiss carries gesture momentum via
+    /// initialVelocity; present starts from rest.
     private func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
-        let stiffness: CGFloat = isPresenting ? 400 : 500
-        let damping: CGFloat = isPresenting ? 38 : 35
+        let dampingRatio: CGFloat = isPresenting ? 1.0 : 0.88
         let velocity = isPresenting ? CGVector.zero : CGVector(dx: 0, dy: springVelocity)
-        let timingParameters = UISpringTimingParameters(mass: 1, stiffness: stiffness, damping: damping, initialVelocity: velocity)
+        let timingParameters = UISpringTimingParameters(dampingRatio: dampingRatio, initialVelocity: velocity)
         let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timingParameters)
         animator.addCompletion { position in
             switch position {

--- a/podcasts/LiquidGlassPlayerAnimator.swift
+++ b/podcasts/LiquidGlassPlayerAnimator.swift
@@ -67,17 +67,24 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
                                     width: containerView.frame.width,
                                     height: containerView.frame.height)
 
-        // Add the full player at its starting frame and force a layout pass so
-        // we can read the artwork's resolved position.
-        let startingPlayerFrame = isPresenting ? offScreenFrame : onScreenFrame
+        // Add the full player to the container. On present, place it offscreen
+        // and force a layout pass so we can read the artwork's resolved
+        // position. On dismiss, leave the frame alone — an interactive gesture
+        // may have already moved it, and snapping back to onScreenFrame would
+        // jump the player (and the artwork inside it) to the top before
+        // animating.
         containerView.addSubview(playerView)
-        playerView.frame = startingPlayerFrame
-        playerView.setNeedsLayout()
-        playerView.layoutIfNeeded()
+        if isPresenting {
+            playerView.frame = offScreenFrame
+            playerView.setNeedsLayout()
+            playerView.layoutIfNeeded()
+        }
 
-        // Compute the artwork target frame in window coords for the full player
-        // at its on-screen position. When presenting, the player is offscreen
-        // by containerView.frame.height — back that out.
+        // Compute the artwork frame in window coords. On present, this is the
+        // target on-screen position — the player is currently offscreen by
+        // containerView.frame.height, so back that out. On dismiss, this is
+        // the artwork's actual (possibly gesture-dragged) position, which is
+        // exactly where the morph should start from.
         var fullPlayerArtworkFrame = fullPlayerArtwork.superview?.convert(fullPlayerArtwork.frame, to: nil) ?? .zero
         if isPresenting {
             fullPlayerArtworkFrame.origin.y -= containerView.frame.height
@@ -109,18 +116,13 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
 
         animate(withDuration: duration) { [self] in
             playerView.frame = self.isPresenting ? onScreenFrame : offScreenFrame
+            artwork?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkFrame
+            artwork?.layer.cornerRadius = self.isPresenting ? self.fullPlayerArtwork.layer.cornerRadius : (self.miniPlayerArtwork.imageView?.layer.cornerRadius ?? 0)
         } completion: { _ in
             self.fullPlayerArtwork.layer.opacity = !self.isVideoPodcast ? 1 : 0
             self.miniPlayerArtwork.layer.opacity = 1
             artwork?.removeFromSuperview()
             transitionContext.completeTransition(true)
-        }
-
-        // Artwork morph: smooth ease, no spring overshoot, so the icon doesn't
-        // bounce as it lands in its destination.
-        UIView.animate(withDuration: duration, delay: 0, options: [.curveEaseInOut, .beginFromCurrentState]) {
-            artwork?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkFrame
-            artwork?.layer.cornerRadius = self.isPresenting ? fullPlayerArtwork.layer.cornerRadius : (miniPlayerArtwork.imageView?.layer.cornerRadius ?? 0)
         }
 
         // Mini player bounce: own spring with low damping so the overshoot reads,

--- a/podcasts/LiquidGlassPlayerAnimator.swift
+++ b/podcasts/LiquidGlassPlayerAnimator.swift
@@ -1,0 +1,162 @@
+import UIKit
+
+@available(iOS 26.0, *)
+class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+    private let fromViewController: UIViewController
+    private let toViewController: UIViewController
+    private let transition: MiniPlayerToFullPlayerAnimator.Transition
+
+    private let miniPlayerArtwork: PodcastImageView
+    private let fullPlayerArtwork: UIImageView
+
+    private let dismissVelocity: CGFloat
+    private let fullPlayerYPosition: CGFloat
+
+    private lazy var springVelocity: CGFloat = {
+        let miniplayerFrame = fromViewController.view.superview?.convert(fromViewController.view.frame, to: nil) ?? .zero
+        let distance = miniplayerFrame.origin.y - fullPlayerYPosition
+        guard distance > 0 else { return 0 }
+        return dismissVelocity / distance
+    }()
+
+    private var duration: TimeInterval {
+        guard !isPresenting || dismissVelocity != 0 else {
+            return 0.3
+        }
+        return 0.2
+    }
+
+    private var isPresenting: Bool {
+        transition == .presenting
+    }
+
+    private var isVideoPodcast: Bool {
+        PlaybackManager.shared.currentEpisode()?.videoPodcast() ?? false
+    }
+
+    init?(fromViewController: UIViewController,
+          toViewController: UIViewController,
+          transition: MiniPlayerToFullPlayerAnimator.Transition,
+          miniPlayerArtwork: PodcastImageView,
+          fullPlayerArtwork: UIImageView,
+          dismissVelocity: CGFloat = 0,
+          fullPlayerYPosition: CGFloat = 0) {
+        self.fromViewController = fromViewController
+        self.toViewController = toViewController
+        self.transition = transition
+        self.miniPlayerArtwork = miniPlayerArtwork
+        self.fullPlayerArtwork = fullPlayerArtwork
+        self.dismissVelocity = dismissVelocity
+        self.fullPlayerYPosition = fullPlayerYPosition
+    }
+
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        duration
+    }
+
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        let containerView = transitionContext.containerView
+
+        guard let playerView = toViewController.view else {
+            transitionContext.completeTransition(true)
+            return
+        }
+
+        let onScreenFrame = containerView.frame
+        let offScreenFrame = CGRect(x: 0, y: containerView.frame.height,
+                                    width: containerView.frame.width,
+                                    height: containerView.frame.height)
+
+        // Add the full player at its starting frame and force a layout pass so
+        // we can read the artwork's resolved position.
+        let startingPlayerFrame = isPresenting ? offScreenFrame : onScreenFrame
+        containerView.addSubview(playerView)
+        playerView.frame = startingPlayerFrame
+        playerView.setNeedsLayout()
+        playerView.layoutIfNeeded()
+
+        // Compute the artwork target frame in window coords for the full player
+        // at its on-screen position. When presenting, the player is offscreen
+        // by containerView.frame.height — back that out.
+        var fullPlayerArtworkFrame = fullPlayerArtwork.superview?.convert(fullPlayerArtwork.frame, to: nil) ?? .zero
+        if isPresenting {
+            fullPlayerArtworkFrame.origin.y -= containerView.frame.height
+        }
+        let miniPlayerArtworkFrame = miniPlayerArtwork.superview?.convert(miniPlayerArtwork.frame, to: nil) ?? .zero
+
+        var artwork: UIImageView?
+        if !isVideoPodcast, fullPlayerArtwork.image != nil {
+            fullPlayerArtwork.layer.opacity = 0
+            miniPlayerArtwork.layer.opacity = 0
+
+            let imageView = UIImageView()
+            imageView.image = fullPlayerArtwork.image
+            imageView.contentMode = fullPlayerArtwork.contentMode
+            imageView.frame = isPresenting ? miniPlayerArtworkFrame : fullPlayerArtworkFrame
+            imageView.layer.cornerRadius = isPresenting ? (miniPlayerArtwork.imageView?.layer.cornerRadius ?? 0) : fullPlayerArtwork.layer.cornerRadius
+            imageView.layer.masksToBounds = true
+            containerView.addSubview(imageView)
+            artwork = imageView
+        }
+
+        let miniPlayerView = fromViewController.view
+        let restingTransform: CGAffineTransform = .identity
+        // Negative y: mini player drops in from above on dismiss (mimicking the
+        // full player's downward exit), and lifts upward as it's covered on
+        // present (mimicking the full player's upward entry).
+        let collapsedTransform = CGAffineTransform(translationX: 0, y: -20).scaledBy(x: 0.92, y: 0.92)
+        miniPlayerView?.transform = isPresenting ? restingTransform : collapsedTransform
+
+        animate(withDuration: duration) { [self] in
+            playerView.frame = self.isPresenting ? onScreenFrame : offScreenFrame
+        } completion: { _ in
+            self.fullPlayerArtwork.layer.opacity = !self.isVideoPodcast ? 1 : 0
+            self.miniPlayerArtwork.layer.opacity = 1
+            artwork?.removeFromSuperview()
+            transitionContext.completeTransition(true)
+        }
+
+        // Artwork morph: smooth ease, no spring overshoot, so the icon doesn't
+        // bounce as it lands in its destination.
+        UIView.animate(withDuration: duration, delay: 0, options: [.curveEaseInOut, .beginFromCurrentState]) {
+            artwork?.frame = self.isPresenting ? fullPlayerArtworkFrame : miniPlayerArtworkFrame
+            artwork?.layer.cornerRadius = self.isPresenting ? fullPlayerArtwork.layer.cornerRadius : (miniPlayerArtwork.imageView?.layer.cornerRadius ?? 0)
+        }
+
+        // Mini player bounce: own spring with low damping so the overshoot reads,
+        // and a small delay on dismiss so the bounce isn't hidden behind the
+        // descending full player. On present, completion forces back to identity
+        // because the mini player is fully covered by then.
+        UIView.animate(withDuration: 0.5,
+                       delay: isPresenting ? 0 : 0.08,
+                       usingSpringWithDamping: 0.7,
+                       initialSpringVelocity: 0,
+                       options: [.allowUserInteraction, .beginFromCurrentState]) {
+            miniPlayerView?.transform = self.isPresenting ? collapsedTransform : restingTransform
+        } completion: { _ in
+            if self.isPresenting {
+                miniPlayerView?.transform = .identity
+            }
+        }
+    }
+
+    /// Spring physics matching the legacy animator: dismiss carries gesture
+    /// momentum via initialVelocity; present starts from rest.
+    private func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
+        let stiffness: CGFloat = isPresenting ? 400 : 500
+        let damping: CGFloat = isPresenting ? 38 : 35
+        let velocity = isPresenting ? CGVector.zero : CGVector(dx: 0, dy: springVelocity)
+        let timingParameters = UISpringTimingParameters(mass: 1, stiffness: stiffness, damping: damping, initialVelocity: velocity)
+        let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timingParameters)
+        animator.addCompletion { position in
+            switch position {
+            case .end:
+                completion?(true)
+            default:
+                break
+            }
+        }
+        animator.addAnimations(animations)
+        animator.startAnimation()
+    }
+}

--- a/podcasts/MiniPlayerViewController+TransitionDelegate.swift
+++ b/podcasts/MiniPlayerViewController+TransitionDelegate.swift
@@ -1,9 +1,14 @@
 import Foundation
+import PocketCastsUtils
 
 extension MiniPlayerViewController: UIViewControllerTransitioningDelegate {
     func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         guard let fullPlayer = dismissed as? PlayerContainerViewController else {
             return nil
+        }
+
+        if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
+            return LiquidGlassPlayerAnimator(fromViewController: self, toViewController: dismissed, transition: .dismissing, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage, dismissVelocity: fullPlayer.dismissVelocity, fullPlayerYPosition: fullPlayer.finalYPositionWhenDismissing)
         }
 
         return MiniPlayerToFullPlayerAnimator(fromViewController: self, toViewController: dismissed, transition: .dismissing, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage, dismissVelocity: fullPlayer.dismissVelocity, fullPlayerYPosition: fullPlayer.finalYPositionWhenDismissing)
@@ -12,6 +17,10 @@ extension MiniPlayerViewController: UIViewControllerTransitioningDelegate {
     func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         guard let fullPlayer = presented as? PlayerContainerViewController else {
             return nil
+        }
+
+        if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
+            return LiquidGlassPlayerAnimator(fromViewController: self, toViewController: presented, transition: .presenting, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage)
         }
 
         return MiniPlayerToFullPlayerAnimator(fromViewController: self, toViewController: presented, transition: .presenting, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage)

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -37,6 +37,11 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
     private let analyticsPlaybackHelper = AnalyticsPlaybackHelper.shared
 
+    private var glassContainer: UIVisualEffectView?
+    private var episodeTitleLabel: UILabel?
+    private var episodeTimeLeftLabel: UILabel?
+
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -44,7 +49,11 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         view.isHidden = false
 
-        setupCorners()
+        if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
+            setupLiquidGlassLayout()
+        } else {
+            setupCorners()
+        }
         addUINotificationObservers()
         playbackStateDidChange()
         themeChanged()
@@ -53,6 +62,102 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private func setupCorners() {
         mainView.layer.cornerRadius = MiniPlayerShadowView.Constants.shadowCornerRadius
         mainView.layer.masksToBounds = true
+    }
+
+    @available(iOS 26.0, *)
+    private func setupLiquidGlassLayout() {
+        gradientView.isHidden = true
+        shadowView.isHidden = true
+        mainView.backgroundColor = .clear
+        mainView.layer.cornerRadius = 0
+        playbackProgressView.isHidden = true
+        upNextBtn.isHidden = true
+
+        let effectView = UIVisualEffectView(effect: UIGlassEffect(style: .regular))
+        effectView.translatesAutoresizingMaskIntoConstraints = false
+        effectView.clipsToBounds = true
+        effectView.layer.cornerCurve = .continuous
+        view.addSubview(effectView)
+        glassContainer = effectView
+
+        let contentView = effectView.contentView
+
+        podcastArtwork.removeFromSuperview()
+        skipBackBtn.removeFromSuperview()
+        playPauseBtn.removeFromSuperview()
+        skipFwdBtn.removeFromSuperview()
+
+        podcastArtwork.translatesAutoresizingMaskIntoConstraints = false
+        skipBackBtn.translatesAutoresizingMaskIntoConstraints = false
+        playPauseBtn.translatesAutoresizingMaskIntoConstraints = false
+        skipFwdBtn.translatesAutoresizingMaskIntoConstraints = false
+
+        podcastArtwork.layer.cornerRadius = 6
+        podcastArtwork.layer.masksToBounds = true
+
+        playPauseBtn.visualSize = 28
+
+        let title = UILabel()
+        title.translatesAutoresizingMaskIntoConstraints = false
+        title.font = .font(ofSize: 12, weight: .medium, scalingWith: .subheadline)
+        title.numberOfLines = 1
+        title.lineBreakMode = .byTruncatingTail
+        title.adjustsFontForContentSizeCategory = true
+        episodeTitleLabel = title
+
+        let timeLeft = UILabel()
+        timeLeft.translatesAutoresizingMaskIntoConstraints = false
+        timeLeft.font = .font(ofSize: 11, weight: .regular, scalingWith: .footnote)
+        timeLeft.numberOfLines = 1
+        timeLeft.adjustsFontForContentSizeCategory = true
+        episodeTimeLeftLabel = timeLeft
+
+        let textStack = UIStackView(arrangedSubviews: [title, timeLeft])
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+        textStack.axis = .vertical
+        textStack.alignment = .leading
+        textStack.spacing = 1
+
+        let buttonStack = UIStackView(arrangedSubviews: [skipBackBtn, playPauseBtn, skipFwdBtn])
+        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+        buttonStack.axis = .horizontal
+        buttonStack.alignment = .center
+
+        contentView.addSubview(podcastArtwork)
+        contentView.addSubview(textStack)
+        contentView.addSubview(buttonStack)
+
+        NSLayoutConstraint.activate([
+            effectView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            effectView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            effectView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -12),
+            effectView.heightAnchor.constraint(equalToConstant: 48),
+
+            podcastArtwork.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            podcastArtwork.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            podcastArtwork.widthAnchor.constraint(equalToConstant: 30),
+            podcastArtwork.heightAnchor.constraint(equalToConstant: 30),
+
+            textStack.leadingAnchor.constraint(equalTo: podcastArtwork.trailingAnchor, constant: 10),
+            textStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: 4),
+
+            skipBackBtn.widthAnchor.constraint(equalToConstant: 68),
+            playPauseBtn.widthAnchor.constraint(equalToConstant: 68),
+            skipFwdBtn.widthAnchor.constraint(equalToConstant: 68),
+
+            buttonStack.topAnchor.constraint(equalTo: contentView.topAnchor),
+            buttonStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            buttonStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+        ])
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        if let glassContainer {
+            glassContainer.layer.cornerRadius = glassContainer.bounds.height / 2
+        }
     }
 
     deinit {
@@ -166,6 +271,10 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             lastEpisodeUuidImageLoaded = episode.uuid
             podcastArtwork.setBaseEpisode(episode: episode, size: .list)
         }
+
+        if let episodeTitleLabel, episodeTitleLabel.text != episode.title {
+            episodeTitleLabel.text = episode.title
+        }
     }
 
     @objc private func playbackStarted() {
@@ -240,37 +349,72 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         if amountBuferred > 0 {
             playbackProgressView.buferredAmount = CGFloat(amountBuferred / (duration - currentTime))
         }
+
+        if let episodeTimeLeftLabel {
+            let remaining = max(0, duration - currentTime)
+            let newText: String?
+            if remaining > 0 {
+                let formatted = TimeFormatter.shared.multipleUnitFormattedShortTime(time: remaining)
+                newText = L10n.podcastTimeLeft(formatted)
+            } else {
+                newText = nil
+            }
+            if episodeTimeLeftLabel.text != newText {
+                episodeTimeLeftLabel.text = newText
+            }
+        }
     }
 
     private func updateColors() {
+        view.backgroundColor = .clear
+        playPauseBtn.isPlaying = PlaybackManager.shared.playing()
+
+        if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
+            updateColorsLiquidGlass()
+        } else {
+            updateColorsLegacy()
+        }
+    }
+
+    private func updateColorsLegacy() {
+        gradientView.colors = [ThemeColor.primaryUi02().withAlphaComponent(0), ThemeColor.primaryUi02()]
+
         let actionColor: UIColor
         if let podcast = podcastForEpisode(PlaybackManager.shared.currentEpisode()) {
             actionColor = Theme.isDarkTheme() ? ColorManager.darkThemeTintForPodcast(podcast) : ColorManager.lightThemeTintForPodcast(podcast)
+        } else if let episode = PlaybackManager.shared.currentEpisode() as? UserEpisode, episode.imageColor > 0 {
+            actionColor = AppTheme.userEpisodeColor(number: Int(episode.imageColor))
         } else {
-            if let episode = PlaybackManager.shared.currentEpisode() as? UserEpisode, episode.imageColor > 0 {
-                actionColor = AppTheme.userEpisodeColor(number: Int(episode.imageColor))
-            } else {
-                actionColor = AppTheme.userEpisodeColor(number: 1)
-            }
+            actionColor = AppTheme.userEpisodeColor(number: 1)
         }
-        view.backgroundColor = .clear
-
-        gradientView.colors = [ThemeColor.primaryUi02().withAlphaComponent(0), ThemeColor.primaryUi02()]
-
         let bgColor = ThemeColor.podcastUi02(podcastColor: actionColor)
+        let iconColor = ThemeColor.podcastIcon03(podcastColor: actionColor)
+
         mainView.backgroundColor = bgColor
+
         playPauseBtn.playButtonColor = bgColor
+        playPauseBtn.circleColor = iconColor
 
         playbackProgressView.updateColors()
-
-        let iconColor = ThemeColor.podcastIcon03(podcastColor: actionColor)
-        playPauseBtn.circleColor = iconColor
 
         skipBackBtn.tintColor = iconColor
         skipFwdBtn.tintColor = iconColor
         upNextBtn.iconColor = iconColor
+    }
 
-        playPauseBtn.isPlaying = PlaybackManager.shared.playing()
+    @available(iOS 26.0, *)
+    private func updateColorsLiquidGlass() {
+        let bgColor = ThemeColor.primaryUi02()
+        let iconColor = ThemeColor.primaryText01()
+
+        episodeTitleLabel?.textColor = ThemeColor.primaryText01()
+        episodeTimeLeftLabel?.textColor = ThemeColor.primaryText01()
+
+        playPauseBtn.playButtonColor = bgColor
+        playPauseBtn.circleColor = iconColor
+
+        skipBackBtn.tintColor = iconColor
+        skipFwdBtn.tintColor = iconColor
     }
 
     private func podcastForEpisode(_ episode: BaseEpisode?) -> Podcast? {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -100,7 +100,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         podcastArtwork.layer.cornerRadius = 6
         podcastArtwork.layer.masksToBounds = true
 
-        playPauseBtn.visualSize = 28
+        playPauseBtn.visualSize = 26
 
         let title = UILabel()
         title.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -135,7 +135,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         NSLayoutConstraint.activate([
             effectView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             effectView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            effectView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -12),
+            effectView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -8),
             effectView.heightAnchor.constraint(equalToConstant: 48),
 
             podcastArtwork.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -153,7 +153,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
             buttonStack.topAnchor.constraint(equalTo: contentView.topAnchor),
             buttonStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            buttonStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            buttonStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -8),
         ])
     }
 

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -107,7 +107,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         podcastArtwork.layer.cornerRadius = 6
         podcastArtwork.layer.masksToBounds = true
 
-        playPauseBtn.visualSize = 26
+        playPauseBtn.visualSize = 28
 
         let title = UILabel()
         title.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -73,7 +73,12 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         playbackProgressView.isHidden = true
         upNextBtn.isHidden = true
 
-        let effectView = UIVisualEffectView(effect: UIGlassEffect(style: .regular))
+
+        let effectView = UIVisualEffectView(effect: {
+            let effect = UIGlassEffect(style: .regular)
+            effect.isInteractive = true
+            return effect
+        }())
         effectView.translatesAutoresizingMaskIntoConstraints = false
         effectView.clipsToBounds = true
         effectView.layer.cornerCurve = .continuous

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -38,6 +38,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private let analyticsPlaybackHelper = AnalyticsPlaybackHelper.shared
 
     private var glassContainer: UIVisualEffectView?
+    private var glassGradientLayer: CAGradientLayer?
     private var episodeTitleLabel: UILabel?
     private var episodeTimeLeftLabel: UILabel?
 
@@ -86,6 +87,12 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         glassContainer = effectView
 
         let contentView = effectView.contentView
+
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.startPoint = CGPoint(x: 0, y: 0.5)
+        gradientLayer.endPoint = CGPoint(x: 1, y: 0.5)
+        contentView.layer.insertSublayer(gradientLayer, at: 0)
+        glassGradientLayer = gradientLayer
 
         podcastArtwork.removeFromSuperview()
         skipBackBtn.removeFromSuperview()
@@ -162,6 +169,10 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         if let glassContainer {
             glassContainer.layer.cornerRadius = glassContainer.bounds.height / 2
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            glassGradientLayer?.frame = glassContainer.contentView.bounds
+            CATransaction.commit()
         }
     }
 
@@ -414,6 +425,11 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         skipBackBtn.tintColor = iconColor
         skipFwdBtn.tintColor = iconColor
+
+        glassGradientLayer?.colors = [
+            actionColor.withAlphaComponent(0.06).cgColor,
+            actionColor.withAlphaComponent(0.09).cgColor,
+        ]
     }
 
     private func currentPodcastTintColor() -> UIColor {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -107,14 +107,14 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         title.font = .font(ofSize: 12, weight: .medium, scalingWith: .subheadline)
         title.numberOfLines = 1
         title.lineBreakMode = .byTruncatingTail
-        title.adjustsFontForContentSizeCategory = true
+        title.adjustsFontForContentSizeCategory = false
         episodeTitleLabel = title
 
         let timeLeft = UILabel()
         timeLeft.translatesAutoresizingMaskIntoConstraints = false
         timeLeft.font = .font(ofSize: 11, weight: .regular, scalingWith: .footnote)
         timeLeft.numberOfLines = 1
-        timeLeft.adjustsFontForContentSizeCategory = true
+        timeLeft.adjustsFontForContentSizeCategory = false
         episodeTimeLeftLabel = timeLeft
 
         let textStack = UIStackView(arrangedSubviews: [title, timeLeft])

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -154,13 +154,13 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             textStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: 4),
 
-            skipBackBtn.widthAnchor.constraint(equalToConstant: 68),
-            playPauseBtn.widthAnchor.constraint(equalToConstant: 68),
-            skipFwdBtn.widthAnchor.constraint(equalToConstant: 68),
+            skipBackBtn.widthAnchor.constraint(equalToConstant: 70),
+            playPauseBtn.widthAnchor.constraint(equalToConstant: 70),
+            skipFwdBtn.widthAnchor.constraint(equalToConstant: 70),
 
             buttonStack.topAnchor.constraint(equalTo: contentView.topAnchor),
             buttonStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            buttonStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -8),
+            buttonStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10),
         ])
     }
 

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -384,14 +384,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private func updateColorsLegacy() {
         gradientView.colors = [ThemeColor.primaryUi02().withAlphaComponent(0), ThemeColor.primaryUi02()]
 
-        let actionColor: UIColor
-        if let podcast = podcastForEpisode(PlaybackManager.shared.currentEpisode()) {
-            actionColor = Theme.isDarkTheme() ? ColorManager.darkThemeTintForPodcast(podcast) : ColorManager.lightThemeTintForPodcast(podcast)
-        } else if let episode = PlaybackManager.shared.currentEpisode() as? UserEpisode, episode.imageColor > 0 {
-            actionColor = AppTheme.userEpisodeColor(number: Int(episode.imageColor))
-        } else {
-            actionColor = AppTheme.userEpisodeColor(number: 1)
-        }
+        let actionColor = currentPodcastTintColor()
         let bgColor = ThemeColor.podcastUi02(podcastColor: actionColor)
         let iconColor = ThemeColor.podcastIcon03(podcastColor: actionColor)
 
@@ -409,8 +402,9 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
     @available(iOS 26.0, *)
     private func updateColorsLiquidGlass() {
+        let actionColor = currentPodcastTintColor()
+        let iconColor = ThemeColor.podcastIcon03(podcastColor: actionColor)
         let bgColor = ThemeColor.primaryUi02()
-        let iconColor = ThemeColor.primaryText01()
 
         episodeTitleLabel?.textColor = ThemeColor.primaryText01()
         episodeTimeLeftLabel?.textColor = ThemeColor.primaryText01()
@@ -420,6 +414,16 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         skipBackBtn.tintColor = iconColor
         skipFwdBtn.tintColor = iconColor
+    }
+
+    private func currentPodcastTintColor() -> UIColor {
+        if let podcast = podcastForEpisode(PlaybackManager.shared.currentEpisode()) {
+            return Theme.isDarkTheme() ? ColorManager.darkThemeTintForPodcast(podcast) : ColorManager.lightThemeTintForPodcast(podcast)
+        } else if let episode = PlaybackManager.shared.currentEpisode() as? UserEpisode, episode.imageColor > 0 {
+            return AppTheme.userEpisodeColor(number: Int(episode.imageColor))
+        } else {
+            return AppTheme.userEpisodeColor(number: 1)
+        }
     }
 
     private func podcastForEpisode(_ episode: BaseEpisode?) -> Podcast? {

--- a/podcasts/PlayPauseButton.swift
+++ b/podcasts/PlayPauseButton.swift
@@ -7,6 +7,14 @@ class PlayPauseButton: BasePlayPauseButton {
     // Used to animate given LottieAnimationView doesn't animate with UIView.animate
     private var snapshot: UIView?
 
+    private var circleSizeConstraints: [NSLayoutConstraint] = []
+
+    /// When set, pins the visible circle (and its Lottie animation) to this size,
+    /// decoupling the visual size from the button's tap target.
+    var visualSize: CGFloat? {
+        didSet { updateCircleSizeConstraints() }
+    }
+
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 
@@ -33,11 +41,10 @@ class PlayPauseButton: BasePlayPauseButton {
         circleView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(circleView)
         NSLayoutConstraint.activate([
-            circleView.widthAnchor.constraint(equalTo: widthAnchor),
-            circleView.heightAnchor.constraint(equalTo: heightAnchor),
             circleView.centerXAnchor.constraint(equalTo: centerXAnchor),
             circleView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
+        updateCircleSizeConstraints()
 
         animation.translatesAutoresizingMaskIntoConstraints = false
         addSubview(animation)
@@ -47,6 +54,23 @@ class PlayPauseButton: BasePlayPauseButton {
             animation.widthAnchor.constraint(equalTo: circleView.widthAnchor, multiplier: 0.48),
             animation.heightAnchor.constraint(equalTo: circleView.heightAnchor, multiplier: 0.48)
         ])
+    }
+
+    private func updateCircleSizeConstraints() {
+        guard circleView.superview != nil else { return }
+        NSLayoutConstraint.deactivate(circleSizeConstraints)
+        if let visualSize {
+            circleSizeConstraints = [
+                circleView.widthAnchor.constraint(equalToConstant: visualSize),
+                circleView.heightAnchor.constraint(equalToConstant: visualSize)
+            ]
+        } else {
+            circleSizeConstraints = [
+                circleView.widthAnchor.constraint(equalTo: widthAnchor),
+                circleView.heightAnchor.constraint(equalTo: heightAnchor)
+            ]
+        }
+        NSLayoutConstraint.activate(circleSizeConstraints)
     }
 
     // When using UIVIew.animate LottieAnimationView doesn't play nice with it


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-479.

This PR updates the "Mini Player" with the new design – this was the first thing that was broken the most with `UIDesignRequiresCompatibility` off.

The new design spec also included a couple of minor changes to the layout. The controls are now strictly on the right, so it's now much easier to tap the bar to open the full player – it requires much less precision. The "next up" was removed as there is a dedicated tab bar item for that, and it's available in a full player. The progress view is also replaced by "time left" label.

**Note**: it's the first iteration and it's under the FF. There a couple of open discussion in the channel around it.

<img width="360" alt="Screenshot 2026-04-27 at 4 42 46 PM" src="https://github.com/user-attachments/assets/769612fe-cbe5-4f38-9ce1-8b4d7fbc1916" />


## Test Instructions

**Setup**: Enable “Liquid Glass” FF and set `UIDesignRequiresCompatibility` to `NO` in podcasts-Info.plist

- **Verify** that legacy “Mini Player” works with no changes
- **Verify** that buttons have a nice large tappable area
- **Verify** that hide/show animations work well (had some hiccups there)
- **Verify** that is does NOT resize for the dynamic size (just like the tab bar)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
