### PR TITLE
Enable SwiftLint rule: unused_closure_parameter

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -72,6 +72,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   - trailing_whitespace
 
+  # Unused parameters in a closure should be replaced with `_`.
+  - unused_closure_parameter
+
   - custom_rules
 
 # Rules configuration

--- a/Modules/Sources/EndOfYear/Views/MarqueeTextView.swift
+++ b/Modules/Sources/EndOfYear/Views/MarqueeTextView.swift
@@ -68,7 +68,7 @@ public struct MarqueeTextView: View {
     private func startScrolling() {
         let speed: CGFloat = 0.1
 
-        Timer.scheduledTimer(withTimeInterval: 0.002, repeats: true) { timer in
+        Timer.scheduledTimer(withTimeInterval: 0.002, repeats: true) { _ in
             switch direction {
             case .leading:
                 offset -= speed

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -115,7 +115,7 @@ public class DataManager {
         //Do a vacuum before doing db changes
         vacuumDatabase()
         let duration = DBUtils.measureTime {
-            dbQueue.inTransaction { db, rollback in
+            dbQueue.inTransaction { db, _ in
                 do {
 
                     try? db.executeUpdate("ALTER TABLE SJPodcast DROP COLUMN settings;", values: nil)

--- a/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+UserPodcastRating.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+UserPodcastRating.swift
@@ -15,7 +15,7 @@ public extension ApiServerHandler {
     func getRating(uuid: String) async -> UserPodcastRating? {
         return await withCheckedContinuation { continuation in
             let operation = UserPodcastRatingGetTask(uuid: uuid)
-            operation.completion = { success, userRating in
+            operation.completion = { _, userRating in
                 continuation.resume(returning: userRating)
             }
             apiQueue.addOperation(operation)

--- a/Modules/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -132,7 +132,7 @@ public class DiscoverServerHandler: DiscoverServerHandling {
         }
 
         return await withCheckedContinuation { continuation in
-            performDiscoverRequest(path: source, authenticated: item.isAuthenticated) { data, response, error, _ in
+            performDiscoverRequest(path: source, authenticated: item.isAuthenticated) { _, response, _, _ in
                 let success = response?.extractStatusCode() == 200
                 continuation.resume(returning: success)
             }

--- a/Modules/Sources/PocketCastsUtils/Extensions/StringExtension.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/StringExtension.swift
@@ -64,7 +64,7 @@ public extension String {
     /// Returns a lowercased copy of the string with punctuation removed and spaces replaced
     /// by a single underscore, e.g., "the_quick_brown_fox_jumps_over_the_lazy_dog".
     func lowerSnakeCased() -> String {
-        return enumerated().map { index, character in
+        return enumerated().map { _, character in
             character.isUppercase ? "_\(character.lowercased())" : "\(character)"
         }.joined()
     }

--- a/Pocket Casts App Clip/AppClipAppDelegate.swift
+++ b/Pocket Casts App Clip/AppClipAppDelegate.swift
@@ -34,7 +34,7 @@ class AppClipAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
     private func configureFirebase() {
         FirebaseApp.configure()
 
-        FirebaseManager.refreshRemoteConfig() { [weak self] status in
+        FirebaseManager.refreshRemoteConfig() { [weak self] _ in
             self?.updateRemoteFeatureFlags()
         }
     }

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -83,7 +83,7 @@ struct SignInView: View {
 
     var qrCodeDigits: some View {
         HStack(spacing: 8) {
-            ForEach(Array(model.codes.enumerated()), id: \.offset) { index, code in
+            ForEach(Array(model.codes.enumerated()), id: \.offset) { _, code in
                 Text(code)
                     .font(.caption2)
                     .foregroundStyle(Color.textSecondary)

--- a/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
+++ b/PocketCastsTests/Tests/End of Year/EndOfYearStoriesBuilderTests.swift
@@ -229,7 +229,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let model = EndOfYear2023StoriesModel()
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { year in syncCalled = true; return true })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { _ in syncCalled = true; return true })
         Settings.setHasSyncedEpisodesForPlayback(true, year: 2023)
 
         endOfYearManager.isFullListeningHistoryToReturn = false
@@ -243,7 +243,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let model = EndOfYear2023StoriesModel()
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { year in syncCalled = true; return true })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { _ in syncCalled = true; return true })
         Settings.setHasSyncedEpisodesForPlayback(true, year: 2023)
 
         endOfYearManager.isFullListeningHistoryToReturn = false
@@ -261,7 +261,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let model = EndOfYear2023StoriesModel()
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { year in syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { _ in syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
         Settings.setHasSyncedEpisodesForPlayback(false, year: 2023)
         endOfYearManager.isFullListeningHistoryToReturn = false
         _ = await builder.build()
@@ -278,7 +278,7 @@ class EndOfYearStoriesBuilderTests: XCTestCase {
         let endOfYearManager = EndOfYearManagerMock()
         let dataManager = DataManagerMock(endOfYearManager: endOfYearManager)
         let model = EndOfYear2023StoriesModel()
-        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { year in syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
+        let builder = EndOfYearStoriesBuilder(dataManager: dataManager, model: model, sync: { _ in syncCalledTimes += 1; return true }, hasActiveSubscription: { plusUser })
         Settings.setHasSyncedEpisodesForPlayback(false, year: 2023)
         endOfYearManager.isFullListeningHistoryToReturn = false
         _ = await builder.build()

--- a/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateRetryTests.swift
+++ b/PocketCastsTests/Tests/Utilities/MediaExporterResourceLoaderDelegateRetryTests.swift
@@ -18,7 +18,7 @@ final class MediaExporterResourceLoaderDelegateRetryTests: XCTestCase {
 
         testURL = URL(string: "https://example.com/test.mp3")!
 
-        delegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { status, contentType, downloaded, total in
+        delegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { _, _, _, _ in
             // No-op for the mock callback
         }
     }
@@ -70,7 +70,7 @@ final class MediaExporterResourceLoaderDelegateRetryTests: XCTestCase {
 
         let testDelegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { _, _, _, _ in }
 
-        testDelegate.startDataRequest(with: testURL, retryWithoutUserAgent: false) { url, retryWithoutUserAgent in
+        testDelegate.startDataRequest(with: testURL, retryWithoutUserAgent: false) { _, retryWithoutUserAgent in
             didCreateRequestWithUserAgent = !retryWithoutUserAgent
             expectation.fulfill()
         }
@@ -86,7 +86,7 @@ final class MediaExporterResourceLoaderDelegateRetryTests: XCTestCase {
         var didCreateRequestWithUserAgent = false
         let testDelegate = MediaExporterResourceLoaderDelegate(saveFilePath: tempFilePath) { _, _, _, _ in }
 
-        testDelegate.startDataRequest(with: testURL, retryWithoutUserAgent: true) { url, retryWithoutUserAgent in
+        testDelegate.startDataRequest(with: testURL, retryWithoutUserAgent: true) { _, retryWithoutUserAgent in
             // Simulate request creation and check for User-Agent header
             if !retryWithoutUserAgent {
                 didCreateRequestWithUserAgent = true

--- a/Share Extension/ShareViewController.swift
+++ b/Share Extension/ShareViewController.swift
@@ -38,7 +38,7 @@ class ShareViewController: UIViewController {
     }
 
     private func loadFile(from attachment: NSItemProvider, identifier: String) {
-        attachment.loadItem(forTypeIdentifier: identifier, options: nil) { [weak self] data, error in
+        attachment.loadItem(forTypeIdentifier: identifier, options: nil) { [weak self] data, _ in
             guard let url = data as? URL else {
                 return
             }

--- a/WidgetExtension/Now Playing/NowPlayingEntryView.swift
+++ b/WidgetExtension/Now Playing/NowPlayingEntryView.swift
@@ -253,7 +253,7 @@ struct NowPlayingWidgetEntryView: View {
 
     private var nothingPlaying: some View {
         VStack(alignment: .leading, spacing: 3) {
-            GeometryReader { geometry in
+            GeometryReader { _ in
                 HStack(alignment: .top) {
                     LargeArtworkView()
                         .opacity(0.5)

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -403,37 +403,37 @@ extension AppDelegate {
     }
 
     func setupOnboardingRoutes() {
-        JLRoutes.global().addRoute("/settings/themes") {[weak self] parameters -> Bool in
+        JLRoutes.global().addRoute("/settings/themes") {[weak self] _ -> Bool in
             guard self != nil else { return false }
             NavigationManager.sharedManager.navigateTo(NavigationManager.settingsAppearanceKey, data: [NavigationManager.settingsAppearanceShowThemeKey: true])
             return true
         }
 
-        JLRoutes.global().addRoute("/signup") {[weak self] parameters -> Bool in
+        JLRoutes.global().addRoute("/signup") {[weak self] _ -> Bool in
             guard self != nil else { return false }
             NavigationManager.sharedManager.navigateTo(NavigationManager.signUpPageKey)
             return true
         }
 
-        JLRoutes.global().addRoute("/settings/import") {[weak self] parameters -> Bool in
+        JLRoutes.global().addRoute("/settings/import") {[weak self] _ -> Bool in
             guard self != nil else { return false }
             NavigationManager.sharedManager.navigateTo(NavigationManager.settingsPageKey, data: [NavigationManager.settingsRowKey: SettingsViewController.TableRow.importSteps])
             return true
         }
 
-        JLRoutes.global().addRoute("/settings/storage-and-data") {[weak self] parameters -> Bool in
+        JLRoutes.global().addRoute("/settings/storage-and-data") {[weak self] _ -> Bool in
             guard self != nil else { return false }
             NavigationManager.sharedManager.navigateTo(NavigationManager.settingsPageKey, data: [NavigationManager.settingsRowKey: SettingsViewController.TableRow.storageAndDataUse])
             return true
         }
 
-        JLRoutes.global().addRoute("/filters") {[weak self] parameters -> Bool in
+        JLRoutes.global().addRoute("/filters") {[weak self] _ -> Bool in
             guard self != nil else { return false }
             NavigationManager.sharedManager.navigateTo(NavigationManager.filterPageKey)
             return true
         }
 
-        JLRoutes.global().addRoute("/upsell") { parameters -> Bool in
+        JLRoutes.global().addRoute("/upsell") { _ -> Bool in
             guard let viewController = SceneHelper.rootViewController() else { return false }
             let source = PlusUpgradeViewSource(rawValue: ["source"] as? String ?? PlusUpgradeViewSource.deepLink.rawValue) ?? .unknown
             NavigationManager.sharedManager.navigateTo(NavigationManager.subscriptionRequiredPageKey, data: ["source": source, NavigationManager.subscriptionUpgradeVCKey: viewController])

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -295,7 +295,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func configureFirebase() {
         FirebaseApp.configure()
 
-        FirebaseManager.refreshRemoteConfig() { [weak self] status in
+        FirebaseManager.refreshRemoteConfig() { [weak self] _ in
             self?.updateEndOfYearRemoteValue()
             self?.updateRemoteFeatureFlags()
         }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -76,14 +76,14 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
 
         ServerNotifications.syncCompleted.publisher()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] bookmark in
+            .sink { [weak self] _ in
                 self?.reload()
             }
             .store(in: &cancellables)
 
         feature.objectWillChange
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] bookmark in
+            .sink { [weak self] _ in
                 self?.reload()
                 self?.objectWillChange.send()
             }

--- a/podcasts/Common Components/RichExpandableDescriptionView.swift
+++ b/podcasts/Common Components/RichExpandableDescriptionView.swift
@@ -211,7 +211,7 @@ class RichExpandableLabel: WKWebView {
     }
 
     private func updateLinesRequired() {
-        evaluateJavaScript("countLines()", completionHandler: { [weak self] lines, error in
+        evaluateJavaScript("countLines()", completionHandler: { [weak self] lines, _ in
             guard let self, let linesRequired = lines as? Double else { return }
             collapsed = Int(linesRequired.rounded(.up)) > self.maxLines
         })

--- a/podcasts/Common SwiftUI/Toast/ToastView.swift
+++ b/podcasts/Common SwiftUI/Toast/ToastView.swift
@@ -57,7 +57,7 @@ struct ToastView<Style: ToastTheme>: View {
             .font(size: 14, style: .subheadline, weight: .medium)
         }
         // Wait for the initial content size to be calculated before appearing so we can animate in
-        .onChange(of: contentSize, perform: { newValue in
+        .onChange(of: contentSize, perform: { _ in
             guard !isVisible else { return }
 
             isVisible = true

--- a/podcasts/DiscoverCellType.swift
+++ b/podcasts/DiscoverCellType.swift
@@ -57,7 +57,7 @@ enum DiscoverCellType: CaseIterable {
     }
 
     func createCellRegistration(parentViewController: UIViewController, delegate: DiscoverDelegate) -> UICollectionView.CellRegistration<UICollectionViewCell, ItemType> {
-        return UICollectionView.CellRegistration<UICollectionViewCell, ItemType> { cell, indexPath, item in
+        return UICollectionView.CellRegistration<UICollectionViewCell, ItemType> { cell, _, item in
 
             let existingViewController = (cell.contentConfiguration as? UIViewControllerContentConfiguration)?.viewController as? (UIViewController & DiscoverSummaryProtocol)
 

--- a/podcasts/DiscoverCollectionViewController.swift
+++ b/podcasts/DiscoverCollectionViewController.swift
@@ -224,7 +224,7 @@ extension DiscoverCollectionViewController {
 
     private func configureDataSource() {
 
-        let footerRegistrationCountrySummary = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(elementKind: UICollectionView.elementKindSectionFooter) { [weak self] supplementaryView, elementKind, indexPath in
+        let footerRegistrationCountrySummary = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(elementKind: UICollectionView.elementKindSectionFooter) { [weak self] supplementaryView, _, _ in
             guard let self else { return }
 
             let countrySummary = CountrySummaryViewController()
@@ -234,7 +234,7 @@ extension DiscoverCollectionViewController {
             supplementaryView.contentConfiguration = UIViewControllerContentConfiguration(parentViewController: self, viewController: countrySummary)
         }
 
-        let footerRegistrationEmpty = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(elementKind: UICollectionView.elementKindSectionFooter) { supplementaryView, elementKind, indexPath in
+        let footerRegistrationEmpty = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(elementKind: UICollectionView.elementKindSectionFooter) { supplementaryView, _, _ in
             supplementaryView.contentConfiguration = UIHostingConfiguration {
                 EmptyView()
             }
@@ -244,21 +244,21 @@ extension DiscoverCollectionViewController {
             partialResult[cellType] = cellType.createCellRegistration(parentViewController: self, delegate: self)
         }
 
-        let loadingRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
+        let loadingRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, _, _ in
             cell.contentConfiguration = ContentUnavailableConfiguration.loading()
         }
 
-        let noNetworkRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
+        let noNetworkRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, _, _ in
             cell.contentConfiguration = ContentUnavailableConfiguration.noNetwork { [weak self] in
                 self?.reloadData()
             }
         }
 
-        let noResultsRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
+        let noResultsRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, _, _ in
             cell.contentConfiguration = ContentUnavailableConfiguration.noResults()
         }
 
-        let emptyRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, indexPath, item in
+        let emptyRegistration = UICollectionView.CellRegistration<UICollectionViewCell, Item> { cell, _, _ in
             cell.contentConfiguration = ContentUnavailableConfiguration.empty()
         }
 
@@ -293,8 +293,8 @@ extension DiscoverCollectionViewController {
     }
 
     private func createCompositionalLayout() -> UICollectionViewCompositionalLayout {
-        return UICollectionViewCompositionalLayout { [weak self] (sectionIndex: Int,
-                                                      layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+        return UICollectionViewCompositionalLayout { [weak self] (_: Int,
+                                                      _: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
             let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
                                                   heightDimension: self?.discoverLayout == nil ? .fractionalHeight(0.8) : .estimated(100))
 

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -348,7 +348,7 @@ extension EndOfYear {
             ]
 
             self.notifications = notifications.map {
-                notificationCenter.addObserver(forName: $0, object: nil, queue: .main) { [weak self] notification in
+                notificationCenter.addObserver(forName: $0, object: nil, queue: .main) { [weak self] _ in
                     self?.update()
                 }
             }

--- a/podcasts/End of Year/Stories/2023/EpilogueStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/EpilogueStory2023.swift
@@ -186,7 +186,7 @@ private struct GradientHolographicEffect<Content>: View where Content: View {
 
     @ViewBuilder
     private var gradientView: some View {
-        GeometryReader { proxy in
+        GeometryReader { _ in
             LinearGradient(
                 stops: [
                     Gradient.Stop(color: Color(red: 0.25, green: 0.11, blue: 0.92), location: 0.00),

--- a/podcasts/End of Year/Stories/2024/NumberListened2024.swift
+++ b/podcasts/End of Year/Stories/2024/NumberListened2024.swift
@@ -59,7 +59,7 @@ struct NumberListened2024: ShareableStory {
     @ViewBuilder func podcastMarquee(size: CGSize, shadow: Bool, scale: Double, indices: [Int]) -> some View {
         HStack(spacing: 16) {
             Group {
-                ForEach(Array(zip(indices.indices, indices)), id: \.0) { (index, pos) in
+                ForEach(Array(zip(indices.indices, indices)), id: \.0) { (_, pos) in
                     podcastCover(pos, shadow: shadow)
                 }
             }

--- a/podcasts/End of Year/Stories/2025/IntroStory2025.swift
+++ b/podcasts/End of Year/Stories/2025/IntroStory2025.swift
@@ -78,7 +78,7 @@ struct IntroStory2025: StoryView {
                     }
                 } else {
                     LottieView(animation: .named("end_of_year_2025_intro"))
-                        .animationDidFinish({ completed in
+                        .animationDidFinish({ _ in
                             DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
                                 animationFinished = true
                                 loadCallback?()

--- a/podcasts/End of Year/Stories/2025/ListeningTime2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/ListeningTime2025Story.swift
@@ -35,7 +35,7 @@ struct ListeningTime2025Story: ShareableStory {
     @State private var playModeNumbers: LottiePlaybackMode = .paused(at: .progress(0))
 
     var body: some View {
-        GeometryReader { geometry in
+        GeometryReader { _ in
             ZStack {
                 VStack(alignment: .leading, spacing: 0) {
                     Spacer()
@@ -46,7 +46,7 @@ struct ListeningTime2025Story: ShareableStory {
             .background(content: {
                 ZStack {
                     LottieView(animation: .named("playback2025_listening_time"))
-                        .animationDidFinish({ completed in
+                        .animationDidFinish({ _ in
                         })
                         .configure({ animationView in
                             animationView.contentMode = .scaleAspectFill
@@ -55,7 +55,7 @@ struct ListeningTime2025Story: ShareableStory {
                         .scaledToFill()
                         .ignoresSafeArea()
                     LottieView(animation: .named("playback2025_listening_time_numbers"))
-                        .animationDidFinish({ completed in
+                        .animationDidFinish({ _ in
                         })
                         .configure({ animationView in
                             animationView.contentMode = .scaleAspectFill

--- a/podcasts/End of Year/Stories/2025/NumberListened2025.swift
+++ b/podcasts/End of Year/Stories/2025/NumberListened2025.swift
@@ -56,7 +56,7 @@ struct NumberListened2025: ShareableStory {
     let identifier: String = "number_of_shows"
 
     var body: some View {
-        GeometryReader { proxy in
+        GeometryReader { _ in
             VStack(alignment: .center) {
                 headerView
                 Spacer()
@@ -68,7 +68,7 @@ struct NumberListened2025: ShareableStory {
         }
         .background(content: {
             LottieView(animation: .named("playback_2025_listened"))
-                .animationDidFinish({ completed in
+                .animationDidFinish({ _ in
                 })
                 .configure({ animationView in
                     animationView.contentMode = .scaleToFill
@@ -122,7 +122,7 @@ struct NumberListened2025: ShareableStory {
                 stepCounter.start()
             }
         }
-        .onChange(of: stepCounter.counter) { value in
+        .onChange(of: stepCounter.counter) { _ in
             startCoverAnimation()
         }
     }

--- a/podcasts/End of Year/Stories/2025/Top5Podcasts2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/Top5Podcasts2025Story.swift
@@ -105,7 +105,7 @@ fileprivate struct PodcastCellView: View {
         ZStack {
             HStack(spacing: 0) {
                 LottieView(animation: .named(animationName))
-                    .animationDidFinish({ completed in
+                    .animationDidFinish({ _ in
                     })
                     .configure({ animationView in
                         animationView.contentMode = .scaleToFill

--- a/podcasts/End of Year/Stories/2025/TopSpotStory2025.swift
+++ b/podcasts/End of Year/Stories/2025/TopSpotStory2025.swift
@@ -85,7 +85,7 @@ struct TopSpotStory2025: ShareableStory {
             ZStack {
                 Group {
                     LottieView(animation: .named("playback_2025_top_spot_story"))
-                        .animationDidFinish({ completed in
+                        .animationDidFinish({ _ in
                         })
                         .configure({ animationView in
                             animationView.contentMode = .scaleToFill

--- a/podcasts/Folders/FoldersCoordinator.swift
+++ b/podcasts/Folders/FoldersCoordinator.swift
@@ -209,7 +209,7 @@ class FoldersCoordinator: NSObject {
             NotificationCenter.default.publisher(for: ServerNotifications.iapPurchaseCompleted)
         )
         .receive(on: OperationQueue.main)
-        .sink { [unowned self] notification in
+        .sink { [unowned self] _ in
             refreshAfterUpsellFlow()
         }
         .store(in: &cancellables)
@@ -217,7 +217,7 @@ class FoldersCoordinator: NSObject {
         //Observe Login/Signup notification
         NotificationCenter.default.publisher(for: .onboardingFlowDidDismiss)
         .receive(on: OperationQueue.main)
-        .sink { [unowned self] notification in
+        .sink { [unowned self] _ in
             refreshAfterUpsellFlow()
         }
         .store(in: &cancellables)

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -763,7 +763,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
             return
         }
 
-        NotificationCenter.default.addObserver(forName: .userSignedIn, object: nil, queue: .main) { notification in
+        NotificationCenter.default.addObserver(forName: .userSignedIn, object: nil, queue: .main) { _ in
             self.endOfYear.resetStateIfNeeded()
         }
 
@@ -773,7 +773,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
             self.showEndOfYearPromptIfNeeded()
         }
 
-        NotificationCenter.default.addObserver(forName: .onboardingFlowDidDismiss, object: nil, queue: .main) { notification in
+        NotificationCenter.default.addObserver(forName: .onboardingFlowDidDismiss, object: nil, queue: .main) { _ in
             self.endOfYear.showPromptBasedOnState(in: self)
 
             self.displayEndOfYearBadgeIfNeeded()
@@ -920,7 +920,7 @@ private extension MainTabBarController {
 
         bookmarkManager.onBookmarkCreated
             .receive(on: RunLoop.main)
-            .filter { event in
+            .filter { _ in
                 UIApplication.shared.applicationState == .active
                 && !SceneHelper.isConnectedToCarPlay
                 && NavigationManager.sharedManager.miniPlayer?.playerOpenState == .closed
@@ -941,7 +941,7 @@ private extension MainTabBarController {
         let message = title == L10n.bookmarkDefaultTitle ? L10n.bookmarkAdded : L10n.bookmarkAddedNotification(title)
 
         let action = Toast.Action(title: L10n.changeBookmarkTitle) { [weak self] in
-            let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating, onDismiss: { [weak self] updatedTitle, cancel in
+            let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating, onDismiss: { [weak self] updatedTitle, _ in
                 guard title != updatedTitle else { return }
 
                 self?.handleBookmarkTitleUpdated(updatedTitle: updatedTitle)

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -271,7 +271,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
             tabBarSnapshot?.frame = !self.isPresenting ? tabBarFrame : hiddenTabBarFrame
 
             gradientView.layer.opacity = isPresenting ? 0 : 1
-        } completion: { completed in
+        } completion: { _ in
             self.fullPlayerArtwork.layer.opacity = !self.isVideoPodcast ? 1 : 0
             self.miniPlayerArtwork.layer.opacity = 1
 

--- a/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
@@ -44,7 +44,7 @@ struct LocalSearchEpisodeResultsView: View {
                         cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01)
                     )
                     .listRowBackground(theme.primaryUi01)
-                    .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                    .alignmentGuide(.listRowSeparatorLeading) { _ in
                         return 0
                     }
                 }

--- a/podcasts/New Search/Views/Results/LocalSearchPodcastResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchPodcastResultsView.swift
@@ -37,7 +37,7 @@ struct LocalSearchPodcastResultsView: View {
         List {
             listHeader
             Section {
-                ForEach(Array(currentResults.enumerated()), id: \.element.id) { index, result in
+                ForEach(Array(currentResults.enumerated()), id: \.element.id) { _, result in
                     SearchResultCell(
                         episode: nil,
                         result: result,
@@ -49,7 +49,7 @@ struct LocalSearchPodcastResultsView: View {
                         onSelectResult(result)
                     })
                     .listRowBackground(theme.primaryUi01)
-                    .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                    .alignmentGuide(.listRowSeparatorLeading) { _ in
                         return 0
                     }
                 }

--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -156,14 +156,14 @@ struct NewSearchResultsView: View {
                 case .podcast(let podcast):
                     SearchResultCell(episode: nil, result: podcast, played: false, showDivider: false, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01))
                         .listRowBackground(theme.primaryUi01)
-                        .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                        .alignmentGuide(.listRowSeparatorLeading) { _ in
                             return 0
                         }
                 case .episode(let episode):
                     let played = searchResults.playedEpisodesUUIDs.contains(episode.uuid)
                     SearchResultCell(episode: episode, result: nil, played: played, showDivider: false, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01))
                         .listRowBackground(theme.primaryUi01)
-                        .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                        .alignmentGuide(.listRowSeparatorLeading) { _ in
                             return 0
                         }
             }
@@ -175,7 +175,7 @@ struct NewSearchResultsView: View {
         ForEach(searchResults.podcasts, id: \.self) { localPodcast in
             SearchResultCell(episode: nil, result: localPodcast, played: false, showDivider: false, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01))
                 .listRowBackground(theme.primaryUi01)
-                .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                .alignmentGuide(.listRowSeparatorLeading) { _ in
                     return 0
                 }
         }
@@ -187,13 +187,13 @@ struct NewSearchResultsView: View {
                 case .term(let searchTerm):
                     termRow(term: searchTerm)
                     .listRowBackground(theme.primaryUi01)
-                    .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                    .alignmentGuide(.listRowSeparatorLeading) { _ in
                         return 0
                     }
                 case .podcast:
                     SearchResultCell(episode: nil, result: PodcastFolderSearchResult(from: predictiveSearch), played: false, showDivider: false, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01))
                         .listRowBackground(theme.primaryUi01)
-                        .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                        .alignmentGuide(.listRowSeparatorLeading) { _ in
                             return 0
                         }
                 default:

--- a/podcasts/New Search/Views/Results/PredictiveList.swift
+++ b/podcasts/New Search/Views/Results/PredictiveList.swift
@@ -41,7 +41,7 @@ struct PredictiveList: View {
         ForEach(searchResults.podcasts, id: \.self) { localPodcast in
             SearchResultCell(episode: nil, result: localPodcast, played: false, showDivider: !FeatureFlag.searchImprovements.enabled, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01))
                 .listRowBackground(theme.primaryUi01)
-                .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                .alignmentGuide(.listRowSeparatorLeading) { _ in
                     return 0
                 }
         }
@@ -64,14 +64,14 @@ struct PredictiveList: View {
                     content.padding(EdgeInsets(top: 12, leading: 8, bottom: 0, trailing: 8))
                 }
                 .listRowBackground(theme.primaryUi01)
-                .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                .alignmentGuide(.listRowSeparatorLeading) { _ in
                     return 0
                 }
                 .background(theme.primaryUi01)
             case .podcast:
                 SearchResultCell(episode: nil, result: PodcastFolderSearchResult(from: predictiveSearch), played: false, showDivider: !FeatureFlag.searchImprovements.enabled, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi01))
                     .listRowBackground(theme.primaryUi01)
-                    .alignmentGuide(.listRowSeparatorLeading) { viewDimensions in
+                    .alignmentGuide(.listRowSeparatorLeading) { _ in
                         return 0
                     }
             default:

--- a/podcasts/Onboarding/Import/ImportDetailsView.swift
+++ b/podcasts/Onboarding/Import/ImportDetailsView.swift
@@ -107,11 +107,11 @@ struct ImportDetailsView: View {
                 return
             }
             opmlURLImportResult = .none
-            NotificationCenter.default.addObserver(forName: Notification.Name("SJOpmlImportCompleted"), object: nil, queue: nil) { notification in
+            NotificationCenter.default.addObserver(forName: Notification.Name("SJOpmlImportCompleted"), object: nil, queue: nil) { _ in
                 opmlURLImportResult = .success
                 opmlImportInProgress = false
             }
-            NotificationCenter.default.addObserver(forName: Notification.Name("SJOpmlImportFailed"), object: nil, queue: nil) { notification in
+            NotificationCenter.default.addObserver(forName: Notification.Name("SJOpmlImportFailed"), object: nil, queue: nil) { _ in
                 opmlURLImportResult = .failure
                 opmlImportInProgress = false
             }

--- a/podcasts/Onboarding/Import/ImportViewModel.swift
+++ b/podcasts/Onboarding/Import/ImportViewModel.swift
@@ -166,7 +166,7 @@ extension ImportViewModel {
 // MARK: - OPML from URL
 extension ImportViewModel {
     func importFromURL(_ url: URL, completion: @escaping ((Bool) -> Void)) {
-        let task = URLSession.shared.dataTask(with: url) { data, response, error in
+        let task = URLSession.shared.dataTask(with: url) { data, _, error in
             guard let data else {
                 print("Error downloading data: \(error?.localizedDescription ?? "Unknown error")")
                 completion(false)

--- a/podcasts/Onboarding/OnboardingRecommendationsView.swift
+++ b/podcasts/Onboarding/OnboardingRecommendationsView.swift
@@ -143,7 +143,7 @@ struct OnboardingRecommendationsView: View {
                             } else {
                                 if #available(iOS 17.0, *) {
                                     podcastList()
-                                        .onChange(of: searchTerm) { oldValue, newValue in
+                                        .onChange(of: searchTerm) { _, newValue in
                                             performSearch(term: newValue)
                                         }
                                 } else {

--- a/podcasts/Onboarding/Patron/PatronAppIconUnlock.swift
+++ b/podcasts/Onboarding/Patron/PatronAppIconUnlock.swift
@@ -129,7 +129,7 @@ struct PatronAppIconUnlock: View {
                     .frame(maxWidth: .infinity)
 
                 HighlightedText(L10n.patronUnlockInstructions)
-                    .highlight(L10n.patronUnlockWord, { highlight in
+                    .highlight(L10n.patronUnlockWord, { _ in
                             .init(weight: .bold, color: Color.patronBackgroundColor)
                     })
                     .font(style: .subheadline)

--- a/podcasts/Onboarding/Plus/Account Prompt/UpgradePrompt.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/UpgradePrompt.swift
@@ -38,7 +38,7 @@ struct UpgradePrompt: View {
     }
 
     var body: some View {
-        ContentSizeGeometryReader(content: { proxy in
+        ContentSizeGeometryReader(content: { _ in
             VStack(spacing: 0) {
                 UpgradeRoundedSegmentedControl(selected: $currentSubscriptionPeriod)
                     .padding([.top, .bottom], 16)

--- a/podcasts/Onboarding/Plus/NewUpgrade/Animations/FoldersAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/Animations/FoldersAnimationView.swift
@@ -130,7 +130,7 @@ struct FoldersAnimationView: View {
             VStack {
                 Spacer()
                 HStack(spacing: 0) {
-                    ForEach(Array(zip(folders.indices, folders)), id: \.0) { (index, folder) in
+                    ForEach(Array(zip(folders.indices, folders)), id: \.0) { (_, folder) in
                         FolderPodcastAnimation(folder: folder)
                         Spacer().frame(width: (animationProgress * 20) + 10)
                     }

--- a/podcasts/Onboarding/Plus/UpgradeExperiment/Reviews/PlusPaywallReviewsStars.swift
+++ b/podcasts/Onboarding/Plus/UpgradeExperiment/Reviews/PlusPaywallReviewsStars.swift
@@ -9,7 +9,7 @@ struct PlusPaywallReviewsStars: View {
                 .fill(Color.plusGradient)
                 .mask {
                     HStack(spacing: Constants.containerSpacing) {
-                        ForEach(0..<Constants.maxStars, id: \.self) { index in
+                        ForEach(0..<Constants.maxStars, id: \.self) { _ in
                             Constants.starImage
                                 .renderingMode(.template)
                                 .resizable()

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -92,7 +92,7 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
             viewModel.$toggleIsOn
                 .dropFirst()
                 .receive(on: RunLoop.main)
-                .sink { [weak self] newValue in
+                .sink { [weak self] _ in
                     self?.selectAllSwitchValueChanged()
                 }
                 .store(in: &cancellables)

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderCell.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderCell.swift
@@ -35,7 +35,7 @@ class PodcastHeaderCell: UITableViewCell {
         self.backgroundColor = .clear
         self.selectionStyle = .none
         configureCellFromSwiftUIView(cell: self, viewController: viewController, rootView: {
-            ContentSizeGeometryReader { proxy in
+            ContentSizeGeometryReader { _ in
                 PodcastHeaderView(viewModel: self.viewModel)
                     .setupDefaultEnvironment()
                     .ignoresSafeArea()//Needs to be done in order to allow expansion of the view to navigation area when scrolling up

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
@@ -87,7 +87,7 @@ struct PodcastHeaderView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .foregroundStyle(theme.primaryText01)
             .tint(theme.primaryText01)
-            .environment(\.openURL, OpenURLAction { url in
+            .environment(\.openURL, OpenURLAction { _ in
                 viewModel.categoryTapped()
                 return .handled
             })

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController+NetworkLoad.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController+NetworkLoad.swift
@@ -83,7 +83,7 @@ extension PodcastViewController {
             self.loadingIndicator.stopAnimating()
             UIView.animate(withDuration: 0.5) {
                 self.episodesTable.alpha = 1
-            } completion: { success in
+            } completion: { _ in
                 if FeatureFlag.podcastFeedUpdate.enabled {
                     self.showPodcastFeedReloadTipIfNeeded()
                 }

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -361,7 +361,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
     }
 
     private func setupLogin() {
-        podcastRatingViewModel.presentLogin = { [weak self] viewModel in
+        podcastRatingViewModel.presentLogin = { [weak self] _ in
             self?.showLogin(message: L10n.ratingLoginRequired)
         }
     }

--- a/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
@@ -9,7 +9,7 @@ struct AccountHeaderView: View {
     @State private var showingChampion = false
 
     var body: some View {
-        container { proxy in
+        container { _ in
             VStack(spacing: FeatureFlag.newOnboardingUpgrade.enabled ? 8 : Constants.padding.vertical) {
                 SubscriptionProfileImage(viewModel: viewModel)
                     .frame(width: Constants.imageSize, height: Constants.imageSize)

--- a/podcasts/Profile - SwiftUI/Common Views/ProfileImage.swift
+++ b/podcasts/Profile - SwiftUI/Common Views/ProfileImage.swift
@@ -17,7 +17,7 @@ struct ProfileImage: View {
                     .placeholder { _ in defaultProfileView }
                     .resizable()
                     .forceRefresh(forceRefresh)
-                    .onSuccess { result in
+                    .onSuccess { _ in
                         forceRefresh = false
                     }
                     .aspectRatio(contentMode: .fill)

--- a/podcasts/Profile - SwiftUI/Common Views/SubscriptionBadge.swift
+++ b/podcasts/Profile - SwiftUI/Common Views/SubscriptionBadge.swift
@@ -140,7 +140,7 @@ struct SubscriptionBadge: View {
 // MARK: - Preview
 struct SubscriptionBadge_Preview: PreviewProvider {
     static var previews: some View {
-        GeometryReader { proxy in
+        GeometryReader { _ in
             VStack(alignment: .leading) {
                 HStack {
                     SubscriptionBadge(tier: .none) // Won't display

--- a/podcasts/Referrals/ReferralsClaimPass.swift
+++ b/podcasts/Referrals/ReferralsClaimPass.swift
@@ -58,7 +58,7 @@ class ReferralClaimPassModel: ObservableObject {
         //Observe Login/Signup notification
         NotificationCenter.default.publisher(for: .onboardingFlowDidDismiss)
         .receive(on: OperationQueue.main)
-        .sink { [unowned self] notification in
+        .sink { [unowned self] _ in
             Task {
                 await refreshStatusAfterLogin()
             }
@@ -68,7 +68,7 @@ class ReferralClaimPassModel: ObservableObject {
         //Observe Login/Signup notification
         NotificationCenter.default.publisher(for: ServerNotifications.iapProductsUpdated)
         .receive(on: OperationQueue.main)
-        .sink { [unowned self] notification in
+        .sink { [unowned self] _ in
             Task {
                 await loadOfferInfo()
             }

--- a/podcasts/Sharing/AudioWaveformView.swift
+++ b/podcasts/Sharing/AudioWaveformView.swift
@@ -31,7 +31,7 @@ struct AudioWaveformView: View {
     }
 
     var body: some View {
-        GeometryReader { geometry in
+        GeometryReader { _ in
             Canvas { context, size in
                 let lineCount = Int(width / (lineWidth + lineSpacing))
                 let midY = size.height / 2

--- a/podcasts/Sharing/Clip/ClipPlaybackManager.swift
+++ b/podcasts/Sharing/Clip/ClipPlaybackManager.swift
@@ -41,7 +41,7 @@ class ClipPlaybackManager: ObservableObject {
 
         let playbackCMTime = CMTime(seconds: playbackTime, preferredTimescale: .audio)
 
-        normalPlaybackManager.activateAudioSession(completion: { [weak self] activated in
+        normalPlaybackManager.activateAudioSession(completion: { [weak self] _ in
             if Thread.current.isMainThread {
                 self?.startPlayer(at: playbackCMTime)
             } else {

--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -69,7 +69,7 @@ struct MediaTrimView: View {
     private func a11yLabel(time: Binding<TimeInterval>) -> Binding<String> {
         Binding<String>(
             get: { time.wrappedValue.localizedTimeDescription ?? "Unknown" },
-            set: { newValue in
+            set: { _ in
                 () // Read-only
             }
         )

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -76,7 +76,7 @@ enum ShareDestination: Hashable {
             let receiver = rect.sink { rect in
                 activityViewController.popoverPresentationController?.sourceRect = rect
             }
-            activityViewController.completionWithItemsHandler = { activityType, completed, returnedItems, activityError in
+            activityViewController.completionWithItemsHandler = { _, _, _, _ in
                 receiver.cancel()
             }
             vc.presentedViewController?.present(activityViewController, animated: true, completion: {

--- a/podcasts/SleepTimerManager.swift
+++ b/podcasts/SleepTimerManager.swift
@@ -155,7 +155,7 @@ class BackgroundShakeObserver {
         if manager.isDeviceMotionAvailable {
             manager.deviceMotionUpdateInterval = motionUpdateInterval
 
-            manager.startDeviceMotionUpdates(to: .main) { [weak self] data, error in
+            manager.startDeviceMotionUpdates(to: .main) { [weak self] data, _ in
                 guard let data else {
                     return
                 }

--- a/podcasts/TipView.swift
+++ b/podcasts/TipView.swift
@@ -10,7 +10,7 @@ struct TipView: View {
     @EnvironmentObject var theme: Theme
 
     var body: some View {
-        ContentSizeGeometryReader { proxy in
+        ContentSizeGeometryReader { _ in
             TipViewStatic(title: title, message: message, onTap: onTap)
         } contentSizeUpdated: { size in
             sizeChanged(size)
@@ -80,7 +80,7 @@ struct TipView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
             Spacer()
-            TipView(title: L10n.referralsTipTitle(3), message: L10n.referralsTipMessage("2 Months"), sizeChanged: { size in }, onTap: nil).setupDefaultEnvironment()
+            TipView(title: L10n.referralsTipTitle(3), message: L10n.referralsTipMessage("2 Months"), sizeChanged: { _ in }, onTap: nil).setupDefaultEnvironment()
             Spacer()
         }
     }

--- a/podcasts/TranscriptShelfButton.swift
+++ b/podcasts/TranscriptShelfButton.swift
@@ -47,7 +47,7 @@ extension CheckTranscriptAvailability {
             self?.hasGeneratedTranscripts = hasGeneratedTranscripts
         }
 
-        NotificationCenter.default.addObserver(forName: Constants.Notifications.playbackTrackChanged, object: nil, queue: .main) { [weak self] notification in
+        NotificationCenter.default.addObserver(forName: Constants.Notifications.playbackTrackChanged, object: nil, queue: .main) { [weak self] _ in
             self?.checkTranscriptAvailability()
         }
     }

--- a/podcasts/UpNextViewController+Swipe.swift
+++ b/podcasts/UpNextViewController+Swipe.swift
@@ -70,7 +70,7 @@ extension UpNextViewController: SwipeTableViewCellDelegate {
 
             if FeatureFlag.playlistsRebranding.enabled,
                let episode = DataManager.sharedManager.episodeInUpNextAt(index: indexPath.row + 1) as? Episode {
-                let shareAction = SwipeAction(style: .default, title: nil) { [weak self] _, indexPath in
+                let shareAction = SwipeAction(style: .default, title: nil) { [weak self] _, _ in
                     guard let self else { return }
                     Analytics.track(
                         .episodeSwipeActionPerformed,

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -409,7 +409,7 @@ private extension UploadedViewController {
 
         PaidFeature.bookmarks.objectWillChange
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] bookmark in
+            .sink { [weak self] _ in
                 self?.handleReloadFromNotification()
             }
             .store(in: &cancellables)

--- a/podcasts/Utilities/SwiftUI/Motion.swift
+++ b/podcasts/Utilities/SwiftUI/Motion.swift
@@ -43,7 +43,7 @@ class MotionManager: ObservableObject {
         self.motionManager.stopDeviceMotionUpdates()
 
         self.motionManager.deviceMotionUpdateInterval = Config.updateInterval
-        self.motionManager.startDeviceMotionUpdates(to: .main) { (data, error) in
+        self.motionManager.startDeviceMotionUpdates(to: .main) { (data, _) in
             guard let data else { return }
 
             self.update(data)

--- a/podcasts/Watch Communication/WatchManager.swift
+++ b/podcasts/Watch Communication/WatchManager.swift
@@ -531,7 +531,7 @@ class WatchManager: NSObject, WCSessionDelegate {
             guard let self else { return }
             self.sendStateToWatch()
             if FeatureFlag.refreshAndSaveWatchLogsOnSend.enabled {
-                WatchManager.shared.requestLogFile { log in
+                WatchManager.shared.requestLogFile { _ in
                     // We do nothing here, the log file will be cached as a result of requesting
                 }
             }


### PR DESCRIPTION
Enables the [`unused_closure_parameter`](https://realm.github.io/SwiftLint/unused_closure_parameter.html) SwiftLint rule, which flags unused parameters in a closure and recommends replacing them with `_`.

## Changes

- Added `unused_closure_parameter` to `only_rules` in `.swiftlint.yml`.
- Ran `make format` to auto-fix all violations.

## Numbers

- Auto-fixed violations: ~97 across 61 files.
- Manual (agentic) fixes: 0.
- Violations left for human review: 0.

This is part of the Orchard SwiftLint rollout campaign.