### PR TITLE
Minor performance improvements in PodcastListCell

### DIFF
--- a/podcasts/Common Components/PodcastHeartView.swift
+++ b/podcasts/Common Components/PodcastHeartView.swift
@@ -23,6 +23,7 @@ class PodcastHeartView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
+        setupViews()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -37,7 +38,10 @@ class PodcastHeartView: UIView {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        setupViews()
+    }
 
+    private func setupViews() {
         backgroundColor = UIColor.clear
 
         shadowView = UIView(frame: bounds)

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -19,8 +19,6 @@ class PodcastImageView: UIView {
 
     func setPodcast(uuid: String, size: PodcastThumbnailSize) {
         guard let imageView else { return }
-        imageView.removeConstraints(imageView.constraints)
-        imageView.anchorToAllSidesOf(view: self)
         ImageManager.sharedManager.loadImage(podcastUuid: uuid, imageView: imageView, size: size, showPlaceHolder: true)
         adjustForSize(size)
     }

--- a/podcasts/Podcasts/All Podcasts/Cells/PodcastListCell.swift
+++ b/podcasts/Podcasts/All Podcasts/Cells/PodcastListCell.swift
@@ -40,15 +40,11 @@ class PodcastListCell: ThemeableCollectionCell {
         if badgeType == .allUnplayed {
             unplayedHeight.constant = 28
 
-            unplayedBadge.layoutIfNeeded()
-
             unplayedBadge.showsNumber = true
             unplayedBadge.unplayedCount = podcast.cachedUnreadCount > 99 ? 99 : podcast.cachedUnreadCount
             unplayedBadge.isHidden = podcast.cachedUnreadCount == 0
         } else if badgeType == .latestEpisode {
             unplayedHeight.constant = 12
-
-            unplayedBadge.layoutIfNeeded()
 
             unplayedBadge.showsNumber = false
             unplayedBadge.isHidden = podcast.cachedUnreadCount == 0
@@ -81,7 +77,6 @@ class PodcastListCell: ThemeableCollectionCell {
             case .off:
                 break
         }
-        unplayedBadge.layoutIfNeeded()
 
         podcastTitle.updateNumberOfLines(regular: 1, accessibility: 3)
     }

--- a/podcasts/Podcasts/All Podcasts/Cells/PodcastListCell.swift
+++ b/podcasts/Podcasts/All Podcasts/Cells/PodcastListCell.swift
@@ -18,9 +18,11 @@ class PodcastListCell: ThemeableCollectionCell {
         }
     }
 
-    @IBOutlet var supporterHeart: PodcastHeartView!
     @IBOutlet var unplayedBadge: UnplayedBadge!
     @IBOutlet var unplayedHeight: NSLayoutConstraint!
+    @IBOutlet var contentStackView: UIStackView!
+
+    private var supporterHeart: PodcastHeartView?
 
     private var badgeType: BadgeType = .off
 
@@ -54,13 +56,29 @@ class PodcastListCell: ThemeableCollectionCell {
 
         unplayedBadge.updateColors()
 
-        supporterHeart.isHidden = !podcast.isPaid
         if podcast.isPaid {
-            supporterHeart.setPodcastColor(podcast: podcast)
-            supporterHeart.isShadowHidden = true
+            let heart = supporterHeart ?? makeSupporterHeart()
+            heart.isHidden = false
+            heart.setPodcastColor(podcast: podcast)
+            heart.isShadowHidden = true
+        } else {
+            supporterHeart?.isHidden = true
         }
 
         updateSize()
+    }
+
+    private func makeSupporterHeart() -> PodcastHeartView {
+        let heart = PodcastHeartView(frame: CGRect(x: 0, y: 0, width: 28, height: 28))
+        heart.translatesAutoresizingMaskIntoConstraints = false
+        let unplayedIndex = contentStackView.arrangedSubviews.firstIndex(of: unplayedBadge) ?? contentStackView.arrangedSubviews.count
+        contentStackView.insertArrangedSubview(heart, at: unplayedIndex)
+        NSLayoutConstraint.activate([
+            heart.widthAnchor.constraint(equalToConstant: 28),
+            heart.widthAnchor.constraint(equalTo: heart.heightAnchor),
+        ])
+        supporterHeart = heart
+        return heart
     }
 
     private func updateSize() {

--- a/podcasts/Podcasts/All Podcasts/Cells/PodcastListCell.xib
+++ b/podcasts/Podcasts/All Podcasts/Cells/PodcastListCell.xib
@@ -61,14 +61,6 @@
                                     <constraint firstAttribute="trailing" secondItem="yeO-fD-Pus" secondAttribute="trailing" id="kDB-Qf-uFi"/>
                                 </constraints>
                             </view>
-                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xn0-WO-sv3" customClass="PodcastHeartView" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="185" y="18.5" width="28" height="28"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="28" id="1OC-aL-ntf"/>
-                                    <constraint firstAttribute="width" secondItem="Xn0-WO-sv3" secondAttribute="height" multiplier="1:1" id="rsW-of-Jgo"/>
-                                </constraints>
-                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="81p-Se-BkH" customClass="UnplayedBadge" customModule="podcasts" customModuleProvider="target">
                                 <rect key="frame" x="190" y="18.5" width="28" height="28"/>
                                 <accessibility key="accessibilityConfiguration">
@@ -98,7 +90,7 @@
                 <outlet property="podcastImage" destination="Hcf-Xf-PkZ" id="Kzo-IV-2Gi"/>
                 <outlet property="podcastInfo" destination="yxZ-29-LTD" id="cMs-Fj-wuA"/>
                 <outlet property="podcastTitle" destination="yeO-fD-Pus" id="NZu-c6-t9R"/>
-                <outlet property="supporterHeart" destination="Xn0-WO-sv3" id="J0B-f9-J9j"/>
+                <outlet property="contentStackView" destination="3hO-nA-0Nr" id="ZZj-cs-stk"/>
                 <outlet property="unplayedBadge" destination="81p-Se-BkH" id="j0n-hB-JdY"/>
                 <outlet property="unplayedHeight" destination="JsO-OM-Vu5" id="w1p-he-P3I"/>
             </connections>


### PR DESCRIPTION
Implements the follow three optimizations that Claude identified after looking at the trace:

```
  2. Remove the three forced layoutIfNeeded() calls in PodcastListCell

  podcasts/Podcasts/All Podcasts/Cells/PodcastListCell.swift:43, 51, 84

  unplayedBadge.layoutIfNeeded()  // ×3 across populateFrom + updateSize
  Setting the constraint constant is enough; UIKit lays out on the next pass. With 60+ visible cells over a scroll, that's ~180 redundant layout cycles.

  3. Stop re-anchoring imageView constraints on every setPodcast

  podcasts/PodcastImageView.swift:22-23

  imageView.removeConstraints(imageView.constraints)
  imageView.anchorToAllSidesOf(view: self)
  setupView() (line 136) already anchors the imageView once. This redundant remove+re-add fires on every cell display — that's the bulk of the 60ms in
  setPodcast.

  4. Stop churning CAGradientLayers in PodcastHeartView.updateColors

  podcasts/Common Components/PodcastHeartView.swift:87-111

  updateColors() calls removeFromSuperlayer + addSublayer on both gradient layers every time — including from awakeFromNib, setGradientColors, and theme change.
  For paid podcasts this fires on every cell reuse. Add the layers once in awakeFromNib, then only update colors / frame thereafter.

  5. Make PodcastHeartView lazy / hide work for non-paid podcasts

  podcasts/Common Components/PodcastHeartView.swift:38-71

  Most podcasts are not paid (supporterHeart.isHidden = !podcast.isPaid), but awakeFromNib builds shadow view, circle view, image view, and runs updateColors()
  for every PodcastListCell instance. That's the 5–6ms awakeFromNib cost per cell init. Either (a) skip layer setup until first setPodcastColor, or (b) drop the
  IBOutlet and instantiate programmatically only for paid podcasts.
```

## To test

- Hardcoded this for testing paid podcasts: `if podcast.isPaid`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
