### PR TITLE
Fix missing system appearance observer

### DIFF
--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -141,9 +141,12 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     private var cancellables = Set<AnyCancellable>()
 
+    private var systemAppearanceObservation: Any?
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        registerSceneAppearanceObserverIfNeeded()
         fireSystemThemeMayHaveChanged()
         checkSubscriptionStatusChanged()
         checkPromotionFinishedAcknowledged()
@@ -838,6 +841,23 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     @objc private func willEnterForeground() {
         fireSystemThemeMayHaveChanged()
         checkSubscriptionStatusChanged()
+    }
+
+    // The window's `overrideUserInterfaceStyle` masks system appearance changes
+    // from view controllers inside it, so `traitCollectionDidChange` never fires
+    // for system light/dark flips. Observe at the scene level instead — scene
+    // traits aren't affected by the per-window override.
+    private func registerSceneAppearanceObserverIfNeeded() {
+        guard systemAppearanceObservation == nil,
+              LiquidGlass.isEnabled,
+              #available(iOS 17.0, *),
+              let scene = view.window?.windowScene else { return }
+        systemAppearanceObservation = scene.registerForTraitChanges(
+            [UITraitUserInterfaceStyle.self]
+        ) { [weak self] (scene: UIWindowScene, _: UITraitCollection) in
+            Theme.systemIsDark = (scene.traitCollection.userInterfaceStyle == .dark)
+            self?.fireSystemThemeMayHaveChanged()
+        }
     }
 
     private var lastNotifiedAboutDark: Bool?

--- a/podcasts/SceneDelegate.swift
+++ b/podcasts/SceneDelegate.swift
@@ -4,6 +4,8 @@ import PocketCastsUtils
 
 class SceneDelegate: UIResponder, UISceneDelegate, UIWindowSceneDelegate {
     var window: UIWindow?
+    private var systemAppearanceObservation: Any?
+
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
@@ -16,6 +18,19 @@ class SceneDelegate: UIResponder, UISceneDelegate, UIWindowSceneDelegate {
         Theme.systemIsDark = (windowScene.traitCollection.userInterfaceStyle == .dark)
         window.applyInterfaceStyleForActiveTheme()
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
+
+        // The window's `overrideUserInterfaceStyle` masks system appearance changes
+        // from view controllers inside the window, so `MainTabBarController.traitCollectionDidChange`
+        // never fires for system light/dark flips. Observe at the scene level instead —
+        // scene traits are not affected by the per-window override.
+        if LiquidGlass.isEnabled, #available(iOS 17.0, *) {
+            systemAppearanceObservation = windowScene.registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (scene: UIWindowScene, _: UITraitCollection) in
+                let isDark = (scene.traitCollection.userInterfaceStyle == .dark)
+                guard Theme.systemIsDark != isDark else { return }
+                Theme.systemIsDark = isDark
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.systemThemeMayHaveChanged, object: isDark)
+            }
+        }
 
         window.makeKeyAndVisible()
 

--- a/podcasts/SceneDelegate.swift
+++ b/podcasts/SceneDelegate.swift
@@ -4,7 +4,6 @@ import PocketCastsUtils
 
 class SceneDelegate: UIResponder, UISceneDelegate, UIWindowSceneDelegate {
     var window: UIWindow?
-    private var systemAppearanceObservation: Any?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
@@ -18,19 +17,6 @@ class SceneDelegate: UIResponder, UISceneDelegate, UIWindowSceneDelegate {
         Theme.systemIsDark = (windowScene.traitCollection.userInterfaceStyle == .dark)
         window.applyInterfaceStyleForActiveTheme()
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
-
-        // The window's `overrideUserInterfaceStyle` masks system appearance changes
-        // from view controllers inside the window, so `MainTabBarController.traitCollectionDidChange`
-        // never fires for system light/dark flips. Observe at the scene level instead —
-        // scene traits are not affected by the per-window override.
-        if LiquidGlass.isEnabled, #available(iOS 17.0, *) {
-            systemAppearanceObservation = windowScene.registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (scene: UIWindowScene, _: UITraitCollection) in
-                let isDark = (scene.traitCollection.userInterfaceStyle == .dark)
-                guard Theme.systemIsDark != isDark else { return }
-                Theme.systemIsDark = isDark
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.systemThemeMayHaveChanged, object: isDark)
-            }
-        }
 
         window.makeKeyAndVisible()
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes a regression introduced in https://github.com/Automattic/pocket-casts-ios/pull/4284 by adding a new system appearance observer. The linked PR added code that sets appearance override on `UIWindow`. 

## To test

- Verify that if you change the system theme (light/dark) while the app is running, the app is updated accordingly 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
