### PR TITLE
Fix first reload of the Playlists screen always being animated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 8.12
 -----
 - Add animations when tapping backward or forward in mini player [#4214](https://github.com/Automattic/pocket-casts-ios/pull/4214)
+- Fix first reload of the Playlists screen always being animated [#4228](https://github.com/Automattic/pocket-casts-ios/pull/4228)
 
 8.11
 -----

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -263,13 +263,13 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
             if FeatureFlag.playlistsRebranding.enabled {
                 let oldData = self.listPlaylistItems
-
-                let changeSet = StagedChangeset(source: oldData, target: newData)
+                let isFirstLoad = self.firstTimeLoading
 
                 if oldData.isContentEqual(to: newData) {
                     DispatchQueue.main.async {
                         self.newFilterButton.isHidden = false
                         self.loadingIndicator.stopAnimating()
+                        self.firstTimeLoading = false
                     }
                     return
                 }
@@ -277,17 +277,25 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
                 DispatchQueue.main.async {
                     self.newFilterButton.isHidden = false
                     self.loadingIndicator.stopAnimating()
-                    do {
-                        try SJCommonUtils.catchException { [weak self] in
-                            self?.filtersTable.reload(using: changeSet, with: .fade) { [weak self] newData in
-                                self?.listPlaylistItems = newData
-                            }
-                        }
-                    } catch {
-                        if let data = changeSet.last?.data {
-                            self.listPlaylistItems = data
-                        }
+
+                    if isFirstLoad {
+                        self.listPlaylistItems = newData
                         self.filtersTable.reloadData()
+                        self.firstTimeLoading = false
+                    } else {
+                        let changeSet = StagedChangeset(source: oldData, target: newData)
+                        do {
+                            try SJCommonUtils.catchException { [weak self] in
+                                self?.filtersTable.reload(using: changeSet, with: .fade) { [weak self] newData in
+                                    self?.listPlaylistItems = newData
+                                }
+                            }
+                        } catch {
+                            if let data = changeSet.last?.data {
+                                self.listPlaylistItems = data
+                            }
+                            self.filtersTable.reloadData()
+                        }
                     }
                 }
                 return


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

n/a

Fix a small annoyance where the first time you open "Playlists" during a session, it would render the list with animations making it appear as if something changed in the list.

https://github.com/user-attachments/assets/e62741a9-5cfe-4f9a-a013-f636474bbc20

## To test

- Verify the first load of Playlists is not animated

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
