### PR TITLE
Add context-aware ellipsis menu to Up Next episodes

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -81,9 +81,15 @@ struct MoreButtonStyle: ButtonStyle {
 
 struct EpisodeRowWithActions: View {
 
+    enum Context {
+        case `default`
+        case upNext
+    }
+
     let episode: MockEpisode
     var podcastTitle: String?
     var podcastDescription: String?
+    var context: Context = .default
 
     @FocusState private var focusedElement: FocusElement?
     @State private var isPlaying = false
@@ -105,6 +111,22 @@ struct EpisodeRowWithActions: View {
 
     private var isEpisodeFocused: Bool {
         focusedElement == .episode
+    }
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        switch context {
+        case .default:
+            Button(L10n.playNextInUpNext) {}
+            Button(L10n.playLastInUpNext) {}
+            Button(L10n.markPlayed) {}
+            Button(L10n.archive) {}
+        case .upNext:
+            Button(L10n.playNext) {}
+            Button(L10n.playLast) {}
+            Button(L10n.removeFromUpNext) {}
+        }
+        Button(L10n.tvEpisodeInfo) {}
     }
 
     var body: some View {
@@ -151,11 +173,7 @@ struct EpisodeRowWithActions: View {
             .ignoresSafeArea()
         }
         .confirmationDialog(episode.title, isPresented: $isShowingActions) {
-            Button(L10n.playNextInUpNext) {}
-            Button(L10n.playLastInUpNext) {}
-            Button(L10n.markPlayed) {}
-            Button(L10n.archive) {}
-            Button(L10n.tvEpisodeInfo) {}
+            actionButtons
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -97,6 +97,14 @@ struct PodcastDetailView: View {
         }
     }
 
+    private func episodeRow(for episode: MockEpisode) -> some View {
+        EpisodeRowWithActions(
+            episode: episode,
+            podcastTitle: model.podcast.title,
+            podcastDescription: model.podcast.podcastDescription
+        )
+    }
+
     @Namespace private var episodeListNamespace
 
     var episodeContent: some View {
@@ -112,11 +120,7 @@ struct PodcastDetailView: View {
                                 .font(.caption)
                                 .foregroundStyle(Color.textSecondary)
                         }
-                        EpisodeRowWithActions(
-                            episode: recommended,
-                            podcastTitle: model.podcast.title,
-                            podcastDescription: model.podcast.podcastDescription
-                        )
+                        episodeRow(for: recommended)
                         .prefersDefaultFocus(in: episodeListNamespace)
                     }
                 }
@@ -127,11 +131,7 @@ struct PodcastDetailView: View {
                         .foregroundStyle(Color.textPrimary)
                     LazyVStack {
                         ForEach(model.podcast.episodes) { episode in
-                            EpisodeRowWithActions(
-                                episode: episode,
-                                podcastTitle: model.podcast.title,
-                                podcastDescription: model.podcast.podcastDescription
-                            )
+                            episodeRow(for: episode)
                         }
                     }
                 }

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -27,18 +27,16 @@ struct UpNextView: View {
     }
 
     var upNextView: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack {
-                        Text(L10n.tvTabUpNext)
-                            .font(.title2)
-                            .foregroundStyle(Color.textPrimary)
-                        Spacer()
-                    }
-                    upNextListView
-                        .frame(maxWidth: 1160)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack {
+                    Text(L10n.tvTabUpNext)
+                        .font(.title2)
+                        .foregroundStyle(Color.textPrimary)
+                    Spacer()
                 }
+                upNextListView
+                    .frame(maxWidth: 1160)
             }
         }
     }
@@ -52,27 +50,13 @@ struct UpNextView: View {
     @Namespace private var rowNamespace
     var upNextListView: some View {
         LazyVStack(alignment: .leading) {
-            ForEach(Array(model.episodes.enumerated()), id: \.element.id) { index, episode in
-                NavigationLink(value: episode) {
-                    EpisodeRow(episode: episode)
-                }
-                .buttonStyle(.card)
-                .prefersDefaultFocus(index == 0, in: rowNamespace)
+            ForEach(model.episodes) { episode in
+                EpisodeRowWithActions(episode: episode, context: .upNext)
+                    .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
             }
         }
         .focusScope(rowNamespace)
         .padding(24)
-        .navigationDestination(for: MockEpisode.self) { episode in
-            VStack {
-                Button {
-
-                } label: {
-                    Text("Episode \(episode.title) details coming soon")
-                        .font(.title2)
-                        .foregroundStyle(Color.textPrimary)
-                }
-            }
-        }
     }
 
 }


### PR DESCRIPTION
## Summary changes

• Add ellipsis action button to Up Next episodes — each episode now shows the same focus-revealed ellipsis button used in podcast/playlist detail views
• Context-aware action menus via a new Context enum on Episode​Row​With​Actions: Up Next shows Play Next, Play Last, Remove from Up Next, Episode Info; podcast/playlist detail keeps Play Next in Up Next, Play Last in Up Next, Mark Played, Archive, Episode Info
• Remove unused Navigation​Stack and placeholder navigation destination from Up​Next​View
• Code simplifications: extract shared action​Buttons view builder (deduplicating tv​Episode​Info across contexts), simplify For​Each by removing enumerated(), and extract episode​Row(for:) helper in Podcast​Detail​View

## To test

• [ ] Navigate to Up Next on tvOS — verify the ellipsis button appears when an episode row gains focus
• [ ] Tap the ellipsis on an Up Next episode — verify the action sheet shows: Play Next, Play Last, Remove from Up Next, Episode Info

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.


https://github.com/user-attachments/assets/7cb76904-b814-421f-912d-0e6fdb93e6f1


