### PR TITLE
Podcast and playlist details: Episode list button and background image

### DIFF
--- a/Pocket Casts TV App/UI/Common/BlurredCoverBackground.swift
+++ b/Pocket Casts TV App/UI/Common/BlurredCoverBackground.swift
@@ -1,28 +1,24 @@
 import SwiftUI
 
-struct BlurredCoverBackground: ViewModifier {
-    let imageName: String?
+struct BlurredCoverBackground<Background: View>: ViewModifier {
     let size: CGFloat
+    @ViewBuilder let background: Background
 
     func body(content: Content) -> some View {
         content
             .background(alignment: .topLeading) {
-                if let imageName {
-                    Image(imageName)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(width: size * 1.5, height: size * 1.5)
-                        .blur(radius: 100)
-                        .opacity(0.75)
-                        .offset(x: -(size * 0.5), y: -(size * 0.5))
-                        .allowsHitTesting(false)
-                }
+                background
+                    .frame(width: size * 1.5, height: size * 1.5)
+                    .blur(radius: 100)
+                    .opacity(0.7)
+                    .offset(x: -(size * 0.5), y: -(size * 0.5))
+                    .allowsHitTesting(false)
             }
     }
 }
 
 extension View {
-    func blurredCoverBackground(_ imageName: String?, size: CGFloat) -> some View {
-        modifier(BlurredCoverBackground(imageName: imageName, size: size))
+    func blurredCoverBackground<Background: View>(size: CGFloat, @ViewBuilder _ background: () -> Background) -> some View {
+        modifier(BlurredCoverBackground(size: size, background: background))
     }
 }

--- a/Pocket Casts TV App/UI/Common/BlurredCoverBackground.swift
+++ b/Pocket Casts TV App/UI/Common/BlurredCoverBackground.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct BlurredCoverBackground: ViewModifier {
+    let imageName: String?
+    let size: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .background(alignment: .topLeading) {
+                if let imageName {
+                    Image(imageName)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                        .frame(width: size * 1.5, height: size * 1.5)
+                        .blur(radius: 100)
+                        .opacity(0.75)
+                        .offset(x: -(size * 0.5), y: -(size * 0.5))
+                        .allowsHitTesting(false)
+                }
+            }
+    }
+}
+
+extension View {
+    func blurredCoverBackground(_ imageName: String?, size: CGFloat) -> some View {
+        modifier(BlurredCoverBackground(imageName: imageName, size: size))
+    }
+}

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -45,7 +45,28 @@ struct PlaylistDetailView: View {
                 .frame(width: Layout.infoPanelWidth)
             episodeList
         }
-        .blurredCoverBackground(model.coverImages.first, size: Layout.mosaicSize)
+        .blurredCoverBackground(size: Layout.mosaicSize) {
+            blurredMosaic
+        }
+    }
+
+    @ViewBuilder
+    private var blurredMosaic: some View {
+        let images = model.coverImages
+        if images.count >= 4 {
+            VStack(spacing: 0) {
+                HStack(spacing: 0) {
+                    Image(images[0]).resizable().aspectRatio(contentMode: .fill)
+                    Image(images[1]).resizable().aspectRatio(contentMode: .fill)
+                }
+                HStack(spacing: 0) {
+                    Image(images[2]).resizable().aspectRatio(contentMode: .fill)
+                    Image(images[3]).resizable().aspectRatio(contentMode: .fill)
+                }
+            }
+        } else if let first = images.first {
+            Image(first).resizable().aspectRatio(contentMode: .fill)
+        }
     }
 
     @ViewBuilder
@@ -89,6 +110,7 @@ struct PlaylistDetailView: View {
     var playlistInfo: some View {
         VStack(alignment: .leading, spacing: 40) {
             mosaicCover
+                .shadow(color: .black.opacity(0.6), radius: 40, x: 0, y: 20)
             VStack(alignment: .leading, spacing: 8) {
                 Text(model.playlist.manual ? "" : L10n.smartPlaylist)
                     .font(.caption)

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -45,6 +45,18 @@ struct PlaylistDetailView: View {
                 .frame(width: Layout.infoPanelWidth)
             episodeList
         }
+        .background(alignment: .topLeading) {
+            if let firstImage = model.coverImages.first {
+                Image(firstImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: Layout.mosaicSize * 1.5, height: Layout.mosaicSize * 1.5)
+                    .blur(radius: 100)
+                    .opacity(0.75)
+                    .offset(x: -(Layout.mosaicSize * 0.5), y: -(Layout.mosaicSize * 0.5))
+                    .allowsHitTesting(false)
+            }
+        }
     }
 
     @ViewBuilder

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -117,7 +117,7 @@ struct PlaylistDetailView: View {
         ScrollView {
             LazyVStack {
                 ForEach(model.playlist.episodes) { episode in
-                    EpisodePlayerButton(
+                    EpisodeRowWithActions(
                         episode: episode,
                         podcastTitle: model.playlist.title
                     )

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -45,18 +45,7 @@ struct PlaylistDetailView: View {
                 .frame(width: Layout.infoPanelWidth)
             episodeList
         }
-        .background(alignment: .topLeading) {
-            if let firstImage = model.coverImages.first {
-                Image(firstImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: Layout.mosaicSize * 1.5, height: Layout.mosaicSize * 1.5)
-                    .blur(radius: 100)
-                    .opacity(0.75)
-                    .offset(x: -(Layout.mosaicSize * 0.5), y: -(Layout.mosaicSize * 0.5))
-                    .allowsHitTesting(false)
-            }
-        }
+        .blurredCoverBackground(model.coverImages.first, size: Layout.mosaicSize)
     }
 
     @ViewBuilder

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -159,7 +159,6 @@ struct EpisodeRowWithActions: View {
             Button(L10n.markPlayed) {}
             Button(L10n.archive) {}
             Button(L10n.tvEpisodeInfo) {}
-            Button(L10n.cancel, role: .cancel) {}
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -14,8 +14,13 @@ struct EpisodeRowButtonStyle: ButtonStyle {
 struct EpisodeRow: View {
 
     let episode: MockEpisode
+    var isActive: Bool?
 
-    @Environment(\.isFocused) var isFocused: Bool
+    @Environment(\.isFocused) private var isFocused: Bool
+
+    private var isHighlighted: Bool {
+        isActive ?? isFocused
+    }
 
     enum Layout {
         static let episodeImageSize = CGFloat(124)
@@ -40,24 +45,130 @@ struct EpisodeRow: View {
             VStack(alignment: .leading) {
                 Text(displayDate(for: episode.publishedDate))
                     .font(.caption)
-                    .foregroundColor(isFocused ? .textSecondaryActive : .textSecondary)
+                    .foregroundColor(isHighlighted ? .textSecondaryActive : .textSecondary)
                 Text(episode.title)
                     .font(.body)
-                    .foregroundColor(isFocused ? .textPrimaryActive : .textPrimary)
+                    .foregroundColor(isHighlighted ? .textPrimaryActive : .textPrimary)
+                    .lineLimit(2)
                 Text(displayDuration(for: episode.duration))
                     .font(.caption)
-                    .foregroundColor(isFocused ? .textSecondaryActive : .textSecondary)
+                    .foregroundColor(isHighlighted ? .textSecondaryActive : .textSecondary)
             }
             Spacer()
         }
         .padding(24)
-        .background(isFocused ? Color.backgroundActive : Color.backgroundSunken)
+        .background(isHighlighted ? Color.backgroundActive : Color.backgroundSunken)
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 }
 
+struct MoreButtonStyle: ButtonStyle {
+    @Environment(\.isFocused) var isFocused: Bool
+
+    private enum Layout {
+        static let size = CGFloat(72)
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.caption)
+            .frame(width: Layout.size, height: Layout.size)
+            .background(isFocused ? Color.backgroundActive : Color.backgroundOverlay)
+            .foregroundColor(isFocused ? .textPrimaryActive : .textPrimary)
+            .clipShape(Circle())
+            .scaleEffect(isFocused ? 1.1 : 1.0)
+            .animation(.easeInOut(duration: 0.15), value: isFocused)
+    }
+}
+
+struct EpisodeRowWithActions: View {
+
+    let episode: MockEpisode
+    var podcastTitle: String?
+    var podcastDescription: String?
+
+    @FocusState private var focusedElement: FocusElement?
+    @State private var isPlaying = false
+    @State private var isShowingActions = false
+    @State private var restoreFocus = false
+
+    private enum FocusElement: Hashable {
+        case episode
+        case more
+    }
+
+    private enum Layout {
+        static let spacing = CGFloat(32)
+    }
+
+    private var shouldShowMoreButton: Bool {
+        focusedElement != nil || isShowingActions || restoreFocus
+    }
+
+    private var isEpisodeFocused: Bool {
+        focusedElement == .episode
+    }
+
+    var body: some View {
+        HStack(spacing: Layout.spacing) {
+            Button {
+                isPlaying = true
+            } label: {
+                EpisodeRow(episode: episode, isActive: isEpisodeFocused)
+            }
+            .buttonStyle(EpisodeRowButtonStyle())
+            .focused($focusedElement, equals: .episode)
+
+            if shouldShowMoreButton {
+                Button {
+                    restoreFocus = true
+                    isShowingActions = true
+                } label: {
+                    Image(systemName: "ellipsis")
+                }
+                .buttonStyle(MoreButtonStyle())
+                .focused($focusedElement, equals: .more)
+                .transition(.opacity.combined(with: .scale(scale: 0.8)).animation(.easeOut(duration: 0.2).delay(0.15)))
+            }
+        }
+        .defaultFocus($focusedElement, .episode)
+        .animation(.easeInOut(duration: 0.2), value: shouldShowMoreButton)
+        .onChange(of: isShowingActions) { _, showing in
+            if !showing {
+                DispatchQueue.main.async {
+                    var transaction = Transaction()
+                    transaction.disablesAnimations = true
+                    withTransaction(transaction) {
+                        focusedElement = .more
+                        restoreFocus = false
+                    }
+                }
+            }
+        }
+        .fullScreenCover(isPresented: $isPlaying) {
+            EpisodePlayerView(
+                episode: episode,
+                podcastTitle: podcastTitle,
+                podcastDescription: podcastDescription
+            )
+            .ignoresSafeArea()
+        }
+        .confirmationDialog(episode.title, isPresented: $isShowingActions) {
+            Button(L10n.playNextInUpNext) {}
+            Button(L10n.playLastInUpNext) {}
+            Button(L10n.markPlayed) {}
+            Button(L10n.archive) {}
+            Button(L10n.tvEpisodeInfo) {}
+            Button(L10n.cancel, role: .cancel) {}
+        }
+    }
+}
+
 #Preview {
-    EpisodeRow(episode: MockData.makePodcasts().first!.episodes.first!)
-        .environment(AppCoordinator())
-        .environment(MainTabRouter())
+    EpisodeRowWithActions(
+        episode: MockData.makePodcasts().first!.episodes.first!,
+        podcastTitle: "The Daily"
+    )
+    .environment(AppCoordinator())
+    .environment(MainTabRouter())
 }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -26,14 +26,12 @@ struct EpisodeRow: View {
         static let episodeImageSize = CGFloat(124)
     }
 
-    func displayDate(for date: Date) -> String {
-        let episodeDate = DateFormatHelper.sharedHelper.tinyLocalizedFormat(date).localizedUppercase
-        return episodeDate
+    private func displayDate(for date: Date) -> String {
+        DateFormatHelper.sharedHelper.tinyLocalizedFormat(date).localizedUppercase
     }
 
-    func displayDuration(for time: Double) -> String {
-        let time = TimeFormatter.shared.multipleUnitFormattedShortTime(time: time)
-        return time
+    private func displayDuration(for time: Double) -> String {
+        TimeFormatter.shared.multipleUnitFormattedShortTime(time: time)
     }
 
     var body: some View {
@@ -134,14 +132,13 @@ struct EpisodeRowWithActions: View {
         .defaultFocus($focusedElement, .episode)
         .animation(.easeInOut(duration: 0.2), value: shouldShowMoreButton)
         .onChange(of: isShowingActions) { _, showing in
-            if !showing {
-                DispatchQueue.main.async {
-                    var transaction = Transaction()
-                    transaction.disablesAnimations = true
-                    withTransaction(transaction) {
-                        focusedElement = .more
-                        restoreFocus = false
-                    }
+            guard !showing else { return }
+            DispatchQueue.main.async {
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    focusedElement = .more
+                    restoreFocus = false
                 }
             }
         }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -46,6 +46,16 @@ struct PodcastDetailView: View {
                 .frame(width: Layout.infoPanelWidth)
             episodeContent
         }
+        .background(alignment: .topLeading) {
+            Image(model.podcast.image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: Layout.podcastImageSize * 1.5, height: Layout.podcastImageSize * 1.5)
+                .blur(radius: 100)
+                .opacity(0.75)
+                .offset(x: -(Layout.podcastImageSize * 0.5), y: -(Layout.podcastImageSize * 0.5))
+                .allowsHitTesting(false)
+        }
     }
 
     var podcastInfo: some View {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -45,7 +45,11 @@ struct PodcastDetailView: View {
                 .frame(width: Layout.infoPanelWidth)
             episodeContent
         }
-        .blurredCoverBackground(model.podcast.image, size: Layout.podcastImageSize)
+        .blurredCoverBackground(size: Layout.podcastImageSize) {
+            Image(model.podcast.image)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        }
     }
 
     var podcastInfo: some View {
@@ -54,6 +58,7 @@ struct PodcastDetailView: View {
                 .resizable()
                 .frame(width: Layout.podcastImageSize, height: Layout.podcastImageSize)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
+                .shadow(color: .black.opacity(0.6), radius: 40, x: 0, y: 20)
             VStack(alignment: .leading, spacing: 8) {
                 Text(model.podcast.author ?? "")
                     .font(.caption)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -13,7 +13,6 @@ struct PodcastDetailView: View {
 
     enum Layout {
         static let podcastImageSize = CGFloat(418)
-        static let episodeImageSize = CGFloat(124)
         static let infoPanelWidth = CGFloat(568)
         static let gutter = CGFloat(24)
     }
@@ -46,16 +45,7 @@ struct PodcastDetailView: View {
                 .frame(width: Layout.infoPanelWidth)
             episodeContent
         }
-        .background(alignment: .topLeading) {
-            Image(model.podcast.image)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: Layout.podcastImageSize * 1.5, height: Layout.podcastImageSize * 1.5)
-                .blur(radius: 100)
-                .opacity(0.75)
-                .offset(x: -(Layout.podcastImageSize * 0.5), y: -(Layout.podcastImageSize * 0.5))
-                .allowsHitTesting(false)
-        }
+        .blurredCoverBackground(model.podcast.image, size: Layout.podcastImageSize)
     }
 
     var podcastInfo: some View {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -105,7 +105,7 @@ struct PodcastDetailView: View {
                                 .font(.caption)
                                 .foregroundStyle(Color.textSecondary)
                         }
-                        EpisodePlayerButton(
+                        EpisodeRowWithActions(
                             episode: recommended,
                             podcastTitle: model.podcast.title,
                             podcastDescription: model.podcast.podcastDescription
@@ -120,7 +120,7 @@ struct PodcastDetailView: View {
                         .foregroundStyle(Color.textPrimary)
                     LazyVStack {
                         ForEach(model.podcast.episodes) { episode in
-                            EpisodePlayerButton(
+                            EpisodeRowWithActions(
                                 episode: episode,
                                 podcastTitle: model.podcast.title,
                                 podcastDescription: model.podcast.podcastDescription

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4253,6 +4253,8 @@ internal enum L10n {
   internal static var tvCreateAccountSubtitle: String { return L10n.tr("Localizable", "tv_create_account_subtitle", fallback: "Scan this code to get started on your phone, it only takes a minute.") }
   /// tv create account title
   internal static var tvCreateAccountTitle: String { return L10n.tr("Localizable", "tv_create_account_title", fallback: "Create your free account") }
+  /// tv episode action to view episode info
+  internal static var tvEpisodeInfo: String { return L10n.tr("Localizable", "tv_episode_info", fallback: "Episode info") }
   /// tv keep listening title
   internal static var tvHomeKeepListeningTitle: String { return L10n.tr("Localizable", "tv_home_keep_listening_title", fallback: "Keep listening") }
   /// tv home new releases section title

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5983,6 +5983,9 @@
 /* tv podcast detail all episodes section title */
 "tv_podcast_detail_all_episodes" = "All episodes";
 
+/* tv episode action to view episode info */
+"tv_episode_info" = "Episode info";
+
 /* tv playlist detail episode count. '%1$@' is a placeholder for the number of episodes. */
 "tv_playlist_detail_episode_count" = "%1$@ episodes";
 


### PR DESCRIPTION
## Changes summary

• Add ellipsis action button to episode rows in podcast and playlist detail views, with a confirmation dialog for episode actions (Play Next/Last, Mark Played, Archive, Episode Info)
• Add blurred cover art background behind the info panel on podcast and playlist detail views, using a shared Blurred​Cover​Background ViewModifier
• Playlist blur background composites all 4 mosaic cover images (when available) for a richer color blend
• Add drop shadow to podcast/playlist cover art for elevation effect
• Clean up Episode​Row helpers and remove unused layout constants

## To test

• [ ] Open a podcast detail view — verify blurred background appears behind the info panel with drop shadow on the cover art
• [ ] Open a playlist detail view with 4+ podcasts — verify the blurred background shows a blend of all covers
• [ ] Open a playlist with fewer than 4 podcasts — verify single cover or logo fallback works
• [ ] Focus an episode row — verify the ellipsis button animates in
• [ ] Tap the ellipsis button — verify the confirmation dialog appears with all action options
• [ ] Dismiss the dialog — verify focus returns to the ellipsis button without layout jank
• [ ] Tap an episode row — verify the player opens correctly
• [ ] Check HomeView episode rows still work (uses Episode​Player​Button, not affected by changes)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.


https://github.com/user-attachments/assets/dfa7b949-fcd9-4f30-88cb-be6cf36244ec
