### PR TITLE
Fix new Auto Layout warning in PCSearchController

### DIFF
--- a/podcasts/Common Components/Search/PCSearchBarController.swift
+++ b/podcasts/Common Components/Search/PCSearchBarController.swift
@@ -88,7 +88,7 @@ class PCSearchBarController: UIViewController {
         let progress = min(1, max(0, height / Self.defaultHeight))
         // Pill itself shrinks in place; contents fade on a steeper curve so the text/icons are
         // gone well before the pill finishes collapsing — closer to the native bar.
-        let contentAlpha = max(0, progress * 2 - 1)
+        let contentAlpha = max(0, progress * 1.66 - 1)
         searchIcon.alpha = contentAlpha
         searchTextField.alpha = contentAlpha
         clearSearchBtn.alpha = contentAlpha

--- a/podcasts/Common Components/Search/PCSearchBarController.xib
+++ b/podcasts/Common Components/Search/PCSearchBarController.xib
@@ -94,7 +94,7 @@
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="iXt-pK-0hH" secondAttribute="trailing" constant="16" id="3fD-b3-0XO"/>
                 <constraint firstItem="Cpm-2R-PJM" firstAttribute="leading" secondItem="iXt-pK-0hH" secondAttribute="trailing" constant="8" id="BZL-hf-0a7"/>
-                <constraint firstAttribute="bottom" secondItem="Cpm-2R-PJM" secondAttribute="bottom" constant="16" id="S29-sS-5Ao"/>
+                <constraint firstAttribute="bottom" secondItem="Cpm-2R-PJM" secondAttribute="bottom" constant="16" priority="999" id="S29-sS-5Ao"/>
                 <constraint firstItem="iXt-pK-0hH" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="pTp-PI-l01"/>
                 <constraint firstItem="iXt-pK-0hH" firstAttribute="height" secondItem="i5M-Pr-FkT" secondAttribute="height" multiplier="0.66666666666666666" priority="999" id="pPh-PI-l02"/>
                 <constraint firstItem="iXt-pK-0hH" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="16" id="bqj-xC-Ccd"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes new warning I added earlier:

```
Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x6000022d2850 V:|-(0)-[UIView:0x1061c9320]   (active, names: '|':UIView:0x1064cd620 )>",
    "<NSLayoutConstraint:0x6000022d2940 V:[UIButton:0x1064cb190]-(16)-|   (active, names: '|':UIView:0x1064cd620 )>",
    "<NSLayoutConstraint:0x6000022d29e0 UIButton:0x1064cb190.centerY == UIView:0x1061c9320.centerY   (active)>",
    "<NSLayoutConstraint:0x6000022d6710 UIView:0x1064cd620.height == 0   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x6000022d29e0 UIButton:0x1064cb190.centerY == UIView:0x1061c9320.centerY   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
```

I also slightly tweaked how fast the placeholder title disappears on scroll.

## To test

n/a

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
