### PR TITLE
Enable SwiftLint rule: vertical_whitespace_closing_braces

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -102,6 +102,9 @@ only_rules:
   # Unused parameters in a closure should be replaced with `_`.
   - unused_closure_parameter
 
+  # Don't include vertical whitespace (empty line) before closing braces.
+  - vertical_whitespace_closing_braces
+
   - custom_rules
 
 # Rules configuration

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
@@ -679,5 +679,4 @@ class UserEpisodeDataManager {
 
         return values
     }
-
 }

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -125,7 +125,6 @@ public class DataManager {
                     try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_non_null_download_task_id ON SJEpisode(downloadTaskId) WHERE downloadTaskId IS NOT NULL;", values: nil)
                     try db.executeUpdate("CREATE INDEX IF NOT EXISTS episode_added_date ON SJEpisode (addedDate);", values: nil)
                 } catch {
-
                 }
             }
         }
@@ -1290,7 +1289,6 @@ public extension DataManager {
 
     func episodesStartedAndCompleted(in year: Int) -> EpisodesStartedAndCompleted {
         endOfYearManager.episodesStartedAndCompleted(in: year, dbQueue: dbQueue)
-
     }
 
     func summarizedRatings(in year: Int) -> [UInt32: Int]? {

--- a/Modules/Sources/PocketCastsDataModel/Public/NetworkDataUsage/NetworkDataUsageManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/NetworkDataUsage/NetworkDataUsageManager.swift
@@ -83,7 +83,6 @@ public struct NetworkDataUsageManager {
 
         return .wifi
     }
-
 }
 
 // MARK: - Schema Creation

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralValidateTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralValidateTask.swift
@@ -16,7 +16,6 @@ public struct ReferralOfferDetail: Codable {
     public let nonce: String?
     public let signature: String?
     public let keyIdentifier: String?
-
 }
 
 class ReferralValidateTask: ApiBaseTask, @unchecked Sendable {

--- a/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+Account.swift
@@ -88,7 +88,6 @@ public extension ApiServerHandler {
                 } catch {
                     completion(false, nil, nil)
                 }
-
             }.resume()
         } catch {
             FileLog.shared.addMessage("registerAccount failed \(error.localizedDescription)")
@@ -128,7 +127,6 @@ public extension ApiServerHandler {
                     FileLog.shared.addMessage("Error occurred while trying to unpack token request \(error.localizedDescription)")
                     completion(nil, nil, nil)
                 }
-
             }.resume()
         } catch {
             FileLog.shared.addMessage("obtainToken failed \(error.localizedDescription)")
@@ -169,7 +167,6 @@ public extension ApiServerHandler {
                     FileLog.shared.addMessage("Error occurred while trying to unpack token request \(error.localizedDescription)")
                     continuation.resume(throwing: APIError.UNKNOWN)
                 }
-
             }.resume()
         }
     }

--- a/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -83,7 +83,6 @@ public extension ApiServerHandler {
         data.scope = scope.rawValue
 
         return ServerHelper.createProtoRequest(url: url, data: try! data.serializedData())
-
     }
 
     private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds, provider: SocialAuthProvider) -> URLRequest? {

--- a/Modules/Sources/PocketCastsServer/Public/API/ValidatePromoCodeHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/ValidatePromoCodeHandler.swift
@@ -48,7 +48,6 @@ public class ValidatePromoCodeTask {
                     }
                 }
                 completion(false, nil, nil)
-
             }.resume()
         } catch {
             FileLog.shared.addMessage("Validate Promo Code Request Protobuf Encoding failed")

--- a/Modules/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Refresh/MainServerHandler.swift
@@ -131,7 +131,6 @@ public class MainServerHandler {
             } catch {
                 completion(ImportOpmlResponse.failedResponse())
             }
-
         }.resume()
     }
 
@@ -165,7 +164,6 @@ public class MainServerHandler {
             } catch {
                 completion(ExportPodcastsResponse.failedResponse())
             }
-
         }.resume()
     }
 
@@ -196,7 +194,6 @@ public class MainServerHandler {
             } catch {
                 completion(ShareListResponse.failedResponse())
             }
-
         }.resume()
     }
 
@@ -315,7 +312,6 @@ public class MainServerHandler {
 
             FileLog.shared.addMessage("Server indicated podcast refresh was successful")
             completion(true)
-
         }.resume()
     }
 
@@ -349,7 +345,6 @@ public class MainServerHandler {
             } catch {
                 completion(nil)
             }
-
         }.resume()
     }
 

--- a/Modules/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
@@ -75,7 +75,6 @@ class PodcastSearchOperation: Operation {
             }
 
             self.dispatchGroup.leave()
-
         }.resume()
         _ = dispatchGroup.wait(timeout: .now() + 15.seconds)
 

--- a/Modules/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -61,7 +61,6 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
             default:
                 return nil
         }
-
     }
 
     public init?(from combinedResult: CombinedSearchResult) {

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -71,7 +71,6 @@ public class SyncManager {
         KeychainHelper.removeKey(ServerConstants.Values.refreshTokenKey)
         KeychainHelper.removeKey(ServerConstants.Values.appleAuthUserIDKey)
     }
-
 }
 
 // MARK: - Sync Reason

--- a/Modules/Sources/PocketCastsServer/Public/Upload/UploadManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Upload/UploadManager.swift
@@ -249,7 +249,6 @@ public class UploadManager: NSObject {
                 self.uploadingEpisodesCache[taskId] = episode
             }
             uploadTask?.resume()
-
         })
     }
 }

--- a/Modules/Tests/PocketCastsDataModelTests/EpisodeDataManagerTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/EpisodeDataManagerTests.swift
@@ -1385,5 +1385,4 @@ final class EpisodeDataManagerTests: DataManagerTestCase {
         dataManager.save(episode: episode)
         return episode
     }
-
 }

--- a/Modules/Tests/PocketCastsServerTests/SettingsStoreTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/SettingsStoreTests.swift
@@ -56,6 +56,4 @@ class SettingsStoreTests: XCTestCase {
         XCTAssertNotEqual(secondStore.settings.name, initialName, "Access value should fetch UserDefaults and not initial value of instance")
         XCTAssertEqual(secondStore.settings.name, changedName, "Accessed value on second reference should match changed value")
     }
-
-
 }

--- a/Modules/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
+++ b/Modules/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
@@ -295,5 +295,4 @@ private extension Api_BookmarkResponse {
                           time: bookmark.time,
                           created: bookmark.created)
     }
-
 }

--- a/Modules/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
+++ b/Modules/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
@@ -126,5 +126,4 @@ final class LogBufferTests: XCTestCase {
         XCTAssertTrue(messages[1].contains("Log Message 2"))
         XCTAssertTrue(messages[2].contains("Log Message 3"))
     }
-
 }

--- a/Modules/Tests/PocketCastsUtilsTests/Logging/LogPersistenceSpy.swift
+++ b/Modules/Tests/PocketCastsUtilsTests/Logging/LogPersistenceSpy.swift
@@ -13,5 +13,4 @@ final class LogPersistenceSpy: PersistentTextWriting {
         writeCount += 1
         lastWrittenChunk = text
     }
-
 }

--- a/Modules/Tests/PocketCastsUtilsTests/Logging/LogPersistenceStub.swift
+++ b/Modules/Tests/PocketCastsUtilsTests/Logging/LogPersistenceStub.swift
@@ -7,5 +7,4 @@ final class LogPersistenceStub: PersistentTextWriting {
     func write(_ text: String) {
         // No operation
     }
-
 }

--- a/Pocket Casts App Clip/AppClipAppDelegate.swift
+++ b/Pocket Casts App Clip/AppClipAppDelegate.swift
@@ -28,7 +28,6 @@ class AppClipAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
 
     func application(_ application: UIApplication,
                      didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-
     }
 
     private func configureFirebase() {

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -188,7 +188,7 @@ struct MockData {
                     episodes.append(episode)
                 }
             }
-            let playlist: EpisodeFilter = EpisodeFilter()
+            let playlist = EpisodeFilter()
             playlist.uuid = UUID().uuidString
             playlist.playlistName = name
             playlist.manual = !smart

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -86,7 +86,6 @@ struct SignInView: View {
         .foregroundColor(.clear)
         .frame(width: 566, height: 1)
         .background(Color.textDisabled)
-
     }
 
     @FocusState private var focusedField: Field?

--- a/Pocket Casts TV App/UI/Common/EmptyDataView.swift
+++ b/Pocket Casts TV App/UI/Common/EmptyDataView.swift
@@ -25,7 +25,6 @@ struct EmptyDataView: View {
                 }
             }
             Spacer()
-
         }
     }
 }

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -75,7 +75,6 @@ struct CenterButton: View {
         VStack {
             Spacer()
             Button(title) {
-
             }
             Spacer()
         }
@@ -157,7 +156,6 @@ struct MainTabView: View {
 
     var rightAccessory: some View {
         Button {
-
         } label: {
             ProfileImage(email: coordinator.userEmail)
                 .frame(width: 64, height: 64)

--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -53,7 +53,6 @@ struct PlaylistCell: View {
                 }
             }
             .padding(.horizontal, 36)
-
         }
         .padding(.horizontal, 36)
         .frame(height: Layout.cardHeight)
@@ -64,7 +63,6 @@ struct PlaylistCell: View {
             model.load()
         }
     }
-
 }
 
 #Preview {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -36,7 +36,6 @@ class PlaylistDetailsViewModel {
     }
 
     func playAll() {
-
     }
 
     var playlistName: String {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -101,5 +101,4 @@ class MockEpisodeRowViewModel: Identifiable {
     var displayDuration: String {
         return episode.duration.formatted()
     }
-
 }

--- a/Pocket Casts TV App/UI/Podcasts/FolderCardViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderCardViewModel.swift
@@ -22,5 +22,4 @@ class FolderCardViewModel {
             }
         }
     }
-
 }

--- a/Pocket Casts TV App/UI/RootView.swift
+++ b/Pocket Casts TV App/UI/RootView.swift
@@ -24,7 +24,6 @@ struct RootView: View {
         .task {
             await coordinator.load()
         }
-
     }
 }
 

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -31,7 +31,7 @@ protocol SearchableViewModel: AnyObject, Observation.Observable {
 @MainActor
 class SearchViewModel: SearchableViewModel {
 
-    private var dataManager: DataManager = DataManager.sharedManager
+    private var dataManager = DataManager.sharedManager
 
     var state: SearchState = .query
 

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -58,7 +58,6 @@ struct UpNextView: View {
         .focusScope(rowNamespace)
         .padding(24)
     }
-
 }
 
 #Preview {

--- a/Pocket Casts Watch App/UI/Main Page/SourceInterfaceModel.swift
+++ b/Pocket Casts Watch App/UI/Main Page/SourceInterfaceModel.swift
@@ -124,7 +124,6 @@ class SourceInterfaceModel: ObservableObject {
             RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: false)
         }
         SourceManager.shared.setSource(newSource: .watch)
-
     }
 
     private func nowPlayingEpisodesMatchOnBothSources() -> Bool {

--- a/PocketCastsTests/Tests/Playback/Effects/AudioUtilsTests.swift
+++ b/PocketCastsTests/Tests/Playback/Effects/AudioUtilsTests.swift
@@ -168,5 +168,4 @@ final class AudioUtilsTests: XCTestCase {
             }
         }
     }
-
 }

--- a/PocketCastsTests/Tests/Player/Transcripts/ComposeFilterTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/ComposeFilterTests.swift
@@ -68,5 +68,4 @@ final class ComposeFilterTests: XCTestCase {
 
         XCTAssertEqual(filtered.trim(), expected.trim())
     }
-
 }

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptModelFilterTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptModelFilterTests.swift
@@ -193,5 +193,4 @@ final class TranscriptModelFilterTests: XCTestCase {
 
         XCTAssertEqual(model.isEmtpy, true)
     }
-
 }

--- a/podcasts/AccountActionCell.swift
+++ b/podcasts/AccountActionCell.swift
@@ -98,5 +98,4 @@ class AccountActionCell: ThemeableCell {
         cellImage.updateSizeConstraints(to: iconSize)
         disclosureImageView?.updateSizeConstraints(to: iconSize)
     }
-
 }

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -128,7 +128,6 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
             }
 
             updateTableRows(newRows: newTableRows)
-
         } else {
             var newTableRows: [[TableRow]] = [accountOptions, [.privacyPolicy, .termsOfUse], [.logout], [.deleteAccount]]
 

--- a/podcasts/ArrayExtension.swift
+++ b/podcasts/ArrayExtension.swift
@@ -15,7 +15,6 @@ extension Array {
             } else {
                 output.append([self[i]])
             }
-
         }
         return output
     }

--- a/podcasts/BackgroundShakeObserver.swift
+++ b/podcasts/BackgroundShakeObserver.swift
@@ -3,7 +3,6 @@ class BackgroundShakeObserver {
     var whenShook: (() -> Void)?
 
     func stopObserving() {
-
     }
 }
 #else
@@ -56,7 +55,6 @@ class BackgroundShakeObserver {
                         self?.whenShook?()
                     }
                 }
-
             }
         }
     }

--- a/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
@@ -34,7 +34,6 @@ class BookmarkRowViewModel: ObservableObject {
         let dataManager = DataManager.sharedManager
         if let episode = bookmark.episode ?? dataManager.findBaseEpisode(uuid: bookmark.episodeUuid) {
             updateFromEpisode(episode)
-
         } else if let podcastUuid = bookmark.podcastUuid {
             ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: bookmark.episodeUuid, podcastUuid: podcastUuid) { [weak self] episode in
                 if let episode {

--- a/podcasts/CancelConfirmationView.swift
+++ b/podcasts/CancelConfirmationView.swift
@@ -49,7 +49,6 @@ struct CancelConfirmationView: View {
                     }
                     buttons
                 }
-
             }
             .padding([.leading, .trailing], Constants.padding.horizontal)
         }

--- a/podcasts/Categories/CategoryButtonStyle.swift
+++ b/podcasts/Categories/CategoryButtonStyle.swift
@@ -95,14 +95,12 @@ struct CategoryButtonStyle: ButtonStyle {
 
 #Preview("normal") {
     Button("Hello", action: {
-
     }).buttonStyle(CategoryButtonStyle(isSelected: false))
     .previewWithAllThemes()
 }
 
 #Preview("selected") {
     Button("Hello", action: {
-
     }).buttonStyle(CategoryButtonStyle(isSelected: true))
     .previewWithAllThemes()
 }
@@ -111,7 +109,6 @@ struct CategoryButtonStyle: ButtonStyle {
     var buttonStyle = CategoryButtonStyle(isSelected: false)
     buttonStyle.forcePressed = true
     return Button("Hello", action: {
-
     }).buttonStyle(buttonStyle)
     .applyButtonEffect(isPressed: true)
     .previewWithAllThemes()
@@ -121,7 +118,6 @@ struct CategoryButtonStyle: ButtonStyle {
     var buttonStyle = CategoryButtonStyle(isSelected: false, cornerStyle: .circle)
     buttonStyle.forcePressed = true
     return Button(action: {
-
     }, label: {
         Image(systemName: "xmark")
             .imageScale(.small)

--- a/podcasts/ChaptersHeader.swift
+++ b/podcasts/ChaptersHeader.swift
@@ -131,7 +131,6 @@ class ChaptersHeader: UIView {
         chaptersLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         toggleButton.setContentCompressionResistancePriority(.required, for: .vertical)
     }
-
 }
 
 protocol ChaptersHeaderDelegate: AnyObject {

--- a/podcasts/Common Components/CircleView.swift
+++ b/podcasts/Common Components/CircleView.swift
@@ -24,6 +24,5 @@ class CircleView: UIView {
         path.lineWidth = borderWidth
         borderColor.setStroke()
         path.stroke()
-
     }
 }

--- a/podcasts/Common Components/MultiSelect/MultiSelectActionController.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectActionController.swift
@@ -39,7 +39,6 @@ class MultiSelectActionController: UIViewController, UITableViewDelegate, UITabl
             editButton.setTitle(L10n.edit, for: .normal)
             editButton.titleLabel?.font = UIFont.font(ofSize: 15, weight: .bold, scalingWith: .largeTitle)
             editButton.titleLabel?.adjustsFontForContentSizeCategory = true
-
         }
     }
 

--- a/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
+++ b/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
@@ -103,7 +103,6 @@ struct MultiSelectRow_Previews: PreviewProvider {
                         Text("Hello World")
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
-
                 } onSelectionToggled: {
                     withAnimation {
                         selected.toggle()
@@ -112,7 +111,6 @@ struct MultiSelectRow_Previews: PreviewProvider {
                 .selectButtonStyle(tintColor: .black, checkColor: .white, strokeColor: .black)
                 .padding()
                 .background(Color.blue)
-
             }
             .frame(maxWidth: .infinity)
         }

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -276,7 +276,6 @@ struct DeveloperMenu: View {
                     Text("Cancelled subscription, but has passed expiration date")
                         .font(Font.footnote)
                 }
-
             } header: {
                 VStack {
                     Text("Subscription Testing")
@@ -443,6 +442,5 @@ extension Bundle {
         }
 
         return identifier
-
     }
 }

--- a/podcasts/DiscoverCollectionHeader.swift
+++ b/podcasts/DiscoverCollectionHeader.swift
@@ -90,7 +90,6 @@ class DiscoverCollectionHeader: UICollectionReusableView {
             descriptionLabel.style = .primaryText02
             descriptionLabel.font = .font(ofSize: 13, weight: .regular, scalingWith: .footnote)
             descriptionLabel.adjustsFontForContentSizeCategory = true
-
         }
     }
 

--- a/podcasts/DiscoverPodcastTableCell.swift
+++ b/podcasts/DiscoverPodcastTableCell.swift
@@ -162,5 +162,4 @@ class DiscoverPodcastTableCell: ThemeableCell {
             updateSize()
         }
     }
-
 }

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -714,7 +714,6 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     func removeEpisodeFromCache(_ episode: BaseEpisode) {
         progressManager.removeProgressForEpisode(episode.uuid)
-
     }
 
     private func resumeDownload(tempFilePath: String, session: URLSession, request: URLRequest, previousDownloadFailed: Bool, taskId: String, estimatedBytes: Int64, retryWithoutUserAgent: Bool = false) {

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -312,5 +312,4 @@ extension AutoDownloadLimit {
             return L10n.autoDownloadLimitNumberOfEpisodesShow(self.rawValue)
         }
     }
-
 }

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -10,7 +10,6 @@ class EffectsViewController: SimpleNotificationsViewController {
             headingLbl.text = L10n.playbackEffects.localizedUppercase
             headingLbl.font = UIFont.font(ofSize: 13, weight: .medium, scalingWith: .title1)
             headingLbl.adjustsFontForContentSizeCategory = true
-
         }
     }
 

--- a/podcasts/End of Year/Stories/2023/CompletionRateStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/CompletionRateStory2023.swift
@@ -69,7 +69,6 @@ struct CompletionRateStory2023: ShareableStory {
                             )
                             .foregroundColor(Color(red: 0.56, green: 0.59, blue: 0.64))
                             .padding(.top, -geometry.size.height * 0.02)
-
                         }
                     }
 

--- a/podcasts/End of Year/Stories/2023/ListeningTimeStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/ListeningTimeStory2023.swift
@@ -130,7 +130,6 @@ struct CircleDays: View {
                     circles(numberOfLines: numberOfLines, numberOfBallsPerLine: numberOfBallsPerLine, ballWidth: ballFinalWidth, ballPadding: ballPadding)
                 }
             )
-
         )
     }
 

--- a/podcasts/End of Year/Stories/2023/YearOverYearStory2023.swift
+++ b/podcasts/End of Year/Stories/2023/YearOverYearStory2023.swift
@@ -104,11 +104,9 @@ struct YearOverYearStory2023: ShareableStory {
                                 )
                                 .frame(height: rightBarPercentageSize * proxy.size.height)
                                 .modifier(animationViewModel.animate($rightBarPercentageSize, to: finalRightBarPercentageSize))
-
                             }
                         }
                     }
-
                 }
             }
             .background(.black)

--- a/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
+++ b/podcasts/End of Year/Stories/2024/EpilogueStory2024.swift
@@ -63,7 +63,6 @@ struct EpilogueStory2024: StoryView {
             .padding(.horizontal, 24)
             .padding(.vertical, 6)
         }
-
     }
 
     func onAppear() {

--- a/podcasts/End of Year/Stories/2024/IntroStory2024.swift
+++ b/podcasts/End of Year/Stories/2024/IntroStory2024.swift
@@ -34,11 +34,9 @@ struct IntroStory2024: StoryView {
                                 .multilineTextAlignment(.center)
                         }
                             .foregroundStyle(backgroundTextColor)
-
                     }
                     .ignoresSafeArea()
                 )
-
             }
         }
         .background(backgroundColor)

--- a/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Ratings2024Story.swift
@@ -123,7 +123,6 @@ struct Ratings2024Story: ShareableStory {
         default:
             return ""
         }
-
     }
 
     private var mostCommonRating: UInt32 {

--- a/podcasts/End of Year/Stories/2024/YearOverYearCompare2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/YearOverYearCompare2024Story.swift
@@ -141,7 +141,6 @@ struct YearOverYearCompare2024Story: ShareableStory {
             } else {
                 return (parentSize.height * 0.02, parentSize.height * 0.25)
             }
-
         }
     }
 

--- a/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
+++ b/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
@@ -137,7 +137,6 @@ class BottomSheetSwiftUIWrapper<ContentView: View>: UIViewController, UISheetPre
             }
         }
     }
-
 }
 
 extension UIViewController {

--- a/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
+++ b/podcasts/End of Year/Stories/Views/CommonStoryViews.swift
@@ -101,7 +101,6 @@ struct StoryLabel: View {
         case .pillarSubtitle:
             return 14
         }
-
     }
 
     private var horizontalPadding: CGFloat {

--- a/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
+++ b/podcasts/End of Year/Stories/Views/PaidStoryWallView.swift
@@ -21,7 +21,6 @@ struct PaidStoryWallView: View {
                     }
 
                     NavigationManager.sharedManager.showUpsellView(from: storiesViewController, source: .endOfYear, flow: SyncManager.isUserLoggedIn() ? .endOfYearUpsell : .endOfYear)
-
                 }
                 .buttonStyle(StoriesButtonStyle(color: .black, icon: nil))
             }

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -24,8 +24,6 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         self.podcastIndexChapterRetriever = podcastIndexChapterRetriever
         self.dataManager = dataManager
         self.transcriptDataRetriever = transcriptDataRetriever
-
-
     }
 
     func loadShowNotes(

--- a/podcasts/Folder History/FolderHistoryView.swift
+++ b/podcasts/Folder History/FolderHistoryView.swift
@@ -11,7 +11,6 @@ struct FolderHistoryView: View {
     var body: some View {
         List {
             Section {
-
             } footer: {
                 Text(L10n.foldersHistoryExplanation)
                     .foregroundStyle(theme.primaryText02)

--- a/podcasts/Folders/FoldersCoordinator.swift
+++ b/podcasts/Folders/FoldersCoordinator.swift
@@ -150,7 +150,6 @@ class FoldersCoordinator: NSObject {
         let hostingController = UIHostingController(rootView: suggestedFoldersView.environmentObject(Theme.sharedTheme))
         vc.present(hostingController, animated: true, completion: nil)
         hostingController.sheetPresentationController?.delegate = self
-
     }
 
     private func applySuggestedFolders(_ suggestedFolders: [SuggestedFolder]) {

--- a/podcasts/HorizontalCollectionListViewController.swift
+++ b/podcasts/HorizontalCollectionListViewController.swift
@@ -30,5 +30,4 @@ class HorizontalCollectionListViewController: ThemedHostingController<Horizontal
             AnalyticsHelper.listImpression(listId: listId, category: categoryId)
         }
     }
-
 }

--- a/podcasts/HowToShareActionImageView.swift
+++ b/podcasts/HowToShareActionImageView.swift
@@ -62,7 +62,6 @@ struct HowToShareActionImageView: View {
             }
         }
         .padding(.top, 28)
-
     }
 
     @ViewBuilder

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -167,7 +167,6 @@ class ListeningHistoryViewController: PCViewController {
             DataManager.sharedManager.clearAllEpisodePlayInteractions()
             if SyncManager.isUserLoggedIn() { ServerSettings.setLastClearHistoryDate(Date()) }
             self.refreshEpisodes(animated: true)
-
         })
         optionPicker.setNoActionCallback {
             Analytics.track(.listeningHistoryClearConfirmationDismissed)

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -976,7 +976,6 @@ private extension MainTabBarController {
             }
         }
     }
-
 }
 
 // MARK: - Analytics

--- a/podcasts/ManageDownloadsCoordinator.swift
+++ b/podcasts/ManageDownloadsCoordinator.swift
@@ -43,5 +43,4 @@ class ManageDownloadsCoordinator {
             }
         return
     }
-
 }

--- a/podcasts/MediaExporterResourceLoaderDelegate.swift
+++ b/podcasts/MediaExporterResourceLoaderDelegate.swift
@@ -440,6 +440,5 @@ class MediaExporterResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelega
     @objc private func handleAppWillTerminate() {
         invalidateAndCancelSession(shouldResetData: false)
     }
-
 }
 #endif

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -287,7 +287,6 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
 
             transitionContext.completeTransition(true)
         }
-
     }
 
     /// Use spring animation for both present and dismiss.

--- a/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchEpisodeResultsView.swift
@@ -88,5 +88,4 @@ struct LocalSearchEpisodeResultsView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.top, 48)
     }
-
 }

--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -167,7 +167,6 @@ struct NewSearchResultsView: View {
                             return 0
                         }
             }
-
         }
     }
 

--- a/podcasts/New Search/Views/Results/PodcastCarouselView.swift
+++ b/podcasts/New Search/Views/Results/PodcastCarouselView.swift
@@ -104,7 +104,6 @@ struct PodcastsCarouselView: View {
 
                 // Set the id of the carousel to make sure the we reset the position when the search changes
                 .id(searchResults.podcasts.map { $0.id })
-
             } else if !searchResults.isShowingLocalResultsOnly {
                 EmptyStateView(title: L10n.discoverNoPodcastsFound,
                                message: L10n.discoverNoPodcastsFoundMsg,
@@ -159,7 +158,6 @@ struct PodcastResultCell: View {
         VStack(alignment: .leading) {
             ZStack(alignment: .bottomTrailing) {
                 Button(action: {
-
                 }) {
                     Group {
                         switch result.kind {

--- a/podcasts/New Search/Views/Results/PredictiveList.swift
+++ b/podcasts/New Search/Views/Results/PredictiveList.swift
@@ -111,5 +111,4 @@ struct PredictiveList: View {
             .background(theme.primaryUi01)
         })
     }
-
 }

--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -151,7 +151,6 @@ enum NotificationType: String {
                 return false
         }
     }
-
 }
 
 enum NotificationsGroup: CaseIterable {
@@ -383,7 +382,6 @@ class NotificationsCoordinator {
                     let date = intervalTrigger.nextTriggerDate() ?? Date()
                     FileLog.shared.addMessage("Notification: \(notificationRequest.identifier) - \(date.formatted())\n")
                 }
-
             }
             FileLog.shared.addMessage("\n---- End ----\n")
         }

--- a/podcasts/NotificationsViewController.swift
+++ b/podcasts/NotificationsViewController.swift
@@ -221,7 +221,6 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
         default:
             return
         }
-
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -241,7 +240,6 @@ class NotificationsViewController: PCViewController, UITableViewDataSource, UITa
         default:
             return nil
         }
-
     }
 
     func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -104,7 +104,6 @@ extension NowPlayingPlayerItemViewController {
 
     @objc func updateChapterInfo() {
         updateChapterInfoWithChapters(PlaybackManager.shared.currentChapters())
-
     }
 
     private func updateChapterInfoForTime(_ time: TimeInterval) {

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -181,7 +181,6 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
             let metrics = UIFontMetrics(forTextStyle: .largeTitle)
             timeRemaining.font = metrics.scaledFont(for: baseFont)
             timeRemaining.adjustsFontForContentSizeCategory = true
-
         }
     }
 

--- a/podcasts/Onboarding/DiscoverPodcastsGridView.swift
+++ b/podcasts/Onboarding/DiscoverPodcastsGridView.swift
@@ -64,5 +64,4 @@ struct DiscoverPodcastsGridView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: Constants.itemHeight)
     }
-
 }

--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -190,7 +190,6 @@ private struct LoginLandingContent: View {
     var loginHeaderHeight: Double {
         calculatedHeaderHeightSmall + (smallHeight ? Config.topPaddingSmallDevice : Config.topPadding)
     }
-
 }
 
 // MARK: - Models

--- a/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
+++ b/podcasts/Onboarding/Models/PlusPricingInfoModel.swift
@@ -118,7 +118,6 @@ class PlusPricingInfoModel: ObservableObject {
                 return L10n.pricingTermsAfterDiscount(rawPrice, duration, offerEndDateLocalized.nonBreakingSpaces())
             }
         }
-
     }
 
     enum PriceAvailablity {

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -108,7 +108,6 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
 
             // Reset the nav flow to only show the welcome controller
             navigationController.setViewControllers([controller], animated: true)
-
         }
 
         // Dismiss the current flow

--- a/podcasts/Onboarding/Patron/PatronUnlockButton.swift
+++ b/podcasts/Onboarding/Patron/PatronUnlockButton.swift
@@ -55,7 +55,6 @@ struct PatronUnlockButton: View {
                         }
 
                         finish()
-
                     }
                     // Use an overlay with an Action to send the progress whenever the view redraws
                     // This provides a smoother effect than onChange and SwiftUI doesn't complain about sending

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
@@ -51,7 +51,6 @@ class PlusAccountPromptTableCell: ThemeableCell {
             self.separatorInset = UIEdgeInsets(top: 0, left: .greatestFiniteMagnitude, bottom: 0, right: 0)
             self.style = .primaryUi03
         }
-
     }
 
     // Update the model's parent so we can present the modal

--- a/podcasts/Onboarding/Plus/NewUpgrade/Animations/BookmarksAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/Animations/BookmarksAnimationView.swift
@@ -99,7 +99,6 @@ struct BookmarksAnimationView: View {
         }
         .padding(.horizontal, 16)
     }
-
 }
 
 #Preview {

--- a/podcasts/Onboarding/Plus/NewUpgrade/Animations/FoldersAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/Animations/FoldersAnimationView.swift
@@ -151,7 +151,6 @@ struct FoldersAnimationView: View {
             animationProgress = 1
         }
     }
-
 }
 
 #Preview {

--- a/podcasts/Onboarding/Plus/NewUpgrade/Animations/PreSelectChaptersAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/Animations/PreSelectChaptersAnimationView.swift
@@ -82,7 +82,6 @@ struct PreSelectChaptersAnimationView: View {
         }
         .padding(.horizontal, 16)
     }
-
 }
 
 #Preview {

--- a/podcasts/Onboarding/Plus/PlusHostingViewController.swift
+++ b/podcasts/Onboarding/Plus/PlusHostingViewController.swift
@@ -16,5 +16,4 @@ class PlusHostingViewController<Content>: OnboardingHostingViewController<Conten
         super.viewWillDisappear(animated)
         navigationController?.navigationBar.tintColor = iconTintColor
     }
-
 }

--- a/podcasts/Onboarding/Plus/PlusPurchaseModal.swift
+++ b/podcasts/Onboarding/Plus/PlusPurchaseModal.swift
@@ -136,7 +136,6 @@ struct PlusPurchaseModal: View {
     enum Config {
         static let backgroundColorHex = "#282829"
     }
-
 }
 
 // MARK: - Config

--- a/podcasts/Onboarding/Plus/UpgradeCard.swift
+++ b/podcasts/Onboarding/Plus/UpgradeCard.swift
@@ -83,7 +83,6 @@ struct UpgradeCard: View {
                 .padding(.bottom, 0)
             }
             .padding(24)
-
         }
         .background(theme.primaryUi01)
         .cornerRadius(24)

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -135,7 +135,6 @@ struct UpgradeLandingView: View {
                         }
                 }
             }
-
         }
         .background(Color.plusBackgroundColor)
     }

--- a/podcasts/Onboarding/Welcome/WelcomeView.swift
+++ b/podcasts/Onboarding/Welcome/WelcomeView.swift
@@ -194,7 +194,6 @@ private struct Label: View {
                 return content.font(size: 15, style: .subheadline, weight: .medium, maxSizeCategory: .extraExtraExtraLarge)
             case .newsletterDescription:
                 return content.font(size: 13, style: .footnote, maxSizeCategory: .extraExtraExtraLarge)
-
             }
         }
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2354,7 +2354,6 @@ class PlaybackManager: ServerPlaybackDelegate {
             } else {
                 Analytics.track(.autoplayFinishedLastEpisode)
             }
-
         }
 
         // Nothing to autoplay or Up Next has items, reset the latest played from

--- a/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
+++ b/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
@@ -222,7 +222,6 @@ actor PlaylistMetadataLoader {
             } catch {
                 return cache.images[playlistID] ?? []
             }
-
         }
         imagesTasks[playlistID] = task
         return await task.value

--- a/podcasts/PlaylistViewController+MultiSelect.swift
+++ b/podcasts/PlaylistViewController+MultiSelect.swift
@@ -31,7 +31,6 @@ extension PlaylistViewController: MultiSelectActionDelegate {
             }, completion: { _ in
                 self.multiSelectActionInProgress = false
                 self.isMultiSelectEnabled = false
-
             })
         }
     }

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderCell.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderCell.swift
@@ -50,7 +50,6 @@ class PodcastHeaderCell: UITableViewCell {
                     viewController.tableView().beginUpdates()
                     viewController.tableView().endUpdates()
                 }
-
             }
         })
     }

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
@@ -161,7 +161,6 @@ struct PodcastHeaderView: View {
                     .opacity(viewModel.isSubscribed ? 0 : 1)
                 )
                 .clipped()
-
         }
         .buttonStyle(.plain)
     }
@@ -179,7 +178,6 @@ struct PodcastHeaderView: View {
                             .inset(by: 0.5)
                             .stroke(theme.primaryUi05, lineWidth: 1)
                     )
-
             } else {
                 // Subscribed state - compact button with other actions
                 fundingImage(width: iconSize, height: iconSize, padding: 8.0)

--- a/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
+++ b/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
@@ -280,35 +280,30 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
         let noneAction = OptionAction(label: L10n.none, selected: episodeGrouping == PodcastGrouping.none) { [weak self] in
             self?.setGroupingSetting(.none)
             Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.none])
-
         }
         optionPicker.addAction(action: noneAction)
 
         let downloadedAction = OptionAction(label: L10n.statusDownloaded, selected: episodeGrouping == PodcastGrouping.downloaded) { [weak self] in
             self?.setGroupingSetting(.downloaded)
             Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.downloaded])
-
         }
         optionPicker.addAction(action: downloadedAction)
 
         let unplayedAction = OptionAction(label: L10n.statusUnplayed, selected: episodeGrouping == PodcastGrouping.unplayed) { [weak self] in
             self?.setGroupingSetting(.unplayed)
             Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.unplayed])
-
         }
         optionPicker.addAction(action: unplayedAction)
 
         let seasonAction = OptionAction(label: L10n.season, selected: episodeGrouping == PodcastGrouping.season) { [weak self] in
             self?.setGroupingSetting(.season)
             Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.season])
-
         }
         optionPicker.addAction(action: seasonAction)
 
         let starAction = OptionAction(label: L10n.statusStarred, selected: episodeGrouping == PodcastGrouping.starred) { [weak self] in
             self?.setGroupingSetting(.starred)
             Analytics.track(.podcastsScreenEpisodeGroupingChanged, properties: ["value": PodcastGrouping.starred])
-
         }
         optionPicker.addAction(action: starAction)
 

--- a/podcasts/Profile - SwiftUI/Common Views/ProfileInfoLabels.swift
+++ b/podcasts/Profile - SwiftUI/Common Views/ProfileInfoLabels.swift
@@ -94,7 +94,6 @@ struct ProfileInfoLabels_Previews: PreviewProvider {
                                                      displayName: "Hellllllllllllllllllllllloooooooooooo Worrrrrrrrrrrllllllddd"))
                     Divider()
                 }
-
             }
             .padding()
             .background(theme.primaryUi01)

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -632,7 +632,6 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         }
         return vc
     }
-
 }
 
 extension ProfileViewController: UIPopoverPresentationControllerDelegate {

--- a/podcasts/Referrals/ReferralCardAnimatedGradientView.swift
+++ b/podcasts/Referrals/ReferralCardAnimatedGradientView.swift
@@ -77,5 +77,4 @@ struct ReferralCardAnimatedGradientView: View {
         }
         .cornerRadius(15)
         .frame(width: 315, height: 200)
-
 }

--- a/podcasts/ThemeColor.swift
+++ b/podcasts/ThemeColor.swift
@@ -6084,5 +6084,4 @@ struct ThemeColor {
             return ThemeColor.category19ContrastDark
         }
     }
-
 }

--- a/podcasts/ThemeSelectorView.swift
+++ b/podcasts/ThemeSelectorView.swift
@@ -82,7 +82,6 @@ struct ThemePreviewView: View {
 struct ThemeSelectorView_Previews: PreviewProvider {
     static var previews: some View {
         ThemeSelectorView(title: L10n.appearanceThemeSelect, onThemeSelected: { _ in
-
         }, dismissAction: {}, selectedTheme: .dark)
             .environmentObject(Theme.sharedTheme)
     }

--- a/podcasts/TimeSliderLayer.swift
+++ b/podcasts/TimeSliderLayer.swift
@@ -209,5 +209,4 @@ class TimeSliderLayer: CALayer {
     private func animationLineWidth() -> CGFloat {
         (leftHalfRect.size.width + rightHalfRect.size.width) / 3
     }
-
 }

--- a/podcasts/TranscriptErrorView.swift
+++ b/podcasts/TranscriptErrorView.swift
@@ -25,7 +25,6 @@ class TranscriptErrorView: UIView {
                 containerView.heightAnchor.constraint(equalTo: heightAnchor)
             ]
         )
-
     }
 
     required init?(coder: NSCoder) {

--- a/podcasts/TranscriptModel.swift
+++ b/podcasts/TranscriptModel.swift
@@ -14,7 +14,6 @@ struct TranscriptCue: Sendable {
 }
 
 extension NSAttributedString: @retroactive @unchecked Sendable {
-
 }
 
 struct TranscriptModel: Sendable {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -818,7 +818,6 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
                     formattedText.addAttributes(highlightStyle, range: NSRange(location: indice, length: searchTermLength))
                 }
-
             }
         }
         formattedText.endEditing()

--- a/podcasts/Up Next History/UpNextHistoryView.swift
+++ b/podcasts/Up Next History/UpNextHistoryView.swift
@@ -11,7 +11,6 @@ struct UpNextHistoryView: View {
     var body: some View {
         List {
             Section {
-
             } footer: {
                 Text(L10n.upNextHistoryExplanation)
                     .foregroundStyle(theme.primaryText02)

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -196,7 +196,6 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
         let addFileAction = OptionAction(label: L10n.fileUploadAddFile, icon: "filter_add") { [weak self] in
             Analytics.track(.uploadedFilesOptionsModalOptionTapped, properties: ["option": "add_file"])
             self?.addFile()
-
         }
         optionsPicker.addAction(action: addFileAction)
 

--- a/podcasts/UserEpisodeDetailViewController.swift
+++ b/podcasts/UserEpisodeDetailViewController.swift
@@ -385,7 +385,6 @@ class UserEpisodeDetailViewController: UIViewController {
                 guard let self else { return }
                 self.containerViewHeight.constant = UserEpisodeDetailViewController.containerHeightWithoutError
                 self.view.layoutIfNeeded()
-
             }) { [weak self] _ in
                 self?.errorContainerView.alpha = 0
                 self?.errorContainerView.isHidden = true

--- a/podcasts/Utilities/SwiftUI/ActionBarOverlayView.swift
+++ b/podcasts/Utilities/SwiftUI/ActionBarOverlayView.swift
@@ -173,7 +173,6 @@ struct ActionBarOverlayView_Previews: PreviewProvider {
 
                     Spacer()
                 }.frame(maxWidth: .infinity)
-
             }, actions: [
                 .init(imageName: "shelf_archive", title: "Archive", action: {
                     print("one")

--- a/podcasts/Utilities/SwiftUI/ContentSizeGeometryReader.swift
+++ b/podcasts/Utilities/SwiftUI/ContentSizeGeometryReader.swift
@@ -60,7 +60,6 @@ struct ContentHeightView_Previews: PreviewProvider {
                         Rectangle()
                             .frame(width: 200, height: 200)
                     }
-
                 }
                 .background(Color.blue)
             }

--- a/podcasts/Utilities/SwiftUI/HighlightedText.swift
+++ b/podcasts/Utilities/SwiftUI/HighlightedText.swift
@@ -148,7 +148,6 @@ struct HighlightedText: View {
         return result
             .replacingOccurrences(of: startToken, with: "^[")
             .replacingOccurrences(of: endToken, with: "](highlight: true)")
-
     }
 
     // MARK: - Public structs

--- a/podcasts/Utilities/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/Utilities/SwiftUI/HorizontalCarousel.swift
@@ -335,7 +335,6 @@ struct HorizontalCarousel_Preview: PreviewProvider {
                         .padding(5)
                         .background((!isConstant ? Color.blue : Color.clear).cornerRadius(10))
                         .foregroundColor(!isConstant ? Color.white : nil)
-
                     }
                     HStack {
                         Text("Peek Amount")

--- a/podcasts/Utilities/SwiftUI/NonBlockingLongPressView.swift
+++ b/podcasts/Utilities/SwiftUI/NonBlockingLongPressView.swift
@@ -74,7 +74,6 @@ struct NonBlockingLongPressView_Previews: PreviewProvider {
                             Text("Row \(index)")
                                 .padding()
                                 .background(Color.blue)
-
                         } onLongPressed: {
                             print("Long Pressed!")
                         }

--- a/podcasts/VideoViewController.swift
+++ b/podcasts/VideoViewController.swift
@@ -399,7 +399,6 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
             } else {
                 UIView.animate(withDuration: 0.3, animations: {
                     self.view.frame = CGRect(x: 0, y: 0, width: self.view.frame.size.width, height: self.view.frame.size.height)
-
                 }, completion: { (_: Bool) in
                     self.view.frame = CGRect(x: 0, y: 0, width: self.view.frame.size.width, height: self.view.frame.size.height)
                     self.closeToSafeTopConstraint.isActive = true

--- a/podcasts/Whats New/SlumberViews.swift
+++ b/podcasts/Whats New/SlumberViews.swift
@@ -21,7 +21,6 @@ struct SlumberWhatsNewHeader: View {
                 PodcastCover(podcastUuid: "62200ab0-b7ec-0139-f606-0acc26574db2")
                     .offset(y: distance)
                     .animation(.easeInOut(duration: 3).repeatForever(autoreverses: true).delay(1.2), value: distance)
-
             }
                 .frame(width: 120, height: 120)
         }


### PR DESCRIPTION
## Summary

Enables SwiftLint's [`vertical_whitespace_closing_braces`](https://realm.github.io/SwiftLint/vertical_whitespace_closing_braces.html) rule.

The rule forbids blank lines immediately before a closing brace, keeping function and type bodies compact.

- 140 violations resolved by `make format` across 116 Swift files.
- No manual edits or `swiftlint:disable` suppressions were required.
- Formatting-only change — local build deferred to CI (the local Xcode SDK is missing an iOS 26.4 API used by `CarPlay/CarPlaySceneDelegate+Convert.swift` on trunk; that file is not touched by this PR).

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

## Test plan

- [ ] CI build is green.
- [ ] `swiftlint lint --strict --no-cache` is clean against the rule.

🤖 Generated with [Claude Code](https://claude.ai/code)