### PR TITLE
Liquid Glass: Fix more screen pinning to bottom safe area instead of bottom

### DIFF
--- a/podcasts/AccountViewController.xib
+++ b/podcasts/AccountViewController.xib
@@ -34,7 +34,7 @@
                 <constraint firstItem="LDy-dc-GWZ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Hsu-MD-VIW"/>
                 <constraint firstItem="LDy-dc-GWZ" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Ppn-J2-73Q"/>
                 <constraint firstItem="LDy-dc-GWZ" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="Z0r-84-seL"/>
-                <constraint firstItem="LDy-dc-GWZ" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="m2H-O3-JgV"/>
+                <constraint firstItem="LDy-dc-GWZ" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="m2H-O3-JgV"/>
             </constraints>
             <point key="canvasLocation" x="137.68115942028987" y="124.55357142857142"/>
         </view>

--- a/podcasts/AutoArchiveViewController.xib
+++ b/podcasts/AutoArchiveViewController.xib
@@ -33,7 +33,7 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="6zO-v4-qaS" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="7dc-bg-gWW"/>
-                <constraint firstItem="6zO-v4-qaS" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="cfk-s2-6KR"/>
+                <constraint firstItem="6zO-v4-qaS" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="cfk-s2-6KR"/>
                 <constraint firstItem="6zO-v4-qaS" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="s7h-zm-YZI"/>
                 <constraint firstItem="6zO-v4-qaS" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="tpz-OA-mgq"/>
             </constraints>

--- a/podcasts/ListeningHistoryViewController.xib
+++ b/podcasts/ListeningHistoryViewController.xib
@@ -44,7 +44,7 @@
             <constraints>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="3Md-gV-ah7"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="4F5-oG-IJr"/>
-                <constraint firstItem="A8m-ib-xHF" firstAttribute="bottom" secondItem="QnB-mS-nOl" secondAttribute="bottom" id="5vw-fO-ZlE"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="QnB-mS-nOl" secondAttribute="bottom" id="5vw-fO-ZlE"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="6xF-nj-xUx"/>
                 <constraint firstItem="QnB-mS-nOl" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="8" id="uQa-1R-jHE"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="z7n-3L-B2X"/>

--- a/podcasts/ListeningHistoryViewController.xib
+++ b/podcasts/ListeningHistoryViewController.xib
@@ -45,7 +45,7 @@
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="3Md-gV-ah7"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="4F5-oG-IJr"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="bottom" secondItem="QnB-mS-nOl" secondAttribute="bottom" id="5vw-fO-ZlE"/>
-                <constraint firstItem="A8m-ib-xHF" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="6xF-nj-xUx"/>
+                <constraint firstItem="A8m-ib-xHF" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="6xF-nj-xUx"/>
                 <constraint firstItem="QnB-mS-nOl" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="8" id="uQa-1R-jHE"/>
                 <constraint firstItem="A8m-ib-xHF" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="z7n-3L-B2X"/>
                 <constraint firstAttribute="trailing" secondItem="QnB-mS-nOl" secondAttribute="trailing" constant="8" id="zdH-Yp-qq2"/>

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -326,7 +326,7 @@ class PlaylistDetailViewController: FakeNavViewController {
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.topAnchor.constraint(equalTo: view.topAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
 
             blurHeaderView.bottomAnchor.constraint(equalTo: tableView.topAnchor, constant: PodcastHeaderView.Constants.largeImageSize),
             blurHeaderView.heightAnchor.constraint(equalTo: view.widthAnchor, constant: 40),

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -318,7 +318,7 @@ class PlaylistDetailViewController: FakeNavViewController {
         multiSelectFooter = MultiSelectFooterView(frame: .zero)
         view.addSubview(multiSelectFooter)
 
-        multiSelectFooterBottomConstraint = tableView.bottomAnchor.constraint(equalTo: multiSelectFooter.bottomAnchor)
+        multiSelectFooterBottomConstraint = view.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: multiSelectFooter.bottomAnchor)
 
         view.insertSubview(emptyStateNavView, belowSubview: fakeNavView)
 

--- a/podcasts/PlaylistShortcutsViewController.xib
+++ b/podcasts/PlaylistShortcutsViewController.xib
@@ -62,7 +62,7 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemYellowColor"/>
             <constraints>
-                <constraint firstItem="2JC-9l-vjf" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="Dhc-QH-8Ok"/>
+                <constraint firstItem="2JC-9l-vjf" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="Dhc-QH-8Ok"/>
                 <constraint firstItem="KYO-Ms-nzL" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="E5V-by-YM9"/>
                 <constraint firstItem="r9C-Jc-RZi" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="Go5-7L-8GF"/>
                 <constraint firstItem="r9C-Jc-RZi" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="Ofu-p8-bEW"/>

--- a/podcasts/PlaylistsShortcutsViewController.xib
+++ b/podcasts/PlaylistsShortcutsViewController.xib
@@ -31,7 +31,7 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="xyy-JE-OAf" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="6J8-o8-htl"/>
+                <constraint firstItem="xyy-JE-OAf" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="6J8-o8-htl"/>
                 <constraint firstItem="xyy-JE-OAf" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="VMX-w1-2ws"/>
                 <constraint firstItem="xyy-JE-OAf" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="dTM-4U-8F7"/>
                 <constraint firstItem="xyy-JE-OAf" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="q32-7H-waS"/>

--- a/podcasts/PodcastShortcutsViewController.xib
+++ b/podcasts/PodcastShortcutsViewController.xib
@@ -33,7 +33,7 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="L7D-jX-HGq" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="7N2-ie-hc9"/>
-                <constraint firstItem="L7D-jX-HGq" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="HZQ-4b-YcM"/>
+                <constraint firstItem="L7D-jX-HGq" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="HZQ-4b-YcM"/>
                 <constraint firstItem="L7D-jX-HGq" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="MQO-nm-rLX"/>
                 <constraint firstItem="L7D-jX-HGq" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="QPz-8e-Znx"/>
             </constraints>

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController.xib
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController.xib
@@ -33,7 +33,7 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="tgC-Bb-blq" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="6rM-NW-2X2"/>
-                <constraint firstItem="tgC-Bb-blq" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="PfI-ki-F1o"/>
+                <constraint firstItem="tgC-Bb-blq" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="PfI-ki-F1o"/>
                 <constraint firstItem="tgC-Bb-blq" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="hdz-nz-Ka5"/>
                 <constraint firstItem="tgC-Bb-blq" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="topMargin" id="orp-JN-eFo"/>
             </constraints>

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.xib
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.xib
@@ -34,7 +34,7 @@
             <constraints>
                 <constraint firstItem="wRJ-Ai-h5m" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="ON2-LG-i0A"/>
                 <constraint firstItem="wRJ-Ai-h5m" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="Tzq-2l-bc9"/>
-                <constraint firstItem="wRJ-Ai-h5m" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="lbZ-Ug-zF3"/>
+                <constraint firstItem="wRJ-Ai-h5m" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="lbZ-Ug-zF3"/>
                 <constraint firstItem="wRJ-Ai-h5m" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="tfe-tN-MnU"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.xib
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.xib
@@ -139,7 +139,7 @@
                 <constraint firstItem="rCn-kh-SHx" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Hqo-uM-afL"/>
                 <constraint firstItem="vOg-9D-tbz" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="QmA-n5-aN8"/>
                 <constraint firstItem="AZp-uk-Ky7" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" id="VcH-B8-uIB"/>
-                <constraint firstItem="vOg-9D-tbz" firstAttribute="bottom" secondItem="Lj6-2A-raj" secondAttribute="bottom" id="XlV-rU-xYe"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="Lj6-2A-raj" secondAttribute="bottom" id="XlV-rU-xYe"/>
                 <constraint firstItem="vOg-9D-tbz" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="YIb-Ui-04J"/>
                 <constraint firstItem="Lj6-2A-raj" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="8" id="YgU-IM-76c"/>
                 <constraint firstItem="A5O-Jp-ZY7" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="bHb-h2-dtt"/>

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.xib
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.xib
@@ -135,7 +135,7 @@
                 <constraint firstItem="A5O-Jp-ZY7" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="9ck-5W-tuG"/>
                 <constraint firstAttribute="bottomMargin" secondItem="A5O-Jp-ZY7" secondAttribute="bottom" id="9qb-Ae-Bih"/>
                 <constraint firstItem="rCn-kh-SHx" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="AiL-19-Ix1"/>
-                <constraint firstItem="vOg-9D-tbz" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="HIb-Ka-db3"/>
+                <constraint firstItem="vOg-9D-tbz" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="HIb-Ka-db3"/>
                 <constraint firstItem="rCn-kh-SHx" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Hqo-uM-afL"/>
                 <constraint firstItem="vOg-9D-tbz" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="QmA-n5-aN8"/>
                 <constraint firstItem="AZp-uk-Ky7" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" id="VcH-B8-uIB"/>

--- a/podcasts/SiriSettingsViewController.xib
+++ b/podcasts/SiriSettingsViewController.xib
@@ -80,7 +80,7 @@
                 <constraint firstItem="eW4-Ox-6Vm" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="Xow-BY-yjO"/>
                 <constraint firstItem="kao-bE-oer" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" id="bNc-fM-BOD"/>
                 <constraint firstItem="kao-bE-oer" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="bvk-1F-o0P"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="eW4-Ox-6Vm" secondAttribute="bottom" id="hJe-QI-Np2"/>
+                <constraint firstItem="i5M-Pr-FkT" firstAttribute="bottom" secondItem="eW4-Ox-6Vm" secondAttribute="bottom" id="hJe-QI-Np2"/>
                 <constraint firstItem="c2J-nw-wT2" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="hhT-6i-EDz"/>
                 <constraint firstItem="kao-bE-oer" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="pHi-lh-uHy"/>
             </constraints>

--- a/podcasts/SupporterContributionsViewController.xib
+++ b/podcasts/SupporterContributionsViewController.xib
@@ -33,7 +33,7 @@
                 <constraint firstItem="MUt-AR-Jjk" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="6EJ-wV-68A"/>
                 <constraint firstItem="MUt-AR-Jjk" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="6Wb-br-NIL"/>
                 <constraint firstItem="MUt-AR-Jjk" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="LTK-ha-iLC"/>
-                <constraint firstItem="MUt-AR-Jjk" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="MUK-oI-VfF"/>
+                <constraint firstItem="MUt-AR-Jjk" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="MUK-oI-VfF"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="139" y="153"/>

--- a/podcasts/SupporterPodcastViewController.xib
+++ b/podcasts/SupporterPodcastViewController.xib
@@ -50,7 +50,7 @@
                 <constraint firstItem="8Nr-wR-Lkv" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="LST-Cw-8TU"/>
                 <constraint firstItem="8Nr-wR-Lkv" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="MBz-QW-bgN"/>
                 <constraint firstItem="8Nr-wR-Lkv" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="UlL-WF-0S0"/>
-                <constraint firstItem="8Nr-wR-Lkv" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="nI1-Ju-RyD"/>
+                <constraint firstItem="8Nr-wR-Lkv" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="nI1-Ju-RyD"/>
             </constraints>
             <point key="canvasLocation" x="139" y="145"/>
         </view>

--- a/podcasts/UploadedSettingsViewController.xib
+++ b/podcasts/UploadedSettingsViewController.xib
@@ -35,7 +35,7 @@
                 <constraint firstItem="0eS-Ku-0Pk" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="3r5-hd-OuF"/>
                 <constraint firstItem="0eS-Ku-0Pk" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="kbM-ZW-5Tb"/>
                 <constraint firstItem="0eS-Ku-0Pk" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="pvD-9T-hIa"/>
-                <constraint firstItem="0eS-Ku-0Pk" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="rBN-Ts-68J"/>
+                <constraint firstItem="0eS-Ku-0Pk" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="rBN-Ts-68J"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
         </view>

--- a/podcasts/WatchSettingsViewController.xib
+++ b/podcasts/WatchSettingsViewController.xib
@@ -30,7 +30,7 @@
             </subviews>
             <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
             <constraints>
-                <constraint firstItem="taG-l9-Ybb" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" id="4VF-88-WsC"/>
+                <constraint firstItem="taG-l9-Ybb" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="4VF-88-WsC"/>
                 <constraint firstItem="taG-l9-Ybb" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="I7o-fr-VFm"/>
                 <constraint firstItem="taG-l9-Ybb" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="L9J-GC-pHs"/>
                 <constraint firstItem="taG-l9-Ybb" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="rro-aR-Zfb"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-623.

I identified and fixed more areas with incorrect bottom constraints. I think it should be all now.

Before / After

<img width="340" alt="Screenshot 2026-04-28 at 4 31 58 PM" src="https://github.com/user-attachments/assets/dca11cc2-1eb3-4234-9102-b6a560f1560c" /> <img width="340" alt="Screenshot 2026-04-28 at 4 33 58 PM" src="https://github.com/user-attachments/assets/77c875bf-9534-4882-a273-fe7524f0e20d" />

## To test

Test the screens from the commit (see .xib names) on iOS 26 with `UIDesignRequiresCompatibility` on and off.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
