### PR TITLE
Remove redundant endEditing from scrollViewDidScroll in Podcast Details

### DIFF
--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -367,10 +367,6 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
             }
             updateNavBarBlur()
         }
-
-        if scrollView.isDragging || scrollView.isDecelerating {
-            dismissKeyboardForScrollIfNeeded()
-        }
     }
 
     /// Forces the standard (blurred) navigation bar appearance whenever multi-select is on or the


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

This registers in a profiler (`endEditing`).

## To test

Verify that keyboard during search still gets dismissed via "willBegin" delegate methods.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
