### PR TITLE
SwiftLint: Disable prefer_zero_over_explicit_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -72,9 +72,6 @@ only_rules:
   # the declaration.
   - opening_brace
 
-  # Prefer `0` over explicit `Int(0)` / `CGFloat(0)` etc.
-  - prefer_zero_over_explicit_init
-
   # `nil` coalescing on a non-optional is redundant.
   - redundant_nil_coalescing
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Would it be worth reverting this one? Writing `CGPoint(x: 0, y: 0)` is pretty common. I just ran into it in some clean generated code:

<img width="600" alt="Screenshot 2026-05-07 at 9 57 30 AM" src="https://github.com/user-attachments/assets/7e097432-95ea-4b58-9a72-18d1f8efbf3c" />

More broadly, I wonder if we could be a bit selective about which rules we opt into – focusing on ones that catch genuinely problematic patterns (like `.sorted({ ... }).max()`) and skipping the ones that are more stylistic. My main concern is that warnings showing up on otherwise harmless code, especially in generated files, could become noisy over time.

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
