### PR TITLE
TV: Sign-in and initial sync flow

### DIFF
--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -216,7 +216,6 @@ struct MockData {
             return stubPodcasts
         }
         let frequencies = ["Released weekly", "Released daily", "Released biweekly", "Released monthly"]
-        let nextDays = ["Next episode Monday", "Next episode Tuesday", "Next episode Wednesday", "Next episode Thursday", "Next episode Friday"]
         let numberOfPodcasts = 48
         var results = [Podcast]()
         for i in (0..<numberOfPodcasts) {

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -222,6 +222,7 @@ struct MockData {
         for i in (0..<numberOfPodcasts) {
             let podcast = Podcast()
             podcast.id = Int64(i)
+            podcast.uuid = UUID().uuidString
             podcast.title = podcastNames[i % podcastNames.count]
             podcast.author = authorNames[i % authorNames.count]
             podcast.podcastDescription = "Here is a fun description for this"

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsUtils
+import PocketCastsDataModel
 import SwiftUI
 
 struct MockEpisode: Identifiable, Hashable, Equatable {
@@ -206,5 +207,32 @@ struct MockData {
         }
         upNext = episodes
         return episodes
+    }
+
+    static var stubPodcasts: [Podcast] = []
+
+    static func makeStubPodcasts() -> [Podcast] {
+        guard stubPodcasts.isEmpty else {
+            return stubPodcasts
+        }
+        let frequencies = ["Released weekly", "Released daily", "Released biweekly", "Released monthly"]
+        let nextDays = ["Next episode Monday", "Next episode Tuesday", "Next episode Wednesday", "Next episode Thursday", "Next episode Friday"]
+        let numberOfPodcasts = 48
+        var results = [Podcast]()
+        for i in (0..<numberOfPodcasts) {
+            let podcast = Podcast()
+            podcast.id = Int64(i)
+            podcast.title = podcastNames[i % podcastNames.count]
+            podcast.author = authorNames[i % authorNames.count]
+            podcast.podcastDescription = "Here is a fun description for this"
+            podcast.podcastUrl = "https://\(podcastNames[i % podcastNames.count].lowercased().replacingOccurrences(of: " ", with: "")).com"
+            podcast.episodeFrequency = frequencies[i % frequencies.count]
+            podcast.estimatedNextEpisode = Date.now.advanced(by: 1.days)
+            results.append(podcast)
+        }
+        self.stubPodcasts = results
+        return self.stubPodcasts
+
+
     }
 }

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -61,8 +61,10 @@ struct SignInView: View {
             }
         }
         .onChange(of: model.state) {
-            dismiss()
-            coordinator.state = .userSync
+            if case .finished = model.state {
+                dismiss()
+                coordinator.state = .userSync
+            }
         }
     }
 
@@ -113,17 +115,27 @@ struct SignInView: View {
                         await model.manualSignIn(username: username, password: password)
                     }
                 }
-
+            if case .error(_, let errorMessage) = model.state {
+                Text(errorMessage)
+            }
             Button() {
                 Task {
                     await model.manualSignIn(username: username, password: password)
                 }
             } label: {
-                Text("Sign In")
-                    .frame(minWidth: 300)
+                switch model.state {
+                case .start, .error:
+                    Text("Sign In")
+                        .frame(minWidth: 300)
+                case .waiting:
+                    ProgressView()
+                default:
+                    EmptyView()
+                }
             }
-            .disabled(username.isEmpty || password.isEmpty)
+            .disabled(username.isEmpty || password.isEmpty || model.state == .waiting)
         }
+        .frame(maxWidth: 500)
     }
 }
 

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -108,10 +108,16 @@ struct SignInView: View {
                 .textContentType(.password)
                 .focused($focusedField, equals: .password)
                 .submitLabel(.done)
-                .onSubmit { model.manualSignIn(username: username, password: password) }
+                .onSubmit {
+                    Task {
+                        await model.manualSignIn(username: username, password: password)
+                    }
+                }
 
             Button() {
-                model.manualSignIn(username: username, password: password)
+                Task {
+                    await model.manualSignIn(username: username, password: password)
+                }
             } label: {
                 Text("Sign In")
                     .frame(minWidth: 300)

--- a/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
@@ -9,8 +9,10 @@ class SignInViewModel {
 
     enum State: Equatable, Hashable {
         case waiting
+        case error
         case finished
     }
+
     var state: State = .waiting
 
     var codes: [String] = ["J", "M", "R", "S", "3", "W"]
@@ -28,12 +30,12 @@ class SignInViewModel {
         do {
             let response = try await AuthenticationHelper.validateLogin(username: username, password: password, scope: .mobile)
             if response.token != nil {
-                self.state = .finished
+                state = .finished
             }
         } catch let apiError as APIError {
-            print(apiError)
+            state = .error
         } catch {
-            print(error)
+            state = .error
         }
     }
 }

--- a/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
@@ -7,17 +7,33 @@ import PocketCastsServer
 class SignInViewModel {
     private var cancellable: AnyCancellable?
 
-    enum State: Equatable, Hashable {
+    enum State: Equatable {
+        static func == (lhs: SignInViewModel.State, rhs: SignInViewModel.State) -> Bool {
+            switch (lhs, rhs) {
+            case (.start, .start):
+                return true
+            case (.waiting, .waiting):
+                return true
+            case (.finished, .finished):
+                return true
+            case (.error, .error):
+                return true
+            default:
+                return false
+            }
+        }
+        case start
         case waiting
-        case error
+        case error(Error, String)
         case finished
     }
 
-    var state: State = .waiting
+    var state: State = .start
 
     var codes: [String] = ["J", "M", "R", "S", "3", "W"]
 
     func signinWait() {
+        state = .waiting
         cancellable = Timer.publish(every: 5.0, on: .main, in: .common)
                     .autoconnect()
                     .sink { [weak self] _ in
@@ -27,15 +43,16 @@ class SignInViewModel {
     }
 
     func manualSignIn(username: String, password: String) async {
+        state = .waiting
         do {
             let response = try await AuthenticationHelper.validateLogin(username: username, password: password, scope: .mobile)
             if response.token != nil {
                 state = .finished
             }
-        } catch let apiError as APIError {
-            state = .error
+        } catch let error as APIError {
+            state = .error(error, error.localizedDescription)
         } catch {
-            state = .error
+            state = .error(error, "Please try again")
         }
     }
 }

--- a/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Combine
 import PocketCastsServer
 
+@MainActor
 @Observable
 class SignInViewModel {
     private var cancellable: AnyCancellable?
@@ -23,9 +24,16 @@ class SignInViewModel {
                     }
     }
 
-    func manualSignIn(username: String, password: String) {
-        ApiServerHandler.shared.validateLogin(username: username, password: password) { success, userId, error in
-            print("Success: \(success), userId: \(userId ?? "") error: \(error)")
+    func manualSignIn(username: String, password: String) async {
+        do {
+            let response = try await AuthenticationHelper.validateLogin(username: username, password: password, scope: .mobile)
+            if response.token != nil {
+                self.state = .finished
+            }
+        } catch let apiError as APIError {
+            print(apiError)
+        } catch {
+            print(error)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -6,7 +6,7 @@ fileprivate enum Layout {
     static let qrSize = CGFloat(240)
 }
 
-struct SigningInView<ViewModel: SigningInViewModelInterface>: View {
+struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
     @Environment(AppCoordinator.self) var coordinator
 
     @State private var model: ViewModel

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsDataModel
 
 struct SigningInView: View {
     @Environment(AppCoordinator.self) var coordinator
@@ -42,8 +43,7 @@ struct SigningInView: View {
         ScrollView(.horizontal) {
             HStack(spacing: 24, content: {
                 ForEach(model.podcasts) { podcast in
-                    Image(podcast.image)
-                        .resizable()
+                    PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
                         .frame(width: Layout.gridSize, height: Layout.gridSize)
                 }
             }).ignoresSafeArea()

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -20,6 +20,10 @@ struct SigningInView: View {
             Text(L10n.tvSigningInSubtitle)
                 .font(.headline)
                 .foregroundStyle(Color.textSecondary)
+            if let title = model.title {
+                Text(title)
+            }
+            ProgressView(value: model.progress)
             Spacer()
             podcastGrid
             Spacer().frame(height: 100)
@@ -28,18 +32,22 @@ struct SigningInView: View {
             model.sync()
         }
         .onChange(of: model.state) {
-            coordinator.state = .signedIn
+            if model.state == .finished {
+                coordinator.state = .signedIn
+            }
         }
     }
 
     var podcastGrid: some View {
-        HStack(spacing: 24, content: {
-            ForEach(model.podcasts) { podcast in
-                Image(podcast.image)
-                    .resizable()
-                    .frame(width: Layout.gridSize, height: Layout.gridSize)
-            }
-        }).ignoresSafeArea()
+        ScrollView(.horizontal) {
+            HStack(spacing: 24, content: {
+                ForEach(model.podcasts) { podcast in
+                    Image(podcast.image)
+                        .resizable()
+                        .frame(width: Layout.gridSize, height: Layout.gridSize)
+                }
+            }).ignoresSafeArea()
+        }
     }
 }
 

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -9,7 +9,7 @@ fileprivate enum Layout {
 struct SigningInView<ViewModel: SigningInViewModelInterface>: View {
     @Environment(AppCoordinator.self) var coordinator
 
-    @Bindable private var model: ViewModel
+    @State private var model: ViewModel
 
     init(model: ViewModel = SigningInViewModel()) {
         self.model = model

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -1,14 +1,18 @@
 import SwiftUI
 import PocketCastsDataModel
 
-struct SigningInView: View {
+fileprivate enum Layout {
+    static let gridSize = CGFloat(272)
+    static let qrSize = CGFloat(240)
+}
+
+struct SigningInView<ViewModel: SigningInViewModelInterface>: View {
     @Environment(AppCoordinator.self) var coordinator
 
-    @State private var model = SigningInViewModel()
+    @Bindable private var model: ViewModel
 
-    enum Layout {
-        static let gridSize = CGFloat(272)
-        static let qrSize = CGFloat(240)
+    init(model: ViewModel = SigningInViewModel()) {
+        self.model = model
     }
 
     var body: some View {
@@ -52,6 +56,6 @@ struct SigningInView: View {
 }
 
 #Preview {
-    SigningInView()
+    SigningInView(model: SigningInViewModelMock())
         .environment(AppCoordinator())
 }

--- a/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 import Combine
+import PocketCastsServer
+import PocketCastsUtils
 
 @Observable
 class SigningInViewModel {
-    private var cancellable: AnyCancellable?
+    private var cancellables: Set<AnyCancellable> = []
 
     enum State: Equatable, Hashable {
         case waiting
@@ -13,12 +15,84 @@ class SigningInViewModel {
 
     var podcasts: [MockPodcast] = MockData.makePodcasts()
 
+    var totalPodcastsToImport: Int = -1
+    var totalPodcastsImported: Int = 0
+    var title: String?
+    var progress: CGFloat = 0
+
     func sync() {
-        cancellable = Timer.publish(every: 5.0, on: .main, in: .common)
-                    .autoconnect()
-                    .sink { [weak self] _ in
-                        guard let self else { return }
-                        state = .finished
-                    }
+        NotificationCenter.default.publisher(for: ServerNotifications.syncProgressPodcastCount)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                guard let self else {
+                    return
+                }
+                if let number = notification.object as? NSNumber {
+                    totalPodcastsToImport = number.intValue
+                }
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: ServerNotifications.syncProgressPodcastUpto)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                guard let self,
+                      let number = notification.object as? NSNumber
+                else {
+                    return
+                }
+
+                totalPodcastsImported = number.intValue
+                if totalPodcastsToImport > 0 {
+                    title = L10n.syncProgress(totalPodcastsImported.localized(), totalPodcastsToImport.localized())
+                    progress = CGFloat(totalPodcastsImported / totalPodcastsToImport)
+                } else {
+                    // Used when the total number of podcasts to sync isn't known.
+                    title = totalPodcastsImported == 1 ? L10n.syncProgressUnknownCountSingular : L10n.syncProgressUnknownCountPluralFormat(totalPodcastsImported.localized())
+                }
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: ServerNotifications.syncProgressImportedPodcasts)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else {
+                    return
+                }
+
+                title = L10n.syncInProgress
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: .userLoginDidChange)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else {
+                    return
+                }
+
+                title = L10n.syncAccountLogin
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: ServerNotifications.syncCompleted)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else {
+                    return
+                }
+                state = .finished
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: ServerNotifications.syncFailed)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else {
+                    return
+                }
+                state = .finished
+            }
+            .store(in: &cancellables)
     }
 }

--- a/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
@@ -5,10 +5,17 @@ import PocketCastsUtils
 import PocketCastsDataModel
 
 protocol SigningInViewModelInterface: AnyObject, Observation.Observable {
+
+    var state: SigningInState { get }
+
+    var podcasts: [Podcast] { get }
+
     var totalPodcastsToImport: Int { get }
     var totalPodcastsImported: Int { get }
     var title: String? { get }
     var progress: CGFloat { get }
+
+    func sync()
 }
 
 enum SigningInState: Equatable, Hashable {
@@ -151,7 +158,7 @@ class SigningInViewModelMock: SigningInViewModelInterface {
 
     var state: SigningInState = .waiting
 
-    var totalPodcastsToImport: Int = MockData.makePodcasts().count
+    var totalPodcastsToImport: Int = MockData.makeStubPodcasts().count
 
     var totalPodcastsImported: Int = 0
 
@@ -159,7 +166,7 @@ class SigningInViewModelMock: SigningInViewModelInterface {
 
     var progress: CGFloat = 0
 
-    var podcasts: [MockPodcast] = MockData.makePodcasts()
+    var podcasts: [Podcast] = []
 
     func sync() {
         cancellable = Timer.publish(every: 1.0, on: .main, in: .common)
@@ -172,9 +179,8 @@ class SigningInViewModelMock: SigningInViewModelInterface {
                         } else {
                             state = .finished
                         }
-
+                        podcasts = Array(MockData.makeStubPodcasts().prefix(totalPodcastsImported))
                         progress = CGFloat(totalPodcastsImported) / CGFloat(totalPodcastsToImport)
                     }
     }
 }
-

--- a/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
@@ -4,7 +4,7 @@ import PocketCastsServer
 import PocketCastsUtils
 import PocketCastsDataModel
 
-protocol SigningInViewModelInterface: AnyObject, Observation.Observable {
+protocol SigningInViewModelProtocol: AnyObject, Observation.Observable {
 
     var state: SigningInState { get }
 
@@ -24,7 +24,7 @@ enum SigningInState: Equatable, Hashable {
 }
 
 @Observable
-class SigningInViewModel: SigningInViewModelInterface {
+class SigningInViewModel: SigningInViewModelProtocol {
     private var cancellables: Set<AnyCancellable> = []
 
     private(set) var state: SigningInState = .waiting
@@ -152,7 +152,7 @@ class SigningInViewModel: SigningInViewModelInterface {
 }
 
 @Observable
-class SigningInViewModelMock: SigningInViewModelInterface {
+class SigningInViewModelMock: SigningInViewModelProtocol {
 
     private var cancellable: AnyCancellable?
 

--- a/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import Combine
 import PocketCastsServer
 import PocketCastsUtils
+import PocketCastsDataModel
 
 protocol SigningInViewModelInterface: AnyObject, Observation.Observable {
     var totalPodcastsToImport: Int { get }
@@ -19,14 +20,20 @@ enum SigningInState: Equatable, Hashable {
 class SigningInViewModel: SigningInViewModelInterface {
     private var cancellables: Set<AnyCancellable> = []
 
-    var state: SigningInState = .waiting
+    private(set) var state: SigningInState = .waiting
 
-    var podcasts: [MockPodcast] = []
+    var podcasts: [Podcast] = []
 
     var totalPodcastsToImport: Int = -1
     var totalPodcastsImported: Int = 0
     var title: String?
     var progress: CGFloat = 0
+
+    private let dataManager: DataManager
+
+    init(dataManager: DataManager = DataManager.sharedManager) {
+        self.dataManager = dataManager
+    }
 
     func sync() {
         guard cancellables.isEmpty else {
@@ -42,10 +49,9 @@ class SigningInViewModel: SigningInViewModelInterface {
 
     private func fetchPodcasts() {
         Task {
-            let numberOfPodcasts = MockData.makePodcasts().count
-            let podcasts = MockData.makePodcasts().prefix(upTo: Int((CGFloat(numberOfPodcasts) * progress).rounded()) )
+            let podcasts = dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: true)
             await MainActor.run {
-                self.podcasts = Array(podcasts)
+                self.podcasts = podcasts
             }
         }
     }
@@ -139,23 +145,35 @@ class SigningInViewModel: SigningInViewModelInterface {
 }
 
 @Observable
-class SigningInViewModelMock {
+class SigningInViewModelMock: SigningInViewModelInterface {
+
     private var cancellable: AnyCancellable?
 
-    enum State: Equatable, Hashable {
-        case waiting
-        case finished
-    }
-    var state: State = .waiting
+    var state: SigningInState = .waiting
+
+    var totalPodcastsToImport: Int = MockData.makePodcasts().count
+
+    var totalPodcastsImported: Int = 0
+
+    var title: String?
+
+    var progress: CGFloat = 0
 
     var podcasts: [MockPodcast] = MockData.makePodcasts()
 
     func sync() {
-        cancellable = Timer.publish(every: 5.0, on: .main, in: .common)
+        cancellable = Timer.publish(every: 1.0, on: .main, in: .common)
                     .autoconnect()
                     .sink { [weak self] _ in
                         guard let self else { return }
-                        state = .finished
+
+                        if totalPodcastsImported < totalPodcastsToImport {
+                            totalPodcastsImported += 1
+                        } else {
+                            state = .finished
+                        }
+
+                        progress = CGFloat(totalPodcastsImported) / CGFloat(totalPodcastsToImport)
                     }
     }
 }

--- a/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
@@ -3,17 +3,25 @@ import Combine
 import PocketCastsServer
 import PocketCastsUtils
 
+protocol SigningInViewModelInterface: AnyObject, Observation.Observable {
+    var totalPodcastsToImport: Int { get }
+    var totalPodcastsImported: Int { get }
+    var title: String? { get }
+    var progress: CGFloat { get }
+}
+
+enum SigningInState: Equatable, Hashable {
+    case waiting
+    case finished
+}
+
 @Observable
-class SigningInViewModel {
+class SigningInViewModel: SigningInViewModelInterface {
     private var cancellables: Set<AnyCancellable> = []
 
-    enum State: Equatable, Hashable {
-        case waiting
-        case finished
-    }
-    var state: State = .waiting
+    var state: SigningInState = .waiting
 
-    var podcasts: [MockPodcast] = MockData.makePodcasts()
+    var podcasts: [MockPodcast] = []
 
     var totalPodcastsToImport: Int = -1
     var totalPodcastsImported: Int = 0
@@ -24,7 +32,7 @@ class SigningInViewModel {
         guard cancellables.isEmpty else {
             return
         }
-        observeSyncProgressProgressPodcastsCount()
+        observeSyncProgressPodcastsCount()
         observeSyncProgressProgressPodcasts()
         observeSyncProgressImported()
         observeSyncCompleted()
@@ -32,7 +40,17 @@ class SigningInViewModel {
         observeUserLoginDidChange()
     }
 
-    private func observeSyncProgressProgressPodcastsCount() {
+    private func fetchPodcasts() {
+        Task {
+            let numberOfPodcasts = MockData.makePodcasts().count
+            let podcasts = MockData.makePodcasts().prefix(upTo: Int((CGFloat(numberOfPodcasts) * progress).rounded()) )
+            await MainActor.run {
+                self.podcasts = Array(podcasts)
+            }
+        }
+    }
+
+    private func observeSyncProgressPodcastsCount() {
         NotificationCenter.default.publisher(for: ServerNotifications.syncProgressPodcastCount)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] notification in
@@ -59,11 +77,12 @@ class SigningInViewModel {
                 totalPodcastsImported = number.intValue
                 if totalPodcastsToImport > 0 {
                     title = L10n.syncProgress(totalPodcastsImported.localized(), totalPodcastsToImport.localized())
-                    progress = CGFloat(totalPodcastsImported / totalPodcastsToImport)
+                    progress = CGFloat(totalPodcastsImported) / CGFloat(totalPodcastsToImport)
                 } else {
                     // Used when the total number of podcasts to sync isn't known.
                     title = totalPodcastsImported == 1 ? L10n.syncProgressUnknownCountSingular : L10n.syncProgressUnknownCountPluralFormat(totalPodcastsImported.localized())
                 }
+                fetchPodcasts()
             }
             .store(in: &cancellables)
     }
@@ -118,3 +137,26 @@ class SigningInViewModel {
             .store(in: &cancellables)
     }
 }
+
+@Observable
+class SigningInViewModelMock {
+    private var cancellable: AnyCancellable?
+
+    enum State: Equatable, Hashable {
+        case waiting
+        case finished
+    }
+    var state: State = .waiting
+
+    var podcasts: [MockPodcast] = MockData.makePodcasts()
+
+    func sync() {
+        cancellable = Timer.publish(every: 5.0, on: .main, in: .common)
+                    .autoconnect()
+                    .sink { [weak self] _ in
+                        guard let self else { return }
+                        state = .finished
+                    }
+    }
+}
+

--- a/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
@@ -21,6 +21,18 @@ class SigningInViewModel {
     var progress: CGFloat = 0
 
     func sync() {
+        guard cancellables.isEmpty else {
+            return
+        }
+        observeSyncProgressProgressPodcastsCount()
+        observeSyncProgressProgressPodcasts()
+        observeSyncProgressImported()
+        observeSyncCompleted()
+        observeSyncFailed()
+        observeUserLoginDidChange()
+    }
+
+    private func observeSyncProgressProgressPodcastsCount() {
         NotificationCenter.default.publisher(for: ServerNotifications.syncProgressPodcastCount)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] notification in
@@ -32,7 +44,9 @@ class SigningInViewModel {
                 }
             }
             .store(in: &cancellables)
+    }
 
+    private func observeSyncProgressProgressPodcasts() {
         NotificationCenter.default.publisher(for: ServerNotifications.syncProgressPodcastUpto)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] notification in
@@ -52,7 +66,9 @@ class SigningInViewModel {
                 }
             }
             .store(in: &cancellables)
+    }
 
+    fileprivate func observeSyncProgressImported() {
         NotificationCenter.default.publisher(for: ServerNotifications.syncProgressImportedPodcasts)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -63,7 +79,9 @@ class SigningInViewModel {
                 title = L10n.syncInProgress
             }
             .store(in: &cancellables)
+    }
 
+    fileprivate func observeUserLoginDidChange() {
         NotificationCenter.default.publisher(for: .userLoginDidChange)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -74,7 +92,9 @@ class SigningInViewModel {
                 title = L10n.syncAccountLogin
             }
             .store(in: &cancellables)
+    }
 
+    fileprivate func observeSyncCompleted() {
         NotificationCenter.default.publisher(for: ServerNotifications.syncCompleted)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -84,7 +104,9 @@ class SigningInViewModel {
                 state = .finished
             }
             .store(in: &cancellables)
+    }
 
+    fileprivate func observeSyncFailed() {
         NotificationCenter.default.publisher(for: ServerNotifications.syncFailed)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1287,6 +1287,7 @@
 		FF321A722FACA37900226E58 /* HomeGridItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD74F15227F28F6F00222785 /* HomeGridItem.swift */; };
 		FF321A742FACA3F300226E58 /* Folder+Sortable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F872C59449C0089D34F /* Folder+Sortable.swift */; };
 		FF3248CD2FACCDC200226E58 /* PodcastImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD93FDA020157B2000F6EF55 /* PodcastImageView.swift */; };
+		FF3248CE2FACDDCC00226E58 /* NoArtwork.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD8E76C71B9EA709000E20C7 /* NoArtwork.xcassets */; };
 		FF32F3CB2FAB7CDF00226E58 /* ColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9A43ED1D067AF20012FD9B /* ColorManager.swift */; };
 		FF32F3CD2FAB7E1F00226E58 /* PlaybackActionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD6297E200EE26200168DF7 /* PlaybackActionHelper.swift */; };
 		FF32F3CE2FAB7F8E00226E58 /* HapticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48D5A5216DB26A00391F9E /* HapticsHelper.swift */; };
@@ -6754,6 +6755,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FF3248CE2FACDDCC00226E58 /* NoArtwork.xcassets in Resources */,
 				FF49FEAC2F9BBC9A00E68E0C /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1286,6 +1286,7 @@
 		FF321A712FACA36400226E58 /* HomeGridDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD74F15027F28E6600222785 /* HomeGridDataHelper.swift */; };
 		FF321A722FACA37900226E58 /* HomeGridItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD74F15227F28F6F00222785 /* HomeGridItem.swift */; };
 		FF321A742FACA3F300226E58 /* Folder+Sortable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F872C59449C0089D34F /* Folder+Sortable.swift */; };
+		FF3248CD2FACCDC200226E58 /* PodcastImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD93FDA020157B2000F6EF55 /* PodcastImageView.swift */; };
 		FF32F3CB2FAB7CDF00226E58 /* ColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9A43ED1D067AF20012FD9B /* ColorManager.swift */; };
 		FF32F3CD2FAB7E1F00226E58 /* PlaybackActionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD6297E200EE26200168DF7 /* PlaybackActionHelper.swift */; };
 		FF32F3CE2FAB7F8E00226E58 /* HapticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48D5A5216DB26A00391F9E /* HapticsHelper.swift */; };
@@ -2904,6 +2905,13 @@
 			);
 			target = 4694FA5F2799C80300E9CF70 /* Screenshot Automation */;
 		};
+		FF3248CC2FACCDB300226E58 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Create & Edit/Views/PodcastImageViewWrapper.swift",
+			);
+			target = FF4B83AD2F981D8E001B8C56 /* Pocket Casts TV App */;
+		};
 		FF32F3D72FAB82D100226E58 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -3040,7 +3048,7 @@
 		3F584FF02F5685EB005A3593 /* Sonos */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Sonos; sourceTree = "<group>"; };
 		3F584FF12F568604005A3593 /* Main */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Main; sourceTree = "<group>"; };
 		3F584FF22F568621005A3593 /* Syncing */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Syncing; sourceTree = "<group>"; };
-		3F584FF32F56869B005A3593 /* Folders */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Folders; sourceTree = "<group>"; };
+		3F584FF32F56869B005A3593 /* Folders */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (FF3248CC2FACCDB300226E58 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Folders; sourceTree = "<group>"; };
 		3F584FFA2F5687F9005A3593 /* Common Components */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Common Components"; sourceTree = "<group>"; };
 		3F5850042F5689C2005A3593 /* Podcasts */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Podcasts; sourceTree = "<group>"; };
 		3F585D252F568CF8005A3593 /* Episode */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Episode; sourceTree = "<group>"; };
@@ -7727,6 +7735,7 @@
 				FF49FEAF2F9BBCBC00E68E0C /* Strings+L10n.swift in Sources */,
 				FF8FFE622FAA63900086A867 /* SharedConstants.swift in Sources */,
 				FF8FF6A52FAA46D40086A867 /* Settings.swift in Sources */,
+				FF3248CD2FACCDC200226E58 /* PodcastImageView.swift in Sources */,
 				FF8FFE712FAA8F7C0086A867 /* SJCommonUtils.m in Sources */,
 				FF321A742FACA3F300226E58 /* Folder+Sortable.swift in Sources */,
 				FF6024A12FAB46DE00EB3AD5 /* TranscriptFilter.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1296,6 +1296,7 @@
 		FF32F3E62FAB851800226E58 /* PlaylistHeaderViewCellPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF32F3E42FAB850E00226E58 /* PlaylistHeaderViewCellPlaceholder.swift */; };
 		FF32F3E82FAB863700226E58 /* Theme+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = C715EE0E2A0497DB0054A082 /* Theme+Color.swift */; };
 		FF32F3E92FAB86C700226E58 /* PlayerColorHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2F3B9F2366C01400416633 /* PlayerColorHelper.swift */; };
+		FF32F3EB2FAB972700226E58 /* AuthenticationHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4647623028F70CD0006D005A /* AuthenticationHelper.swift */; };
 		FF40C0662C65175B003A9D93 /* TranscriptErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF40C0652C65175B003A9D93 /* TranscriptErrorView.swift */; };
 		FF49232D2F9BCC9500E68E0C /* XcodeTarget_Pocket Casts TV App in Frameworks */ = {isa = PBXBuildFile; productRef = FF49232C2F9BCC9500E68E0C /* XcodeTarget_Pocket Casts TV App */; };
 		FF492A7A2F9BDA9A00E68E0C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF15A4D1B54E8F0000EC323 /* Constants.swift */; };
@@ -7790,6 +7791,7 @@
 				FF492A7A2F9BDA9A00E68E0C /* Constants.swift in Sources */,
 				FF8FFE6E2FAA8F240086A867 /* TranscriptFormat.swift in Sources */,
 				FF65058B2FAA963100C3662E /* Notifications.swift in Sources */,
+				FF32F3EB2FAB972700226E58 /* AuthenticationHelper.swift in Sources */,
 				FF32F3DA2FAB834500226E58 /* PlaylistDetailViewModel+Archive.swift in Sources */,
 				FF32F3D82FAB830100226E58 /* PlaylistArtworkView.swift in Sources */,
 				FF6505A32FAA9F4100C3662E /* TranscriptManager.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1283,6 +1283,9 @@
 		FF26A99A4A1B5C2D00000004 /* MiniPlayerScrollingTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A99B4A1B5C2D00000004 /* MiniPlayerScrollingTitleView.swift */; };
 		FF31C0972EC211890083C7E5 /* playback_2025_plus.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = FF31C0962EC211890083C7E5 /* playback_2025_plus.mp4 */; };
 		FF31C0992EC216600083C7E5 /* playback_2025_plus_background.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = FF31C0982EC216600083C7E5 /* playback_2025_plus_background.mp4 */; };
+		FF321A712FACA36400226E58 /* HomeGridDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD74F15027F28E6600222785 /* HomeGridDataHelper.swift */; };
+		FF321A722FACA37900226E58 /* HomeGridItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD74F15227F28F6F00222785 /* HomeGridItem.swift */; };
+		FF321A742FACA3F300226E58 /* Folder+Sortable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F872C59449C0089D34F /* Folder+Sortable.swift */; };
 		FF32F3CB2FAB7CDF00226E58 /* ColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9A43ED1D067AF20012FD9B /* ColorManager.swift */; };
 		FF32F3CD2FAB7E1F00226E58 /* PlaybackActionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD6297E200EE26200168DF7 /* PlaybackActionHelper.swift */; };
 		FF32F3CE2FAB7F8E00226E58 /* HapticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48D5A5216DB26A00391F9E /* HapticsHelper.swift */; };
@@ -2924,6 +2927,7 @@
 			membershipExceptions = (
 				"Array+Episode.swift",
 				"NetworkUtils+Helpers.swift",
+				"Server+Strings.swift",
 				"String+Differentiable.swift",
 				"String+SentenceCase.swift",
 			);
@@ -2941,6 +2945,7 @@
 			membershipExceptions = (
 				AllArchivedPlaceholder.swift,
 				EpisodeTableHelper.swift,
+				HomeGridListItem.swift,
 				ListEpisode.swift,
 				ListHeader.swift,
 				ListItem.swift,
@@ -7723,6 +7728,7 @@
 				FF8FFE622FAA63900086A867 /* SharedConstants.swift in Sources */,
 				FF8FF6A52FAA46D40086A867 /* Settings.swift in Sources */,
 				FF8FFE712FAA8F7C0086A867 /* SJCommonUtils.m in Sources */,
+				FF321A742FACA3F300226E58 /* Folder+Sortable.swift in Sources */,
 				FF6024A12FAB46DE00EB3AD5 /* TranscriptFilter.swift in Sources */,
 				FF32F3CD2FAB7E1F00226E58 /* PlaybackActionHelper.swift in Sources */,
 				FF8FF6A92FAA489E0086A867 /* UserEpisodeManager.swift in Sources */,
@@ -7771,8 +7777,10 @@
 				FF60249D2FAB443300EB3AD5 /* AppTheme.swift in Sources */,
 				FF8FFE452FAA49D90086A867 /* AnalyticsHelper.swift in Sources */,
 				FF8FFE562FAA5FEC0086A867 /* BackgroundShakeObserver.swift in Sources */,
+				FF321A722FACA37900226E58 /* HomeGridItem.swift in Sources */,
 				FF8FFE632FAA63D10086A867 /* EpisodeFilter+Formatting.swift in Sources */,
 				FF6505962FAA9A3000C3662E /* Debounce.swift in Sources */,
+				FF321A712FACA36400226E58 /* HomeGridDataHelper.swift in Sources */,
 				FF8FFE492FAA4B310086A867 /* BaseEpisode+Formatting.swift in Sources */,
 				FF32F3E82FAB863700226E58 /* Theme+Color.swift in Sources */,
 				FF8FFE4E2FAA4C510086A867 /* FadeOutManager.swift in Sources */,

--- a/podcasts/Lists/HomeGridListItem.swift
+++ b/podcasts/Lists/HomeGridListItem.swift
@@ -1,6 +1,7 @@
 import DifferenceKit
 import Foundation
 import PocketCastsDataModel
+import PocketCastsServer
 
 class HomeGridListItem: ListItem {
     let gridItem: HomeGridItem?

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -1,5 +1,7 @@
 import PocketCastsDataModel
+import PocketCastsUtils
 import UIKit
+import Kingfisher
 
 class PodcastImageView: UIView {
     private var shadowView: UIView?


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-650 <!-- issue number, if applicable -->

Wires up the real authentication and initial sync flow on the tvOS app, replacing the previous mock-only sign-in path.

- `SignInViewModel` now calls `AuthenticationHelper.validateLogin` (async) and tracks `waiting`/`error`/`finished` states; the form invokes it from a `Task`.
- Introduces `SigningInViewModelInterface` and a real `SigningInViewModel` that drives the post-login sync screen by listening to `ServerNotifications` (`syncProgressPodcastCount`, `syncProgressPodcastUpto`, `syncProgressImportedPodcasts`, `syncCompleted`, `syncFailed`) and `userLoginDidChange`, exposing `title` and `progress` plus the live list of podcasts loaded from `DataManager`.
- `SigningInView` is now generic over the interface, shows the localized progress title and a `ProgressView`, scrolls the podcast grid horizontally, and renders real artwork via `PodcastImageViewWrapper`. The mock-backed preview uses a new `SigningInViewModelMock` driven by `MockData.makeStubPodcasts()` (real `Podcast` instances).
- `PodcastImageView` now imports `PocketCastsUtils`/`Kingfisher` so it builds on tvOS, and `HomeGridListItem` imports `PocketCastsServer` so the shared sources compile in the TV target.


 

## To test

1. Launch the **Pocket Casts TV App** target on the tvOS simulator.
2. On the sign-in screen, enter invalid credentials and submit — the view model should land in the `error` state without navigating away.
3. Enter valid Pocket Casts credentials and submit — the app should advance to the **Signing In** screen.
4. On the Signing In screen, verify that:
   - A progress title appears showing the synced/total podcast counts (or the unknown-count variant before the total is known).
   - The progress bar fills as podcasts sync.
   - The horizontal podcast grid scrolls and renders real artwork from the synced library.
5. Once sync completes (or fails), the coordinator transitions to the signed-in state.
6. Run the SwiftUI preview for `SigningInView` to confirm the mock view model still drives the animated preview using stub podcasts.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.