### PR TITLE
TV: Add sign in/out support and QR/manual login switch

### DIFF
--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -14,7 +14,7 @@ class AppCoordinator {
 
     var state: State = .loading
 
-    var userEmail: String?
+    var userState: UserStateModel = UserStateModel()
 
     func load() async {
         // Ensure database and tables are setup before we go forward
@@ -23,13 +23,19 @@ class AppCoordinator {
         ServerConfig.shared.syncDelegate = ServerSyncManager.shared
         ServerConfig.shared.playbackDelegate = PlaybackManager.shared
 
-        userEmail = ServerSettings.syncingEmail()
-
         setupCredentials()
 
         setupUniqueAppId()
 
-        state = .welcome
+        await MainActor.run {
+            userState.refresh()
+            if userState.isLoggedIn {
+                state = .signedIn
+            } else {
+                state = .welcome
+            }
+            self.userState = userState
+        }
     }
 
     private func setupCredentials() {

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -14,7 +14,7 @@ class AppCoordinator {
 
     var state: State = .loading
 
-    var userState: UserStateModel = UserStateModel()
+    var userState = UserStateModel()
 
     func load() async {
         // Ensure database and tables are setup before we go forward

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -34,8 +34,11 @@ class AppCoordinator {
             } else {
                 state = .welcome
             }
-            self.userState = userState
         }
+    }
+
+    func signIn() {
+        state = .welcome
     }
 
     private func setupCredentials() {

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -34,8 +34,8 @@ struct SignInView: View {
 
         var description: String {
             switch self {
-            case .qr: "QR"
-            case .manual: "Manual"
+            case .qr: L10n.tvUserSignInOptionQr
+            case .manual: L10n.tvUserSignInOptionManual
             }
         }
     }
@@ -52,7 +52,7 @@ struct SignInView: View {
                 Text(L10n.tvSignInSubtitle)
                     .font(.headline)
                     .foregroundStyle(Color.textSecondary)
-                Picker("Type", selection: $loginType) {
+                Picker(L10n.tvUserSignInLoginType, selection: $loginType) {
                     ForEach(LoginType.allCases, id: \.self) { type in
                         Text(type.description).tag(type)
                     }

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -28,6 +28,20 @@ struct SignInView: View {
         return attributedString
     }
 
+    enum LoginType: Int, CaseIterable {
+        case qr
+        case manual
+
+        var description: String {
+            switch self {
+            case .qr: "QR"
+            case .manual: "Manual"
+            }
+        }
+    }
+
+    @State private var loginType: LoginType = .manual
+
     var body: some View {
         ZStack(alignment: .top) {
             VStack(spacing: 32) {
@@ -38,26 +52,36 @@ struct SignInView: View {
                 Text(L10n.tvSignInSubtitle)
                     .font(.headline)
                     .foregroundStyle(Color.textSecondary)
-                Spacer()
-                if manualLogin {
+                Picker("Type", selection: $loginType) {
+                    ForEach(LoginType.allCases, id: \.self) { type in
+                        Text(type.description).tag(type)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 500)
+                switch loginType {
+                case .manual:
                     usernamePasswordLogin
-                } else {
+                case .qr:
                     QRCodeView()
+                    separator
+                    Text(L10n.tvSignInEnterCode)
+                        .font(.headline)
+                        .foregroundStyle(Color.textSecondary)
+                    qrCodeDigits
+                    Text(attributed)
+                        .font(.headline)
+                        .foregroundStyle(Color.textSecondary)
                 }
                 Spacer()
-                separator
-                Text(L10n.tvSignInEnterCode)
-                    .font(.headline)
-                    .foregroundStyle(Color.textSecondary)
-                qrCodeDigits
-                Text(attributed)
-                    .font(.headline)
-                    .foregroundStyle(Color.textSecondary)
             }
         }
         .task {
-            if !manualLogin {
+            switch loginType {
+            case .qr:
                 model.signinWait()
+            case .manual:
+                break
             }
         }
         .onChange(of: model.state) {

--- a/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
@@ -33,13 +33,7 @@ class SignInViewModel {
     var codes: [String] = ["J", "M", "R", "S", "3", "W"]
 
     func signinWait() {
-        state = .waiting
-        cancellable = Timer.publish(every: 5.0, on: .main, in: .common)
-                    .autoconnect()
-                    .sink { [weak self] _ in
-                        guard let self else { return }
-                        state = .finished
-                    }
+        //TODO: Implement call to poll for validation
     }
 
     func manualSignIn(username: String, password: String) async {

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -155,21 +155,30 @@ struct MainTabView: View {
         }
     }
 
+    @State var showUserActions: Bool = false
     var rightAccessory: some View {
         Button {
-
+            showUserActions.toggle()
         } label: {
             if let email = coordinator.userState.usernameEmail {
                 ProfileImage(email: email)
                     .frame(width: 64, height: 64)
             } else {
-                Image("")
+                Image(ImageResource.profileTab)
                     .frame(width: 64, height: 64)
             }
         }
         .buttonStyle(.card)
         .focused($focusedArea, equals: .profile)
         .focusSection()
+        .confirmationDialog(L10n.tvUserProfileActions, isPresented: $showUserActions) {
+            if coordinator.userState.isLoggedIn {
+                Button(L10n.accountSignOut, role: .destructive) { coordinator.userState.logout() }
+            } else {
+                Button(L10n.signIn, role: .confirm) { coordinator.signIn() }
+            }
+            Button(L10n.accessibilityDismiss, role: .cancel) { }
+        }
     }
 
     var leftAccessory: some View {

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -159,8 +159,13 @@ struct MainTabView: View {
         Button {
 
         } label: {
-            ProfileImage(email: coordinator.userEmail)
-                .frame(width: 64, height: 64)
+            if let email = coordinator.userState.usernameEmail {
+                ProfileImage(email: email)
+                    .frame(width: 64, height: 64)
+            } else {
+                Image("")
+                    .frame(width: 64, height: 64)
+            }
         }
         .buttonStyle(.card)
         .focused($focusedArea, equals: .profile)

--- a/Pocket Casts TV App/UI/UserStateModel.swift
+++ b/Pocket Casts TV App/UI/UserStateModel.swift
@@ -1,0 +1,35 @@
+import PocketCastsServer
+
+@Observable
+class UserStateModel {
+
+    var isPlusUser: Bool
+    var isLoggedIn: Bool
+    var usernameEmail: String?
+
+    var usernameLabel: String {
+        var usernameLabel = ""
+        if isLoggedIn, isPlusUser {
+            usernameLabel = usernameEmail ?? ""
+        } else {
+            if isLoggedIn {
+                usernameLabel = usernameEmail ?? ""
+            } else {
+                usernameLabel = L10n.signedOut
+            }
+        }
+        return usernameLabel
+    }
+
+    init() {
+        isPlusUser = SubscriptionHelper.hasActiveSubscription()
+        isLoggedIn = SyncManager.isUserLoggedIn()
+        usernameEmail = ServerSettings.syncingEmail()
+    }
+
+    func refresh() {
+        isPlusUser = SubscriptionHelper.hasActiveSubscription()
+        isLoggedIn = SyncManager.isUserLoggedIn()
+        usernameEmail = ServerSettings.syncingEmail()
+    }
+}

--- a/Pocket Casts TV App/UI/UserStateModel.swift
+++ b/Pocket Casts TV App/UI/UserStateModel.swift
@@ -1,7 +1,10 @@
 import PocketCastsServer
+import Combine
 
 @Observable
 class UserStateModel {
+
+    private var cancellables: Set<AnyCancellable> = []
 
     var isPlusUser: Bool
     var isLoggedIn: Bool
@@ -25,11 +28,34 @@ class UserStateModel {
         isPlusUser = SubscriptionHelper.hasActiveSubscription()
         isLoggedIn = SyncManager.isUserLoggedIn()
         usernameEmail = ServerSettings.syncingEmail()
+        setupObservers()
     }
 
     func refresh() {
         isPlusUser = SubscriptionHelper.hasActiveSubscription()
         isLoggedIn = SyncManager.isUserLoggedIn()
         usernameEmail = ServerSettings.syncingEmail()
+    }
+
+    private func setupObservers() {
+        Publishers.Merge(
+            NotificationCenter.default.publisher(for: ServerNotifications.subscriptionStatusChanged),
+            NotificationCenter.default.publisher(for: .userLoginDidChange)
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in
+            guard let self else {
+                return
+            }
+            refresh()
+        }
+        .store(in: &cancellables)
+    }
+
+    func logout() {
+        Task {
+            SignOutHelper.signout()
+            refresh()
+        }
     }
 }

--- a/Pocket Casts TV App/UI/UserStateModel.swift
+++ b/Pocket Casts TV App/UI/UserStateModel.swift
@@ -11,16 +11,7 @@ class UserStateModel {
     var usernameEmail: String?
 
     var usernameLabel: String {
-        var usernameLabel = ""
-        if isLoggedIn, isPlusUser {
-            usernameLabel = usernameEmail ?? ""
-        } else {
-            if isLoggedIn {
-                usernameLabel = usernameEmail ?? ""
-            } else {
-                usernameLabel = L10n.signedOut
-            }
-        }
+        let usernameLabel = isLoggedIn ? (usernameEmail ?? "") : L10n.signedOut
         return usernameLabel
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1317,6 +1317,9 @@
 		FF4A73DA2C876D5E00587128 /* ReferralSendPassVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4A73D92C876D5E00587128 /* ReferralSendPassVC.swift */; };
 		FF4B35662FB327D7004784EC /* PodcastImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B087FC829DC976F0027EAE5 /* PodcastImage.swift */; };
 		FF4B3E392C2D94F300F84DD6 /* TranscriptFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4B3E382C2D94F300F84DD6 /* TranscriptFilter.swift */; };
+		FF4B5C8E2FB4C441004784EC /* SignOutHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D9A4B0240746C30019E469 /* SignOutHelper.swift */; };
+		FF4B5C8F2FB4C48A004784EC /* PodcastManager+Delete.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402772D621B6105D00769811 /* PodcastManager+Delete.swift */; };
+		FF4B5C902FB4C81F004784EC /* TabBar.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BD4F25741F70F17B00B8857E /* TabBar.xcassets */; };
 		FF4E93122BDBF0D800F370AA /* MiniPlayerGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4E93112BDBF0D800F370AA /* MiniPlayerGradientView.swift */; };
 		FF5381A62C90A06400829525 /* ReferralsClaimBannerTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5381A52C90A06400829525 /* ReferralsClaimBannerTableCell.swift */; };
 		FF5381AE2C90FF1500829525 /* ReferralCardMiniView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5381AD2C90FF1500829525 /* ReferralCardMiniView.swift */; };
@@ -6761,6 +6764,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FF4B5C902FB4C81F004784EC /* TabBar.xcassets in Resources */,
 				FF3248CE2FACDDCC00226E58 /* NoArtwork.xcassets in Resources */,
 				FF49FEAC2F9BBC9A00E68E0C /* Localizable.strings in Resources */,
 			);
@@ -7758,6 +7762,7 @@
 				FF8FF69F2FAA46100086A867 /* ServerSyncManager.swift in Sources */,
 				FF8FF6A22FAA468B0086A867 /* PlaybackManager.swift in Sources */,
 				FF60249E2FAB450500EB3AD5 /* ThemeColor.swift in Sources */,
+				FF4B5C8F2FB4C48A004784EC /* PodcastManager+Delete.swift in Sources */,
 				FF8FF6A02FAA46400086A867 /* PodcastManager.swift in Sources */,
 				FF32F3E22FAB846400226E58 /* PlaylistArchiveViewCellPlaceholder.swift in Sources */,
 				FF65059B2FAA9B6E00C3662E /* FileManager+Helper.swift in Sources */,
@@ -7786,6 +7791,7 @@
 				0CF5B7BE2FB3B0E60023691C /* LiquidGlass.swift in Sources */,
 				FF8FFE542FAA5FAC0086A867 /* ArchiveHelper.swift in Sources */,
 				FF8FFE4F2FAA4CCD0086A867 /* PlaybackProtocol.swift in Sources */,
+				FF4B5C8E2FB4C441004784EC /* SignOutHelper.swift in Sources */,
 				FF8FFE442FAA49BE0086A867 /* PodcastManager+Cleanup.swift in Sources */,
 				FF6033FD2FAB4C9700EB3AD5 /* EpisodesDataManager.swift in Sources */,
 				FF8FFE612FAA63750086A867 /* Enumerations.swift in Sources */,

--- a/podcasts/SignOutHelper.swift
+++ b/podcasts/SignOutHelper.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 
 class SignOutHelper {
     class func signout() {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4359,6 +4359,14 @@ internal enum L10n {
   internal static var tvUpNextEmptySubtitle: String { return L10n.tr("Localizable", "tv_up_next_empty_subtitle", fallback: "Add episodes to Up Next and they'll play in order, back to back") }
   /// tv up next empty title
   internal static var tvUpNextEmptyTitle: String { return L10n.tr("Localizable", "tv_up_next_empty_title", fallback: "Nothing queued up") }
+  /// tv User Profile actions title
+  internal static var tvUserProfileActions: String { return L10n.tr("Localizable", "tv_user_profile_actions", fallback: "User settings") }
+  /// tv Sign In Login Type title
+  internal static var tvUserSignInLoginType: String { return L10n.tr("Localizable", "tv_user_sign_in_login_type", fallback: "Login Type") }
+  /// tv Sign In Option Insert User and Pass
+  internal static var tvUserSignInOptionManual: String { return L10n.tr("Localizable", "tv_user_sign_in_option_manual", fallback: "User/Pass") }
+  /// tv Sign In Option QR
+  internal static var tvUserSignInOptionQr: String { return L10n.tr("Localizable", "tv_user_sign_in_option_qr", fallback: "QR") }
   /// tv welcome browse without account
   internal static var tvWelcomeBrowseWithoutAccount: String { return L10n.tr("Localizable", "tv_welcome_browse_without_account", fallback: "Browse without an account") }
   /// tv welcome create free account

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4363,7 +4363,7 @@ internal enum L10n {
   internal static var tvUserProfileActions: String { return L10n.tr("Localizable", "tv_user_profile_actions", fallback: "User settings") }
   /// tv Sign In Login Type title
   internal static var tvUserSignInLoginType: String { return L10n.tr("Localizable", "tv_user_sign_in_login_type", fallback: "Login Type") }
-  /// tv Sign In Option Insert User and Pass
+  /// tv Sign In Option Username and Password
   internal static var tvUserSignInOptionManual: String { return L10n.tr("Localizable", "tv_user_sign_in_option_manual", fallback: "User/Pass") }
   /// tv Sign In Option QR
   internal static var tvUserSignInOptionQr: String { return L10n.tr("Localizable", "tv_user_sign_in_option_qr", fallback: "QR") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6057,3 +6057,16 @@
 
 /* tv up next empty button action title */
 "tv_up_next_empty_action_title" = "Add episodes";
+
+/* tv User Profile actions title */
+"tv_user_profile_actions" = "User settings";
+
+/* tv Sign In Login Type title */
+"tv_user_sign_in_login_type" = "Login Type";
+
+/* tv Sign In Option QR */
+"tv_user_sign_in_option_qr" = "QR";
+
+/* tv Sign In Option Insert User and Pass */
+"tv_user_sign_in_option_manual" = "User/Pass";
+

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6067,6 +6067,6 @@
 /* tv Sign In Option QR */
 "tv_user_sign_in_option_qr" = "QR";
 
-/* tv Sign In Option Insert User and Pass */
+/* tv Sign In Option Username and Password */
 "tv_user_sign_in_option_manual" = "User/Pass";
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-666 <!-- issue number, if applicable -->

Updates the tvOS app login experience and adds basic user state handling:

- Introduces a new `UserStateModel` that tracks login state, Plus subscription status, and the syncing email, refreshing in response to `subscriptionStatusChanged` and `.userLoginDidChange` notifications.
- `AppCoordinator` now uses `UserStateModel` to decide whether to land on the signed-in or welcome screen, and exposes a `signIn()` entry point.
- `SignInView` replaces the previous boolean toggle between manual and QR login with a segmented `Picker` driven by a `LoginType` enum, defaulting to manual sign in.
- `MainTabView` profile button now opens a confirmation dialog with Sign In / Sign Out actions, and shows a placeholder image when there is no logged-in user.
- Adds the `SignOutHelper`, `PodcastManager+Delete`, and `TabBar.xcassets` to the TV target so sign-out works on tvOS.
- Adds new localized strings for the TV user settings dialog and login type picker.

## To test

1. Launch the Pocket Casts TV app while signed out.
2. Verify the welcome screen appears and you can choose between **User/Pass** and **QR** login using the segmented control at the top of the sign-in screen.
3. Sign in via either flow and confirm the app navigates to the signed-in experience and the profile button shows your Gravatar.
4. Open the profile button (top right) and confirm a dialog appears with **Sign Out** and **Dismiss** options.
5. Tap **Sign Out** and confirm the user is signed out, the profile image is replaced with the default profile icon, and the sign-in flow is reachable again.
6. Sign in again from the dialog using **Sign In** to confirm the entry point works while signed out.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.