### PR TITLE
[POC-546] Throttle fingerprint stream + cache full mapping per episode

### DIFF
--- a/PocketCastsTests/Tests/Fingerprint/FingerprintMappingCacheTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintMappingCacheTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+
+@testable import podcasts
+
+final class FingerprintMappingCacheTests: XCTestCase {
+
+    typealias Entry = FingerprintTimingManager.TimeMappingEntry
+
+    private var tempDir: URL!
+    private var audioPath: String!
+    private var referenceData: Data!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("FingerprintMappingCacheTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let audioURL = tempDir.appendingPathComponent("episode.mp3")
+        try Data(repeating: 0xab, count: 1024).write(to: audioURL)
+        audioPath = audioURL.path
+
+        referenceData = Data("reference-bytes-v1".utf8)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+        tempDir = nil
+        audioPath = nil
+        referenceData = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Round-trip
+
+    func testFullCoverageMappingRoundTrips() throws {
+        let entries = makeFullCoverageEntries()
+        FingerprintMappingCache.save(
+            entries,
+            audioFilePath: audioPath,
+            referenceData: referenceData,
+            referenceDuration: 100
+        )
+
+        let loaded = try XCTUnwrap(
+            FingerprintMappingCache.load(audioFilePath: audioPath, referenceData: referenceData)
+        )
+        XCTAssertEqual(loaded.entries.count, entries.count)
+        XCTAssertEqual(loaded.referenceDuration, 100, accuracy: 0.001)
+        for (i, original) in entries.enumerated() {
+            XCTAssertEqual(loaded.entries[i].playbackTime, original.playbackTime, accuracy: 0.001)
+            XCTAssertEqual(loaded.entries[i].referenceTime, original.referenceTime, accuracy: 0.001)
+            XCTAssertEqual(loaded.entries[i].score, original.score, accuracy: 0.0001)
+        }
+    }
+
+    // MARK: - Validations
+
+    func testCacheIsRejectedWhenReferenceHashChanges() {
+        FingerprintMappingCache.save(
+            makeFullCoverageEntries(),
+            audioFilePath: audioPath,
+            referenceData: referenceData,
+            referenceDuration: 100
+        )
+
+        let differentReference = Data("different-reference".utf8)
+        XCTAssertNil(FingerprintMappingCache.load(audioFilePath: audioPath, referenceData: differentReference))
+    }
+
+    func testCacheIsRejectedWhenAudioFileSizeChanges() throws {
+        FingerprintMappingCache.save(
+            makeFullCoverageEntries(),
+            audioFilePath: audioPath,
+            referenceData: referenceData,
+            referenceDuration: 100
+        )
+
+        let url = URL(fileURLWithPath: audioPath)
+        try Data(repeating: 0xcd, count: 4096).write(to: url)
+
+        XCTAssertNil(FingerprintMappingCache.load(audioFilePath: audioPath, referenceData: referenceData))
+    }
+
+    func testPartialCoverageCacheIsNotPersisted() {
+        let partial = [
+            Entry(playbackTime: 0, referenceTime: 0, score: 0.9),
+            Entry(playbackTime: 10, referenceTime: 10, score: 0.9)
+        ]
+        FingerprintMappingCache.save(
+            partial,
+            audioFilePath: audioPath,
+            referenceData: referenceData,
+            referenceDuration: 100
+        )
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: FingerprintMappingCache.mappingPath(forAudioFilePath: audioPath))
+        )
+    }
+
+    func testEmptyEntriesAreNotPersisted() {
+        FingerprintMappingCache.save(
+            [],
+            audioFilePath: audioPath,
+            referenceData: referenceData,
+            referenceDuration: 100
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: FingerprintMappingCache.mappingPath(forAudioFilePath: audioPath))
+        )
+    }
+
+    func testMissingCacheLoadsAsNil() {
+        XCTAssertNil(FingerprintMappingCache.load(audioFilePath: audioPath, referenceData: referenceData))
+    }
+
+    // MARK: - Helpers
+
+    private func makeFullCoverageEntries() -> [Entry] {
+        // Reference duration = 100s; last entry at 99s clears fullCoverageThreshold = 0.95.
+        return stride(from: 0.0, through: 99.0, by: 1.0).map {
+            Entry(playbackTime: $0, referenceTime: $0, score: 0.85)
+        }
+    }
+}

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintMappingCacheTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintMappingCacheTests.swift
@@ -82,6 +82,24 @@ final class FingerprintMappingCacheTests: XCTestCase {
         XCTAssertNil(FingerprintMappingCache.load(audioFilePath: audioPath, referenceData: referenceData))
     }
 
+    func testCacheIsRejectedWhenAudioFileMTimeChanges() throws {
+        FingerprintMappingCache.save(
+            makeFullCoverageEntries(),
+            audioFilePath: audioPath,
+            referenceData: referenceData,
+            referenceDuration: 100
+        )
+
+        // Bump mtime well beyond the load path's 1.0s tolerance, leaving size untouched.
+        let bumpedDate = Date(timeIntervalSinceNow: 60)
+        try FileManager.default.setAttributes(
+            [.modificationDate: bumpedDate],
+            ofItemAtPath: audioPath
+        )
+
+        XCTAssertNil(FingerprintMappingCache.load(audioFilePath: audioPath, referenceData: referenceData))
+    }
+
     func testPartialCoverageCacheIsNotPersisted() {
         let partial = [
             Entry(playbackTime: 0, referenceTime: 0, score: 0.9),

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -68,4 +68,27 @@ enum FingerprintConstants {
     /// to reject near-ties, not demand a huge dominance (which would kill real
     /// matches whose nearby reference windows also score decently).
     static let driftScoreDominanceGap: Float = 0.05
+
+    /// Distance ahead of `PlaybackManager.currentTime()` within which the streaming
+    /// fingerprint loop runs at full speed. Beyond this lead, the loop still
+    /// processes every chunk (so coverage still grows to EOF), but it sleeps
+    /// `outsideLookaheadSleepSeconds` between chunks to bound peak CPU usage.
+    /// **Not a hard cap** — chunks are never skipped.
+    static let lookaheadSeconds: Double = 60
+
+    /// Sleep inserted between fingerprint chunks when the next chunk's start is
+    /// further than `lookaheadSeconds` ahead of the listener's current time.
+    /// Bounds peak CPU on long episodes without dropping any region from the
+    /// mapping, so tap-to-seek's dense-coverage invariant is preserved.
+    static let outsideLookaheadSleepSeconds: TimeInterval = 0.5
+
+    /// Fraction of the reference timeline that a cached mapping must cover for
+    /// it to be loaded as a complete replacement for the streaming fingerprint
+    /// pass. Anything less and the cache is ignored: partial caches that seed a
+    /// short-circuit are how the prior POC-546 attempt got stuck in `.preparing`.
+    static let fullCoverageThreshold: Double = 0.95
+
+    /// Persistent cache schema version. Bump when the on-disk shape changes so
+    /// older files are silently discarded on the next load.
+    static let mappingCacheSchemaVersion: Int = 1
 }

--- a/podcasts/Fingerprint/FingerprintMappingCache.swift
+++ b/podcasts/Fingerprint/FingerprintMappingCache.swift
@@ -1,0 +1,148 @@
+import CryptoKit
+import Foundation
+import PocketCastsUtils
+
+/// Persists the committed playback↔reference time mapping next to the audio
+/// file on disk so that re-opening a transcript for a previously-fingerprinted
+/// downloaded episode skips the audio decode + match pipeline entirely.
+///
+/// The cache is *all-or-nothing*: it's loaded only when the cached mapping
+/// covers (by `fullCoverageThreshold`) the whole reference timeline, the
+/// reference fingerprint bytes hash to the same value, and the underlying
+/// audio file's size+mtime are unchanged. Anything less and the cache is
+/// ignored — partial-cache short-circuits are how the prior POC-546 attempt
+/// trapped the timing manager in `.preparing`.
+enum FingerprintMappingCache {
+
+    struct LoadResult {
+        let entries: [FingerprintTimingManager.TimeMappingEntry]
+        let referenceDuration: Double
+    }
+
+    private struct CachedMapping: Codable {
+        let schemaVersion: Int
+        let referenceHash: String
+        let audioByteSize: UInt64
+        let audioMTime: Double
+        let referenceDuration: Double
+        let entries: [CachedEntry]
+
+        struct CachedEntry: Codable {
+            let p: Double
+            let r: Double
+            let s: Float
+        }
+    }
+
+    static func load(
+        audioFilePath: String,
+        referenceData: Data
+    ) -> LoadResult? {
+        let path = mappingPath(forAudioFilePath: audioFilePath)
+        guard let data = FileManager.default.contents(atPath: path) else { return nil }
+        guard let cached = try? JSONDecoder().decode(CachedMapping.self, from: data) else {
+            FileLog.shared.addMessage(
+                "FingerprintMappingCache: failed to decode cache at \(path) — discarding"
+            )
+            return nil
+        }
+        guard cached.schemaVersion == FingerprintConstants.mappingCacheSchemaVersion else {
+            FileLog.shared.addMessage(
+                "FingerprintMappingCache: schema version mismatch at \(path) — discarding"
+            )
+            return nil
+        }
+        guard cached.referenceHash == sha256(referenceData) else {
+            FileLog.shared.addMessage(
+                "FingerprintMappingCache: reference hash mismatch at \(path) — discarding"
+            )
+            return nil
+        }
+        guard let attrs = audioAttributes(at: audioFilePath),
+              attrs.size == cached.audioByteSize,
+              abs(attrs.mtime - cached.audioMTime) < 1.0 else {
+            FileLog.shared.addMessage(
+                "FingerprintMappingCache: audio file changed at \(audioFilePath) — discarding cache"
+            )
+            return nil
+        }
+        guard let last = cached.entries.last,
+              cached.referenceDuration > 0,
+              last.r / cached.referenceDuration >= FingerprintConstants.fullCoverageThreshold else {
+            FileLog.shared.addMessage(
+                "FingerprintMappingCache: partial coverage at \(path) — ignoring (will run full stream)"
+            )
+            return nil
+        }
+        FileLog.shared.addMessage(
+            "FingerprintMappingCache: loaded \(cached.entries.count) cached mappings from \(path)"
+        )
+        return LoadResult(
+            entries: cached.entries.map {
+                FingerprintTimingManager.TimeMappingEntry(
+                    playbackTime: $0.p,
+                    referenceTime: $0.r,
+                    score: $0.s
+                )
+            },
+            referenceDuration: cached.referenceDuration
+        )
+    }
+
+    static func save(
+        _ entries: [FingerprintTimingManager.TimeMappingEntry],
+        audioFilePath: String,
+        referenceData: Data,
+        referenceDuration: Double
+    ) {
+        guard let last = entries.last,
+              referenceDuration > 0,
+              last.referenceTime / referenceDuration >= FingerprintConstants.fullCoverageThreshold else {
+            return
+        }
+        guard let attrs = audioAttributes(at: audioFilePath) else {
+            FileLog.shared.addMessage(
+                "FingerprintMappingCache: cannot stat audio at \(audioFilePath) — skipping save"
+            )
+            return
+        }
+        let path = mappingPath(forAudioFilePath: audioFilePath)
+        let cached = CachedMapping(
+            schemaVersion: FingerprintConstants.mappingCacheSchemaVersion,
+            referenceHash: sha256(referenceData),
+            audioByteSize: attrs.size,
+            audioMTime: attrs.mtime,
+            referenceDuration: referenceDuration,
+            entries: entries.map {
+                CachedMapping.CachedEntry(p: $0.playbackTime, r: $0.referenceTime, s: $0.score)
+            }
+        )
+        do {
+            let data = try JSONEncoder().encode(cached)
+            try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+            FileLog.shared.addMessage(
+                "FingerprintMappingCache: saved \(entries.count) mappings to \(path)"
+            )
+        } catch {
+            FileLog.shared.addMessage(
+                "FingerprintMappingCache: failed to save to \(path) — \(error.localizedDescription)"
+            )
+        }
+    }
+
+    static func mappingPath(forAudioFilePath audioPath: String) -> String {
+        (audioPath as NSString).deletingPathExtension + ".map.fp.json"
+    }
+
+    private static func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func audioAttributes(at path: String) -> (size: UInt64, mtime: Double)? {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path) else { return nil }
+        let size = (attrs[.size] as? NSNumber)?.uint64Value ?? 0
+        let mtime = (attrs[.modificationDate] as? Date)?.timeIntervalSinceReferenceDate ?? 0
+        guard size > 0, mtime > 0 else { return nil }
+        return (size, mtime)
+    }
+}

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -731,17 +731,24 @@ final class FingerprintTimingManager: NSObject {
     /// audio file. The cache is then a complete replacement on next open —
     /// `FingerprintMappingCache.save` enforces the same coverage threshold the
     /// load path requires, keeping the round-trip safe.
+    ///
+    /// Only the snapshot read runs on `queue`; JSON encoding + disk I/O happen
+    /// on `generationQueue` so they don't stall `queue.sync` callers (the
+    /// `referenceTime(forPlaybackTime:)` / `playbackTime(forReferenceTime:)`
+    /// queries that drive transcript highlighting and tap-to-seek).
     private func persistMappingCacheIfFull(context ctx: GenerationContext) {
         guard !ctx.isStreaming else { return }
         queue.async { [weak self] in
             guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
             let snapshot = self.playbackToReference
-            FingerprintMappingCache.save(
-                snapshot,
-                audioFilePath: ctx.audioFileURL.path,
-                referenceData: ctx.referenceData,
-                referenceDuration: ctx.referenceDuration
-            )
+            self.generationQueue.async {
+                FingerprintMappingCache.save(
+                    snapshot,
+                    audioFilePath: ctx.audioFileURL.path,
+                    referenceData: ctx.referenceData,
+                    referenceDuration: ctx.referenceDuration
+                )
+            }
         }
     }
 

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -35,6 +35,12 @@ final class FingerprintTimingManager: NSObject {
         let isStreaming: Bool
         let duration: Double
         let matcher: CheckpointMatcher
+        /// Raw bytes of the reference fingerprint JSON, used to validate the
+        /// persistent mapping cache via SHA-256.
+        let referenceData: Data
+        /// Total duration of the reference timeline, used to gate the persistent
+        /// mapping cache on full coverage.
+        let referenceDuration: Double
         let isCancelled: () -> Bool
     }
 
@@ -210,6 +216,8 @@ final class FingerprintTimingManager: NSObject {
             isStreaming: ctx.isStreaming,
             duration: ctx.duration,
             matcher: ctx.matcher,
+            referenceData: ctx.referenceData,
+            referenceDuration: ctx.referenceDuration,
             isCancelled: { flag.isCancelled }
         )
         context = newContext
@@ -306,8 +314,8 @@ final class FingerprintTimingManager: NSObject {
 
         let uuid = episode.uuid
 
-        if let reference = loadReference(for: episode) {
-            configureForReference(reference, episode: episode)
+        if let loaded = loadReference(for: episode) {
+            configureForReference(loaded.reference, referenceData: loaded.data, episode: episode)
             return
         }
 
@@ -333,12 +341,16 @@ final class FingerprintTimingManager: NSObject {
                 }
 
                 self.saveReferenceData(data, for: episode)
-                self.configureForReference(reference, episode: episode)
+                self.configureForReference(reference, referenceData: data, episode: episode)
             }
         }
     }
 
-    private func configureForReference(_ reference: ReferenceFingerprint, episode: BaseEpisode) {
+    private func configureForReference(
+        _ reference: ReferenceFingerprint,
+        referenceData: Data,
+        episode: BaseEpisode
+    ) {
         let uuid = episode.uuid
 
         let source = resolveAudioSource(for: episode)
@@ -401,6 +413,8 @@ final class FingerprintTimingManager: NSObject {
             isStreaming: isStreaming,
             duration: duration,
             matcher: matcher,
+            referenceData: referenceData,
+            referenceDuration: reference.totalDuration,
             isCancelled: { flag.isCancelled }
         )
         context = newContext
@@ -409,6 +423,27 @@ final class FingerprintTimingManager: NSObject {
         FileLog.shared.addMessage(
             "FingerprintTimingManager: preparing for \(uuid) (\(libraryCheckpoints.count) checkpoints)"
         )
+
+        // All-or-nothing cache: only short-circuit the stream if a previous
+        // session persisted a mapping that covers the whole reference timeline
+        // for this exact audio file + reference. Partial caches are ignored
+        // (the failed branch's `inRange` short-circuit on partial coverage was
+        // what trapped the manager in `.preparing`).
+        if !isStreaming,
+           let cached = FingerprintMappingCache.load(
+               audioFilePath: audioFileURL.path,
+               referenceData: referenceData
+           ) {
+            for entry in cached.entries {
+                insertMapping(entry)
+            }
+            filterLastTrusted = cached.entries.last
+            updateState(.active(coverage: cached.entries.count))
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: skipping stream — full mapping loaded from cache for \(uuid)"
+            )
+            return
+        }
 
         let startPosition = PlaybackManager.shared.currentTime()
         startStream(context: newContext, fromPosition: startPosition)
@@ -437,6 +472,7 @@ final class FingerprintTimingManager: NSObject {
                     "FingerprintTimingManager: streaming fingerprint completed (started at \(String(format: "%.1f", aligned))s)"
                 )
                 #endif
+                self.persistMappingCacheIfFull(context: ctx)
                 self.finishIfStillPreparing(terminalState: .unavailable, context: ctx)
             } catch StreamError.cancelled {
                 #if DEBUG
@@ -508,6 +544,8 @@ final class FingerprintTimingManager: NSObject {
 
         while true {
             if ctx.isCancelled() { throw StreamError.cancelled }
+            let nextChunkStartSeconds = Double(audioFile.framePosition) / format.sampleRate
+            try throttleIfBeyondLookahead(nextChunkStartSeconds: nextChunkStartSeconds, context: ctx)
             try audioFile.read(into: buffer, frameCount: chunkFrames)
             if buffer.frameLength == 0 { break }
 
@@ -638,6 +676,9 @@ final class FingerprintTimingManager: NSObject {
             let framesAvailable = AVAudioFrameCount(safeEnd - lastProcessedFrame)
             let framesToRead = min(framesAvailable, chunkFrames)
 
+            let nextChunkStartSeconds = Double(lastProcessedFrame) / fmt.sampleRate
+            try throttleIfBeyondLookahead(nextChunkStartSeconds: nextChunkStartSeconds, context: ctx)
+
             do {
                 try audioFile.read(into: buf, frameCount: framesToRead)
             } catch {
@@ -682,6 +723,45 @@ final class FingerprintTimingManager: NSObject {
                 + "read \(String(format: "%.1f", readSeconds))s of audio, "
                 + "emitted \(windowsEmitted) windows, "
                 + "stall accum \(String(format: "%.1f", stallAccumSeconds))s"
+        )
+    }
+
+    /// Once the streaming loop reaches EOF, persist the committed mapping to
+    /// disk if (and only if) it covers the whole reference timeline for this
+    /// audio file. The cache is then a complete replacement on next open —
+    /// `FingerprintMappingCache.save` enforces the same coverage threshold the
+    /// load path requires, keeping the round-trip safe.
+    private func persistMappingCacheIfFull(context ctx: GenerationContext) {
+        guard !ctx.isStreaming else { return }
+        queue.async { [weak self] in
+            guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
+            let snapshot = self.playbackToReference
+            FingerprintMappingCache.save(
+                snapshot,
+                audioFilePath: ctx.audioFileURL.path,
+                referenceData: ctx.referenceData,
+                referenceDuration: ctx.referenceDuration
+            )
+        }
+    }
+
+    /// Yield CPU briefly when the next chunk to fingerprint sits more than
+    /// `lookaheadSeconds` ahead of the listener's current playback time. This
+    /// keeps coverage growing to EOF — the chunk is **never** skipped — while
+    /// bounding peak CPU on long episodes the listener hasn't reached yet.
+    /// Capping the loop instead of throttling it (the prior POC-546 attempt)
+    /// dropped tail regions from the mapping and broke tap-to-seek for any cue
+    /// further than `lookaheadSeconds` ahead.
+    private func throttleIfBeyondLookahead(
+        nextChunkStartSeconds: Double,
+        context ctx: GenerationContext
+    ) throws {
+        let currentPlayback = PlaybackManager.shared.currentTime()
+        let lead = nextChunkStartSeconds - currentPlayback
+        guard lead > FingerprintConstants.lookaheadSeconds else { return }
+        try sleepWithCancellation(
+            seconds: FingerprintConstants.outsideLookaheadSleepSeconds,
+            context: ctx
         )
     }
 
@@ -986,10 +1066,11 @@ final class FingerprintTimingManager: NSObject {
 
     // MARK: - Helpers
 
-    private func loadReference(for episode: BaseEpisode) -> ReferenceFingerprint? {
+    private func loadReference(for episode: BaseEpisode) -> (data: Data, reference: ReferenceFingerprint)? {
         let path = referencePath(for: episode)
-        guard let data = FileManager.default.contents(atPath: path) else { return nil }
-        return ReferenceFingerprint.decode(from: data)
+        guard let data = FileManager.default.contents(atPath: path),
+              let reference = ReferenceFingerprint.decode(from: data) else { return nil }
+        return (data, reference)
     }
 
     private func referencePath(for episode: BaseEpisode) -> String {

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -434,9 +434,12 @@ final class FingerprintTimingManager: NSObject {
                audioFilePath: audioFileURL.path,
                referenceData: referenceData
            ) {
-            for entry in cached.entries {
-                insertMapping(entry)
-            }
+            // The cache is produced from `playbackToReference` (already sorted
+            // by `playbackTime`), so assign it directly and sort once for the
+            // reference-keyed view — avoids the O(n²) cost of routing every
+            // entry through `insertMapping`'s per-entry `Array.insert`.
+            playbackToReference = cached.entries
+            referenceToPlayback = cached.entries.sorted { $0.referenceTime < $1.referenceTime }
             filterLastTrusted = cached.entries.last
             updateState(.active(coverage: cached.entries.count))
             FileLog.shared.addMessage(

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -105,6 +105,11 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         link.add(to: .main, forMode: .common)
         link.isPaused = !playbackManager.isPlayingEpisode
         highlightDisplayLink = link
+        // Opening the transcript while paused leaves the link paused, so
+        // `playbackProgress` won't fire and the initial highlight wouldn't
+        // appear. Force one position update so the current cue is shown even
+        // if playback never resumes.
+        updateTranscriptPosition()
     }
 
     private func stopHighlightDisplayLink() {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -103,12 +103,25 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         stopHighlightDisplayLink()
         let link = CADisplayLink(target: self, selector: #selector(highlightTick))
         link.add(to: .main, forMode: .common)
+        link.isPaused = !playbackManager.isPlayingEpisode
         highlightDisplayLink = link
     }
 
     private func stopHighlightDisplayLink() {
         highlightDisplayLink?.invalidate()
         highlightDisplayLink = nil
+    }
+
+    /// Toggle the highlight display link based purely on whether playback is
+    /// advancing. We deliberately don't gate on `FingerprintTimingManager.state`
+    /// here — the existing `guard case .active = ...` inside
+    /// `updateTranscriptPosition` already short-circuits the per-tick highlight
+    /// work when the manager isn't ready, and stacking a second gate at the
+    /// display-link level is what trapped the manager in `.preparing` on the
+    /// prior POC-546 attempt (the link would pause before the manager could
+    /// post a state change).
+    @objc private func updateHighlightDisplayLinkPauseState() {
+        highlightDisplayLink?.isPaused = !playbackManager.isPlayingEpisode
     }
 
     @objc private func highlightTick() {
@@ -794,6 +807,9 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
         if FeatureFlag.syncedTranscripts.enabled {
             addCustomObserver(Constants.Notifications.playbackProgress, selector: #selector(updateTranscriptPosition))
+            addCustomObserver(Constants.Notifications.playbackStarted, selector: #selector(updateHighlightDisplayLinkPauseState))
+            addCustomObserver(Constants.Notifications.playbackPaused, selector: #selector(updateHighlightDisplayLinkPauseState))
+            addCustomObserver(Constants.Notifications.playbackEnded, selector: #selector(updateHighlightDisplayLinkPauseState))
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: POC-546 |
|:---:|

## Summary

The synced-transcripts feature decodes the entire episode audio every time the transcript opens, building a dense playback↔reference mapping that tap-to-seek interpolates over. This PR adds three perf wins designed to **preserve that dense-coverage invariant** (the prior POC-546 attempt — branch `leandro/poc-546-fingerprint-lookahead-and-cache` — broke tap-to-seek by hard-capping the stream).

- **Throttle (not cap) the streaming fingerprint loop.** When the next chunk's start is more than `lookaheadSeconds` (60 s) ahead of `PlaybackManager.currentTime()`, sleep `outsideLookaheadSleepSeconds` (0.5 s) before processing it. The chunk is *never* skipped, so coverage still grows to EOF and tap-to-seek still works for cues anywhere in the transcript — peak CPU is just bounded on long episodes the listener hasn't reached yet.
- **Persist the committed mapping to `<audio>.map.fp.json`** once the stream completes with full coverage. Validated on load against a SHA-256 of the reference fingerprint bytes, the audio file's size + mtime, a schema version, and a 95% reference-timeline coverage threshold. On a hit, hydrate the mappings and skip the stream entirely. Partial caches are *ignored*, not merged — that avoids the stuck-in-`.preparing` failure mode the previous attempt had.
- **Pause the transcript's `CADisplayLink`** when playback isn't advancing. Gated only on `playbackManager.isPlayingEpisode`, not on `FingerprintTimingManager.state` — stacking a state-level gate at the display-link level was what trapped the manager in `.preparing` on the previous attempt.

## To test

The key regression to watch for is **tap-to-seek on cues far ahead of current playback** — that is what the previous attempt broke.

1. Enable `FeatureFlag.syncedTranscripts`.
2. Open the transcript on a long downloaded episode (60+ min) at the very start. Don't play.
3. Wait long enough for the stream to be well past the lookahead window if it weren't throttled (~30 s wall-clock).
4. **Tap a cue near the end of the transcript.** It should eventually map and seek correctly. With the previous attempt this would never work.
5. Let the stream complete (state → `.active`, log: `FingerprintTimingManager: streaming fingerprint completed` and `FingerprintMappingCache: saved … mappings`).
6. Force-quit and relaunch. Re-open the transcript on the same episode. State should go to `.active` immediately (`FingerprintTimingManager: skipping stream — full mapping loaded from cache`). Tap-to-seek anywhere should still land correctly.
7. Pause playback while the transcript is open. Profile main thread — `highlightTick` should not fire at 60 Hz. Resume playback → ticks resume.
8. Cache miss path: delete `<audio>.map.fp.json` (or modify audio mtime). Re-open transcript. Stream should run; tap-to-seek should work as on `trunk`.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes. (`FingerprintMappingCacheTests` — round-trip + hash mismatch + audio-mtime mismatch + partial-coverage rejection + missing-cache + empty-entries.)
- [x] I have updated (or requested that someone edit) the spreadsheet to reflect any new or changed analytics. *(no analytics added)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)