### PR TITLE
PCIOS-456: Remove "SETTINGS" section header from Auto Download screen

### DIFF
--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -54,10 +54,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let headerFrame = CGRect(x: 0, y: 0, width: 0, height: Constants.Values.tableSectionHeaderHeight)
-
-        let firstRowInSection = tableRows()[section][0]
-        return firstRowInSection == .onlyOnWifi ? SettingsTableHeader(frame: headerFrame, title: L10n.settings.localizedUppercase) : nil
+        nil
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-456/auto-download-screen-las-section-has-settings-title

## Summary
Remove the "SETTINGS" section header title from the last section of the Auto Download settings screen. No other sections had header titles, and the label was redundant since all sections contain settings.

## Changes
- Simplified `viewForHeaderInSection` in `DownloadSettingsViewController.swift` to always return `nil`, removing the "SETTINGS" header above the "Only on Unmetered Wifi" toggle.

## Verification
- **Lint**: PASS
- **Tests**: N/A (UI-only change, no testable logic changed)
- **Build**: PASS (`make build_staging`)
- **Diff review**: PASS — confirmed only the intended change, no unintended modifications

## Confidence
**HIGH** — The fix is a straightforward removal of a section header that was only applied to the last section. The assignee's comment explicitly confirmed this as the desired change.

---
This PR was created autonomously by linear-solver.
Triage complexity: trivial | [Linear issue](https://linear.app/a8c/issue/PCIOS-456/auto-download-screen-las-section-has-settings-title)