### PR TITLE
Optimize UIViewControllerContentConfiguration

### DIFF
--- a/podcasts/UIViewControllerContentConfiguration.swift
+++ b/podcasts/UIViewControllerContentConfiguration.swift
@@ -1,4 +1,6 @@
-final class UIViewControllerContentConfiguration: UIContentConfiguration {
+import UIKit
+
+struct UIViewControllerContentConfiguration: UIContentConfiguration {
     let viewController: UIViewController
     let parentViewController: UIViewController
 
@@ -8,24 +10,35 @@ final class UIViewControllerContentConfiguration: UIContentConfiguration {
     }
 
     func makeContentView() -> UIView & UIContentView {
-        return ViewControllerContainerContentView(configuration: self)
+        ViewControllerContainerContentView(configuration: self)
     }
 
     func updated(for state: UIConfigurationState) -> UIViewControllerContentConfiguration {
-        return self
+        self
     }
 }
 
-class ViewControllerContainerContentView: UIView, UIContentView {
+final class ViewControllerContainerContentView: UIView, UIContentView {
     var configuration: UIContentConfiguration {
+        get { _configuration }
+        set {
+            guard let newValue = newValue as? UIViewControllerContentConfiguration else {
+                return assertionFailure("Unsupported configuration")
+            }
+            _configuration = newValue
+        }
+    }
+
+    private var _configuration: UIViewControllerContentConfiguration {
         didSet {
+            guard oldValue.viewController !== _configuration.viewController else { return }
             subviews.first?.removeFromSuperview()
             setupConstraints()
         }
     }
 
     init(configuration: UIViewControllerContentConfiguration) {
-        self.configuration = configuration
+        self._configuration = configuration
         super.init(frame: .zero)
         setupConstraints()
     }
@@ -35,9 +48,7 @@ class ViewControllerContainerContentView: UIView, UIContentView {
     }
 
     private func setupConstraints() {
-        guard let configuration = configuration as? UIViewControllerContentConfiguration else { return }
-
-        let viewController = configuration.viewController
+        let viewController = _configuration.viewController
         addSubview(viewController.view)
         viewController.view.translatesAutoresizingMaskIntoConstraints = false
 
@@ -47,14 +58,11 @@ class ViewControllerContainerContentView: UIView, UIContentView {
             viewController.view.trailingAnchor.constraint(equalTo: trailingAnchor),
             viewController.view.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
-
-        configuration.parentViewController.addChild(viewController)
+        _configuration.parentViewController.addChild(viewController)
     }
 
     override func systemLayoutSizeFitting(_ targetSize: CGSize, withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority, verticalFittingPriority: UILayoutPriority) -> CGSize {
-        guard let vc = (configuration as? UIViewControllerContentConfiguration)?.viewController else {
-            return super.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: horizontalFittingPriority, verticalFittingPriority: verticalFittingPriority)
-        }
+        let vc = _configuration.viewController
 
         vc.view.layoutSubviews()
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

This is the highest-value optimization in Discover as `setupConstraints` keeps firing when nothing changes as you scroll.

<img width="781" height="169" alt="Screenshot 2026-05-08 at 8 56 40 AM" src="https://github.com/user-attachments/assets/e163b027-476c-40e9-ad14-6e20f6c14d9d" />

- Make `UIViewControllerContentConfiguration` a struct (fewer heap allocations)
- Reduce number of dynamic casts to `UIViewControllerContentConfiguration` to minimum (one)
- Skip relayout if nothing changes

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
