### PR TITLE
Enable SwiftLint rule: redundant_type_annotation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -72,6 +72,9 @@ only_rules:
   # `nil` coalescing on a non-optional is redundant.
   - redundant_nil_coalescing
 
+  # Type annotations are redundant when the type can be inferred.
+  - redundant_type_annotation
+
   # Prefer shorthand optional binding `if let foo {` over `if let foo = foo {`.
   - shorthand_optional_binding
 

--- a/Modules/Sources/EndOfYear/StoryShareableProvider.swift
+++ b/Modules/Sources/EndOfYear/StoryShareableProvider.swift
@@ -9,7 +9,7 @@ import PocketCastsUtils
 /// avoid blocking the main thread and the share sheet
 /// having a delay when appearing.
 public class StoryShareableProvider: UIActivityItemProvider {
-    public static var shared: StoryShareableProvider = StoryShareableProvider()
+    public static var shared = StoryShareableProvider()
 
     public var generatedItem: Any?
 

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -61,7 +61,7 @@ public class Podcast: NSObject, Identifiable {
     @objc public var fundingURL: String?
 
     @GRDBIgnore
-    public var settings: PodcastSettings = PodcastSettings.defaults
+    public var settings = PodcastSettings.defaults
 
     // transient not saved to database
     @GRDBIgnore

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -84,7 +84,7 @@ struct CenterButton: View {
 
 struct MainTabView: View {
 
-    @State private var tabSelection: MainTabRouter = MainTabRouter()
+    @State private var tabSelection = MainTabRouter()
     @FocusState private var focusedArea: FocusArea?
     @State private var scrollOffset: Double = 0
 

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -29,7 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private var backgroundSignOutListener: BackgroundSignOutListener?
     private(set) var appInstallState: AppLifecycleAnalytics.AppInstallState?
 
-    lazy var whatsNew: WhatsNew = WhatsNew()
+    lazy var whatsNew = WhatsNew()
 
     // MARK: - App Lifecycle
 

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -88,8 +88,8 @@ struct CategoriesPillsView: View {
     @Namespace private var animation
 
     fileprivate enum Constants {
-        static let buttonInsets: EdgeInsets = EdgeInsets(top: 2, leading: 16, bottom: 16, trailing: 16)
-        static let selectedButtonInsets: EdgeInsets = EdgeInsets(top: 2, leading: 16, bottom: 0, trailing: 16)
+        static let buttonInsets = EdgeInsets(top: 2, leading: 16, bottom: 16, trailing: 16)
+        static let selectedButtonInsets = EdgeInsets(top: 2, leading: 16, bottom: 0, trailing: 16)
     }
 
     var body: some View {

--- a/podcasts/ChaptersViewController.swift
+++ b/podcasts/ChaptersViewController.swift
@@ -19,7 +19,7 @@ class ChaptersViewController: PlayerItemViewController {
         return header
     }()
 
-    lazy var playbackManager: PlaybackManager = PlaybackManager.shared
+    lazy var playbackManager = PlaybackManager.shared
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/podcasts/Common SwiftUI/HairlineSeparator.swift
+++ b/podcasts/Common SwiftUI/HairlineSeparator.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// A separator which is drawn as 1 physical pixel. This mirrors the separator used in UITableView
 struct HairlineSeparator: View {
-    var color: Color = Color(UIColor.separator)
+    var color = Color(UIColor.separator)
 
     @Environment(\.displayScale) private var scale
 

--- a/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
@@ -7,7 +7,7 @@ struct Ratings2024Story: ShareableStory {
     let ratings: [UInt32: Int]
 
     let foregroundColor: Color = .black
-    let backgroundColor: Color = Color(hex: "#EFECAD")
+    let backgroundColor = Color(hex: "#EFECAD")
     private let ratingsBlogPostURL = URL(string: "https://blog.pocketcasts.com/2024/08/20/podcast-ratings/")!
 
     @ObservedObject private var animationViewModel = PlayPauseAnimationViewModel(duration: 0.8, animation: Animation.spring(_:))

--- a/podcasts/End of Year/Stories/2025/NumberListened2025.swift
+++ b/podcasts/End of Year/Stories/2025/NumberListened2025.swift
@@ -95,11 +95,11 @@ struct NumberListened2025: ShareableStory {
     }
 
     func calculateDimensions(for index: Int) -> (CGFloat, CGFloat, Double, CGFloat) {
-        let shift: CGFloat = CGFloat(index - 3)
+        let shift = CGFloat(index - 3)
         let direction: CGFloat = shift <= 0 ? -1 : 1
         let size: CGFloat = Constants.coverSize - CGFloat(abs(shift) * Constants.xOffset)
-        let offset: CGFloat = CGFloat(shift * Constants.yOffset)
-        let zOffset: Double = Double(CGFloat(itemsCount) - abs(shift))
+        let offset = CGFloat(shift * Constants.yOffset)
+        let zOffset = Double(CGFloat(itemsCount) - abs(shift))
         return (size, offset, zOffset, direction)
     }
 

--- a/podcasts/End of Year/Stories/2025/Ratings2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/Ratings2025Story.swift
@@ -8,8 +8,8 @@ struct Ratings2025Story: ShareableStory {
     let ratings: [UInt32: Int]
 
     let foregroundColor: Color = .white
-    let backgroundColor: Color = Color(hex: "#A22828")
-    let barColor: Color = Color(hex: "#FF4562")
+    let backgroundColor = Color(hex: "#A22828")
+    let barColor = Color(hex: "#FF4562")
 
     private let ratingsBlogPostURL = URL(string: "https://blog.pocketcasts.com/2024/08/20/podcast-ratings/")!
 

--- a/podcasts/End of Year/StoriesDataSource.swift
+++ b/podcasts/End of Year/StoriesDataSource.swift
@@ -151,7 +151,7 @@ class PauseState: ObservableObject {
 }
 
 struct PauseStateKey: EnvironmentKey {
-    static let defaultValue: PauseState = PauseState()
+    static let defaultValue = PauseState()
 }
 
 extension EnvironmentValues {

--- a/podcasts/EndOfYearDeveloperMenuButton.swift
+++ b/podcasts/EndOfYearDeveloperMenuButton.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct EndOfYearDeveloperMenuButton: View {
     @State var showPickerAlert: Bool = false
-    @State var selectedYear: EndOfYear.Year = EndOfYear.Year.y2024
+    @State var selectedYear = EndOfYear.Year.y2024
 
     var body: some View {
         Button("Reset modal/profile badge") {

--- a/podcasts/ExpandedCollectionViewController+CollectionView.swift
+++ b/podcasts/ExpandedCollectionViewController+CollectionView.swift
@@ -49,7 +49,7 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         guard podcastCollection != nil else { return CGSize.zero }
 
-        let headerView: DiscoverCollectionHeader = DiscoverCollectionHeader.fromNib()
+        let headerView = DiscoverCollectionHeader.fromNib()
         headerView.populate(podcastCollection: podcastCollection)
 
         return headerView.systemLayoutSizeFitting(CGSize(width: collectionView.frame.width, height: UIView.layoutFittingExpandedSize.height),

--- a/podcasts/ExpandedCollectionViewController+CollectionView.swift
+++ b/podcasts/ExpandedCollectionViewController+CollectionView.swift
@@ -49,7 +49,8 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, referenceSizeForHeaderInSection section: Int) -> CGSize {
         guard podcastCollection != nil else { return CGSize.zero }
 
-        let headerView = DiscoverCollectionHeader.fromNib()
+        // swiftlint:disable:next redundant_type_annotation
+        let headerView: DiscoverCollectionHeader = DiscoverCollectionHeader.fromNib()
         headerView.populate(podcastCollection: podcastCollection)
 
         return headerView.systemLayoutSizeFitting(CGSize(width: collectionView.frame.width, height: UIView.layoutFittingExpandedSize.height),

--- a/podcasts/Folders/Create & Edit/Views/SuggestedFoldersView.swift
+++ b/podcasts/Folders/Create & Edit/Views/SuggestedFoldersView.swift
@@ -18,7 +18,7 @@ struct SuggestedFoldersView: View {
 
     @State private var applySuggestedFoldersConfirmation = false
 
-    @ObservedObject var model: SuggestedFoldersModel = SuggestedFoldersModel()
+    @ObservedObject var model = SuggestedFoldersModel()
 
     let source: AnalyticsSource
 

--- a/podcasts/Folders/FoldersCoordinator.swift
+++ b/podcasts/Folders/FoldersCoordinator.swift
@@ -18,7 +18,7 @@ class FoldersCoordinator: NSObject {
 
     private var currentSource: AnalyticsSource = .unknown
 
-    private let startingTime: Date = Date.now
+    private let startingTime = Date.now
 
     private let navigationManager: NavigationManager
     private let dataManager: DataManager

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -34,7 +34,7 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
 
     private var session: URLSession?
     var response: URLResponse?
-    private var pendingRequests: Set<AVAssetResourceLoadingRequest> = Set<AVAssetResourceLoadingRequest>()
+    private var pendingRequests = Set<AVAssetResourceLoadingRequest>()
     private var isDownloadComplete = false
     var deleteFileOnRelease = false
     var hasRetriedWithoutUserAgent = false

--- a/podcasts/MiniPlayerGradientView.swift
+++ b/podcasts/MiniPlayerGradientView.swift
@@ -7,7 +7,7 @@ class MiniPlayerGradientView: UIView {
             updateView()
         }
     }
-    private var gradientLayer: CAGradientLayer = CAGradientLayer()
+    private var gradientLayer = CAGradientLayer()
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -14,8 +14,8 @@ extension SearchResultsDelegate {
 }
 
 class SearchResultsViewController: UIHostingController<AnyView> {
-    private let displaySearch: SearchVisibilityModel = SearchVisibilityModel()
-    private let searchHistoryModel: SearchHistoryModel = SearchHistoryModel.shared
+    private let displaySearch = SearchVisibilityModel()
+    private let searchHistoryModel = SearchHistoryModel.shared
     private let searchResults: SearchResultsModel
     private let searchAnalyticsHelper: SearchAnalyticsHelper
 

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -316,7 +316,7 @@ enum NotificationsGroup: CaseIterable {
 
 class NotificationsCoordinator {
 
-    static let shared: NotificationsCoordinator = NotificationsCoordinator()
+    static let shared = NotificationsCoordinator()
 
     var debugMode: Bool = false
 

--- a/podcasts/Notifications/NotificationsPermissionsView.swift
+++ b/podcasts/Notifications/NotificationsPermissionsView.swift
@@ -76,7 +76,7 @@ struct NotificationsPermissionsView: View {
 
     @EnvironmentObject var theme: Theme
 
-    @StateObject var viewModel: NotificationsPermissionsViewModel = NotificationsPermissionsViewModel()
+    @StateObject var viewModel = NotificationsPermissionsViewModel()
 
     @ViewBuilder
     private func optionRow(for option: NotificationsPermissionsViewModel.NotificationOption) -> some View {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1017,7 +1017,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         func shortUserAttributedMessage(mainColor: UIColor, interactiveColor: UIColor) -> NSAttributedString {
             let baseText = self.shortUserMessage
-            let learnMore: String = String(L10n.learnMore).sentenceCased
+            let learnMore = String(L10n.learnMore).sentenceCased
             let attributedString = NSMutableAttributedString(string: baseText, attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .medium)])
             if self.userAction != nil {
                 attributedString.append(NSAttributedString(string: " ", attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .medium)]))

--- a/podcasts/Sharing/Clip/ClipPlaybackManager.swift
+++ b/podcasts/Sharing/Clip/ClipPlaybackManager.swift
@@ -19,7 +19,7 @@ class ClipPlaybackManager: ObservableObject {
     private var isSeeking: Bool = false
     private var cancellables = Set<AnyCancellable>()
 
-    @ObservedObject var clipTime: ClipTime = ClipTime(start: 0, end: 0)
+    @ObservedObject var clipTime = ClipTime(start: 0, end: 0)
 
     func play(episode: BaseEpisode, clipTime: ObservedObject<ClipTime>) {
         if avPlayer != nil {

--- a/podcasts/Utilities/SwiftUI/SelectCircleButtonStyle.swift
+++ b/podcasts/Utilities/SwiftUI/SelectCircleButtonStyle.swift
@@ -5,7 +5,7 @@ struct SelectCircleButtonStyle: ButtonStyle {
 
     @Binding var selected: Bool
 
-    var stroke: StrokeStyle = StrokeStyle(lineWidth: 2)
+    var stroke = StrokeStyle(lineWidth: 2)
     var multiSelectButtonSize: CGFloat = 24
     var checkSize: CGFloat = 22
 

--- a/podcasts/Whats New/ClipsWhatsNewView.swift
+++ b/podcasts/Whats New/ClipsWhatsNewView.swift
@@ -4,7 +4,7 @@ struct ClipsWhatsNewView: View {
     @State private var isVisible = false
 
     enum Constants {
-        static var previewSize: CGSize = CGSize(width: 138, height: 175)
+        static var previewSize = CGSize(width: 138, height: 175)
         static var fadeInDuration: Double = 0.8 // Used for fade-in of preview + delay of logos
     }
 


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`redundant_type_annotation`](https://realm.github.io/SwiftLint/redundant_type_annotation.html) rule.

The rule flags `let foo: Int = 5` where the type annotation is implied by the literal/expression on the right.

- Auto-fixed by `swiftlint --fix`.
- The change is type-preserving — local build deferred to CI.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)
