### PR TITLE
Ensure UpNext is synced when entering screen and login

### DIFF
--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -21,7 +21,8 @@ class AppCoordinator {
         let _ = DataManager.sharedManager
 
         ServerConfig.shared.syncDelegate = ServerSyncManager.shared
-
+        ServerConfig.shared.playbackDelegate = PlaybackManager.shared
+        
         userEmail = ServerSettings.syncingEmail()
 
         setupCredentials()

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -22,7 +22,7 @@ class AppCoordinator {
 
         ServerConfig.shared.syncDelegate = ServerSyncManager.shared
         ServerConfig.shared.playbackDelegate = PlaybackManager.shared
-        
+
         userEmail = ServerSettings.syncingEmail()
 
         setupCredentials()

--- a/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
@@ -19,7 +19,8 @@ protocol SigningInViewModelProtocol: AnyObject, Observation.Observable {
 }
 
 enum SigningInState: Equatable, Hashable {
-    case waiting
+    case waitingForPodcastsSync
+    case waitingForUpNextSync
     case finished
 }
 
@@ -27,7 +28,7 @@ enum SigningInState: Equatable, Hashable {
 class SigningInViewModel: SigningInViewModelProtocol {
     private var cancellables: Set<AnyCancellable> = []
 
-    private(set) var state: SigningInState = .waiting
+    private(set) var state: SigningInState = .waitingForPodcastsSync
 
     var podcasts: [Podcast] = []
 
@@ -37,9 +38,11 @@ class SigningInViewModel: SigningInViewModelProtocol {
     var progress: CGFloat = 0
 
     private let dataManager: DataManager
+    private let refreshManager: RefreshManager
 
-    init(dataManager: DataManager = DataManager.sharedManager) {
+    init(dataManager: DataManager = DataManager.sharedManager, refreshManager: RefreshManager = RefreshManager.shared ) {
         self.dataManager = dataManager
+        self.refreshManager = refreshManager
     }
 
     func sync() {
@@ -107,8 +110,9 @@ class SigningInViewModel: SigningInViewModelProtocol {
                 guard let self else {
                     return
                 }
-
                 title = L10n.syncInProgress
+                state = .waitingForUpNextSync
+                refreshManager.syncUpNext()
             }
             .store(in: &cancellables)
     }
@@ -156,7 +160,7 @@ class SigningInViewModelMock: SigningInViewModelProtocol {
 
     private var cancellable: AnyCancellable?
 
-    var state: SigningInState = .waiting
+    var state: SigningInState = .waitingForPodcastsSync
 
     var totalPodcastsToImport: Int = MockData.makeStubPodcasts().count
 

--- a/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
@@ -112,6 +112,7 @@ class SigningInViewModel: SigningInViewModelProtocol {
                 }
                 title = L10n.syncInProgress
                 state = .waitingForUpNextSync
+                SyncManager.syncReason = .login
                 refreshManager.syncUpNext()
             }
             .store(in: &cancellables)

--- a/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
@@ -21,7 +21,7 @@ class UpNextViewModel {
     init(dataManager: DataManager = DataManager.sharedManager, refreshManager: RefreshManager = RefreshManager.shared) {
         self.dataManager = dataManager
         self.refreshManager = refreshManager
-        observeUpNextSyncCompleted()
+        observeUpNextChanges()
     }
 
     func load() {
@@ -54,7 +54,7 @@ class UpNextViewModel {
         dataManager.allUpNextEpisodes()
     }
 
-    fileprivate func observeUpNextSyncCompleted() {
+    fileprivate func observeUpNextChanges() {
         NotificationCenter.default.publisher(for: Constants.Notifications.upNextQueueChanged)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in

--- a/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
@@ -25,8 +25,18 @@ class UpNextViewModel {
     }
 
     func load() {
+        refreshServerData()
+        fetchLocalData()
+    }
+
+    private func refreshServerData() {
         Task {
             refreshManager.syncUpNext()
+        }
+    }
+
+    private func fetchLocalData() {
+        Task {
             let fetched = fetchUpNextEpisodes()
             let episodes = fetched.map { episode in
                 let podcast = (episode as? Episode).flatMap { $0.parentPodcast(dataManager: dataManager) }

--- a/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
@@ -31,6 +31,7 @@ class UpNextViewModel {
 
     private func refreshServerData() {
         Task {
+            SyncManager.syncReason = nil
             refreshManager.syncUpNext()
         }
     }

--- a/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import Combine
 import PocketCastsDataModel
+import PocketCastsServer
 
 @Observable
 class UpNextViewModel {
-
+    private var cancellables: Set<AnyCancellable> = []
     private let dataManager: DataManager
+    private let refreshManager: RefreshManager
 
     enum State: Equatable, Hashable {
         case loading
@@ -16,12 +18,15 @@ class UpNextViewModel {
     var state: State = .loading
     var episodes: [EpisodeRowViewModel] = []
 
-    init(dataManager: DataManager = DataManager.sharedManager) {
+    init(dataManager: DataManager = DataManager.sharedManager, refreshManager: RefreshManager = RefreshManager.shared) {
         self.dataManager = dataManager
+        self.refreshManager = refreshManager
+        observeUpNextSyncCompleted()
     }
 
     func load() {
         Task {
+            refreshManager.syncUpNext()
             let fetched = fetchUpNextEpisodes()
             let episodes = fetched.map { episode in
                 let podcast = (episode as? Episode).flatMap { $0.parentPodcast(dataManager: dataManager) }
@@ -37,5 +42,17 @@ class UpNextViewModel {
 
     private func fetchUpNextEpisodes() -> [BaseEpisode] {
         dataManager.allUpNextEpisodes()
+    }
+
+    fileprivate func observeUpNextSyncCompleted() {
+        NotificationCenter.default.publisher(for: Constants.Notifications.upNextQueueChanged)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else {
+                    return
+                }
+                load()
+            }
+            .store(in: &cancellables)
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-656 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Ensure that UpNext data is synced on login and refreshed when accessing screen

## To test

1. Start the app
2. Login with an user with UpNext Sync history
3. Go to UpNext tab
4. Check if data shows correctly
5. Change UpNext on mobile or web
6. Exit and Enter back to UpNext
7. Check if upnext queue is refreshed

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
