### PR TITLE
Liquid Glass: Show your profile picture in the profile tab

### DIFF
--- a/podcasts/Extensions/UIImage+Avatar.swift
+++ b/podcasts/Extensions/UIImage+Avatar.swift
@@ -1,0 +1,26 @@
+import UIKit
+
+extension UIImage {
+    /// Returns a circular icon scaled to the given point size, rendered at the screen's native pixel scale.
+    func gravatarIcon(size: CGFloat) -> UIImage {
+        let pointSize = CGSize(width: size, height: size)
+        let sourceDiameter = min(self.size.width, self.size.height)
+        let sourceOrigin = CGPoint(
+            x: (sourceDiameter - self.size.width) / 2,
+            y: (sourceDiameter - self.size.height) / 2
+        )
+        let scale = pointSize.width / sourceDiameter
+        let drawRect = CGRect(
+            x: sourceOrigin.x * scale,
+            y: sourceOrigin.y * scale,
+            width: self.size.width * scale,
+            height: self.size.height * scale
+        )
+
+        let icon = UIGraphicsImageRenderer(size: pointSize).image { _ in
+            UIBezierPath(ovalIn: CGRect(origin: .zero, size: pointSize)).addClip()
+            draw(in: drawRect)
+        }
+        return icon.withRenderingMode(.alwaysOriginal)
+    }
+}

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -3,6 +3,7 @@ import PocketCastsServer
 import SafariServices
 import UIKit
 import Combine
+import Kingfisher
 import PocketCastsUtils
 import SwiftUI
 
@@ -127,6 +128,9 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(unhideNavBar), name: Constants.Notifications.unhideNavBarRequested, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(profileSeen), name: Constants.Notifications.profileSeen, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshProfileTabAvatar), name: .userLoginDidChange, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshProfileTabAvatarForcingReload), name: Constants.Notifications.avatarNeedsRefreshing, object: nil)
+        refreshProfileTabAvatar()
 
         observersForEndOfYearStats()
         addBookmarkCreatedToastHandler()
@@ -1133,5 +1137,47 @@ extension MainTabBarController {
     private func updateErrorColor() {
         errorBanner.backgroundColor = AppTheme.tabBarBackgroundColor()
         errorLabel.textColor = AppTheme.mainTextColor()
+    }
+}
+
+// MARK: - Profile tab avatar
+
+private extension MainTabBarController {
+    static let profileTabIconSize: CGFloat = 26
+
+    @objc func refreshProfileTabAvatar() {
+        loadProfileTabAvatar(forceRefresh: false)
+    }
+
+    @objc func refreshProfileTabAvatarForcingReload() {
+        loadProfileTabAvatar(forceRefresh: true)
+    }
+
+    func loadProfileTabAvatar(forceRefresh: Bool) {
+        guard FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) else { return }
+
+        guard let email = ServerSettings.syncingEmail(), !email.isEmpty,
+              let url = URL(string: "https://www.gravatar.com/avatar/\(email.sha256)?d=404&s=256") else {
+            resetProfileTabImage()
+            return
+        }
+
+        let resource = KF.ImageResource(downloadURL: url, cacheKey: email)
+        var options: KingfisherOptionsInfo = []
+        if forceRefresh {
+            options.append(.forceRefresh)
+        }
+
+        KingfisherManager.shared.retrieveImage(with: resource, options: options) { [weak self] result in
+            guard let self, case .success(let value) = result else { return }
+            let icon = value.image.gravatarIcon(size: Self.profileTabIconSize)
+            self.profileTabBarItem.image = icon
+            self.profileTabBarItem.selectedImage = icon
+        }
+    }
+
+    func resetProfileTabImage() {
+        profileTabBarItem.image = UIImage(named: "profile_tab")
+        profileTabBarItem.selectedImage = nil
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-624.

<img width="684" height="368" alt="Screenshot 2026-04-28 at 4 16 56 PM" src="https://github.com/user-attachments/assets/f1c31bda-8919-410b-a5aa-92298f060bf7" />

## To test

- **Verify** your profile picture is shown in the "profile" tab when available

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
