### PR TITLE
POC-569: Improve synced transcript auto-scroll anchoring

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Extensions/UI/UITextView+scrollToRange.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/UI/UITextView+scrollToRange.swift
@@ -3,6 +3,8 @@ import UIKit
 
 extension UITextView {
     public func scrollToRange(_ range: NSRange, verticalAnchor: CGFloat = 0.5) {
+        let clampedAnchor = min(max(verticalAnchor, 0), 1)
+
         // Ensure layout is up-to-date
         layoutManager.ensureLayout(for: textContainer)
 
@@ -14,7 +16,7 @@ extension UITextView {
 
         var visibleRect = CGRect(
             x: finalRect.origin.x - (bounds.width / 2) + (finalRect.width / 2),
-            y: finalRect.origin.y - (bounds.height * verticalAnchor) + (finalRect.height / 2),
+            y: finalRect.origin.y - (bounds.height * clampedAnchor) + (finalRect.height / 2),
             width: bounds.width,
             height: bounds.height
         ).inset(by: contentInset)

--- a/Modules/Sources/PocketCastsUtils/Extensions/UI/UITextView+scrollToRange.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/UI/UITextView+scrollToRange.swift
@@ -2,7 +2,7 @@
 import UIKit
 
 extension UITextView {
-    public func scrollToRange(_ range: NSRange) {
+    public func scrollToRange(_ range: NSRange, verticalAnchor: CGFloat = 0.5) {
         // Ensure layout is up-to-date
         layoutManager.ensureLayout(for: textContainer)
 
@@ -12,10 +12,9 @@ extension UITextView {
 
         let finalRect = rect.offsetBy(dx: textContainerInset.left, dy: textContainerInset.top)
 
-        // Calculate the rectangle to scroll to such that the finalRect is centered
         var visibleRect = CGRect(
             x: finalRect.origin.x - (bounds.width / 2) + (finalRect.width / 2),
-            y: finalRect.origin.y - (bounds.height / 2) + (finalRect.height / 2),
+            y: finalRect.origin.y - (bounds.height * verticalAnchor) + (finalRect.height / 2),
             width: bounds.width,
             height: bounds.height
         ).inset(by: contentInset)

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -841,8 +841,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             previousRange = range
             transcriptView.attributedText = styleText(transcript: transcript, position: position)
             if !isUserScrolling, !isSearching, !isAutoScrollSuppressed {
-                let scrollRange = NSRange(location: range.location, length: range.length * 2)
-                transcriptView.scrollRangeToVisible(scrollRange)
+                transcriptView.scrollToRange(range, verticalAnchor: 0.3)
             }
             #if DEBUG
             let intoCue = position - cue.startTime
@@ -922,7 +921,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         // highlight is static and yanking the view back to it would fight the
         // user who deliberately scrolled elsewhere to read.
         guard !isSearching, !isUserScrolling, playbackManager.isPlayingEpisode, let previousRange else { return }
-        transcriptView.scrollToRange(previousRange)
+        transcriptView.scrollToRange(previousRange, verticalAnchor: 0.3)
     }
 
     @objc private func transcriptTapped(_ gesture: UITapGestureRecognizer) {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -21,6 +21,10 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private var autoScrollBackWorkItem: DispatchWorkItem?
     private static let autoScrollBackDelay: TimeInterval = 5.0
 
+    // Position the active cue ~30% from the top of the visible area so a few
+    // upcoming lines are always visible below it.
+    private static let highlightVerticalAnchor: CGFloat = 0.3
+
     // `playbackProgress` fires roughly once per second, which means the highlight
     // can land up to ~1s after a cue boundary. Drive updates off the display
     // refresh instead so transitions land within one frame (~16ms at 60Hz).
@@ -841,7 +845,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             previousRange = range
             transcriptView.attributedText = styleText(transcript: transcript, position: position)
             if !isUserScrolling, !isSearching, !isAutoScrollSuppressed {
-                transcriptView.scrollToRange(range, verticalAnchor: 0.3)
+                transcriptView.scrollToRange(range, verticalAnchor: Self.highlightVerticalAnchor)
             }
             #if DEBUG
             let intoCue = position - cue.startTime
@@ -921,7 +925,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         // highlight is static and yanking the view back to it would fight the
         // user who deliberately scrolled elsewhere to read.
         guard !isSearching, !isUserScrolling, playbackManager.isPlayingEpisode, let previousRange else { return }
-        transcriptView.scrollToRange(previousRange, verticalAnchor: 0.3)
+        transcriptView.scrollToRange(previousRange, verticalAnchor: Self.highlightVerticalAnchor)
     }
 
     @objc private func transcriptTapped(_ gesture: UITapGestureRecognizer) {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/POC-569/improve-synced-transcript-auto-scroll-anchoring

## Summary
During synced transcript playback, the active highlighted cue would drift to the bottom of the screen because `scrollRangeToVisible` only scrolls the minimum amount needed. This PR anchors the active cue at ~30% from the top of the visible area for a consistent reading position.

## Changes
- Added a `verticalAnchor` parameter (default `0.5`) to `UITextView.scrollToRange(_:verticalAnchor:)` — existing callers (search navigation) keep centered behavior unchanged.
- Replaced `scrollRangeToVisible` in `updateTranscriptPosition()` with `scrollToRange(range, verticalAnchor: 0.3)`, removing the `length * 2` workaround.
- Updated `scrollBackToCurrentHighlight()` to use the same 30% anchoring so auto-scroll recovery matches normal playback.

## Verification
- **Lint**: PASS
- **Tests**: PASS — 318 tests, 0 failures
- **Diff review**: PASS — confirmed only intended changes, no debug artifacts
- **Secret scan**: PASS — no credentials in diff

## Confidence
**HIGH** — The change is minimal and surgical: one new default parameter in a UITextView extension, and two call-site updates. Build and all tests pass. Search navigation is unaffected since it uses the default `0.5` anchor. Edge cases (beginning/end of transcript) are handled by existing clamping logic.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/POC-569/improve-synced-transcript-auto-scroll-anchoring)