### PR TITLE
Remove unused code from FakeNavViewController

### DIFF
--- a/podcasts/Common Components/FakeNavViewController.swift
+++ b/podcasts/Common Components/FakeNavViewController.swift
@@ -19,19 +19,12 @@ class FakeNavViewController: PCViewController, UIScrollViewDelegate {
         }
     }
 
-    enum NavDisplayMode {
-        case navController, card
-    }
-
-    var showNavBarOnHide = true
-
-    var displayMode = NavDisplayMode.navController
     var closeTapped: (() -> Void)?
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let navBar = LegacyFakeNavigationBar(displayMode: displayMode)
+        let navBar = LegacyFakeNavigationBar()
         navBar.onCloseTapped = { [weak self] in
             self?.closeTapped?()
         }
@@ -63,25 +56,11 @@ class FakeNavViewController: PCViewController, UIScrollViewDelegate {
         }
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        if displayMode == .navController, showNavBarOnHide {
-            if let navController = navigationController {
-                navController.setNavigationBarHidden(false, animated: true)
-            } else {
-                // there's a case when iOS pops a tab that it takes away our navigationController earlier than normal, handle that here
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.unhideNavBarRequested)
-            }
-        }
-    }
-
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        if let window = view.window {
-            let statusBarHeight = displayMode == .card ? 9 : UIUtil.statusBarHeight(in: window)
-            navBar.height = FakeNavViewController.navBarBaseHeight + statusBarHeight
+        if view.window != nil {
+            navBar.height = FakeNavViewController.navBarBaseHeight + 9
         }
     }
 
@@ -151,13 +130,11 @@ private final class LegacyFakeNavigationBar: UIView {
     }
 
     private let titleLabel = UILabel()
-    private let displayMode: FakeNavViewController.NavDisplayMode
     private var heightConstraint: NSLayoutConstraint!
     private var titleMaxWidthConstraint: NSLayoutConstraint!
     private var backButtonLeadingConstraint: NSLayoutConstraint!
 
-    init(displayMode: FakeNavViewController.NavDisplayMode) {
-        self.displayMode = displayMode
+    init() {
         self.backButton = UIButton(frame: CGRect(x: 0, y: 21, width: 40, height: 44))
         super.init(frame: .zero)
         setUp()
@@ -177,22 +154,13 @@ private final class LegacyFakeNavigationBar: UIView {
 
         backButton.isPointerInteractionEnabled = true
         backButton.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
-        let backImage = displayMode == .navController ? UIImage(systemName: "chevron.backward") : UIImage(named: "episode-close")
-        backButton.setImage(backImage, for: .normal)
+        backButton.setImage(UIImage(named: "episode-close"), for: .normal)
         backButton.accessibilityLabel = L10n.close
         backButton.accessibilityIdentifier = "Close"
         addSubview(backButton)
         backButton.translatesAutoresizingMaskIntoConstraints = false
-        var margin: CGFloat = 0
-        var buttonSize: CGFloat = 44
-        if displayMode == .navController {
-            buttonSize = 32
-            backButton.layer.cornerRadius = buttonSize / 2
-            backButton.layer.masksToBounds = true
-            margin = 16
-        }
-        let leadingOffset: CGFloat = displayMode == .navController ? margin : 6
-        backButtonLeadingConstraint = backButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: leadingOffset)
+        let buttonSize: CGFloat = 44
+        backButtonLeadingConstraint = backButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6)
         NSLayoutConstraint.activate([
             backButton.widthAnchor.constraint(equalToConstant: buttonSize),
             backButton.heightAnchor.constraint(equalToConstant: buttonSize),
@@ -226,23 +194,7 @@ private final class LegacyFakeNavigationBar: UIView {
     func addRightActionButton(_ button: UIButton) {
         button.isPointerInteractionEnabled = true
         addSubview(button)
-        var buttonSize: CGFloat = 44
-        var imageSize: CGFloat = 24
-        if displayMode == .navController {
-            buttonSize = 32
-            imageSize = 20
-            button.imageView?.contentMode = .scaleAspectFit
-            if let imageView = button.imageView {
-                imageView.translatesAutoresizingMaskIntoConstraints = false
-                imageView.frame = CGRect(x: 0, y: 0, width: imageSize, height: imageSize)
-                NSLayoutConstraint.activate([
-                    imageView.widthAnchor.constraint(equalToConstant: imageSize),
-                    imageView.heightAnchor.constraint(equalToConstant: imageSize),
-                ])
-            }
-            button.layer.cornerRadius = buttonSize / 2
-            button.layer.masksToBounds = true
-        }
+        let buttonSize: CGFloat = 44
         button.translatesAutoresizingMaskIntoConstraints = false
         if rightActionButtons.isEmpty {
             // if there are no other buttons, anchor this one to the edge

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -47,7 +47,6 @@ struct Constants {
         static let remoteCommandSettingsChanged = NSNotification.Name(rawValue: "SJRemoteCommandSettingsChanged")
         static let currentlyPlayingEpisodeUpdated = NSNotification.Name(rawValue: "SJCurrentlyPlayingEpisodeUpdated")
         static let sleepTimerChanged = NSNotification.Name(rawValue: "SJSleepTimerChanged")
-        static let unhideNavBarRequested = NSNotification.Name(rawValue: "SJUnhideNavBar")
         static let videoPlaybackEngineSwitched = NSNotification.Name(rawValue: "SJVideoPlaybackEngineSwitched")
 
         // episode notifications

--- a/podcasts/Episode/EpisodeDetailViewController.swift
+++ b/podcasts/Episode/EpisodeDetailViewController.swift
@@ -212,7 +212,6 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     // MARK: - View
 
     override func viewDidLoad() {
-        displayMode = .card
         super.viewDidLoad()
 
         addBookmarksTabIfNeeded()

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -126,7 +126,6 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         NotificationCenter.default.addObserver(self, selector: #selector(textEditingDidEnd), name: Constants.Notifications.textEditingDidEnd, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleFollowSystemThemeTurnedOn), name: Constants.Notifications.followSystemThemeTurnedOn, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(unhideNavBar), name: Constants.Notifications.unhideNavBarRequested, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(profileSeen), name: Constants.Notifications.profileSeen, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(refreshProfileTabAvatar), name: .userLoginDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(refreshProfileTabAvatarForcingReload), name: Constants.Notifications.avatarNeedsRefreshing, object: nil)
@@ -849,12 +848,6 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         if lastNotifiedAboutDark == nil || isDark != lastNotifiedAboutDark {
             lastNotifiedAboutDark = isDark
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.systemThemeMayHaveChanged, object: isDark)
-        }
-    }
-
-    @objc private func unhideNavBar() {
-        if let navController = selectedViewController as? UINavigationController {
-            navController.setNavigationBarHidden(false, animated: true)
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

`FakeNavViewController` is now only used in `EpisodeDetailViewController` (and I plan to remove it from there as well if time allows; low priority).

## To test

Smoke test "Episode Details" screen.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
