### PR TITLE
POC-589: Enable `syncedTranscripts`

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -403,7 +403,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .generatedTranscripts:
             true
         case .syncedTranscripts:
-            false
+            true
         case .libroFm:
             false
         case .encourageAccountCreation:

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -74,7 +74,15 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
             let externalTranscripts = metadata?.transcripts ?? []
             var pocketCastsTranscripts: [Episode.Metadata.Transcript] = []
 
-            if let episode = dataManager.findEpisode(uuid: episodeUuid),
+            #if DEBUG
+            let forceGeneratedTranscript = FeatureFlag.syncedTranscripts.enabled
+            #else
+            let forceGeneratedTranscript = false
+            #endif
+
+            if forceGeneratedTranscript {
+                pocketCastsTranscripts = [buildGeneratedTranscript(podcastUuid: podcastUuid, episodeUuid: episodeUuid)]
+            } else if let episode = dataManager.findEpisode(uuid: episodeUuid),
                       let hasTranscript = episode.hasGeneratedTranscript {
                 if hasTranscript {
                     let transcript = buildGeneratedTranscript(podcastUuid: podcastUuid, episodeUuid: episodeUuid)

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -74,15 +74,7 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
             let externalTranscripts = metadata?.transcripts ?? []
             var pocketCastsTranscripts: [Episode.Metadata.Transcript] = []
 
-            #if DEBUG
-            let forceGeneratedTranscript = FeatureFlag.syncedTranscripts.enabled
-            #else
-            let forceGeneratedTranscript = false
-            #endif
-
-            if forceGeneratedTranscript {
-                pocketCastsTranscripts = [buildGeneratedTranscript(podcastUuid: podcastUuid, episodeUuid: episodeUuid)]
-            } else if let episode = dataManager.findEpisode(uuid: episodeUuid),
+            if let episode = dataManager.findEpisode(uuid: episodeUuid),
                       let hasTranscript = episode.hasGeneratedTranscript {
                 if hasTranscript {
                     let transcript = buildGeneratedTranscript(podcastUuid: podcastUuid, episodeUuid: episodeUuid)

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -73,17 +73,8 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         if FeatureFlag.generatedTranscripts.enabled {
             let externalTranscripts = metadata?.transcripts ?? []
             var pocketCastsTranscripts: [Episode.Metadata.Transcript] = []
-
-            #if DEBUG
-            let forceGeneratedTranscript = FeatureFlag.syncedTranscripts.enabled
-            #else
-            let forceGeneratedTranscript = false
-            #endif
-
-            if forceGeneratedTranscript {
-                pocketCastsTranscripts = [buildGeneratedTranscript(podcastUuid: podcastUuid, episodeUuid: episodeUuid)]
-            } else if let episode = dataManager.findEpisode(uuid: episodeUuid),
-                      let hasTranscript = episode.hasGeneratedTranscript {
+            if let episode = dataManager.findEpisode(uuid: episodeUuid),
+               let hasTranscript = episode.hasGeneratedTranscript {
                 if hasTranscript {
                     let transcript = buildGeneratedTranscript(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
                     pocketCastsTranscripts = [transcript]

--- a/podcasts/Episode+Transcript.swift
+++ b/podcasts/Episode+Transcript.swift
@@ -6,9 +6,23 @@ extension Episode {
         Task.init {
             let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier(), episodeUuid: uuid)
 
+            let transcriptsAvailable: Bool
+            let hasGeneratedTranscripts: Bool
+
+            #if DEBUG
+            if FeatureFlag.syncedTranscripts.enabled {
+                transcriptsAvailable = true
+                hasGeneratedTranscripts = metadata?.hasGeneratedTranscripts ?? false
+            } else {
+                guard let metadata else { return }
+                transcriptsAvailable = !metadata.transcripts.isEmpty
+                hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
+            }
+            #else
             guard let metadata else { return }
-            let transcriptsAvailable = !metadata.transcripts.isEmpty
-            let hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
+            transcriptsAvailable = !metadata.transcripts.isEmpty
+            hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
+            #endif
 
             let userInfo: [AnyHashable: Any] = [
                 "episodeUuid": uuid,

--- a/podcasts/Episode+Transcript.swift
+++ b/podcasts/Episode+Transcript.swift
@@ -1,35 +1,18 @@
 import PocketCastsDataModel
-import PocketCastsUtils
 
 extension Episode {
     func checkTranscriptAvailability() {
         Task.init {
-            let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier(), episodeUuid: uuid)
-
-            let transcriptsAvailable: Bool
-            let hasGeneratedTranscripts: Bool
-
-            #if DEBUG
-            if FeatureFlag.syncedTranscripts.enabled {
-                transcriptsAvailable = true
-                hasGeneratedTranscripts = metadata?.hasGeneratedTranscripts ?? false
-            } else {
-                guard let metadata else { return }
-                transcriptsAvailable = !metadata.transcripts.isEmpty
-                hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
+            if let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier(), episodeUuid: uuid) {
+                let transcriptsAvailable = !metadata.transcripts.isEmpty
+                let hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
+                let userInfo = [
+                    "episodeUuid": uuid,
+                    "isAvailable": transcriptsAvailable,
+                    "hasGeneratedTranscripts": hasGeneratedTranscripts
+                ]
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeTranscriptAvailabilityChanged, userInfo: userInfo)
             }
-            #else
-            guard let metadata else { return }
-            transcriptsAvailable = !metadata.transcripts.isEmpty
-            hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
-            #endif
-
-            let userInfo: [AnyHashable: Any] = [
-                "episodeUuid": uuid,
-                "isAvailable": transcriptsAvailable,
-                "hasGeneratedTranscripts": hasGeneratedTranscripts
-            ]
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeTranscriptAvailabilityChanged, userInfo: userInfo)
         }
     }
 }

--- a/podcasts/Episode+Transcript.swift
+++ b/podcasts/Episode+Transcript.swift
@@ -6,23 +6,9 @@ extension Episode {
         Task.init {
             let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier(), episodeUuid: uuid)
 
-            let transcriptsAvailable: Bool
-            let hasGeneratedTranscripts: Bool
-
-            #if DEBUG
-            if FeatureFlag.syncedTranscripts.enabled {
-                transcriptsAvailable = true
-                hasGeneratedTranscripts = metadata?.hasGeneratedTranscripts ?? false
-            } else {
-                guard let metadata else { return }
-                transcriptsAvailable = !metadata.transcripts.isEmpty
-                hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
-            }
-            #else
             guard let metadata else { return }
-            transcriptsAvailable = !metadata.transcripts.isEmpty
-            hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
-            #endif
+            let transcriptsAvailable = !metadata.transcripts.isEmpty
+            let hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
 
             let userInfo: [AnyHashable: Any] = [
                 "episodeUuid": uuid,

--- a/podcasts/Episode+Transcript.swift
+++ b/podcasts/Episode+Transcript.swift
@@ -1,4 +1,5 @@
 import PocketCastsDataModel
+import PocketCastsUtils
 
 extension Episode {
     func checkTranscriptAvailability() {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/POC-589/enable-syncedtranscripts

## Summary
Enable the `syncedTranscripts` feature flag so synced transcripts with playback timing are active by default.

## Changes
- Set `FeatureFlag.syncedTranscripts` default from `false` to `true` in `FeatureFlag.swift`

## Verification
- **Lint**: PASS — `make format` ran cleanly
- **Tests**: FAIL — pre-existing build failure on trunk (CarPlay SDK `CPPlaybackConfiguration` not found); unrelated to this change
- **Diff review**: PASS — single-line change, no unintended modifications

## Confidence
**HIGH** — This is a one-line flag flip matching the exact pattern used for all other enabled flags in the file. The build/test failure is pre-existing on trunk and unrelated.

---
This PR was created autonomously by linear-solver.
Triage complexity: simple | [Linear issue](https://linear.app/a8c/issue/POC-589/enable-syncedtranscripts)