### PR TITLE
[PC-TV] UI tweaks

### DIFF
--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -38,16 +38,102 @@ struct MockPlaylist: Identifiable, Hashable, Equatable {
 
 struct MockData {
 
+    private static let podcastNames = [
+        "The Daily", "Serial", "Radiolab", "This American Life",
+        "99% Invisible", "Freakonomics Radio", "How I Built This",
+        "Planet Money", "The Moth", "Conan O'Brien Needs a Friend",
+        "SmartLess", "Armchair Expert", "WTF with Marc Maron",
+        "Reply All", "Heavyweight", "Criminal", "Revisionist History",
+        "Hidden Brain", "Stuff You Should Know", "TED Radio Hour",
+        "The Joe Rogan Experience", "Call Her Daddy", "My Favorite Murder",
+        "Sword and Scale", "Lore", "S-Town", "Snap Judgment",
+        "Invisibilia", "Up First", "Fresh Air", "Pod Save America",
+        "The Ben Shapiro Show", "Darknet Diaries", "Song Exploder",
+        "Everything Everywhere Daily", "Philosophize This!",
+        "The Happiness Lab", "Lex Fridman Podcast", "Hardcore History",
+        "No Such Thing As A Fish", "Science Vs", "Throughline",
+        "Slow Burn", "Ear Hustle", "Wind of Change", "Dolly Parton's America",
+        "Nice White Parents", "The Ezra Klein Show"
+    ]
+
+    private static let authorNames = [
+        "The New York Times", "Sarah Koenig", "WNYC Studios", "Ira Glass",
+        "Roman Mars", "Dubner Productions", "Guy Raz / NPR",
+        "NPR", "The Moth", "Team Coco", "Wondery", "Dax Shepard",
+        "Marc Maron", "Gimlet Media", "Jonathan Goldstein", "Phoebe Judge",
+        "Malcolm Gladwell", "Shankar Vedantam", "iHeartPodcasts", "TED",
+        "Spotify", "Barstool Sports", "Exactly Right", "Incongruity",
+        "Aaron Mahnke", "Serial Productions", "Snap Judgment",
+        "NPR", "NPR", "NPR", "Crooked Media", "The Daily Wire",
+        "Jack Rhysider", "Hrishikesh Hirway", "Gary Arndt",
+        "Stephen West", "Dr. Laurie Santos", "Lex Fridman", "Dan Carlin",
+        "QI", "Gimlet Media", "NPR", "Slate", "PRX",
+        "Pineapple Street Studios", "WNYC Studios", "Serial Productions",
+        "New York Times Opinion"
+    ]
+
+    private static let episodeTitles = [
+        "The Search for Life Beyond Earth",
+        "Why We Can't Stop Scrolling",
+        "Inside the Algorithm",
+        "The Last Day of Pompeii",
+        "How Music Hijacks Your Brain",
+        "The $70 Billion Ghost",
+        "What Happens When You Die?",
+        "The Spy Who Changed Everything",
+        "Why Do We Dream?",
+        "The Secret History of Coffee",
+        "Lost Cities of the Amazon",
+        "The Psychology of Conspiracy Theories",
+        "How Language Shapes Thought",
+        "The Rise and Fall of Theranos",
+        "What AI Can't Do (Yet)",
+        "The Ocean's Deepest Secrets",
+        "Why Nostalgia Is Good for You",
+        "The Man Who Solved the Market",
+        "How Pandemics End",
+        "The Science of Addiction",
+        "Living on Mars: A Reality Check",
+        "The Forgotten Women of NASA",
+        "Why We Procrastinate",
+        "The Dark Side of Social Media",
+        "How Trees Talk to Each Other",
+        "The Mystery of Dark Matter",
+        "Why Sleep Is Your Superpower",
+        "The Economics of Happiness",
+        "How Your Gut Controls Your Brain",
+        "The Art of Negotiation",
+        "When Algorithms Go Wrong",
+        "The History of the Internet",
+        "Why Silence Is So Loud",
+        "The Future of Work",
+        "How Cults Recruit Normal People",
+        "The Science Behind Déjà Vu",
+        "What Makes a Song a Hit?",
+        "The Hidden Cost of Fast Fashion",
+        "Why We Love True Crime",
+        "The Next Pandemic",
+        "How Memory Works (and Fails)",
+        "The Ethics of Gene Editing",
+        "Why Cities Make Us Lonely",
+        "The Power of Boredom",
+        "How Volcanoes Changed History",
+        "The Truth About Multitasking",
+        "Why We Need Strangers",
+        "The Invention of Money"
+    ]
+
     static func makePodcasts() -> [MockPodcast] {
         let numberOfPodcasts = 48
         var results = [MockPodcast]()
         for i in (0..<numberOfPodcasts) {
             var episodes: [MockEpisode] = []
             let podcastImageName = "Covers/login-cover-\( (i % 10) + 1)"
-            for i in (0..<numberOfPodcasts) {
-                episodes.append(MockEpisode(uuid: UUID().uuidString, title: "Episode \(i+1)", publishedDate: Date.now.weeksAgo(i), duration: Double.random(in: (5.minutes...1.hours)), image: podcastImageName))
+            for j in (0..<numberOfPodcasts) {
+                let titleIndex = (i + j) % episodeTitles.count
+                episodes.append(MockEpisode(uuid: UUID().uuidString, title: episodeTitles[titleIndex], publishedDate: Date.now.weeksAgo(j), duration: Double.random(in: (5.minutes...1.hours)), image: podcastImageName))
             }
-            results.append(MockPodcast(id: UUID().uuidString, title: "Podcast \(i+1)", author: "Author \(i+1)", podcastDescription: "Here is a fun description for this", image: podcastImageName, episodes: episodes))
+            results.append(MockPodcast(id: UUID().uuidString, title: podcastNames[i % podcastNames.count], author: authorNames[i % authorNames.count], podcastDescription: "Here is a fun description for this", image: podcastImageName, episodes: episodes))
         }
         return results
     }
@@ -61,11 +147,12 @@ struct MockData {
             ("TV Stuff", false, Color(red: 0.21, green: 0.22, blue: 0.14)),
             ("My favorites", true, Color(red: 0.5, green: 0.35, blue: 0.12))
         ]
-        for (name, smart, color) in playlistsSpec {
+        for (index, (name, smart, color)) in playlistsSpec.enumerated() {
             var episodes: [MockEpisode] = []
-            for i in (0..<Int.random(in: 1..<numberOfEpisodes)) {
+            for i in (0..<Int.random(in: 3..<numberOfEpisodes)) {
                 let podcastImageName = "Covers/login-cover-\( Int.random(in: (1...10)))"
-                episodes.append(MockEpisode(uuid: UUID().uuidString, title: "Episode \(i+1)", publishedDate: Date.now.weeksAgo(i), duration: Double.random(in: (5.minutes...1.hours)), image: podcastImageName))
+                let titleIndex = (index * 7 + i) % episodeTitles.count
+                episodes.append(MockEpisode(uuid: UUID().uuidString, title: episodeTitles[titleIndex], publishedDate: Date.now.weeksAgo(i), duration: Double.random(in: (5.minutes...1.hours)), image: podcastImageName))
             }
             results.append(MockPlaylist(id: UUID().uuidString, title: name, manual: !smart, episodes: episodes, color: color))
         }

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -26,6 +26,10 @@ struct MockPodcast: Identifiable, Hashable, Equatable {
     var podcastDescription: String?
     var image: String
     var episodes: [MockEpisode]
+    var network: String?
+    var website: String?
+    var frequency: String?
+    var nextEpisodeDate: String?
 }
 
 struct MockPlaylist: Identifiable, Hashable, Equatable {
@@ -133,7 +137,20 @@ struct MockData {
                 let titleIndex = (i + j) % episodeTitles.count
                 episodes.append(MockEpisode(uuid: UUID().uuidString, title: episodeTitles[titleIndex], publishedDate: Date.now.weeksAgo(j), duration: Double.random(in: (5.minutes...1.hours)), image: podcastImageName))
             }
-            results.append(MockPodcast(id: UUID().uuidString, title: podcastNames[i % podcastNames.count], author: authorNames[i % authorNames.count], podcastDescription: "Here is a fun description for this", image: podcastImageName, episodes: episodes))
+            let frequencies = ["Released weekly", "Released daily", "Released biweekly", "Released monthly"]
+            let nextDays = ["Next episode Monday", "Next episode Tuesday", "Next episode Wednesday", "Next episode Thursday", "Next episode Friday"]
+            results.append(MockPodcast(
+                id: UUID().uuidString,
+                title: podcastNames[i % podcastNames.count],
+                author: authorNames[i % authorNames.count],
+                podcastDescription: "Here is a fun description for this",
+                image: podcastImageName,
+                episodes: episodes,
+                network: authorNames[i % authorNames.count],
+                website: "https://\(podcastNames[i % podcastNames.count].lowercased().replacingOccurrences(of: " ", with: "")).com",
+                frequency: frequencies[i % frequencies.count],
+                nextEpisodeDate: nextDays[i % nextDays.count]
+            ))
         }
         return results
     }

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -166,7 +166,7 @@ struct MockData {
         ]
         for (index, (name, smart, color)) in playlistsSpec.enumerated() {
             var episodes: [MockEpisode] = []
-            for i in (0..<Int.random(in: 3..<numberOfEpisodes)) {
+            for i in (0..<Int.random(in: 0..<numberOfEpisodes)) {
                 let podcastImageName = "Covers/login-cover-\( Int.random(in: (1...10)))"
                 let titleIndex = (index * 7 + i) % episodeTitles.count
                 episodes.append(MockEpisode(uuid: UUID().uuidString, title: episodeTitles[titleIndex], publishedDate: Date.now.weeksAgo(i), duration: Double.random(in: (5.minutes...1.hours)), image: podcastImageName))

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -77,7 +77,7 @@ struct HomeView: View {
                     if let currentPlaying = model.currentPlaying {
                         NavigationLink(value: currentPlaying) {
                             EpisodeRow(episode: currentPlaying)
-                        }.buttonStyle(.card)
+                        }.buttonStyle(EpisodeRowButtonStyle())
                     }
                     Text(L10n.tvHomeRecommendedForYouTitle)
                         .font(.title3)
@@ -89,7 +89,7 @@ struct HomeView: View {
                     if let upNext = model.upNext {
                         NavigationLink(value: upNext) {
                             EpisodeRow(episode: upNext)
-                        }.buttonStyle(.card)
+                        }.buttonStyle(EpisodeRowButtonStyle())
                     }
                 }
                 .navigationDestination(for: MockEpisode.self) { episode in

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -75,11 +75,8 @@ struct HomeView: View {
                         .font(.title2)
                         .foregroundStyle(Color.textPrimary)
                     if let currentPlaying = model.currentPlaying {
-                        NavigationLink(value: currentPlaying) {
-                            EpisodeRow(episode: currentPlaying)
-                        }
-                        .buttonStyle(EpisodeRowButtonStyle())
-                        .frame(maxWidth: 864, alignment: .leading)
+                        EpisodePlayerButton(episode: currentPlaying)
+                            .frame(maxWidth: 864, alignment: .leading)
                     }
                     Text(L10n.tvHomeRecommendedForYouTitle)
                         .font(.title3)
@@ -89,16 +86,8 @@ struct HomeView: View {
                         .font(.title3)
                         .foregroundStyle(Color.textPrimary)
                     if let upNext = model.upNext {
-                        NavigationLink(value: upNext) {
-                            EpisodeRow(episode: upNext)
-                        }
-                        .buttonStyle(EpisodeRowButtonStyle())
-                        .frame(maxWidth: 864, alignment: .leading)
-                    }
-                }
-                .navigationDestination(for: MockEpisode.self) { episode in
-                    Button(episode.title) {
-
+                        EpisodePlayerButton(episode: upNext)
+                            .frame(maxWidth: 864, alignment: .leading)
                     }
                 }
             }

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -77,7 +77,9 @@ struct HomeView: View {
                     if let currentPlaying = model.currentPlaying {
                         NavigationLink(value: currentPlaying) {
                             EpisodeRow(episode: currentPlaying)
-                        }.buttonStyle(EpisodeRowButtonStyle())
+                        }
+                        .buttonStyle(EpisodeRowButtonStyle())
+                        .frame(maxWidth: 864, alignment: .leading)
                     }
                     Text(L10n.tvHomeRecommendedForYouTitle)
                         .font(.title3)
@@ -89,7 +91,9 @@ struct HomeView: View {
                     if let upNext = model.upNext {
                         NavigationLink(value: upNext) {
                             EpisodeRow(episode: upNext)
-                        }.buttonStyle(EpisodeRowButtonStyle())
+                        }
+                        .buttonStyle(EpisodeRowButtonStyle())
+                        .frame(maxWidth: 864, alignment: .leading)
                     }
                 }
                 .navigationDestination(for: MockEpisode.self) { episode in

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -14,9 +14,14 @@ class HomeViewModel {
 
     var state: State = .loading
 
-    var podcasts: [MockPodcast] = MockData.makePodcasts()
-    var currentPlaying: MockEpisode? = MockData.makePlaylists().first?.episodes.first
-    var upNext: MockEpisode? = MockData.makePlaylists().last?.episodes.first
+    private static let allPodcasts = MockData.makePodcasts()
+    private static let allPlaylists = MockData.makePlaylists()
+
+    var podcasts: [MockPodcast] = allPodcasts
+    var currentPlaying: MockEpisode? = allPlaylists.first?.episodes.first
+    var upNext: [MockEpisode] = Array(allPlaylists.flatMap(\.episodes).prefix(3))
+    var recentlyPlayed: [MockPodcast] = Array(allPodcasts.shuffled().prefix(10))
+    var newReleases: [MockEpisode] = allPodcasts.prefix(8).compactMap(\.episodes.first)
 
     func load() {
         //Mock data load
@@ -78,17 +83,26 @@ struct HomeView: View {
                         EpisodePlayerButton(episode: currentPlaying)
                             .frame(maxWidth: 864, alignment: .leading)
                     }
-                    Text(L10n.tvHomeRecommendedForYouTitle)
-                        .font(.title3)
-                        .foregroundStyle(Color.textPrimary)
-                    discoverCollection
+                    VStack(alignment: .leading, spacing: 24) {
+                        Text(L10n.tvHomeRecommendedForYouTitle)
+                            .font(.title3)
+                            .foregroundStyle(Color.textPrimary)
+                        discoverCollection
+                    }
                     Text(L10n.tvTabUpNext)
                         .font(.title3)
                         .foregroundStyle(Color.textPrimary)
-                    if let upNext = model.upNext {
-                        EpisodePlayerButton(episode: upNext)
-                            .frame(maxWidth: 864, alignment: .leading)
+                    upNextRow
+                    VStack(alignment: .leading, spacing: 24) {
+                        Text(L10n.tvHomeRecentlyPlayed)
+                            .font(.title3)
+                            .foregroundStyle(Color.textPrimary)
+                        recentlyPlayedRow
                     }
+                    Text(L10n.tvHomeNewReleases)
+                        .font(.title3)
+                        .foregroundStyle(Color.textPrimary)
+                    newReleasesRow
                 }
             }
         }
@@ -114,6 +128,45 @@ struct HomeView: View {
             .navigationDestination(for: MockPodcast.self) { podcast in
                 PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
             }
+        }
+    }
+    var upNextRow: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: 24) {
+                ForEach(model.upNext) { episode in
+                    EpisodePlayerButton(episode: episode)
+                        .frame(width: 864)
+                }
+            }
+            .padding(.horizontal, 24)
+        }
+    }
+
+    var recentlyPlayedRow: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: 0) {
+                ForEach(model.recentlyPlayed) { podcast in
+                    NavigationLink(value: podcast) {
+                        Image(podcast.image)
+                            .resizable()
+                            .frame(width: Layout.gridSize, height: Layout.gridSize)
+                    }
+                    .buttonStyle(.card)
+                    .padding(24)
+                }
+            }
+        }
+    }
+
+    var newReleasesRow: some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: 24) {
+                ForEach(model.newReleases) { episode in
+                    EpisodePlayerButton(episode: episode)
+                        .frame(width: 864)
+                }
+            }
+            .padding(.horizontal, 24)
         }
     }
 }

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -98,9 +98,8 @@ struct MainTabView: View {
             .focused($focusedArea, equals: .tabBar)
         }.overlay(alignment: .top) {
             accessoryView
-        }.onAppear {
-            focusedArea = .tabBar
         }
+        .defaultFocus($focusedArea, .tabBar)
         // Intercept right-swipe from tab bar to profile
         .onMoveCommand { direction in
             handleMove(direction)

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -64,6 +64,7 @@ struct CenterButton: View {
 @Observable
 final class MainTabRouter {
     var selectedTab: MainTab = .home
+    var isShowingDetail: Bool = false
 }
 
 struct MainTabView: View {
@@ -111,17 +112,20 @@ struct MainTabView: View {
         }
     }
 
+    @ViewBuilder
     var accessoryView: some View {
-        VStack() {
-            HStack() {
-                leftAccessory
+        if !tabSelection.isShowingDetail {
+            VStack() {
+                HStack() {
+                    leftAccessory
+                    Spacer()
+                    rightAccessory
+                }
+                .padding(.vertical, 48)
+                .padding(.horizontal, 84)
+                .offset(x: 0, y: -scrollOffset)
                 Spacer()
-                rightAccessory
             }
-            .padding(.vertical, 48)
-            .padding(.horizontal, 84)
-            .offset(x: 0, y: -scrollOffset)
-            Spacer()
         }
     }
 

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -70,7 +70,6 @@ struct MainTabView: View {
 
     @State private var tabSelection: MainTabRouter = MainTabRouter()
     @FocusState private var focusedArea: FocusArea?
-
     @State private var scrollOffset: Double = 0
 
     enum FocusArea: Hashable {
@@ -107,7 +106,7 @@ struct MainTabView: View {
         .ignoresSafeArea()
         .onScrollGeometryChange(for: Double.self) { geometry in
             geometry.contentInsets.top + geometry.contentOffset.y
-        } action: { before, after in
+        } action: { _, after in
             self.scrollOffset = after
         }
     }

--- a/Pocket Casts TV App/UI/Player/EpisodePlayerView.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodePlayerView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import AVKit
+
+struct EpisodePlayerView: UIViewControllerRepresentable {
+    let episode: MockEpisode
+    var podcastTitle: String?
+    var podcastDescription: String?
+
+    private static let sampleURL = URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8")!
+
+    func makeUIViewController(context: Context) -> AVPlayerViewController {
+        let player = AVPlayer(url: Self.sampleURL)
+        let controller = AVPlayerViewController()
+        controller.player = player
+        controller.player?.currentItem?.externalMetadata = createMetadataItems()
+        player.play()
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: AVPlayerViewController, context: Context) {}
+
+    private func createMetadataItems() -> [AVMetadataItem] {
+        var items = [
+            makeMetadataItem(.commonIdentifierTitle, value: episode.title)
+        ]
+        if let podcastTitle {
+            items.append(makeMetadataItem(.iTunesMetadataTrackSubTitle, value: podcastTitle))
+        }
+        if let imageData = UIImage(named: episode.image)?.pngData() {
+            items.append(makeMetadataItem(.commonIdentifierArtwork, value: imageData))
+        }
+        if let podcastDescription {
+            items.append(makeMetadataItem(.commonIdentifierDescription, value: podcastDescription))
+        }
+        return items
+    }
+
+    private func makeMetadataItem(_ identifier: AVMetadataIdentifier, value: Any) -> AVMetadataItem {
+        let item = AVMutableMetadataItem()
+        item.identifier = identifier
+        item.value = value as? NSCopying & NSObjectProtocol
+        item.extendedLanguageTag = "und"
+        return item.copy() as! AVMetadataItem
+    }
+}
+
+struct EpisodePlayerButton: View {
+    let episode: MockEpisode
+    var podcastTitle: String?
+    var podcastDescription: String?
+    @State private var isPlaying = false
+
+    var body: some View {
+        Button {
+            isPlaying = true
+        } label: {
+            EpisodeRow(episode: episode)
+        }
+        .buttonStyle(EpisodeRowButtonStyle())
+        .fullScreenCover(isPresented: $isPlaying) {
+            EpisodePlayerView(
+                episode: episode,
+                podcastTitle: podcastTitle,
+                podcastDescription: podcastDescription
+            )
+            .ignoresSafeArea()
+        }
+    }
+}
+
+#Preview {
+    EpisodePlayerButton(
+        episode: MockData.makePodcasts().first!.episodes.first!,
+        podcastTitle: "The Daily"
+    )
+}

--- a/Pocket Casts TV App/UI/Player/EpisodePlayerView.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodePlayerView.swift
@@ -6,13 +6,18 @@ struct EpisodePlayerView: UIViewControllerRepresentable {
     var podcastTitle: String?
     var podcastDescription: String?
 
-    private static let sampleURL = URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8")!
+    private static let sampleURL = URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_4x3/bipbop_4x3_variant.m3u8")!
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
         let player = AVPlayer(url: Self.sampleURL)
         let controller = AVPlayerViewController()
         controller.player = player
         controller.player?.currentItem?.externalMetadata = createMetadataItems()
+        controller.transportBarCustomMenuItems = [
+            makePlaybackSpeedMenu(player: player),
+            makePlaybackEffectsMenu()
+        ]
+        controller.allowedSubtitleOptionLanguages = []
         player.play()
         return controller
     }
@@ -33,6 +38,58 @@ struct EpisodePlayerView: UIViewControllerRepresentable {
             items.append(makeMetadataItem(.commonIdentifierDescription, value: podcastDescription))
         }
         return items
+    }
+
+    private func makePlaybackSpeedMenu(player: AVPlayer) -> UIMenu {
+        let speeds = stride(from: 1.0, through: 3.0, by: 0.1).map { $0 }
+        let actions = speeds.map { speed in
+            UIAction(
+                title: String(format: "%.1fx", speed),
+                state: speed == 1.0 ? .on : .off
+            ) { action in
+                player.rate = Float(speed)
+                if let menu = action.sender as? UIMenu {
+                    menu.children.compactMap { $0 as? UIAction }.forEach { $0.state = .off }
+                }
+                action.state = .on
+            }
+        }
+        return UIMenu(
+            title: L10n.tvPlayerPlaybackSpeed,
+            image: UIImage(systemName: "gauge.with.dots.needle.33percent"),
+            children: [UIMenu(title: "", options: [.displayInline, .singleSelection], children: actions)]
+        )
+    }
+
+    private func makePlaybackEffectsMenu() -> UIMenu {
+        let volumeBoostAction = UIAction(
+            title: L10n.tvPlayerVolumeBoost,
+            image: UIImage(systemName: "speaker.wave.3"),
+            state: .off
+        ) { action in
+            action.state = action.state == .off ? .on : .off
+        }
+
+        let trimOptions: [(String, UIAction.State)] = [
+            (L10n.tvPlayerTrimSilenceOff, .on),
+            (L10n.tvPlayerTrimSilenceMild, .off),
+            (L10n.tvPlayerTrimSilenceMedium, .off),
+            (L10n.tvPlayerTrimSilenceMadMax, .off)
+        ]
+        let trimActions = trimOptions.map { title, state in
+            UIAction(title: title, state: state) { _ in }
+        }
+        let trimSubmenu = UIMenu(
+            title: L10n.tvPlayerTrimSilence,
+            options: [.displayInline, .singleSelection],
+            children: trimActions
+        )
+
+        return UIMenu(
+            title: L10n.tvPlayerPlaybackEffects,
+            image: UIImage(systemName: "slider.horizontal.3"),
+            children: [volumeBoostAction, trimSubmenu]
+        )
     }
 
     private func makeMetadataItem(_ identifier: AVMetadataIdentifier, value: Any) -> AVMetadataItem {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -62,7 +62,13 @@ class PlaylistDetailViewModel {
 
 struct PlaylistDetailView: View {
 
+    @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
     let model: PlaylistDetailViewModel
+    @FocusState private var focusedSection: FocusSection?
+
+    enum FocusSection: Hashable {
+        case episodes
+    }
 
     enum Layout {
         static let mosaicSize = CGFloat(418)
@@ -81,6 +87,9 @@ struct PlaylistDetailView: View {
             }
         }
         .toolbar(.hidden, for: .tabBar)
+        .defaultFocus($focusedSection, .episodes)
+        .onAppear { tabRouter.isShowingDetail = true }
+        .onDisappear { tabRouter.isShowingDetail = false }
         .task {
             model.load()
         }
@@ -163,11 +172,13 @@ struct PlaylistDetailView: View {
             .padding(.horizontal, 24)
             .padding(.bottom, 24)
         }
+        .focused($focusedSection, equals: .episodes)
     }
 }
 
 #Preview {
+    let router = MainTabRouter()
     PlaylistDetailView(model: PlaylistDetailViewModel(playlist: MockData.makePlaylists().first!))
         .environment(AppCoordinator())
-        .environment(MainTabRouter())
+        .environment(router)
 }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -95,7 +95,6 @@ struct PlaylistDetailView: View {
                 .frame(width: Layout.infoPanelWidth)
             episodeList
         }
-        .toolbar(.hidden, for: .tabBar)
     }
 
     var mosaicCover: some View {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -1,0 +1,179 @@
+import SwiftUI
+import Combine
+import PocketCastsUtils
+
+@Observable
+class PlaylistDetailViewModel {
+
+    private var cancellable: AnyCancellable?
+
+    enum State: Equatable, Hashable {
+        case loading
+        case ready
+    }
+
+    var state: State = .loading
+
+    let playlist: MockPlaylist
+
+    init(playlist: MockPlaylist) {
+        self.playlist = playlist
+    }
+
+    func load() {
+        cancellable = Timer.publish(every: 1.0, on: .main, in: .common, options: nil)
+            .autoconnect()
+            .sink { [weak self] _ in
+                guard let self else { return }
+                state = .ready
+                cancellable?.cancel()
+                cancellable = nil
+            }
+    }
+
+    func playAll() {
+
+    }
+
+    var totalDuration: String {
+        let total = playlist.episodes.reduce(0) { $0 + $1.duration }
+        return TimeFormatter.shared.multipleUnitFormattedShortTime(time: total)
+    }
+
+    var episodeCountText: String {
+        return L10n.tvPlaylistDetailEpisodeCount(playlist.episodes.count)
+    }
+
+    var coverImages: [String] {
+        var seen = Set<String>()
+        var unique = [String]()
+        for episode in playlist.episodes {
+            if seen.insert(episode.image).inserted {
+                unique.append(episode.image)
+            }
+            if unique.count == 4 { break }
+        }
+        while unique.count < 4, let first = unique.first {
+            unique.append(first)
+        }
+        return unique
+    }
+}
+
+struct PlaylistDetailView: View {
+
+    let model: PlaylistDetailViewModel
+
+    enum Layout {
+        static let mosaicSize = CGFloat(418)
+        static let mosaicTileSize = CGFloat(209)
+    }
+
+    var body: some View {
+        ZStack {
+            switch model.state {
+            case .loading:
+                loadingView
+            case .ready:
+                playlistView
+            }
+        }
+        .task {
+            model.load()
+        }
+    }
+
+    var loadingView: some View {
+        ProgressView()
+    }
+
+    var playlistView: some View {
+        HStack(alignment: .top) {
+            playlistInfo
+            VStack {
+                episodeList
+            }
+            Spacer()
+        }
+        .toolbar(.hidden, for: .tabBar)
+    }
+
+    var mosaicCover: some View {
+        let images = model.coverImages
+        return VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                Image(images[0])
+                    .resizable()
+                    .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
+                Image(images[1])
+                    .resizable()
+                    .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
+            }
+            HStack(spacing: 0) {
+                Image(images[2])
+                    .resizable()
+                    .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
+                Image(images[3])
+                    .resizable()
+                    .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
+            }
+        }
+        .frame(width: Layout.mosaicSize, height: Layout.mosaicSize)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    var playlistInfo: some View {
+        VStack(alignment: .leading, spacing: 40) {
+            mosaicCover
+            VStack(alignment: .leading, spacing: 8) {
+                Text(model.playlist.manual ? "" : L10n.smartPlaylist)
+                    .font(.caption)
+                    .foregroundColor(.textSecondary)
+                Text(model.playlist.title)
+                    .font(.title2)
+                    .foregroundColor(.textPrimary)
+                Text("\(model.episodeCountText) · \(model.totalDuration)")
+                    .font(.caption)
+                    .foregroundColor(.textSecondary)
+            }
+            Button {
+                model.playAll()
+            } label: {
+                Text(L10n.tvPlaylistDetailPlayAll)
+                    .font(.caption2)
+            }
+        }
+        .focusSection()
+    }
+
+    var episodeList: some View {
+        ScrollView {
+            LazyVStack {
+                ForEach(model.playlist.episodes) { episode in
+                    NavigationLink(value: episode) {
+                        EpisodeRow(episode: episode)
+                    }
+                    .buttonStyle(EpisodeRowButtonStyle())
+                }
+            }
+            .navigationDestination(for: MockEpisode.self) { episode in
+                VStack {
+                    Button {
+
+                    } label: {
+                        Text("Episode \(episode.title) details coming soon")
+                            .font(.title2)
+                            .foregroundStyle(Color.textPrimary)
+                    }
+                }
+            }
+            .padding(24)
+        }
+    }
+}
+
+#Preview {
+    PlaylistDetailView(model: PlaylistDetailViewModel(playlist: MockData.makePlaylists().first!))
+        .environment(AppCoordinator())
+        .environment(MainTabRouter())
+}

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -67,6 +67,8 @@ struct PlaylistDetailView: View {
     enum Layout {
         static let mosaicSize = CGFloat(418)
         static let mosaicTileSize = CGFloat(209)
+        static let infoPanelWidth = CGFloat(568)
+        static let gutter = CGFloat(24)
     }
 
     var body: some View {
@@ -88,12 +90,10 @@ struct PlaylistDetailView: View {
     }
 
     var playlistView: some View {
-        HStack(alignment: .top) {
+        HStack(alignment: .top, spacing: Layout.gutter) {
             playlistInfo
-            VStack {
-                episodeList
-            }
-            Spacer()
+                .frame(width: Layout.infoPanelWidth)
+            episodeList
         }
         .toolbar(.hidden, for: .tabBar)
     }
@@ -167,7 +167,8 @@ struct PlaylistDetailView: View {
                     }
                 }
             }
-            .padding(24)
+            .padding(.horizontal, 24)
+            .padding(.bottom, 24)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -80,6 +80,7 @@ struct PlaylistDetailView: View {
                 playlistView
             }
         }
+        .toolbar(.hidden, for: .tabBar)
         .task {
             model.load()
         }
@@ -145,27 +146,20 @@ struct PlaylistDetailView: View {
         .focusSection()
     }
 
+    @Namespace private var episodeListNamespace
+
     var episodeList: some View {
         ScrollView {
             LazyVStack {
                 ForEach(model.playlist.episodes) { episode in
-                    NavigationLink(value: episode) {
-                        EpisodeRow(episode: episode)
-                    }
-                    .buttonStyle(EpisodeRowButtonStyle())
+                    EpisodePlayerButton(
+                        episode: episode,
+                        podcastTitle: model.playlist.title
+                    )
+                    .prefersDefaultFocus(episode.id == model.playlist.episodes.first?.id, in: episodeListNamespace)
                 }
             }
-            .navigationDestination(for: MockEpisode.self) { episode in
-                VStack {
-                    Button {
-
-                    } label: {
-                        Text("Episode \(episode.title) details coming soon")
-                            .font(.title2)
-                            .foregroundStyle(Color.textPrimary)
-                    }
-                }
-            }
+            .focusScope(episodeListNamespace)
             .padding(.horizontal, 24)
             .padding(.bottom, 24)
         }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -53,9 +53,6 @@ class PlaylistDetailViewModel {
             }
             if unique.count == 4 { break }
         }
-        while unique.count < 4, let first = unique.first {
-            unique.append(first)
-        }
         return unique
     }
 }
@@ -107,28 +104,42 @@ struct PlaylistDetailView: View {
         }
     }
 
+    @ViewBuilder
     var mosaicCover: some View {
         let images = model.coverImages
-        return VStack(spacing: 0) {
-            HStack(spacing: 0) {
-                Image(images[0])
-                    .resizable()
-                    .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
-                Image(images[1])
-                    .resizable()
-                    .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
+        switch images.count {
+        case 0:
+            Image(ImageResource.pcLogo)
+                .resizable()
+                .frame(width: Layout.mosaicSize, height: Layout.mosaicSize)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        case 1...3:
+            Image(images[0])
+                .resizable()
+                .frame(width: Layout.mosaicSize, height: Layout.mosaicSize)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        default:
+            VStack(spacing: 0) {
+                HStack(spacing: 0) {
+                    Image(images[0])
+                        .resizable()
+                        .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
+                    Image(images[1])
+                        .resizable()
+                        .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
+                }
+                HStack(spacing: 0) {
+                    Image(images[2])
+                        .resizable()
+                        .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
+                    Image(images[3])
+                        .resizable()
+                        .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
+                }
             }
-            HStack(spacing: 0) {
-                Image(images[2])
-                    .resizable()
-                    .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
-                Image(images[3])
-                    .resizable()
-                    .frame(width: Layout.mosaicTileSize, height: Layout.mosaicTileSize)
-            }
+            .frame(width: Layout.mosaicSize, height: Layout.mosaicSize)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
         }
-        .frame(width: Layout.mosaicSize, height: Layout.mosaicSize)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
     var playlistInfo: some View {
@@ -145,11 +156,13 @@ struct PlaylistDetailView: View {
                     .font(.caption)
                     .foregroundColor(.textSecondary)
             }
-            Button {
-                model.playAll()
-            } label: {
-                Text(L10n.tvPlaylistDetailPlayAll)
-                    .font(.caption2)
+            if !model.playlist.episodes.isEmpty {
+                Button {
+                    model.playAll()
+                } label: {
+                    Text(L10n.tvPlaylistDetailPlayAll)
+                        .font(.caption2)
+                }
             }
         }
         .focusSection()

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -96,17 +96,7 @@ struct PlaylistsView: View {
         })
         .focusScope(listNamespace)
         .navigationDestination(for: MockPlaylist.self) { playlist in
-            VStack {
-                Button {
-
-                } label: {
-                    Text("Playlist \(playlist.title) details coming soon")
-                        .font(.title2)
-                        .foregroundStyle(Color.textPrimary)
-                }
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-            .padding()
+            PlaylistDetailView(model: PlaylistDetailViewModel(playlist: playlist))
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -53,7 +53,6 @@ struct EpisodeRow: View {
         .padding(24)
         .background(isFocused ? Color.backgroundActive : Color.backgroundSunken)
         .clipShape(RoundedRectangle(cornerRadius: 12))
-        .frame(maxWidth: 864)
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -1,9 +1,21 @@
 import SwiftUI
 import PocketCastsUtils
 
+struct EpisodeRowButtonStyle: ButtonStyle {
+    @Environment(\.isFocused) var isFocused: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(isFocused ? 1.02 : 1.0)
+            .animation(.easeInOut(duration: 0.15), value: isFocused)
+    }
+}
+
 struct EpisodeRow: View {
 
     let episode: MockEpisode
+
+    @Environment(\.isFocused) var isFocused: Bool
 
     enum Layout {
         static let episodeImageSize = CGFloat(124)
@@ -28,18 +40,19 @@ struct EpisodeRow: View {
             VStack(alignment: .leading) {
                 Text(displayDate(for: episode.publishedDate))
                     .font(.caption)
-                    .foregroundColor(.textSecondary)
+                    .foregroundColor(isFocused ? .textSecondaryActive : .textSecondary)
                 Text(episode.title)
                     .font(.body)
-                    .foregroundColor(.textPrimary)
+                    .foregroundColor(isFocused ? .textPrimaryActive : .textPrimary)
                 Text(displayDuration(for: episode.duration))
                     .font(.caption)
-                    .foregroundColor(.textSecondary)
+                    .foregroundColor(isFocused ? .textSecondaryActive : .textSecondary)
             }
             Spacer()
         }
         .padding(24)
-        .background(Color.backgroundSunken)
+        .background(isFocused ? Color.backgroundActive : Color.backgroundSunken)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
         .frame(maxWidth: 864)
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -43,6 +43,8 @@ struct PodcastDetailView: View {
     enum Layout {
         static let podcastImageSize = CGFloat(418)
         static let episodeImageSize = CGFloat(124)
+        static let infoPanelWidth = CGFloat(568)
+        static let gutter = CGFloat(24)
     }
 
     var body: some View {
@@ -64,12 +66,10 @@ struct PodcastDetailView: View {
     }
 
     var podcastView: some View {
-        HStack(alignment: .top) {
+        HStack(alignment: .top, spacing: Layout.gutter) {
             podcastInfo
-            VStack {
-                episodeList
-            }
-            Spacer()
+                .frame(width: Layout.infoPanelWidth)
+            episodeList
         }
         .toolbar(.hidden, for: .tabBar)
     }
@@ -130,7 +130,8 @@ struct PodcastDetailView: View {
                     }
                 }
             }
-            .padding(24)
+            .padding(.horizontal, 24)
+            .padding(.bottom, 24)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -71,7 +71,7 @@ struct PodcastDetailView: View {
             }
             Spacer()
         }
-        .toolbar(.visible, for: .tabBar)
+        .toolbar(.hidden, for: .tabBar)
     }
 
     var podcastInfo: some View {
@@ -79,7 +79,7 @@ struct PodcastDetailView: View {
             Image(model.podcast.image)
                 .resizable()
                 .frame(width: Layout.podcastImageSize, height: Layout.podcastImageSize)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
             VStack(alignment: .leading, spacing: 8) {
                 Text(model.podcast.author ?? "")
                     .font(.caption)
@@ -106,6 +106,7 @@ struct PodcastDetailView: View {
                 }
             }
         }
+        .focusSection()
     }
 
     var episodeList: some View {
@@ -115,7 +116,7 @@ struct PodcastDetailView: View {
                     NavigationLink(value: episode) {
                         EpisodeRow(episode: episode)
                     }
-                    .buttonStyle(.card)
+                    .buttonStyle(EpisodeRowButtonStyle())
                 }
             }
             .navigationDestination(for: MockEpisode.self) { episode in

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -14,9 +14,11 @@ class PodcastDetailViewModel {
     var state: State = .loading
 
     let podcast: MockPodcast
+    let recommendedEpisode: MockEpisode?
 
     init(podcast: MockPodcast) {
         self.podcast = podcast
+        self.recommendedEpisode = podcast.episodes.randomElement()
     }
 
     func load() {
@@ -56,6 +58,7 @@ struct PodcastDetailView: View {
                 podcastView
             }
         }
+        .toolbar(.hidden, for: .tabBar)
         .task {
             model.load()
         }
@@ -69,7 +72,7 @@ struct PodcastDetailView: View {
         HStack(alignment: .top, spacing: Layout.gutter) {
             podcastInfo
                 .frame(width: Layout.infoPanelWidth)
-            episodeList
+            episodeContent
         }
     }
 
@@ -108,27 +111,46 @@ struct PodcastDetailView: View {
         .focusSection()
     }
 
-    var episodeList: some View {
-        ScrollView {
-            LazyVStack() {
-                ForEach(model.podcast.episodes) { episode in
-                    NavigationLink(value: episode) {
-                        EpisodeRow(episode: episode)
-                    }
-                    .buttonStyle(EpisodeRowButtonStyle())
-                }
-            }
-            .navigationDestination(for: MockEpisode.self) { episode in
-                VStack {
-                    Button {
+    @Namespace private var episodeListNamespace
 
-                    } label: {
-                        Text("Episode \(episode.title) details coming soon")
-                            .font(.title2)
-                            .foregroundStyle(Color.textPrimary)
+    var episodeContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 40) {
+                if let recommended = model.recommendedEpisode {
+                    VStack(alignment: .leading, spacing: 16) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(L10n.tvPodcastDetailStartHere)
+                                .font(.title3)
+                                .foregroundStyle(Color.textPrimary)
+                            Text(L10n.tvPodcastDetailStartHereSubtitle)
+                                .font(.caption)
+                                .foregroundStyle(Color.textSecondary)
+                        }
+                        EpisodePlayerButton(
+                            episode: recommended,
+                            podcastTitle: model.podcast.title,
+                            podcastDescription: model.podcast.podcastDescription
+                        )
+                        .prefersDefaultFocus(in: episodeListNamespace)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(L10n.tvPodcastDetailAllEpisodes)
+                        .font(.title3)
+                        .foregroundStyle(Color.textPrimary)
+                    LazyVStack {
+                        ForEach(model.podcast.episodes) { episode in
+                            EpisodePlayerButton(
+                                episode: episode,
+                                podcastTitle: model.podcast.title,
+                                podcastDescription: model.podcast.podcastDescription
+                            )
+                        }
                     }
                 }
             }
+            .focusScope(episodeListNamespace)
             .padding(.horizontal, 24)
             .padding(.bottom, 24)
         }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -49,6 +49,7 @@ struct PodcastDetailView: View {
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
     let model: PodcastDetailViewModel
     @FocusState private var focusedSection: FocusSection?
+    @State private var isShowingMoreInfo = false
 
     enum FocusSection: Hashable {
         case episodes
@@ -119,7 +120,7 @@ struct PodcastDetailView: View {
                     .font(.caption2)
                 }
                 Button() {
-                    model.follow()
+                    isShowingMoreInfo = true
                 } label: {
                     Text(L10n.tvPodcastDetailMoreInfoTitle)
                         .font(.caption2)
@@ -128,6 +129,9 @@ struct PodcastDetailView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .focusSection()
+        .sheet(isPresented: $isShowingMoreInfo) {
+            PodcastMoreInfoView(podcast: model.podcast)
+        }
     }
 
     @Namespace private var episodeListNamespace

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -71,7 +71,6 @@ struct PodcastDetailView: View {
                 .frame(width: Layout.infoPanelWidth)
             episodeList
         }
-        .toolbar(.hidden, for: .tabBar)
     }
 
     var podcastInfo: some View {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -33,14 +33,26 @@ class PodcastDetailViewModel {
             }
     }
 
-    func follow() {
+    var isFollowing: Bool = false
 
+    func follow() {
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            isFollowing.toggle()
+        }
     }
 }
 
 struct PodcastDetailView: View {
 
+    @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
     let model: PodcastDetailViewModel
+    @FocusState private var focusedSection: FocusSection?
+
+    enum FocusSection: Hashable {
+        case episodes
+    }
 
     enum Layout {
         static let podcastImageSize = CGFloat(418)
@@ -59,6 +71,9 @@ struct PodcastDetailView: View {
             }
         }
         .toolbar(.hidden, for: .tabBar)
+        .defaultFocus($focusedSection, .episodes)
+        .onAppear { tabRouter.isShowingDetail = true }
+        .onDisappear { tabRouter.isShowingDetail = false }
         .task {
             model.load()
         }
@@ -97,8 +112,11 @@ struct PodcastDetailView: View {
                 Button() {
                     model.follow()
                 } label: {
-                    Text(L10n.tvPodcastDetailFollowTitle)
-                        .font(.caption2)
+                    Label(
+                        model.isFollowing ? L10n.tvPodcastDetailFollowingTitle : L10n.tvPodcastDetailFollowTitle,
+                        systemImage: model.isFollowing ? "checkmark" : "plus"
+                    )
+                    .font(.caption2)
                 }
                 Button() {
                     model.follow()
@@ -108,6 +126,7 @@ struct PodcastDetailView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .focusSection()
     }
 
@@ -154,11 +173,13 @@ struct PodcastDetailView: View {
             .padding(.horizontal, 24)
             .padding(.bottom, 24)
         }
+        .focused($focusedSection, equals: .episodes)
     }
 }
 
 #Preview {
+    let router = MainTabRouter()
     PodcastDetailView(model: PodcastDetailViewModel(podcast: MockData.makePodcasts().first!))
         .environment(AppCoordinator())
-        .environment(MainTabRouter())
+        .environment(router)
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+struct PodcastMoreInfoView: View {
+
+    let podcast: MockPodcast
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 48) {
+            HStack(alignment: .top, spacing: 40) {
+                Image(podcast.image)
+                    .resizable()
+                    .frame(width: 240, height: 240)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(podcast.author ?? "")
+                        .font(.caption)
+                        .foregroundStyle(Color.textSecondary)
+                    Text(podcast.title)
+                        .font(.title2)
+                        .foregroundStyle(Color.textPrimary)
+                }
+            }
+
+            if let description = podcast.podcastDescription {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(L10n.tvPodcastDetailAbout)
+                        .font(.title3)
+                        .foregroundStyle(Color.textPrimary)
+                    Text(description)
+                        .font(.body)
+                        .foregroundStyle(Color.textSecondary)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 24) {
+                if let network = podcast.network {
+                    infoRow(label: L10n.tvPodcastDetailNetwork, value: network)
+                }
+                if let website = podcast.website {
+                    infoRow(label: L10n.tvPodcastDetailWebsite, value: website)
+                }
+                if let frequency = podcast.frequency {
+                    infoRow(label: L10n.tvPodcastDetailSchedule, value: frequency)
+                }
+                if let nextEpisode = podcast.nextEpisodeDate {
+                    infoRow(label: L10n.tvPodcastDetailNextEpisode, value: nextEpisode)
+                }
+            }
+        }
+        .padding(80)
+        .frame(width: 862, alignment: .leading)
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func infoRow(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(Color.textSecondary)
+            Text(value)
+                .font(.body)
+                .foregroundStyle(Color.textPrimary)
+        }
+    }
+}
+
+#Preview {
+    PodcastMoreInfoView(podcast: MockData.makePodcasts().first!)
+}

--- a/Pocket Casts TV App/UI/WelcomeView.swift
+++ b/Pocket Casts TV App/UI/WelcomeView.swift
@@ -9,13 +9,14 @@ struct WelcomeView: View {
     @Environment(AppCoordinator.self) var coordinator
 
     @State var model = WelcomeViewModel()
+    @State private var animating = false
 
     enum Layout {
         static let gridSize = CGFloat(272)
-    }
-
-    let items: [GridItem] = (0..<8).map { _ in
-        GridItem(.fixed(Layout.gridSize))
+        static let gridSpacing = CGFloat(16)
+        static let columnsPerRow = 8
+        static let animationOffset = CGFloat(200)
+        static let animationDuration = 30.0
     }
 
     enum Destination: Hashable {
@@ -26,15 +27,19 @@ struct WelcomeView: View {
     var body: some View {
         NavigationStack {
             ZStack(alignment: .center) {
-                VStack(spacing: 32) {
+                VStack(spacing: 24) {
                     Spacer()
                     Image(ImageResource.pcLogo)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(height: 108)
                     Text(L10n.tvWelcomeTitle)
                         .font(.title)
                     Text(L10n.tvWelcomeSubtitle)
                         .font(.headline)
                         .foregroundColor(Color.textSecondary)
-                    HStack {
+                        .padding(.bottom, 16)
+                    HStack(spacing: 16) {
                         NavigationLink(value: Destination.signIn) {
                             Text(L10n.tvWelcomeSignIn)
                         }
@@ -46,8 +51,6 @@ struct WelcomeView: View {
                     Button(L10n.tvWelcomeBrowseWithoutAccount) {
                         coordinator.state = .browsing
                     }
-                    .buttonStyle(.plain)
-                    .foregroundColor(Color.textSecondary)
                 }
             }
             .navigationDestination(for: Destination.self) { destination in
@@ -67,14 +70,33 @@ struct WelcomeView: View {
         }
     }
 
+    var podcastRows: [[MockPodcast]] {
+        stride(from: 0, to: model.podcasts.count, by: Layout.columnsPerRow).map {
+            Array(model.podcasts[$0..<min($0 + Layout.columnsPerRow, model.podcasts.count)])
+        }
+    }
+
     var podcastGrid: some View {
-        LazyVGrid(columns: items, content: {
-            ForEach(model.podcasts) { podcast in
-                Image(podcast.image)
-                    .resizable()
-                    .frame(width: Layout.gridSize, height: Layout.gridSize)
+        VStack(spacing: Layout.gridSpacing) {
+            ForEach(Array(podcastRows.enumerated()), id: \.offset) { rowIndex, row in
+                HStack(spacing: Layout.gridSpacing) {
+                    ForEach(row) { podcast in
+                        Image(podcast.image)
+                            .resizable()
+                            .frame(width: Layout.gridSize, height: Layout.gridSize)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                }
+                .offset(x: animating
+                    ? (rowIndex.isMultiple(of: 2) ? Layout.animationOffset : -Layout.animationOffset)
+                    : (rowIndex.isMultiple(of: 2) ? -Layout.animationOffset : Layout.animationOffset))
             }
-        })
+        }
+        .onAppear {
+            withAnimation(.linear(duration: Layout.animationDuration).repeatForever(autoreverses: true)) {
+                animating = true
+            }
+        }
     }
 
     var gradientView: some View {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4306,7 +4306,7 @@ internal enum L10n {
   /// tv welcome sign in
   internal static var tvWelcomeSignIn: String { return L10n.tr("Localizable", "tv_welcome_sign_in", fallback: "Sign in") }
   /// tv welcome subtitle
-  internal static var tvWelcomeSubtitle: String { return L10n.tr("Localizable", "tv_welcome_subtitle", fallback: "Your podcasts on the big screen") }
+  internal static var tvWelcomeSubtitle: String { return L10n.tr("Localizable", "tv_welcome_subtitle", fallback: "Your podcasts. On the big screen. Obviously.") }
   /// tv welcome title
   internal static var tvWelcomeTitle: String { return L10n.tr("Localizable", "tv_welcome_title", fallback: "Welcome to Pocket Casts TV") }
   /// A common string used throughout the app. Prompt to restore the selected item(s) from an archived state.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4255,6 +4255,12 @@ internal enum L10n {
   internal static var tvHomeKeepListeningTitle: String { return L10n.tr("Localizable", "tv_home_keep_listening_title", fallback: "Keep listening") }
   /// tv home recommended for you title
   internal static var tvHomeRecommendedForYouTitle: String { return L10n.tr("Localizable", "tv_home_recommended_for_you_title", fallback: "Recommended for you") }
+  /// tv playlist detail episode count. '%1$@' is a placeholder for the number of episodes.
+  internal static func tvPlaylistDetailEpisodeCount(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "tv_playlist_detail_episode_count", String(describing: p1), fallback: "%1$@ episodes")
+  }
+  /// tv playlist detail play all button title
+  internal static var tvPlaylistDetailPlayAll: String { return L10n.tr("Localizable", "tv_playlist_detail_play_all", fallback: "Play all episodes") }
   /// tv playlists empty button action title
   internal static var tvPlaylistsEmptyActionTitle: String { return L10n.tr("Localizable", "tv_playlists_empty_action_title", fallback: "Create a playlist") }
   /// tv playlists empty subtitle

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4253,6 +4253,10 @@ internal enum L10n {
   internal static var tvCreateAccountTitle: String { return L10n.tr("Localizable", "tv_create_account_title", fallback: "Create your free account") }
   /// tv keep listening title
   internal static var tvHomeKeepListeningTitle: String { return L10n.tr("Localizable", "tv_home_keep_listening_title", fallback: "Keep listening") }
+  /// tv home new releases section title
+  internal static var tvHomeNewReleases: String { return L10n.tr("Localizable", "tv_home_new_releases", fallback: "New releases") }
+  /// tv home recently played section title
+  internal static var tvHomeRecentlyPlayed: String { return L10n.tr("Localizable", "tv_home_recently_played", fallback: "Recently played") }
   /// tv home recommended for you title
   internal static var tvHomeRecommendedForYouTitle: String { return L10n.tr("Localizable", "tv_home_recommended_for_you_title", fallback: "Recommended for you") }
   /// tv playlist detail episode count. '%1$@' is a placeholder for the number of episodes.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4267,10 +4267,16 @@ internal enum L10n {
   internal static var tvPlaylistsEmptySubtitle: String { return L10n.tr("Localizable", "tv_playlists_empty_subtitle", fallback: "Build one manually or let Smart Rules do the sorting for you.") }
   /// tv playlists empty title
   internal static var tvPlaylistsEmptyTitle: String { return L10n.tr("Localizable", "tv_playlists_empty_title", fallback: "Your playlists live here") }
+  /// tv podcast detail all episodes section title
+  internal static var tvPodcastDetailAllEpisodes: String { return L10n.tr("Localizable", "tv_podcast_detail_all_episodes", fallback: "All episodes") }
   /// tv podcast details follow button title
   internal static var tvPodcastDetailFollowTitle: String { return L10n.tr("Localizable", "tv_podcast_detail_follow_title", fallback: "Follow this podcast") }
   /// tv podcast details more info button title
   internal static var tvPodcastDetailMoreInfoTitle: String { return L10n.tr("Localizable", "tv_podcast_detail_more_info_title", fallback: "More info") }
+  /// tv podcast detail recommended episode section title
+  internal static var tvPodcastDetailStartHere: String { return L10n.tr("Localizable", "tv_podcast_detail_start_here", fallback: "The episode to try first") }
+  /// tv podcast detail recommended episode section subtitle
+  internal static var tvPodcastDetailStartHereSubtitle: String { return L10n.tr("Localizable", "tv_podcast_detail_start_here_subtitle", fallback: "This is the one that gets people hooked") }
   /// tv podcasts empty button action title
   internal static var tvPodcastsEmptyActionTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_action_title", fallback: "Discover podcasts") }
   /// tv podcasts empty subtitle

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4287,6 +4287,8 @@ internal enum L10n {
   internal static var tvPlaylistsEmptySubtitle: String { return L10n.tr("Localizable", "tv_playlists_empty_subtitle", fallback: "Build one manually or let Smart Rules do the sorting for you.") }
   /// tv playlists empty title
   internal static var tvPlaylistsEmptyTitle: String { return L10n.tr("Localizable", "tv_playlists_empty_title", fallback: "Your playlists live here") }
+  /// tv podcast more info about section title
+  internal static var tvPodcastDetailAbout: String { return L10n.tr("Localizable", "tv_podcast_detail_about", fallback: "About") }
   /// tv podcast detail all episodes section title
   internal static var tvPodcastDetailAllEpisodes: String { return L10n.tr("Localizable", "tv_podcast_detail_all_episodes", fallback: "All episodes") }
   /// tv podcast details follow button title
@@ -4295,10 +4297,18 @@ internal enum L10n {
   internal static var tvPodcastDetailFollowingTitle: String { return L10n.tr("Localizable", "tv_podcast_detail_following_title", fallback: "Following") }
   /// tv podcast details more info button title
   internal static var tvPodcastDetailMoreInfoTitle: String { return L10n.tr("Localizable", "tv_podcast_detail_more_info_title", fallback: "More info") }
+  /// tv podcast more info network label
+  internal static var tvPodcastDetailNetwork: String { return L10n.tr("Localizable", "tv_podcast_detail_network", fallback: "Network") }
+  /// tv podcast more info next episode label
+  internal static var tvPodcastDetailNextEpisode: String { return L10n.tr("Localizable", "tv_podcast_detail_next_episode", fallback: "Next episode") }
+  /// tv podcast more info schedule label
+  internal static var tvPodcastDetailSchedule: String { return L10n.tr("Localizable", "tv_podcast_detail_schedule", fallback: "Schedule") }
   /// tv podcast detail recommended episode section title
   internal static var tvPodcastDetailStartHere: String { return L10n.tr("Localizable", "tv_podcast_detail_start_here", fallback: "The episode to try first") }
   /// tv podcast detail recommended episode section subtitle
   internal static var tvPodcastDetailStartHereSubtitle: String { return L10n.tr("Localizable", "tv_podcast_detail_start_here_subtitle", fallback: "This is the one that gets people hooked") }
+  /// tv podcast more info website label
+  internal static var tvPodcastDetailWebsite: String { return L10n.tr("Localizable", "tv_podcast_detail_website", fallback: "Website") }
   /// tv podcasts empty button action title
   internal static var tvPodcastsEmptyActionTitle: String { return L10n.tr("Localizable", "tv_podcasts_empty_action_title", fallback: "Discover podcasts") }
   /// tv podcasts empty subtitle

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4259,6 +4259,22 @@ internal enum L10n {
   internal static var tvHomeRecentlyPlayed: String { return L10n.tr("Localizable", "tv_home_recently_played", fallback: "Recently played") }
   /// tv home recommended for you title
   internal static var tvHomeRecommendedForYouTitle: String { return L10n.tr("Localizable", "tv_home_recommended_for_you_title", fallback: "Recommended for you") }
+  /// tv player playback effects menu title
+  internal static var tvPlayerPlaybackEffects: String { return L10n.tr("Localizable", "tv_player_playback_effects", fallback: "Playback effects") }
+  /// tv player playback speed menu title
+  internal static var tvPlayerPlaybackSpeed: String { return L10n.tr("Localizable", "tv_player_playback_speed", fallback: "Playback speed") }
+  /// tv player trim silence section title
+  internal static var tvPlayerTrimSilence: String { return L10n.tr("Localizable", "tv_player_trim_silence", fallback: "Trim silence") }
+  /// tv player trim silence mad max option
+  internal static var tvPlayerTrimSilenceMadMax: String { return L10n.tr("Localizable", "tv_player_trim_silence_mad_max", fallback: "Mad Max") }
+  /// tv player trim silence medium option
+  internal static var tvPlayerTrimSilenceMedium: String { return L10n.tr("Localizable", "tv_player_trim_silence_medium", fallback: "Medium") }
+  /// tv player trim silence mild option
+  internal static var tvPlayerTrimSilenceMild: String { return L10n.tr("Localizable", "tv_player_trim_silence_mild", fallback: "Mild") }
+  /// tv player trim silence off option
+  internal static var tvPlayerTrimSilenceOff: String { return L10n.tr("Localizable", "tv_player_trim_silence_off", fallback: "Off") }
+  /// tv player volume boost toggle title
+  internal static var tvPlayerVolumeBoost: String { return L10n.tr("Localizable", "tv_player_volume_boost", fallback: "Volume boost") }
   /// tv playlist detail episode count. '%1$@' is a placeholder for the number of episodes.
   internal static func tvPlaylistDetailEpisodeCount(_ p1: Any) -> String {
     return L10n.tr("Localizable", "tv_playlist_detail_episode_count", String(describing: p1), fallback: "%1$@ episodes")
@@ -4275,6 +4291,8 @@ internal enum L10n {
   internal static var tvPodcastDetailAllEpisodes: String { return L10n.tr("Localizable", "tv_podcast_detail_all_episodes", fallback: "All episodes") }
   /// tv podcast details follow button title
   internal static var tvPodcastDetailFollowTitle: String { return L10n.tr("Localizable", "tv_podcast_detail_follow_title", fallback: "Follow this podcast") }
+  /// tv podcast details following button title
+  internal static var tvPodcastDetailFollowingTitle: String { return L10n.tr("Localizable", "tv_podcast_detail_following_title", fallback: "Following") }
   /// tv podcast details more info button title
   internal static var tvPodcastDetailMoreInfoTitle: String { return L10n.tr("Localizable", "tv_podcast_detail_more_info_title", fallback: "More info") }
   /// tv podcast detail recommended episode section title

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5953,6 +5953,15 @@
 /* tv podcast details more info button title */
 "tv_podcast_detail_more_info_title" = "More info";
 
+/* tv podcast detail recommended episode section title */
+"tv_podcast_detail_start_here" = "The episode to try first";
+
+/* tv podcast detail recommended episode section subtitle */
+"tv_podcast_detail_start_here_subtitle" = "This is the one that gets people hooked";
+
+/* tv podcast detail all episodes section title */
+"tv_podcast_detail_all_episodes" = "All episodes";
+
 /* tv playlist detail episode count. '%1$@' is a placeholder for the number of episodes. */
 "tv_playlist_detail_episode_count" = "%1$@ episodes";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5950,6 +5950,9 @@
 /* tv podcast details follow button title */
 "tv_podcast_detail_follow_title" = "Follow this podcast";
 
+/* tv podcast details following button title */
+"tv_podcast_detail_following_title" = "Following";
+
 /* tv podcast details more info button title */
 "tv_podcast_detail_more_info_title" = "More info";
 
@@ -5989,7 +5992,29 @@
 /* tv home new releases section title */
 "tv_home_new_releases" = "New releases";
 
+/* tv player playback speed menu title */
+"tv_player_playback_speed" = "Playback speed";
 
+/* tv player playback effects menu title */
+"tv_player_playback_effects" = "Playback effects";
+
+/* tv player volume boost toggle title */
+"tv_player_volume_boost" = "Volume boost";
+
+/* tv player trim silence section title */
+"tv_player_trim_silence" = "Trim silence";
+
+/* tv player trim silence off option */
+"tv_player_trim_silence_off" = "Off";
+
+/* tv player trim silence mild option */
+"tv_player_trim_silence_mild" = "Mild";
+
+/* tv player trim silence medium option */
+"tv_player_trim_silence_medium" = "Medium";
+
+/* tv player trim silence mad max option */
+"tv_player_trim_silence_mad_max" = "Mad Max";
 
 
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5983,6 +5983,12 @@
 /* tv home recommended for you title */
 "tv_home_recommended_for_you_title" = "Recommended for you";
 
+/* tv home recently played section title */
+"tv_home_recently_played" = "Recently played";
+
+/* tv home new releases section title */
+"tv_home_new_releases" = "New releases";
+
 
 
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5900,7 +5900,7 @@
 "tv_welcome_title" = "Welcome to Pocket Casts TV";
 
 /* tv welcome subtitle */
-"tv_welcome_subtitle" = "Your podcasts on the big screen";
+"tv_welcome_subtitle" = "Your podcasts. On the big screen. Obviously.";
 
 /* tv welcome sign in */
 "tv_welcome_sign_in" = "Sign in";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5953,6 +5953,12 @@
 /* tv podcast details more info button title */
 "tv_podcast_detail_more_info_title" = "More info";
 
+/* tv playlist detail episode count. '%1$@' is a placeholder for the number of episodes. */
+"tv_playlist_detail_episode_count" = "%1$@ episodes";
+
+/* tv playlist detail play all button title */
+"tv_playlist_detail_play_all" = "Play all episodes";
+
 /* tv playlists empty title */
 "tv_playlists_empty_title" = "Your playlists live here";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5956,6 +5956,21 @@
 /* tv podcast details more info button title */
 "tv_podcast_detail_more_info_title" = "More info";
 
+/* tv podcast more info network label */
+"tv_podcast_detail_network" = "Network";
+
+/* tv podcast more info website label */
+"tv_podcast_detail_website" = "Website";
+
+/* tv podcast more info schedule label */
+"tv_podcast_detail_schedule" = "Schedule";
+
+/* tv podcast more info about section title */
+"tv_podcast_detail_about" = "About";
+
+/* tv podcast more info next episode label */
+"tv_podcast_detail_next_episode" = "Next episode";
+
 /* tv podcast detail recommended episode section title */
 "tv_podcast_detail_start_here" = "The episode to try first";
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR adds the following changes:
 - Playlist list details views
 - Adds actions to todcast details view like follow and show more
 - Add parallax animation on Welcome View
 - Improves mock data names for podcasts an episode
 - Add a Full Screen player
 - Adds new sections to the home view

## To test

1. Start the app
2. Check the scrolling animation on the welcome view
3. Choose Browse without account
4. Check the home screen new sections ( Up Next with more row, Recently Played, New Releases)
5. Go to Playlists section
6. Choose a playlist
7. Check the mosaic image for the playlist
8. Select an episode
9. Tap on play

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
