### PR TITLE
Folders UI

### DIFF
--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -32,6 +32,13 @@ struct MockPodcast: Identifiable, Hashable, Equatable {
     var nextEpisodeDate: String?
 }
 
+struct MockFolder: Identifiable, Hashable, Equatable {
+    var id: String
+    var name: String
+    var podcastImages: [String]
+    var podcasts: [MockPodcast]
+}
+
 struct MockPlaylist: Identifiable, Hashable, Equatable {
     var id: String
     var title: String
@@ -159,6 +166,27 @@ struct MockData {
         }
         self.podcasts = results
         return self.podcasts
+    }
+
+    static func makeFolders() -> [MockFolder] {
+        let allPodcasts = makePodcasts()
+        return [
+            makeFolder(name: "News", podcastCount: 4, from: allPodcasts, startIndex: 0),
+            makeFolder(name: "Comedy", podcastCount: 1, from: allPodcasts, startIndex: 4),
+            makeFolder(name: "Tech", podcastCount: 2, from: allPodcasts, startIndex: 5),
+            makeFolder(name: "Science", podcastCount: 3, from: allPodcasts, startIndex: 7),
+            makeFolder(name: "My super duper long folder name that keeps on going", podcastCount: 4, from: allPodcasts, startIndex: 10)
+        ]
+    }
+
+    private static func makeFolder(name: String, podcastCount: Int, from allPodcasts: [MockPodcast], startIndex: Int) -> MockFolder {
+        let folderPodcasts = Array(allPodcasts[startIndex..<min(startIndex + podcastCount, allPodcasts.count)])
+        return MockFolder(
+            id: UUID().uuidString,
+            name: name,
+            podcastImages: folderPodcasts.map(\.image),
+            podcasts: folderPodcasts
+        )
     }
 
     static private var playlists: [MockPlaylist] = []

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -35,8 +35,9 @@ struct MockPodcast: Identifiable, Hashable, Equatable {
 struct MockFolder: Identifiable, Hashable, Equatable {
     var id: String
     var name: String
-    var podcastImages: [String]
     var podcasts: [MockPodcast]
+
+    var podcastImages: [String] { podcasts.map(\.image) }
 }
 
 struct MockPlaylist: Identifiable, Hashable, Equatable {
@@ -168,15 +169,20 @@ struct MockData {
         return self.podcasts
     }
 
+    private static var folders: [MockFolder] = []
+
     static func makeFolders() -> [MockFolder] {
+        guard folders.isEmpty else { return folders }
         let allPodcasts = makePodcasts()
-        return [
+        let result = [
             makeFolder(name: "News", podcastCount: 4, from: allPodcasts, startIndex: 0),
             makeFolder(name: "Comedy", podcastCount: 1, from: allPodcasts, startIndex: 4),
             makeFolder(name: "Tech", podcastCount: 2, from: allPodcasts, startIndex: 5),
             makeFolder(name: "Science", podcastCount: 3, from: allPodcasts, startIndex: 7),
             makeFolder(name: "My super duper long folder name that keeps on going", podcastCount: 4, from: allPodcasts, startIndex: 10)
         ]
+        self.folders = result
+        return result
     }
 
     private static func makeFolder(name: String, podcastCount: Int, from allPodcasts: [MockPodcast], startIndex: Int) -> MockFolder {
@@ -184,7 +190,6 @@ struct MockData {
         return MockFolder(
             id: UUID().uuidString,
             name: name,
-            podcastImages: folderPodcasts.map(\.image),
             podcasts: folderPodcasts
         )
     }

--- a/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
@@ -81,6 +81,7 @@ private struct MarqueeText: View {
                 label
                     .offset(x: offset)
                     .onAppear { startScrolling() }
+                    .onDisappear { offset = 0 }
             } else {
                 label
             }

--- a/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+struct FolderCardView: View {
+    let folder: MockFolder
+
+    private let cardSize: CGFloat = PodcastsView.Layout.gridSize
+    private let coverSize: CGFloat = 80
+    private let coverSpacing: CGFloat = 6
+
+    private let gradient = LinearGradient(
+        colors: [Color(red: 0x60/255, green: 0x46/255, blue: 0xE9/255),
+                 Color(red: 0xE7/255, green: 0x4B/255, blue: 0x8A/255)],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            coverGrid
+                .frame(maxHeight: .infinity, alignment: .top)
+                .padding(.top, 24)
+            folderName
+                .padding(.bottom, 16)
+        }
+        .frame(width: cardSize, height: cardSize)
+        .background(gradient)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var coverGrid: some View {
+        Grid(horizontalSpacing: coverSpacing, verticalSpacing: coverSpacing) {
+            GridRow {
+                coverImage(at: 0)
+                coverImage(at: 1)
+            }
+            GridRow {
+                coverImage(at: 2)
+                coverImage(at: 3)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func coverImage(at index: Int) -> some View {
+        if index < folder.podcastImages.count {
+            Image(folder.podcastImages[index])
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: coverSize, height: coverSize)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        } else {
+            Color.black.opacity(0.2)
+                .frame(width: coverSize, height: coverSize)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+    }
+
+    private var folderName: some View {
+        MarqueeText(text: folder.name, maxWidth: cardSize - 32)
+    }
+}
+
+private struct MarqueeText: View {
+    let text: String
+    let maxWidth: CGFloat
+
+    @State private var textWidth: CGFloat = 0
+    @State private var offset: CGFloat = 0
+
+    private var overflows: Bool { textWidth > maxWidth }
+
+    var body: some View {
+        let label = Text(text)
+            .font(.caption)
+            .fontWeight(.semibold)
+            .foregroundStyle(.white)
+            .fixedSize()
+
+        Group {
+            if overflows {
+                label
+                    .offset(x: offset)
+                    .onAppear { startScrolling() }
+            } else {
+                label
+            }
+        }
+        .frame(width: maxWidth, alignment: overflows ? .leading : .center)
+        .clipped()
+        .background(
+            label
+                .hidden()
+                .overlay(GeometryReader { geo in
+                    Color.clear.onAppear { textWidth = geo.size.width }
+                })
+        )
+    }
+
+    private func startScrolling() {
+        let travel = textWidth - maxWidth
+        withAnimation(
+            .linear(duration: Double(travel) / 30)
+            .delay(1)
+            .repeatForever(autoreverses: true)
+        ) {
+            offset = -travel
+        }
+    }
+}
+
+#Preview {
+    let folders = MockData.makeFolders()
+    LazyVGrid(columns: [GridItem(.fixed(250), spacing: 48), GridItem(.fixed(250), spacing: 48)], spacing: 48) {
+        ForEach(folders) { folder in
+            FolderCardView(folder: folder)
+        }
+    }
+    .padding()
+    .background(Color.black)
+}

--- a/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct FolderDetailView: View {
+    let folder: MockFolder
+
+    private let gridColumns: [GridItem] = (0..<6).map { _ in
+        GridItem(.fixed(PodcastsView.Layout.gridSize), spacing: 48)
+    }
+
+    @Namespace private var podcastGridNamespace
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 40) {
+                Text(folder.name)
+                    .font(.title2)
+                    .foregroundStyle(Color.textPrimary)
+                LazyVGrid(columns: gridColumns, spacing: 48) {
+                    ForEach(folder.podcasts) { podcast in
+                        NavigationLink(value: podcast) {
+                            Image(podcast.image)
+                                .resizable()
+                                .frame(width: PodcastsView.Layout.gridSize, height: PodcastsView.Layout.gridSize)
+                        }
+                        .buttonStyle(.card)
+                        .prefersDefaultFocus(folder.podcasts.first?.id == podcast.id, in: podcastGridNamespace)
+                    }
+                }
+                .focusScope(podcastGridNamespace)
+            }
+        }
+        .navigationDestination(for: MockPodcast.self) { podcast in
+            PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        FolderDetailView(folder: MockData.makeFolders().first!)
+    }
+}

--- a/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
@@ -3,19 +3,20 @@ import SwiftUI
 struct FolderDetailView: View {
     let folder: MockFolder
 
-    private let gridColumns: [GridItem] = (0..<6).map { _ in
+    private static let gridColumns: [GridItem] = (0..<6).map { _ in
         GridItem(.fixed(PodcastsView.Layout.gridSize), spacing: 48)
     }
 
     @Namespace private var podcastGridNamespace
 
     var body: some View {
+        let firstID = folder.podcasts.first?.id
         ScrollView {
             VStack(alignment: .leading, spacing: 40) {
                 Text(folder.name)
                     .font(.title2)
                     .foregroundStyle(Color.textPrimary)
-                LazyVGrid(columns: gridColumns, spacing: 48) {
+                LazyVGrid(columns: Self.gridColumns, spacing: 48) {
                     ForEach(folder.podcasts) { podcast in
                         NavigationLink(value: podcast) {
                             Image(podcast.image)
@@ -23,7 +24,7 @@ struct FolderDetailView: View {
                                 .frame(width: PodcastsView.Layout.gridSize, height: PodcastsView.Layout.gridSize)
                         }
                         .buttonStyle(.card)
-                        .prefersDefaultFocus(folder.podcasts.first?.id == podcast.id, in: podcastGridNamespace)
+                        .prefersDefaultFocus(podcast.id == firstID, in: podcastGridNamespace)
                     }
                 }
                 .focusScope(podcastGridNamespace)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 
-private enum GridCellItem {
+private enum GridCellItem: Identifiable {
     case podcast(MockPodcast)
     case folder(MockFolder)
 
     var id: String {
         switch self {
-        case .podcast(let p): return p.id
-        case .folder(let f): return f.id
+        case .podcast(let p): p.id
+        case .folder(let f): f.id
         }
     }
 }
@@ -22,6 +22,10 @@ struct PodcastsView: View {
         static let gridSize = CGFloat(250)
     }
 
+    private static let gridColumns: [GridItem] = (0..<6).map { _ in
+        GridItem(.fixed(Layout.gridSize), spacing: 48)
+    }
+
     var body: some View {
         ZStack {
             switch model.state {
@@ -34,7 +38,7 @@ struct PodcastsView: View {
             }
         }
         .task {
-            model.load()
+            await model.load()
         }
     }
 
@@ -61,10 +65,6 @@ struct PodcastsView: View {
         }
     }
 
-    private let items: [GridItem] = (0..<6).map { _ in
-        GridItem(.fixed(Layout.gridSize), spacing: 48)
-    }
-
     @Namespace private var podcastGridNamespace
 
     private var gridItems: [GridCellItem] {
@@ -78,8 +78,8 @@ struct PodcastsView: View {
 
     var podcastGrid: some View {
         let items = gridItems
-        return LazyVGrid(columns: self.items, spacing: 48, content: {
-            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+        return LazyVGrid(columns: Self.gridColumns, spacing: 48) {
+            ForEach(items) { item in
                 switch item {
                 case .podcast(let podcast):
                     NavigationLink(value: podcast) {
@@ -88,7 +88,7 @@ struct PodcastsView: View {
                             .frame(width: Layout.gridSize, height: Layout.gridSize)
                     }
                     .buttonStyle(.card)
-                    .prefersDefaultFocus(index == 0, in: podcastGridNamespace)
+                    .prefersDefaultFocus(item.id == items.first?.id, in: podcastGridNamespace)
                 case .folder(let folder):
                     NavigationLink(value: folder) {
                         FolderCardView(folder: folder)
@@ -96,7 +96,7 @@ struct PodcastsView: View {
                     .buttonStyle(.card)
                 }
             }
-        })
+        }
         .focusScope(podcastGridNamespace)
         .navigationDestination(for: MockPodcast.self) { podcast in
             PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -1,5 +1,17 @@
 import SwiftUI
 
+private enum GridCellItem {
+    case podcast(MockPodcast)
+    case folder(MockFolder)
+
+    var id: String {
+        switch self {
+        case .podcast(let p): return p.id
+        case .folder(let f): return f.id
+        }
+    }
+}
+
 struct PodcastsView: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
@@ -55,21 +67,42 @@ struct PodcastsView: View {
 
     @Namespace private var podcastGridNamespace
 
+    private var gridItems: [GridCellItem] {
+        var result: [GridCellItem] = model.podcasts.map { .podcast($0) }
+        for (offset, folder) in model.folders.enumerated() {
+            let insertionIndex = min(2 + offset, result.count)
+            result.insert(.folder(folder), at: insertionIndex)
+        }
+        return result
+    }
+
     var podcastGrid: some View {
-        LazyVGrid(columns: items, spacing: 48, content: {
-            ForEach(model.podcasts) { podcast in
-                NavigationLink(value: podcast) {
+        let items = gridItems
+        return LazyVGrid(columns: self.items, spacing: 48, content: {
+            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                switch item {
+                case .podcast(let podcast):
+                    NavigationLink(value: podcast) {
                         Image(podcast.image)
                             .resizable()
                             .frame(width: Layout.gridSize, height: Layout.gridSize)
+                    }
+                    .buttonStyle(.card)
+                    .prefersDefaultFocus(index == 0, in: podcastGridNamespace)
+                case .folder(let folder):
+                    NavigationLink(value: folder) {
+                        FolderCardView(folder: folder)
+                    }
+                    .buttonStyle(.card)
                 }
-                .buttonStyle(.card)
-                .prefersDefaultFocus(model.podcasts.first?.id == podcast.id, in: podcastGridNamespace)
             }
         })
         .focusScope(podcastGridNamespace)
         .navigationDestination(for: MockPodcast.self) { podcast in
             PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
+        }
+        .navigationDestination(for: MockFolder.self) { folder in
+            FolderDetailView(folder: folder)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
@@ -15,6 +15,7 @@ class PodcastsViewModel {
     var state: State = .loading
 
     var podcasts: [MockPodcast] = []
+    var folders: [MockFolder] = []
 
     func load() {
         //Mock data load
@@ -23,6 +24,7 @@ class PodcastsViewModel {
             .sink { [weak self] _ in
                 guard let self else { return }
                 podcasts = MockData.makePodcasts()
+                folders = MockData.makeFolders()
                 state = podcasts.isEmpty ? .empty : .ready
                 cancellable?.cancel()
                 cancellable = nil

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
@@ -1,10 +1,7 @@
 import SwiftUI
-import Combine
 
 @Observable
 class PodcastsViewModel {
-
-    private var cancellable: AnyCancellable?
 
     enum State: Equatable, Hashable {
         case loading
@@ -17,17 +14,10 @@ class PodcastsViewModel {
     var podcasts: [MockPodcast] = []
     var folders: [MockFolder] = []
 
-    func load() {
-        //Mock data load
-        cancellable = Timer.publish(every: 1.0, on: .main, in: .common, options: nil)
-            .autoconnect()
-            .sink { [weak self] _ in
-                guard let self else { return }
-                podcasts = MockData.makePodcasts()
-                folders = MockData.makeFolders()
-                state = podcasts.isEmpty ? .empty : .ready
-                cancellable?.cancel()
-                cancellable = nil
-            }
+    func load() async {
+        try? await Task.sleep(for: .seconds(1))
+        podcasts = MockData.makePodcasts()
+        folders = MockData.makeFolders()
+        state = podcasts.isEmpty ? .empty : .ready
     }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1279,8 +1279,8 @@
 		FF2142D52C07369200672D8D /* MediaExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2142D32C07369200672D8D /* MediaExporter.swift */; };
 		FF26A9924A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */; };
 		FF26A9924A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9934A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift */; };
-		FF26A99A4A1B5C2D00000004 /* MiniPlayerScrollingTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A99B4A1B5C2D00000004 /* MiniPlayerScrollingTitleView.swift */; };
 		FF26A9974A1B5C2D00000003 /* LiquidGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9984A1B5C2D00000003 /* LiquidGlass.swift */; };
+		FF26A99A4A1B5C2D00000004 /* MiniPlayerScrollingTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A99B4A1B5C2D00000004 /* MiniPlayerScrollingTitleView.swift */; };
 		FF31C0972EC211890083C7E5 /* playback_2025_plus.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = FF31C0962EC211890083C7E5 /* playback_2025_plus.mp4 */; };
 		FF31C0992EC216600083C7E5 /* playback_2025_plus_background.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = FF31C0982EC216600083C7E5 /* playback_2025_plus_background.mp4 */; };
 		FF40C0662C65175B003A9D93 /* TranscriptErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF40C0652C65175B003A9D93 /* TranscriptErrorView.swift */; };
@@ -2628,8 +2628,8 @@
 		FF2142D32C07369200672D8D /* MediaExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExporter.swift; sourceTree = "<group>"; };
 		FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassPlayerAnimator.swift; sourceTree = "<group>"; };
 		FF26A9934A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerGlassProgressView.swift; sourceTree = "<group>"; };
-		FF26A99B4A1B5C2D00000004 /* MiniPlayerScrollingTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerScrollingTitleView.swift; sourceTree = "<group>"; };
 		FF26A9984A1B5C2D00000003 /* LiquidGlass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlass.swift; sourceTree = "<group>"; };
+		FF26A99B4A1B5C2D00000004 /* MiniPlayerScrollingTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerScrollingTitleView.swift; sourceTree = "<group>"; };
 		FF31C0962EC211890083C7E5 /* playback_2025_plus.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = playback_2025_plus.mp4; sourceTree = "<group>"; };
 		FF31C0982EC216600083C7E5 /* playback_2025_plus_background.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = playback_2025_plus_background.mp4; sourceTree = "<group>"; };
 		FF40C0652C65175B003A9D93 /* TranscriptErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptErrorView.swift; sourceTree = "<group>"; };


### PR DESCRIPTION
## Summary
- Add `FolderCardView`, 2×2 podcast cover grid, and marquee-scrolling folder name
- Add `FolderDetailView` showing folder podcasts in the same 6-column grid layout
- Interleave folder cards into the Podcasts grid via a `GridCellItem` enum starting at position 3
- Replace Combine with async/await in `PodcastsViewModel`, add folder caching in MockData, and use static grid columns

## Test plan
- [ ] Launch tvOS app and verify folder cards appear in the Podcasts grid interleaved with podcasts
- [ ] Verify the long folder name marquee-scrolls on the card
- [ ] Tap a folder card and verify it navigates to FolderDetailView with the correct podcasts
- [ ] Tap a podcast from FolderDetailView and verify it navigates to PodcastDetailView
- [ ] Verify empty cover slots show a semi-transparent placeholder (folders with <4 podcasts)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.


https://github.com/user-attachments/assets/5323acdc-954c-4c58-8fb2-594dacc6cfb3

