### PR TITLE
[PC TV] Implement playlists mock UI

### DIFF
--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -63,7 +63,7 @@ struct MockData {
         ]
         for (name, smart, color) in playlistsSpec {
             var episodes: [MockEpisode] = []
-            for i in (0..<numberOfEpisodes) {
+            for i in (0..<Int.random(in: 1..<numberOfEpisodes)) {
                 let podcastImageName = "Covers/login-cover-\( Int.random(in: (1..<10)))"
                 episodes.append(MockEpisode(uuid: UUID().uuidString, title: "Episode \(i+1)", publishedDate: Date.now.weeksAgo(i), duration: Double.random(in: (5.minutes...1.hours)), image: podcastImageName))
             }

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -64,7 +64,7 @@ struct MockData {
         for (name, smart, color) in playlistsSpec {
             var episodes: [MockEpisode] = []
             for i in (0..<Int.random(in: 1..<numberOfEpisodes)) {
-                let podcastImageName = "Covers/login-cover-\( Int.random(in: (1..<10)))"
+                let podcastImageName = "Covers/login-cover-\( Int.random(in: (1...10)))"
                 episodes.append(MockEpisode(uuid: UUID().uuidString, title: "Episode \(i+1)", publishedDate: Date.now.weeksAgo(i), duration: Double.random(in: (5.minutes...1.hours)), image: podcastImageName))
             }
             results.append(MockPlaylist(id: UUID().uuidString, title: name, manual: !smart, episodes: episodes, color: color))

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -56,10 +56,10 @@ struct MockData {
         let numberOfEpisodes = 12
         var results = [MockPlaylist]()
         let playlistsSpec: [(String, Bool, Color)] = [
-            ("New Releases", true, Color(red: 0.15, green: 0.25, blue: 0.5)),
-            ("InProgress", true, Color(red: 0.5, green: 0.17, blue: 0.15)),
+            ("New releases", true, Color(red: 0.15, green: 0.25, blue: 0.5)),
+            ("In progress", true, Color(red: 0.5, green: 0.17, blue: 0.15)),
             ("TV Stuff", false, Color(red: 0.21, green: 0.22, blue: 0.14)),
-            ("My Favories", true, Color(red: 0.5, green: 0.35, blue: 0.12))
+            ("My favorites", true, Color(red: 0.5, green: 0.35, blue: 0.12))
         ]
         for (name, smart, color) in playlistsSpec {
             var episodes: [MockEpisode] = []

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsUtils
+import SwiftUI
 
 struct MockEpisode: Identifiable, Hashable, Equatable {
     var uuid: String
@@ -27,6 +28,14 @@ struct MockPodcast: Identifiable, Hashable, Equatable {
     var episodes: [MockEpisode]
 }
 
+struct MockPlaylist: Identifiable, Hashable, Equatable {
+    var id: String
+    var title: String
+    var manual: Bool
+    var episodes: [MockEpisode]
+    var color: Color
+}
+
 struct MockData {
 
     static func makePodcasts() -> [MockPodcast] {
@@ -39,6 +48,26 @@ struct MockData {
                 episodes.append(MockEpisode(uuid: UUID().uuidString, title: "Episode \(i+1)", publishedDate: Date.now.weeksAgo(i), duration: Double.random(in: (5.minutes...1.hours)), image: podcastImageName))
             }
             results.append(MockPodcast(id: UUID().uuidString, title: "Podcast \(i+1)", author: "Author \(i+1)", podcastDescription: "Here is a fun description for this", image: podcastImageName, episodes: episodes))
+        }
+        return results
+    }
+
+    static func makePlaylists() -> [MockPlaylist] {
+        let numberOfEpisodes = 12
+        var results = [MockPlaylist]()
+        let playlistsSpec: [(String, Bool, Color)] = [
+            ("New Releases", true, Color(red: 0.15, green: 0.25, blue: 0.5)),
+            ("InProgress", true, Color(red: 0.5, green: 0.17, blue: 0.15)),
+            ("TV Stuff", false, Color(red: 0.21, green: 0.22, blue: 0.14)),
+            ("My Favories", true, Color(red: 0.5, green: 0.35, blue: 0.12))
+        ]
+        for (name, smart, color) in playlistsSpec {
+            var episodes: [MockEpisode] = []
+            for i in (0..<numberOfEpisodes) {
+                let podcastImageName = "Covers/login-cover-\( Int.random(in: (1..<10)))"
+                episodes.append(MockEpisode(uuid: UUID().uuidString, title: "Episode \(i+1)", publishedDate: Date.now.weeksAgo(i), duration: Double.random(in: (5.minutes...1.hours)), image: podcastImageName))
+            }
+            results.append(MockPlaylist(id: UUID().uuidString, title: name, manual: !smart, episodes: episodes, color: color))
         }
         return results
     }

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -34,6 +34,8 @@ struct MainTabContentView: View {
         switch tab {
         case .podcasts:
             PodcastsView()
+        case .playlists:
+            PlaylistsView()
         default:
             if let title = tab.title {
                 CenterButton(title: title)

--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+struct PlaylistCell: View {
+    let playlist: MockPlaylist
+
+    enum Layout {
+        static let gridSize = CGFloat(496)
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            VStack(alignment: .leading) {
+                Text(playlist.title)
+                Text(playlist.manual ? " " : "Smart Playlist")
+                Spacer()
+                HStack(alignment: .bottom) {
+                    Text("\(playlist.episodes.count) episodes")
+                    Spacer()
+                }
+            }
+            .padding(.vertical, 24)
+            ZStack {
+                ForEach(Array(playlist.episodes.prefix(2).enumerated()), id: \.element) { index, episode in
+                    Image(episode.image)
+                        .resizable()
+                        .frame(width: 156, height: 156)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                        .shadow(color: .black.opacity(0.2), radius: 37.5, x: 0, y: 0)
+                        .offset(x: CGFloat(1-index) * 25.0, y: (CGFloat(2-index) * 25.0))
+                }
+            }
+
+        }
+        .padding(.horizontal, 36)
+        .frame(height: 210)
+        .background(playlist.color)
+        .clipped()
+    }
+
+}
+
+#Preview {
+    PlaylistCell(playlist: MockData.makePlaylists().first!)
+        .environment(AppCoordinator())
+        .environment(MainTabRouter())
+}

--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -35,6 +35,7 @@ struct PlaylistCell: View {
                         .offset(x: CGFloat(1-index) * 25.0, y: (CGFloat(2-index) * 25.0))
                 }
             }
+            .padding(.horizontal, 36)
 
         }
         .padding(.horizontal, 36)

--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -3,8 +3,12 @@ import SwiftUI
 struct PlaylistCell: View {
     let playlist: MockPlaylist
 
+    @Environment(\.isFocused) var isFocused: Bool
+
     enum Layout {
         static let imageSize = CGFloat(156)
+        static let rotationEffect = CGFloat(15)
+        static let cardHeight = CGFloat(258)
     }
 
     var body: some View {
@@ -12,15 +16,15 @@ struct PlaylistCell: View {
             VStack(alignment: .leading) {
                 Text(playlist.title)
                     .font(.headline)
-                    .foregroundColor(Color.textPrimary)
+                    .foregroundColor(isFocused ? Color.textPrimaryActive : Color.textPrimary)
                 Text(playlist.manual ? " " : L10n.smartPlaylist)
                     .font(.caption)
-                    .foregroundColor(Color.textSecondary)
+                    .foregroundColor(isFocused ? Color.textSecondaryActive : Color.textSecondary)
                 Spacer()
                 HStack(alignment: .bottom) {
                     Text( L10n.playlistEpisodesCount(playlist.episodes.count))
                         .font(.caption)
-                        .foregroundColor(Color.textSecondary)
+                        .foregroundColor(isFocused ? Color.textSecondaryActive : Color.textSecondary)
                     Spacer()
                 }
             }
@@ -32,15 +36,17 @@ struct PlaylistCell: View {
                         .frame(width: Layout.imageSize, height: Layout.imageSize)
                         .clipShape(RoundedRectangle(cornerRadius: 6))
                         .shadow(color: .black.opacity(0.2), radius: 37.5, x: 0, y: 0)
-                        .offset(x: CGFloat(1-index) * 25.0, y: (CGFloat(2-index) * 25.0))
+                        .rotationEffect(Angle(degrees: isFocused ? (index == 0 ? Layout.rotationEffect : -Layout.rotationEffect) : 0))
+                        .offset(x: CGFloat(1-index) * 25.0, y: 50 + (CGFloat(2-index) * 25.0))
                 }
             }
             .padding(.horizontal, 36)
 
         }
         .padding(.horizontal, 36)
-        .frame(height: 210)
-        .background(playlist.color)
+        .frame(height: Layout.cardHeight)
+        .background(isFocused ? Color.backgroundActive : playlist.color)
+        .animation(.spring(response: 0.3, dampingFraction: 0.6), value: isFocused)
         .clipped()
     }
 

--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -4,17 +4,23 @@ struct PlaylistCell: View {
     let playlist: MockPlaylist
 
     enum Layout {
-        static let gridSize = CGFloat(496)
+        static let imageSize = CGFloat(156)
     }
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
             VStack(alignment: .leading) {
                 Text(playlist.title)
-                Text(playlist.manual ? " " : "Smart Playlist")
+                    .font(.headline)
+                    .foregroundColor(Color.textPrimary)
+                Text(playlist.manual ? " " : L10n.smartPlaylist)
+                    .font(.caption)
+                    .foregroundColor(Color.textSecondary)
                 Spacer()
                 HStack(alignment: .bottom) {
-                    Text("\(playlist.episodes.count) episodes")
+                    Text( L10n.playlistEpisodesCount(playlist.episodes.count))
+                        .font(.caption)
+                        .foregroundColor(Color.textSecondary)
                     Spacer()
                 }
             }
@@ -23,7 +29,7 @@ struct PlaylistCell: View {
                 ForEach(Array(playlist.episodes.prefix(2).enumerated()), id: \.element) { index, episode in
                     Image(episode.image)
                         .resizable()
-                        .frame(width: 156, height: 156)
+                        .frame(width: Layout.imageSize, height: Layout.imageSize)
                         .clipShape(RoundedRectangle(cornerRadius: 6))
                         .shadow(color: .black.opacity(0.2), radius: 37.5, x: 0, y: 0)
                         .offset(x: CGFloat(1-index) * 25.0, y: (CGFloat(2-index) * 25.0))

--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -17,12 +17,14 @@ struct PlaylistCell: View {
                 Text(playlist.title)
                     .font(.headline)
                     .foregroundColor(isFocused ? Color.textPrimaryActive : Color.textPrimary)
-                Text(playlist.manual ? " " : L10n.smartPlaylist)
-                    .font(.caption)
-                    .foregroundColor(isFocused ? Color.textSecondaryActive : Color.textSecondary)
+                if playlist.manual {
+                    Text(L10n.smartPlaylist)
+                        .font(.caption)
+                        .foregroundColor(isFocused ? Color.textSecondaryActive : Color.textSecondary)
+                }
                 Spacer()
                 HStack(alignment: .bottom) {
-                    Text( L10n.playlistEpisodesCount(playlist.episodes.count))
+                    Text(L10n.playlistEpisodesCount(playlist.episodes.count))
                         .font(.caption)
                         .foregroundColor(isFocused ? Color.textSecondaryActive : Color.textSecondary)
                     Spacer()

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+import Combine
+
+@Observable
+class PlaylistsViewModel {
+
+    private var cancellable: AnyCancellable?
+
+    enum State: Equatable, Hashable {
+        case loading
+        case ready
+        case empty
+    }
+
+    var state: State = .loading
+
+    var playlists: [MockPlaylist] = MockData.makePlaylists()
+
+    func load() {
+        //Mock data load
+        cancellable = Timer.publish(every: 1.0, on: .main, in: .common, options: nil)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let self else { return }
+                state = .ready
+                cancellable?.cancel()
+                cancellable = nil
+            }
+    }
+}
+
+struct PlaylistsView: View {
+    @Environment(AppCoordinator.self) var coordinator
+    @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
+
+    @State private var model = PlaylistsViewModel()
+
+    enum Layout {
+        static let gridSize = CGFloat(496)
+    }
+
+    var body: some View {
+        ZStack {
+            switch model.state {
+            case .loading:
+                loadingView
+            case .ready:
+                playlistsView
+            case .empty:
+                emptyView
+            }
+        }
+        .task {
+            model.load()
+        }
+    }
+
+    var loadingView: some View {
+        ProgressView()
+    }
+
+    var playlistsView: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 40) {
+                    Text(L10n.playlists)
+                        .font(.title)
+                        .foregroundStyle(Color.textPrimary)
+                    playlistsCollection
+                }
+            }
+        }
+    }
+
+    var emptyView: some View {
+        EmptyDataView(title: L10n.tvPlaylistsEmptyTitle, subtitle: L10n.tvPlaylistsEmptySubtitle, actionTitle: L10n.tvPlaylistsEmptyActionTitle) {
+            tabRouter.selectedTab = .home
+        }
+    }
+
+    private let items: [GridItem] = (0..<3).map { _ in
+        GridItem(.fixed(Layout.gridSize), spacing: 48)
+    }
+
+    @Namespace private var listNamespace
+
+    var playlistsCollection: some View {
+        LazyVGrid(columns: items, spacing: 48, content: {
+            ForEach(model.playlists) { playlist in
+                NavigationLink(value: playlist) {
+                    PlaylistCell(playlist: playlist)
+                }
+                .buttonStyle(.card)
+            }
+        })
+        .focusScope(listNamespace)
+        .navigationDestination(for: MockPlaylist.self) { playlist in
+
+        }
+    }
+}
+
+#Preview {
+    PlaylistsView()
+        .environment(AppCoordinator())
+        .environment(MainTabRouter())
+}

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -3,19 +3,19 @@ import Combine
 
 @Observable
 class PlaylistsViewModel {
-    
+
     private var cancellable: AnyCancellable?
-    
+
     enum State: Equatable, Hashable {
         case loading
         case ready
         case empty
     }
-    
+
     var state: State = .loading
-    
+
     var playlists: [MockPlaylist] = MockData.makePlaylists()
-    
+
     func load() {
         //Mock data load
         cancellable = Timer.publish(every: 1.0, on: .main, in: .common, options: nil)
@@ -32,13 +32,13 @@ class PlaylistsViewModel {
 struct PlaylistsView: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
-    
+
     @State private var model = PlaylistsViewModel()
-    
+
     enum Layout {
         static let gridSize = CGFloat(496)
     }
-    
+
     var body: some View {
         ZStack {
             switch model.state {
@@ -54,11 +54,11 @@ struct PlaylistsView: View {
             model.load()
         }
     }
-    
+
     var loadingView: some View {
         ProgressView()
     }
-    
+
     var playlistsView: some View {
         NavigationStack {
             ScrollView {
@@ -71,19 +71,19 @@ struct PlaylistsView: View {
             }
         }
     }
-    
+
     var emptyView: some View {
         EmptyDataView(title: L10n.tvPlaylistsEmptyTitle, subtitle: L10n.tvPlaylistsEmptySubtitle, actionTitle: L10n.tvPlaylistsEmptyActionTitle) {
             tabRouter.selectedTab = .home
         }
     }
-    
+
     private let items: [GridItem] = (0..<3).map { _ in
         GridItem(.flexible(minimum: Layout.gridSize), spacing: 48)
     }
-    
+
     @Namespace private var listNamespace
-    
+
     var playlistsCollection: some View {
         LazyVGrid(columns: items, spacing: 48, content: {
             ForEach(model.playlists) { playlist in
@@ -97,9 +97,13 @@ struct PlaylistsView: View {
         .focusScope(listNamespace)
         .navigationDestination(for: MockPlaylist.self) { playlist in
             VStack {
-                Text("Playlist (\(playlist.title) details coming soon")
-                    .font(.title2)
-                    .foregroundStyle(Color.textPrimary)
+                Button {
+
+                } label: {
+                    Text("Playlist \(playlist.title) details coming soon")
+                        .font(.title2)
+                        .foregroundStyle(Color.textPrimary)
+                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             .padding()

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -79,7 +79,7 @@ struct PlaylistsView: View {
     }
 
     private let items: [GridItem] = (0..<3).map { _ in
-        GridItem(.fixed(Layout.gridSize), spacing: 48)
+        GridItem(.flexible(minimum: Layout.gridSize), spacing: 48)
     }
 
     @Namespace private var listNamespace

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -3,19 +3,19 @@ import Combine
 
 @Observable
 class PlaylistsViewModel {
-
+    
     private var cancellable: AnyCancellable?
-
+    
     enum State: Equatable, Hashable {
         case loading
         case ready
         case empty
     }
-
+    
     var state: State = .loading
-
+    
     var playlists: [MockPlaylist] = MockData.makePlaylists()
-
+    
     func load() {
         //Mock data load
         cancellable = Timer.publish(every: 1.0, on: .main, in: .common, options: nil)
@@ -32,13 +32,13 @@ class PlaylistsViewModel {
 struct PlaylistsView: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
-
+    
     @State private var model = PlaylistsViewModel()
-
+    
     enum Layout {
         static let gridSize = CGFloat(496)
     }
-
+    
     var body: some View {
         ZStack {
             switch model.state {
@@ -54,16 +54,16 @@ struct PlaylistsView: View {
             model.load()
         }
     }
-
+    
     var loadingView: some View {
         ProgressView()
     }
-
+    
     var playlistsView: some View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 40) {
-                    Text(L10n.playlists)
+                    Text(L10n.tvTabPlaylists)
                         .font(.title)
                         .foregroundStyle(Color.textPrimary)
                     playlistsCollection
@@ -71,19 +71,19 @@ struct PlaylistsView: View {
             }
         }
     }
-
+    
     var emptyView: some View {
         EmptyDataView(title: L10n.tvPlaylistsEmptyTitle, subtitle: L10n.tvPlaylistsEmptySubtitle, actionTitle: L10n.tvPlaylistsEmptyActionTitle) {
             tabRouter.selectedTab = .home
         }
     }
-
+    
     private let items: [GridItem] = (0..<3).map { _ in
         GridItem(.flexible(minimum: Layout.gridSize), spacing: 48)
     }
-
+    
     @Namespace private var listNamespace
-
+    
     var playlistsCollection: some View {
         LazyVGrid(columns: items, spacing: 48, content: {
             ForEach(model.playlists) { playlist in
@@ -91,11 +91,18 @@ struct PlaylistsView: View {
                     PlaylistCell(playlist: playlist)
                 }
                 .buttonStyle(.card)
+                .prefersDefaultFocus(playlist.id == model.playlists.first?.id, in: listNamespace)
             }
         })
         .focusScope(listNamespace)
         .navigationDestination(for: MockPlaylist.self) { playlist in
-
+            VStack {
+                Text("Playlist (\(playlist.title) details coming soon")
+                    .font(.title2)
+                    .foregroundStyle(Color.textPrimary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .padding()
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -118,7 +118,15 @@ struct PodcastDetailView: View {
                 }
             }
             .navigationDestination(for: MockEpisode.self) { episode in
-                Text(episode.title)
+                VStack {
+                    Button {
+
+                    } label: {
+                        Text("Episode \(episode.title) details coming soon")
+                            .font(.title2)
+                            .foregroundStyle(Color.textPrimary)
+                    }
+                }
             }
             .padding(24)
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4251,16 +4251,22 @@ internal enum L10n {
   internal static var tvCreateAccountSubtitle: String { return L10n.tr("Localizable", "tv_create_account_subtitle", fallback: "Scan this code to get started on your phone, it only takes a minute.") }
   /// tv create account title
   internal static var tvCreateAccountTitle: String { return L10n.tr("Localizable", "tv_create_account_title", fallback: "Create your free account") }
+  /// tv playlists empty button action title
+  internal static var tvPlaylistsEmptyActionTitle: String { return L10n.tr("Localizable", "tv_playlists_empty_action_title", fallback: "Create a playlist") }
+  /// tv playlists empty subtitle
+  internal static var tvPlaylistsEmptySubtitle: String { return L10n.tr("Localizable", "tv_playlists_empty_subtitle", fallback: "Build one manually or let Smart Rules do the sorting for you.") }
+  /// tv playlists empty title
+  internal static var tvPlaylistsEmptyTitle: String { return L10n.tr("Localizable", "tv_playlists_empty_title", fallback: "Your playlists live here") }
   /// tv podcast details follow button title
   internal static var tvPodcastDetailFollowTitle: String { return L10n.tr("Localizable", "tv_podcast_detail_follow_title", fallback: "Follow this podcast") }
   /// tv podcast details more info button title
   internal static var tvPodcastDetailMoreInfoTitle: String { return L10n.tr("Localizable", "tv_podcast_detail_more_info_title", fallback: "More info") }
   /// tv podcasts empty button action title
-  internal static var tvPodcastsEmptyActionTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_action_title", fallback: "Add podcasts") }
+  internal static var tvPodcastsEmptyActionTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_action_title", fallback: "Discover podcasts") }
   /// tv podcasts empty subtitle
-  internal static var tvPodcastsEmptySubtitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_subtitle", fallback: "Follow some podcasts from the Home page") }
+  internal static var tvPodcastsEmptySubtitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_subtitle", fallback: "Followed podcasts show up here, ready to play.") }
   /// tv podcasts empty title
-  internal static var tvPodcastsEmptyTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_title", fallback: "Time to add some podcasts!") }
+  internal static var tvPodcastsEmptyTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_title", fallback: "Time to fill this up.") }
   /// tv sign enter code
   internal static var tvSignInEnterCode: String { return L10n.tr("Localizable", "tv_sign_in_enter_code", fallback: "or enter the following code") }
   /// tv sign enter code go url.  %1$@ is the visible url and %2$@ the full url to enter the code

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5939,18 +5939,27 @@
 "tv_signing_in_subtitle" = "Your podcasts are syncing, we’ll sign you in soon!";
 
 /* tv podcasts empty title */
-"tv_podcasts_empty_title" = "Time to add some podcasts!";
+"tv_podcasts_empty_title" = "Time to fill this up.";
 
 /* tv podcasts empty subtitle */
-"tv_podcasts_empty_subtitle" = "Follow some podcasts from the Home page";
+"tv_podcasts_empty_subtitle" = "Followed podcasts show up here, ready to play.";
 
 /* tv podcasts empty button action title */
-"tv_podcasts_empty_action_title" = "Add podcasts";
+"tv_podcasts_empty_action_title" = "Discover podcasts";
 
 /* tv podcast details follow button title */
 "tv_podcast_detail_follow_title" = "Follow this podcast";
 
 /* tv podcast details more info button title */
 "tv_podcast_detail_more_info_title" = "More info";
+
+/* tv playlists empty title */
+"tv_playlists_empty_title" = "Your playlists live here";
+
+/* tv playlists empty subtitle */
+"tv_playlists_empty_subtitle" = "Build one manually or let Smart Rules do the sorting for you.";
+
+/* tv playlists empty button action title */
+"tv_playlists_empty_action_title" = "Create a playlist";
 
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-635](https://linear.app/a8c/issue/PCIOS-635/playlists-list-ui) <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Implement Playlist mock UI


https://github.com/user-attachments/assets/eeedb5e0-b80d-4f3d-9930-3c7503a7ff6e



## To test

1. Start the TV App
2. Navigate to Playlists
3. Move around the cells

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
