### PR TITLE
[PC TV] Podcasts tab

### DIFF
--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -9,7 +9,7 @@ struct MockPodcast: Identifiable {
 struct MockData {
 
     static func makePodcasts() -> [MockPodcast] {
-        let numberOfPodcasts = 14
+        let numberOfPodcasts = 48
         var results = [MockPodcast]()
         for i in (0..<numberOfPodcasts) {
             results.append(MockPodcast(id: UUID().uuidString, name: "Podcast \(i+1)", image: "Covers/login-cover-\( (i % 10) + 1)"))

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -39,6 +39,7 @@ struct SigningInView: View {
             Image(ImageResource.pcLogo)
             Text(L10n.tvSigningInTitle)
                 .font(.title)
+                .foregroundStyle(Color.textPrimary)
             Text(L10n.tvSigningInSubtitle)
                 .font(.headline)
                 .foregroundStyle(Color.textSecondary)

--- a/Pocket Casts TV App/UI/Common/EmptyDataView.swift
+++ b/Pocket Casts TV App/UI/Common/EmptyDataView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct EmptyView: View {
+struct EmptyDataView: View {
 
     let title: String
     let subtitle: String?
@@ -31,5 +31,5 @@ struct EmptyView: View {
 }
 
 #Preview {
-    EmptyView(title: "Empty Title", subtitle: "No results to see here!", actionTitle: "Do something", action: nil)
+    EmptyDataView(title: "Empty Title", subtitle: "No results to see here!", actionTitle: "Do something", action: nil)
 }

--- a/Pocket Casts TV App/UI/Common/EmptyView.swift
+++ b/Pocket Casts TV App/UI/Common/EmptyView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct EmptyView: View {
+
+    let title: String
+    let subtitle: String?
+    let actionTitle: String?
+    let action: (() -> ())?
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Spacer()
+            Text(title)
+                .font(.title)
+                .foregroundStyle(Color.textPrimary)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.headline)
+                    .foregroundStyle(Color.textSecondary)
+                Spacer()
+            }
+            if let actionTitle {
+                Button(actionTitle) {
+                    action?()
+                }
+            }
+            Spacer()
+
+        }
+    }
+}
+
+#Preview {
+    EmptyView(title: "Empty Title", subtitle: "No results to see here!", actionTitle: "Do something", action: nil)
+}

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -105,7 +105,7 @@ struct MainTabView: View {
         .ignoresSafeArea()
         .onScrollGeometryChange(for: Double.self) { geometry in
             geometry.contentOffset.y
-        } action: { before, after in            
+        } action: { before, after in
             self.scrollOffset = 150 + after
         }
     }

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import Combine
 
 enum MainTab: Int, CaseIterable, Identifiable {
     case home = 0
@@ -104,9 +103,9 @@ struct MainTabView: View {
         }
         .ignoresSafeArea()
         .onScrollGeometryChange(for: Double.self) { geometry in
-            geometry.contentOffset.y
+            geometry.contentInsets.top + geometry.contentOffset.y
         } action: { before, after in
-            self.scrollOffset = 150 + after
+            self.scrollOffset = after
         }
     }
 

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -68,6 +68,8 @@ struct MainTabView: View {
     @State private var tabSelection: MainTabRouter = MainTabRouter()
     @FocusState private var focusedArea: FocusArea?
 
+    @State private var scrollOffset: Double = 0
+
     enum FocusArea: Hashable {
         case tabBar
         case profile
@@ -91,9 +93,8 @@ struct MainTabView: View {
                 }
             }
             .focused($focusedArea, equals: .tabBar)
-            rightAccessory
-        }.overlay(alignment: .topLeading) {
-            leftAccessory
+        }.background(alignment: .top) {
+            accessoryView
         }.onAppear {
             focusedArea = .tabBar
         }
@@ -102,6 +103,25 @@ struct MainTabView: View {
             handleMove(direction)
         }
         .ignoresSafeArea()
+        .onScrollGeometryChange(for: Double.self) { geometry in
+            geometry.contentOffset.y
+        } action: { before, after in            
+            self.scrollOffset = 150 + after
+        }
+    }
+
+    var accessoryView: some View {
+        VStack() {
+            HStack() {
+                leftAccessory
+                Spacer()
+                rightAccessory
+            }
+            .padding(.vertical, 48)
+            .padding(.horizontal, 84)
+            .offset(x: 0, y: -scrollOffset)
+            Spacer()
+        }
     }
 
     private func handleMove(_ direction: MoveCommandDirection) {
@@ -126,21 +146,19 @@ struct MainTabView: View {
         }
         .buttonStyle(.card)
         .focused($focusedArea, equals: .profile)
-        .padding(.top, 50)
-        .padding(.trailing, 84)
         .focusSection()
     }
 
     var leftAccessory: some View {
-        VStack(alignment: .leading) {
-            Spacer().frame(height: 40)
-            HStack {
-                Spacer().frame(width: 84)
+        //VStack(alignment: .leading) {
+        //    Spacer().frame(height: 40)
+        //    HStack {
+        //        Spacer().frame(width: 84)
                 Image(ImageResource.pcLogo)
-                Spacer()
-            }.frame(height: 78)
-            Spacer()
-        }
+        //        Spacer()
+        //    }.frame(height: 78)
+        //    Spacer()
+       // }
     }
 }
 

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -72,7 +72,7 @@ struct MainTabView: View {
             TabView(selection: $selection) {
                 ForEach(MainTab.allCases) { tab in
                     Tab(value: tab) {
-                        MainTabContentView(tab: tab)                            
+                        MainTabContentView(tab: tab)
                     } label: {
                         Label {
                             if let title = tab.title { Text(title) }

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -92,7 +92,7 @@ struct MainTabView: View {
                 }
             }
             .focused($focusedArea, equals: .tabBar)
-        }.background(alignment: .top) {
+        }.overlay(alignment: .top) {
             accessoryView
         }.onAppear {
             focusedArea = .tabBar

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 enum MainTab: Int, CaseIterable, Identifiable {
     case home = 0
@@ -56,9 +57,15 @@ struct CenterButton: View {
     }
 }
 
+@MainActor
+@Observable
+final class MainTabRouter {
+    var selectedTab: MainTab = .home
+}
+
 struct MainTabView: View {
 
-    @State private var selection: MainTab = .home
+    @State private var tabSelection: MainTabRouter = MainTabRouter()
     @FocusState private var focusedArea: FocusArea?
 
     enum FocusArea: Hashable {
@@ -69,10 +76,11 @@ struct MainTabView: View {
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            TabView(selection: $selection) {
+            TabView(selection: $tabSelection.selectedTab) {
                 ForEach(MainTab.allCases) { tab in
                     Tab(value: tab) {
                         MainTabContentView(tab: tab)
+                            .environment(tabSelection)
                     } label: {
                         Label {
                             if let title = tab.title { Text(title) }
@@ -100,7 +108,7 @@ struct MainTabView: View {
         switch (focusedArea, direction) {
         case (.tabBar, .right):
             // Only jump to profile if we're on the rightmost tab
-            if selection == MainTab.allCases.last {
+            if tabSelection.selectedTab == MainTab.allCases.last {
                 focusedArea = .profile
             }
         case (.profile, .left):

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -150,15 +150,7 @@ struct MainTabView: View {
     }
 
     var leftAccessory: some View {
-        //VStack(alignment: .leading) {
-        //    Spacer().frame(height: 40)
-        //    HStack {
-        //        Spacer().frame(width: 84)
-                Image(ImageResource.pcLogo)
-        //        Spacer()
-        //    }.frame(height: 78)
-        //    Spacer()
-       // }
+        Image(ImageResource.pcLogo)
     }
 }
 

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -31,8 +31,13 @@ struct MainTabContentView: View {
     let tab: MainTab
 
     var body: some View {
-        if let title = tab.title {
-            CenterButton(title: title)
+        switch tab {
+        case .podcasts:
+            PodcastsView()
+        default:
+            if let title = tab.title {
+                CenterButton(title: title)
+            }
         }
     }
 }
@@ -67,7 +72,7 @@ struct MainTabView: View {
             TabView(selection: $selection) {
                 ForEach(MainTab.allCases) { tab in
                     Tab(value: tab) {
-                        MainTabContentView(tab: tab)
+                        MainTabContentView(tab: tab)                            
                     } label: {
                         Label {
                             if let title = tab.title { Text(title) }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -57,15 +57,18 @@ struct PodcastsView: View {
     }
 
     var podcastsView: some View {
-        VStack(alignment: .leading, spacing: 40) {
-            Text(L10n.tvTabPodcasts)
-                .font(.title)
-                .foregroundStyle(Color.textPrimary)
+        ZStack {
             ScrollView {
-                podcastGrid
+                VStack(alignment: .leading, spacing: 40) {
+                    Text(L10n.tvTabPodcasts)
+                        .font(.title)
+                        .foregroundStyle(Color.textPrimary)
+                    podcastGrid
+                }
             }
-            .contentMargins(.vertical, 60, for: .scrollContent)
+            .contentMargins(.vertical, 100, for: .scrollContent)
         }
+        .tabBarMinimizeBehavior(.automatic)
     }
 
     var emptyView: some View {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -68,19 +68,8 @@ struct PodcastsView: View {
     }
 
     var emptyView: some View {
-        VStack(spacing: 32) {
-            Spacer()
-            Text(L10n.tvPodcastsEmptyTitle)
-                .font(.title)
-                .foregroundStyle(Color.textPrimary)
-            Text(L10n.tvPodcastsEmptySubtitle)
-                .font(.headline)
-                .foregroundStyle(Color.textSecondary)
-            Spacer()
-            Button(L10n.tvPodcastsEmptyActionTitle) {
+        EmptyView(title: L10n.tvPodcastsEmptyTitle, subtitle: L10n.tvPodcastsEmptySubtitle, actionTitle: L10n.tvPodcastsEmptyActionTitle) {
 
-            }
-            Spacer()
         }
     }
 

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -57,18 +57,14 @@ struct PodcastsView: View {
     }
 
     var podcastsView: some View {
-        ZStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 40) {
-                    Text(L10n.tvTabPodcasts)
-                        .font(.title)
-                        .foregroundStyle(Color.textPrimary)
-                    podcastGrid
-                }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 40) {
+                Text(L10n.tvTabPodcasts)
+                    .font(.title)
+                    .foregroundStyle(Color.textPrimary)
+                podcastGrid
             }
-            .contentMargins(.vertical, 100, for: .scrollContent)
-        }
-        .tabBarMinimizeBehavior(.automatic)
+        }        
     }
 
     var emptyView: some View {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import Combine
+
+@Observable
+class PodcastsViewModel {
+
+    private var cancellable: AnyCancellable?
+
+    enum State: Equatable, Hashable {
+        case loading
+        case ready
+        case empty
+    }
+
+    var state: State = .loading
+
+    var podcasts: [MockPodcast] = MockData.makePodcasts()
+
+    func load() {
+        cancellable = Timer.publish(every: 1.0, on: .main, in: .common)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let self else { return }
+                state = .ready
+            }
+    }
+}
+
+struct PodcastsView: View {
+    @Environment(AppCoordinator.self) var coordinator
+
+    @State private var model = PodcastsViewModel()
+
+    enum Layout {
+        static let gridSize = CGFloat(250)
+    }
+
+    var body: some View {
+        ZStack {
+            switch model.state {
+            case .loading:
+                loadingView
+            case .ready:
+                podcastsView
+            case .empty:
+                emptyView
+            }
+        }
+        .task {
+            model.load()
+        }
+    }
+
+    var loadingView: some View {
+        ProgressView()
+    }
+
+    var podcastsView: some View {
+        VStack(alignment: .leading, spacing: 40) {
+            Text("Your Podcasts")
+                .font(.title)
+                .foregroundStyle(Color.textPrimary)
+            ScrollView {
+                podcastGrid
+            }
+            .contentMargins(.vertical, 60, for: .scrollContent)
+        }
+    }
+
+    var emptyView: some View {
+        VStack(spacing: 32) {
+            Spacer()
+            Text("Time to add some podcasts!")
+                .font(.title)
+                .foregroundStyle(Color.textPrimary)
+            Text("Follow some podcasts at the home page")
+                .font(.headline)
+                .foregroundStyle(Color.textSecondary)
+            Spacer()
+            Button("Add podcasts") {
+
+            }
+            Spacer()
+        }
+    }
+
+    private let items: [GridItem] = (0..<6).map { _ in
+        GridItem(.fixed(Layout.gridSize), spacing: 48)
+    }
+
+    var podcastGrid: some View {
+        LazyVGrid(columns: items, spacing: 48, content: {
+            ForEach(model.podcasts) { podcast in
+                Button() {
+
+                } label: {
+                    Image(podcast.image)
+                        .resizable()
+                        .frame(width: Layout.gridSize, height: Layout.gridSize)
+                }.buttonStyle(.card)
+            }
+        })
+    }
+}
+
+#Preview {
+    PodcastsView()
+        .environment(AppCoordinator())
+}

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -21,7 +21,7 @@ class PodcastsViewModel {
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self else { return }
-                state = .ready
+                state = .empty
             }
     }
 }
@@ -57,7 +57,7 @@ struct PodcastsView: View {
 
     var podcastsView: some View {
         VStack(alignment: .leading, spacing: 40) {
-            Text("Your Podcasts")
+            Text(L10n.tvTabPodcasts)
                 .font(.title)
                 .foregroundStyle(Color.textPrimary)
             ScrollView {
@@ -70,14 +70,14 @@ struct PodcastsView: View {
     var emptyView: some View {
         VStack(spacing: 32) {
             Spacer()
-            Text("Time to add some podcasts!")
+            Text(L10n.tvPodcastsEmptyTitle)
                 .font(.title)
                 .foregroundStyle(Color.textPrimary)
-            Text("Follow some podcasts at the home page")
+            Text(L10n.tvPodcastsEmptySubtitle)
                 .font(.headline)
                 .foregroundStyle(Color.textSecondary)
             Spacer()
-            Button("Add podcasts") {
+            Button(L10n.tvPodcastsEmptyActionTitle) {
 
             }
             Spacer()

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -17,11 +17,14 @@ class PodcastsViewModel {
     var podcasts: [MockPodcast] = MockData.makePodcasts()
 
     func load() {
-        cancellable = Timer.publish(every: 1.0, on: .main, in: .common)
+        //Mock data load
+        cancellable = Timer.publish(every: 1.0, on: .main, in: .common, options: nil)
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self else { return }
                 state = .ready
+                cancellable?.cancel()
+                cancellable = nil
             }
     }
 }
@@ -68,7 +71,7 @@ struct PodcastsView: View {
     }
 
     var emptyView: some View {
-        EmptyView(title: L10n.tvPodcastsEmptyTitle, subtitle: L10n.tvPodcastsEmptySubtitle, actionTitle: L10n.tvPodcastsEmptyActionTitle) {
+        EmptyDataView(title: L10n.tvPodcastsEmptyTitle, subtitle: L10n.tvPodcastsEmptySubtitle, actionTitle: L10n.tvPodcastsEmptyActionTitle) {
             tabRouter.selectedTab = .home
         }
     }
@@ -76,6 +79,8 @@ struct PodcastsView: View {
     private let items: [GridItem] = (0..<6).map { _ in
         GridItem(.fixed(Layout.gridSize), spacing: 48)
     }
+
+    @Namespace private var podcastGridNamespace
 
     var podcastGrid: some View {
         LazyVGrid(columns: items, spacing: 48, content: {
@@ -86,13 +91,17 @@ struct PodcastsView: View {
                     Image(podcast.image)
                         .resizable()
                         .frame(width: Layout.gridSize, height: Layout.gridSize)
-                }.buttonStyle(.card)
+                }
+                .buttonStyle(.card)
+                .prefersDefaultFocus(model.podcasts.first?.id == podcast.id, in: podcastGridNamespace)
             }
         })
+        .focusScope(podcastGridNamespace)
     }
 }
 
 #Preview {
     PodcastsView()
         .environment(AppCoordinator())
+        .environment(MainTabRouter())
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -64,7 +64,7 @@ struct PodcastsView: View {
                     .foregroundStyle(Color.textPrimary)
                 podcastGrid
             }
-        }        
+        }
     }
 
     var emptyView: some View {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -21,13 +21,14 @@ class PodcastsViewModel {
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self else { return }
-                state = .empty
+                state = .ready
             }
     }
 }
 
 struct PodcastsView: View {
     @Environment(AppCoordinator.self) var coordinator
+    @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
 
     @State private var model = PodcastsViewModel()
 
@@ -69,7 +70,7 @@ struct PodcastsView: View {
 
     var emptyView: some View {
         EmptyView(title: L10n.tvPodcastsEmptyTitle, subtitle: L10n.tvPodcastsEmptySubtitle, actionTitle: L10n.tvPodcastsEmptyActionTitle) {
-
+            tabRouter.selectedTab = .home
         }
     }
 

--- a/Pocket Casts TV App/UI/WelcomeView.swift
+++ b/Pocket Casts TV App/UI/WelcomeView.swift
@@ -25,9 +25,7 @@ struct WelcomeView: View {
 
     var body: some View {
         NavigationStack {
-            ZStack(alignment: .top) {
-                podcastGrid
-                gradientView
+            ZStack(alignment: .center) {
                 VStack(spacing: 32) {
                     Spacer()
                     Image(ImageResource.pcLogo)
@@ -60,6 +58,12 @@ struct WelcomeView: View {
                     CreateAccountView()
                 }
             }
+            .background {
+                ZStack {
+                    podcastGrid
+                    gradientView
+                }
+            }
         }
     }
 
@@ -70,7 +74,8 @@ struct WelcomeView: View {
                     .resizable()
                     .frame(width: Layout.gridSize, height: Layout.gridSize)
             }
-        }).ignoresSafeArea()
+        })
+        //.ignoresSafeArea()
     }
 
     var gradientView: some View {

--- a/Pocket Casts TV App/UI/WelcomeView.swift
+++ b/Pocket Casts TV App/UI/WelcomeView.swift
@@ -75,7 +75,6 @@ struct WelcomeView: View {
                     .frame(width: Layout.gridSize, height: Layout.gridSize)
             }
         })
-        //.ignoresSafeArea()
     }
 
     var gradientView: some View {

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -348,7 +348,6 @@
 		8B87C47C29F0129A00257B96 /* EpisodeArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87C47B29F0129A00257B96 /* EpisodeArtwork.swift */; };
 		8B907F182AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B907F172AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift */; };
 		8B907F1A2AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B907F192AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift */; };
-		FF26A9924A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */; };
 		8B9D233F2C41B1BE004CD57D /* TranscriptShelfButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9D233E2C41B1BE004CD57D /* TranscriptShelfButton.swift */; };
 		8B9DEFD62906D1CE00075EAB /* EndOfYear.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8B9DEFD52906D1CE00075EAB /* EndOfYear.xcassets */; };
 		8BA55A1528CA8FEB002BECC5 /* PrivacySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */; };
@@ -573,7 +572,6 @@
 		BD1F07F91BAAA6F0007A768D /* CategoryPodcastsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1F07F71BAAA6F0007A768D /* CategoryPodcastsViewController.swift */; };
 		BD1F07FA1BAAA6F0007A768D /* CategoryPodcastsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = BD1F07F81BAAA6F0007A768D /* CategoryPodcastsViewController.xib */; };
 		BD1F977C1FD7894C00F89CCD /* MiniPlayerShadowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1F977B1FD7894C00F89CCD /* MiniPlayerShadowView.swift */; };
-		FF26A9924A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9934A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift */; };
 		BD1F97821FD7C64600F89CCD /* PlaylistViewController+TableData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD1F97811FD7C64600F89CCD /* PlaylistViewController+TableData.swift */; };
 		BD21D4A222DED42100D5888B /* ThemeableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD21D4A122DED42100D5888B /* ThemeableView.swift */; };
 		BD2219F1253EAEAF000025BE /* PlaybackCatchUpHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2219F0253EAEAF000025BE /* PlaybackCatchUpHelper.swift */; };
@@ -1282,6 +1280,8 @@
 		FF1F27052F224C5C001908BE /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
 		FF2142D42C07369200672D8D /* MediaExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2142D32C07369200672D8D /* MediaExporter.swift */; };
 		FF2142D52C07369200672D8D /* MediaExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2142D32C07369200672D8D /* MediaExporter.swift */; };
+		FF26A9924A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */; };
+		FF26A9924A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9934A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift */; };
 		FF31C0972EC211890083C7E5 /* playback_2025_plus.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = FF31C0962EC211890083C7E5 /* playback_2025_plus.mp4 */; };
 		FF31C0992EC216600083C7E5 /* playback_2025_plus_background.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = FF31C0982EC216600083C7E5 /* playback_2025_plus_background.mp4 */; };
 		FF40C0662C65175B003A9D93 /* TranscriptErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF40C0652C65175B003A9D93 /* TranscriptErrorView.swift */; };
@@ -1858,7 +1858,6 @@
 		8B87C47B29F0129A00257B96 /* EpisodeArtwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeArtwork.swift; sourceTree = "<group>"; };
 		8B907F172AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MiniPlayerViewController+TransitionDelegate.swift"; sourceTree = "<group>"; };
 		8B907F192AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerToFullPlayerAnimator.swift; sourceTree = "<group>"; };
-		FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassPlayerAnimator.swift; sourceTree = "<group>"; };
 		8B9D233E2C41B1BE004CD57D /* TranscriptShelfButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptShelfButton.swift; sourceTree = "<group>"; };
 		8B9DEFD52906D1CE00075EAB /* EndOfYear.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = EndOfYear.xcassets; sourceTree = "<group>"; };
 		8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsViewController.swift; sourceTree = "<group>"; };
@@ -2078,7 +2077,6 @@
 		BD1F07F71BAAA6F0007A768D /* CategoryPodcastsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoryPodcastsViewController.swift; sourceTree = "<group>"; };
 		BD1F07F81BAAA6F0007A768D /* CategoryPodcastsViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CategoryPodcastsViewController.xib; sourceTree = "<group>"; };
 		BD1F977B1FD7894C00F89CCD /* MiniPlayerShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerShadowView.swift; sourceTree = "<group>"; };
-		FF26A9934A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerGlassProgressView.swift; sourceTree = "<group>"; };
 		BD1F97811FD7C64600F89CCD /* PlaylistViewController+TableData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PlaylistViewController+TableData.swift"; sourceTree = "<group>"; };
 		BD2063301B5351D500DBB592 /* podcasts-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "podcasts-Bridging-Header.h"; sourceTree = "<group>"; };
 		BD21D4A122DED42100D5888B /* ThemeableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeableView.swift; sourceTree = "<group>"; };
@@ -2632,6 +2630,8 @@
 		FF1DF0242C8F4E2F0028B8D8 /* ReferralsClaimBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralsClaimBannerView.swift; sourceTree = "<group>"; };
 		FF1EC6852CECBC73006FBF9B /* ManageDownloadsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDownloadsCoordinator.swift; sourceTree = "<group>"; };
 		FF2142D32C07369200672D8D /* MediaExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExporter.swift; sourceTree = "<group>"; };
+		FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassPlayerAnimator.swift; sourceTree = "<group>"; };
+		FF26A9934A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerGlassProgressView.swift; sourceTree = "<group>"; };
 		FF31C0962EC211890083C7E5 /* playback_2025_plus.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = playback_2025_plus.mp4; sourceTree = "<group>"; };
 		FF31C0982EC216600083C7E5 /* playback_2025_plus_background.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = playback_2025_plus_background.mp4; sourceTree = "<group>"; };
 		FF40C0652C65175B003A9D93 /* TranscriptErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptErrorView.swift; sourceTree = "<group>"; };

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2640"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4251,6 +4251,12 @@ internal enum L10n {
   internal static var tvCreateAccountSubtitle: String { return L10n.tr("Localizable", "tv_create_account_subtitle", fallback: "Scan this code to get started on your phone, it only takes a minute.") }
   /// tv create account title
   internal static var tvCreateAccountTitle: String { return L10n.tr("Localizable", "tv_create_account_title", fallback: "Create your free account") }
+  /// tv podcasts_empty button action title
+  internal static var tvPodcastsEmptyActionTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_action_title", fallback: "Add podcasts") }
+  /// tv podcasts_empty subtitle
+  internal static var tvPodcastsEmptySubtitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_subtitle", fallback: "Follow some podcasts at the home page") }
+  /// tv podcasts_empty title
+  internal static var tvPodcastsEmptyTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_title", fallback: "Time to add some podcasts!") }
   /// tv sign enter code
   internal static var tvSignInEnterCode: String { return L10n.tr("Localizable", "tv_sign_in_enter_code", fallback: "or enter the following code") }
   /// tv sign enter code go url.  %1$@ is the visible url and %2$@ the full url to enter the code

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4254,7 +4254,7 @@ internal enum L10n {
   /// tv podcasts_empty button action title
   internal static var tvPodcastsEmptyActionTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_action_title", fallback: "Add podcasts") }
   /// tv podcasts_empty subtitle
-  internal static var tvPodcastsEmptySubtitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_subtitle", fallback: "Follow some podcasts at the home page") }
+  internal static var tvPodcastsEmptySubtitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_subtitle", fallback: "Follow some podcasts from the Home page") }
   /// tv podcasts_empty title
   internal static var tvPodcastsEmptyTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_title", fallback: "Time to add some podcasts!") }
   /// tv sign enter code

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5938,6 +5938,13 @@
 /* tv signing in subtitle */
 "tv_signing_in_subtitle" = "Your podcasts are syncing, we’ll sign you in soon!";
 
+/* tv podcasts_empty title */
+"tv_podcasts_empty_title" = "Time to add some podcasts!";
 
+/* tv podcasts_empty subtitle */
+"tv_podcasts_empty_subtitle" = "Follow some podcasts at the home page";
+
+/* tv podcasts_empty button action title */
+"tv_podcasts_empty_action_title" = "Add podcasts";
 
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5942,7 +5942,7 @@
 "tv_podcasts_empty_title" = "Time to add some podcasts!";
 
 /* tv podcasts_empty subtitle */
-"tv_podcasts_empty_subtitle" = "Follow some podcasts at the home page";
+"tv_podcasts_empty_subtitle" = "Follow some podcasts from the Home page";
 
 /* tv podcasts_empty button action title */
 "tv_podcasts_empty_action_title" = "Add podcasts";


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-633](https://linear.app/a8c/issue/PCIOS-633/podcasts-list-ui) <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Add the podcasts tab view.

https://github.com/user-attachments/assets/cd0eefbc-905b-426e-9d8b-69f88d1335dc

## To test

1. Start the app
2. Enter with browse without an account
3. Select the podcasts tab
4. Check that podcasts show and you can move around

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
