### PR TITLE
Liquid Glass: Mini player as UITabBarAccessory

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -349,6 +349,8 @@
 		8B87C47C29F0129A00257B96 /* EpisodeArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87C47B29F0129A00257B96 /* EpisodeArtwork.swift */; };
 		8B907F182AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B907F172AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift */; };
 		8B907F1A2AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B907F192AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift */; };
+		FF26A9924A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */; };
+		FF26A9974A1B5C2D00000003 /* LiquidGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9984A1B5C2D00000003 /* LiquidGlass.swift */; };
 		8B9D233F2C41B1BE004CD57D /* TranscriptShelfButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9D233E2C41B1BE004CD57D /* TranscriptShelfButton.swift */; };
 		8B9DEFD62906D1CE00075EAB /* EndOfYear.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8B9DEFD52906D1CE00075EAB /* EndOfYear.xcassets */; };
 		8BA55A1528CA8FEB002BECC5 /* PrivacySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */; };
@@ -1858,6 +1860,8 @@
 		8B87C47B29F0129A00257B96 /* EpisodeArtwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeArtwork.swift; sourceTree = "<group>"; };
 		8B907F172AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MiniPlayerViewController+TransitionDelegate.swift"; sourceTree = "<group>"; };
 		8B907F192AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerToFullPlayerAnimator.swift; sourceTree = "<group>"; };
+		FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassPlayerAnimator.swift; sourceTree = "<group>"; };
+		FF26A9984A1B5C2D00000003 /* LiquidGlass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlass.swift; sourceTree = "<group>"; };
 		8B9D233E2C41B1BE004CD57D /* TranscriptShelfButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptShelfButton.swift; sourceTree = "<group>"; };
 		8B9DEFD52906D1CE00075EAB /* EndOfYear.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = EndOfYear.xcassets; sourceTree = "<group>"; };
 		8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsViewController.swift; sourceTree = "<group>"; };
@@ -3793,6 +3797,7 @@
 				BDB5F0CC20450FDC00437669 /* Enumerations.swift */,
 				BDD525372047782600AAD211 /* SJUIUtils.swift */,
 				BDF15A4D1B54E8F0000EC323 /* Constants.swift */,
+				FF26A9984A1B5C2D00000003 /* LiquidGlass.swift */,
 				BDD3018D1EFB9574004A9972 /* WatchConstants.swift */,
 				BD48D5A5216DB26A00391F9E /* HapticsHelper.swift */,
 				C7C4CAF228ABFD0900CFC8CF /* Notifications.swift */,
@@ -7172,6 +7177,7 @@
 				BD03DF8C1CACDB75005A127E /* ButtonCell.swift in Sources */,
 				8B907F1A2AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift in Sources */,
 				FF26A9924A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift in Sources */,
+				FF26A9974A1B5C2D00000003 /* LiquidGlass.swift in Sources */,
 				4085299F247C9682007FE8AA /* SupporterContributionsViewController.swift in Sources */,
 				BDB165E0208078D5007B57CD /* DownloadManager+URLSessionDelegate.swift in Sources */,
 				C713D4F62A04C90500A78468 /* AccountHeaderView.swift in Sources */,

--- a/podcasts/Extensions/UIScrollView+MiniPlayer.swift
+++ b/podcasts/Extensions/UIScrollView+MiniPlayer.swift
@@ -2,6 +2,8 @@ import Foundation
 
 extension UIScrollView {
     func applyInsetForMiniPlayer(additionalBottomInset: CGFloat = 0) {
+        guard !LiquidGlass.isEnabled else {return }
+
         let existingInset = contentInset
         contentInset = UIEdgeInsets(top: existingInset.top, left: existingInset.left, bottom: existingInset.bottom + Constants.Values.miniPlayerOffset + additionalBottomInset, right: existingInset.right)
 
@@ -10,6 +12,8 @@ extension UIScrollView {
     }
 
     func updateContentInset(multiSelectEnabled: Bool, ignoreMiniPlayer: Bool = false) {
+        guard !LiquidGlass.isEnabled else {return }
+
         let existingInset = contentInset
         let multiSelectFooterOffset: CGFloat = multiSelectEnabled ? 80 : 0
         let miniPlayerOffset: CGFloat = (ignoreMiniPlayer || PlaybackManager.shared.currentEpisode() == nil) ? 0 : Constants.Values.miniPlayerOffset

--- a/podcasts/LiquidGlass.swift
+++ b/podcasts/LiquidGlass.swift
@@ -1,0 +1,10 @@
+import Foundation
+import PocketCastsUtils
+
+enum LiquidGlass {
+    static var isEnabled: Bool {
+        guard FeatureFlag.liquidGlass.enabled else { return false }
+        if #available(iOS 26.0, *) { return true }
+        return false
+    }
+}

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -262,16 +262,25 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         let miniPlayer = MiniPlayerViewController(nibName: "MiniPlayerViewController", bundle: nil)
         NavigationManager.sharedManager.miniPlayer = miniPlayer
 
-        miniPlayer.view.translatesAutoresizingMaskIntoConstraints = false
-        view.insertSubview(miniPlayer.view, belowSubview: tabBar)
+        if miniPlayer.isUsingTabAccessory, #available(iOS 26.0, *) {
+            addChild(miniPlayer)
+            miniPlayer.didMove(toParent: self)
+            tabBarMinimizeBehavior = .onScrollDown
+            // Load the view so XIB outlets and observers are wired up before
+            // it's installed as a tab accessory contentView.
+            miniPlayer.loadViewIfNeeded()
+        } else {
+            miniPlayer.view.translatesAutoresizingMaskIntoConstraints = false
+            view.insertSubview(miniPlayer.view, belowSubview: tabBar)
 
-        NSLayoutConstraint.activate([
-            miniPlayer.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            miniPlayer.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            miniPlayer.view.bottomAnchor.constraint(equalTo: tabBar.topAnchor)
-        ])
+            NSLayoutConstraint.activate([
+                miniPlayer.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                miniPlayer.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                miniPlayer.view.bottomAnchor.constraint(equalTo: tabBar.topAnchor)
+            ])
 
-        miniPlayer.changeHeightTo(miniPlayer.desiredHeight())
+            miniPlayer.changeHeightTo(miniPlayer.desiredHeight())
+        }
     }
 
     // MARK: - UITabBarDelegate

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -265,7 +265,6 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         if miniPlayer.isUsingTabAccessory, #available(iOS 26.0, *) {
             addChild(miniPlayer)
             miniPlayer.didMove(toParent: self)
-            tabBarMinimizeBehavior = .onScrollDown
             // Load the view so XIB outlets and observers are wired up before
             // it's installed as a tab accessory contentView.
             miniPlayer.loadViewIfNeeded()

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -262,7 +262,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         let miniPlayer = MiniPlayerViewController(nibName: "MiniPlayerViewController", bundle: nil)
         NavigationManager.sharedManager.miniPlayer = miniPlayer
 
-        if miniPlayer.isUsingTabAccessory, #available(iOS 26.0, *) {
+        if LiquidGlass.isEnabled, #available(iOS 26.0, *) {
             addChild(miniPlayer)
             miniPlayer.didMove(toParent: self)
             // Load the view so XIB outlets and observers are wired up before

--- a/podcasts/MiniPlayerGlassProgressView.swift
+++ b/podcasts/MiniPlayerGlassProgressView.swift
@@ -8,7 +8,7 @@ final class MiniPlayerGlassProgressView: UIView {
     }
 
     var tintColorOverride: UIColor = .black {
-        didSet { applyColors() }
+        didSet { playbackLayer.backgroundColor = tintColorOverride.cgColor }
     }
 
     private let trackLayer = CALayer()
@@ -18,16 +18,12 @@ final class MiniPlayerGlassProgressView: UIView {
         super.init(frame: frame)
         layer.addSublayer(trackLayer)
         layer.addSublayer(playbackLayer)
-        applyColors()
+        trackLayer.backgroundColor = UIColor.gray.withAlphaComponent(0.3).cgColor
+        playbackLayer.backgroundColor = tintColorOverride.cgColor
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    private func applyColors() {
-        trackLayer.backgroundColor = tintColorOverride.withAlphaComponent(0.1).cgColor
-        playbackLayer.backgroundColor = tintColorOverride.cgColor
     }
 
     override func layoutSubviews() {

--- a/podcasts/MiniPlayerGlassProgressView.swift
+++ b/podcasts/MiniPlayerGlassProgressView.swift
@@ -26,7 +26,7 @@ final class MiniPlayerGlassProgressView: UIView {
     }
 
     private func applyColors() {
-        trackLayer.backgroundColor = tintColorOverride.withAlphaComponent(0.25).cgColor
+        trackLayer.backgroundColor = tintColorOverride.withAlphaComponent(0.1).cgColor
         playbackLayer.backgroundColor = tintColorOverride.cgColor
     }
 

--- a/podcasts/MiniPlayerGlassProgressView.swift
+++ b/podcasts/MiniPlayerGlassProgressView.swift
@@ -7,24 +7,16 @@ final class MiniPlayerGlassProgressView: UIView {
         }
     }
 
-    var downloadProgress: CGFloat = 0 {
-        didSet {
-            if downloadProgress != oldValue { setNeedsLayout() }
-        }
-    }
-
     var tintColorOverride: UIColor = .black {
         didSet { applyColors() }
     }
 
     private let trackLayer = CALayer()
-    private let downloadLayer = CALayer()
     private let playbackLayer = CALayer()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
         layer.addSublayer(trackLayer)
-        layer.addSublayer(downloadLayer)
         layer.addSublayer(playbackLayer)
         applyColors()
     }
@@ -34,8 +26,7 @@ final class MiniPlayerGlassProgressView: UIView {
     }
 
     private func applyColors() {
-        trackLayer.backgroundColor = tintColorOverride.withAlphaComponent(0.10).cgColor
-        downloadLayer.backgroundColor = tintColorOverride.withAlphaComponent(0.25).cgColor
+        trackLayer.backgroundColor = tintColorOverride.withAlphaComponent(0.25).cgColor
         playbackLayer.backgroundColor = tintColorOverride.cgColor
     }
 
@@ -51,10 +42,6 @@ final class MiniPlayerGlassProgressView: UIView {
 
         trackLayer.frame = bounds
         trackLayer.cornerRadius = radius
-
-        let clampedDownload = max(0, min(1, downloadProgress))
-        downloadLayer.frame = CGRect(x: 0, y: 0, width: width * clampedDownload, height: height)
-        downloadLayer.cornerRadius = radius
 
         let clampedPlayback = max(0, min(1, playbackProgress))
         playbackLayer.frame = CGRect(x: 0, y: 0, width: width * clampedPlayback, height: height)

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -6,6 +6,7 @@ extension MiniPlayerViewController {
         if isUsingTabAccessory, #available(iOS 26.0, *) {
             guard let tabBarController = parent as? UITabBarController, tabBarController.bottomAccessory != nil else { return }
             tabBarController.setBottomAccessory(nil, animated: animated)
+            tabBarController.tabBarMinimizeBehavior = .never
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.miniPlayerDidDisappear)
             return
         }
@@ -35,6 +36,7 @@ extension MiniPlayerViewController {
             guard let tabBarController = parent as? UITabBarController, tabBarController.bottomAccessory == nil else { return }
             let accessory = UITabAccessory(contentView: view)
             tabBarController.setBottomAccessory(accessory, animated: true)
+            tabBarController.tabBarMinimizeBehavior = .onScrollDown
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.miniPlayerDidAppear)
             return
         }

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -3,6 +3,13 @@ import PocketCastsUtils
 
 extension MiniPlayerViewController {
     func hideMiniPlayer(_ animated: Bool) {
+        if isUsingTabAccessory, #available(iOS 26.0, *) {
+            guard let tabBarController = parent as? UITabBarController, tabBarController.bottomAccessory != nil else { return }
+            tabBarController.setBottomAccessory(nil, animated: animated)
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.miniPlayerDidDisappear)
+            return
+        }
+
         if !miniPlayerShowing() { return } // already hidden
 
         if animated {
@@ -21,10 +28,18 @@ extension MiniPlayerViewController {
     }
 
     func showMiniPlayer() {
-        if miniPlayerShowing() { return }
-
         // only show if something is playing
         if PlaybackManager.shared.currentEpisode() == nil { return }
+
+        if isUsingTabAccessory, #available(iOS 26.0, *) {
+            guard let tabBarController = parent as? UITabBarController, tabBarController.bottomAccessory == nil else { return }
+            let accessory = UITabAccessory(contentView: view)
+            tabBarController.setBottomAccessory(accessory, animated: true)
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.miniPlayerDidAppear)
+            return
+        }
+
+        if miniPlayerShowing() { return }
 
         changeHeightTo(desiredHeight())
         moveToHiddenBottomPosition()

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 
 extension MiniPlayerViewController {
     func hideMiniPlayer(_ animated: Bool) {
-        if isUsingTabAccessory, #available(iOS 26.0, *) {
+        if LiquidGlass.isEnabled, #available(iOS 26, *) {
             guard let tabBarController = parent as? UITabBarController, tabBarController.bottomAccessory != nil else { return }
             tabBarController.setBottomAccessory(nil, animated: animated)
             tabBarController.tabBarMinimizeBehavior = .never
@@ -32,7 +32,7 @@ extension MiniPlayerViewController {
         // only show if something is playing
         if PlaybackManager.shared.currentEpisode() == nil { return }
 
-        if isUsingTabAccessory, #available(iOS 26.0, *) {
+        if LiquidGlass.isEnabled, #available(iOS 26.0, *) {
             guard let tabBarController = parent as? UITabBarController, tabBarController.bottomAccessory == nil else { return }
             let accessory = UITabAccessory(contentView: view)
             tabBarController.setBottomAccessory(accessory, animated: true)

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -14,6 +14,10 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     @IBOutlet var skipBackBtn: UIButton!
     @IBOutlet var skipFwdBtn: UIButton!
 
+    @IBOutlet var skipBackBtnWidthConstraint: NSLayoutConstraint!
+    @IBOutlet var playPauseBtnWidthConstraint: NSLayoutConstraint!
+    @IBOutlet var skipFwdBtnWidthConstraint: NSLayoutConstraint!
+
     @IBOutlet var upNextBtn: UpNextButton!
 
     @IBOutlet var playbackProgressView: ProgressLine!
@@ -40,6 +44,9 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private var episodeTitleLabel: UILabel?
     private var episodeTimeLeftLabel: UILabel?
     private var glassProgressView: MiniPlayerGlassProgressView?
+
+    private var glassButtonStack: UIStackView?
+    private var accessoryEnvironmentConstraints: [NSLayoutConstraint] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -122,6 +129,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         buttonStack.translatesAutoresizingMaskIntoConstraints = false
         buttonStack.axis = .horizontal
         buttonStack.alignment = .center
+        glassButtonStack = buttonStack
 
         view.addSubview(podcastArtwork)
         view.addSubview(textStack)
@@ -137,18 +145,34 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             textStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: 2),
 
-            progressView.widthAnchor.constraint(equalToConstant: 40),
             progressView.heightAnchor.constraint(equalToConstant: 5),
-
-            skipBackBtn.widthAnchor.constraint(equalToConstant: 70),
-            playPauseBtn.widthAnchor.constraint(equalToConstant: 70),
-            skipFwdBtn.widthAnchor.constraint(equalToConstant: 70),
 
             buttonStack.topAnchor.constraint(equalTo: view.topAnchor),
             buttonStack.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -8),
             buttonStack.heightAnchor.constraint(equalToConstant: 56),
         ])
+
+        view.registerForTraitChanges([UITraitTabAccessoryEnvironment.self]) { (view: UIView, _) in
+            view.setNeedsUpdateConstraints()
+        }
+    }
+
+    override func updateViewConstraints() {
+        if #available(iOS 26.0, *), let glassButtonStack, let glassProgressView {
+            let isInline = view.traitCollection.tabAccessoryEnvironment == .inline
+            let buttonWidth: CGFloat = isInline ? 40 : 44
+            skipBackBtnWidthConstraint.constant = buttonWidth
+            playPauseBtnWidthConstraint.constant = buttonWidth
+            skipFwdBtnWidthConstraint.constant = buttonWidth
+
+            NSLayoutConstraint.deactivate(accessoryEnvironmentConstraints)
+            accessoryEnvironmentConstraints = [
+                glassProgressView.widthAnchor.constraint(equalToConstant: isInline ? 34 : 40),
+                glassButtonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: isInline ? -4 : -8),
+            ]
+            NSLayoutConstraint.activate(accessoryEnvironmentConstraints)
+        }
+        super.updateViewConstraints()
     }
 
     deinit {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -143,9 +143,9 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
             textStack.leadingAnchor.constraint(equalTo: podcastArtwork.trailingAnchor, constant: 10),
             textStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: -4),
+            textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: 2),
 
-            progressView.widthAnchor.constraint(equalToConstant: 50),
+            progressView.widthAnchor.constraint(equalToConstant: 44),
             progressView.heightAnchor.constraint(equalToConstant: 5),
 
             skipBackBtn.widthAnchor.constraint(equalToConstant: 70),
@@ -154,7 +154,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
             buttonStack.topAnchor.constraint(equalTo: view.topAnchor),
             buttonStack.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -4),
+            buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -8),
             buttonStack.heightAnchor.constraint(equalToConstant: 56),
         ])
     }

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -145,7 +145,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             textStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: 2),
 
-            progressView.widthAnchor.constraint(equalToConstant: 44),
+            progressView.widthAnchor.constraint(equalToConstant: 40),
             progressView.heightAnchor.constraint(equalToConstant: 5),
 
             skipBackBtn.widthAnchor.constraint(equalToConstant: 70),

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -41,14 +41,6 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private var episodeTimeLeftLabel: UILabel?
     private var glassProgressView: MiniPlayerGlassProgressView?
 
-    var isUsingTabAccessory: Bool {
-        if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
-            return true
-        }
-        return false
-    }
-
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -294,9 +286,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     }
 
     func miniPlayerShowing() -> Bool {
-        if isUsingTabAccessory, #available(iOS 26, *) {
-            return (parent as? UITabBarController)?.bottomAccessory != nil
-        }
+        assert(!LiquidGlass.isEnabled, "Should never be used when Liquid Glass is on")
         return !view.isHidden
     }
 
@@ -341,7 +331,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     }
 
     @objc private func statusBarHeightDidChange() {
-        if miniPlayerShowing() {
+        if !LiquidGlass.isEnabled, miniPlayerShowing() {
             hideMiniPlayer(false)
             showMiniPlayer()
         }

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -386,16 +386,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             playbackProgressView.buferredAmount = CGFloat(amountBuferred / (duration - currentTime))
         }
 
-        if let glassProgressView {
-            let downloadProgress: CGFloat
-            if duration > 0 {
-                downloadProgress = min(1, CGFloat((currentTime + amountBuferred) / duration))
-            } else {
-                downloadProgress = 0
-            }
-            glassProgressView.playbackProgress = progress
-            glassProgressView.downloadProgress = downloadProgress
-        }
+        glassProgressView?.playbackProgress = progress
 
         if let episodeTimeLeftLabel {
             let remaining = max(0, duration - currentTime)

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -37,11 +37,16 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
     private let analyticsPlaybackHelper = AnalyticsPlaybackHelper.shared
 
-    private var glassContainer: UIVisualEffectView?
-    private var glassGradientLayer: CAGradientLayer?
     private var episodeTitleLabel: UILabel?
     private var episodeTimeLeftLabel: UILabel?
     private var glassProgressView: MiniPlayerGlassProgressView?
+
+    var isUsingTabAccessory: Bool {
+        if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
+            return true
+        }
+        return false
+    }
 
 
     override func viewDidLoad() {
@@ -70,30 +75,11 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private func setupLiquidGlassLayout() {
         gradientView.isHidden = true
         shadowView.isHidden = true
-        mainView.backgroundColor = .clear
-        mainView.layer.cornerRadius = 0
+        mainView.isHidden = true
         playbackProgressView.isHidden = true
         upNextBtn.isHidden = true
 
-
-        let effectView = UIVisualEffectView(effect: {
-            let effect = UIGlassEffect(style: .regular)
-            effect.isInteractive = true
-            return effect
-        }())
-        effectView.translatesAutoresizingMaskIntoConstraints = false
-        effectView.clipsToBounds = true
-        effectView.layer.cornerCurve = .continuous
-        view.addSubview(effectView)
-        glassContainer = effectView
-
-        let contentView = effectView.contentView
-
-        let gradientLayer = CAGradientLayer()
-        gradientLayer.startPoint = CGPoint(x: 0, y: 0.5)
-        gradientLayer.endPoint = CGPoint(x: 1, y: 0.5)
-        contentView.layer.insertSublayer(gradientLayer, at: 0)
-        glassGradientLayer = gradientLayer
+        view.backgroundColor = .clear
 
         podcastArtwork.removeFromSuperview()
         skipBackBtn.removeFromSuperview()
@@ -112,7 +98,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         let title = UILabel()
         title.translatesAutoresizingMaskIntoConstraints = false
-        title.font = .font(ofSize: 12, weight: .medium, scalingWith: .subheadline)
+        title.font = .font(ofSize: 13, weight: .medium, scalingWith: .subheadline)
         title.numberOfLines = 1
         title.lineBreakMode = .byTruncatingTail
         title.adjustsFontForContentSizeCategory = false
@@ -145,24 +131,19 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         buttonStack.axis = .horizontal
         buttonStack.alignment = .center
 
-        contentView.addSubview(podcastArtwork)
-        contentView.addSubview(textStack)
-        contentView.addSubview(buttonStack)
+        view.addSubview(podcastArtwork)
+        view.addSubview(textStack)
+        view.addSubview(buttonStack)
 
         NSLayoutConstraint.activate([
-            effectView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            effectView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            effectView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -8),
-            effectView.heightAnchor.constraint(equalToConstant: 48),
-
-            podcastArtwork.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-            podcastArtwork.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            podcastArtwork.widthAnchor.constraint(equalToConstant: 30),
-            podcastArtwork.heightAnchor.constraint(equalToConstant: 30),
+            podcastArtwork.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
+            podcastArtwork.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            podcastArtwork.widthAnchor.constraint(equalToConstant: 32),
+            podcastArtwork.heightAnchor.constraint(equalToConstant: 32),
 
             textStack.leadingAnchor.constraint(equalTo: podcastArtwork.trailingAnchor, constant: 10),
-            textStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-            textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: 4),
+            textStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: -4),
 
             progressView.widthAnchor.constraint(equalToConstant: 50),
             progressView.heightAnchor.constraint(equalToConstant: 5),
@@ -171,22 +152,11 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             playPauseBtn.widthAnchor.constraint(equalToConstant: 70),
             skipFwdBtn.widthAnchor.constraint(equalToConstant: 70),
 
-            buttonStack.topAnchor.constraint(equalTo: contentView.topAnchor),
-            buttonStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            buttonStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10),
+            buttonStack.topAnchor.constraint(equalTo: view.topAnchor),
+            buttonStack.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -4),
+            buttonStack.heightAnchor.constraint(equalToConstant: 56),
         ])
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        if let glassContainer {
-            glassContainer.layer.cornerRadius = glassContainer.bounds.height / 2
-            CATransaction.begin()
-            CATransaction.setDisableActions(true)
-            glassGradientLayer?.frame = glassContainer.contentView.bounds
-            CATransaction.commit()
-        }
     }
 
     deinit {
@@ -324,7 +294,10 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     }
 
     func miniPlayerShowing() -> Bool {
-        !view.isHidden
+        if isUsingTabAccessory, #available(iOS 26, *) {
+            return (parent as? UITabBarController)?.bottomAccessory != nil
+        }
+        return !view.isHidden
     }
 
     private func setupForEpisode(_ episode: BaseEpisode) {
@@ -476,7 +449,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         let bgColor = ThemeColor.primaryUi02()
 
         episodeTitleLabel?.textColor = ThemeColor.primaryText01()
-        episodeTimeLeftLabel?.textColor = ThemeColor.primaryText01()
+        episodeTimeLeftLabel?.textColor = ThemeColor.primaryText02()
 
         playPauseBtn.playButtonColor = bgColor
         playPauseBtn.circleColor = iconColor
@@ -485,11 +458,6 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         skipFwdBtn.tintColor = iconColor
 
         glassProgressView?.tintColorOverride = actionColor
-
-        glassGradientLayer?.colors = [
-            actionColor.withAlphaComponent(0.06).cgColor,
-            actionColor.withAlphaComponent(0.09).cgColor,
-        ]
     }
 
     private func currentPodcastTintColor() -> UIColor {

--- a/podcasts/MiniPlayerViewController.xib
+++ b/podcasts/MiniPlayerViewController.xib
@@ -17,8 +17,11 @@
                 <outlet property="playbackProgressView" destination="aWD-bx-vF2" id="vpI-fM-bgO"/>
                 <outlet property="podcastArtwork" destination="tJx-CO-hRe" id="Kzl-ZM-bdq"/>
                 <outlet property="shadowView" destination="H6s-IT-ngQ" id="r3I-mU-Ie7"/>
+                <outlet property="playPauseBtnWidthConstraint" destination="Q9t-vc-8fw" id="WP2-Mn-Ply"/>
                 <outlet property="skipBackBtn" destination="92g-6h-Yd9" id="i61-v9-wgd"/>
+                <outlet property="skipBackBtnWidthConstraint" destination="nOK-wd-Pse" id="WB1-Mn-Ply"/>
                 <outlet property="skipFwdBtn" destination="JHq-wc-GDV" id="Pkp-0D-lfF"/>
+                <outlet property="skipFwdBtnWidthConstraint" destination="lSC-b9-3WW" id="WF3-Mn-Ply"/>
                 <outlet property="upNextBtn" destination="nTH-nm-IG6" id="QNQ-hP-BL6"/>
                 <outlet property="view" destination="1" id="3"/>
             </connections>

--- a/podcasts/WhatsNewViewController.swift
+++ b/podcasts/WhatsNewViewController.swift
@@ -56,7 +56,7 @@ class WhatsNewViewController: PCViewController, UIScrollViewDelegate, TinyPageCo
         scrollView.isPagingEnabled = true
         scrollView.isDirectionalLockEnabled = true
 
-        if Settings.whatsNewLastAcknowledged() == whatsNewInfo.versionCode, appDelegate()?.miniPlayer()?.miniPlayerShowing() ?? false {
+        if !LiquidGlass.isEnabled, Settings.whatsNewLastAcknowledged() == whatsNewInfo.versionCode, appDelegate()?.miniPlayer()?.miniPlayerShowing() ?? false {
             shadowViewBottomConstraint.constant = shadowViewBottomConstraint.constant - Constants.Values.miniPlayerOffset
         }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-641.

A follow-up to https://github.com/Automattic/pocket-casts-ios/pull/4204#issuecomment-4335262840.

- Show mini player using `UITabAccessory`
- Disable redundant `contentInsets` customization. The scroll views adjust automatically based on safe area
- Minor visual improvement to the mini player

**Note:** there may be more work to be done, but nothing should be broken with FF off

https://github.com/user-attachments/assets/0bfa5a35-0b34-4043-a19b-a5fa4afc59e4

## To Test

- Most importantly, **verify** that there is no impact on the production code (code review)
- **Verify** that the tab bar is collapsed on scroll and **only** if mini player is present (native iOS 26 feature)
- **Verify** that the bottom safe area is generally not horribly broken (there are related PRs open)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
