### PR TITLE
Add animations when tapping backward or forward in mini player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 8.12
 -----
-
+- Add animations when tapping backward or forward in mini player [#4214](https://github.com/Automattic/pocket-casts-ios/pull/4214)
 
 8.11
 -----

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -206,6 +206,16 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
     private func animateSkipButton(_ button: UIButton, clockwise: Bool) {
         guard let imageView = button.imageView else { return }
+
+        if UIAccessibility.isReduceMotionEnabled {
+            let alpha = CAKeyframeAnimation(keyPath: "opacity")
+            alpha.values = [1.0, 0.4, 1.0]
+            alpha.keyTimes = [0, 0.4, 1]
+            alpha.duration = 0.3
+            imageView.layer.add(alpha, forKey: "skipAlpha")
+            return
+        }
+
         let duration: CFTimeInterval = 0.7
 
         let rotation = CABasicAnimation(keyPath: "transform.rotation.z")

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -194,12 +194,36 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         analyticsPlaybackHelper.currentSource = analyticsSource
         HapticsHelper.triggerSkipBackHaptic()
         PlaybackManager.shared.skipBack()
+        animateSkipButton(skipBackBtn, clockwise: false)
     }
 
     @IBAction func skipForwardTapped(_ sender: Any) {
         analyticsPlaybackHelper.currentSource = analyticsSource
         HapticsHelper.triggerSkipForwardHaptic()
         PlaybackManager.shared.skipForward()
+        animateSkipButton(skipFwdBtn, clockwise: true)
+    }
+
+    private func animateSkipButton(_ button: UIButton, clockwise: Bool) {
+        guard let imageView = button.imageView else { return }
+        let duration: CFTimeInterval = 0.5
+
+        let rotation = CABasicAnimation(keyPath: "transform.rotation.z")
+        rotation.fromValue = 0
+        rotation.toValue = clockwise ? CGFloat.pi * 2 : -CGFloat.pi * 2
+        rotation.duration = duration
+        rotation.timingFunction = CAMediaTimingFunction(controlPoints: 0.2, 0.9, 0.3, 1.0)
+        imageView.layer.add(rotation, forKey: "skipRotation")
+
+        let scale = CAKeyframeAnimation(keyPath: "transform.scale")
+        scale.values = [1.0, 0.85, 1.0]
+        scale.keyTimes = [0, 0.4, 1]
+        scale.duration = duration
+        scale.timingFunctions = [
+            CAMediaTimingFunction(name: .easeInEaseOut),
+            CAMediaTimingFunction(name: .easeInEaseOut),
+        ]
+        imageView.layer.add(scale, forKey: "skipScale")
     }
 
     func desiredHeight() -> CGFloat {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -206,7 +206,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
     private func animateSkipButton(_ button: UIButton, clockwise: Bool) {
         guard let imageView = button.imageView else { return }
-        let duration: CFTimeInterval = 0.5
+        let duration: CFTimeInterval = 0.7
 
         let rotation = CABasicAnimation(keyPath: "transform.rotation.z")
         rotation.fromValue = 0


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-626.

As suggested by @rviljoen [here](https://github.com/Automattic/pocket-casts-ios/pull/4204#issuecomment-4335262840). These use different assets from the full player, so we don't have a Lottie animation, but I think this programmatic one is also pretty nice.

https://github.com/user-attachments/assets/2b4460fb-fab1-4b8a-83d2-99c8abb28eae

## To test

- **Verify** that skip buttons in mini player are now animated.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
