### PR TITLE
Fix header view appearing after a long delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 8.13
 -----
-
+- Fix an issue with Podcast header view sometimes appearing after a noticable delay [#4305](https://github.com/Automattic/pocket-casts-ios/pull/4305)
 
 8.12
 -----

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderModel.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderModel.swift
@@ -70,11 +70,12 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
 
     private static func makeDisplayCategoryAndAuthor(for podcast: Podcast) -> AttributedString {
         let category = podcast.podcastCategory?.localized(seperatingWith: \.isNewline) ?? ""
-        var markdown = "[\(category)](http://pocketcasts.com)"
+        var attributed = AttributedString(category)
+        attributed.link = URL(string: "http://pocketcasts.com")
         if let author = podcast.author {
-            markdown += " · \(author)"
+            attributed.append(AttributedString(" · \(author)"))
         }
-        return (try? AttributedString(markdown: markdown)) ?? AttributedString("")
+        return attributed
     }
 
     var displayAuthor: String? {

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -74,7 +74,12 @@ protocol PodcastActionsDelegate: AnyObject {
 
 class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigninDelegate, MultiSelectActionDelegate {
     var podcast: Podcast?
-    var episodeInfo = [ArraySection<String, ListItem>]()
+    var episodeInfo: [ArraySection<String, ListItem>] = {
+        // Seed with the search-header section so the podcast header row renders
+        // immediately on first layout, without waiting for the async episode fetch.
+        let searchHeader = ListHeader(headerTitle: L10n.search, isSectionHeader: true, sectionNumber: -1)
+        return [ArraySection(model: searchHeader.headerTitle, elements: [searchHeader])]
+    }()
     var uuidsThatMatchSearch = [String]()
     var featuredPodcast = false
     var listUuid: String?


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

The header view is currently rendered only after episodes are loaded. On the first load, it takes 60+ ms, which is noticeable during push. With this change, the header is shown instantly on `viewWillAppear`. There is still a tiny bit of a delay due to how the header and its layout are implemented, but it's a noticeable improvement.

## To test

Before / After


https://github.com/user-attachments/assets/58910086-c244-4158-828e-094bd6aaaa6a


https://github.com/user-attachments/assets/ab7e0390-7717-4f2f-b2d2-d482a7b93844



## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
