### PR TITLE
Optimize makeDisplayCategoryAndAuthor

### DIFF
--- a/Pocket Casts TV App/UI/Player/EpisodePlayerView.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodePlayerView.swift
@@ -46,7 +46,7 @@ struct EpisodePlayerView: UIViewControllerRepresentable {
     }
 
     private func makePlaybackSpeedMenu(player: AVPlayer) -> UIMenu {
-        let speeds = stride(from: 1.0, through: 3.0, by: 0.1).map { $0 }
+        let speeds = Array(stride(from: 1.0, through: 3.0, by: 0.1))
         let actions = speeds.map { speed in
             UIAction(
                 title: String(format: "%.1fx", speed),

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderModel.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderModel.swift
@@ -70,11 +70,12 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
 
     private static func makeDisplayCategoryAndAuthor(for podcast: Podcast) -> AttributedString {
         let category = podcast.podcastCategory?.localized(seperatingWith: \.isNewline) ?? ""
-        var markdown = "[\(category)](http://pocketcasts.com)"
+        var result = AttributedString(category)
+        result.link = URL(string: "http://pocketcasts.com")
         if let author = podcast.author {
-            markdown += " · \(author)"
+            result += AttributedString(" · \(author)")
         }
-        return (try? AttributedString(markdown: markdown)) ?? AttributedString("")
+        return result
     }
 
     var displayAuthor: String? {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

The Markdown parser is expensive. It takes a whole 16ms when pushing the Podcast Details screen just for this method.

<img width="670"  alt="Screenshot 2026-05-13 at 10 37 59 AM" src="https://github.com/user-attachments/assets/000502c8-6d99-404f-b7ce-a1a3b0869a5a" />

## To test

It renders this label and makes it tappable:

<img width="456" height="972" alt="Screenshot 2026-05-13 at 10 40 35 AM" src="https://github.com/user-attachments/assets/8eddacaf-418e-4052-bae1-92b1c1c49285" />

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
