### PR TITLE
[PC-TV] My podcasts connected to data

### DIFF
--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -265,7 +265,33 @@ struct MockData {
         }
         self.stubPodcasts = results
         return self.stubPodcasts
+    }
 
+    private static func makeStubFolder(name: String, podcastCount: Int, from allPodcasts: [Podcast], startIndex: Int) -> Folder {
+        let folderPodcasts = Array(allPodcasts[startIndex..<min(startIndex + podcastCount, allPodcasts.count)])
+        let folder = Folder()
+        folder.uuid = UUID().uuidString
+        folder.name =  name
+        folder.color = 0
+        for podcast in folderPodcasts {
+            podcast.folderUuid = folder.uuid
+        }
+        return folder
+    }
 
+    static var stubFolders: [Folder] = []
+
+    static func makeStubFolders() -> [Folder] {
+        guard stubFolders.isEmpty else { return stubFolders }
+        let allPodcasts = makeStubPodcasts()
+        let result = [
+            makeStubFolder(name: "News", podcastCount: 4, from: allPodcasts, startIndex: 0),
+            makeStubFolder(name: "Comedy", podcastCount: 1, from: allPodcasts, startIndex: 4),
+            makeStubFolder(name: "Tech", podcastCount: 2, from: allPodcasts, startIndex: 5),
+            makeStubFolder(name: "Science", podcastCount: 3, from: allPodcasts, startIndex: 7),
+            makeStubFolder(name: "My super duper long folder name that keeps on going", podcastCount: 4, from: allPodcasts, startIndex: 10)
+        ]
+        self.stubFolders = result
+        return result
     }
 }

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -222,6 +222,7 @@ struct MockData {
         for i in (0..<numberOfPodcasts) {
             let podcast = Podcast()
             podcast.id = Int64(i)
+            podcast.uuid = UUID().uuidString
             podcast.title = podcastNames[i % podcastNames.count]
             podcast.author = authorNames[i % authorNames.count]
             podcast.podcastDescription = "Here is a fun description for this"

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -89,8 +89,8 @@ struct HomeView: View {
                 }
             })
             .focusScope(podcastGridNamespace)
-            .navigationDestination(for: MockPodcast.self) { podcast in
-                PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
+            .navigationDestination(for: MockPodcast.self) { _ in
+                //PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
             }
         }
     }

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsDataModel
 
 struct HomeView: View {
     @Environment(AppCoordinator.self) var coordinator
@@ -79,18 +80,17 @@ struct HomeView: View {
             LazyHStack(spacing: 0, content: {
                 ForEach(model.podcasts) { podcast in
                     NavigationLink(value: podcast) {
-                        Image(podcast.image)
-                            .resizable()
+                        PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
                             .frame(width: Layout.gridSize, height: Layout.gridSize)
                     }
                     .buttonStyle(.card)
                     .padding(24)
-                    .prefersDefaultFocus(model.podcasts.first?.id == podcast.id, in: podcastGridNamespace)
+                    .prefersDefaultFocus(model.podcasts.first?.uuid == podcast.uuid, in: podcastGridNamespace)
                 }
             })
             .focusScope(podcastGridNamespace)
-            .navigationDestination(for: MockPodcast.self) { _ in
-                //PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
+            .navigationDestination(for: Podcast.self) { podcast in
+                PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
             }
         }
     }
@@ -111,8 +111,7 @@ struct HomeView: View {
             LazyHStack(spacing: 0) {
                 ForEach(model.recentlyPlayed) { podcast in
                     NavigationLink(value: podcast) {
-                        Image(podcast.image)
-                            .resizable()
+                        PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
                             .frame(width: Layout.gridSize, height: Layout.gridSize)
                     }
                     .buttonStyle(.card)

--- a/Pocket Casts TV App/UI/Home/HomeViewModel.swift
+++ b/Pocket Casts TV App/UI/Home/HomeViewModel.swift
@@ -1,10 +1,15 @@
 import SwiftUI
 import Combine
+import PocketCastsDataModel
 
 @Observable
 class HomeViewModel {
 
-    private var cancellable: AnyCancellable?
+    private let dataManager: DataManager
+
+    init(dataManager: DataManager = DataManager.sharedManager) {
+        self.dataManager = dataManager
+    }
 
     enum State: Equatable, Hashable {
         case loading
@@ -14,26 +19,24 @@ class HomeViewModel {
 
     var state: State = .loading
 
-    var podcasts: [MockPodcast] = []
+    var podcasts: [Podcast] = []
     var currentPlaying: MockEpisode?
     var upNext: [MockEpisode] = []
-    var recentlyPlayed: [MockPodcast] = []
+    var recentlyPlayed: [Podcast] = []
     var newReleases: [MockEpisode] = []
 
     func load() {
-        //Mock data load
-        cancellable = Timer.publish(every: 1.0, on: .main, in: .common, options: nil)
-            .autoconnect()
-            .sink { [weak self] _ in
-                guard let self else { return }
-                podcasts = MockData.makePodcasts()
-                currentPlaying = MockData.makePlaylists().first?.episodes.first
-                upNext = Array(MockData.makeUpNext().prefix(3))
-                recentlyPlayed = Array(podcasts.shuffled().prefix(10))
-                newReleases = podcasts.prefix(8).compactMap(\.episodes.first)
-                state = .ready
-                cancellable?.cancel()
-                cancellable = nil
-            }
+        Task {
+            podcasts = fetchPodcasts()
+            currentPlaying = MockData.makePlaylists().first?.episodes.first
+            upNext = Array(MockData.makeUpNext().prefix(3))
+            recentlyPlayed = Array(podcasts.shuffled().prefix(10))
+            newReleases = MockData.makePodcasts().prefix(8).compactMap(\.episodes.first)
+            state = .ready
+        }
+    }
+
+    private func fetchPodcasts() -> [Podcast] {
+        return Array(dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: false).prefix(20))
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
@@ -1,7 +1,8 @@
 import SwiftUI
+import PocketCastsDataModel
 
 struct FolderCardView: View {
-    let folder: MockFolder
+    let folder: Folder
 
     private let cardSize: CGFloat = 250
     private let coverSize: CGFloat = 80
@@ -23,7 +24,7 @@ struct FolderCardView: View {
                 .padding(.bottom, 16)
         }
         .frame(width: cardSize, height: cardSize)
-        .background(gradient)
+        .background(Color(uiColor: AppTheme.folderColor(colorInt: folder.color)))
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
@@ -42,17 +43,17 @@ struct FolderCardView: View {
 
     @ViewBuilder
     private func coverImage(at index: Int) -> some View {
-        if index < folder.podcastImages.count {
-            Image(folder.podcastImages[index])
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-                .frame(width: coverSize, height: coverSize)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-        } else {
+//        if index < folder.podcastImages.count {
+//            Image(folder.podcastImages[index])
+//                .resizable()
+//                .aspectRatio(contentMode: .fill)
+//                .frame(width: coverSize, height: coverSize)
+//                .clipShape(RoundedRectangle(cornerRadius: 6))
+//        } else {
             Color.black.opacity(0.2)
                 .frame(width: coverSize, height: coverSize)
                 .clipShape(RoundedRectangle(cornerRadius: 6))
-        }
+//        }
     }
 
     private var folderName: some View {
@@ -109,13 +110,13 @@ private struct MarqueeText: View {
     }
 }
 
-#Preview {
-    let folders = MockData.makeFolders()
-    LazyVGrid(columns: [GridItem(.fixed(250), spacing: 48), GridItem(.fixed(250), spacing: 48)], spacing: 48) {
-        ForEach(folders) { folder in
-            FolderCardView(folder: folder)
-        }
-    }
-    .padding()
-    .background(Color.black)
-}
+//#Preview {
+//    let folders = MockData.makeFolders()
+//    LazyVGrid(columns: [GridItem(.fixed(250), spacing: 48), GridItem(.fixed(250), spacing: 48)], spacing: 48) {
+//        ForEach(folders) { folder in
+//            FolderCardView(folder: folder)
+//        }
+//    }
+//    .padding()
+//    .background(Color.black)
+//}

--- a/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
@@ -2,7 +2,12 @@ import SwiftUI
 import PocketCastsDataModel
 
 struct FolderCardView: View {
-    let folder: Folder
+
+    @State var model: FolderCardViewModel
+
+    init(folder: Folder) {
+        self.model = FolderCardViewModel(folder: folder)
+    }
 
     private let cardSize: CGFloat = 250
     private let coverSize: CGFloat = 80
@@ -24,8 +29,11 @@ struct FolderCardView: View {
                 .padding(.bottom, 16)
         }
         .frame(width: cardSize, height: cardSize)
-        .background(Color(uiColor: AppTheme.folderColor(colorInt: folder.color)))
+        .background(Color(uiColor: AppTheme.folderColor(colorInt: model.folder.color)))
         .clipShape(RoundedRectangle(cornerRadius: 12))
+        .task {
+            model.load()
+        }
     }
 
     private var coverGrid: some View {
@@ -43,21 +51,19 @@ struct FolderCardView: View {
 
     @ViewBuilder
     private func coverImage(at index: Int) -> some View {
-//        if index < folder.podcastImages.count {
-//            Image(folder.podcastImages[index])
-//                .resizable()
-//                .aspectRatio(contentMode: .fill)
-//                .frame(width: coverSize, height: coverSize)
-//                .clipShape(RoundedRectangle(cornerRadius: 6))
-//        } else {
+        if index < model.topPodcastsUuids.count {
+            PodcastImageViewWrapper(podcastUUID: model.topPodcastsUuids[index], size: .list)
+                .frame(width: coverSize, height: coverSize)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        } else {
             Color.black.opacity(0.2)
                 .frame(width: coverSize, height: coverSize)
                 .clipShape(RoundedRectangle(cornerRadius: 6))
-//        }
+        }
     }
 
     private var folderName: some View {
-        MarqueeText(text: folder.name, maxWidth: cardSize - 32)
+        MarqueeText(text: model.folder.name, maxWidth: cardSize - 32)
     }
 }
 
@@ -110,13 +116,13 @@ private struct MarqueeText: View {
     }
 }
 
-//#Preview {
-//    let folders = MockData.makeFolders()
-//    LazyVGrid(columns: [GridItem(.fixed(250), spacing: 48), GridItem(.fixed(250), spacing: 48)], spacing: 48) {
-//        ForEach(folders) { folder in
-//            FolderCardView(folder: folder)
-//        }
-//    }
-//    .padding()
-//    .background(Color.black)
-//}
+#Preview {
+    let folders = MockData.makeStubFolders()
+    LazyVGrid(columns: [GridItem(.fixed(250), spacing: 48), GridItem(.fixed(250), spacing: 48)], spacing: 48) {
+        ForEach(folders) { folder in
+            FolderCardView(folder: folder)
+        }
+    }
+    .padding()
+    .background(Color.black)
+}

--- a/Pocket Casts TV App/UI/Podcasts/FolderCardViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderCardViewModel.swift
@@ -1,0 +1,26 @@
+import PocketCastsDataModel
+
+@Observable
+class FolderCardViewModel {
+
+    let folder: Folder
+    let dataManager: DataManager
+
+    var topPodcastsUuids: [String] = []
+
+    init(folder: Folder, dataManager: DataManager = DataManager.sharedManager) {
+        self.folder = folder
+        self.dataManager = dataManager
+    }
+
+    func load() {
+        Task { [weak self] in
+            guard let self else { return }
+            let podcastUuids = dataManager.topPodcastsUuidInFolder(folder: folder)
+            await MainActor.run {
+                self.topPodcastsUuids = podcastUuids
+            }
+        }
+    }
+
+}

--- a/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
@@ -1,7 +1,13 @@
 import SwiftUI
+import PocketCastsDataModel
 
 struct FolderDetailView: View {
-    let folder: MockFolder
+
+    @State var model: FolderDetailViewModel
+
+    init(folder: Folder) {
+        self.model = FolderDetailViewModel(folder: folder)
+    }
 
     enum Layout {
         static var gridSize = CGFloat(250)
@@ -13,17 +19,16 @@ struct FolderDetailView: View {
     @Namespace private var podcastGridNamespace
 
     var body: some View {
-        let firstID = folder.podcasts.first?.id
+        let firstID = model.podcasts.first?.id
         ScrollView {
             VStack(alignment: .leading, spacing: 40) {
-                Text(folder.name)
+                Text(model.folder.name)
                     .font(.title2)
                     .foregroundStyle(Color.textPrimary)
                 LazyVGrid(columns: Self.gridColumns, spacing: 48) {
-                    ForEach(folder.podcasts) { podcast in
+                    ForEach(model.podcasts) { podcast in
                         NavigationLink(value: podcast) {
-                            Image(podcast.image)
-                                .resizable()
+                            PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
                                 .frame(width: Layout.gridSize, height: Layout.gridSize)
                         }
                         .buttonStyle(.card)
@@ -33,14 +38,17 @@ struct FolderDetailView: View {
                 .focusScope(podcastGridNamespace)
             }
         }
-        .navigationDestination(for: MockPodcast.self) { podcast in
+        .navigationDestination(for: Podcast.self) { podcast in
             PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
+        }
+        .task {
+            model.load()
         }
     }
 }
 
 #Preview {
     NavigationStack {
-        FolderDetailView(folder: MockData.makeFolders().first!)
+        FolderDetailView(folder: MockData.makeStubFolders().first!)
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/FolderDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderDetailViewModel.swift
@@ -1,0 +1,27 @@
+import Combine
+import Foundation
+import PocketCastsDataModel
+
+@Observable
+class FolderDetailViewModel {
+
+    var folder: Folder
+    var podcasts = [Podcast]()
+    private var dataManager: DataManager
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init(folder: Folder, dataManager: DataManager = DataManager.sharedManager) {
+        self.folder = folder
+        self.dataManager = dataManager
+    }
+
+    func load() {
+        Task {
+            let podcasts = dataManager.allPodcastsInFolder(folder: folder)
+            await MainActor.run {
+                self.podcasts = podcasts
+            }
+        }
+    }
+}

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsDataModel
 
 struct PodcastDetailView: View {
 
@@ -46,16 +47,13 @@ struct PodcastDetailView: View {
             episodeContent
         }
         .blurredCoverBackground(size: Layout.podcastImageSize) {
-            Image(model.podcast.image)
-                .resizable()
-                .aspectRatio(contentMode: .fill)
+            PodcastImageViewWrapper(podcastUUID: model.podcast.uuid, size: .page)
         }
     }
 
     var podcastInfo: some View {
         VStack(alignment: .leading, spacing: 40) {
-            Image(model.podcast.image)
-                .resizable()
+            PodcastImageViewWrapper(podcastUUID: model.podcast.uuid, size: .page)
                 .frame(width: Layout.podcastImageSize, height: Layout.podcastImageSize)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .shadow(color: .black.opacity(0.6), radius: 40, x: 0, y: 20)
@@ -63,7 +61,7 @@ struct PodcastDetailView: View {
                 Text(model.podcast.author ?? "")
                     .font(.caption)
                     .foregroundColor(.textSecondary)
-                Text(model.podcast.title)
+                Text(model.podcast.title ?? "")
                     .font(.title2)
                     .foregroundColor(.textPrimary)
                 Text(model.podcast.podcastDescription ?? "")
@@ -93,7 +91,7 @@ struct PodcastDetailView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .focusSection()
         .sheet(isPresented: $isShowingMoreInfo) {
-            PodcastMoreInfoView(podcast: model.podcast)
+            //PodcastMoreInfoView(podcast: model.podcast)
         }
     }
 
@@ -130,7 +128,7 @@ struct PodcastDetailView: View {
                         .font(.title3)
                         .foregroundStyle(Color.textPrimary)
                     LazyVStack {
-                        ForEach(model.podcast.episodes) { episode in
+                        ForEach(model.episodes) { episode in
                             episodeRow(for: episode)
                         }
                     }
@@ -146,7 +144,7 @@ struct PodcastDetailView: View {
 
 #Preview {
     let router = MainTabRouter()
-    PodcastDetailView(model: PodcastDetailViewModel(podcast: MockData.makePodcasts().first!))
+    PodcastDetailView(model: PodcastDetailViewModel(podcast: MockData.makeStubPodcasts().first!))
         .environment(AppCoordinator())
         .environment(router)
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -91,7 +91,7 @@ struct PodcastDetailView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .focusSection()
         .sheet(isPresented: $isShowingMoreInfo) {
-            //PodcastMoreInfoView(podcast: model.podcast)
+            PodcastMoreInfoView(podcast: model.podcast)
         }
     }
 

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -4,9 +4,18 @@ import PocketCastsDataModel
 struct PodcastDetailView: View {
 
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
-    let model: PodcastDetailViewModel
+    @State var model: PodcastDetailViewModel
+
     @FocusState private var focusedSection: FocusSection?
     @State private var isShowingMoreInfo = false
+
+    init(podcast: Podcast) {
+        self.model = PodcastDetailViewModel(podcast: podcast)
+    }
+
+    init(model: PodcastDetailViewModel) {
+        self.model = model
+    }
 
     enum FocusSection: Hashable {
         case episodes
@@ -70,10 +79,12 @@ struct PodcastDetailView: View {
             }
             HStack(spacing: 8) {
                 Button() {
-                    model.follow()
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
+                        model.follow()
+                    }
                 } label: {
                     HStack(spacing: 6) {
-                        Image(systemName: model.isFollowing ? "checkmark" : "plus")
+                        Image(systemName: model.podcast.subscribed != 0 ? "checkmark" : "plus")
                             .contentTransition(.symbolEffect(.replace))
                         Text(model.isFollowing ? L10n.tvPodcastDetailFollowingTitle : L10n.tvPodcastDetailFollowTitle)
                             .contentTransition(.interpolate)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Combine
+import PocketCastsDataModel
 
 @Observable
 class PodcastDetailViewModel {
@@ -13,24 +14,19 @@ class PodcastDetailViewModel {
 
     var state: State = .loading
 
-    let podcast: MockPodcast
+    let podcast: Podcast
+    let episodes: [MockEpisode]
+
     let recommendedEpisode: MockEpisode?
 
-    init(podcast: MockPodcast) {
+    init(podcast: Podcast) {
         self.podcast = podcast
-        self.recommendedEpisode = podcast.episodes.randomElement()
+        self.episodes = MockData.makePodcasts().first?.episodes ?? []
+        self.recommendedEpisode = MockData.makePodcasts().first?.episodes.randomElement()
     }
 
     func load() {
-        //Mock data load
-        cancellable = Timer.publish(every: 1.0, on: .main, in: .common, options: nil)
-            .autoconnect()
-            .sink { [weak self] _ in
-                guard let self else { return }
-                state = .ready
-                cancellable?.cancel()
-                cancellable = nil
-            }
+        state = .ready
     }
 
     var isFollowing: Bool = false

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -14,7 +14,7 @@ class PodcastDetailViewModel {
 
     var state: State = .loading
 
-    let podcast: Podcast
+    var podcast: Podcast
     let episodes: [MockEpisode]
 
     let recommendedEpisode: MockEpisode?
@@ -29,11 +29,11 @@ class PodcastDetailViewModel {
         state = .ready
     }
 
-    var isFollowing: Bool = false
+    var isFollowing: Bool {
+        podcast.isSubscribed()
+    }
 
     func follow() {
-        withAnimation(.spring(response: 0.35, dampingFraction: 0.7)) {
-            isFollowing.toggle()
-        }
+        podcast.subscribed = 0
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
@@ -1,22 +1,22 @@
 import SwiftUI
+import PocketCastsDataModel
 
 struct PodcastMoreInfoView: View {
 
-    let podcast: MockPodcast
+    let podcast: Podcast
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         VStack(alignment: .leading, spacing: 48) {
             HStack(alignment: .top, spacing: 40) {
-                Image(podcast.image)
-                    .resizable()
+                PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
                     .frame(width: 240, height: 240)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                 VStack(alignment: .leading, spacing: 8) {
                     Text(podcast.author ?? "")
                         .font(.caption)
                         .foregroundStyle(Color.textSecondary)
-                    Text(podcast.title)
+                    Text(podcast.title ?? "")
                         .font(.title2)
                         .foregroundStyle(Color.textPrimary)
                 }
@@ -34,16 +34,16 @@ struct PodcastMoreInfoView: View {
             }
 
             VStack(alignment: .leading, spacing: 24) {
-                if let network = podcast.network {
+                if let network = podcast.author {
                     infoRow(label: L10n.tvPodcastDetailNetwork, value: network)
                 }
-                if let website = podcast.website {
+                if let website = podcast.podcastUrl {
                     infoRow(label: L10n.tvPodcastDetailWebsite, value: website)
                 }
-                if let frequency = podcast.frequency {
+                if let frequency = podcast.displayableFrequency() {
                     infoRow(label: L10n.tvPodcastDetailSchedule, value: frequency)
                 }
-                if let nextEpisode = podcast.nextEpisodeDate {
+                if let nextEpisode = podcast.displayableNextEpisodeDate() {
                     infoRow(label: L10n.tvPodcastDetailNextEpisode, value: nextEpisode)
                 }
             }
@@ -66,5 +66,5 @@ struct PodcastMoreInfoView: View {
 }
 
 #Preview {
-    PodcastMoreInfoView(podcast: MockData.makePodcasts().first!)
+    PodcastMoreInfoView(podcast: MockData.makeStubPodcasts().first!)
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -5,7 +5,7 @@ fileprivate enum Layout {
     static let gridSize = CGFloat(250)
 }
 
-struct PodcastsView<ViewModel: PodcastsViewModelInterface>: View {
+struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
 

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -1,13 +1,18 @@
 import SwiftUI
+import PocketCastsDataModel
 
-struct PodcastsView: View {
+fileprivate enum Layout {
+    static let gridSize = CGFloat(250)
+}
+
+struct PodcastsView<ViewModel: PodcastsViewModelInterface>: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
 
-    @State private var model = PodcastsViewModel()
+    @Bindable private var model: ViewModel
 
-    enum Layout {
-        static let gridSize = CGFloat(250)
+    init(model: ViewModel = PodcastsViewModelMock()) {
+        self.model = model
     }
 
     var body: some View {
@@ -22,7 +27,7 @@ struct PodcastsView: View {
             }
         }
         .task {
-            model.load()
+            await model.load()
         }
     }
 
@@ -57,17 +62,14 @@ struct PodcastsView: View {
 
     var podcastGrid: some View {
         LazyVGrid(columns: items, spacing: 48, content: {
-            ForEach(model.podcasts) { podcast in
+            ForEach(model.podcasts, id: \.uuid) { podcast in
                 NavigationLink(value: podcast) {
-                        Image(podcast.image)
-                            .resizable()
-                            .frame(width: Layout.gridSize, height: Layout.gridSize)
+                    PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
+                        .frame(width: Layout.gridSize, height: Layout.gridSize)
                 }
                 .buttonStyle(.card)
-                .prefersDefaultFocus(model.podcasts.first?.id == podcast.id, in: podcastGridNamespace)
             }
         })
-        .focusScope(podcastGridNamespace)
         .navigationDestination(for: MockPodcast.self) { podcast in
             PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
         }
@@ -75,7 +77,7 @@ struct PodcastsView: View {
 }
 
 #Preview {
-    PodcastsView()
+    PodcastsView(model: PodcastsViewModelMock())
         .environment(AppCoordinator())
         .environment(MainTabRouter())
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -81,7 +81,7 @@ struct PodcastsView<ViewModel: PodcastsViewModelInterface>: View {
         .navigationDestination(for: Podcast.self) { podcast in
             PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
         }
-        .navigationDestination(for: MockFolder.self) { folder in
+        .navigationDestination(for: Folder.self) { folder in
             FolderDetailView(folder: folder)
         }
     }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -79,7 +79,7 @@ struct PodcastsView<ViewModel: PodcastsViewModelInterface>: View {
         }
         .focusScope(podcastGridNamespace)
         .navigationDestination(for: Podcast.self) { podcast in
-            PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
+            PodcastDetailView(podcast: podcast)
         }
         .navigationDestination(for: Folder.self) { folder in
             FolderDetailView(folder: folder)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -78,7 +78,7 @@ struct PodcastsView<ViewModel: PodcastsViewModelInterface>: View {
             }
         }
         .focusScope(podcastGridNamespace)
-        .navigationDestination(for: MockPodcast.self) { podcast in
+        .navigationDestination(for: Podcast.self) { podcast in
             PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
         }
         .navigationDestination(for: MockFolder.self) { folder in

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -9,9 +9,9 @@ struct PodcastsView<ViewModel: PodcastsViewModelInterface>: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
 
-    @Bindable private var model: ViewModel
+    @State private var model: ViewModel
 
-    init(model: ViewModel = PodcastsViewModelMock()) {
+    init(model: ViewModel = PodcastsViewModel()) {
         self.model = model
     }
 

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -63,15 +63,13 @@ struct PodcastsView<ViewModel: PodcastsViewModelInterface>: View {
     var podcastGrid: some View {
         LazyVGrid(columns: gridColumns, spacing: 48) {
             ForEach(model.items) { item in
-                switch item {
-                case .podcast(let podcast):
+                if let podcast = item.podcast {
                     NavigationLink(value: podcast) {
                         PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
                             .frame(width: Layout.gridSize, height: Layout.gridSize)
                     }
                     .buttonStyle(.card)
-                    //.prefersDefaultFocus(item.id == items.first?.id, in: podcastGridNamespace)
-                case .folder(let folder):
+                } else if let folder = item.folder {
                     NavigationLink(value: folder) {
                         FolderCardView(folder: folder)
                     }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
@@ -4,18 +4,6 @@ import PocketCastsServer
 import PocketCastsUtils
 import PocketCastsDataModel
 
-enum GridCellItem: Identifiable {
-    case podcast(Podcast)
-    case folder(MockFolder)
-
-    var id: String {
-        switch self {
-        case .podcast(let p): p.uuid
-        case .folder(let f): f.id
-        }
-    }
-}
-
 enum PodcastViewModelState: Equatable, Hashable {
     case loading
     case ready
@@ -26,7 +14,7 @@ protocol PodcastsViewModelInterface: AnyObject, Observation.Observable {
 
     var state: PodcastViewModelState { get }
 
-    var items: [GridCellItem] { get }
+    var items: [HomeGridItem] { get }
 
     func load() async
 }
@@ -37,7 +25,7 @@ class PodcastsViewModel: PodcastsViewModelInterface {
 
     private(set) var state: PodcastViewModelState = .loading
 
-    var items: [GridCellItem] = []
+    var items: [HomeGridItem] = []
 
     private let dataManager: DataManager
 
@@ -51,9 +39,9 @@ class PodcastsViewModel: PodcastsViewModelInterface {
 
     private func fetchPodcasts() async {
         Task {
-            let podcasts = dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: false)
+            let gridItems = HomeGridDataHelper.gridItems(orderedBy: .titleAtoZ)
             await MainActor.run {
-                self.items = podcasts.map { GridCellItem.podcast($0) }
+                self.items = gridItems
                 self.state = .ready
             }
         }
@@ -67,7 +55,7 @@ class PodcastsViewModelMock: PodcastsViewModelInterface {
 
     var state: PodcastViewModelState = .loading
 
-    var items: [GridCellItem] = []
+    var items: [HomeGridItem] = []
 
     func load() async {
         //Mock data load
@@ -75,7 +63,7 @@ class PodcastsViewModelMock: PodcastsViewModelInterface {
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self else { return }
-                items = MockData.makeStubPodcasts().map { GridCellItem.podcast($0)}
+                items = MockData.makeStubPodcasts().map { HomeGridItem(podcast: $0) }
                 state = items.isEmpty ? .empty : .ready
                 cancellable?.cancel()
                 cancellable = nil

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
@@ -1,28 +1,69 @@
 import SwiftUI
 import Combine
+import PocketCastsServer
+import PocketCastsUtils
+import PocketCastsDataModel
+
+enum PodcastViewModelState: Equatable, Hashable {
+    case loading
+    case ready
+    case empty
+}
+
+protocol PodcastsViewModelInterface: AnyObject, Observation.Observable {
+
+    var state: PodcastViewModelState { get }
+
+    var podcasts: [Podcast] { get }
+
+    func load() async
+}
 
 @Observable
-class PodcastsViewModel {
+class PodcastsViewModel: PodcastsViewModelInterface {
+    private var cancellables: Set<AnyCancellable> = []
+
+    private(set) var state: PodcastViewModelState = .loading
+
+    var podcasts: [Podcast] = []
+
+    private let dataManager: DataManager
+
+    init(dataManager: DataManager = DataManager.sharedManager) {
+        self.dataManager = dataManager
+    }
+
+    func load() async {
+        await fetchPodcasts()
+    }
+
+    private func fetchPodcasts() async {
+        Task {
+            let podcasts = dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: false)
+            await MainActor.run {
+                self.podcasts = podcasts
+                self.state = .ready
+            }
+        }
+    }
+}
+
+@Observable
+class PodcastsViewModelMock: PodcastsViewModelInterface {
 
     private var cancellable: AnyCancellable?
 
-    enum State: Equatable, Hashable {
-        case loading
-        case ready
-        case empty
-    }
+    var state: PodcastViewModelState = .loading
 
-    var state: State = .loading
+    var podcasts: [Podcast] = []
 
-    var podcasts: [MockPodcast] = []
-
-    func load() {
+    func load() async {
         //Mock data load
         cancellable = Timer.publish(every: 1.0, on: .main, in: .common, options: nil)
             .autoconnect()
             .sink { [weak self] _ in
                 guard let self else { return }
-                podcasts = MockData.makePodcasts()
+                podcasts = MockData.makeStubPodcasts()
                 state = podcasts.isEmpty ? .empty : .ready
                 cancellable?.cancel()
                 cancellable = nil

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
@@ -10,7 +10,7 @@ enum PodcastViewModelState: Equatable, Hashable {
     case empty
 }
 
-protocol PodcastsViewModelInterface: AnyObject, Observation.Observable {
+protocol PodcastsViewModelProtocol: AnyObject, Observation.Observable {
 
     var state: PodcastViewModelState { get }
 
@@ -20,7 +20,7 @@ protocol PodcastsViewModelInterface: AnyObject, Observation.Observable {
 }
 
 @Observable
-class PodcastsViewModel: PodcastsViewModelInterface {
+class PodcastsViewModel: PodcastsViewModelProtocol {
     private var cancellables: Set<AnyCancellable> = []
 
     private(set) var state: PodcastViewModelState = .loading
@@ -49,7 +49,7 @@ class PodcastsViewModel: PodcastsViewModelInterface {
 }
 
 @Observable
-class PodcastsViewModelMock: PodcastsViewModelInterface {
+class PodcastsViewModelMock: PodcastsViewModelProtocol {
 
     private var cancellable: AnyCancellable?
 

--- a/Pocket Casts TV App/UI/Search/SearchPodcastResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchPodcastResultsView.swift
@@ -1,8 +1,9 @@
 import SwiftUI
+import PocketCastsDataModel
 
 struct SearchPodcastsResultsView: View {
 
-    let podcasts: [MockPodcast]
+    let podcasts: [Podcast]
 
     enum Layout {
         static let cellSize = CGFloat(250)
@@ -17,14 +18,13 @@ struct SearchPodcastsResultsView: View {
             LazyVGrid(columns: items, spacing: 48, content: {
                 ForEach(podcasts) { podcast in
                     NavigationLink(value: podcast) {
-                        Image(podcast.image)
-                            .resizable()
+                        PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)                            
                             .frame(width: Layout.cellSize, height: Layout.cellSize)
                     }
                     .buttonStyle(.card)
                 }
             })
-            .navigationDestination(for: MockPodcast.self) { podcast in
+            .navigationDestination(for: Podcast.self) { podcast in
                 PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
             }
         }

--- a/Pocket Casts TV App/UI/Search/SearchPodcastResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchPodcastResultsView.swift
@@ -18,7 +18,7 @@ struct SearchPodcastsResultsView: View {
             LazyVGrid(columns: items, spacing: 48, content: {
                 ForEach(podcasts) { podcast in
                     NavigationLink(value: podcast) {
-                        PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)                            
+                        PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
                             .frame(width: Layout.cellSize, height: Layout.cellSize)
                     }
                     .buttonStyle(.card)

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -42,10 +42,8 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                     }
                 }
             }
-            .onSubmit(of: .search) {
-                model.search(query: searchText)
-            }
             .onChange(of: searchText) { _, newValue in
+                model.search(query: searchText)
                 model.autoComplete(query: newValue)
             }
         }

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -43,7 +43,7 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                 }
             }
             .onChange(of: searchText) { _, newValue in
-                model.search(query: searchText)
+                model.search(query: newValue)
                 model.autoComplete(query: newValue)
             }
         }

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsDataModel
 
 enum SearchScope: String, CaseIterable {
     case all = "All"
@@ -17,7 +18,7 @@ enum SearchState {
 protocol SearchableViewModel: AnyObject, Observation.Observable {
     var state: SearchState { get }
     var scope: SearchScope { get set }
-    var results: [MockPodcast] { get }
+    var results: [Podcast] { get }
     var searchHistory: [String] { get }
     var autoCompleteSuggestions: [String] { get }
 
@@ -30,11 +31,13 @@ protocol SearchableViewModel: AnyObject, Observation.Observable {
 @MainActor
 class SearchViewModel: SearchableViewModel {
 
+    private var dataManager: DataManager = DataManager.sharedManager
+
     var state: SearchState = .query
 
     var scope: SearchScope = .all
 
-    var results: [MockPodcast] = []
+    var results: [Podcast] = []
 
     var searchHistory: [String] = ["Conan"]
 
@@ -75,18 +78,24 @@ class SearchViewModel: SearchableViewModel {
     }
 
     func autoComplete(query: String) {
-        autoCompleteSuggestions = MockData.makePodcasts().filter() { podcast in
-            podcast.title.localizedCaseInsensitiveContains(query)
-        }.map {
+        let podcasts = dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: true)
+        autoCompleteSuggestions = podcasts.filter() { podcast in
+            if let title = podcast.title {
+                return title.localizedCaseInsensitiveContains(query)
+            }
+            return false
+        }.compactMap {
             $0.title
         }
     }
 
-    private func fetchPodcasts(query: String) async throws -> [MockPodcast] {
-        // Replace with your actual API call
-        try await Task.sleep(nanoseconds: 500_000_000)
-        return MockData.makePodcasts().filter() { podcast in
-            podcast.title.localizedCaseInsensitiveContains(query)
+    private func fetchPodcasts(query: String) async throws -> [Podcast] {
+        let podcasts = dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: true)
+        return podcasts.filter() { podcast in
+            if let title = podcast.title {
+                return title.localizedCaseInsensitiveContains(query)
+            }
+            return false
         }
     }
 }

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -78,24 +78,13 @@ class SearchViewModel: SearchableViewModel {
     }
 
     func autoComplete(query: String) {
-        let podcasts = dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: true)
-        autoCompleteSuggestions = podcasts.filter() { podcast in
-            if let title = podcast.title {
-                return title.localizedCaseInsensitiveContains(query)
-            }
-            return false
-        }.compactMap {
+        let podcasts = dataManager.searchPodcasts(term: query)
+        autoCompleteSuggestions = podcasts.compactMap {
             $0.title
         }
     }
 
     private func fetchPodcasts(query: String) async throws -> [Podcast] {
-        let podcasts = dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: true)
-        return podcasts.filter() { podcast in
-            if let title = podcast.title {
-                return title.localizedCaseInsensitiveContains(query)
-            }
-            return false
-        }
+        return dataManager.searchPodcasts(term: query)
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-651 <!-- issue number, if applicable -->
Refs PCIOS-652

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR hooks up the real data of Podcasts to show in the Your Podcasts Screen.
It shows Podcast and Folders, and you can navigate inside Podcast and Folders.
On the Podcast detail you can check the More Info for the real details.
Episodes info is still stubbed and will be done on a follow up PR

## To test

1. Start the TV app
2. Enter valid Pocket Casts credentials and submit — the app should advance to the **Signing In** screen.
3. After the sync is done
4. Go to Your Podcast tab
5. This should show your podcasts and folders
6. Move around in the podcasts and folder
7. Check inside podcasts

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.