### PR TITLE
Liquid Glass: Add indeterminate progress bar to new mini player

### DIFF
--- a/podcasts/MiniPlayerGlassProgressView.swift
+++ b/podcasts/MiniPlayerGlassProgressView.swift
@@ -21,7 +21,7 @@ final class MiniPlayerGlassProgressView: UIView {
             guard indeterminate != oldValue else { return }
             updateBufferVisibility()
             indeterminateLayer.isHidden = !indeterminate
-            if indeterminate {
+            if indeterminate, !UIAccessibility.isReduceMotionEnabled {
                 startIndeterminateAnimation()
             } else {
                 indeterminateLayer.removeAllAnimations()

--- a/podcasts/MiniPlayerGlassProgressView.swift
+++ b/podcasts/MiniPlayerGlassProgressView.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import UIKit
 
 final class MiniPlayerGlassProgressView: UIView {
@@ -7,20 +8,54 @@ final class MiniPlayerGlassProgressView: UIView {
         }
     }
 
+    var bufferedAmount: CGFloat = 0 {
+        didSet {
+            guard bufferedAmount != oldValue else { return }
+            setNeedsLayout()
+            updateBufferColor()
+        }
+    }
+
+    var indeterminate: Bool = false {
+        didSet {
+            guard indeterminate != oldValue else { return }
+            updateBufferVisibility()
+            indeterminateLayer.isHidden = !indeterminate
+            if indeterminate {
+                startIndeterminateAnimation()
+            } else {
+                indeterminateLayer.removeAllAnimations()
+            }
+        }
+    }
+
     var tintColorOverride: UIColor = .black {
-        didSet { playbackLayer.backgroundColor = tintColorOverride.cgColor }
+        didSet { applyTintColor() }
     }
 
     private let trackLayer = CALayer()
     private let playbackLayer = CALayer()
+    private let bufferLayer = CALayer()
+    private let indeterminateLayer = CAGradientLayer()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        layer.masksToBounds = true
         layer.addSublayer(trackLayer)
+        layer.addSublayer(bufferLayer)
         layer.addSublayer(playbackLayer)
-        trackLayer.backgroundColor = UIColor.gray.withAlphaComponent(0.3).cgColor
-        playbackLayer.backgroundColor = tintColorOverride.cgColor
+        layer.addSublayer(indeterminateLayer)
+        trackLayer.backgroundColor = MiniPlayerGlassProgressView.trackColor.cgColor
+        bufferLayer.backgroundColor = MiniPlayerGlassProgressView.bufferColor.cgColor
+        bufferLayer.isHidden = true
+        indeterminateLayer.isHidden = true
+        indeterminateLayer.startPoint = CGPoint(x: 0, y: 0.5)
+        indeterminateLayer.endPoint = CGPoint(x: 1, y: 0.5)
+        applyTintColor()
     }
+
+    private static let trackColor = UIColor.gray.withAlphaComponent(0.27)
+    private static let bufferColor = UIColor.gray.withAlphaComponent(0.32)
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -36,13 +71,147 @@ final class MiniPlayerGlassProgressView: UIView {
         let height = bounds.height
         let radius = height / 2
 
+        layer.cornerRadius = radius
         trackLayer.frame = bounds
         trackLayer.cornerRadius = radius
 
         let clampedPlayback = max(0, min(1, playbackProgress))
-        playbackLayer.frame = CGRect(x: 0, y: 0, width: width * clampedPlayback, height: height)
+        let progressWidth = width * clampedPlayback
+        playbackLayer.frame = CGRect(x: 0, y: 0, width: progressWidth, height: height)
         playbackLayer.cornerRadius = radius
+
+        updateBufferVisibility()
+        if !bufferLayer.isHidden {
+            let clampedBuffer = max(0, min(1, bufferedAmount))
+            bufferLayer.frame = CGRect(x: 0, y: 0, width: width * clampedBuffer, height: height)
+            bufferLayer.cornerRadius = radius
+        }
+
+        if indeterminate {
+            if indeterminateLayer.animation(forKey: "shimmer") == nil {
+                startIndeterminateAnimation()
+            }
+        }
 
         CATransaction.commit()
     }
+
+    private func applyTintColor() {
+        playbackLayer.backgroundColor = tintColorOverride.cgColor
+        let edge = UIColor.white.withAlphaComponent(0).cgColor
+        let peak = UIColor.white.withAlphaComponent(0.55).cgColor
+        indeterminateLayer.colors = [edge, peak, edge]
+        indeterminateLayer.locations = [0, 0.5, 1]
+    }
+
+    private func updateBufferVisibility() {
+        bufferLayer.isHidden = indeterminate || bufferedAmount <= 0
+    }
+
+    private func updateBufferColor() {
+        let target = bufferedAmount >= 1 ? Self.trackColor : Self.bufferColor
+        let current = bufferLayer.backgroundColor
+        guard current != target.cgColor else { return }
+
+        let animation = CABasicAnimation(keyPath: "backgroundColor")
+        animation.fromValue = current
+        animation.toValue = target.cgColor
+        animation.duration = 0.5
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        bufferLayer.add(animation, forKey: "bufferColorFade")
+        bufferLayer.backgroundColor = target.cgColor
+    }
+
+    private func startIndeterminateAnimation() {
+        indeterminateLayer.removeAllAnimations()
+
+        let width = bounds.width
+        let height = bounds.height
+        guard width > 0, height > 0 else { return }
+
+        let gradientWidth = width
+        indeterminateLayer.anchorPoint = CGPoint(x: 0.5, y: 0.5)
+        indeterminateLayer.bounds = CGRect(x: 0, y: 0, width: gradientWidth, height: height)
+        indeterminateLayer.position = CGPoint(x: -gradientWidth / 2, y: height / 2)
+
+        let animation = CABasicAnimation(keyPath: "position.x")
+        animation.fromValue = -gradientWidth / 2
+        animation.toValue = width + gradientWidth / 2
+        animation.duration = 1.4
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        animation.repeatCount = .greatestFiniteMagnitude
+        indeterminateLayer.add(animation, forKey: "shimmer")
+    }
+}
+
+private struct GlassProgressPreview: UIViewRepresentable {
+    var progress: CGFloat = 0
+    var bufferedAmount: CGFloat = 0
+    var indeterminate: Bool = false
+    var tint: UIColor = .systemPurple
+
+    func makeUIView(context: Context) -> MiniPlayerGlassProgressView {
+        MiniPlayerGlassProgressView()
+    }
+
+    func updateUIView(_ view: MiniPlayerGlassProgressView, context: Context) {
+        view.tintColorOverride = tint
+        view.playbackProgress = progress
+        view.bufferedAmount = bufferedAmount
+        view.indeterminate = indeterminate
+    }
+}
+
+private struct GlassProgressPreviewRow<Content: View>: View {
+    let label: String
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(label)
+                .font(.caption)
+                .frame(width: 120, alignment: .leading)
+            content()
+                .frame(width: 44, height: 5)
+        }
+    }
+}
+
+#Preview("States") {
+    VStack(alignment: .leading, spacing: 16) {
+        GlassProgressPreviewRow(label: "Empty") {
+            GlassProgressPreview(progress: 0)
+        }
+        GlassProgressPreviewRow(label: "40%") {
+            GlassProgressPreview(progress: 0.4)
+        }
+        GlassProgressPreviewRow(label: "Complete") {
+            GlassProgressPreview(progress: 1)
+        }
+        GlassProgressPreviewRow(label: "With buffer") {
+            GlassProgressPreview(progress: 0.3, bufferedAmount: 0.5)
+        }
+        GlassProgressPreviewRow(label: "Buffer only") {
+            GlassProgressPreview(progress: 0, bufferedAmount: 0.6)
+        }
+        GlassProgressPreviewRow(label: "Indeterminate") {
+            GlassProgressPreview(indeterminate: true)
+        }
+        GlassProgressPreviewRow(label: "Custom tint") {
+            GlassProgressPreview(progress: 0.6, tint: .systemOrange)
+        }
+    }
+    .padding()
+}
+
+#Preview("Inline width") {
+    VStack(alignment: .leading, spacing: 16) {
+        GlassProgressPreview(progress: 0.4)
+            .frame(width: 34, height: 5)
+        GlassProgressPreview(progress: 0.4, bufferedAmount: 0.5)
+            .frame(width: 34, height: 5)
+        GlassProgressPreview(indeterminate: true)
+            .frame(width: 34, height: 5)
+    }
+    .padding()
 }

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -178,7 +178,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
             NSLayoutConstraint.deactivate(accessoryEnvironmentConstraints)
             accessoryEnvironmentConstraints = [
-                glassProgressView.widthAnchor.constraint(equalToConstant: isInline ? 34 : 40),
+                glassProgressView.widthAnchor.constraint(equalToConstant: isInline ? 34 : 44),
                 glassButtonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: isInline ? -4 : -8),
             ]
             NSLayoutConstraint.activate(accessoryEnvironmentConstraints)
@@ -412,6 +412,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         }
 
         glassProgressView?.playbackProgress = progress
+        glassProgressView?.indeterminate = PlaybackManager.shared.buffering() && PlaybackManager.shared.playing()
 
         if let episodeTimeLeftLabel {
             let remaining = max(0, duration - currentTime)

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -403,8 +403,10 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             progress = min(1, CGFloat(currentTime / duration))
         }
 
+        let isIndeterminate = PlaybackManager.shared.buffering() && PlaybackManager.shared.playing()
+
         playbackProgressView.progress = progress
-        playbackProgressView.indeterminant = PlaybackManager.shared.buffering() && PlaybackManager.shared.playing()
+        playbackProgressView.indeterminant = isIndeterminate
 
         let amountBuferred = PlaybackManager.shared.futureBufferAvailable()
         if amountBuferred > 0 {
@@ -412,7 +414,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         }
 
         glassProgressView?.playbackProgress = progress
-        glassProgressView?.indeterminate = PlaybackManager.shared.buffering() && PlaybackManager.shared.playing()
+        glassProgressView?.indeterminate = isIndeterminate
 
         if let episodeTimeLeftLabel {
             let remaining = max(0, duration - currentTime)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

- Adds understated `indeterminate` state to new mini progress view
- Make the progress view a notch wider
- Add "buffered" layer as well. I tried enabling it, but it seems a bit misleading at the moment. It seems to show the amount that the player buffered and not the download progress. In practice, we want to see the download progress. @SergioEstevao ,wdyt? How would you recommend approaching it?

## To test

- **Verify** that is shows a small indeterminate effect

https://github.com/user-attachments/assets/14577a8d-0027-4c2e-8357-ae845198eb72



## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
