### PR TITLE
Liquid Glass: Update mini player to carry upward velocity on presentation

### DIFF
--- a/podcasts/LiquidGlassPlayerAnimator.swift
+++ b/podcasts/LiquidGlassPlayerAnimator.swift
@@ -9,24 +9,37 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
     private let miniPlayerArtwork: PodcastImageView
     private let fullPlayerArtwork: UIImageView
 
-    private let dismissVelocity: CGFloat
+    /// Signed y-velocity of the gesture handing off to the animation.
+    /// Positive = downward (dismiss flick), negative = upward (present flick),
+    /// zero for taps and programmatic transitions. The sign matches UIKit
+    /// screen-space, so it can be fed straight into a CGVector dy and the
+    /// spring will move with the gesture rather than against it.
+    private let gestureVelocity: CGFloat
     private let fullPlayerYPosition: CGFloat
 
     private lazy var springVelocity: CGFloat = {
-        let miniplayerFrame = fromViewController.view.superview?.convert(fromViewController.view.frame, to: nil) ?? .zero
-        let distance = miniplayerFrame.origin.y - fullPlayerYPosition
+        let distance: CGFloat
+        if isPresenting {
+            // Present travels the full container height (offscreen-bottom → top).
+            distance = fromViewController.view.window?.bounds.height
+                ?? fromViewController.view.bounds.height
+        } else {
+            let miniplayerFrame = fromViewController.view.superview?.convert(fromViewController.view.frame, to: nil) ?? .zero
+            distance = miniplayerFrame.origin.y - fullPlayerYPosition
+        }
         guard distance > 0 else { return 0 }
-        return dismissVelocity / distance
+        // distance is always positive; gestureVelocity carries the sign, so the
+        // resulting spring dy points in the same direction as the gesture.
+        return gestureVelocity / distance
     }()
 
     private var duration: TimeInterval {
-        if isPresenting {
-            return 0.55
-        }
-        // Dismiss: scale duration with gesture velocity so slow flicks get a
-        // longer settle (no rushed feel) while fast flicks finish quickly and
-        // keep up with the user's intent.
-        return 0.45 - min(0.15, dismissVelocity / 8000)
+        // Scale duration with gesture speed so slow flicks get a longer settle
+        // (no rushed feel) while fast flicks finish quickly and keep up with
+        // the user's intent. Taps (speed = 0) hold the resting duration.
+        let speed = abs(gestureVelocity)
+        let base: TimeInterval = isPresenting ? 0.55 : 0.45
+        return base - min(0.15, speed / 8000)
     }
 
     private var isPresenting: Bool {
@@ -42,14 +55,14 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
           transition: MiniPlayerToFullPlayerAnimator.Transition,
           miniPlayerArtwork: PodcastImageView,
           fullPlayerArtwork: UIImageView,
-          dismissVelocity: CGFloat = 0,
+          gestureVelocity: CGFloat = 0,
           fullPlayerYPosition: CGFloat = 0) {
         self.fromViewController = fromViewController
         self.toViewController = toViewController
         self.transition = transition
         self.miniPlayerArtwork = miniPlayerArtwork
         self.fullPlayerArtwork = fullPlayerArtwork
-        self.dismissVelocity = dismissVelocity
+        self.gestureVelocity = gestureVelocity
         self.fullPlayerYPosition = fullPlayerYPosition
     }
 
@@ -177,13 +190,14 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
     }
 
     /// Critically damped spring (no overshoot) used for the main present and
-    /// dismiss move. On dismiss, initialVelocity carries the gesture's
-    /// momentum into the animation so it doesn't lurch when the user lets go;
-    /// on present we start from rest. The mini player's absorb on dismiss uses
+    /// dismiss move. initialVelocity carries the gesture's momentum into the
+    /// animation so it doesn't lurch when the user lets go — positive dy for
+    /// downward dismiss flicks, negative dy for upward present flicks. Taps
+    /// pass zero and start from rest. The mini player's absorb on dismiss uses
     /// a separate bouncier spring — see `animateMiniPlayerAbsorb`.
     private func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
         let dampingRatio: CGFloat = 1.0
-        let velocity = isPresenting ? CGVector.zero : CGVector(dx: 0, dy: springVelocity)
+        let velocity = CGVector(dx: 0, dy: springVelocity)
         let timingParameters = UISpringTimingParameters(dampingRatio: dampingRatio, initialVelocity: velocity)
         let animator = UIViewPropertyAnimator(duration: duration, timingParameters: timingParameters)
         animator.addCompletion { position in

--- a/podcasts/LiquidGlassPlayerAnimator.swift
+++ b/podcasts/LiquidGlassPlayerAnimator.swift
@@ -18,19 +18,26 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
     private let fullPlayerYPosition: CGFloat
 
     private lazy var springVelocity: CGFloat = {
-        let distance: CGFloat
+        // UISpringTimingParameters.initialVelocity is normalized against the
+        // signed animation displacement (end − start), not absolute distance.
+        // A positive normalized value means "moving toward the end state."
+        // Present moves up from y = containerHeight to y = 0, so displacement
+        // is negative; dismiss moves down from the player's current y to the
+        // mini player's y, so displacement is positive. Dividing an upward
+        // present-flick's negative screen-space velocity by a positive
+        // distance would give UIKit a velocity that points away from the end
+        // and the spring would fight the motion at handoff.
+        let displacement: CGFloat
         if isPresenting {
-            // Present travels the full container height (offscreen-bottom → top).
-            distance = fromViewController.view.window?.bounds.height
+            let height = fromViewController.view.window?.bounds.height
                 ?? fromViewController.view.bounds.height
+            displacement = -height
         } else {
             let miniplayerFrame = fromViewController.view.superview?.convert(fromViewController.view.frame, to: nil) ?? .zero
-            distance = miniplayerFrame.origin.y - fullPlayerYPosition
+            displacement = miniplayerFrame.origin.y - fullPlayerYPosition
         }
-        guard distance > 0 else { return 0 }
-        // distance is always positive; gestureVelocity carries the sign, so the
-        // resulting spring dy points in the same direction as the gesture.
-        return gestureVelocity / distance
+        guard displacement != 0 else { return 0 }
+        return gestureVelocity / displacement
     }()
 
     private var duration: TimeInterval {
@@ -191,10 +198,12 @@ class LiquidGlassPlayerAnimator: NSObject, UIViewControllerAnimatedTransitioning
 
     /// Critically damped spring (no overshoot) used for the main present and
     /// dismiss move. initialVelocity carries the gesture's momentum into the
-    /// animation so it doesn't lurch when the user lets go — positive dy for
-    /// downward dismiss flicks, negative dy for upward present flicks. Taps
-    /// pass zero and start from rest. The mini player's absorb on dismiss uses
-    /// a separate bouncier spring — see `animateMiniPlayerAbsorb`.
+    /// animation so it doesn't lurch when the user lets go. springVelocity is
+    /// already normalized against signed displacement, so a gesture moving
+    /// toward the animation's end state produces a positive dy regardless of
+    /// transition direction. Taps pass zero and start from rest. The mini
+    /// player's absorb on dismiss uses a separate bouncier spring — see
+    /// `animateMiniPlayerAbsorb`.
     private func animate(withDuration duration: TimeInterval, animations: @escaping () -> Void, completion: ((Bool) -> Void)? = nil) {
         let dampingRatio: CGFloat = 1.0
         let velocity = CGVector(dx: 0, dy: springVelocity)

--- a/podcasts/MiniPlayerViewController+Gestures.swift
+++ b/podcasts/MiniPlayerViewController+Gestures.swift
@@ -39,6 +39,10 @@ extension MiniPlayerViewController: UIGestureRecognizerDelegate {
         // rather than waiting for the gesture to end. This makes the transition
         // feel immediate and responsive.
         if recognizer.state == .began {
+            // Recognizer y-velocity is negative for an upward flick; pass it
+            // through verbatim so the present spring carries the gesture's
+            // momentum (and a fast flick shortens the duration).
+            pendingPresentVelocity = recognizer.velocity(in: view).y
             openFullScreenPlayer()
         }
     }

--- a/podcasts/MiniPlayerViewController+TransitionDelegate.swift
+++ b/podcasts/MiniPlayerViewController+TransitionDelegate.swift
@@ -8,7 +8,7 @@ extension MiniPlayerViewController: UIViewControllerTransitioningDelegate {
         }
 
         if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
-            return LiquidGlassPlayerAnimator(fromViewController: self, toViewController: dismissed, transition: .dismissing, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage, dismissVelocity: fullPlayer.dismissVelocity, fullPlayerYPosition: fullPlayer.finalYPositionWhenDismissing)
+            return LiquidGlassPlayerAnimator(fromViewController: self, toViewController: dismissed, transition: .dismissing, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage, gestureVelocity: fullPlayer.dismissVelocity, fullPlayerYPosition: fullPlayer.finalYPositionWhenDismissing)
         }
 
         return MiniPlayerToFullPlayerAnimator(fromViewController: self, toViewController: dismissed, transition: .dismissing, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage, dismissVelocity: fullPlayer.dismissVelocity, fullPlayerYPosition: fullPlayer.finalYPositionWhenDismissing)
@@ -19,8 +19,13 @@ extension MiniPlayerViewController: UIViewControllerTransitioningDelegate {
             return nil
         }
 
+        // Consume the gesture velocity exactly once — taps and programmatic
+        // opens reach this delegate with pendingPresentVelocity == 0.
+        let presentVelocity = pendingPresentVelocity
+        pendingPresentVelocity = 0
+
         if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
-            return LiquidGlassPlayerAnimator(fromViewController: self, toViewController: presented, transition: .presenting, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage)
+            return LiquidGlassPlayerAnimator(fromViewController: self, toViewController: presented, transition: .presenting, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage, gestureVelocity: presentVelocity)
         }
 
         return MiniPlayerToFullPlayerAnimator(fromViewController: self, toViewController: presented, transition: .presenting, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.episodeImage)

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -32,6 +32,12 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private var lastEpisodeUuidAutoOpened = ""
     var fullScreenPlayer: PlayerContainerViewController?
 
+    /// Carries the upward pan velocity from the open-gesture recognizer to
+    /// the transition delegate so the present animation can match the flick's
+    /// momentum. Negative = upward (the gesture direction). Reset to 0 after
+    /// the delegate consumes it so a subsequent tap-driven open starts at rest.
+    var pendingPresentVelocity: CGFloat = 0
+
     var panUpRecognizer: UIPanGestureRecognizer!
     var longPressRecognizer: UILongPressGestureRecognizer!
 

--- a/podcasts/PlayerContainerViewController+Gestures.swift
+++ b/podcasts/PlayerContainerViewController+Gestures.swift
@@ -27,8 +27,13 @@ extension PlayerContainerViewController: UIGestureRecognizerDelegate {
             // If the swipe is too quick, we dismiss
             let translation = sender.translation(in: view)
             let velocity = sender.velocity(in: view)
-            let closing = (translation.y > view.frame.size.height * Self.minimumScreenRatioToHide) ||
-            (velocity.y > Self.minimumVelocityToHide) || velocity.y > 1000
+            // An upward flick at release cancels the dismiss even if the
+            // player was dragged past the threshold — the user is flicking
+            // back up to keep the player open.
+            let pastThreshold = translation.y > view.frame.size.height * Self.minimumScreenRatioToHide
+            let downwardFlick = velocity.y > Self.minimumVelocityToHide
+            let upwardFlick = velocity.y < 0
+            let closing = !upwardFlick && (pastThreshold || downwardFlick)
             dismissVelocity = velocity.y
 
             if closing {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

When you swipe, the full player now appears a bit faster, as you would expect.

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
