### PR TITLE
Liquid Glass: Move isPlaying line back to the end of updateColors

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -425,13 +425,14 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
     private func updateColors() {
         view.backgroundColor = .clear
-        playPauseBtn.isPlaying = PlaybackManager.shared.playing()
 
         if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
             updateColorsLiquidGlass()
         } else {
             updateColorsLegacy()
         }
+
+        playPauseBtn.isPlaying = PlaybackManager.shared.playing()
     }
 
     private func updateColorsLegacy() {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

This should NOT have any effect, but moving it back to the end of `updateColors` just in case it does.

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
