### PR TITLE
Liquid Glass: Enable transparent navigation bars

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 
 /* Begin PBXBuildFile section */
 		0C364CA72FAB8BAA00B46BDA /* MiniPlayerLongPressPreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C364CA62FAB8BAA00B46BDA /* MiniPlayerLongPressPreviewViewController.swift */; };
+		0C7BFA882FAD2A8C00C1E5FF /* LiquidGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9984A1B5C2D00000003 /* LiquidGlass.swift */; };
 		0CCC37A62FA3C30200BA79D1 /* SmartPlaylistRulesSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCC37A52FA3C30200BA79D1 /* SmartPlaylistRulesSectionView.swift */; };
 		10097D282CC7DADA00E682A3 /* UpNext.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 10097D272CC7DADA00E682A3 /* UpNext.xcassets */; };
 		100C99552CE7B801008D73E9 /* CancelSubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100C99542CE7B801008D73E9 /* CancelSubscriptionView.swift */; };
@@ -7600,6 +7601,7 @@
 			files = (
 				F57ABBFC2CECEBD800CC50AF /* ArchiveHelper.swift in Sources */,
 				F5F5094D2CEBF448007D6E39 /* SimpleActionView.swift in Sources */,
+				0C7BFA882FAD2A8C00C1E5FF /* LiquidGlass.swift in Sources */,
 				F5F509292CEBEF09007D6E39 /* TranscriptsDataRetriever.swift in Sources */,
 				F5F509102CEBEBC0007D6E39 /* PlaybackEffects.swift in Sources */,
 				F5F509552CEBF5D6007D6E39 /* TintableImageView.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		0C364CA72FAB8BAA00B46BDA /* MiniPlayerLongPressPreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C364CA62FAB8BAA00B46BDA /* MiniPlayerLongPressPreviewViewController.swift */; };
 		0C7BFA882FAD2A8C00C1E5FF /* LiquidGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9984A1B5C2D00000003 /* LiquidGlass.swift */; };
 		0CCC37A62FA3C30200BA79D1 /* SmartPlaylistRulesSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCC37A52FA3C30200BA79D1 /* SmartPlaylistRulesSectionView.swift */; };
+		0CF5B7BE2FB3B0E60023691C /* LiquidGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9984A1B5C2D00000003 /* LiquidGlass.swift */; };
 		10097D282CC7DADA00E682A3 /* UpNext.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 10097D272CC7DADA00E682A3 /* UpNext.xcassets */; };
 		100C99552CE7B801008D73E9 /* CancelSubscriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100C99542CE7B801008D73E9 /* CancelSubscriptionView.swift */; };
 		102864A92CECEDB20098B2A9 /* CancelSubscriptionViewRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102864A82CECEDB20098B2A9 /* CancelSubscriptionViewRow.swift */; };
@@ -7780,6 +7781,7 @@
 				FF6505A02FAA9DE400C3662E /* PlaybackItem.swift in Sources */,
 				FF8FFE6A2FAA8E950086A867 /* PodcastIndexChapterDataRetriever.swift in Sources */,
 				FF8FFE532FAA4D210086A867 /* BookmarkManager.swift in Sources */,
+				0CF5B7BE2FB3B0E60023691C /* LiquidGlass.swift in Sources */,
 				FF8FFE542FAA5FAC0086A867 /* ArchiveHelper.swift in Sources */,
 				FF8FFE4F2FAA4CCD0086A867 /* PlaybackProtocol.swift in Sources */,
 				FF8FFE442FAA49BE0086A867 /* PodcastManager+Cleanup.swift in Sources */,

--- a/podcasts/AccountViewController.xib
+++ b/podcasts/AccountViewController.xib
@@ -31,9 +31,9 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="LDy-dc-GWZ" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="Hsu-MD-VIW"/>
-                <constraint firstItem="LDy-dc-GWZ" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Ppn-J2-73Q"/>
-                <constraint firstItem="LDy-dc-GWZ" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="Z0r-84-seL"/>
+                <constraint firstItem="LDy-dc-GWZ" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="Hsu-MD-VIW"/>
+                <constraint firstItem="LDy-dc-GWZ" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="Ppn-J2-73Q"/>
+                <constraint firstItem="LDy-dc-GWZ" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="Z0r-84-seL"/>
                 <constraint firstItem="LDy-dc-GWZ" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="m2H-O3-JgV"/>
             </constraints>
             <point key="canvasLocation" x="137.68115942028987" y="124.55357142857142"/>

--- a/podcasts/AppTheme.swift
+++ b/podcasts/AppTheme.swift
@@ -570,8 +570,14 @@ class AppTheme {
     #if !os(tvOS)
     class func defaultStatusBarStyle() -> UIStatusBarStyle {
         switch Theme.sharedTheme.activeTheme {
-        case .dark, .extraDark, .electric, .classic, .indigo, .contrastDark:
+        case .dark, .extraDark, .electric, .contrastDark:
             return UIStatusBarStyle.lightContent
+        case .classic, .indigo:
+            if LiquidGlass.isEnabled {
+                return UIStatusBarStyle.darkContent
+            } else {
+                return UIStatusBarStyle.lightContent
+            }
         case .light, .rosé, .contrastLight:
             return UIStatusBarStyle.darkContent
         }

--- a/podcasts/AppearanceViewController.swift
+++ b/podcasts/AppearanceViewController.swift
@@ -155,12 +155,12 @@ class AppearanceViewController: PCViewController, UITableViewDataSource, UITable
             SJUIUtils.showAlert(title: L10n.appearanceRefreshAllArtworkConfTitle, message: L10n.appearanceRefreshAllArtworkConfMsg, from: self)
             refreshAllPodcastArtwork()
         } else if row == .lightTheme {
-            presentThemePicker(selectedTheme: Theme.preferredLightTheme()) { [weak self] theme in
-                Theme.setPreferredLightTheme(theme, systemIsDark: self?.traitCollection.userInterfaceStyle == .dark)
+            presentThemePicker(selectedTheme: Theme.preferredLightTheme()) { theme in
+                Theme.setPreferredLightTheme(theme, systemIsDark: Theme.systemIsDark)
             }
         } else if row == .darkTheme {
-            presentThemePicker(selectedTheme: Theme.preferredDarkTheme()) { [weak self] theme in
-                Theme.setPreferredDarkTheme(theme, systemIsDark: self?.traitCollection.userInterfaceStyle == .dark, userInitiated: true)
+            presentThemePicker(selectedTheme: Theme.preferredDarkTheme()) { theme in
+                Theme.setPreferredDarkTheme(theme, systemIsDark: Theme.systemIsDark, userInitiated: true)
             }
         }
     }

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -27,7 +27,7 @@ struct CategoriesSelectorView: View {
                 PlaceholderPillsView()
             }
         }
-        .background(theme.secondaryUi01)
+        .background(LiquidGlass.isEnabled ? .clear : theme.secondaryUi01)
         .task(id: discoverItemObservable.item?.source) {
             let result = await discoverItemObservable.load()
             self.categories = result?.categories

--- a/podcasts/Common Components/Search/PCSearchBarController+Scrolling.swift
+++ b/podcasts/Common Components/Search/PCSearchBarController+Scrolling.swift
@@ -25,6 +25,12 @@ extension PCSearchBarController {
             view.layoutIfNeeded()
             updateCollapseAppearance()
         }
+
+        // Only sync during an active drag — leaving programmatic animations (snap-to-open
+        // below, deceleration) to settle on their own, then resync at the end.
+        if tracksContentInsetToBarHeight, scrollView.isDragging {
+            syncContentInsetToBarHeight(scrollView)
+        }
     }
 
     func parentScrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
@@ -43,6 +49,23 @@ extension PCSearchBarController {
             scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: -PCSearchBarController.defaultHeight - topOffset), animated: true)
         } else if shouldAnimateUp {
             scrollView.setContentOffset(CGPoint(x: scrollView.contentOffset.x, y: -topOffset), animated: true)
+        }
+    }
+
+    func parentScrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        guard tracksContentInsetToBarHeight else { return }
+        syncContentInsetToBarHeight(scrollView)
+    }
+
+    func parentScrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        guard tracksContentInsetToBarHeight else { return }
+        syncContentInsetToBarHeight(scrollView)
+    }
+
+    private func syncContentInsetToBarHeight(_ scrollView: UIScrollView) {
+        guard let height = searchControllerHeightConstraint?.constant else { return }
+        if scrollView.contentInset.top != height {
+            scrollView.contentInset.top = height
         }
     }
 }

--- a/podcasts/Common Components/Search/PCSearchBarController.swift
+++ b/podcasts/Common Components/Search/PCSearchBarController.swift
@@ -118,6 +118,31 @@ class PCSearchBarController: UIViewController {
     }
 
     private func updateColors() {
+        if LiquidGlass.isEnabled {
+            configureAppearance()
+        } else {
+            configureLegacyAppearnace()
+        }
+    }
+
+    private func configureAppearance() {
+        view.backgroundColor = .clear
+        searchTextField.backgroundColor = .clear
+        searchTextField.keyboardAppearance = AppTheme.keyboardAppearance()
+        roundedBackgroundView.backgroundColor = ThemeColor.primaryField01()
+
+        let textColor = ThemeColor.primaryText01()
+        searchTextField.textColor = textColor
+        cancelButton.setTitleColor(textColor, for: .normal)
+
+        updatePlaceholderColor()
+
+        let iconColor = ThemeColor.primaryIcon02()
+        searchIcon.tintColor = iconColor
+        clearSearchBtn.tintColor = iconColor
+    }
+
+    private func configureLegacyAppearnace() {
         view.backgroundColor = backgroundColorOverride ?? ThemeColor.secondaryUi01()
         searchTextField.backgroundColor = UIColor.clear
         searchTextField.keyboardAppearance = AppTheme.keyboardAppearance()
@@ -135,7 +160,10 @@ class PCSearchBarController: UIViewController {
     }
 
     private func updatePlaceholderColor() {
-        let placeholderColor = backgroundColorOverride == nil ? ThemeColor.secondaryText02() : ThemeColor.primaryText02()
+        var placeholderColor = backgroundColorOverride == nil ? ThemeColor.secondaryText02() : ThemeColor.primaryText02()
+        if LiquidGlass.isEnabled {
+            placeholderColor = ThemeColor.primaryText02()
+        }
         searchTextField.attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: [NSAttributedString.Key.foregroundColor: placeholderColor])
     }
 

--- a/podcasts/Common Components/Search/PCSearchBarController.swift
+++ b/podcasts/Common Components/Search/PCSearchBarController.swift
@@ -55,6 +55,13 @@ class PCSearchBarController: UIViewController {
     /// the safe area, and the pill, icons and placeholder fade and shrink together.
     var searchControllerHeightConstraint: NSLayoutConstraint?
 
+    /// When `true`, the scrolling extension keeps the parent scroll view's `contentInset.top`
+    /// matched to the bar's current height. Use this with plain-style `UITableView`s whose
+    /// section headers pin to `adjustedContentInset.top` — otherwise headers stay pinned where
+    /// the (now-collapsed) bar used to be, leaving a gap under the nav bar. Callers must also
+    /// forward `scrollViewDidEndDecelerating` and `scrollViewDidEndScrollingAnimation`.
+    var tracksContentInsetToBarHeight = false
+
     var searchDebounce = 1.seconds
     var searchTimer: Timer?
 

--- a/podcasts/Common Components/View Controllers/PCViewController.swift
+++ b/podcasts/Common Components/View Controllers/PCViewController.swift
@@ -147,6 +147,8 @@ class PCViewController: SimpleNotificationsViewController {
     }
 
     private func setupNavBar(animated: Bool) {
+        guard !LiquidGlass.isEnabled else { return }
+
         guard let navController = navigationController else { return }
 
         guard !useTransparentNavigationBarAppearance else {
@@ -197,16 +199,14 @@ class PCViewController: SimpleNotificationsViewController {
     /// UIKit animates the appearance swap. When Liquid Glass is enabled the system handles the
     /// at-edge/scrolled transition on its own, so we just install its default background once.
     func setTransparentNavBarScrolled(_ scrolled: Bool) {
+        guard !LiquidGlass.isEnabled else {
+            return // It's a no-op since on iOS 26 we already use default transparent bars
+        }
+
         guard let navigationBar = navigationController?.navigationBar else {
             return assertionFailure("navigationBar is missing")
         }
         let appearance = UINavigationBarAppearance()
-        if LiquidGlass.isEnabled {
-            appearance.configureWithDefaultBackground()
-            navigationBar.standardAppearance = appearance
-            navigationBar.scrollEdgeAppearance = appearance
-            return
-        }
         appearance.configureWithTransparentBackground()
         if scrolled {
             appearance.backgroundEffect = UIBlurEffect(style: .regular)

--- a/podcasts/FilterDurationViewController.swift
+++ b/podcasts/FilterDurationViewController.swift
@@ -207,13 +207,15 @@ class FilterDurationViewController: PCViewController {
         navigationBar?.prefersLargeTitles = true
         navigationController?.navigationItem.largeTitleDisplayMode = .automatic
 
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = backgroundColor
-        appearance.shadowColor = .clear
-        appearance.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor: ThemeColor.primaryText01()]
-        appearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: ThemeColor.primaryText02()]
-        navigationBar?.scrollEdgeAppearance = appearance
-        navigationBar?.standardAppearance = appearance
+        if !LiquidGlass.isEnabled {
+            let appearance = UINavigationBarAppearance()
+            appearance.backgroundColor = backgroundColor
+            appearance.shadowColor = .clear
+            appearance.largeTitleTextAttributes = [NSAttributedString.Key.foregroundColor: ThemeColor.primaryText01()]
+            appearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: ThemeColor.primaryText02()]
+            navigationBar?.scrollEdgeAppearance = appearance
+            navigationBar?.standardAppearance = appearance
+        }
     }
 
     @IBAction private func saveTapped() {

--- a/podcasts/LargeNavBarViewController.swift
+++ b/podcasts/LargeNavBarViewController.swift
@@ -1,4 +1,5 @@
-import Foundation
+import UIKit
+
 class LargeNavBarViewController: PCViewController {
     func setupLargeTitle() {
         changeNavTint(titleColor: nil, iconsColor: AppTheme.colorForStyle(.primaryIcon02))
@@ -6,6 +7,13 @@ class LargeNavBarViewController: PCViewController {
         navigationController?.navigationItem.largeTitleDisplayMode = .automatic
         navigationController?.navigationBar.sizeToFit()
         largeTitleFont = UIFont.font(ofSize: 22, weight: .bold, scalingWith: .title2)
+
+        if !LiquidGlass.isEnabled {
+            configureLegacyOpqaueNavBarAppearance()
+        }
+    }
+
+    private func configureLegacyOpqaueNavBarAppearance() {
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = AppTheme.colorForStyle(.primaryUi01)
         appearance.shadowColor = .clear

--- a/podcasts/LargeNavBarViewController.swift
+++ b/podcasts/LargeNavBarViewController.swift
@@ -9,11 +9,11 @@ class LargeNavBarViewController: PCViewController {
         largeTitleFont = UIFont.font(ofSize: 22, weight: .bold, scalingWith: .title2)
 
         if !LiquidGlass.isEnabled {
-            configureLegacyOpqaueNavBarAppearance()
+            configureLegacyOpaqueNavBarAppearance()
         }
     }
 
-    private func configureLegacyOpqaueNavBarAppearance() {
+    private func configureLegacyOpaqueNavBarAppearance() {
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = AppTheme.colorForStyle(.primaryUi01)
         appearance.shadowColor = .clear

--- a/podcasts/LiquidGlass.swift
+++ b/podcasts/LiquidGlass.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 import PocketCastsUtils
 
 enum LiquidGlass {
@@ -7,6 +8,27 @@ enum LiquidGlass {
         if #available(iOS 26.0, *) { return true }
         return false
     }
+}
+
+extension UIWindow {
+    /// Forces the window's interface style to match the active in-app theme so the
+    /// Liquid Glass material renders with the right tint immediately, instead of
+    /// briefly flashing the system appearance before the app's appearance overrides land.
+    /// Read the actual system appearance via `view.systemUserInterfaceStyle` instead of
+    /// `traitCollection.userInterfaceStyle`, which reflects this override.
+    func applyInterfaceStyleForActiveTheme() {
+        guard LiquidGlass.isEnabled else { return }
+        overrideUserInterfaceStyle = Theme.sharedTheme.activeTheme.isDark ? .dark : .light
+    }
+}
+
+extension Theme {
+    /// True if the *system* (not the in-app theme) is currently in dark mode.
+    /// Captured at scene setup before we override the window, and refreshed in
+    /// `MainTabBarController.traitCollectionDidChange`. Reads must come from the
+    /// window scene's trait collection, since per-window `overrideUserInterfaceStyle`
+    /// would otherwise pollute it.
+    static var systemIsDark: Bool = false
 }
 
 extension Constants {

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -326,6 +326,10 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
             searchController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
         ])
         searchController.searchControllerHeightConstraint = heightConstraint
+        // Plain-style table view pins section headers below `adjustedContentInset.top`, so keep
+        // the inset matched to the bar height — otherwise headers would pin where the (collapsed)
+        // bar used to be, leaving a gap under the nav bar.
+        searchController.tracksContentInsetToBarHeight = true
 
         searchController.placeholderText = L10n.search
         searchController.setupScrollView(listeningHistoryTable, hideSearchInitially: false)
@@ -343,5 +347,13 @@ extension ListeningHistoryViewController {
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
         searchController?.parentScrollViewDidEndDragging(scrollView, willDecelerate: decelerate)
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        searchController?.parentScrollViewDidEndDecelerating(scrollView)
+    }
+
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        searchController?.parentScrollViewDidEndScrollingAnimation(scrollView)
     }
 }

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -318,18 +318,30 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
         view.addSubview(searchController.view)
         searchController.didMove(toParent: self)
 
+        let heightConstraint = searchController.view.heightAnchor.constraint(equalToConstant: 0)
         NSLayoutConstraint.activate([
             searchController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             searchController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            searchController.view.heightAnchor.constraint(equalToConstant: PCSearchBarController.defaultHeight),
+            heightConstraint,
             searchController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
         ])
+        searchController.searchControllerHeightConstraint = heightConstraint
 
         searchController.placeholderText = L10n.search
         searchController.setupScrollView(listeningHistoryTable, hideSearchInitially: false)
         searchController.searchDebounce = Settings.podcastSearchDebounceTime()
         searchController.searchDelegate = self
+    }
+}
 
-        listeningHistoryTable.verticalScrollIndicatorInsets.top = PCSearchBarController.defaultHeight
+// MARK: - UIScrollViewDelegate
+
+extension ListeningHistoryViewController {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        searchController?.parentScrollViewDidScroll(scrollView)
+    }
+
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        searchController?.parentScrollViewDidEndDragging(scrollView, willDecelerate: decelerate)
     }
 }

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -248,6 +248,9 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
+        if let scene = view.window?.windowScene {
+            Theme.systemIsDark = (scene.traitCollection.userInterfaceStyle == .dark)
+        }
         fixTarBarTraitCollectionOnIpadForiOS18()
         fireSystemThemeMayHaveChanged()
     }
@@ -603,8 +606,8 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
             let appearanceViewController = AppearanceViewController()
             navController.pushViewController(appearanceViewController, animated: !showThemeSelection)
             if showThemeSelection {
-                appearanceViewController.presentThemePicker(selectedTheme: Theme.preferredLightTheme()) { [weak self] theme in
-                    Theme.setPreferredLightTheme(theme, systemIsDark: self?.traitCollection.userInterfaceStyle == .dark)
+                appearanceViewController.presentThemePicker(selectedTheme: Theme.preferredLightTheme()) { theme in
+                    Theme.setPreferredLightTheme(theme, systemIsDark: Theme.systemIsDark)
                 }
             }
         }
@@ -805,6 +808,11 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         guard !LiquidGlass.isEnabled else { return }
 
         self.view.backgroundColor = AppTheme.viewBackgroundColor()
+        tabBar.unselectedItemTintColor = AppTheme.unselectedTabBarItemColor()
+        tabBar.tintColor = AppTheme.tabBarItemTintColor()
+
+        guard !LiquidGlass.isEnabled else { return }
+
         let appearance = UITabBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = AppTheme.tabBarBackgroundColor()
@@ -820,8 +828,6 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         tabBar.standardAppearance = appearance
         tabBar.scrollEdgeAppearance = appearance
-        tabBar.unselectedItemTintColor = AppTheme.unselectedTabBarItemColor()
-        tabBar.tintColor = AppTheme.tabBarItemTintColor()
     }
 
     private func displayEndOfYearBadgeIfNeeded() {
@@ -839,9 +845,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     private func fireSystemThemeMayHaveChanged() {
         if !Settings.shouldFollowSystemTheme() { return } // if the user has turned this off, then ignore system theme changes
 
-        let style = traitCollection.userInterfaceStyle
-
-        let isDark = (style == .dark)
+        let isDark = Theme.systemIsDark
         if lastNotifiedAboutDark == nil || isDark != lastNotifiedAboutDark {
             lastNotifiedAboutDark = isDark
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.systemThemeMayHaveChanged, object: isDark)

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -130,11 +130,11 @@ class NewPlaylistViewController: PCViewController {
         navigationItem.largeTitleDisplayMode = .always
 
         if !LiquidGlass.isEnabled {
-            configureLegacyOpqaueNavBarAppearance()
+            configureLegacyOpaqueNavBarAppearance()
         }
     }
 
-    private func configureLegacyOpqaueNavBarAppearance() {
+    private func configureLegacyOpaqueNavBarAppearance() {
         let appearance = UINavigationBarAppearance()
         appearance.backgroundColor = AppTheme.viewBackgroundColor()
         appearance.largeTitleTextAttributes = [

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -129,8 +129,14 @@ class NewPlaylistViewController: PCViewController {
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationItem.largeTitleDisplayMode = .always
 
+        if !LiquidGlass.isEnabled {
+            configureLegacyOpqaueNavBarAppearance()
+        }
+    }
+
+    private func configureLegacyOpqaueNavBarAppearance() {
         let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = backgroundColor
+        appearance.backgroundColor = AppTheme.viewBackgroundColor()
         appearance.largeTitleTextAttributes = [
             NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
         ]

--- a/podcasts/New Creation/New Preview/PlaylistPreviewViewController.swift
+++ b/podcasts/New Creation/New Preview/PlaylistPreviewViewController.swift
@@ -116,11 +116,13 @@ class PlaylistPreviewViewController: PCViewController {
         navigationItem.titleView = smallTitleLabel
         navigationItem.titleView?.isHidden = true
 
-        let appearance = UINavigationBarAppearance()
-        appearance.configureWithTransparentBackground()
-        navigationBar.standardAppearance = appearance
-        navigationBar.scrollEdgeAppearance = appearance
-        navigationBar.tintColor = AppTheme.colorForStyle(.primaryIcon03)
+        if !LiquidGlass.isEnabled {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithTransparentBackground()
+            navigationBar.standardAppearance = appearance
+            navigationBar.scrollEdgeAppearance = appearance
+            navigationBar.tintColor = AppTheme.colorForStyle(.primaryIcon03)
+        }
     }
 
     override func handleThemeChanged() {

--- a/podcasts/New Detail/Custom Order/PlaylistDetailCustomOrderViewController.swift
+++ b/podcasts/New Detail/Custom Order/PlaylistDetailCustomOrderViewController.swift
@@ -54,14 +54,16 @@ class PlaylistDetailCustomOrderViewController: PCViewController {
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.largeTitleDisplayMode = .never
 
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = AppTheme.colorForStyle(.primaryUi01)
-        appearance.titleTextAttributes = [
-            NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
-        ]
-        navigationController?.navigationBar.scrollEdgeAppearance = appearance
-        navigationController?.navigationBar.standardAppearance = appearance
-        navigationController?.navigationBar.sizeToFit()
+        if !LiquidGlass.isEnabled {
+            let appearance = UINavigationBarAppearance()
+            appearance.backgroundColor = AppTheme.colorForStyle(.primaryUi01)
+            appearance.titleTextAttributes = [
+                NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
+            ]
+            navigationController?.navigationBar.scrollEdgeAppearance = appearance
+            navigationController?.navigationBar.standardAppearance = appearance
+            navigationController?.navigationBar.sizeToFit()
+        }
     }
 
     private func setupContent() {

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -89,17 +89,19 @@ class ManualPlaylistsChooserViewController: PCViewController {
         navigationController?.navigationBar.prefersLargeTitles = false
         navigationItem.largeTitleDisplayMode = .never
 
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = backgroundColor
-        appearance.largeTitleTextAttributes = [
-            NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
-        ]
-        appearance.titleTextAttributes = [
-            NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
-        ]
-        navigationController?.navigationBar.scrollEdgeAppearance = appearance
-        navigationController?.navigationBar.standardAppearance = appearance
-        navigationController?.navigationBar.sizeToFit()
+        if !LiquidGlass.isEnabled {
+            let appearance = UINavigationBarAppearance()
+            appearance.backgroundColor = backgroundColor
+            appearance.largeTitleTextAttributes = [
+                NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
+            ]
+            appearance.titleTextAttributes = [
+                NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
+            ]
+            navigationController?.navigationBar.scrollEdgeAppearance = appearance
+            navigationController?.navigationBar.standardAppearance = appearance
+            navigationController?.navigationBar.sizeToFit()
+        }
     }
 
     private func setupContent() {

--- a/podcasts/Onboarding/Intro Carousel/IntroCarouselView.swift
+++ b/podcasts/Onboarding/Intro Carousel/IntroCarouselView.swift
@@ -39,7 +39,7 @@ class IntroCarouselHostingController<Content>: OnboardingHostingViewController<C
             destinationVC.navigationItem.leftBarButtonItem?.customView?.alpha = alpha
             destinationVC.navigationItem.rightBarButtonItem?.customView?.alpha = alpha
             destinationVC.navigationItem.titleView?.alpha = alpha
-            if let navigationBar = destinationVC.navigationController?.navigationBar {
+            if !LiquidGlass.isEnabled, let navigationBar = destinationVC.navigationController?.navigationBar {
                 let navigationBarAppearance = UINavigationBarAppearance()
                 navigationBarAppearance.configureWithOpaqueBackground()
                 navigationBarAppearance.shadowColor = nil

--- a/podcasts/Onboarding/OnboardingHostingViewController.swift
+++ b/podcasts/Onboarding/OnboardingHostingViewController.swift
@@ -71,6 +71,8 @@ class OnboardingHostingViewController<Content>: UIHostingController<Content>, UI
     }
 
     private func apply() {
+        guard !LiquidGlass.isEnabled else { return }
+
         let barAppearance = UINavigationBar.appearance(whenContainedInInstancesOf: [Self.self])
 
         let appearance = UINavigationBarAppearance()

--- a/podcasts/PCHostingController.swift
+++ b/podcasts/PCHostingController.swift
@@ -79,6 +79,7 @@ class PCHostingController<Content>: ThemedHostingController<Content> where Conte
     }
 
     private func setupNavBar() {
+        guard !LiquidGlass.isEnabled else { return }
         configureNavBarFor(theme: Theme.preferredLightTheme(), traits: UITraitCollection(userInterfaceStyle: .light))
 
         let preferredThemeWhenDark = Settings.shouldFollowSystemTheme() ? Theme.preferredDarkTheme() : Theme.preferredLightTheme()

--- a/podcasts/PCNavigationController.swift
+++ b/podcasts/PCNavigationController.swift
@@ -46,6 +46,8 @@ class PCNavigationController: UINavigationController, UIGestureRecognizerDelegat
     }
 
     private func updateNavColors() {
+        guard !LiquidGlass.isEnabled else { return }
+
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = AppTheme.colorForStyle(navStyle, themeOverride: themeOverride)

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -84,7 +84,9 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
 
         if FeatureFlag.playlistsRebranding.enabled {
             let barButton = UIBarButtonItem(image: UIImage(named: "playlist_add_icon"), style: .plain, target: self, action: #selector(addNewFilter))
-            barButton.tintColor = ThemeColor.secondaryIcon01()
+            if !LiquidGlass.isEnabled {
+                barButton.tintColor = ThemeColor.secondaryIcon01()
+            }
             customRightBtn = barButton
         } else {
             customRightBtn = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(editTapped))
@@ -225,7 +227,9 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
         newFilterButton.titleLabel?.textColor = ThemeColor.primaryInteractive01()
         if FeatureFlag.playlistsRebranding.enabled {
             view.backgroundColor = ThemeColor.primaryUi04()
-            customRightBtn?.tintColor = ThemeColor.secondaryIcon01()
+            if !LiquidGlass.isEnabled {
+                customRightBtn?.tintColor = ThemeColor.secondaryIcon01()
+            }
         }
     }
 

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -131,17 +131,19 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
             navigationItem.largeTitleDisplayMode = .always
         }
 
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = backgroundColor
-        appearance.largeTitleTextAttributes = [
-            NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01),
-            NSAttributedString.Key.font: UIFont.font(ofSize: 22, weight: .bold, scalingWith: .title2)
-        ]
-        appearance.titleTextAttributes = [
-            NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
-        ]
-        navigationController?.navigationBar.scrollEdgeAppearance = appearance
-        navigationController?.navigationBar.standardAppearance = appearance
+        if !LiquidGlass.isEnabled {
+            let appearance = UINavigationBarAppearance()
+            appearance.backgroundColor = backgroundColor
+            appearance.largeTitleTextAttributes = [
+                NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01),
+                NSAttributedString.Key.font: UIFont.font(ofSize: 22, weight: .bold, scalingWith: .title2)
+            ]
+            appearance.titleTextAttributes = [
+                NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
+            ]
+            navigationController?.navigationBar.scrollEdgeAppearance = appearance
+            navigationController?.navigationBar.standardAppearance = appearance
+        }
     }
 
     func setupCloseButton() {

--- a/podcasts/ProfileViewController.xib
+++ b/podcasts/ProfileViewController.xib
@@ -38,7 +38,7 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="O6Y-M5-xeo" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="4rA-N2-3HO"/>
-                <constraint firstItem="O6Y-M5-xeo" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="GCr-QO-46Y"/>
+                <constraint firstItem="O6Y-M5-xeo" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="GCr-QO-46Y"/>
                 <constraint firstItem="O6Y-M5-xeo" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="PlA-1A-FZa"/>
                 <constraint firstItem="O6Y-M5-xeo" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="ftE-yJ-kHz"/>
             </constraints>

--- a/podcasts/SceneDelegate.swift
+++ b/podcasts/SceneDelegate.swift
@@ -11,6 +11,12 @@ class SceneDelegate: UIResponder, UISceneDelegate, UIWindowSceneDelegate {
         self.window = window
         window.rootViewController = MainTabBarController()
 
+        // Capture the system style before applying any window-level override so the
+        // initial value reflects the actual system, not our override.
+        Theme.systemIsDark = (windowScene.traitCollection.userInterfaceStyle == .dark)
+        window.applyInterfaceStyleForActiveTheme()
+        NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
+
         window.makeKeyAndVisible()
 
         if let shortcutItem = connectionOptions.shortcutItem {
@@ -47,5 +53,9 @@ class SceneDelegate: UIResponder, UISceneDelegate, UIWindowSceneDelegate {
                      performActionFor shortcutItem: UIApplicationShortcutItem,
                      completionHandler: @escaping (Bool) -> Void) {
         appDelegate()?.handleShortcutItem(shortcutItem)
+    }
+
+    @objc private func themeDidChange() {
+        window?.applyInterfaceStyleForActiveTheme()
     }
 }

--- a/podcasts/StarredFilterOverlayController.swift
+++ b/podcasts/StarredFilterOverlayController.swift
@@ -73,17 +73,19 @@ class StarredFilterOverlayController: PCViewController {
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationItem.largeTitleDisplayMode = .always
 
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = AppTheme.colorForStyle(.primaryUi01)
-        appearance.largeTitleTextAttributes = [
-            NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
-        ]
-        appearance.titleTextAttributes = [
-            NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
-        ]
-        navigationController?.navigationBar.scrollEdgeAppearance = appearance
-        navigationController?.navigationBar.standardAppearance = appearance
-        navigationController?.navigationBar.sizeToFit()
+        if !LiquidGlass.isEnabled {
+            let appearance = UINavigationBarAppearance()
+            appearance.backgroundColor = AppTheme.colorForStyle(.primaryUi01)
+            appearance.largeTitleTextAttributes = [
+                NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
+            ]
+            appearance.titleTextAttributes = [
+                NSAttributedString.Key.foregroundColor: AppTheme.colorForStyle(.primaryText01)
+            ]
+            navigationController?.navigationBar.scrollEdgeAppearance = appearance
+            navigationController?.navigationBar.standardAppearance = appearance
+            navigationController?.navigationBar.sizeToFit()
+        }
     }
 
     private func setupViewModel() {

--- a/podcasts/Theme.swift
+++ b/podcasts/Theme.swift
@@ -247,7 +247,7 @@ class Theme: ObservableObject {
             return Theme.preferredLightTheme()
         }
 
-        return UITraitCollection.current.userInterfaceStyle == .dark ? Theme.preferredDarkTheme() : Theme.preferredLightTheme()
+        return Theme.systemIsDark ? Theme.preferredDarkTheme() : Theme.preferredLightTheme()
     }
 
     func changeThemeAnimated(_ theme: ThemeType, topLevelView: UIView, originView: UIView) {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-619.

There are three main changes in this PR:

1. Disable ALL navigation bar customization when `LiquidGlass.isEnabled`
2. Update search bars and category picker in Discover to use clear background
3. Set `overrideUserInterfaceStyle` on the root `UIWindow` so it affects ALL controls


The third part is critical because without it glass controls perform poorly when you select any dark theme as "light theme":

https://github.com/user-attachments/assets/ec914e9e-848b-4569-b657-015673ca60d1

## To test

Smoke test as many screens and themes as you can. There will likely be some defects remaining. I plan to fix them forward in the integration branch.

https://github.com/user-attachments/assets/fd581aec-d071-4f45-8ec6-6100f142a6bc


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
