### PR TITLE
Add help text to Storage & Data Use screen for iOS storage discrepancy

### DIFF
--- a/podcasts/StorageAndDataUseViewController.swift
+++ b/podcasts/StorageAndDataUseViewController.swift
@@ -11,6 +11,8 @@ class StorageAndDataUseViewController: PCViewController, UITableViewDelegate, UI
             settingsTable.estimatedRowHeight = UITableView.automaticDimension
             settingsTable.estimatedSectionHeaderHeight = UITableView.automaticDimension
             settingsTable.sectionHeaderHeight = UITableView.automaticDimension
+            settingsTable.estimatedSectionFooterHeight = UITableView.automaticDimension
+            settingsTable.sectionFooterHeight = UITableView.automaticDimension
         }
     }
 
@@ -49,6 +51,27 @@ class StorageAndDataUseViewController: PCViewController, UITableViewDelegate, UI
         }
 
         return SettingsTableHeader(frame: headerFrame, title: L10n.settingsStorageMobileData)
+    }
+
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        guard section == usageSection else { return nil }
+
+        let footer = UIView()
+        let label = ThemeableLabel()
+        label.style = .primaryText02
+        label.text = L10n.settingsStorageUsageFooter
+        label.numberOfLines = 0
+        label.font = UIFont.font(ofSize: 13, weight: .regular, scalingWith: .footnote)
+        label.adjustsFontForContentSizeCategory = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        footer.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: footer.topAnchor, constant: 12),
+            label.leadingAnchor.constraint(equalTo: footer.leadingAnchor, constant: 16),
+            label.trailingAnchor.constraint(equalTo: footer.trailingAnchor, constant: -16),
+            label.bottomAnchor.constraint(equalTo: footer.bottomAnchor, constant: -12)
+        ])
+        return footer
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2816,7 +2816,7 @@
 "settings_storage_usage" = "USAGE";
 
 /* Footer note on the Storage & Data Use screen explaining why iOS may report higher storage than the app does. */
-"settings_storage_usage_footer" = "iOS storage figures may differ from ours — system caching is normal and reclaimed automatically.";
+"settings_storage_usage_footer" = "This may differ from the storage shown in your iPhone Settings. iOS manages cached data automatically and frees it up when needed.";
 
 /* Title for the settings screen */
 "settings_title" = "Podcast Settings";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2815,6 +2815,9 @@
 /* Section header for information about storage space used. */
 "settings_storage_usage" = "USAGE";
 
+/* Footer note on the Storage & Data Use screen explaining why iOS may report higher storage than the app does. */
+"settings_storage_usage_footer" = "iOS storage figures may differ from ours — system caching is normal and reclaimed automatically.";
+
 /* Title for the settings screen */
 "settings_title" = "Podcast Settings";
 


### PR DESCRIPTION
Adds an explanatory footer under the Usage section clarifying that iOS may report higher storage than the app does — this is due to OS-level caching outside the app's control, and is expected behavior.

Fixes #55: [Add help text on "Storage & Data Use" screen for iOS discrepancy](https://github.com/Automattic/pocket-casts-ios/issues/55)

Adds an explanatory footer beneath the Usage section on the Storage & Data Use screen, clarifying why iOS may report higher storage usage than the app does. The discrepancy is caused by OS-level caching that is outside the app's control and reclaimed automatically.

**Original proposed text:**
"iOS may report higher storage usage than shown here. The system caches data it can automatically reclaim when storage is needed — this is normal and outside the app's control."

**Updated text from:**
"iOS storage figures may differ from ours — system caching is normal and reclaimed automatically."

**to new text snippet:**
"This may differ from the storage shown in your iPhone Settings. iOS manages cached data automatically and frees it up when needed."

## To test
1. Open the app
2. Go to **Settings → Storage & Data Use**
3. Confirm a short explanatory note appears beneath the Usage > Downloaded Files section

## Screenshot
<img width="240" alt="Storage and Data Info text for iOS" src="https://github.com/user-attachments/assets/1abf3d60-ffb8-43ea-a013-0ce3060eafdd" />



## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
