### PR TITLE
Refine tvOS animations: follow button, playlist covers, welcome grid

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -39,7 +39,11 @@ struct PlaylistCell: View {
                         .clipShape(RoundedRectangle(cornerRadius: 6))
                         .shadow(color: .black.opacity(0.2), radius: 37.5, x: 0, y: 0)
                         .rotationEffect(Angle(degrees: isFocused ? (index == 0 ? Layout.rotationEffect : -Layout.rotationEffect) : 0))
-                        .offset(x: CGFloat(1-index) * 25.0, y: 50 + (CGFloat(2-index) * 25.0))
+                        .scaleEffect(isFocused ? 1.25 : 1.0)
+                        .offset(
+                            x: CGFloat(1 - index) * 25.0 - 24 + (index == 0 && !isFocused ? 8 : 0),
+                            y: 50 + CGFloat(2 - index) * 25.0 + (index == 0 && !isFocused ? 8 : 0) - (index == 1 ? 8 : 0)
+                        )
                 }
             }
             .padding(.horizontal, 36)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -74,10 +74,12 @@ struct PodcastDetailView: View {
                 Button() {
                     model.follow()
                 } label: {
-                    Label(
-                        model.isFollowing ? L10n.tvPodcastDetailFollowingTitle : L10n.tvPodcastDetailFollowTitle,
-                        systemImage: model.isFollowing ? "checkmark" : "plus"
-                    )
+                    HStack(spacing: 6) {
+                        Image(systemName: model.isFollowing ? "checkmark" : "plus")
+                            .contentTransition(.symbolEffect(.replace))
+                        Text(model.isFollowing ? L10n.tvPodcastDetailFollowingTitle : L10n.tvPodcastDetailFollowTitle)
+                            .contentTransition(.interpolate)
+                    }
                     .font(.caption2)
                 }
                 Button() {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -36,9 +36,7 @@ class PodcastDetailViewModel {
     var isFollowing: Bool = false
 
     func follow() {
-        var transaction = Transaction()
-        transaction.disablesAnimations = true
-        withTransaction(transaction) {
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
             isFollowing.toggle()
         }
     }

--- a/Pocket Casts TV App/UI/WelcomeView.swift
+++ b/Pocket Casts TV App/UI/WelcomeView.swift
@@ -11,7 +11,7 @@ struct WelcomeView: View {
         static let gridSpacing = CGFloat(16)
         static let columnsPerRow = 8
         static let animationOffset = CGFloat(200)
-        static let animationDuration = 30.0
+        static let animationDuration = 20.0
     }
 
     enum Destination: Hashable {
@@ -87,6 +87,7 @@ struct WelcomeView: View {
                     : (rowIndex.isMultiple(of: 2) ? -Layout.animationOffset : Layout.animationOffset))
             }
         }
+        .offset(y: 40)
         .onAppear {
             withAnimation(.linear(duration: Layout.animationDuration).repeatForever(autoreverses: true)) {
                 animating = true
@@ -103,8 +104,8 @@ struct WelcomeView: View {
                 Gradient.Stop(color: Color.backgroundSurface, location: 0.00),
                 Gradient.Stop(color: Color.backgroundSurface.opacity(0.5), location: 1.00),
               ],
-              startPoint: UnitPoint(x: 0.5, y: 0.41),
-              endPoint: UnitPoint(x: 0.5, y: 0.13)
+              startPoint: UnitPoint(x: 0.5, y: 0.45),
+              endPoint: UnitPoint(x: 0.5, y: 0.17)
             )
           )
     }


### PR DESCRIPTION
- Animate follow button with symbol morph and text interpolation
- Add scale and positional offsets to playlist cell cover animations
- Speed up welcome screen grid animation and adjust cover/gradient positioning

## To test

• [ ] Open any podcast detail view → tap the "Follow this podcast" button → verify the plus icon smoothly morphs into a checkmark and the text transitions to "Following" with a spring bounce. Tap again to verify the reverse animation
• [ ] Navigate to the Playlists tab → move focus across playlist pills → verify the two cover images scale up, tilt apart, and the back cover separates with depth. Verify the spring animation feels bouncy but not excessive
• [ ] Open the welcome/login screen → verify the top row of covers is fully visible (not clipped), the scrolling animation feels lively, and the gradient fades in below the cover grid without cutting off too much artwork

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.


https://github.com/user-attachments/assets/b34a03fb-8da3-46e5-8f77-59d3d89735be
