### PR TITLE
Liquid Glass: Show exact time left in mini player

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -130,7 +130,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         let bottomRow = UIStackView(arrangedSubviews: [progressView, timeLeft])
         bottomRow.axis = .horizontal
         bottomRow.alignment = .center
-        bottomRow.spacing = 8
+        bottomRow.spacing = 6
 
         let textStack = UIStackView(arrangedSubviews: [title, bottomRow])
         textStack.translatesAutoresizingMaskIntoConstraints = false
@@ -420,8 +420,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             let remaining = max(0, duration - currentTime)
             let newText: String?
             if remaining > 0 {
-                let formatted = TimeFormatter.shared.multipleUnitFormattedShortTime(time: remaining)
-                newText = L10n.podcastTimeLeft(formatted)
+                newText = "-" + TimeFormatter.shared.playTimeFormat(time: remaining)
             } else {
                 newText = nil
             }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Show exact time left as the actual player to make it easier to see what happens especially if you skip back/forward.

<img width="456" height="241" alt="Screenshot 2026-05-13 at 5 44 17 PM" src="https://github.com/user-attachments/assets/cbe8c92c-4fb0-4466-8ee5-c57a13bb6116" />



## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
