### PR TITLE
[PC-TV] QR code

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -46,6 +46,14 @@ public enum ServerConstants {
             production() ? "https://shownotes.pocketcasts.com/generated_transcripts/" : "https://shownotes.pocketcasts.net/generated_transcripts/"
         }
 
+        public static var tvPair: String {
+            production() ? "https://pocketcasts.com/pair" : "https://pocketcasts.net/pair"
+        }
+
+        public static var tvCreate: String {
+            production() ? "https://pocketcasts.com/create" : "https://pocketcasts.net/create"
+        }
+
         public static let support = "https://support.pocketcasts.com/ios/"
         public static let cancelSubscription = "https://support.pocketcasts.com/knowledge-base/how-to-cancel-a-subscription/"
         public static let termsOfUse = "https://support.pocketcasts.com/article/terms-of-use/"

--- a/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
+++ b/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsServer
 
 struct CreateAccountView: View {
 
@@ -18,7 +19,7 @@ struct CreateAccountView: View {
                     .font(.headline)
                     .foregroundStyle(Color.textSecondary)
                 Spacer()
-                QRCodeView()
+                QRCodeView(url: ServerConstants.Urls.tvCreate)
                 Spacer()
                 Text(L10n.tvCreateAccountComeBack)
                     .font(.headline)

--- a/Pocket Casts TV App/UI/Auth/QRCodeView.swift
+++ b/Pocket Casts TV App/UI/Auth/QRCodeView.swift
@@ -1,22 +1,54 @@
 import SwiftUI
+import CoreImage.CIFilterBuiltins
 
 struct QRCodeView: View {
+
+    let url: String
+    @State var uiImage: UIImage?
+
+    private let context = CIContext()
 
     enum Layout {
         static let qrSize = CGFloat(240)
     }
 
+    func generateQRImage() async {
+        var resultImage: UIImage?
+        let qrCodeGenerator = CIFilter.qrCodeGenerator()
+        qrCodeGenerator.message = url.data(using: .ascii)!
+        qrCodeGenerator.correctionLevel = "H"
+        if let outputImage = qrCodeGenerator.outputImage {
+            // Scale up so the QR code stays crisp on a TV screen
+            let transform = CGAffineTransform(scaleX: 10, y: 10)
+            let scaledImage = outputImage.transformed(by: transform)
+
+            if let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) {
+                resultImage = UIImage(cgImage: cgImage)
+            }
+        }
+        await MainActor.run {
+            uiImage = resultImage
+        }
+    }
+
     var body: some View {
         ZStack {
-            Image(ImageResource.qrCode)
-                .resizable()
-                .frame(width: Layout.qrSize, height: Layout.qrSize)
+            if let uiImage {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .frame(width: Layout.qrSize, height: Layout.qrSize)
+            } else {
+                ProgressView()
+            }
         }
         .padding()
         .background(.white)
+        .task {
+            await generateQRImage()
+        }
     }
 }
 
 #Preview {
-    QRCodeView()
+    QRCodeView(url: "https://pocketcasts.com")
 }

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -15,7 +15,7 @@ struct SignInView: View {
     }
 
     var attributed: AttributedString {
-        let baseString = L10n.tvSignInEnterCodeGoUrl("pocketcasts.com/pair", "https://pocketcasts.com/pair")
+        let baseString = L10n.tvSignInEnterCodeGoUrl(model.pairURLPretty, model.pairURLString)
         var attributedString = (try? AttributedString(markdown: baseString)) ?? AttributedString(baseString)
 
         var linkStyle = AttributeContainer()
@@ -40,7 +40,7 @@ struct SignInView: View {
         }
     }
 
-    @State private var loginType: LoginType = .manual
+    @State private var loginType: LoginType = .qr
 
     var body: some View {
         ZStack(alignment: .top) {
@@ -63,7 +63,7 @@ struct SignInView: View {
                 case .manual:
                     usernamePasswordLogin
                 case .qr:
-                    QRCodeView()
+                    QRCodeView(url: model.pairURLString)
                     separator
                     Text(L10n.tvSignInEnterCode)
                         .font(.headline)

--- a/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
@@ -55,4 +55,17 @@ class SignInViewModel {
             state = .error(error, "Please try again")
         }
     }
+
+    var pairURLPretty: String {
+        guard let url = URL(string: ServerConstants.Urls.tvPair),
+             let host = url.host()
+        else {
+            return ServerConstants.Urls.tvPair
+        }
+        return host + url.path()
+    }
+
+    var pairURLString: String {
+        return ServerConstants.Urls.tvPair
+    }
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR updates the sign in screen to use real QR codes that link to the PC URL

## To test

1. Start the app from scratch
2. Tap on Sign
3. Choose the QR code option
4. Check if the QR code is shown
5. Check if the link opens `https://pocketcasts.com/pair` ( There is currently an issue where AppClip of the app is intercepting all `pocketcasts.com` URLs coming from QR codes, so the app clips domains need to be updated )

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
