### PR TITLE
Enable SwiftLint zero-violation rules (4 rules)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -53,6 +53,9 @@ only_rules:
   # explicit empty-string separator since that is the default.
   - joined_default_parameter
 
+  # Prefer `last(where:)` over `filter { }.last`.
+  - last_where
+
   # MARK comment should be in valid format.
   - mark
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -49,6 +49,9 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
+  # Prefer `flatMap { ... }` over `map { ... }.reduce([], +)`.
+  - flatmap_over_map_reduce
+
   # When calling the `joined` method on an array of strings, omit an
   # explicit empty-string separator since that is the default.
   - joined_default_parameter

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -69,6 +69,9 @@ only_rules:
   # Prefer `0` over explicit `Int(0)` / `CGFloat(0)` etc.
   - prefer_zero_over_explicit_init
 
+  # `nil` coalescing on a non-optional is redundant.
+  - redundant_nil_coalescing
+
   # Prefer shorthand optional binding `if let foo {` over `if let foo = foo {`.
   - shorthand_optional_binding
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -27,6 +27,9 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # Prefer `contains` over `filter(where:).count`.
+  - contains_over_filter_count
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 


### PR DESCRIPTION
## Summary

Bundles four zero-violation SwiftLint rule enables into a single PR to reduce reviewer churn.

All four rules:

- have **0 violations** in the current codebase, so each is a `.swiftlint.yml`-only change;
- guard against the corresponding pattern landing in future code.

Rules in this bundle, one commit each:

- [`contains_over_filter_count`](https://realm.github.io/SwiftLint/contains_over_filter_count.html) — prefer `xs.contains { ... }` over `xs.filter { ... }.count > 0` (and `== 0` / `!= 0`).
- [`last_where`](https://realm.github.io/SwiftLint/last_where.html) — prefer `xs.last { ... }` over `xs.filter { ... }.last`.
- [`flatmap_over_map_reduce`](https://realm.github.io/SwiftLint/flatmap_over_map_reduce.html) — prefer `flatMap` over `map { ... }.reduce([], +)`.
- [`redundant_nil_coalescing`](https://realm.github.io/SwiftLint/redundant_nil_coalescing.html) — flag `?? nil` on a non-optional LHS.

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Supersedes

- #4238 — Enable SwiftLint rule: contains_over_filter_count
- #4246 — Enable SwiftLint rule: last_where
- #4249 — Enable SwiftLint rule: flatmap_over_map_reduce
- #4251 — Enable SwiftLint rule: redundant_nil_coalescing

The superseded PRs will be closed with a backlink to this one.

## Test plan

- [ ] CI build is green.

🤖 Generated with [Claude Code](https://claude.ai/code)