### PR TITLE
POC-564: Range-aware mapping query to avoid stale highlights outside cached coverage

### DIFF
--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -447,12 +447,21 @@ final class FingerprintTimingManager: NSObject {
             // entry through `insertMapping`'s per-entry `Array.insert`.
             playbackToReference = cached.entries
             referenceToPlayback = cached.entries.sorted { $0.referenceTime < $1.referenceTime }
-            filterLastTrusted = cached.entries.last
-            updateState(.active(coverage: cached.entries.count))
+
+            let currentTime = PlaybackManager.shared.currentTime()
+            if isWithinMappedRange(currentTime) {
+                filterLastTrusted = cached.entries.last
+                updateState(.active(coverage: cached.entries.count))
+                FileLog.shared.addMessage(
+                    "FingerprintTimingManager: skipping stream — full mapping loaded from cache for \(uuid)"
+                )
+                return
+            }
+
             FileLog.shared.addMessage(
-                "FingerprintTimingManager: skipping stream — full mapping loaded from cache for \(uuid)"
+                "FingerprintTimingManager: cache loaded for \(uuid) but playback at "
+                    + "\(String(format: "%.1f", currentTime))s is outside cached range — starting stream"
             )
-            return
         }
 
         let startPosition = PlaybackManager.shared.currentTime()

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -430,6 +430,9 @@ final class FingerprintTimingManager: NSObject {
             "FingerprintTimingManager: preparing for \(uuid) (\(libraryCheckpoints.count) checkpoints)"
         )
 
+        // Capture once so the range check, log, and stream start all use the same position.
+        let currentTime = PlaybackManager.shared.currentTime()
+
         // All-or-nothing cache: only short-circuit the stream if a previous
         // session persisted a mapping that covers the whole reference timeline
         // for this exact audio file + reference. Partial caches are ignored
@@ -448,7 +451,6 @@ final class FingerprintTimingManager: NSObject {
             playbackToReference = cached.entries
             referenceToPlayback = cached.entries.sorted { $0.referenceTime < $1.referenceTime }
 
-            let currentTime = PlaybackManager.shared.currentTime()
             if isWithinMappedRange(currentTime) {
                 filterLastTrusted = cached.entries.last
                 updateState(.active(coverage: cached.entries.count))
@@ -464,8 +466,7 @@ final class FingerprintTimingManager: NSObject {
             )
         }
 
-        let startPosition = PlaybackManager.shared.currentTime()
-        startStream(context: newContext, fromPosition: startPosition)
+        startStream(context: newContext, fromPosition: currentTime)
     }
 
     // MARK: - Streaming Fingerprint Processing


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/POC-564/range-aware-mapping-query-to-avoid-stale-highlights-outside-cached

## Summary
When a cached mapping is loaded for a downloaded episode, the manager was unconditionally set to `.active` — even when the current playback position was outside the cached entries' playback range. This caused `referenceTime(forPlaybackTime:)` to extrapolate from stale boundary anchors, producing incorrect transcript highlights until new stream-generated anchors arrived.

## Changes
- In the cache-loading block of `configureForReference`, check `isWithinMappedRange(currentTime)` after populating the mapping arrays from cache
- Only set `.active` and return (skipping the stream) if playback is within the cached range
- If playback is outside the cached range, keep the loaded entries but fall through to start a stream from the current position — the state remains `.preparing` until the stream produces enough local coverage

## Verification
- **Lint**: PASS
- **Tests**: FAIL — pre-existing CarPlay build errors on trunk (`CPPlaybackConfiguration` not in scope), unrelated to this change
- **Diff review**: PASS — confirmed only the intended one-file change, no debug statements or hardcoded values

## Confidence
**HIGH** — The fix is a straightforward guard on an existing helper (`isWithinMappedRange`) applied at the exact site identified in the issue. The fall-through path reuses the existing stream-start logic already exercised by every non-cached preparation.

---
This PR was created autonomously by linear-solver.
Triage complexity: simple | [Linear issue](https://linear.app/a8c/issue/POC-564/range-aware-mapping-query-to-avoid-stale-highlights-outside-cached)