### PR TITLE
Fix an issue with refresh control triggering haptics without your input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 8.12
 -----
-
+- Fix an issue with refresh control triggering haptics without your input [#4213](https://github.com/Automattic/pocket-casts-ios/pull/4213)
 
 8.11
 -----

--- a/podcasts/Common Components/PCRefreshControl.swift
+++ b/podcasts/Common Components/PCRefreshControl.swift
@@ -335,7 +335,10 @@ private extension PCRefreshControl {
 extension PCRefreshControl {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let scrollAmount = -scrollView.contentOffset.y
-        if scrollAmount > 0 {
+        // Only react while the user's finger is on the scroll view; ignore
+        // momentum-driven bounce-back so a fast flick to the top doesn't fire
+        // the pull-to-refresh haptic without an actual pull gesture.
+        if scrollAmount > 0, scrollView.isTracking {
             didPullDown(scrollAmount)
         } else if scrollAmount < 0 {
             endRefreshing(false)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-631.

This one has been driving me nuts.

## To test

(see the ticket)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
