### PR TITLE
Optimize EpisodeCell

### DIFF
--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -52,9 +52,22 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
 
     @IBOutlet var starIndicator: UIImageView! {
         didSet {
-            starIndicator.image = UIImage(named: "list_starred")?.tintedImage(ThemeColor.support10())
+            starIndicator.image = EpisodeCell.starIndicatorImage(for: Theme.sharedTheme.activeTheme)
         }
     }
+
+    private static var starIndicatorImageCache: [Theme.ThemeType: UIImage] = [:]
+
+    private static func starIndicatorImage(for theme: Theme.ThemeType) -> UIImage? {
+        if let cached = starIndicatorImageCache[theme] {
+            return cached
+        }
+        let image = UIImage(named: "list_starred")?.tintedImage(ThemeColor.support10(for: theme))
+        starIndicatorImageCache[theme] = image
+        return image
+    }
+
+    private var lastAppliedTheme: Theme.ThemeType?
 
     @IBOutlet var videoIndicator: UIImageView!
     @IBOutlet var actionButton: MainEpisodeActionView! {
@@ -570,10 +583,14 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
 
     // Handle theme change
     override func handleThemeDidChange() {
-        selectCircleView.layer.borderColor = ThemeColor.primaryIcon02().cgColor
-        selectTickImageView.backgroundColor = ThemeColor.primaryInteractive01()
-        selectTickImageView.tintColor = ThemeColor.primaryInteractive02()
-        starIndicator.image = UIImage(named: "list_starred")?.tintedImage(ThemeColor.support10())
+        let theme = themeOverride ?? Theme.sharedTheme.activeTheme
+        guard lastAppliedTheme != theme else { return }
+        lastAppliedTheme = theme
+
+        selectCircleView.layer.borderColor = ThemeColor.primaryIcon02(for: theme).cgColor
+        selectTickImageView.backgroundColor = ThemeColor.primaryInteractive01(for: theme)
+        selectTickImageView.tintColor = ThemeColor.primaryInteractive02(for: theme)
+        starIndicator.image = EpisodeCell.starIndicatorImage(for: theme)
     }
 
     private func updateSize() {


### PR DESCRIPTION
The following line is the biggest bottleneck in `EpisodeCell`:

```
UIImage(named: "list_starred")?.tintedImage(ThemeColor.support10(for: theme))
```

The cell gets hammered with `handleThemeDidChange` calls during scrolling and redraws the same image over and over.

## To test

- **Verify** star icon is rendered for liked episodes

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
