### PR TITLE
[PC TV] Podcast details

### DIFF
--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -14,6 +14,8 @@ struct MockEpisode: Identifiable, Hashable, Equatable {
     func displayableTitle() -> String {
         return title
     }
+
+    var image: String
 }
 
 struct MockPodcast: Identifiable, Hashable, Equatable {
@@ -32,10 +34,11 @@ struct MockData {
         var results = [MockPodcast]()
         for i in (0..<numberOfPodcasts) {
             var episodes: [MockEpisode] = []
+            let podcastImageName = "Covers/login-cover-\( (i % 10) + 1)"
             for i in (0..<numberOfPodcasts) {
-                episodes.append(MockEpisode(uuid: UUID().uuidString, title: "Episode \(i+1)", publishedDate: Date.now.weeksAgo(i), duration: Double.random(in: (5.minutes...1.hours))))
+                episodes.append(MockEpisode(uuid: UUID().uuidString, title: "Episode \(i+1)", publishedDate: Date.now.weeksAgo(i), duration: Double.random(in: (5.minutes...1.hours)), image: podcastImageName))
             }
-            results.append(MockPodcast(id: UUID().uuidString, title: "Podcast \(i+1)", author: "Author \(i+1)", podcastDescription: "Here is a fun description for this", image: "Covers/login-cover-\( (i % 10) + 1)", episodes: episodes))
+            results.append(MockPodcast(id: UUID().uuidString, title: "Podcast \(i+1)", author: "Author \(i+1)", podcastDescription: "Here is a fun description for this", image: podcastImageName, episodes: episodes))
         }
         return results
     }

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -1,9 +1,28 @@
 import Foundation
+import PocketCastsUtils
 
-struct MockPodcast: Identifiable {
+struct MockEpisode: Identifiable, Hashable, Equatable {
+    var uuid: String
+    var title: String
+    var publishedDate: Date
+    var duration: Double
+
+    var id: String {
+        return uuid
+    }
+
+    func displayableTitle() -> String {
+        return title
+    }
+}
+
+struct MockPodcast: Identifiable, Hashable, Equatable {
     var id: String
-    var name: String
+    var title: String
+    var author: String?
+    var podcastDescription: String?
     var image: String
+    var episodes: [MockEpisode]
 }
 
 struct MockData {
@@ -12,7 +31,11 @@ struct MockData {
         let numberOfPodcasts = 48
         var results = [MockPodcast]()
         for i in (0..<numberOfPodcasts) {
-            results.append(MockPodcast(id: UUID().uuidString, name: "Podcast \(i+1)", image: "Covers/login-cover-\( (i % 10) + 1)"))
+            var episodes: [MockEpisode] = []
+            for i in (0..<numberOfPodcasts) {
+                episodes.append(MockEpisode(uuid: UUID().uuidString, title: "Episode \(i+1)", publishedDate: Date.now.weeksAgo(i), duration: Double.random(in: (5.minutes...1.hours))))
+            }
+            results.append(MockPodcast(id: UUID().uuidString, title: "Podcast \(i+1)", author: "Author \(i+1)", podcastDescription: "Here is a fun description for this", image: "Covers/login-cover-\( (i % 10) + 1)", episodes: episodes))
         }
         return results
     }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -39,7 +39,7 @@ struct EpisodeRow: View {
             Spacer()
         }
         .padding(24)
-        .backgroundStyle(Color.backgroundSunken)
+        .background(Color.backgroundSunken)
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import PocketCastsUtils
+
+struct EpisodeRow: View {
+
+    let episode: MockEpisode
+
+    enum Layout {
+        static let episodeImageSize = CGFloat(124)
+    }
+
+    func displayDate(for date: Date) -> String {
+        let episodeDate = DateFormatHelper.sharedHelper.tinyLocalizedFormat(date).localizedUppercase
+        return episodeDate
+    }
+
+    func displayDuration(for time: Double) -> String {
+        let time = TimeFormatter.shared.multipleUnitFormattedShortTime(time: time)
+        return time
+    }
+
+    var body: some View {
+        HStack(spacing: 24) {
+            Image(episode.image)
+                .resizable()
+                .frame(width: Layout.episodeImageSize, height: Layout.episodeImageSize)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            VStack(alignment: .leading) {
+                Text(displayDate(for: episode.publishedDate))
+                    .font(.caption)
+                    .foregroundColor(.textSecondary)
+                Text(episode.title)
+                    .font(.body)
+                    .foregroundColor(.textPrimary)
+                Text(displayDuration(for: episode.duration))
+                    .font(.caption)
+                    .foregroundColor(.textSecondary)
+            }
+            Spacer()
+        }
+        .padding(24)
+        .backgroundStyle(Color.backgroundSunken)
+    }
+}
+
+#Preview {
+    EpisodeRow(episode: MockData.makePodcasts().first!.episodes.first!)
+        .environment(AppCoordinator())
+        .environment(MainTabRouter())
+}

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -75,9 +75,11 @@ struct PodcastDetailView: View {
     }
 
     var podcastView: some View {
-        HStack {
+        HStack(alignment: .top) {
             podcastInfo
-            episodeList
+            VStack {                
+                episodeList
+            }
         }
     }
 
@@ -116,24 +118,26 @@ struct PodcastDetailView: View {
     }
 
     var episodeList: some View {
-        List() {
-            ForEach(model.podcast.episodes) { episode in
-                Button() {
+        ScrollView {
+            LazyVStack() {
+                ForEach(model.podcast.episodes) { episode in
+                    Button() {
 
-                } label: {
-                    HStack {
-                        Image(model.podcast.image)
-                            .resizable()
-                            .frame(width: Layout.episodeImageSize, height: Layout.episodeImageSize)
-                        VStack(alignment: .leading) {
-                            Text(model.displayDate(for: episode.publishedDate))
-                            Text(episode.title)
-                            Text(model.displayDuration(for: episode.duration))
+                    } label: {
+                        HStack {
+                            Image(model.podcast.image)
+                                .resizable()
+                                .frame(width: Layout.episodeImageSize, height: Layout.episodeImageSize)
+                            VStack(alignment: .leading) {
+                                Text(model.displayDate(for: episode.publishedDate))
+                                Text(episode.title)
+                                Text(model.displayDuration(for: episode.duration))
+                            }
+                            Spacer()
                         }
-                        Spacer()
                     }
+                    .buttonStyle(.card)
                 }
-                .buttonStyle(.card)
             }
         }
     }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -30,7 +30,7 @@ class PodcastDetailViewModel {
                 cancellable?.cancel()
                 cancellable = nil
             }
-    }    
+    }
 
     func follow() {
 

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import Combine
-import PocketCastsUtils
 
 @Observable
 class PodcastDetailViewModel {
@@ -71,6 +70,7 @@ struct PodcastDetailView: View {
                 episodeList
             }
         }
+        .toolbar(.visible, for: .tabBar)
     }
 
     var podcastInfo: some View {
@@ -94,13 +94,13 @@ struct PodcastDetailView: View {
                 Button() {
                     model.follow()
                 } label: {
-                    Text("Follow")
+                    Text(L10n.tvPodcastDetailFollowTitle)
                         .font(.caption2)
                 }
                 Button() {
                     model.follow()
                 } label: {
-                    Text("More Info")
+                    Text(L10n.tvPodcastDetailMoreInfoTitle)
                         .font(.caption2)
                 }
             }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+import Combine
+import PocketCastsUtils
+
+@Observable
+class PodcastDetailViewModel {
+
+    private var cancellable: AnyCancellable?
+
+    enum State: Equatable, Hashable {
+        case loading
+        case ready
+    }
+
+    var state: State = .loading
+
+    let podcast: MockPodcast
+
+    init(podcast: MockPodcast) {
+        self.podcast = podcast
+    }
+
+    func load() {
+        //Mock data load
+        cancellable = Timer.publish(every: 1.0, on: .main, in: .common, options: nil)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let self else { return }
+                state = .ready
+                cancellable?.cancel()
+                cancellable = nil
+            }
+    }
+
+    func displayDate(for date: Date) -> String {
+        let episodeDate = DateFormatHelper.sharedHelper.tinyLocalizedFormat(date).localizedUppercase
+        return episodeDate
+    }
+
+    func displayDuration(for time: Double) -> String {
+        let time = TimeFormatter.shared.multipleUnitFormattedShortTime(time: time)
+        return time
+    }
+
+    func follow() {
+
+    }
+}
+
+struct PodcastDetailView: View {
+
+    let model: PodcastDetailViewModel
+
+    enum Layout {
+        static let podcastImageSize = CGFloat(418)
+        static let episodeImageSize = CGFloat(124)
+    }
+
+    var body: some View {
+        ZStack {
+            switch model.state {
+            case .loading:
+                loadingView
+            case .ready:
+                podcastView
+            }
+        }
+        .task {
+            model.load()
+        }
+    }
+
+    var loadingView: some View {
+        ProgressView()
+    }
+
+    var podcastView: some View {
+        HStack {
+            podcastInfo
+            episodeList
+        }
+    }
+
+    var podcastInfo: some View {
+        VStack(alignment: .leading, spacing: 40) {
+            Image(model.podcast.image)
+                .resizable()
+                .frame(width: Layout.podcastImageSize, height: Layout.podcastImageSize)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+            VStack(alignment: .leading, spacing: 8) {
+                Text(model.podcast.author ?? "")
+                    .font(.caption)
+                    .foregroundColor(.textSecondary)
+                Text(model.podcast.title)
+                    .font(.title2)
+                    .foregroundColor(.textPrimary)
+                Text(model.podcast.podcastDescription ?? "")
+                    .font(.caption)
+                    .foregroundColor(.textSecondary)
+            }
+            HStack {
+                Button() {
+                    model.follow()
+                } label: {
+                    Text("Follow")
+                        .font(.caption2)
+                }
+                Button() {
+                    model.follow()
+                } label: {
+                    Text("More Info")
+                        .font(.caption2)
+                }
+            }
+        }
+    }
+
+    var episodeList: some View {
+        List() {
+            ForEach(model.podcast.episodes) { episode in
+                Button() {
+
+                } label: {
+                    HStack {
+                        Image(model.podcast.image)
+                            .resizable()
+                            .frame(width: Layout.episodeImageSize, height: Layout.episodeImageSize)
+                        VStack(alignment: .leading) {
+                            Text(model.displayDate(for: episode.publishedDate))
+                            Text(episode.title)
+                            Text(model.displayDuration(for: episode.duration))
+                        }
+                        Spacer()
+                    }
+                }
+                .buttonStyle(.card)
+            }
+        }
+    }
+}
+
+#Preview {
+    PodcastDetailView(model: PodcastDetailViewModel(podcast: MockData.makePodcasts().first!))
+        .environment(AppCoordinator())
+        .environment(MainTabRouter())
+}

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -30,17 +30,7 @@ class PodcastDetailViewModel {
                 cancellable?.cancel()
                 cancellable = nil
             }
-    }
-
-    func displayDate(for date: Date) -> String {
-        let episodeDate = DateFormatHelper.sharedHelper.tinyLocalizedFormat(date).localizedUppercase
-        return episodeDate
-    }
-
-    func displayDuration(for time: Double) -> String {
-        let time = TimeFormatter.shared.multipleUnitFormattedShortTime(time: time)
-        return time
-    }
+    }    
 
     func follow() {
 
@@ -77,7 +67,7 @@ struct PodcastDetailView: View {
     var podcastView: some View {
         HStack(alignment: .top) {
             podcastInfo
-            VStack {                
+            VStack {
                 episodeList
             }
         }
@@ -100,7 +90,7 @@ struct PodcastDetailView: View {
                     .font(.caption)
                     .foregroundColor(.textSecondary)
             }
-            HStack {
+            HStack(spacing: 8) {
                 Button() {
                     model.follow()
                 } label: {
@@ -121,24 +111,16 @@ struct PodcastDetailView: View {
         ScrollView {
             LazyVStack() {
                 ForEach(model.podcast.episodes) { episode in
-                    Button() {
-
-                    } label: {
-                        HStack {
-                            Image(model.podcast.image)
-                                .resizable()
-                                .frame(width: Layout.episodeImageSize, height: Layout.episodeImageSize)
-                            VStack(alignment: .leading) {
-                                Text(model.displayDate(for: episode.publishedDate))
-                                Text(episode.title)
-                                Text(model.displayDuration(for: episode.duration))
-                            }
-                            Spacer()
-                        }
+                    NavigationLink(value: episode) {
+                        EpisodeRow(episode: episode)
                     }
                     .buttonStyle(.card)
                 }
             }
+            .navigationDestination(for: MockEpisode.self) { episode in
+                Text(episode.title)
+            }
+            .padding(24)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -88,9 +88,9 @@ struct PodcastsView: View {
         LazyVGrid(columns: items, spacing: 48, content: {
             ForEach(model.podcasts) { podcast in
                 NavigationLink(value: podcast) {
-                    Image(podcast.image)
-                        .resizable()
-                        .frame(width: Layout.gridSize, height: Layout.gridSize)
+                        Image(podcast.image)
+                            .resizable()
+                            .frame(width: Layout.gridSize, height: Layout.gridSize)
                 }
                 .buttonStyle(.card)
                 .prefersDefaultFocus(model.podcasts.first?.id == podcast.id, in: podcastGridNamespace)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -60,12 +60,14 @@ struct PodcastsView: View {
     }
 
     var podcastsView: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 40) {
-                Text(L10n.tvTabPodcasts)
-                    .font(.title)
-                    .foregroundStyle(Color.textPrimary)
-                podcastGrid
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 40) {
+                    Text(L10n.tvTabPodcasts)
+                        .font(.title)
+                        .foregroundStyle(Color.textPrimary)
+                    podcastGrid
+                }
             }
         }
     }
@@ -85,9 +87,7 @@ struct PodcastsView: View {
     var podcastGrid: some View {
         LazyVGrid(columns: items, spacing: 48, content: {
             ForEach(model.podcasts) { podcast in
-                Button() {
-
-                } label: {
+                NavigationLink(value: podcast) {
                     Image(podcast.image)
                         .resizable()
                         .frame(width: Layout.gridSize, height: Layout.gridSize)
@@ -97,6 +97,9 @@ struct PodcastsView: View {
             }
         })
         .focusScope(podcastGridNamespace)
+        .navigationDestination(for: MockPodcast.self) { podcast in
+            PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
+        }
     }
 }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4251,11 +4251,15 @@ internal enum L10n {
   internal static var tvCreateAccountSubtitle: String { return L10n.tr("Localizable", "tv_create_account_subtitle", fallback: "Scan this code to get started on your phone, it only takes a minute.") }
   /// tv create account title
   internal static var tvCreateAccountTitle: String { return L10n.tr("Localizable", "tv_create_account_title", fallback: "Create your free account") }
-  /// tv podcasts_empty button action title
+  /// tv podcast details follow button title
+  internal static var tvPodcastDetailFollowTitle: String { return L10n.tr("Localizable", "tv_podcast_detail_follow_title", fallback: "Follow this podcast") }
+  /// tv podcast details more info button title
+  internal static var tvPodcastDetailMoreInfoTitle: String { return L10n.tr("Localizable", "tv_podcast_detail_more_info_title", fallback: "More info") }
+  /// tv podcasts empty button action title
   internal static var tvPodcastsEmptyActionTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_action_title", fallback: "Add podcasts") }
-  /// tv podcasts_empty subtitle
+  /// tv podcasts empty subtitle
   internal static var tvPodcastsEmptySubtitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_subtitle", fallback: "Follow some podcasts from the Home page") }
-  /// tv podcasts_empty title
+  /// tv podcasts empty title
   internal static var tvPodcastsEmptyTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_title", fallback: "Time to add some podcasts!") }
   /// tv sign enter code
   internal static var tvSignInEnterCode: String { return L10n.tr("Localizable", "tv_sign_in_enter_code", fallback: "or enter the following code") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5938,13 +5938,19 @@
 /* tv signing in subtitle */
 "tv_signing_in_subtitle" = "Your podcasts are syncing, we’ll sign you in soon!";
 
-/* tv podcasts_empty title */
+/* tv podcasts empty title */
 "tv_podcasts_empty_title" = "Time to add some podcasts!";
 
-/* tv podcasts_empty subtitle */
+/* tv podcasts empty subtitle */
 "tv_podcasts_empty_subtitle" = "Follow some podcasts from the Home page";
 
-/* tv podcasts_empty button action title */
+/* tv podcasts empty button action title */
 "tv_podcasts_empty_action_title" = "Add podcasts";
+
+/* tv podcast details follow button title */
+"tv_podcast_detail_follow_title" = "Follow this podcast";
+
+/* tv podcast details more info button title */
+"tv_podcast_detail_more_info_title" = "More info";
 
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-634](https://linear.app/a8c/issue/PCIOS-634/podcast-detail-ui) <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Implements the UI for Podcast details

https://github.com/user-attachments/assets/2e86f747-591a-4ec8-ae20-f0f4dc11330d


## To test

1. Start the app
2. Navigate to podcasts
3. Tap on a podcast
4. Check if the UI works correctly

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
