### PR TITLE
Liquid Glass: Add MiniPlayerGlassProgressView

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -573,6 +573,7 @@
 		BD1F07F91BAAA6F0007A768D /* CategoryPodcastsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1F07F71BAAA6F0007A768D /* CategoryPodcastsViewController.swift */; };
 		BD1F07FA1BAAA6F0007A768D /* CategoryPodcastsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD1F07F81BAAA6F0007A768D /* CategoryPodcastsViewController.xib */; };
 		BD1F977C1FD7894C00F89CCD /* MiniPlayerShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1F977B1FD7894C00F89CCD /* MiniPlayerShadowView.swift */; };
+		FF26A9924A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9934A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift */; };
 		BD1F97821FD7C64600F89CCD /* PlaylistViewController+TableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1F97811FD7C64600F89CCD /* PlaylistViewController+TableData.swift */; };
 		BD21D4A222DED42100D5888B /* ThemeableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21D4A122DED42100D5888B /* ThemeableView.swift */; };
 		BD2219F1253EAEAF000025BE /* PlaybackCatchUpHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2219F0253EAEAF000025BE /* PlaybackCatchUpHelper.swift */; };
@@ -2077,6 +2078,7 @@
 		BD1F07F71BAAA6F0007A768D /* CategoryPodcastsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryPodcastsViewController.swift; sourceTree = "<group>"; };
 		BD1F07F81BAAA6F0007A768D /* CategoryPodcastsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CategoryPodcastsViewController.xib; sourceTree = "<group>"; };
 		BD1F977B1FD7894C00F89CCD /* MiniPlayerShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerShadowView.swift; sourceTree = "<group>"; };
+		FF26A9934A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerGlassProgressView.swift; sourceTree = "<group>"; };
 		BD1F97811FD7C64600F89CCD /* PlaylistViewController+TableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaylistViewController+TableData.swift"; sourceTree = "<group>"; };
 		BD2063301B5351D500DBB592 /* podcasts-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "podcasts-Bridging-Header.h"; sourceTree = "<group>"; };
 		BD21D4A122DED42100D5888B /* ThemeableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeableView.swift; sourceTree = "<group>"; };
@@ -4741,6 +4743,7 @@
 				BD3EB3AD179E622A00D0731C /* MiniPlayerViewController.xib */,
 				BD1F977B1FD7894C00F89CCD /* MiniPlayerShadowView.swift */,
 				FF4E93112BDBF0D800F370AA /* MiniPlayerGradientView.swift */,
+				FF26A9934A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift */,
 				8B907F192AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift */,
 				FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */,
 			);
@@ -6885,6 +6888,7 @@
 				8BC060082AB1FA0400A4FEC6 /* PlayEpisodeIntent.swift in Sources */,
 				40DD88ED215DB18300277A4E /* PlaylistIconChooserCell.swift in Sources */,
 				BD1F977C1FD7894C00F89CCD /* MiniPlayerShadowView.swift in Sources */,
+				FF26A9924A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift in Sources */,
 				9AF6468D2E5B57D800627836 /* PlaylistHeaderView.swift in Sources */,
 				BDC063D2246A66B900208446 /* DownloadManager+SessionManagement.swift in Sources */,
 				9AA14FA72E37EA5900464A5A /* PlaylistsOnboardingCardView.swift in Sources */,

--- a/podcasts/MiniPlayerGlassProgressView.swift
+++ b/podcasts/MiniPlayerGlassProgressView.swift
@@ -1,0 +1,65 @@
+import UIKit
+
+final class MiniPlayerGlassProgressView: UIView {
+    var playbackProgress: CGFloat = 0 {
+        didSet {
+            if playbackProgress != oldValue { setNeedsLayout() }
+        }
+    }
+
+    var downloadProgress: CGFloat = 0 {
+        didSet {
+            if downloadProgress != oldValue { setNeedsLayout() }
+        }
+    }
+
+    var tintColorOverride: UIColor = .black {
+        didSet { applyColors() }
+    }
+
+    private let trackLayer = CALayer()
+    private let downloadLayer = CALayer()
+    private let playbackLayer = CALayer()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        layer.addSublayer(trackLayer)
+        layer.addSublayer(downloadLayer)
+        layer.addSublayer(playbackLayer)
+        applyColors()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func applyColors() {
+        trackLayer.backgroundColor = tintColorOverride.withAlphaComponent(0.10).cgColor
+        downloadLayer.backgroundColor = tintColorOverride.withAlphaComponent(0.25).cgColor
+        playbackLayer.backgroundColor = tintColorOverride.cgColor
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+
+        let width = bounds.width
+        let height = bounds.height
+        let radius = height / 2
+
+        trackLayer.frame = bounds
+        trackLayer.cornerRadius = radius
+
+        let clampedDownload = max(0, min(1, downloadProgress))
+        downloadLayer.frame = CGRect(x: 0, y: 0, width: width * clampedDownload, height: height)
+        downloadLayer.cornerRadius = radius
+
+        let clampedPlayback = max(0, min(1, playbackProgress))
+        playbackLayer.frame = CGRect(x: 0, y: 0, width: width * clampedPlayback, height: height)
+        playbackLayer.cornerRadius = radius
+
+        CATransaction.commit()
+    }
+}

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -41,6 +41,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private var glassGradientLayer: CAGradientLayer?
     private var episodeTitleLabel: UILabel?
     private var episodeTimeLeftLabel: UILabel?
+    private var glassProgressView: MiniPlayerGlassProgressView?
 
 
     override func viewDidLoad() {
@@ -124,11 +125,20 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         timeLeft.adjustsFontForContentSizeCategory = false
         episodeTimeLeftLabel = timeLeft
 
-        let textStack = UIStackView(arrangedSubviews: [title, timeLeft])
+        let progressView = MiniPlayerGlassProgressView()
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        glassProgressView = progressView
+
+        let bottomRow = UIStackView(arrangedSubviews: [progressView, timeLeft])
+        bottomRow.axis = .horizontal
+        bottomRow.alignment = .center
+        bottomRow.spacing = 8
+
+        let textStack = UIStackView(arrangedSubviews: [title, bottomRow])
         textStack.translatesAutoresizingMaskIntoConstraints = false
         textStack.axis = .vertical
         textStack.alignment = .leading
-        textStack.spacing = 1
+        textStack.spacing = 2
 
         let buttonStack = UIStackView(arrangedSubviews: [skipBackBtn, playPauseBtn, skipFwdBtn])
         buttonStack.translatesAutoresizingMaskIntoConstraints = false
@@ -153,6 +163,9 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             textStack.leadingAnchor.constraint(equalTo: podcastArtwork.trailingAnchor, constant: 10),
             textStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
             textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: 4),
+
+            progressView.widthAnchor.constraint(equalToConstant: 50),
+            progressView.heightAnchor.constraint(equalToConstant: 5),
 
             skipBackBtn.widthAnchor.constraint(equalToConstant: 70),
             playPauseBtn.widthAnchor.constraint(equalToConstant: 70),
@@ -366,6 +379,17 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             playbackProgressView.buferredAmount = CGFloat(amountBuferred / (duration - currentTime))
         }
 
+        if let glassProgressView {
+            let downloadProgress: CGFloat
+            if duration > 0 {
+                downloadProgress = min(1, CGFloat((currentTime + amountBuferred) / duration))
+            } else {
+                downloadProgress = 0
+            }
+            glassProgressView.playbackProgress = progress
+            glassProgressView.downloadProgress = downloadProgress
+        }
+
         if let episodeTimeLeftLabel {
             let remaining = max(0, duration - currentTime)
             let newText: String?
@@ -425,6 +449,8 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         skipBackBtn.tintColor = iconColor
         skipFwdBtn.tintColor = iconColor
+
+        glassProgressView?.tintColorOverride = actionColor
 
         glassGradientLayer?.colors = [
             actionColor.withAlphaComponent(0.06).cgColor,

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -120,7 +120,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         let timeLeft = UILabel()
         timeLeft.translatesAutoresizingMaskIntoConstraints = false
-        timeLeft.font = .font(ofSize: 11, weight: .regular, scalingWith: .footnote)
+        timeLeft.font = .font(ofSize: 10, weight: .regular, scalingWith: .footnote)
         timeLeft.numberOfLines = 1
         timeLeft.adjustsFontForContentSizeCategory = false
         episodeTimeLeftLabel = timeLeft


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-625.

<img width="456" height="227" alt="image" src="https://github.com/user-attachments/assets/e1255e10-7896-4482-ba73-1aa23568dc06" />

## To test

- **Verify** that it shows download progress when playing like the previous mini-player does.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
