### PR TITLE
TV: Home  view

### DIFF
--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+import Combine
+
+@Observable
+class HomeViewModel {
+
+    private var cancellable: AnyCancellable?
+
+    enum State: Equatable, Hashable {
+        case loading
+        case ready
+        case empty
+    }
+
+    var state: State = .loading
+
+    var podcasts: [MockPodcast] = MockData.makePodcasts()
+    var currentPlaying: MockEpisode? = MockData.makePlaylists().first?.episodes.first
+    var upNext: MockEpisode? = MockData.makePlaylists().last?.episodes.first
+
+    func load() {
+        //Mock data load
+        cancellable = Timer.publish(every: 1.0, on: .main, in: .common, options: nil)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let self else { return }
+                state = .ready
+                cancellable?.cancel()
+                cancellable = nil
+            }
+    }
+}
+
+struct HomeView: View {
+    @Environment(AppCoordinator.self) var coordinator
+    @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
+
+    @State private var model = HomeViewModel()
+
+    enum Layout {
+        static let gridSize = CGFloat(250)
+    }
+
+    var body: some View {
+        ZStack {
+            switch model.state {
+            case .loading:
+                loadingView
+            case .ready:
+                homeView
+            case .empty:
+                emptyView
+            }
+        }
+        .task {
+            model.load()
+        }
+    }
+
+    var loadingView: some View {
+        ProgressView()
+    }
+
+    var emptyView: some View {
+        EmptyDataView(title: L10n.tvPodcastsEmptyTitle, subtitle: L10n.tvPodcastsEmptySubtitle, actionTitle: L10n.tvPodcastsEmptyActionTitle) {
+            tabRouter.selectedTab = .home
+        }
+    }
+
+    var homeView: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 40) {
+                    Text("Keep listening")
+                        .font(.title)
+                        .foregroundStyle(Color.textPrimary)
+                    if let currentPlaying = model.currentPlaying {
+                        NavigationLink(value: currentPlaying) {
+                            EpisodeRow(episode: currentPlaying)
+                        }.buttonStyle(.card)
+                    }
+                    Text("Recommended for you")
+                        .font(.title)
+                        .foregroundStyle(Color.textPrimary)
+                    discoverCollection
+                    Text("Up next")
+                        .font(.title)
+                        .foregroundStyle(Color.textPrimary)
+                    if let upNext = model.upNext {
+                        NavigationLink(value: upNext) {
+                            EpisodeRow(episode: upNext)
+                        }.buttonStyle(.card)
+                    }
+                }
+                .navigationDestination(for: MockEpisode.self) { episode in
+                    Button(episode.title) {
+
+                    }
+                }
+            }
+        }
+    }
+
+    @Namespace private var podcastGridNamespace
+
+    var discoverCollection: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: 0, content: {
+                ForEach(model.podcasts) { podcast in
+                    NavigationLink(value: podcast) {
+                        Image(podcast.image)
+                            .resizable()
+                            .frame(width: Layout.gridSize, height: Layout.gridSize)
+                    }
+                    .buttonStyle(.card)
+                    .padding(24)
+                    .prefersDefaultFocus(model.podcasts.first?.id == podcast.id, in: podcastGridNamespace)
+                }
+            })
+            .focusScope(podcastGridNamespace)
+            .navigationDestination(for: MockPodcast.self) { podcast in
+                PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
+            }
+        }
+    }
+}
+
+#Preview {
+    HomeView()
+        .environment(AppCoordinator())
+        .environment(MainTabRouter())
+}

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -71,20 +71,20 @@ struct HomeView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 40) {
-                    Text("Keep listening")
-                        .font(.title)
+                    Text(L10n.tvHomeKeepListeningTitle)
+                        .font(.title2)
                         .foregroundStyle(Color.textPrimary)
                     if let currentPlaying = model.currentPlaying {
                         NavigationLink(value: currentPlaying) {
                             EpisodeRow(episode: currentPlaying)
                         }.buttonStyle(.card)
                     }
-                    Text("Recommended for you")
-                        .font(.title)
+                    Text(L10n.tvHomeRecommendedForYouTitle)
+                        .font(.title3)
                         .foregroundStyle(Color.textPrimary)
                     discoverCollection
-                    Text("Up next")
-                        .font(.title)
+                    Text(L10n.tvTabUpNext)
+                        .font(.title3)
                         .foregroundStyle(Color.textPrimary)
                     if let upNext = model.upNext {
                         NavigationLink(value: upNext) {

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -32,6 +32,8 @@ struct MainTabContentView: View {
 
     var body: some View {
         switch tab {
+        case .home:
+            HomeView()
         case .podcasts:
             PodcastsView()
         case .playlists:

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -40,6 +40,7 @@ struct EpisodeRow: View {
         }
         .padding(24)
         .background(Color.backgroundSunken)
+        .frame(maxWidth: 864)
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -118,7 +118,9 @@ struct PodcastDetailView: View {
                 }
             }
             .navigationDestination(for: MockEpisode.self) { episode in
-                Text(episode.title)
+                Button(episode.title) {
+                    
+                }
             }
             .padding(24)
         }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -69,6 +69,7 @@ struct PodcastDetailView: View {
             VStack {
                 episodeList
             }
+            Spacer()
         }
         .toolbar(.visible, for: .tabBar)
     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4251,6 +4251,10 @@ internal enum L10n {
   internal static var tvCreateAccountSubtitle: String { return L10n.tr("Localizable", "tv_create_account_subtitle", fallback: "Scan this code to get started on your phone, it only takes a minute.") }
   /// tv create account title
   internal static var tvCreateAccountTitle: String { return L10n.tr("Localizable", "tv_create_account_title", fallback: "Create your free account") }
+  /// tv keep listening title
+  internal static var tvHomeKeepListeningTitle: String { return L10n.tr("Localizable", "tv_home_keep_listening_title", fallback: "Keep listening") }
+  /// tv home recommended for you title
+  internal static var tvHomeRecommendedForYouTitle: String { return L10n.tr("Localizable", "tv_home_recommended_for_you_title", fallback: "Recommended for you") }
   /// tv playlists empty button action title
   internal static var tvPlaylistsEmptyActionTitle: String { return L10n.tr("Localizable", "tv_playlists_empty_action_title", fallback: "Create a playlist") }
   /// tv playlists empty subtitle

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5962,4 +5962,13 @@
 /* tv playlists empty button action title */
 "tv_playlists_empty_action_title" = "Create a playlist";
 
+/* tv keep listening title */
+"tv_home_keep_listening_title" = "Keep listening";
+
+/* tv home recommended for you title */
+"tv_home_recommended_for_you_title" = "Recommended for you";
+
+
+
+
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-

Lays out the initial Home and Playlists screens for the Pocket Casts TV app, plus minor wiring/polish across the TV target.

- Adds `HomeView` with sectioned layout for the TV home screen.
- Hooks the new views into `MainTabView` and enables back navigation in podcast detail.
- Adds the localized strings used by the new screens.

## To test

1. Build and run the **Pocket Casts TV App** target on the tvOS simulator.
2. On launch, verify the Home tab renders sections with podcasts/episodes laid out correctly.
3. Move focus across cells and confirm the selection animation feels right.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.