### PR TITLE
PCIOS-72: Fix sharing episode artwork

### DIFF
--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -88,7 +88,7 @@ enum ShareDestination: Hashable {
 
     @MainActor
     static fileprivate func shareImage(_ option: SharingModal.Option, style: ShareImageStyle) -> UIImage {
-        let imageView = ShareImageView(info: option.imageInfo, style: style, angle: .constant(0))
+        let imageView = ShareImageView(info: option.imageInfo(), style: style, angle: .constant(0))
         return imageView.snapshot()
     }
 

--- a/podcasts/Sharing/ShareDestination.swift
+++ b/podcasts/Sharing/ShareDestination.swift
@@ -87,12 +87,6 @@ enum ShareDestination: Hashable {
     }
 
     @MainActor
-    static fileprivate func shareImage(_ option: SharingModal.Option, style: ShareImageStyle) -> UIImage {
-        let imageView = ShareImageView(info: option.imageInfo(), style: style, angle: .constant(0))
-        return imageView.snapshot()
-    }
-
-    @MainActor
     private func instagramShare(data: Data, type: UTType, url: String) {
         let attributionURL = url
         let appID = ApiCredentials.instagramAppID

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -181,12 +181,12 @@ extension SharingModal.Option {
         }
     }
 
-    var imageInfo: ShareImageInfo {
+    func imageInfo(episodeArtworkUrl: URL? = nil) -> ShareImageInfo {
         let gradient = Gradient(colors: [
             Color(uiColor: ColorManager.lightThemeTintForPodcast(podcast)),
             Color(uiColor: UIColor.calculateColor(orgColor: UIColor.black, overlayColor: ColorManager.lightThemeTintForPodcast(podcast).withAlphaComponent(0.8))),
         ])
-        let artwork = ImageManager.sharedManager.podcastUrl(imageSize: .page, uuid: podcast.uuid)
+        let artwork = episodeArtworkUrl ?? ImageManager.sharedManager.podcastUrl(imageSize: .page, uuid: podcast.uuid)
         let imageInfo = ShareImageInfo(name: name ?? "",
                                        title: title ?? "",
                                        description: description ?? "",
@@ -195,14 +195,25 @@ extension SharingModal.Option {
         return imageInfo
     }
 
+    func loadEpisodeArtworkUrl() async -> URL? {
+        guard Settings.loadEmbeddedImages, let episode else { return nil }
+        guard let urlString = try? await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(
+            podcastUuid: episode.podcastUuid,
+            episodeUuid: episode.uuid
+        ) else { return nil }
+        return URL(string: urlString)
+    }
+
     @MainActor
     func shareData(style: ShareImageStyle, destination: ShareDestination, clipUUID: String, progress: Binding<Float?>) async throws -> [ActivityItemSourceItem] {
         let url = URL(string: shareURL) as NSURL?
+        let episodeArtwork = await loadEpisodeArtworkUrl()
+        let info = imageInfo(episodeArtworkUrl: episodeArtwork)
 
         let media: Any?
         switch self {
         case .clipShare(let episode, let clipTime, _):
-            media = try await mediaData(imageInfo: imageInfo, style: style, episode: episode, clipTime: clipTime, destination: destination, clipUUID: clipUUID, scale: Constants.exportedAssetScale, progress: progress)
+            media = try await mediaData(imageInfo: info, style: style, episode: episode, clipTime: clipTime, destination: destination, clipUUID: clipUUID, scale: Constants.exportedAssetScale, progress: progress)
         default:
             let size: CGSize
             switch destination {
@@ -211,7 +222,7 @@ extension SharingModal.Option {
             default:
                 size = CGSize(width: style.previewSize.width, height: style.previewSize.height)
             }
-            media = ShareImageView(info: imageInfo, style: style, angle: .constant(0)).frame(width: size.width, height: size.height).snapshot(scale: Constants.exportedAssetScale)
+            media = ShareImageView(info: info, style: style, angle: .constant(0)).frame(width: size.width, height: size.height).snapshot(scale: Constants.exportedAssetScale)
         }
 
         return [url.map { ActivityItemSourceItem(item: $0, disallowedActivityTypes: [.airDrop]) },

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -45,6 +45,7 @@ struct SharingView: View {
 
     @State private var shareable: Shareable
     @State private var isExporting: Bool = false
+    @State private var episodeArtworkUrl: URL?
 
     @ObservedObject var clipTime: ClipTime
 
@@ -105,6 +106,9 @@ struct SharingView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .foregroundStyle(Color.white)
+        .task {
+            episodeArtworkUrl = await shareable.option.loadEpisodeArtworkUrl()
+        }
     }
 
     @ViewBuilder var title: some View {
@@ -181,7 +185,7 @@ struct SharingView: View {
     }
 
     @ViewBuilder func image(style: ShareImageStyle, containerHeight: CGFloat) -> some View {
-        ShareImageView(info: shareable.option.imageInfo, style: style, angle: .constant(0))
+        ShareImageView(info: shareable.option.imageInfo(episodeArtworkUrl: episodeArtworkUrl), style: style, angle: .constant(0))
             .frame(width: style.previewSize.width, height: style.previewSize.height)
             .fixedSize()
             .clipShape(RoundedRectangle(cornerRadius: 12))


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-72/fix-sharing-episode-artwork

## Summary
When the "Use Episode Artwork" setting is enabled, sharing an episode, episode with timestamp, or clip incorrectly showed the podcast artwork instead of the episode artwork. This fix loads the episode artwork URL from show notes when the setting is enabled and uses it in the sharing flow.

## Changes
- Changed `SharingModal.Option.imageInfo` from a computed property to a method accepting an optional `episodeArtworkUrl` parameter, falling back to podcast artwork when not provided
- Added `loadEpisodeArtworkUrl()` async method on `SharingModal.Option` that checks the "Use Episode Artwork" setting and fetches the episode artwork URL from `ShowInfoCoordinator`
- Updated `shareData()` to load and use episode artwork for the exported share image
- Updated `SharingView` to load episode artwork on appear and pass it to the preview

## Verification
- **Lint**: PASS — `make format` ran cleanly
- **Tests**: FAIL — pre-existing CarPlay SDK build error (`CPPlaybackConfiguration` not in scope) prevents test suite from running; unrelated to this change
- **Diff review**: PASS — confirmed no unintended changes, no debug statements, changes scoped to sharing flow only
- **Secret scan**: PASS — no secrets in diff

## Confidence
**MEDIUM** — The logic follows the same pattern used elsewhere in the app (e.g., `PlaylistCellViewModel.loadImagesURLs`) for loading episode artwork URLs. The fix correctly gates on `Settings.loadEmbeddedImages` and gracefully falls back to podcast artwork. However, unable to run tests due to pre-existing build issues, and unable to test the UI manually.

## Known Issues
- Tests could not run due to a pre-existing build failure in `CarPlaySceneDelegate+Convert.swift` (`CPPlaybackConfiguration` not in scope). This is unrelated to the sharing changes.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/PCIOS-72/fix-sharing-episode-artwork)