### PR TITLE
Enable SwiftLint rule: array_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,6 +21,9 @@ excluded:
 # Rules – Opt-in only, so we can progressively introduce new ones
 #
 only_rules:
+  # Prefer `Array(xs)` over `xs.map { $0 }`.
+  - array_init
+
   # Colons should be next to the identifier when specifying a type.
   - colon
 

--- a/podcasts/CountrySummaryViewController.swift
+++ b/podcasts/CountrySummaryViewController.swift
@@ -54,7 +54,7 @@ class CountrySummaryViewController: UIViewController, DiscoverSummaryProtocol {
         countryChooser.changed = { [weak self] region in
             self?.updateRegion(region)
         }
-        let regions = Array(serverRegions().values.map { $0 })
+        let regions = Array(serverRegions().values)
         countryChooser.regions = regions.sorted(by: { region1, region2 -> Bool in
             region1.name.localized.compare(region2.name.localized) == .orderedAscending
         })


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`array_init`](https://realm.github.io/SwiftLint/array_init.html) rule.

The rule prefers `Array(xs)` over the `xs.map { $0 }` identity transform when converting a sequence into an Array.

- See commit message for the violation count and any rewrites.
- The change is type-preserving — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
