### PR TITLE
Podcasts: Improve initial transition

### DIFF
--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -74,7 +74,10 @@ protocol PodcastActionsDelegate: AnyObject {
 
 class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, SyncSigninDelegate, MultiSelectActionDelegate {
     var podcast: Podcast?
-    var episodeInfo = [ArraySection<String, ListItem>]()
+    var episodeInfo: [ArraySection<String, ListItem>] = {
+        let searchHeader = ListHeader(headerTitle: L10n.search, isSectionHeader: true, sectionNumber: -1)
+        return [ArraySection<String, ListItem>(model: searchHeader.headerTitle, elements: [searchHeader])]
+    }()
     var uuidsThatMatchSearch = [String]()
     var featuredPodcast = false
     var listUuid: String?
@@ -337,6 +340,7 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
         setupBookmarkViewModel()
 
         setupRefreshControl()
+        reloadData()
 
         // Keep external action bar aligned with mini player
         NotificationCenter.default.addObserver(self, selector: #selector(miniPlayerStatusDidChange), name: Constants.Notifications.miniPlayerDidAppear, object: nil)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

This PR fixes an issue where the header in Podcasts is displayed after a delay (when episodes are loaded, which takes 60+ ms). The header is now shown immediately, fixing the transition animation.


Before / After

<img width="340" alt="Screenshot 2026-05-06 at 12 26 51 PM" src="https://github.com/user-attachments/assets/86df2231-4cc6-4a7c-adf0-c150d84d2ded" /> <img width="340"  alt="Screenshot 2026-05-07 at 3 26 37 PM" src="https://github.com/user-attachments/assets/06ca4055-101b-4ab0-a229-a45e6ae35c9a" />


## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
