### PR TITLE
Liquid Glass: Fix swipe to dismiss in Podcast, Playlist

### DIFF
--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -247,14 +247,22 @@ class PlaylistDetailViewController: PCViewController, UIScrollViewDelegate {
         )
         customRightBtn = defaultRightBarButton
 
-        defaultBackBarButton = FakeNavBarButton.makeBarButtonItem(
-            image: UIImage(systemName: "chevron.backward"),
-            accessibilityLabel: L10n.back,
-            target: self,
-            action: #selector(backButtonTapped)
-        )
-        navigationItem.leftBarButtonItem = defaultBackBarButton
-        navigationItem.setHidesBackButton(true, animated: false)
+        if !LiquidGlass.isEnabled {
+            defaultBackBarButton = FakeNavBarButton.makeBarButtonItem(
+                image: UIImage(systemName: "chevron.backward"),
+                accessibilityLabel: L10n.back,
+                target: self,
+                action: #selector(backButtonTapped)
+            )
+            navigationItem.leftBarButtonItem = defaultBackBarButton
+            navigationItem.setHidesBackButton(true, animated: false)
+
+            if let navController = navigationController as? PCNavigationController {
+                navController.enableInteractivePopGestureWorkaround()
+            } else {
+                assertionFailure("Expected PCNavigationController")
+            }
+        }
     }
 
     private func setupContent() {
@@ -488,13 +496,21 @@ class PlaylistDetailViewController: PCViewController, UIScrollViewDelegate {
 
             let selectAll = UIBarButtonItem(title: L10n.selectAll, style: .plain, target: self, action: #selector(selectAllTapped))
             multiSelectAllBarButton = selectAll
-            navigationItem.setLeftBarButton(selectAll, animated: false)
+            navigationItem.setLeftBarButton(selectAll, animated: true)
+            if LiquidGlass.isEnabled {
+                navigationItem.setHidesBackButton(true, animated: true)
+            }
             updateSelectAllBtn()
         } else {
             multiSelectCancelBarButton = nil
             multiSelectAllBarButton = nil
             customRightBtn = defaultRightBarButton
-            navigationItem.setLeftBarButton(defaultBackBarButton, animated: false)
+            if LiquidGlass.isEnabled {
+                navigationItem.setLeftBarButton(nil, animated: true)
+                navigationItem.setHidesBackButton(false, animated: true)
+            } else {
+                navigationItem.setLeftBarButton(defaultBackBarButton, animated: false)
+            }
             refreshRightButtons()
         }
         updateNavBarBlur()

--- a/podcasts/PCNavigationController.swift
+++ b/podcasts/PCNavigationController.swift
@@ -30,6 +30,10 @@ class PCNavigationController: UINavigationController, UIGestureRecognizerDelegat
 
     override func setNavigationBarHidden(_ hidden: Bool, animated: Bool) {
         super.setNavigationBarHidden(hidden, animated: animated)
+        enableInteractivePopGestureWorkaround()
+    }
+
+    func enableInteractivePopGestureWorkaround() {
         interactivePopGestureRecognizer?.delegate = self
     }
 

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -321,14 +321,22 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
         )
         customRightBtn = shareBarButtonItem
 
-        defaultBackBarButton = FakeNavBarButton.makeBarButtonItem(
-            image: UIImage(systemName: "chevron.backward"),
-            accessibilityLabel: L10n.back,
-            target: self,
-            action: #selector(backButtonTapped)
-        )
-        navigationItem.leftBarButtonItem = defaultBackBarButton
-        navigationItem.setHidesBackButton(true, animated: false)
+        if !LiquidGlass.isEnabled {
+            defaultBackBarButton = FakeNavBarButton.makeBarButtonItem(
+                image: UIImage(systemName: "chevron.backward"),
+                accessibilityLabel: L10n.back,
+                target: self,
+                action: #selector(backButtonTapped)
+            )
+            navigationItem.leftBarButtonItem = defaultBackBarButton
+            navigationItem.setHidesBackButton(true, animated: false)
+
+            if let navController = navigationController as? PCNavigationController {
+                navController.enableInteractivePopGestureWorkaround()
+            } else {
+                assertionFailure("Expected PCNavigationController")
+            }
+        }
 
         loadPodcastInfo()
 
@@ -825,13 +833,21 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
 
             let selectAll = UIBarButtonItem(title: L10n.selectAll, style: .plain, target: self, action: #selector(selectAllTapped))
             multiSelectAllBarButton = selectAll
-            navigationItem.setLeftBarButton(selectAll, animated: false)
+            navigationItem.setLeftBarButton(selectAll, animated: true)
+            if LiquidGlass.isEnabled {
+                navigationItem.setHidesBackButton(true, animated: true)
+            }
             updateSelectAllBtn()
         } else {
             multiSelectCancelBarButton = nil
             multiSelectAllBarButton = nil
             customRightBtn = shareBarButtonItem
-            navigationItem.setLeftBarButton(defaultBackBarButton, animated: false)
+            if LiquidGlass.isEnabled {
+                navigationItem.setLeftBarButton(nil, animated: true)
+                navigationItem.setHidesBackButton(false, animated: true)
+            } else {
+                navigationItem.setLeftBarButton(defaultBackBarButton, animated: false)
+            }
             supportsGoogleCast = true
             refreshRightButtons()
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

If you hide the back button, the view controller doesn't seem to set up the edge swipe gesture.

The solution is a bit of a mess, but it simplifies things moving forward.

- On iOS 26, we now simply show the standard back button (minimum hacks)
- On iOS 18 and earlier, I re-enabled this workaround in `PCNavigationControler`:

```swift
    override func setNavigationBarHidden(_ hidden: Bool, animated: Bool) {
        super.setNavigationBarHidden(hidden, animated: animated)
        enableInteractivePopGestureWorkaround()
    }

    func enableInteractivePopGestureWorkaround() {
        interactivePopGestureRecognizer?.delegate = self
    }
```

It would previously get enabled automatically when the controller would call `setNavigationBarHidden`. Since I removed this  call in previous PRs it broke this workaround.

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
