### PR TITLE
POC-606: Synced Transcripts should only work with generated transcripts

### DIFF
--- a/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
+++ b/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
@@ -120,7 +120,7 @@ private class ShowInfoCoordinatorMock: ShowInfoCoordinating {
     }
 
     func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
-        return (transcripts: [], hasGeneratedTranscripts: false)
+        return (transcripts: [], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
     }
 }
 

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
@@ -19,20 +19,20 @@ final class TranscriptManagerTests: XCTestCase {
 
         func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
             guard let transcriptURL = Bundle(for: Self.self).url(forResource: "sample", withExtension: "vtt") else {
-                return (transcripts: [], hasGeneratedTranscripts: false)
+                return (transcripts: [], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
             }
             let transcript = Episode.Metadata.Transcript(url: transcriptURL.absoluteString, type: "text/vtt", language: nil)
-            return (transcripts: [transcript], hasGeneratedTranscripts: false)
+            return (transcripts: [transcript], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
         }
     }
 
     class EmptyMockShowCoordinator: MockShowCoordinator {
         override func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
             guard let transcriptURL = Bundle(for: Self.self).url(forResource: "empty_sample", withExtension: "vtt") else {
-                return (transcripts: [], hasGeneratedTranscripts: false)
+                return (transcripts: [], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
             }
             let transcript = Episode.Metadata.Transcript(url: transcriptURL.absoluteString, type: "text/vtt", language: nil)
-            return (transcripts: [transcript], hasGeneratedTranscripts: false)
+            return (transcripts: [transcript], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
         }
     }
 

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
@@ -26,6 +26,16 @@ final class TranscriptManagerTests: XCTestCase {
         }
     }
 
+    class GeneratedMockShowCoordinator: MockShowCoordinator {
+        override func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
+            guard let transcriptURL = Bundle(for: Self.self).url(forResource: "sample", withExtension: "vtt") else {
+                return (transcripts: [], hasGeneratedTranscripts: true, isDisplayingGeneratedTranscript: true)
+            }
+            let transcript = Episode.Metadata.Transcript(url: transcriptURL.absoluteString, type: "text/vtt", language: nil)
+            return (transcripts: [transcript], hasGeneratedTranscripts: true, isDisplayingGeneratedTranscript: true)
+        }
+    }
+
     class EmptyMockShowCoordinator: MockShowCoordinator {
         override func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
             guard let transcriptURL = Bundle(for: Self.self).url(forResource: "empty_sample", withExtension: "vtt") else {
@@ -44,6 +54,20 @@ final class TranscriptManagerTests: XCTestCase {
 
         XCTAssertFalse(model.cues.isEmpty)
         XCTAssertEqual(model.cues.count, 13)
+    }
+
+    func testIsDisplayingGeneratedTranscriptPropagatesTrue() async throws {
+        let manager = TranscriptManager(episodeUUID: UUID().uuidString, podcastUUID: UUID().uuidString, showCoordinator: GeneratedMockShowCoordinator())
+        _ = try await manager.loadTranscript()
+        XCTAssertTrue(manager.isDisplayingGeneratedTranscript)
+        XCTAssertTrue(manager.hasGeneratedTranscripts)
+    }
+
+    func testIsDisplayingGeneratedTranscriptPropagatesFalse() async throws {
+        let manager = TranscriptManager(episodeUUID: UUID().uuidString, podcastUUID: UUID().uuidString, showCoordinator: MockShowCoordinator())
+        _ = try await manager.loadTranscript()
+        XCTAssertFalse(manager.isDisplayingGeneratedTranscript)
+        XCTAssertFalse(manager.hasGeneratedTranscripts)
     }
 
     func testEmptyLoadingTranscript() async {

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsServer
 
 protocol ShowInfoCoordinating {
-    typealias EpisodeTranscriptData = (transcripts: [Episode.Metadata.Transcript], hasGeneratedTranscripts: Bool)
+    typealias EpisodeTranscriptData = (transcripts: [Episode.Metadata.Transcript], hasGeneratedTranscripts: Bool, isDisplayingGeneratedTranscript: Bool)
 
     func loadShowNotes(
         podcastUuid: String,

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -66,7 +66,7 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
 
     public func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
 #if os(watchOS)
-        return (transcripts: [], hasGeneratedTranscripts: false)
+        return (transcripts: [], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
 #else
         let metadata = try await loadShowInfo(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
 
@@ -83,14 +83,15 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
                 pocketCastsTranscripts = metadata?.pocketCastsTranscripts ?? []
             }
 
+            let isDisplayingGenerated = externalTranscripts.isEmpty && !pocketCastsTranscripts.isEmpty
             let transcripts = externalTranscripts.isEmpty ? pocketCastsTranscripts : externalTranscripts
-            return (transcripts: transcripts, hasGeneratedTranscripts: !pocketCastsTranscripts.isEmpty)
+            return (transcripts: transcripts, hasGeneratedTranscripts: !pocketCastsTranscripts.isEmpty, isDisplayingGeneratedTranscript: isDisplayingGenerated)
         }
 
         guard let transcripts = metadata?.transcripts else {
-            return (transcripts: [], hasGeneratedTranscripts: false)
+            return (transcripts: [], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
         }
-        return (transcripts: transcripts, hasGeneratedTranscripts: false)
+        return (transcripts: transcripts, hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
 #endif
     }
 

--- a/podcasts/TranscriptManager.swift
+++ b/podcasts/TranscriptManager.swift
@@ -38,6 +38,7 @@ class TranscriptManager {
     let showCoordinator: ShowInfoCoordinating
 
     private(set) var hasGeneratedTranscripts: Bool = false
+    private(set) var isDisplayingGeneratedTranscript: Bool = false
 
     init(episodeUUID: String, podcastUUID: String, showCoordinator: ShowInfoCoordinating = ShowInfoCoordinator.shared) {
         self.episodeUUID = episodeUUID
@@ -53,6 +54,7 @@ class TranscriptManager {
         }
         var transcriptsAvailable = metadata.transcripts
         hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
+        isDisplayingGeneratedTranscript = metadata.isDisplayingGeneratedTranscript
         while let transcript = TranscriptFormat.bestTranscript(from: transcriptsAvailable) {
             do {
                 let model = try await loadTranscript(transcript)

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -525,10 +525,6 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         loadTranscript()
         addObservers()
         (transcriptView as UIScrollView).delegate = self
-        if FeatureFlag.syncedTranscripts.enabled, !showFromEpisode {
-            FingerprintTimingManager.shared.prepareForCurrentEpisode()
-        }
-        startHighlightDisplayLink()
         #if DEBUG
         let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
             self?.debugOverlay?.update()
@@ -587,9 +583,6 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         resetKmp()
         resetSearch()
         loadTranscript()
-        if FeatureFlag.syncedTranscripts.enabled {
-            FingerprintTimingManager.shared.prepareForCurrentEpisode()
-        }
     }
 
     @objc private func closeTapped() {
@@ -635,7 +628,12 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 let isDisplayingGenerated = transcriptManager.isDisplayingGeneratedTranscript
                 await MainActor.run {
                     self.setHasGeneratedTranscripts(hasGeneratedTranscripts)
-                    if !isDisplayingGenerated {
+                    if isDisplayingGenerated {
+                        if FeatureFlag.syncedTranscripts.enabled, !self.showFromEpisode {
+                            FingerprintTimingManager.shared.prepareForCurrentEpisode()
+                        }
+                        self.startHighlightDisplayLink()
+                    } else {
                         self.stopSyncedTranscripts()
                     }
                     UIView.animate(withDuration: 0.25) {
@@ -657,6 +655,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 }
                 await show(transcript: transcript, resetPosition: shouldResetPosition)
             } catch {
+                await stopSyncedTranscripts()
                 await track(.transcriptError, properties: ["error_code": (error as NSError).code])
                 await show(error: error)
             }

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -550,6 +550,11 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         #endif
     }
 
+    private func stopSyncedTranscripts() {
+        FingerprintTimingManager.shared.stop()
+        stopHighlightDisplayLink()
+    }
+
     override func themeDidChange() {
         updateColors()
     }
@@ -627,8 +632,12 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             do {
                 let transcript = try await transcriptManager.loadTranscript()
                 let hasGeneratedTranscripts = FeatureFlag.generatedTranscripts.enabled && transcriptManager.hasGeneratedTranscripts
+                let isDisplayingGenerated = transcriptManager.isDisplayingGeneratedTranscript
                 await MainActor.run {
                     self.setHasGeneratedTranscripts(hasGeneratedTranscripts)
+                    if !isDisplayingGenerated {
+                        self.stopSyncedTranscripts()
+                    }
                     UIView.animate(withDuration: 0.25) {
                         if hasGeneratedTranscripts, self.shouldShowPremiumView {
                             self.stackView.alpha = 0


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/POC-606/synced-transcripts-should-only-work-with-generated-transcripts

## Summary
Synced transcript features (fingerprint-based highlighting and tap-to-seek) should only activate when the displayed transcript was generated by Pocket Casts, not when using a show-provided (external) transcript.

## Changes
- Added `isDisplayingGeneratedTranscript` field to `EpisodeTranscriptData` tuple to distinguish "generated transcripts exist" from "the displayed transcript is the generated one"
- Set `isDisplayingGeneratedTranscript = true` only when external transcripts are empty and generated ones are used (i.e., the displayed transcript is actually the Pocket Casts-generated one)
- Propagated the new field through `TranscriptManager`
- In `TranscriptViewController`, after the transcript loads: if the displayed transcript is not generated, stop the `FingerprintTimingManager` and display link to disable synced features (highlighting, auto-scroll, tap-to-seek)

## Verification
- **Lint**: PASS — `make format` ran cleanly
- **Tests**: FAIL — pre-existing build error in `CarPlaySceneDelegate+Convert.swift` (`CPPlaybackConfiguration` not in scope) prevents test execution; unrelated to this PR
- **Diff review**: PASS — confirmed only transcript-related files changed, no unintended changes
- **Secret scan**: PASS — no credentials in diff

## Confidence
**HIGH** — The logic is straightforward: `isDisplayingGeneratedTranscript` mirrors the existing transcript-source selection logic in `ShowInfoCoordinator`, and the gating in the view controller cleanly stops fingerprinting when the transcript is external. All synced transcript behaviors (highlighting, tap-to-seek, auto-scroll) are already gated on `FingerprintTimingManager.shared.state` being `.active`, so stopping the manager effectively disables them.

## Known Issues
- Tests could not run due to pre-existing `CPPlaybackConfiguration` build error in the CarPlay target (unrelated to this PR)

---
This PR was created autonomously by linear-solver.
Triage complexity: simple | [Linear issue](https://linear.app/a8c/issue/POC-606/synced-transcripts-should-only-work-with-generated-transcripts)