### PR TITLE
[PC TV] Revamp playback effects menu and add toast feedback

### DIFF
--- a/Pocket Casts TV App/UI/Common/TVToast.swift
+++ b/Pocket Casts TV App/UI/Common/TVToast.swift
@@ -1,0 +1,64 @@
+import UIKit
+
+final class TVToast {
+    static let shared = TVToast()
+
+    private weak var overlayView: UIView?
+    private var toastView: UIView?
+    private var dismissTask: Task<Void, Never>?
+
+    func configure(with overlayView: UIView?) {
+        self.overlayView = overlayView
+    }
+
+    func show(_ message: String) {
+        dismissTask?.cancel()
+        toastView?.removeFromSuperview()
+
+        guard let overlayView else { return }
+
+        let label = PaddedLabel()
+        label.text = message
+        label.font = .preferredFont(forTextStyle: .caption1)
+        label.textColor = .white
+        label.backgroundColor = UIColor.white.withAlphaComponent(0.15)
+        label.layer.cornerRadius = 10
+        label.clipsToBounds = true
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        overlayView.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: overlayView.safeAreaLayoutGuide.topAnchor, constant: 32),
+            label.trailingAnchor.constraint(equalTo: overlayView.safeAreaLayoutGuide.trailingAnchor, constant: -48)
+        ])
+
+        label.alpha = 0
+        UIView.animate(withDuration: 0.3) {
+            label.alpha = 1
+        }
+
+        toastView = label
+
+        dismissTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(3))
+            guard !Task.isCancelled else { return }
+            UIView.animate(withDuration: 0.3) {
+                label.alpha = 0
+            } completion: { _ in
+                label.removeFromSuperview()
+            }
+        }
+    }
+}
+
+private class PaddedLabel: UILabel {
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: UIEdgeInsets(top: 12, left: 20, bottom: 12, right: 20)))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+        return CGSize(width: size.width + 40, height: size.height + 24)
+    }
+}

--- a/Pocket Casts TV App/UI/Player/EpisodePlayerView.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodePlayerView.swift
@@ -18,6 +18,7 @@ struct EpisodePlayerView: UIViewControllerRepresentable {
             makePlaybackEffectsMenu()
         ]
         controller.allowedSubtitleOptionLanguages = []
+        TVToast.shared.configure(with: controller.contentOverlayView)
         player.play()
         return controller
     }
@@ -52,6 +53,7 @@ struct EpisodePlayerView: UIViewControllerRepresentable {
                     menu.children.compactMap { $0 as? UIAction }.forEach { $0.state = .off }
                 }
                 action.state = .on
+                TVToast.shared.show(String(format: "Playback speed set to %.1fx", speed))
             }
         }
         return UIMenu(
@@ -62,13 +64,17 @@ struct EpisodePlayerView: UIViewControllerRepresentable {
     }
 
     private func makePlaybackEffectsMenu() -> UIMenu {
-        let volumeBoostAction = UIAction(
-            title: L10n.tvPlayerVolumeBoost,
-            image: UIImage(systemName: "speaker.wave.3"),
-            state: .off
-        ) { action in
-            action.state = action.state == .off ? .on : .off
+        let volumeBoostOff = UIAction(title: L10n.off, state: .on) { _ in
+            TVToast.shared.show("Volume boost off")
         }
+        let volumeBoostOn = UIAction(title: L10n.on, state: .off) { _ in
+            TVToast.shared.show("Volume boost on")
+        }
+        let volumeBoostSection = UIMenu(
+            title: L10n.tvPlayerVolumeBoost,
+            options: [.displayInline, .singleSelection],
+            children: [volumeBoostOff, volumeBoostOn]
+        )
 
         let trimOptions: [(String, UIAction.State)] = [
             (L10n.tvPlayerTrimSilenceOff, .on),
@@ -77,18 +83,20 @@ struct EpisodePlayerView: UIViewControllerRepresentable {
             (L10n.tvPlayerTrimSilenceMadMax, .off)
         ]
         let trimActions = trimOptions.map { title, state in
-            UIAction(title: title, state: state) { _ in }
+            UIAction(title: title, state: state) { _ in
+                TVToast.shared.show("Trim silence: \(title)")
+            }
         }
-        let trimSubmenu = UIMenu(
+        let trimSection = UIMenu(
             title: L10n.tvPlayerTrimSilence,
             options: [.displayInline, .singleSelection],
             children: trimActions
         )
 
         return UIMenu(
-            title: L10n.tvPlayerPlaybackEffects,
-            image: UIImage(systemName: "slider.horizontal.3"),
-            children: [volumeBoostAction, trimSubmenu]
+            title: L10n.tvPlayerVolumeBoost,
+            image: UIImage(systemName: "speaker.wave.3"),
+            children: [volumeBoostSection, trimSection]
         )
     }
 

--- a/Pocket Casts TV App/UI/Player/EpisodePlayerView.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodePlayerView.swift
@@ -53,7 +53,7 @@ struct EpisodePlayerView: UIViewControllerRepresentable {
                     menu.children.compactMap { $0 as? UIAction }.forEach { $0.state = .off }
                 }
                 action.state = .on
-                TVToast.shared.show(String(format: "Playback speed set to %.1fx", speed))
+                TVToast.shared.show(L10n.tvPlayerPlaybackSpeedSet(String(format: "%.1fx", speed)))
             }
         }
         return UIMenu(
@@ -65,10 +65,10 @@ struct EpisodePlayerView: UIViewControllerRepresentable {
 
     private func makePlaybackEffectsMenu() -> UIMenu {
         let volumeBoostOff = UIAction(title: L10n.off, state: .on) { _ in
-            TVToast.shared.show("Volume boost off")
+            TVToast.shared.show(L10n.tvPlayerVolumeBoostOff)
         }
         let volumeBoostOn = UIAction(title: L10n.on, state: .off) { _ in
-            TVToast.shared.show("Volume boost on")
+            TVToast.shared.show(L10n.tvPlayerVolumeBoostOn)
         }
         let volumeBoostSection = UIMenu(
             title: L10n.tvPlayerVolumeBoost,
@@ -84,7 +84,7 @@ struct EpisodePlayerView: UIViewControllerRepresentable {
         ]
         let trimActions = trimOptions.map { title, state in
             UIAction(title: title, state: state) { _ in
-                TVToast.shared.show("Trim silence: \(title)")
+                TVToast.shared.show(L10n.tvPlayerTrimSilenceSet(title))
             }
         }
         let trimSection = UIMenu(

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4267,6 +4267,10 @@ internal enum L10n {
   internal static var tvPlayerPlaybackEffects: String { return L10n.tr("Localizable", "tv_player_playback_effects", fallback: "Playback effects") }
   /// tv player playback speed menu title
   internal static var tvPlayerPlaybackSpeed: String { return L10n.tr("Localizable", "tv_player_playback_speed", fallback: "Playback speed") }
+  /// tv player toast shown when playback speed changes. '%1$@' is a placeholder for the speed value like 1.5x.
+  internal static func tvPlayerPlaybackSpeedSet(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "tv_player_playback_speed_set", String(describing: p1), fallback: "Playback speed set to %1$@")
+  }
   /// tv player trim silence section title
   internal static var tvPlayerTrimSilence: String { return L10n.tr("Localizable", "tv_player_trim_silence", fallback: "Trim silence") }
   /// tv player trim silence mad max option
@@ -4277,8 +4281,16 @@ internal enum L10n {
   internal static var tvPlayerTrimSilenceMild: String { return L10n.tr("Localizable", "tv_player_trim_silence_mild", fallback: "Mild") }
   /// tv player trim silence off option
   internal static var tvPlayerTrimSilenceOff: String { return L10n.tr("Localizable", "tv_player_trim_silence_off", fallback: "Off") }
+  /// tv player toast shown when trim silence setting changes. '%1$@' is a placeholder for the selected option name.
+  internal static func tvPlayerTrimSilenceSet(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "tv_player_trim_silence_set", String(describing: p1), fallback: "Trim silence: %1$@")
+  }
   /// tv player volume boost toggle title
   internal static var tvPlayerVolumeBoost: String { return L10n.tr("Localizable", "tv_player_volume_boost", fallback: "Volume boost") }
+  /// tv player toast shown when volume boost is turned off
+  internal static var tvPlayerVolumeBoostOff: String { return L10n.tr("Localizable", "tv_player_volume_boost_off", fallback: "Volume boost off") }
+  /// tv player toast shown when volume boost is turned on
+  internal static var tvPlayerVolumeBoostOn: String { return L10n.tr("Localizable", "tv_player_volume_boost_on", fallback: "Volume boost on") }
   /// tv playlist detail episode count. '%1$@' is a placeholder for the number of episodes.
   internal static func tvPlaylistDetailEpisodeCount(_ p1: Any) -> String {
     return L10n.tr("Localizable", "tv_playlist_detail_episode_count", String(describing: p1), fallback: "%1$@ episodes")

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6037,6 +6037,18 @@
 /* tv player trim silence mad max option */
 "tv_player_trim_silence_mad_max" = "Mad Max";
 
+/* tv player toast shown when playback speed changes. %1$@ is the speed value like 1.5x */
+"tv_player_playback_speed_set" = "Playback speed set to %1$@";
+
+/* tv player toast shown when volume boost is turned off */
+"tv_player_volume_boost_off" = "Volume boost off";
+
+/* tv player toast shown when volume boost is turned on */
+"tv_player_volume_boost_on" = "Volume boost on";
+
+/* tv player toast shown when trim silence setting changes. %1$@ is the selected option name */
+"tv_player_trim_silence_set" = "Trim silence: %1$@";
+
 /* tv up next empty title */
 "tv_up_next_empty_title" = "Nothing queued up";
 


### PR DESCRIPTION
## Summary
- Revamps the player effects menu: renames "Playback Effects" to "Volume Boost", replaces the toggle with explicit On/Off options, and keeps Trim Silence with Off/Mild/Medium/Mad Max — all flat in one menu
- Adds toast feedback using AVPlayerViewController's `contentOverlayView` when users change playback speed, volume boost, or trim silence settings
- Introduces a lightweight `TVToast` component that renders non-interactive overlays on top of the player without interfering with focus

## Test plan
- [ ] Open the player and verify the effects menu is titled "Volume Boost" with a speaker icon
- [ ] Verify Volume Boost section shows On/Off options (Off selected by default)
- [ ] Verify Trim Silence section shows Off/Mild/Medium/Mad Max (Off selected by default)
- [ ] Change playback speed and confirm a toast appears (e.g. "Playback speed set to 1.5x")
- [ ] Toggle volume boost and confirm a toast appears
- [ ] Change trim silence and confirm a toast appears
- [ ] Verify toast auto-dismisses after ~3 seconds
- [ ] Verify focus is not disrupted after interacting with any option

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.


https://github.com/user-attachments/assets/06e2076b-8aff-4252-83d8-7d9d93f71350
