### PR TITLE
Liquid Glass: Fix Auto Layout warnings in mini player

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -23,6 +23,8 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     @IBOutlet var playbackProgressView: ProgressLine!
 
     @IBOutlet var podcastArtwork: PodcastImageView!
+    @IBOutlet var podcastArtworkWidthConstraint: NSLayoutConstraint!
+    @IBOutlet var podcastArtworkHeightConstraint: NSLayoutConstraint!
     @IBOutlet var mainView: UIView!
     @IBOutlet var shadowView: UIView!
 
@@ -91,6 +93,9 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         playPauseBtn.removeFromSuperview()
         skipFwdBtn.removeFromSuperview()
 
+        podcastArtworkWidthConstraint.constant = 32
+        podcastArtworkHeightConstraint.constant = 32
+
         podcastArtwork.translatesAutoresizingMaskIntoConstraints = false
         skipBackBtn.translatesAutoresizingMaskIntoConstraints = false
         playPauseBtn.translatesAutoresizingMaskIntoConstraints = false
@@ -141,8 +146,6 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         NSLayoutConstraint.activate([
             podcastArtwork.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
             podcastArtwork.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            podcastArtwork.widthAnchor.constraint(equalToConstant: 32),
-            podcastArtwork.heightAnchor.constraint(equalToConstant: 32),
 
             textStack.leadingAnchor.constraint(equalTo: podcastArtwork.trailingAnchor, constant: 10),
             textStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),

--- a/podcasts/MiniPlayerViewController.xib
+++ b/podcasts/MiniPlayerViewController.xib
@@ -16,6 +16,8 @@
                 <outlet property="playPauseBtn" destination="CjL-4C-tuh" id="Y8g-6z-ZoN"/>
                 <outlet property="playbackProgressView" destination="aWD-bx-vF2" id="vpI-fM-bgO"/>
                 <outlet property="podcastArtwork" destination="tJx-CO-hRe" id="Kzl-ZM-bdq"/>
+                <outlet property="podcastArtworkHeightConstraint" destination="dnA-Im-DKw" id="Kzl-ZM-hgt"/>
+                <outlet property="podcastArtworkWidthConstraint" destination="nch-ve-CD6" id="Kzl-ZM-wdt"/>
                 <outlet property="shadowView" destination="H6s-IT-ngQ" id="r3I-mU-Ie7"/>
                 <outlet property="playPauseBtnWidthConstraint" destination="Q9t-vc-8fw" id="WP2-Mn-Ply"/>
                 <outlet property="skipBackBtn" destination="92g-6h-Yd9" id="i61-v9-wgd"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes the following new warning:

```
Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x1066b5ae0 podcasts.PodcastImageView:0x109f79880.width == 44   (active)>",
    "<NSLayoutConstraint:0x109c5b2f0 podcasts.PodcastImageView:0x109f79880.width == 32   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x1066b5ae0 podcasts.PodcastImageView:0x109f79880.width == 44   (active)>
```

Root cause: on Liquid Glass, we were adding new size constraints instead of modifying the existing ones from .xib.

## To test

- **Verify** no warning in console; artwork still rendered OK

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
