### PR TITLE
PCIOS-459: iOS: Small folder label needs more padding

### DIFF
--- a/podcasts/Podcasts/All Podcasts/Cells/FolderPreviewView.swift
+++ b/podcasts/Podcasts/All Podcasts/Cells/FolderPreviewView.swift
@@ -6,6 +6,7 @@ class FolderPreviewView: UIView {
     private let interPreviewPadding: CGFloat = 4
 
     private let labelBottomMargin = CGFloat(6)
+    private let labelHorizontalPadding: CGFloat = 4
 
     private let imageSizeRatio: CGFloat = 120 / 40
     private let imageSizeRatioNoLabel: CGFloat = 120 / 44
@@ -131,8 +132,8 @@ class FolderPreviewView: UIView {
 
                 nameLabelVerticalPositionConstraint = label.centerYAnchor.constraint(equalTo: bottomAnchor, constant: -labelBottomMargin)
                 NSLayoutConstraint.activate([
-                    label.leadingAnchor.constraint(equalTo: leadingAnchor),
-                    label.trailingAnchor.constraint(equalTo: trailingAnchor),
+                    label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: labelHorizontalPadding),
+                    label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -labelHorizontalPadding),
                     nameLabelVerticalPositionConstraint!
                 ])
             }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-459/ios-small-folder-label-needs-more-padding

## Summary
Added horizontal padding to the folder name label in `FolderPreviewView` so the text no longer sits flush against the folder image edges.

## Changes
- Added a `labelHorizontalPadding` constant (4pt) to `FolderPreviewView.swift`
- Applied the padding to the label's leading and trailing anchor constraints

## Verification
- **Lint**: PASS — `make format` ran cleanly
- **Tests**: N/A — no unit tests cover this UI constraint; build fails are pre-existing CarPlay SDK issues unrelated to this change
- **Diff review**: PASS — single file changed, only the intended constraint modifications

## Confidence
**HIGH** — Straightforward constraint padding fix in the only relevant file. The 4pt value matches the existing `interPreviewPadding` convention used elsewhere in the same view.

---
This PR was created autonomously by linear-solver.
Triage complexity: simple | [Linear issue](https://linear.app/a8c/issue/PCIOS-459/ios-small-folder-label-needs-more-padding)