### PR TITLE
[PC-TV] Set profile image

### DIFF
--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -14,11 +14,15 @@ class AppCoordinator {
 
     var state: State = .loading
 
+    var userEmail: String?
+
     func load() async {
         // Ensure database and tables are setup before we go forward
         let _ = DataManager.sharedManager
 
         ServerConfig.shared.syncDelegate = ServerSyncManager.shared
+
+        userEmail = ServerSettings.syncingEmail()
 
         setupCredentials()
 

--- a/Pocket Casts TV App/UI/Common/ProfileImage.swift
+++ b/Pocket Casts TV App/UI/Common/ProfileImage.swift
@@ -4,7 +4,6 @@ import PocketCastsUtils
 
 /// Shows the default profile image view and attempts to load the gravatar using the email
 struct ProfileImage: View {
-    @EnvironmentObject var theme: Theme
     let email: String?
     private let avatarRefreshPublisher = NotificationCenter.default.publisher(for: Constants.Notifications.avatarNeedsRefreshing)
     @State private var forceRefresh: Bool = false
@@ -51,12 +50,10 @@ struct ProfileImage: View {
 
     private var defaultProfileView: some View {
         ZStack {
-            theme.primaryUi05
             Image("profileAvatar")
                 .renderingMode(.template)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
-                .foregroundColor(theme.primaryUi01)
                 .padding()
         }
     }

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -174,4 +174,5 @@ struct MainTabView: View {
 
 #Preview {
     MainTabView()
+        .environment(AppCoordinator())
 }

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -87,6 +87,7 @@ struct MainTabView: View {
     @State private var tabSelection: MainTabRouter = MainTabRouter()
     @FocusState private var focusedArea: FocusArea?
     @State private var scrollOffset: Double = 0
+    @Environment(AppCoordinator.self) var coordinator
 
     enum FocusArea: Hashable {
         case tabBar
@@ -158,7 +159,8 @@ struct MainTabView: View {
         Button {
 
         } label: {
-            Image(ImageResource.userPlaceholder)
+            ProfileImage(email: coordinator.userEmail)
+                .frame(width: 64, height: 64)
         }
         .buttonStyle(.card)
         .focused($focusedArea, equals: .profile)

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1288,7 +1288,6 @@
 		FF321A742FACA3F300226E58 /* Folder+Sortable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F872C59449C0089D34F /* Folder+Sortable.swift */; };
 		FF3248CD2FACCDC200226E58 /* PodcastImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD93FDA020157B2000F6EF55 /* PodcastImageView.swift */; };
 		FF3248CE2FACDDCC00226E58 /* NoArtwork.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD8E76C71B9EA709000E20C7 /* NoArtwork.xcassets */; };
-		FF32AD6F2FAF6EC700226E58 /* ProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D4ED2A04C90400A78468 /* ProfileImage.swift */; };
 		FF32F3CB2FAB7CDF00226E58 /* ColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9A43ED1D067AF20012FD9B /* ColorManager.swift */; };
 		FF32F3CD2FAB7E1F00226E58 /* PlaybackActionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD6297E200EE26200168DF7 /* PlaybackActionHelper.swift */; };
 		FF32F3CE2FAB7F8E00226E58 /* HapticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48D5A5216DB26A00391F9E /* HapticsHelper.swift */; };
@@ -7807,7 +7806,6 @@
 				FF32F3CB2FAB7CDF00226E58 /* ColorManager.swift in Sources */,
 				FF8FF6A42FAA46B60086A867 /* EpisodeManager.swift in Sources */,
 				FF6033FC2FAB4C8300EB3AD5 /* AutoplayHelper.swift in Sources */,
-				FF32AD6F2FAF6EC700226E58 /* ProfileImage.swift in Sources */,
 				FF49FEAD2F9BBCA900E68E0C /* LocalizationHelpers.swift in Sources */,
 				FF492A7A2F9BDA9A00E68E0C /* Constants.swift in Sources */,
 				FF8FFE6E2FAA8F240086A867 /* TranscriptFormat.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1288,6 +1288,7 @@
 		FF321A742FACA3F300226E58 /* Folder+Sortable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10756F872C59449C0089D34F /* Folder+Sortable.swift */; };
 		FF3248CD2FACCDC200226E58 /* PodcastImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD93FDA020157B2000F6EF55 /* PodcastImageView.swift */; };
 		FF3248CE2FACDDCC00226E58 /* NoArtwork.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD8E76C71B9EA709000E20C7 /* NoArtwork.xcassets */; };
+		FF32AD6F2FAF6EC700226E58 /* ProfileImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C713D4ED2A04C90400A78468 /* ProfileImage.swift */; };
 		FF32F3CB2FAB7CDF00226E58 /* ColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9A43ED1D067AF20012FD9B /* ColorManager.swift */; };
 		FF32F3CD2FAB7E1F00226E58 /* PlaybackActionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD6297E200EE26200168DF7 /* PlaybackActionHelper.swift */; };
 		FF32F3CE2FAB7F8E00226E58 /* HapticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48D5A5216DB26A00391F9E /* HapticsHelper.swift */; };
@@ -7806,6 +7807,7 @@
 				FF32F3CB2FAB7CDF00226E58 /* ColorManager.swift in Sources */,
 				FF8FF6A42FAA46B60086A867 /* EpisodeManager.swift in Sources */,
 				FF6033FC2FAB4C8300EB3AD5 /* AutoplayHelper.swift in Sources */,
+				FF32AD6F2FAF6EC700226E58 /* ProfileImage.swift in Sources */,
 				FF49FEAD2F9BBCA900E68E0C /* LocalizationHelpers.swift in Sources */,
 				FF492A7A2F9BDA9A00E68E0C /* Constants.swift in Sources */,
 				FF8FFE6E2FAA8F240086A867 /* TranscriptFormat.swift in Sources */,

--- a/podcasts/Profile - SwiftUI/Common Views/ProfileImage.swift
+++ b/podcasts/Profile - SwiftUI/Common Views/ProfileImage.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Kingfisher
+import PocketCastsUtils
 
 /// Shows the default profile image view and attempts to load the gravatar using the email
 struct ProfileImage: View {
@@ -50,13 +51,16 @@ struct ProfileImage: View {
 
     private var defaultProfileView: some View {
         ZStack {
+        #if !os(tvOS)
             theme.primaryUi05
-
+        #endif
             Image("profileAvatar")
                 .renderingMode(.template)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
+#if !os(tvOS)
                 .foregroundColor(theme.primaryUi01)
+#endif
                 .padding()
         }
     }


### PR DESCRIPTION
📘 Part of: # |  <!-- project issue number, if applicable -->
:---:|

Fixes PCIOS-653

Replaces the static user-placeholder image in the tvOS profile button with a real `ProfileImage` view that loads the signed-in user's Gravatar (with a default fallback when no avatar is available). The signed-in email is captured on `AppCoordinator.load()` from `ServerSettings.syncingEmail()` and read by `MainTabView` via the environment.

A new tvOS-dedicated `ProfileImage` view lives under `Pocket Casts TV App/UI/Common/ProfileImage.swift` so the iOS one can keep its theme-driven background; the iOS variant only picks up an explicit `import PocketCastsUtils` here.

## To test

1. Run the tvOS target signed in with an account that has a Gravatar configured for its email.
2. Navigate to the top of the main tab bar and focus the profile button — the Gravatar should load in place of the old placeholder image.
3. Sign out / sign in with an account that has no Gravatar — the default profile avatar should render.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.