### PR TITLE
Convert legacy dialogs to native UIAlertController under Liquid Glass

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -348,7 +348,6 @@
 		8B87C47C29F0129A00257B96 /* EpisodeArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B87C47B29F0129A00257B96 /* EpisodeArtwork.swift */; };
 		8B907F182AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B907F172AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift */; };
 		8B907F1A2AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B907F192AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift */; };
-		FF26A9924A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */; };
 		8B9D233F2C41B1BE004CD57D /* TranscriptShelfButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9D233E2C41B1BE004CD57D /* TranscriptShelfButton.swift */; };
 		8B9DEFD62906D1CE00075EAB /* EndOfYear.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8B9DEFD52906D1CE00075EAB /* EndOfYear.xcassets */; };
 		8BA55A1528CA8FEB002BECC5 /* PrivacySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */; };
@@ -1281,6 +1280,7 @@
 		FF1F27052F224C5C001908BE /* UIFont+FontStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7F87F0F2913242B00C15980 /* UIFont+FontStyle.swift */; };
 		FF2142D42C07369200672D8D /* MediaExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2142D32C07369200672D8D /* MediaExporter.swift */; };
 		FF2142D52C07369200672D8D /* MediaExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2142D32C07369200672D8D /* MediaExporter.swift */; };
+		FF26A9924A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */; };
 		FF31C0972EC211890083C7E5 /* playback_2025_plus.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = FF31C0962EC211890083C7E5 /* playback_2025_plus.mp4 */; };
 		FF31C0992EC216600083C7E5 /* playback_2025_plus_background.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = FF31C0982EC216600083C7E5 /* playback_2025_plus_background.mp4 */; };
 		FF40C0662C65175B003A9D93 /* TranscriptErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF40C0652C65175B003A9D93 /* TranscriptErrorView.swift */; };
@@ -1857,7 +1857,6 @@
 		8B87C47B29F0129A00257B96 /* EpisodeArtwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpisodeArtwork.swift; sourceTree = "<group>"; };
 		8B907F172AA8E1F100926F4F /* MiniPlayerViewController+TransitionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MiniPlayerViewController+TransitionDelegate.swift"; sourceTree = "<group>"; };
 		8B907F192AA8E5E500926F4F /* MiniPlayerToFullPlayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerToFullPlayerAnimator.swift; sourceTree = "<group>"; };
-		FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassPlayerAnimator.swift; sourceTree = "<group>"; };
 		8B9D233E2C41B1BE004CD57D /* TranscriptShelfButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptShelfButton.swift; sourceTree = "<group>"; };
 		8B9DEFD52906D1CE00075EAB /* EndOfYear.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = EndOfYear.xcassets; sourceTree = "<group>"; };
 		8BA55A1428CA8FEB002BECC5 /* PrivacySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsViewController.swift; sourceTree = "<group>"; };
@@ -2630,6 +2629,7 @@
 		FF1DF0242C8F4E2F0028B8D8 /* ReferralsClaimBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferralsClaimBannerView.swift; sourceTree = "<group>"; };
 		FF1EC6852CECBC73006FBF9B /* ManageDownloadsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageDownloadsCoordinator.swift; sourceTree = "<group>"; };
 		FF2142D32C07369200672D8D /* MediaExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExporter.swift; sourceTree = "<group>"; };
+		FF26A9914A1B5C2D00000001 /* LiquidGlassPlayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassPlayerAnimator.swift; sourceTree = "<group>"; };
 		FF31C0962EC211890083C7E5 /* playback_2025_plus.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = playback_2025_plus.mp4; sourceTree = "<group>"; };
 		FF31C0982EC216600083C7E5 /* playback_2025_plus_background.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = playback_2025_plus_background.mp4; sourceTree = "<group>"; };
 		FF40C0652C65175B003A9D93 /* TranscriptErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptErrorView.swift; sourceTree = "<group>"; };

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2640"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/podcasts/AccountViewController+TableView.swift
+++ b/podcasts/AccountViewController+TableView.swift
@@ -224,22 +224,37 @@ extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
     private func showSignOutWarning() {
         let numSubscriptionPodcasts = DataManager.sharedManager.allPaidPodcasts().count
 
-        let signOutAction = OptionAction(label: L10n.accountSignOut, icon: "signout") { [weak self] in
-            SignOutHelper.signout()
-            self?.navigationController?.popViewController(animated: true)
-        }
-        signOutAction.destructive = true
+        if FeatureFlag.liquidGlass.enabled {
+            let message: String?
+            if numSubscriptionPodcasts > 0 {
+                message = L10n.accountSignOutSupporterPrompt(numSubscriptionPodcasts.localized()) + "\n\n" + L10n.accountSignOutSupporterSubtitle
+            } else {
+                message = nil
+            }
 
-        if numSubscriptionPodcasts > 0 {
-            let options = OptionsPicker(title: "", iconTintStyle: .support05)
-            options.addDescriptiveActions(title: L10n.accountSignOut, message: L10n.accountSignOutSupporterPrompt(numSubscriptionPodcasts.localized()) + "\n\n" + L10n.accountSignOutSupporterSubtitle, icon: "signout", actions: [signOutAction])
-
-            options.show(statusBarStyle: preferredStatusBarStyle)
+            let alert = UIAlertController(title: L10n.areYouSure, message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.accountSignOut, style: .destructive) { [weak self] _ in
+                SignOutHelper.signout()
+                self?.navigationController?.popViewController(animated: true)
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            present(alert, animated: true)
         } else {
-            let options = OptionsPicker(title: L10n.areYouSure)
-            options.addAction(action: signOutAction)
+            let signOutAction = OptionAction(label: L10n.accountSignOut, icon: "signout") { [weak self] in
+                SignOutHelper.signout()
+                self?.navigationController?.popViewController(animated: true)
+            }
+            signOutAction.destructive = true
 
-            options.show(statusBarStyle: preferredStatusBarStyle)
+            if numSubscriptionPodcasts > 0 {
+                let options = OptionsPicker(title: "", iconTintStyle: .support05)
+                options.addDescriptiveActions(title: L10n.accountSignOut, message: L10n.accountSignOutSupporterPrompt(numSubscriptionPodcasts.localized()) + "\n\n" + L10n.accountSignOutSupporterSubtitle, icon: "signout", actions: [signOutAction])
+                options.show(statusBarStyle: preferredStatusBarStyle)
+            } else {
+                let options = OptionsPicker(title: L10n.areYouSure)
+                options.addAction(action: signOutAction)
+                options.show(statusBarStyle: preferredStatusBarStyle)
+            }
         }
     }
 

--- a/podcasts/AccountViewController+TableView.swift
+++ b/podcasts/AccountViewController+TableView.swift
@@ -225,19 +225,12 @@ extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
         let numSubscriptionPodcasts = DataManager.sharedManager.allPaidPodcasts().count
 
         if FeatureFlag.liquidGlass.enabled {
-            let message: String?
-            if numSubscriptionPodcasts > 0 {
-                message = L10n.accountSignOutSupporterPrompt(numSubscriptionPodcasts.localized()) + "\n\n" + L10n.accountSignOutSupporterSubtitle
-            } else {
-                message = nil
-            }
-
-            let alert = UIAlertController(title: L10n.areYouSure, message: message, preferredStyle: .alert)
+            let alert = UIAlertController(title: L10n.accountSignOutAlertTitle, message: L10n.accountSignOutAlertMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             alert.addAction(UIAlertAction(title: L10n.accountSignOut, style: .destructive) { [weak self] _ in
                 SignOutHelper.signout()
                 self?.navigationController?.popViewController(animated: true)
             })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             present(alert, animated: true)
         } else {
             let signOutAction = OptionAction(label: L10n.accountSignOut, icon: "signout") { [weak self] in

--- a/podcasts/AccountViewController+TableView.swift
+++ b/podcasts/AccountViewController+TableView.swift
@@ -222,33 +222,20 @@ extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     private func showSignOutWarning() {
-        let numSubscriptionPodcasts = DataManager.sharedManager.allPaidPodcasts().count
-
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.accountSignOutAlertTitle, message: L10n.accountSignOutAlertMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            alert.addAction(UIAlertAction(title: L10n.accountSignOut, style: .destructive) { [weak self] _ in
-                SignOutHelper.signout()
-                self?.navigationController?.popViewController(animated: true)
-            })
-            present(alert, animated: true)
-        } else {
-            let signOutAction = OptionAction(label: L10n.accountSignOut, icon: "signout") { [weak self] in
-                SignOutHelper.signout()
-                self?.navigationController?.popViewController(animated: true)
-            }
-            signOutAction.destructive = true
-
-            if numSubscriptionPodcasts > 0 {
-                let options = OptionsPicker(title: "", iconTintStyle: .support05)
-                options.addDescriptiveActions(title: L10n.accountSignOut, message: L10n.accountSignOutSupporterPrompt(numSubscriptionPodcasts.localized()) + "\n\n" + L10n.accountSignOutSupporterSubtitle, icon: "signout", actions: [signOutAction])
-                options.show(statusBarStyle: preferredStatusBarStyle)
-            } else {
-                let options = OptionsPicker(title: L10n.areYouSure)
-                options.addAction(action: signOutAction)
-                options.show(statusBarStyle: preferredStatusBarStyle)
-            }
+        let signOutAction = OptionAction(label: L10n.accountSignOut, icon: "signout") { [weak self] in
+            SignOutHelper.signout()
+            self?.navigationController?.popViewController(animated: true)
         }
+        signOutAction.destructive = true
+
+        let options = OptionsPicker(title: L10n.accountSignOutAlertTitle, iconTintStyle: .support05)
+        options.addDescriptiveActions(
+            title: L10n.accountSignOutAlertTitle,
+            message: L10n.accountSignOutAlertMessage,
+            icon: "signout",
+            actions: [signOutAction]
+        )
+        options.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     private func deleteAccountTapped() {

--- a/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
@@ -281,10 +281,19 @@ class MultiSelectHelper {
 
         if FeatureFlag.liquidGlass.enabled {
             let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
-            var message = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
-            if !onWifi, !Settings.mobileDataAllowed() {
-                message = L10n.downloadDataWarningAlert + (message.isEmpty ? "" : "\n" + message)
+            let totalSize = downloadableEpisodes.prefix(actualDownloadCount).reduce(Int64(0)) { $0 + $1.sizeInBytes }
+            var messageParts = [String]()
+            if totalSize > 0 {
+                let sizeString = SizeFormatter.shared.noDecimalFormat(bytes: totalSize)
+                messageParts.append(L10n.downloadEstimatedSize(sizeString))
             }
+            if downloadLimitExceeded {
+                messageParts.append(L10n.bulkDownloadMax)
+            }
+            if !onWifi, !Settings.mobileDataAllowed() {
+                messageParts.append(L10n.downloadDataWarningAlert)
+            }
+            let message = messageParts.joined(separator: "\n")
 
             let alert = UIAlertController(title: title, message: message.isEmpty ? nil : message, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: downloadText, style: onWifi ? .default : .destructive) { _ in

--- a/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
@@ -78,7 +78,7 @@ class MultiSelectHelper {
             let alert: UIAlertController
 
             if downloadedEpisodes.isEmpty {
-                title = L10n.deleteFromCloud
+                title = L10n.alertDeleteFromCloud
                 warningMessage = deleteFileMessage(uploadedEpisodes.count)
                 alert = UIAlertController(title: title, message: warningMessage, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: L10n.deleteFromCloud, style: .destructive) { _ in
@@ -90,7 +90,7 @@ class MultiSelectHelper {
                     }
                 })
             } else if uploadedEpisodes.isEmpty {
-                title = L10n.deleteFromDevice
+                title = L10n.alertDeleteFromDevice
                 warningMessage = deleteFileMessage(downloadedEpisodes.count)
                 alert = UIAlertController(title: title, message: warningMessage, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .destructive) { _ in
@@ -102,7 +102,7 @@ class MultiSelectHelper {
                     }
                 })
             } else {
-                title = L10n.deleteFile
+                title = L10n.alertDeleteFile
                 warningMessage = deleteFileMessage(downloadedEpisodes.count)
                 alert = UIAlertController(title: title, message: warningMessage, preferredStyle: .alert)
                 alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .default) { _ in
@@ -280,7 +280,7 @@ class MultiSelectHelper {
         let downloadText = L10n.downloadCountPrompt(selectedEpisodes.count).localizedUppercase
 
         if FeatureFlag.liquidGlass.enabled {
-            let title = onWifi ? L10n.download : L10n.notOnWifi
+            let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
             var message = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
             if !onWifi, !Settings.mobileDataAllowed() {
                 message = L10n.downloadDataWarningAlert + (message.isEmpty ? "" : "\n" + message)

--- a/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
@@ -72,63 +72,110 @@ class MultiSelectHelper {
         let downloadedEpisodes = selectedEpisodes.filter { $0.downloaded(pathFinder: DownloadManager.shared) }
         let uploadedEpisodes = selectedEpisodes.filter { $0.uploaded() }
 
-        let confirmPicker: OptionsPicker
-        if downloadedEpisodes.isEmpty {
-            confirmPicker = OptionsPicker(title: nil)
-            let deleteFromCloudAction = OptionAction(label: L10n.deleteFromCloud, icon: nil) { () in
-                DispatchQueue.global().async {
-                    for episode in uploadedEpisodes {
-                        UserEpisodeManager.deleteFromCloud(episode: episode)
-                    }
+        if FeatureFlag.liquidGlass.enabled {
+            let title: String
+            let warningMessage: String
+            let alert: UIAlertController
 
-                    actionDelegate.multiSelectActionCompleted()
-                }
+            if downloadedEpisodes.isEmpty {
+                title = L10n.deleteFromCloud
+                warningMessage = deleteFileMessage(uploadedEpisodes.count)
+                alert = UIAlertController(title: title, message: warningMessage, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: L10n.deleteFromCloud, style: .destructive) { _ in
+                    DispatchQueue.global().async {
+                        for episode in uploadedEpisodes {
+                            UserEpisodeManager.deleteFromCloud(episode: episode)
+                        }
+                        actionDelegate.multiSelectActionCompleted()
+                    }
+                })
+            } else if uploadedEpisodes.isEmpty {
+                title = L10n.deleteFromDevice
+                warningMessage = deleteFileMessage(downloadedEpisodes.count)
+                alert = UIAlertController(title: title, message: warningMessage, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .destructive) { _ in
+                    DispatchQueue.global().async {
+                        for episode in downloadedEpisodes {
+                            UserEpisodeManager.deleteFromDevice(userEpisode: episode)
+                        }
+                        actionDelegate.multiSelectActionCompleted()
+                    }
+                })
+            } else {
+                title = L10n.deleteFile
+                warningMessage = deleteFileMessage(downloadedEpisodes.count)
+                alert = UIAlertController(title: title, message: warningMessage, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .default) { _ in
+                    DispatchQueue.global().async {
+                        for episode in downloadedEpisodes {
+                            UserEpisodeManager.deleteFromDevice(userEpisode: episode)
+                        }
+                        actionDelegate.multiSelectActionCompleted()
+                    }
+                })
+                alert.addAction(UIAlertAction(title: L10n.deleteEverywhere, style: .destructive) { _ in
+                    DispatchQueue.global().async {
+                        for episode in selectedEpisodes {
+                            UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
+                        }
+                        actionDelegate.multiSelectActionCompleted()
+                    }
+                })
             }
 
-            let warningMessage = deleteFileMessage(uploadedEpisodes.count)
-            confirmPicker.addDescriptiveActions(title: L10n.deleteFromCloud, message: warningMessage, icon: "episode-delete", actions: [deleteFromCloudAction])
-        } else if uploadedEpisodes.isEmpty {
-            confirmPicker = OptionsPicker(title: nil)
-            let deleteFromDeviceAction = OptionAction(label: L10n.deleteFromDeviceOnly, icon: nil) { () in
-                DispatchQueue.global().async {
-                    for episode in downloadedEpisodes {
-                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                    }
-
-                    actionDelegate.multiSelectActionCompleted()
-                }
-            }
-
-            let warningMessage = deleteFileMessage(downloadedEpisodes.count)
-            confirmPicker.addDescriptiveActions(title: L10n.deleteFromDevice, message: warningMessage, icon: "episode-delete", actions: [deleteFromDeviceAction])
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            actionDelegate.multiSelectPresentingViewController().present(alert, animated: true)
         } else {
-            confirmPicker = OptionsPicker(title: nil)
-            let deleteEverwhereAction = OptionAction(label: L10n.deleteEverywhere, icon: nil) { () in
-                DispatchQueue.global().async {
-                    for episode in selectedEpisodes {
-                        UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
+            let confirmPicker: OptionsPicker
+            if downloadedEpisodes.isEmpty {
+                confirmPicker = OptionsPicker(title: nil)
+                let deleteFromCloudAction = OptionAction(label: L10n.deleteFromCloud, icon: nil) { () in
+                    DispatchQueue.global().async {
+                        for episode in uploadedEpisodes {
+                            UserEpisodeManager.deleteFromCloud(episode: episode)
+                        }
+                        actionDelegate.multiSelectActionCompleted()
                     }
-
-                    actionDelegate.multiSelectActionCompleted()
                 }
+                let warningMessage = deleteFileMessage(uploadedEpisodes.count)
+                confirmPicker.addDescriptiveActions(title: L10n.deleteFromCloud, message: warningMessage, icon: "episode-delete", actions: [deleteFromCloudAction])
+            } else if uploadedEpisodes.isEmpty {
+                confirmPicker = OptionsPicker(title: nil)
+                let deleteFromDeviceAction = OptionAction(label: L10n.deleteFromDeviceOnly, icon: nil) { () in
+                    DispatchQueue.global().async {
+                        for episode in downloadedEpisodes {
+                            UserEpisodeManager.deleteFromDevice(userEpisode: episode)
+                        }
+                        actionDelegate.multiSelectActionCompleted()
+                    }
+                }
+                let warningMessage = deleteFileMessage(downloadedEpisodes.count)
+                confirmPicker.addDescriptiveActions(title: L10n.deleteFromDevice, message: warningMessage, icon: "episode-delete", actions: [deleteFromDeviceAction])
+            } else {
+                confirmPicker = OptionsPicker(title: nil)
+                let deleteEverywhereAction = OptionAction(label: L10n.deleteEverywhere, icon: nil) { () in
+                    DispatchQueue.global().async {
+                        for episode in selectedEpisodes {
+                            UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
+                        }
+                        actionDelegate.multiSelectActionCompleted()
+                    }
+                }
+                let deleteFromDeviceAction = OptionAction(label: L10n.deleteFromDeviceOnly, icon: nil) { () in
+                    DispatchQueue.global().async {
+                        for episode in downloadedEpisodes {
+                            UserEpisodeManager.deleteFromDevice(userEpisode: episode)
+                        }
+                        actionDelegate.multiSelectActionCompleted()
+                    }
+                }
+                deleteFromDeviceAction.outline = true
+                let warningMessage = deleteFileMessage(downloadedEpisodes.count)
+                confirmPicker.addDescriptiveActions(title: L10n.deleteFile, message: warningMessage, icon: "episode-delete", actions: [deleteFromDeviceAction, deleteEverywhereAction])
             }
 
-            let deleteFromDeviceAction = OptionAction(label: L10n.deleteFromDeviceOnly, icon: nil) { () in
-                DispatchQueue.global().async {
-                    for episode in downloadedEpisodes {
-                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                    }
-
-                    actionDelegate.multiSelectActionCompleted()
-                }
-            }
-            deleteFromDeviceAction.outline = true
-
-            let warningMessage = deleteFileMessage(downloadedEpisodes.count)
-            confirmPicker.addDescriptiveActions(title: L10n.deleteFile, message: warningMessage, icon: "episode-delete", actions: [deleteFromDeviceAction, deleteEverwhereAction])
+            confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())
         }
-
-        confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())
     }
 
     private class func archiveEpisodes(actionDelegate: MultiSelectActionDelegate) {
@@ -221,40 +268,71 @@ class MultiSelectHelper {
             return
         }
 
-        let downloadText = L10n.downloadCountPrompt(selectedEpisodes.count).localizedUppercase
-        let downloadAction = OptionAction(label: downloadText, icon: nil) { () in
+        let onWifi = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
+
+        if onWifi, downloadableCount < 5 {
+            let status = L10n.multiSelectDownloadingEpisodesFormat(selectedEpisodes.count.localized())
+            actionDelegate.multiSelectActionBegan(status: status)
             MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
-            actionDelegate.multiSelectActionCompleted()
+            return
         }
 
-        let confirmPicker = OptionsPicker(title: nil)
-        var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
+        let downloadText = L10n.downloadCountPrompt(selectedEpisodes.count).localizedUppercase
 
-        if NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
-            if downloadableCount < 5 {
-                let status = L10n.multiSelectDownloadingEpisodesFormat(selectedEpisodes.count.localized())
-                actionDelegate.multiSelectActionBegan(status: status)
+        if FeatureFlag.liquidGlass.enabled {
+            let title = onWifi ? L10n.download : L10n.notOnWifi
+            var message = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
+            if !onWifi, !Settings.mobileDataAllowed() {
+                message = L10n.downloadDataWarningAlert + (message.isEmpty ? "" : "\n" + message)
+            }
+
+            let alert = UIAlertController(title: title, message: message.isEmpty ? nil : message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: downloadText, style: onWifi ? .default : .destructive) { _ in
                 MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
-                return
-            } else {
-                confirmPicker.addDescriptiveActions(title: L10n.download, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
+                actionDelegate.multiSelectActionCompleted()
+            })
+            if !onWifi {
+                alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
+                    let status = L10n.multiSelectQueuingEpisodesFormat(selectedEpisodes.count.localized())
+                    actionDelegate.multiSelectActionBegan(status: status)
+                    queueEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
+                })
+                if !Settings.mobileDataAllowed() {
+                    alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
+                        if let url = URL(string: "pktc://settings/storage-and-data") {
+                            UIApplication.shared.open(url)
+                        }
+                    })
+                }
             }
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            actionDelegate.multiSelectPresentingViewController().present(alert, animated: true)
         } else {
-            let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                let status = L10n.multiSelectQueuingEpisodesFormat(selectedEpisodes.count.localized())
-                actionDelegate.multiSelectActionBegan(status: status)
-                queueEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
-            }
-            queueAction.outline = true
-
-            if !Settings.mobileDataAllowed() {
-                warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
+            let downloadAction = OptionAction(label: downloadText, icon: nil) { () in
+                MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
+                actionDelegate.multiSelectActionCompleted()
             }
 
-            confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
+            let confirmPicker = OptionsPicker(title: nil)
+            var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
+
+            if onWifi {
+                confirmPicker.addDescriptiveActions(title: L10n.download, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
+            } else {
+                let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
+                    let status = L10n.multiSelectQueuingEpisodesFormat(selectedEpisodes.count.localized())
+                    actionDelegate.multiSelectActionBegan(status: status)
+                    queueEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
+                }
+                queueAction.outline = true
+                if !Settings.mobileDataAllowed() {
+                    warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
+                }
+                confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
+            }
+
+            confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())
         }
-
-        confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())
     }
 
     private class func downloadEpisodes(_ episodes: [BaseEpisode], actionDelegate: MultiSelectActionDelegate) {

--- a/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
@@ -72,110 +72,67 @@ class MultiSelectHelper {
         let downloadedEpisodes = selectedEpisodes.filter { $0.downloaded(pathFinder: DownloadManager.shared) }
         let uploadedEpisodes = selectedEpisodes.filter { $0.uploaded() }
 
-        if FeatureFlag.liquidGlass.enabled {
-            let title: String
-            let warningMessage: String
-            let alert: UIAlertController
-
-            if downloadedEpisodes.isEmpty {
-                title = L10n.alertDeleteFromCloud
-                warningMessage = deleteFileMessage(uploadedEpisodes.count)
-                alert = UIAlertController(title: title, message: warningMessage, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: L10n.deleteFromCloud, style: .destructive) { _ in
-                    DispatchQueue.global().async {
-                        for episode in uploadedEpisodes {
-                            UserEpisodeManager.deleteFromCloud(episode: episode)
-                        }
-                        actionDelegate.multiSelectActionCompleted()
+        let confirmPicker = OptionsPicker(title: nil)
+        if downloadedEpisodes.isEmpty {
+            let deleteFromCloudAction = OptionAction(label: L10n.deleteFromCloud, icon: "episode-delete") { () in
+                DispatchQueue.global().async {
+                    for episode in uploadedEpisodes {
+                        UserEpisodeManager.deleteFromCloud(episode: episode)
                     }
-                })
-            } else if uploadedEpisodes.isEmpty {
-                title = L10n.alertDeleteFromDevice
-                warningMessage = deleteFileMessage(downloadedEpisodes.count)
-                alert = UIAlertController(title: title, message: warningMessage, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .destructive) { _ in
-                    DispatchQueue.global().async {
-                        for episode in downloadedEpisodes {
-                            UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                        }
-                        actionDelegate.multiSelectActionCompleted()
-                    }
-                })
-            } else {
-                title = L10n.alertDeleteFile
-                warningMessage = deleteFileMessage(downloadedEpisodes.count)
-                alert = UIAlertController(title: title, message: warningMessage, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .default) { _ in
-                    DispatchQueue.global().async {
-                        for episode in downloadedEpisodes {
-                            UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                        }
-                        actionDelegate.multiSelectActionCompleted()
-                    }
-                })
-                alert.addAction(UIAlertAction(title: L10n.deleteEverywhere, style: .destructive) { _ in
-                    DispatchQueue.global().async {
-                        for episode in selectedEpisodes {
-                            UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
-                        }
-                        actionDelegate.multiSelectActionCompleted()
-                    }
-                })
+                    actionDelegate.multiSelectActionCompleted()
+                }
             }
-
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            actionDelegate.multiSelectPresentingViewController().present(alert, animated: true)
+            deleteFromCloudAction.destructive = true
+            confirmPicker.addDescriptiveActions(
+                title: L10n.alertDeleteFromCloud,
+                message: deleteFileMessage(uploadedEpisodes.count),
+                icon: "episode-delete",
+                actions: [deleteFromCloudAction]
+            )
+        } else if uploadedEpisodes.isEmpty {
+            let deleteFromDeviceAction = OptionAction(label: L10n.deleteFromDeviceOnly, icon: "episode-delete") { () in
+                DispatchQueue.global().async {
+                    for episode in downloadedEpisodes {
+                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
+                    }
+                    actionDelegate.multiSelectActionCompleted()
+                }
+            }
+            deleteFromDeviceAction.destructive = true
+            confirmPicker.addDescriptiveActions(
+                title: L10n.alertDeleteFromDevice,
+                message: deleteFileMessage(downloadedEpisodes.count),
+                icon: "episode-delete",
+                actions: [deleteFromDeviceAction]
+            )
         } else {
-            let confirmPicker: OptionsPicker
-            if downloadedEpisodes.isEmpty {
-                confirmPicker = OptionsPicker(title: nil)
-                let deleteFromCloudAction = OptionAction(label: L10n.deleteFromCloud, icon: nil) { () in
-                    DispatchQueue.global().async {
-                        for episode in uploadedEpisodes {
-                            UserEpisodeManager.deleteFromCloud(episode: episode)
-                        }
-                        actionDelegate.multiSelectActionCompleted()
+            let deleteFromDeviceAction = OptionAction(label: L10n.deleteFromDeviceOnly, icon: "episode-delete") { () in
+                DispatchQueue.global().async {
+                    for episode in downloadedEpisodes {
+                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
                     }
+                    actionDelegate.multiSelectActionCompleted()
                 }
-                let warningMessage = deleteFileMessage(uploadedEpisodes.count)
-                confirmPicker.addDescriptiveActions(title: L10n.deleteFromCloud, message: warningMessage, icon: "episode-delete", actions: [deleteFromCloudAction])
-            } else if uploadedEpisodes.isEmpty {
-                confirmPicker = OptionsPicker(title: nil)
-                let deleteFromDeviceAction = OptionAction(label: L10n.deleteFromDeviceOnly, icon: nil) { () in
-                    DispatchQueue.global().async {
-                        for episode in downloadedEpisodes {
-                            UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                        }
-                        actionDelegate.multiSelectActionCompleted()
-                    }
-                }
-                let warningMessage = deleteFileMessage(downloadedEpisodes.count)
-                confirmPicker.addDescriptiveActions(title: L10n.deleteFromDevice, message: warningMessage, icon: "episode-delete", actions: [deleteFromDeviceAction])
-            } else {
-                confirmPicker = OptionsPicker(title: nil)
-                let deleteEverywhereAction = OptionAction(label: L10n.deleteEverywhere, icon: nil) { () in
-                    DispatchQueue.global().async {
-                        for episode in selectedEpisodes {
-                            UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
-                        }
-                        actionDelegate.multiSelectActionCompleted()
-                    }
-                }
-                let deleteFromDeviceAction = OptionAction(label: L10n.deleteFromDeviceOnly, icon: nil) { () in
-                    DispatchQueue.global().async {
-                        for episode in downloadedEpisodes {
-                            UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                        }
-                        actionDelegate.multiSelectActionCompleted()
-                    }
-                }
-                deleteFromDeviceAction.outline = true
-                let warningMessage = deleteFileMessage(downloadedEpisodes.count)
-                confirmPicker.addDescriptiveActions(title: L10n.deleteFile, message: warningMessage, icon: "episode-delete", actions: [deleteFromDeviceAction, deleteEverywhereAction])
             }
-
-            confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())
+            deleteFromDeviceAction.outline = true
+            let deleteEverywhereAction = OptionAction(label: L10n.deleteEverywhere, icon: "episode-delete") { () in
+                DispatchQueue.global().async {
+                    for episode in selectedEpisodes {
+                        UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
+                    }
+                    actionDelegate.multiSelectActionCompleted()
+                }
+            }
+            deleteEverywhereAction.destructive = true
+            confirmPicker.addDescriptiveActions(
+                title: L10n.alertDeleteFile,
+                message: deleteFileMessage(downloadedEpisodes.count),
+                icon: "episode-delete",
+                actions: [deleteFromDeviceAction, deleteEverywhereAction]
+            )
         }
+
+        confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())
     }
 
     private class func archiveEpisodes(actionDelegate: MultiSelectActionDelegate) {
@@ -278,70 +235,53 @@ class MultiSelectHelper {
         }
 
         let downloadText = L10n.downloadCountPrompt(selectedEpisodes.count)
-
-        if FeatureFlag.liquidGlass.enabled {
-            let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
-            let totalSize = downloadableEpisodes.prefix(actualDownloadCount).reduce(Int64(0)) { $0 + $1.sizeInBytes }
-            var messageParts = [String]()
-            if totalSize > 0 {
-                let sizeString = SizeFormatter.shared.noDecimalFormat(bytes: totalSize)
-                messageParts.append(L10n.downloadEstimatedSize(sizeString))
-            }
-            if downloadLimitExceeded {
-                messageParts.append(L10n.bulkDownloadMax)
-            }
-            if !onWifi, !Settings.mobileDataAllowed() {
-                messageParts.append(L10n.downloadDataWarningAlert)
-            }
-            let message = messageParts.joined(separator: "\n")
-
-            let alert = UIAlertController(title: title, message: message.isEmpty ? nil : message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: downloadText, style: onWifi ? .default : .destructive) { _ in
-                MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
-                actionDelegate.multiSelectActionCompleted()
-            })
-            if !onWifi {
-                alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
-                    let status = L10n.multiSelectQueuingEpisodesFormat(selectedEpisodes.count.localized())
-                    actionDelegate.multiSelectActionBegan(status: status)
-                    queueEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
-                })
-                if !Settings.mobileDataAllowed() {
-                    alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
-                        if let url = URL(string: "pktc://settings/storage-and-data") {
-                            UIApplication.shared.open(url)
-                        }
-                    })
-                }
-            }
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            actionDelegate.multiSelectPresentingViewController().present(alert, animated: true)
-        } else {
-            let downloadAction = OptionAction(label: downloadText.localizedUppercase, icon: nil) { () in
-                MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
-                actionDelegate.multiSelectActionCompleted()
-            }
-
-            let confirmPicker = OptionsPicker(title: nil)
-            var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
-
-            if onWifi {
-                confirmPicker.addDescriptiveActions(title: L10n.download, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
-            } else {
-                let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                    let status = L10n.multiSelectQueuingEpisodesFormat(selectedEpisodes.count.localized())
-                    actionDelegate.multiSelectActionBegan(status: status)
-                    queueEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
-                }
-                queueAction.outline = true
-                if !Settings.mobileDataAllowed() {
-                    warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
-                }
-                confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
-            }
-
-            confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())
+        let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
+        let totalSize = downloadableEpisodes.prefix(actualDownloadCount).reduce(Int64(0)) { $0 + $1.sizeInBytes }
+        var messageParts = [String]()
+        if totalSize > 0 {
+            let sizeString = SizeFormatter.shared.noDecimalFormat(bytes: totalSize)
+            messageParts.append(L10n.downloadEstimatedSize(sizeString))
         }
+        if downloadLimitExceeded {
+            messageParts.append(L10n.bulkDownloadMax)
+        }
+        if !onWifi, !Settings.mobileDataAllowed() {
+            messageParts.append(L10n.downloadDataWarningAlert)
+        }
+        let message = messageParts.joined(separator: "\n")
+
+        let downloadAction = OptionAction(label: downloadText, icon: onWifi ? "filter_downloaded" : nil) { () in
+            MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
+            actionDelegate.multiSelectActionCompleted()
+        }
+        downloadAction.destructive = !onWifi
+
+        var actions: [OptionAction] = [downloadAction]
+        if !onWifi {
+            let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
+                let status = L10n.multiSelectQueuingEpisodesFormat(selectedEpisodes.count.localized())
+                actionDelegate.multiSelectActionBegan(status: status)
+                queueEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
+            }
+            queueAction.outline = true
+            actions.append(queueAction)
+            if !Settings.mobileDataAllowed() {
+                actions.append(OptionAction(label: L10n.settings, icon: nil) {
+                    if let url = URL(string: "pktc://settings/storage-and-data") {
+                        UIApplication.shared.open(url)
+                    }
+                })
+            }
+        }
+
+        let confirmPicker = OptionsPicker(title: nil)
+        confirmPicker.addDescriptiveActions(
+            title: title,
+            message: message.isEmpty ? nil : message,
+            icon: onWifi ? "filter_downloaded" : "option-alert",
+            actions: actions
+        )
+        confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())
     }
 
     private class func downloadEpisodes(_ episodes: [BaseEpisode], actionDelegate: MultiSelectActionDelegate) {

--- a/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
@@ -277,7 +277,7 @@ class MultiSelectHelper {
             return
         }
 
-        let downloadText = L10n.downloadCountPrompt(selectedEpisodes.count).localizedUppercase
+        let downloadText = L10n.downloadCountPrompt(selectedEpisodes.count)
 
         if FeatureFlag.liquidGlass.enabled {
             let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
@@ -317,7 +317,7 @@ class MultiSelectHelper {
             alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             actionDelegate.multiSelectPresentingViewController().present(alert, animated: true)
         } else {
-            let downloadAction = OptionAction(label: downloadText, icon: nil) { () in
+            let downloadAction = OptionAction(label: downloadText.localizedUppercase, icon: nil) { () in
                 MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
                 actionDelegate.multiSelectActionCompleted()
             }

--- a/podcasts/Common Components/Options Picker/OptionsPickerHelper.swift
+++ b/podcasts/Common Components/Options Picker/OptionsPickerHelper.swift
@@ -4,19 +4,26 @@ import UIKit
 class OptionsPickerHelper {
     class func playAllWarning(episodeCount: Int, confirmAction: @escaping () -> Void) {
         if PlaybackManager.shared.queue.upNextCount() == 0 {
-            // there's nothing to over-write, so nothing to confirm either
             confirmAction()
             return
         }
 
         let playableEpisodesLabel = episodeCount == 1 ? L10n.playerOptionsPlayEpisodeSingular : L10n.playerOptionsPlayEpisodesPlural(episodeCount.localized())
-        let playAction = OptionAction(label: playableEpisodesLabel, icon: nil, action: {
-            confirmAction()
-        })
 
-        let warningPicker = OptionsPicker(title: "")
-        warningPicker.addDescriptiveActions(title: L10n.playAll, message: L10n.playerOptionsPlayAllMessage, icon: "filter_play", actions: [playAction])
-
-        warningPicker.show(statusBarStyle: .default)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.playAll, message: L10n.playerOptionsPlayAllMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: playableEpisodesLabel, style: .default) { _ in
+                confirmAction()
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            SceneHelper.rootViewController()?.present(alert, animated: true)
+        } else {
+            let playAction = OptionAction(label: playableEpisodesLabel, icon: nil, action: {
+                confirmAction()
+            })
+            let warningPicker = OptionsPicker(title: "")
+            warningPicker.addDescriptiveActions(title: L10n.playAll, message: L10n.playerOptionsPlayAllMessage, icon: "filter_play", actions: [playAction])
+            warningPicker.show(statusBarStyle: .default)
+        }
     }
 }

--- a/podcasts/Common Components/Options Picker/OptionsPickerHelper.swift
+++ b/podcasts/Common Components/Options Picker/OptionsPickerHelper.swift
@@ -11,7 +11,7 @@ class OptionsPickerHelper {
         let playableEpisodesLabel = episodeCount == 1 ? L10n.playerOptionsPlayEpisodeSingular : L10n.playerOptionsPlayEpisodesPlural(episodeCount.localized())
 
         if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.playAll, message: L10n.playerOptionsPlayAllMessage, preferredStyle: .alert)
+            let alert = UIAlertController(title: L10n.alertPlayAll, message: L10n.playerOptionsPlayAllMessage, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: playableEpisodesLabel, style: .default) { _ in
                 confirmAction()
             })

--- a/podcasts/Common Components/Options Picker/OptionsPickerHelper.swift
+++ b/podcasts/Common Components/Options Picker/OptionsPickerHelper.swift
@@ -10,20 +10,16 @@ class OptionsPickerHelper {
 
         let playableEpisodesLabel = episodeCount == 1 ? L10n.playerOptionsPlayEpisodeSingular : L10n.playerOptionsPlayEpisodesPlural(episodeCount.localized())
 
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.alertPlayAll, message: L10n.playerOptionsPlayAllMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: playableEpisodesLabel, style: .default) { _ in
-                confirmAction()
-            })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            SceneHelper.rootViewController()?.present(alert, animated: true)
-        } else {
-            let playAction = OptionAction(label: playableEpisodesLabel, icon: nil, action: {
-                confirmAction()
-            })
-            let warningPicker = OptionsPicker(title: "")
-            warningPicker.addDescriptiveActions(title: L10n.playAll, message: L10n.playerOptionsPlayAllMessage, icon: "filter_play", actions: [playAction])
-            warningPicker.show(statusBarStyle: .default)
-        }
+        let playAction = OptionAction(label: playableEpisodesLabel, icon: "filter_play", action: {
+            confirmAction()
+        })
+        let warningPicker = OptionsPicker(title: "")
+        warningPicker.addDescriptiveActions(
+            title: L10n.alertPlayAll,
+            message: L10n.playerOptionsPlayAllMessage,
+            icon: "filter_play",
+            actions: [playAction]
+        )
+        warningPicker.show(statusBarStyle: .default)
     }
 }

--- a/podcasts/DownloadedFilesViewController.swift
+++ b/podcasts/DownloadedFilesViewController.swift
@@ -156,7 +156,7 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
     private func confirmCleanup() {
         Analytics.track(.downloadsCleanUpButtonTapped)
         if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.cleanUp, message: L10n.downloadedFilesCleanupConfirmation, preferredStyle: .alert)
+            let alert = UIAlertController(title: L10n.alertCleanUp, message: L10n.downloadedFilesCleanupConfirmation, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L10n.delete, style: .destructive) { [weak self] _ in
                 self?.performDelete()
             })

--- a/podcasts/DownloadedFilesViewController.swift
+++ b/podcasts/DownloadedFilesViewController.swift
@@ -155,14 +155,22 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
 
     private func confirmCleanup() {
         Analytics.track(.downloadsCleanUpButtonTapped)
-        let confirmOption = OptionsPicker(title: nil)
-        let deleteAction = OptionAction(label: L10n.delete, icon: nil) {
-            self.performDelete()
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.cleanUp, message: L10n.downloadedFilesCleanupConfirmation, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.delete, style: .destructive) { [weak self] _ in
+                self?.performDelete()
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            present(alert, animated: true)
+        } else {
+            let confirmOption = OptionsPicker(title: nil)
+            let deleteAction = OptionAction(label: L10n.delete, icon: nil) {
+                self.performDelete()
+            }
+            deleteAction.destructive = true
+            confirmOption.addDescriptiveActions(title: L10n.cleanUp, message: L10n.downloadedFilesCleanupConfirmation, icon: "option-delete", actions: [deleteAction])
+            confirmOption.show(statusBarStyle: preferredStatusBarStyle)
         }
-        deleteAction.destructive = true
-        confirmOption.addDescriptiveActions(title: L10n.cleanUp, message: L10n.downloadedFilesCleanupConfirmation, icon: "option-delete", actions: [deleteAction])
-
-        confirmOption.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     private func performDelete() {

--- a/podcasts/DownloadedFilesViewController.swift
+++ b/podcasts/DownloadedFilesViewController.swift
@@ -155,22 +155,19 @@ class DownloadedFilesViewController: PCViewController, UITableViewDelegate, UITa
 
     private func confirmCleanup() {
         Analytics.track(.downloadsCleanUpButtonTapped)
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.alertCleanUp, message: L10n.downloadedFilesCleanupConfirmation, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.delete, style: .destructive) { [weak self] _ in
-                self?.performDelete()
-            })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            present(alert, animated: true)
-        } else {
-            let confirmOption = OptionsPicker(title: nil)
-            let deleteAction = OptionAction(label: L10n.delete, icon: nil) {
-                self.performDelete()
-            }
-            deleteAction.destructive = true
-            confirmOption.addDescriptiveActions(title: L10n.cleanUp, message: L10n.downloadedFilesCleanupConfirmation, icon: "option-delete", actions: [deleteAction])
-            confirmOption.show(statusBarStyle: preferredStatusBarStyle)
+        let deleteAction = OptionAction(label: L10n.delete, icon: "option-delete") { [weak self] in
+            self?.performDelete()
         }
+        deleteAction.destructive = true
+
+        let confirmOption = OptionsPicker(title: nil)
+        confirmOption.addDescriptiveActions(
+            title: L10n.alertCleanUp,
+            message: L10n.downloadedFilesCleanupConfirmation,
+            icon: "option-delete",
+            actions: [deleteAction]
+        )
+        confirmOption.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     private func performDelete() {

--- a/podcasts/Episode/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+Actions.swift
@@ -96,12 +96,13 @@ extension EpisodeDetailViewController {
     @IBAction func downloadTapped(_ sender: UIButton) {
         if episode.downloaded(pathFinder: DownloadManager.shared) {
             if FeatureFlag.liquidGlass.enabled {
-                let alert = UIAlertController(title: L10n.podcastDetailsRemoveDownloadAlertTitle, message: nil, preferredStyle: .alert)
+                let sizeStr = SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
+                let alert = UIAlertController(title: L10n.podcastDetailsRemoveDownloadAlertTitle, message: L10n.podcastDetailsRemoveDownloadAlertMessage(sizeStr), preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
                 alert.addAction(UIAlertAction(title: L10n.remove, style: .destructive) { [weak self] _ in
                     self?.deleteDownloadedFile()
                     self?.updateColors()
                 })
-                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
                 present(alert, animated: true)
             } else {
                 let confirmation = OptionsPicker(title: L10n.podcastDetailsRemoveDownload)

--- a/podcasts/Episode/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+Actions.swift
@@ -95,15 +95,24 @@ extension EpisodeDetailViewController {
 
     @IBAction func downloadTapped(_ sender: UIButton) {
         if episode.downloaded(pathFinder: DownloadManager.shared) {
-            let confirmation = OptionsPicker(title: L10n.podcastDetailsRemoveDownload)
-            let yesAction = OptionAction(label: L10n.remove, icon: nil) {
-                self.deleteDownloadedFile()
-                self.updateColors()
+            if FeatureFlag.liquidGlass.enabled {
+                let alert = UIAlertController(title: L10n.podcastDetailsRemoveDownloadAlertTitle, message: nil, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: L10n.remove, style: .destructive) { [weak self] _ in
+                    self?.deleteDownloadedFile()
+                    self?.updateColors()
+                })
+                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+                present(alert, animated: true)
+            } else {
+                let confirmation = OptionsPicker(title: L10n.podcastDetailsRemoveDownload)
+                let yesAction = OptionAction(label: L10n.remove, icon: nil) {
+                    self.deleteDownloadedFile()
+                    self.updateColors()
+                }
+                yesAction.destructive = true
+                confirmation.addAction(action: yesAction)
+                confirmation.show(statusBarStyle: preferredStatusBarStyle)
             }
-            yesAction.destructive = true
-            confirmation.addAction(action: yesAction)
-
-            confirmation.show(statusBarStyle: preferredStatusBarStyle)
         } else if episode.downloading() || episode.queued() || episode.waitingForWifi() {
             PlaybackActionHelper.stopDownload(episodeUuid: episode.uuid)
         } else {

--- a/podcasts/Episode/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+Actions.swift
@@ -95,25 +95,21 @@ extension EpisodeDetailViewController {
 
     @IBAction func downloadTapped(_ sender: UIButton) {
         if episode.downloaded(pathFinder: DownloadManager.shared) {
-            if FeatureFlag.liquidGlass.enabled {
-                let sizeStr = SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
-                let alert = UIAlertController(title: L10n.podcastDetailsRemoveDownloadAlertTitle, message: L10n.podcastDetailsRemoveDownloadAlertMessage(sizeStr), preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-                alert.addAction(UIAlertAction(title: L10n.remove, style: .destructive) { [weak self] _ in
-                    self?.deleteDownloadedFile()
-                    self?.updateColors()
-                })
-                present(alert, animated: true)
-            } else {
-                let confirmation = OptionsPicker(title: L10n.podcastDetailsRemoveDownload)
-                let yesAction = OptionAction(label: L10n.remove, icon: nil) {
-                    self.deleteDownloadedFile()
-                    self.updateColors()
-                }
-                yesAction.destructive = true
-                confirmation.addAction(action: yesAction)
-                confirmation.show(statusBarStyle: preferredStatusBarStyle)
+            let sizeStr = SizeFormatter.shared.noDecimalFormat(bytes: episode.sizeInBytes)
+            let removeAction = OptionAction(label: L10n.remove, icon: "filter_trash") { [weak self] in
+                self?.deleteDownloadedFile()
+                self?.updateColors()
             }
+            removeAction.destructive = true
+
+            let confirmation = OptionsPicker(title: nil)
+            confirmation.addDescriptiveActions(
+                title: L10n.podcastDetailsRemoveDownloadAlertTitle,
+                message: L10n.podcastDetailsRemoveDownloadAlertMessage(sizeStr),
+                icon: "filter_trash",
+                actions: [removeAction]
+            )
+            confirmation.show(statusBarStyle: preferredStatusBarStyle)
         } else if episode.downloading() || episode.queued() || episode.waitingForWifi() {
             PlaybackActionHelper.stopDownload(episodeUuid: episode.uuid)
         } else {

--- a/podcasts/Extensions/NetworkUtils+Helpers.swift
+++ b/podcasts/Extensions/NetworkUtils+Helpers.swift
@@ -2,6 +2,7 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
+import UIKit
 
 extension NetworkUtils {
     func downloadEpisodeRequested(autoDownloadStatus: AutoDownloadStatus, _ allowed: ((_ later: Bool) -> Void)?, disallowed: (() -> Void)?) {
@@ -13,22 +14,38 @@ extension NetworkUtils {
             return
         }
 
-        let optionsPicker = OptionsPicker(title: nil)
-        let downloadAction = OptionAction(label: L10n.podcastDownloadNow, icon: nil) {
-            allowed?(false)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.notOnWifi, message: L10n.downloadDataWarningAlert, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.podcastDownloadNow, style: .default) { _ in
+                allowed?(false)
+            })
+            alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
+                allowed?(true)
+            })
+            alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
+                if let url = URL(string: "pktc://settings/storage-and-data") {
+                    UIApplication.shared.open(url)
+                }
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
+                disallowed?()
+            })
+            SceneHelper.rootViewController()?.present(alert, animated: true)
+        } else {
+            let optionsPicker = OptionsPicker(title: nil)
+            let downloadAction = OptionAction(label: L10n.podcastDownloadNow, icon: nil) {
+                allowed?(false)
+            }
+            let laterAction = OptionAction(label: L10n.queueForLater, icon: nil) {
+                allowed?(true)
+            }
+            laterAction.outline = true
+            optionsPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data"), icon: "option-alert", actions: [downloadAction, laterAction])
+            optionsPicker.setNoActionCallback {
+                disallowed?()
+            }
+            optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
         }
-        let laterAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-            allowed?(true)
-        }
-        laterAction.outline = true
-
-        optionsPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data"), icon: "option-alert", actions: [downloadAction, laterAction])
-
-        optionsPicker.setNoActionCallback {
-            disallowed?()
-        }
-
-        optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
     }
 
     func streamEpisodeRequested(_ allowed: (() -> Void)?, disallowed: (() -> Void)?) {
@@ -38,17 +55,31 @@ extension NetworkUtils {
             return
         }
 
-        let optionsPicker = OptionsPicker(title: nil)
-        let streamAction = OptionAction(label: L10n.podcastStreamConfirmation, icon: nil) {
-            allowed?()
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.notOnWifi, message: L10n.podcastStreamDataWarningAlert, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.podcastStreamConfirmation, style: .default) { _ in
+                allowed?()
+            })
+            alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
+                if let url = URL(string: "pktc://settings/storage-and-data") {
+                    UIApplication.shared.open(url)
+                }
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
+                disallowed?()
+            })
+            SceneHelper.rootViewController()?.present(alert, animated: true)
+        } else {
+            let optionsPicker = OptionsPicker(title: nil)
+            let streamAction = OptionAction(label: L10n.podcastStreamConfirmation, icon: nil) {
+                allowed?()
+            }
+            optionsPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: L10n.podcastStreamDataWarningWithSettings("pktc://settings/storage-and-data"), icon: "option-alert", actions: [streamAction])
+            optionsPicker.setNoActionCallback {
+                disallowed?()
+            }
+            optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
         }
-        optionsPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: L10n.podcastStreamDataWarningWithSettings("pktc://settings/storage-and-data"), icon: "option-alert", actions: [streamAction])
-
-        optionsPicker.setNoActionCallback {
-            disallowed?()
-        }
-
-        optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
     }
 
     // MARK: - Upload Helpers
@@ -62,20 +93,32 @@ extension NetworkUtils {
             return
         }
 
-        let optionsPicker = OptionsPicker(title: nil)
-        let uploadAction = OptionAction(label: "Upload Now", icon: nil) {
-            allowed?(false)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.notOnWifi, message: nil, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.podcastUploadConfirmation, style: .default) { _ in
+                allowed?(false)
+            })
+            alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
+                allowed?(true)
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
+                disallowed?()
+            })
+            SceneHelper.rootViewController()?.present(alert, animated: true)
+        } else {
+            let optionsPicker = OptionsPicker(title: nil)
+            let uploadAction = OptionAction(label: "Upload Now", icon: nil) {
+                allowed?(false)
+            }
+            let laterAction = OptionAction(label: L10n.queueForLater, icon: nil) {
+                allowed?(true)
+            }
+            laterAction.outline = true
+            optionsPicker.addDescriptiveActions(title: L10n.notOnWifi, message: "", icon: "option-alert", actions: [uploadAction, laterAction])
+            optionsPicker.setNoActionCallback {
+                disallowed?()
+            }
+            optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
         }
-        let laterAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-            allowed?(true)
-        }
-        laterAction.outline = true
-        optionsPicker.addDescriptiveActions(title: L10n.notOnWifi, message: "", icon: "option-alert", actions: [uploadAction, laterAction])
-
-        optionsPicker.setNoActionCallback {
-            disallowed?()
-        }
-
-        optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
     }
 }

--- a/podcasts/Extensions/NetworkUtils+Helpers.swift
+++ b/podcasts/Extensions/NetworkUtils+Helpers.swift
@@ -14,38 +14,34 @@ extension NetworkUtils {
             return
         }
 
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.notOnWifi, message: L10n.downloadDataWarningAlert, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.podcastDownloadNow, style: .default) { _ in
-                allowed?(false)
-            })
-            alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
-                allowed?(true)
-            })
-            alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
+        let downloadAction = OptionAction(label: L10n.podcastDownloadNow, icon: nil) {
+            allowed?(false)
+        }
+        let laterAction = OptionAction(label: L10n.queueForLater, icon: nil) {
+            allowed?(true)
+        }
+        laterAction.outline = true
+
+        var actions: [OptionAction] = [downloadAction, laterAction]
+        if !Settings.mobileDataAllowed() {
+            actions.append(OptionAction(label: L10n.settings, icon: nil) {
                 if let url = URL(string: "pktc://settings/storage-and-data") {
                     UIApplication.shared.open(url)
                 }
             })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
-                disallowed?()
-            })
-            SceneHelper.rootViewController()?.present(alert, animated: true)
-        } else {
-            let optionsPicker = OptionsPicker(title: nil)
-            let downloadAction = OptionAction(label: L10n.podcastDownloadNow, icon: nil) {
-                allowed?(false)
-            }
-            let laterAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                allowed?(true)
-            }
-            laterAction.outline = true
-            optionsPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data"), icon: "option-alert", actions: [downloadAction, laterAction])
-            optionsPicker.setNoActionCallback {
-                disallowed?()
-            }
-            optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
         }
+
+        let optionsPicker = OptionsPicker(title: nil)
+        optionsPicker.addDescriptiveActions(
+            title: L10n.notOnWifi,
+            message: L10n.downloadDataWarningAlert,
+            icon: "option-alert",
+            actions: actions
+        )
+        optionsPicker.setNoActionCallback {
+            disallowed?()
+        }
+        optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
     }
 
     func streamEpisodeRequested(_ allowed: (() -> Void)?, disallowed: (() -> Void)?) {
@@ -55,31 +51,30 @@ extension NetworkUtils {
             return
         }
 
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.notOnWifi, message: L10n.podcastStreamDataWarningAlert, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.podcastStreamConfirmation, style: .default) { _ in
-                allowed?()
-            })
-            alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
+        let streamAction = OptionAction(label: L10n.podcastStreamConfirmation, icon: nil) {
+            allowed?()
+        }
+
+        var actions: [OptionAction] = [streamAction]
+        if !Settings.mobileDataAllowed() {
+            actions.append(OptionAction(label: L10n.settings, icon: nil) {
                 if let url = URL(string: "pktc://settings/storage-and-data") {
                     UIApplication.shared.open(url)
                 }
             })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
-                disallowed?()
-            })
-            SceneHelper.rootViewController()?.present(alert, animated: true)
-        } else {
-            let optionsPicker = OptionsPicker(title: nil)
-            let streamAction = OptionAction(label: L10n.podcastStreamConfirmation, icon: nil) {
-                allowed?()
-            }
-            optionsPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: L10n.podcastStreamDataWarningWithSettings("pktc://settings/storage-and-data"), icon: "option-alert", actions: [streamAction])
-            optionsPicker.setNoActionCallback {
-                disallowed?()
-            }
-            optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
         }
+
+        let optionsPicker = OptionsPicker(title: nil)
+        optionsPicker.addDescriptiveActions(
+            title: L10n.notOnWifi,
+            message: L10n.podcastStreamDataWarningAlert,
+            icon: "option-alert",
+            actions: actions
+        )
+        optionsPicker.setNoActionCallback {
+            disallowed?()
+        }
+        optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
     }
 
     // MARK: - Upload Helpers
@@ -93,32 +88,24 @@ extension NetworkUtils {
             return
         }
 
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.notOnWifi, message: nil, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.podcastUploadConfirmation, style: .default) { _ in
-                allowed?(false)
-            })
-            alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
-                allowed?(true)
-            })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
-                disallowed?()
-            })
-            SceneHelper.rootViewController()?.present(alert, animated: true)
-        } else {
-            let optionsPicker = OptionsPicker(title: nil)
-            let uploadAction = OptionAction(label: "Upload Now", icon: nil) {
-                allowed?(false)
-            }
-            let laterAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                allowed?(true)
-            }
-            laterAction.outline = true
-            optionsPicker.addDescriptiveActions(title: L10n.notOnWifi, message: "", icon: "option-alert", actions: [uploadAction, laterAction])
-            optionsPicker.setNoActionCallback {
-                disallowed?()
-            }
-            optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
+        let uploadAction = OptionAction(label: L10n.podcastUploadConfirmation, icon: nil) {
+            allowed?(false)
         }
+        let laterAction = OptionAction(label: L10n.queueForLater, icon: nil) {
+            allowed?(true)
+        }
+        laterAction.outline = true
+
+        let optionsPicker = OptionsPicker(title: nil)
+        optionsPicker.addDescriptiveActions(
+            title: L10n.notOnWifi,
+            message: nil,
+            icon: "option-alert",
+            actions: [uploadAction, laterAction]
+        )
+        optionsPicker.setNoActionCallback {
+            disallowed?()
+        }
+        optionsPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
     }
 }

--- a/podcasts/FilterEditOptionsViewController.swift
+++ b/podcasts/FilterEditOptionsViewController.swift
@@ -355,7 +355,7 @@ extension FilterEditOptionsViewController {
         Analytics.track(.filterDeleteTriggered, properties: analyticsProperties)
 
         if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.playlistsDeleteAlertTitle, message: L10n.playlistsDeleteAlertMessage, preferredStyle: .alert)
+            let alert = UIAlertController(title: L10n.alertDeletePlaylist, message: L10n.playlistsDeleteAlertMessage, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L10n.delete, style: .destructive) { [weak self] _ in
                 self?.delete(playlist: playlist)
             })

--- a/podcasts/FilterEditOptionsViewController.swift
+++ b/podcasts/FilterEditOptionsViewController.swift
@@ -353,28 +353,28 @@ extension FilterEditOptionsViewController {
         let playlistType = playlist.manual ? "manual" : "smart"
         let analyticsProperties = ["filter_type": playlistType]
         Analytics.track(.filterDeleteTriggered, properties: analyticsProperties)
-        let delete = OptionAction(
-            label: L10n.delete,
-            icon: nil,
-            action: { [weak self] in
-                self?.delete(playlist: playlist)
-            }
-        )
-        delete.destructive = true
 
-        let picker = OptionsPicker(title: "")
-        picker.addDescriptiveActions(
-            title: L10n.playlistsDeleteAlertTitle,
-            message: L10n.playlistsDeleteAlertMessage,
-            icon: "option-alert",
-            actions: [
-                delete
-            ]
-        )
-        picker.setNoActionCallback {
-            Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.playlistsDeleteAlertTitle, message: L10n.playlistsDeleteAlertMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.delete, style: .destructive) { [weak self] _ in
+                self?.delete(playlist: playlist)
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
+                Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
+            })
+            present(alert, animated: true)
+        } else {
+            let delete = OptionAction(label: L10n.delete, icon: nil, action: { [weak self] in
+                self?.delete(playlist: playlist)
+            })
+            delete.destructive = true
+            let picker = OptionsPicker(title: "")
+            picker.addDescriptiveActions(title: L10n.playlistsDeleteAlertTitle, message: L10n.playlistsDeleteAlertMessage, icon: "option-alert", actions: [delete])
+            picker.setNoActionCallback {
+                Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
+            }
+            picker.show(statusBarStyle: .default)
         }
-        picker.show(statusBarStyle: .default)
     }
 
     fileprivate func delete(playlist: EpisodeFilter) {

--- a/podcasts/FilterEditOptionsViewController.swift
+++ b/podcasts/FilterEditOptionsViewController.swift
@@ -354,27 +354,22 @@ extension FilterEditOptionsViewController {
         let analyticsProperties = ["filter_type": playlistType]
         Analytics.track(.filterDeleteTriggered, properties: analyticsProperties)
 
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.alertDeletePlaylist, message: L10n.playlistsDeleteAlertMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.delete, style: .destructive) { [weak self] _ in
-                self?.delete(playlist: playlist)
-            })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
-                Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
-            })
-            present(alert, animated: true)
-        } else {
-            let delete = OptionAction(label: L10n.delete, icon: nil, action: { [weak self] in
-                self?.delete(playlist: playlist)
-            })
-            delete.destructive = true
-            let picker = OptionsPicker(title: "")
-            picker.addDescriptiveActions(title: L10n.playlistsDeleteAlertTitle, message: L10n.playlistsDeleteAlertMessage, icon: "option-alert", actions: [delete])
-            picker.setNoActionCallback {
-                Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
-            }
-            picker.show(statusBarStyle: .default)
+        let delete = OptionAction(label: L10n.delete, icon: "option-alert", action: { [weak self] in
+            self?.delete(playlist: playlist)
+        })
+        delete.destructive = true
+
+        let picker = OptionsPicker(title: "")
+        picker.addDescriptiveActions(
+            title: L10n.alertDeletePlaylist,
+            message: L10n.playlistsDeleteAlertMessage,
+            icon: "option-alert",
+            actions: [delete]
+        )
+        picker.setNoActionCallback {
+            Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
         }
+        picker.show(statusBarStyle: .default)
     }
 
     fileprivate func delete(playlist: EpisodeFilter) {

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -161,19 +161,32 @@ class ListeningHistoryViewController: PCViewController {
     }
 
     @objc func clearTapped() {
-        let optionPicker = OptionsPicker(title: "")
-        let clearAllAction = OptionAction(label: L10n.historyClearAll, icon: nil, action: {
-            Analytics.track(.listeningHistoryCleared)
-            DataManager.sharedManager.clearAllEpisodePlayInteractions()
-            if SyncManager.isUserLoggedIn() { ServerSettings.setLastClearHistoryDate(Date()) }
-            self.refreshEpisodes(animated: true)
-
-        })
-        optionPicker.setNoActionCallback {
-            Analytics.track(.listeningHistoryClearConfirmationDismissed)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.historyClearAllDetails, message: L10n.historyClearAllDetailsMsg, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.historyClearAll, style: .destructive) { [weak self] _ in
+                Analytics.track(.listeningHistoryCleared)
+                DataManager.sharedManager.clearAllEpisodePlayInteractions()
+                if SyncManager.isUserLoggedIn() { ServerSettings.setLastClearHistoryDate(Date()) }
+                self?.refreshEpisodes(animated: true)
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
+                Analytics.track(.listeningHistoryClearConfirmationDismissed)
+            })
+            present(alert, animated: true)
+        } else {
+            let optionPicker = OptionsPicker(title: "")
+            let clearAllAction = OptionAction(label: L10n.historyClearAll, icon: nil, action: {
+                Analytics.track(.listeningHistoryCleared)
+                DataManager.sharedManager.clearAllEpisodePlayInteractions()
+                if SyncManager.isUserLoggedIn() { ServerSettings.setLastClearHistoryDate(Date()) }
+                self.refreshEpisodes(animated: true)
+            })
+            optionPicker.setNoActionCallback {
+                Analytics.track(.listeningHistoryClearConfirmationDismissed)
+            }
+            optionPicker.addDescriptiveActions(title: L10n.historyClearAllDetails, message: L10n.historyClearAllDetailsMsg, icon: "option-cleanup", actions: [clearAllAction])
+            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
         }
-        optionPicker.addDescriptiveActions(title: L10n.historyClearAllDetails, message: L10n.historyClearAllDetailsMsg, icon: "option-cleanup", actions: [clearAllAction])
-        optionPicker.show(statusBarStyle: preferredStatusBarStyle)
         Analytics.track(.listeningHistoryClearConfirmationShown)
     }
 

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -162,7 +162,7 @@ class ListeningHistoryViewController: PCViewController {
 
     @objc func clearTapped() {
         if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.historyClearAllDetails, message: L10n.historyClearAllDetailsMsg, preferredStyle: .alert)
+            let alert = UIAlertController(title: L10n.alertClearListeningHistory, message: L10n.historyClearAllDetailsMsg, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L10n.historyClearAll, style: .destructive) { [weak self] _ in
                 Analytics.track(.listeningHistoryCleared)
                 DataManager.sharedManager.clearAllEpisodePlayInteractions()

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -161,32 +161,25 @@ class ListeningHistoryViewController: PCViewController {
     }
 
     @objc func clearTapped() {
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.alertClearListeningHistory, message: L10n.historyClearAllDetailsMsg, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.historyClearAll, style: .destructive) { [weak self] _ in
-                Analytics.track(.listeningHistoryCleared)
-                DataManager.sharedManager.clearAllEpisodePlayInteractions()
-                if SyncManager.isUserLoggedIn() { ServerSettings.setLastClearHistoryDate(Date()) }
-                self?.refreshEpisodes(animated: true)
-            })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
-                Analytics.track(.listeningHistoryClearConfirmationDismissed)
-            })
-            present(alert, animated: true)
-        } else {
-            let optionPicker = OptionsPicker(title: "")
-            let clearAllAction = OptionAction(label: L10n.historyClearAll, icon: nil, action: {
-                Analytics.track(.listeningHistoryCleared)
-                DataManager.sharedManager.clearAllEpisodePlayInteractions()
-                if SyncManager.isUserLoggedIn() { ServerSettings.setLastClearHistoryDate(Date()) }
-                self.refreshEpisodes(animated: true)
-            })
-            optionPicker.setNoActionCallback {
-                Analytics.track(.listeningHistoryClearConfirmationDismissed)
-            }
-            optionPicker.addDescriptiveActions(title: L10n.historyClearAllDetails, message: L10n.historyClearAllDetailsMsg, icon: "option-cleanup", actions: [clearAllAction])
-            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+        let clearAllAction = OptionAction(label: L10n.historyClearAll, icon: "option-cleanup", action: { [weak self] in
+            Analytics.track(.listeningHistoryCleared)
+            DataManager.sharedManager.clearAllEpisodePlayInteractions()
+            if SyncManager.isUserLoggedIn() { ServerSettings.setLastClearHistoryDate(Date()) }
+            self?.refreshEpisodes(animated: true)
+        })
+        clearAllAction.destructive = true
+
+        let optionPicker = OptionsPicker(title: "")
+        optionPicker.setNoActionCallback {
+            Analytics.track(.listeningHistoryClearConfirmationDismissed)
         }
+        optionPicker.addDescriptiveActions(
+            title: L10n.alertClearListeningHistory,
+            message: L10n.historyClearAllDetailsMsg,
+            icon: "option-cleanup",
+            actions: [clearAllAction]
+        )
+        optionPicker.show(statusBarStyle: preferredStatusBarStyle)
         Analytics.track(.listeningHistoryClearConfirmationShown)
     }
 

--- a/podcasts/MiniPlayerViewController+Gestures.swift
+++ b/podcasts/MiniPlayerViewController+Gestures.swift
@@ -54,7 +54,7 @@ extension MiniPlayerViewController: UIGestureRecognizerDelegate {
 
         if FeatureFlag.liquidGlass.enabled {
             let alert = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.markPlayedShort, style: .default) { [weak self] _ in
+            alert.addAction(UIAlertAction(title: L10n.markPlayed, style: .default) { [weak self] _ in
                 Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "mark_played"])
                 if let episode = PlaybackManager.shared.currentEpisode() {
                     guard let self else { return }

--- a/podcasts/MiniPlayerViewController+Gestures.swift
+++ b/podcasts/MiniPlayerViewController+Gestures.swift
@@ -52,35 +52,55 @@ extension MiniPlayerViewController: UIGestureRecognizerDelegate {
     private func showLongPressMenu(_ touchPoint: CGPoint) {
         Analytics.track(.miniPlayerLongPressMenuShown)
 
-        let optionsPicker = OptionsPicker(title: nil)
-        let markAsPlayedAction = OptionAction(label: L10n.markPlayedShort, icon: "episode-markasplayed") {
-            Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "mark_played"])
-            if let episode = PlaybackManager.shared.currentEpisode() {
-                AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
-                EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.markPlayedShort, style: .default) { [weak self] _ in
+                Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "mark_played"])
+                if let episode = PlaybackManager.shared.currentEpisode() {
+                    guard let self else { return }
+                    AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
+                    EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
+                }
+            })
+            alert.addAction(UIAlertAction(title: L10n.miniPlayerClose, style: .destructive) { [weak self] _ in
+                Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "close_and_clear_up_next"])
+                FileLog.shared.addMessage("Close and Clear Up Next pressed from the mini player")
+                self?.removeAllCustomObservers()
+                self?.hideMiniPlayer(true)
+                PlaybackManager.shared.endPlayback()
+                self?.addUINotificationObservers()
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
+                Analytics.track(.miniPlayerLongPressMenuDismissed)
+            })
+            present(alert, animated: true)
+        } else {
+            let optionsPicker = OptionsPicker(title: nil)
+            let markAsPlayedAction = OptionAction(label: L10n.markPlayedShort, icon: "episode-markasplayed") {
+                Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "mark_played"])
+                if let episode = PlaybackManager.shared.currentEpisode() {
+                    AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
+                    EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
+                }
             }
+            optionsPicker.addAction(action: markAsPlayedAction)
+
+            let closeAction = OptionAction(label: L10n.miniPlayerClose, icon: "close") {
+                Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "close_and_clear_up_next"])
+                FileLog.shared.addMessage("Close and Clear Up Next pressed from the mini player")
+                self.removeAllCustomObservers()
+                self.hideMiniPlayer(true)
+                PlaybackManager.shared.endPlayback()
+                self.addUINotificationObservers()
+            }
+            closeAction.destructive = true
+            optionsPicker.addAction(action: closeAction)
+
+            optionsPicker.setNoActionCallback {
+                Analytics.track(.miniPlayerLongPressMenuDismissed)
+            }
+            optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
         }
-        optionsPicker.addAction(action: markAsPlayedAction)
-
-        let closeAction = OptionAction(label: L10n.miniPlayerClose, icon: "close") {
-            Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "close_and_clear_up_next"])
-
-            FileLog.shared.addMessage("Close and Clear Up Next pressed from the mini player")
-            self.removeAllCustomObservers()
-
-            self.hideMiniPlayer(true)
-            PlaybackManager.shared.endPlayback()
-
-            self.addUINotificationObservers()
-        }
-        closeAction.destructive = true
-        optionsPicker.addAction(action: closeAction)
-
-        optionsPicker.setNoActionCallback {
-            Analytics.track(.miniPlayerLongPressMenuDismissed)
-        }
-
-        optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     @objc private func miniPlayerTapped() {

--- a/podcasts/MiniPlayerViewController+Gestures.swift
+++ b/podcasts/MiniPlayerViewController+Gestures.swift
@@ -52,55 +52,31 @@ extension MiniPlayerViewController: UIGestureRecognizerDelegate {
     private func showLongPressMenu(_ touchPoint: CGPoint) {
         Analytics.track(.miniPlayerLongPressMenuShown)
 
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.markPlayed, style: .default) { [weak self] _ in
-                Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "mark_played"])
-                if let episode = PlaybackManager.shared.currentEpisode() {
-                    guard let self else { return }
-                    AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
-                    EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
-                }
-            })
-            alert.addAction(UIAlertAction(title: L10n.miniPlayerClose, style: .destructive) { [weak self] _ in
-                Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "close_and_clear_up_next"])
-                FileLog.shared.addMessage("Close and Clear Up Next pressed from the mini player")
-                self?.removeAllCustomObservers()
-                self?.hideMiniPlayer(true)
-                PlaybackManager.shared.endPlayback()
-                self?.addUINotificationObservers()
-            })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
-                Analytics.track(.miniPlayerLongPressMenuDismissed)
-            })
-            present(alert, animated: true)
-        } else {
-            let optionsPicker = OptionsPicker(title: nil)
-            let markAsPlayedAction = OptionAction(label: L10n.markPlayedShort, icon: "episode-markasplayed") {
-                Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "mark_played"])
-                if let episode = PlaybackManager.shared.currentEpisode() {
-                    AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
-                    EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
-                }
+        let optionsPicker = OptionsPicker(title: nil)
+        let markAsPlayedAction = OptionAction(label: L10n.markPlayedShort, icon: "episode-markasplayed") {
+            Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "mark_played"])
+            if let episode = PlaybackManager.shared.currentEpisode() {
+                AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
+                EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
             }
-            optionsPicker.addAction(action: markAsPlayedAction)
-
-            let closeAction = OptionAction(label: L10n.miniPlayerClose, icon: "close") {
-                Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "close_and_clear_up_next"])
-                FileLog.shared.addMessage("Close and Clear Up Next pressed from the mini player")
-                self.removeAllCustomObservers()
-                self.hideMiniPlayer(true)
-                PlaybackManager.shared.endPlayback()
-                self.addUINotificationObservers()
-            }
-            closeAction.destructive = true
-            optionsPicker.addAction(action: closeAction)
-
-            optionsPicker.setNoActionCallback {
-                Analytics.track(.miniPlayerLongPressMenuDismissed)
-            }
-            optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
         }
+        optionsPicker.addAction(action: markAsPlayedAction)
+
+        let closeAction = OptionAction(label: L10n.miniPlayerClose, icon: "close") {
+            Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "close_and_clear_up_next"])
+            FileLog.shared.addMessage("Close and Clear Up Next pressed from the mini player")
+            self.removeAllCustomObservers()
+            self.hideMiniPlayer(true)
+            PlaybackManager.shared.endPlayback()
+            self.addUINotificationObservers()
+        }
+        closeAction.destructive = true
+        optionsPicker.addAction(action: closeAction)
+
+        optionsPicker.setNoActionCallback {
+            Analytics.track(.miniPlayerLongPressMenuDismissed)
+        }
+        optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     @objc private func miniPlayerTapped() {

--- a/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
@@ -132,42 +132,84 @@ extension PlaylistDetailViewController {
             let actualDownloadCount = downloadLimitExceeded ? Constants.Limits.maxBulkDownloads : downloadableCount
             if actualDownloadCount == 0 { return }
             let downloadText = L10n.downloadCountPrompt(actualDownloadCount)
-            let downloadAction = OptionAction(label: downloadText, icon: nil) { [weak self] in
-                self?.downloadAll()
-            }
 
-            let confirmPicker = OptionsPicker(title: nil)
-            var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
+            let onWifi = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
 
-            if NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
-                confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
+            if FeatureFlag.liquidGlass.enabled {
+                let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
+                let downloadable = self.downloadableEpisodes(from: self.viewModel.episodes)
+                let totalSize = self.estimatedDownloadSize(from: downloadable, limit: actualDownloadCount)
+                var messageParts = [String]()
+                if totalSize > 0 {
+                    let sizeString = SizeFormatter.shared.noDecimalFormat(bytes: totalSize)
+                    messageParts.append(L10n.downloadEstimatedSize(sizeString))
+                }
+                if downloadLimitExceeded {
+                    messageParts.append(L10n.bulkDownloadMax)
+                }
+                if !onWifi, !Settings.mobileDataAllowed() {
+                    messageParts.append(L10n.downloadDataWarningAlert)
+                }
+                let message = messageParts.joined(separator: "\n")
+
+                let alert = UIAlertController(title: title, message: message.isEmpty ? nil : message, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: downloadText, style: onWifi ? .default : .destructive) { _ in
+                    self.downloadAll()
+                })
+                if !onWifi {
+                    alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
+                        self.queueAll()
+                    })
+                    if !Settings.mobileDataAllowed() {
+                        alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
+                            if let url = URL(string: "pktc://settings/storage-and-data") {
+                                UIApplication.shared.open(url)
+                            }
+                        })
+                    }
+                }
+                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+                self.present(alert, animated: true)
             } else {
-                downloadAction.destructive = true
-
-                let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                    self.queueAll()
+                let downloadAction = OptionAction(label: downloadText, icon: nil) { [weak self] in
+                    self?.downloadAll()
                 }
 
-                if !Settings.mobileDataAllowed() {
-                    warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
-                }
+                let confirmPicker = OptionsPicker(title: nil)
+                var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
 
-                confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
+                if onWifi {
+                    confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
+                } else {
+                    downloadAction.destructive = true
+
+                    let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
+                        self.queueAll()
+                    }
+
+                    if !Settings.mobileDataAllowed() {
+                        warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
+                    }
+
+                    confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
+                }
+                confirmPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
             }
-            confirmPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
+        }
+    }
+
+    private func downloadableEpisodes(from listEpisodes: [ListEpisode]) -> [ListEpisode] {
+        listEpisodes.filter {
+            !$0.episode.downloaded(pathFinder: DownloadManager.shared) && !$0.episode.downloading() && !$0.episode.queued()
         }
     }
 
     private func downloadableCount(listEpisodes: [ListEpisode]) -> Int {
-        if listEpisodes.isEmpty { return 0 }
-        var count = 0
+        downloadableEpisodes(from: listEpisodes).count
+    }
 
-        for listEpisode in listEpisodes {
-            if !listEpisode.episode.downloaded(pathFinder: DownloadManager.shared), !listEpisode.episode.downloading(), !listEpisode.episode.queued() {
-                count += 1
-            }
-        }
-        return count
+    private func estimatedDownloadSize(from listEpisodes: [ListEpisode], limit: Int) -> Int64 {
+        listEpisodes.prefix(limit).reduce(0) { $0 + $1.episode.sizeInBytes }
     }
 
     private func downloadAll() {

--- a/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+EditActions.swift
@@ -135,66 +135,49 @@ extension PlaylistDetailViewController {
 
             let onWifi = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
 
-            if FeatureFlag.liquidGlass.enabled {
-                let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
-                let downloadable = self.downloadableEpisodes(from: self.viewModel.episodes)
-                let totalSize = self.estimatedDownloadSize(from: downloadable, limit: actualDownloadCount)
-                var messageParts = [String]()
-                if totalSize > 0 {
-                    let sizeString = SizeFormatter.shared.noDecimalFormat(bytes: totalSize)
-                    messageParts.append(L10n.downloadEstimatedSize(sizeString))
-                }
-                if downloadLimitExceeded {
-                    messageParts.append(L10n.bulkDownloadMax)
-                }
-                if !onWifi, !Settings.mobileDataAllowed() {
-                    messageParts.append(L10n.downloadDataWarningAlert)
-                }
-                let message = messageParts.joined(separator: "\n")
-
-                let alert = UIAlertController(title: title, message: message.isEmpty ? nil : message, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: downloadText, style: onWifi ? .default : .destructive) { _ in
-                    self.downloadAll()
-                })
-                if !onWifi {
-                    alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
-                        self.queueAll()
-                    })
-                    if !Settings.mobileDataAllowed() {
-                        alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
-                            if let url = URL(string: "pktc://settings/storage-and-data") {
-                                UIApplication.shared.open(url)
-                            }
-                        })
-                    }
-                }
-                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-                self.present(alert, animated: true)
-            } else {
-                let downloadAction = OptionAction(label: downloadText, icon: nil) { [weak self] in
-                    self?.downloadAll()
-                }
-
-                let confirmPicker = OptionsPicker(title: nil)
-                var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
-
-                if onWifi {
-                    confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
-                } else {
-                    downloadAction.destructive = true
-
-                    let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                        self.queueAll()
-                    }
-
-                    if !Settings.mobileDataAllowed() {
-                        warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
-                    }
-
-                    confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
-                }
-                confirmPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
+            let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
+            let downloadable = self.downloadableEpisodes(from: self.viewModel.episodes)
+            let totalSize = self.estimatedDownloadSize(from: downloadable, limit: actualDownloadCount)
+            var messageParts = [String]()
+            if totalSize > 0 {
+                let sizeString = SizeFormatter.shared.noDecimalFormat(bytes: totalSize)
+                messageParts.append(L10n.downloadEstimatedSize(sizeString))
             }
+            if downloadLimitExceeded {
+                messageParts.append(L10n.bulkDownloadMax)
+            }
+            if !onWifi, !Settings.mobileDataAllowed() {
+                messageParts.append(L10n.downloadDataWarningAlert)
+            }
+            let message = messageParts.joined(separator: "\n")
+
+            let downloadAction = OptionAction(label: downloadText, icon: onWifi ? "filter_downloaded" : nil) { [weak self] in
+                self?.downloadAll()
+            }
+            downloadAction.destructive = !onWifi
+
+            var actions: [OptionAction] = [downloadAction]
+            if !onWifi {
+                actions.append(OptionAction(label: L10n.queueForLater, icon: nil) {
+                    self.queueAll()
+                })
+                if !Settings.mobileDataAllowed() {
+                    actions.append(OptionAction(label: L10n.settings, icon: nil) {
+                        if let url = URL(string: "pktc://settings/storage-and-data") {
+                            UIApplication.shared.open(url)
+                        }
+                    })
+                }
+            }
+
+            let confirmPicker = OptionsPicker(title: nil)
+            confirmPicker.addDescriptiveActions(
+                title: title,
+                message: message.isEmpty ? nil : message,
+                icon: onWifi ? "filter_downloaded" : "option-alert",
+                actions: actions
+            )
+            confirmPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
         }
     }
 

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -460,15 +460,25 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     private func markPlayed() {
         guard let episode = PlaybackManager.shared.currentEpisode() else { return }
 
-        let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)
-
-        let markPlayedAction = OptionAction(label: L10n.markPlayedShort, icon: nil) {
-            AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
-            EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.playerMarkAsPlayedConfirmation, message: nil, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.markPlayedShort, style: .destructive) { [weak self] _ in
+                guard let self else { return }
+                AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
+                EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            present(alert, animated: true)
+        } else {
+            let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)
+            let markPlayedAction = OptionAction(label: L10n.markPlayedShort, icon: nil) {
+                AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
+                EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
+            }
+            markPlayedAction.destructive = true
+            optionsPicker.addDescriptiveActions(title: L10n.playerMarkAsPlayedConfirmation, message: nil, icon: "shelf_played", actions: [markPlayedAction])
+            optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
         }
-        markPlayedAction.destructive = true
-        optionsPicker.addDescriptiveActions(title: L10n.playerMarkAsPlayedConfirmation, message: nil, icon: "shelf_played", actions: [markPlayedAction])
-        optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     private func delete() {
@@ -483,14 +493,22 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
 
-        let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)
-
-        let archiveAction = OptionAction(label: L10n.archive, icon: nil) {
-            EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.playerArchivedConfirmation, message: nil, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.archive, style: .destructive) { _ in
+                EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            present(alert, animated: true)
+        } else {
+            let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)
+            let archiveAction = OptionAction(label: L10n.archive, icon: nil) {
+                EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
+            }
+            archiveAction.destructive = true
+            optionsPicker.addDescriptiveActions(title: L10n.playerArchivedConfirmation, message: nil, icon: "shelf_archive", actions: [archiveAction])
+            optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
         }
-        archiveAction.destructive = true
-        optionsPicker.addDescriptiveActions(title: L10n.playerArchivedConfirmation, message: nil, icon: "shelf_archive", actions: [archiveAction])
-        optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
     }
     #endif
 

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -461,13 +461,13 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
         guard let episode = PlaybackManager.shared.currentEpisode() else { return }
 
         if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.playerMarkAsPlayedConfirmation, message: nil, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.markPlayedShort, style: .destructive) { [weak self] _ in
+            let alert = UIAlertController(title: L10n.playerMarkAsPlayedAlertTitle, message: L10n.playerMarkAsPlayedAlertMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            alert.addAction(UIAlertAction(title: L10n.markPlayed, style: .destructive) { [weak self] _ in
                 guard let self else { return }
                 AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
                 EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
             })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             present(alert, animated: true)
         } else {
             let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)
@@ -494,11 +494,11 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
         AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
 
         if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.playerArchivedConfirmation, message: nil, preferredStyle: .alert)
+            let alert = UIAlertController(title: L10n.playerArchivedConfirmation, message: L10n.playerArchiveAlertMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             alert.addAction(UIAlertAction(title: L10n.archive, style: .destructive) { _ in
                 EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
             })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             present(alert, animated: true)
         } else {
             let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -460,25 +460,21 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     private func markPlayed() {
         guard let episode = PlaybackManager.shared.currentEpisode() else { return }
 
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.playerMarkAsPlayedAlertTitle, message: L10n.playerMarkAsPlayedAlertMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            alert.addAction(UIAlertAction(title: L10n.markPlayed, style: .destructive) { [weak self] _ in
-                guard let self else { return }
-                AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
-                EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
-            })
-            present(alert, animated: true)
-        } else {
-            let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)
-            let markPlayedAction = OptionAction(label: L10n.markPlayedShort, icon: nil) {
-                AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
-                EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
-            }
-            markPlayedAction.destructive = true
-            optionsPicker.addDescriptiveActions(title: L10n.playerMarkAsPlayedConfirmation, message: nil, icon: "shelf_played", actions: [markPlayedAction])
-            optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
+        let markPlayedAction = OptionAction(label: L10n.markPlayed, icon: "shelf_played") { [weak self] in
+            guard let self else { return }
+            AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
+            EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
         }
+        markPlayedAction.destructive = true
+
+        let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)
+        optionsPicker.addDescriptiveActions(
+            title: L10n.playerMarkAsPlayedAlertTitle,
+            message: L10n.playerMarkAsPlayedAlertMessage,
+            icon: "shelf_played",
+            actions: [markPlayedAction]
+        )
+        optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     private func delete() {
@@ -493,22 +489,19 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
 
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.playerArchivedConfirmation, message: L10n.playerArchiveAlertMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            alert.addAction(UIAlertAction(title: L10n.archive, style: .destructive) { _ in
-                EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
-            })
-            present(alert, animated: true)
-        } else {
-            let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)
-            let archiveAction = OptionAction(label: L10n.archive, icon: nil) {
-                EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
-            }
-            archiveAction.destructive = true
-            optionsPicker.addDescriptiveActions(title: L10n.playerArchivedConfirmation, message: nil, icon: "shelf_archive", actions: [archiveAction])
-            optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
+        let archiveAction = OptionAction(label: L10n.archive, icon: "shelf_archive") {
+            EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
         }
+        archiveAction.destructive = true
+
+        let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)
+        optionsPicker.addDescriptiveActions(
+            title: L10n.playerArchivedConfirmation,
+            message: L10n.playerArchiveAlertMessage,
+            icon: "shelf_archive",
+            actions: [archiveAction]
+        )
+        optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
     }
     #endif
 

--- a/podcasts/OptionsPicker.swift
+++ b/podcasts/OptionsPicker.swift
@@ -1,4 +1,5 @@
 import UIKit
+import PocketCastsUtils
 
 class OptionsPicker {
     private var title: String?
@@ -6,6 +7,13 @@ class OptionsPicker {
     private var optionsController: OptionsPickerRootController?
 
     private var noActionCallback: (() -> Void)?
+
+    // Captured state used to rebuild the picker as a native UIAlertController
+    // when `FeatureFlag.liquidGlass` is enabled. Populated alongside the legacy
+    // calls to `optionsController` so call sites don't need a flag-aware branch.
+    private var descriptiveTitle: String?
+    private var descriptiveMessage: String?
+    private var capturedActions: [OptionAction] = []
 
     init(title: String?, themeOverride: Theme.ThemeType? = nil, iconTintStyle: ThemeStyle = .primaryIcon01, colors: OptionsPickerRootController.Colors? = nil, portraitOnly: Bool = true) {
         self.title = title
@@ -20,6 +28,7 @@ class OptionsPicker {
     }
 
     func addAction(action: OptionAction) {
+        capturedActions.append(action)
         optionsController?.addAction(action: action)
     }
 
@@ -30,14 +39,22 @@ class OptionsPicker {
     }
 
     func addSegmentedAction(name: String, icon: String?, actions: [OptionAction]) {
+        // Segmented actions don't have a native alert equivalent, so they're
+        // tracked only for the legacy picker.
         optionsController?.addSegmentedAction(name: name, icon: icon, actions: actions)
     }
 
     func addDescriptiveActions(title: String, message: String?, icon: String, actions: [OptionAction]) {
+        descriptiveTitle = title
+        descriptiveMessage = message
+        capturedActions.append(contentsOf: actions)
         optionsController?.addDescriptiveActions(title: title, message: message, icon: icon, actions: actions)
     }
 
     func addAttributedDescriptiveActions(title: String, message: String, icon: String, actions: [OptionAction]) {
+        descriptiveTitle = title
+        descriptiveMessage = message
+        capturedActions.append(contentsOf: actions)
         optionsController?.addAttributedDescriptiveActions(title: title, message: message, icon: icon, actions: actions)
     }
 
@@ -46,8 +63,15 @@ class OptionsPicker {
     }
 
     func show(statusBarStyle: UIStatusBarStyle? = nil) {
+        if FeatureFlag.liquidGlass.enabled {
+            presentAsNativeAlert()
+        } else {
+            presentAsLegacyPicker(statusBarStyle: statusBarStyle)
+        }
+    }
+
+    private func presentAsLegacyPicker(statusBarStyle: UIStatusBarStyle?) {
         guard let rootController = optionsController else { return }
-        //TODO: Figure this out and fix it
         #if !APPCLIP
         window = SceneHelper.newMainScreenWindow()
         #endif
@@ -61,6 +85,26 @@ class OptionsPicker {
         }
         rootController.aboutToPresentOptions(bottomPadding: additionalPaddingRequired)
         rootController.animateIn()
+    }
+
+    private func presentAsNativeAlert() {
+        let alert = UIAlertController(title: descriptiveTitle ?? title, message: descriptiveMessage, preferredStyle: .alert)
+
+        for action in capturedActions {
+            let style: UIAlertAction.Style = action.destructive ? .destructive : .default
+            alert.addAction(UIAlertAction(title: action.label, style: style) { _ in
+                action.action()
+            })
+        }
+
+        let noActionCallback = self.noActionCallback
+        alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
+            noActionCallback?()
+        })
+
+        #if !APPCLIP
+        SceneHelper.rootViewController()?.present(alert, animated: true)
+        #endif
     }
 
     func controllerDidAnimateOut(optionChosen: Bool) {

--- a/podcasts/OptionsPicker.swift
+++ b/podcasts/OptionsPicker.swift
@@ -63,7 +63,11 @@ class OptionsPicker {
     }
 
     func show(statusBarStyle: UIStatusBarStyle? = nil) {
-        if FeatureFlag.liquidGlass.enabled {
+        // Promote to native UIAlertController only when there is descriptive
+        // context (i.e. a confirmation prompt). Plain action lists stay as the
+        // legacy bottom-sheet picker so menu-style surfaces aren't accidentally
+        // rendered as alerts.
+        if FeatureFlag.liquidGlass.enabled, descriptiveTitle != nil {
             presentAsNativeAlert()
         } else {
             presentAsLegacyPicker(statusBarStyle: statusBarStyle)

--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -345,29 +345,71 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
             let actualDownloadCount = downloadLimitExceeded ? Constants.Limits.maxBulkDownloads : downloadableCount
             if actualDownloadCount == 0 { return }
             let downloadText = L10n.downloadCountPrompt(actualDownloadCount)
-            let downloadAction = OptionAction(label: downloadText, icon: nil) { [weak self] in
-                self?.downloadAll()
-            }
 
-            let confirmPicker = OptionsPicker(title: nil)
-            var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
+            let onWifi = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
 
-            if NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
-                confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
+            if FeatureFlag.liquidGlass.enabled {
+                let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
+                let downloadable = self.episodes.filter {
+                    !$0.episode.downloaded(pathFinder: DownloadManager.shared) && !$0.episode.downloading() && !$0.episode.queued()
+                }
+                let totalSize = downloadable.prefix(actualDownloadCount).reduce(Int64(0)) { $0 + $1.episode.sizeInBytes }
+                var messageParts = [String]()
+                if totalSize > 0 {
+                    let sizeString = SizeFormatter.shared.noDecimalFormat(bytes: totalSize)
+                    messageParts.append(L10n.downloadEstimatedSize(sizeString))
+                }
+                if downloadLimitExceeded {
+                    messageParts.append(L10n.bulkDownloadMax)
+                }
+                if !onWifi, !Settings.mobileDataAllowed() {
+                    messageParts.append(L10n.downloadDataWarningAlert)
+                }
+                let message = messageParts.joined(separator: "\n")
+
+                let alert = UIAlertController(title: title, message: message.isEmpty ? nil : message, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: downloadText, style: onWifi ? .default : .destructive) { _ in
+                    self.downloadAll()
+                })
+                if !onWifi {
+                    alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
+                        self.queueAll()
+                    })
+                    if !Settings.mobileDataAllowed() {
+                        alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
+                            if let url = URL(string: "pktc://settings/storage-and-data") {
+                                UIApplication.shared.open(url)
+                            }
+                        })
+                    }
+                }
+                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+                self.present(alert, animated: true)
             } else {
-                downloadAction.destructive = true
-
-                let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                    self.queueAll()
+                let downloadAction = OptionAction(label: downloadText, icon: nil) { [weak self] in
+                    self?.downloadAll()
                 }
 
-                if !Settings.mobileDataAllowed() {
-                    warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
-                }
+                let confirmPicker = OptionsPicker(title: nil)
+                var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
 
-                confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
+                if onWifi {
+                    confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
+                } else {
+                    downloadAction.destructive = true
+
+                    let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
+                        self.queueAll()
+                    }
+
+                    if !Settings.mobileDataAllowed() {
+                        warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
+                    }
+
+                    confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
+                }
+                confirmPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
             }
-            confirmPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
         }
 
         optionsPicker.addAction(action: sortAction)

--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -348,68 +348,51 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
 
             let onWifi = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
 
-            if FeatureFlag.liquidGlass.enabled {
-                let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
-                let downloadable = self.episodes.filter {
-                    !$0.episode.downloaded(pathFinder: DownloadManager.shared) && !$0.episode.downloading() && !$0.episode.queued()
-                }
-                let totalSize = downloadable.prefix(actualDownloadCount).reduce(Int64(0)) { $0 + $1.episode.sizeInBytes }
-                var messageParts = [String]()
-                if totalSize > 0 {
-                    let sizeString = SizeFormatter.shared.noDecimalFormat(bytes: totalSize)
-                    messageParts.append(L10n.downloadEstimatedSize(sizeString))
-                }
-                if downloadLimitExceeded {
-                    messageParts.append(L10n.bulkDownloadMax)
-                }
-                if !onWifi, !Settings.mobileDataAllowed() {
-                    messageParts.append(L10n.downloadDataWarningAlert)
-                }
-                let message = messageParts.joined(separator: "\n")
-
-                let alert = UIAlertController(title: title, message: message.isEmpty ? nil : message, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: downloadText, style: onWifi ? .default : .destructive) { _ in
-                    self.downloadAll()
-                })
-                if !onWifi {
-                    alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
-                        self.queueAll()
-                    })
-                    if !Settings.mobileDataAllowed() {
-                        alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
-                            if let url = URL(string: "pktc://settings/storage-and-data") {
-                                UIApplication.shared.open(url)
-                            }
-                        })
-                    }
-                }
-                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-                self.present(alert, animated: true)
-            } else {
-                let downloadAction = OptionAction(label: downloadText, icon: nil) { [weak self] in
-                    self?.downloadAll()
-                }
-
-                let confirmPicker = OptionsPicker(title: nil)
-                var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
-
-                if onWifi {
-                    confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
-                } else {
-                    downloadAction.destructive = true
-
-                    let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                        self.queueAll()
-                    }
-
-                    if !Settings.mobileDataAllowed() {
-                        warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
-                    }
-
-                    confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
-                }
-                confirmPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
+            let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
+            let downloadable = self.episodes.filter {
+                !$0.episode.downloaded(pathFinder: DownloadManager.shared) && !$0.episode.downloading() && !$0.episode.queued()
             }
+            let totalSize = downloadable.prefix(actualDownloadCount).reduce(Int64(0)) { $0 + $1.episode.sizeInBytes }
+            var messageParts = [String]()
+            if totalSize > 0 {
+                let sizeString = SizeFormatter.shared.noDecimalFormat(bytes: totalSize)
+                messageParts.append(L10n.downloadEstimatedSize(sizeString))
+            }
+            if downloadLimitExceeded {
+                messageParts.append(L10n.bulkDownloadMax)
+            }
+            if !onWifi, !Settings.mobileDataAllowed() {
+                messageParts.append(L10n.downloadDataWarningAlert)
+            }
+            let message = messageParts.joined(separator: "\n")
+
+            let downloadAction = OptionAction(label: downloadText, icon: onWifi ? "filter_downloaded" : nil) { [weak self] in
+                self?.downloadAll()
+            }
+            downloadAction.destructive = !onWifi
+
+            var actions: [OptionAction] = [downloadAction]
+            if !onWifi {
+                actions.append(OptionAction(label: L10n.queueForLater, icon: nil) {
+                    self.queueAll()
+                })
+                if !Settings.mobileDataAllowed() {
+                    actions.append(OptionAction(label: L10n.settings, icon: nil) {
+                        if let url = URL(string: "pktc://settings/storage-and-data") {
+                            UIApplication.shared.open(url)
+                        }
+                    })
+                }
+            }
+
+            let confirmPicker = OptionsPicker(title: nil)
+            confirmPicker.addDescriptiveActions(
+                title: title,
+                message: message.isEmpty ? nil : message,
+                icon: onWifi ? "filter_downloaded" : "option-alert",
+                actions: actions
+            )
+            confirmPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
         }
 
         optionsPicker.addAction(action: sortAction)

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -176,7 +176,7 @@ extension PlaylistsViewController {
         Analytics.track(.filterDeleteTriggered, properties: analyticsProperties)
 
         if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.playlistsDeleteAlertTitle, message: L10n.playlistsDeleteAlertMessage, preferredStyle: .alert)
+            let alert = UIAlertController(title: L10n.alertDeletePlaylist, message: L10n.playlistsDeleteAlertMessage, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L10n.delete, style: .destructive) { [weak self] _ in
                 self?.delete(playlist: playlist, at: indexPath, in: tableView)
             })

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -174,28 +174,28 @@ extension PlaylistsViewController {
         let playlistType = playlist.manual ? "manual" : "smart"
         let analyticsProperties = ["filter_type": playlistType]
         Analytics.track(.filterDeleteTriggered, properties: analyticsProperties)
-        let delete = OptionAction(
-            label: L10n.delete,
-            icon: nil,
-            action: { [weak self] in
-                self?.delete(playlist: playlist, at: indexPath, in: tableView)
-            }
-        )
-        delete.destructive = true
 
-        let picker = OptionsPicker(title: "")
-        picker.addDescriptiveActions(
-            title: L10n.playlistsDeleteAlertTitle,
-            message: L10n.playlistsDeleteAlertMessage,
-            icon: "option-alert",
-            actions: [
-                delete
-            ]
-        )
-        picker.setNoActionCallback {
-            Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.playlistsDeleteAlertTitle, message: L10n.playlistsDeleteAlertMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.delete, style: .destructive) { [weak self] _ in
+                self?.delete(playlist: playlist, at: indexPath, in: tableView)
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
+                Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
+            })
+            present(alert, animated: true)
+        } else {
+            let delete = OptionAction(label: L10n.delete, icon: nil, action: { [weak self] in
+                self?.delete(playlist: playlist, at: indexPath, in: tableView)
+            })
+            delete.destructive = true
+            let picker = OptionsPicker(title: "")
+            picker.addDescriptiveActions(title: L10n.playlistsDeleteAlertTitle, message: L10n.playlistsDeleteAlertMessage, icon: "option-alert", actions: [delete])
+            picker.setNoActionCallback {
+                Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
+            }
+            picker.show(statusBarStyle: .default)
         }
-        picker.show(statusBarStyle: .default)
     }
 
     fileprivate func delete(playlist: EpisodeFilter, at indexPath: IndexPath, in tableView: UITableView) {

--- a/podcasts/PlaylistsViewController+Table.swift
+++ b/podcasts/PlaylistsViewController+Table.swift
@@ -175,27 +175,22 @@ extension PlaylistsViewController {
         let analyticsProperties = ["filter_type": playlistType]
         Analytics.track(.filterDeleteTriggered, properties: analyticsProperties)
 
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.alertDeletePlaylist, message: L10n.playlistsDeleteAlertMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.delete, style: .destructive) { [weak self] _ in
-                self?.delete(playlist: playlist, at: indexPath, in: tableView)
-            })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
-                Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
-            })
-            present(alert, animated: true)
-        } else {
-            let delete = OptionAction(label: L10n.delete, icon: nil, action: { [weak self] in
-                self?.delete(playlist: playlist, at: indexPath, in: tableView)
-            })
-            delete.destructive = true
-            let picker = OptionsPicker(title: "")
-            picker.addDescriptiveActions(title: L10n.playlistsDeleteAlertTitle, message: L10n.playlistsDeleteAlertMessage, icon: "option-alert", actions: [delete])
-            picker.setNoActionCallback {
-                Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
-            }
-            picker.show(statusBarStyle: .default)
+        let delete = OptionAction(label: L10n.delete, icon: "option-alert", action: { [weak self] in
+            self?.delete(playlist: playlist, at: indexPath, in: tableView)
+        })
+        delete.destructive = true
+
+        let picker = OptionsPicker(title: "")
+        picker.addDescriptiveActions(
+            title: L10n.alertDeletePlaylist,
+            message: L10n.playlistsDeleteAlertMessage,
+            icon: "option-alert",
+            actions: [delete]
+        )
+        picker.setNoActionCallback {
+            Analytics.track(.filterDeleteDismissed, properties: analyticsProperties)
         }
+        picker.show(statusBarStyle: .default)
     }
 
     fileprivate func delete(playlist: EpisodeFilter, at indexPath: IndexPath, in tableView: UITableView) {

--- a/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
+++ b/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
@@ -170,30 +170,55 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
             let actualDownloadCount = downloadLimitExceeded ? Constants.Limits.maxBulkDownloads : downloadableCount
             if actualDownloadCount == 0 { return }
             let downloadText = L10n.downloadCountPrompt(actualDownloadCount)
-            let downloadAction = OptionAction(label: downloadText, icon: nil) { () in
-                delegate.downloadAllTapped()
-            }
 
-            let confirmPicker = OptionsPicker(title: nil)
-            var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
+            if FeatureFlag.liquidGlass.enabled {
+                let onWifi = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
+                let title = onWifi ? L10n.downloadAll : L10n.notOnWifi
+                var message = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
+                if !onWifi, !Settings.mobileDataAllowed() {
+                    message = L10n.downloadDataWarningAlert + (message.isEmpty ? "" : "\n" + message)
+                }
 
-            if NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
-                confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
+                let alert = UIAlertController(title: title, message: message.isEmpty ? nil : message, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: downloadText, style: onWifi ? .default : .destructive) { _ in
+                    delegate.downloadAllTapped()
+                })
+                if !onWifi {
+                    alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
+                        delegate.queueAllTapped()
+                    })
+                    if !Settings.mobileDataAllowed() {
+                        alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
+                            if let url = URL(string: "pktc://settings/storage-and-data") {
+                                UIApplication.shared.open(url)
+                            }
+                        })
+                    }
+                }
+                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+                self?.present(alert, animated: true)
             } else {
-                downloadAction.destructive = true
-
-                let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                    delegate.queueAllTapped()
+                let downloadAction = OptionAction(label: downloadText, icon: nil) { () in
+                    delegate.downloadAllTapped()
                 }
-                queueAction.outline = true
+                let confirmPicker = OptionsPicker(title: nil)
+                var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
 
-                if !Settings.mobileDataAllowed() {
-                    warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
+                if NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
+                    confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
+                } else {
+                    downloadAction.destructive = true
+                    let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
+                        delegate.queueAllTapped()
+                    }
+                    queueAction.outline = true
+                    if !Settings.mobileDataAllowed() {
+                        warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
+                    }
+                    confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
                 }
-                confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
+                confirmPicker.show(statusBarStyle: self?.preferredStatusBarStyle ?? .default)
             }
-
-            confirmPicker.show(statusBarStyle: self?.preferredStatusBarStyle ?? .default)
         }
         optionPicker.addAction(action: downloadAllAction)
 
@@ -240,15 +265,25 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
     private func confirmArchiveAll(episodeCount: Int, playedOnly: Bool) {
         guard let podcastDelegate else { return }
 
-        let archiveAllConfirm = OptionsPicker(title: nil)
-        let archiveAllAction = OptionAction(label: episodeCount == 1 ? L10n.podcastArchiveEpisodeCountSingular : L10n.podcastArchiveEpisodesCountPluralFormat(episodeCount.localized()), icon: nil, action: {
-            podcastDelegate.archiveAllTapped(playedOnly: playedOnly)
-        })
-        archiveAllAction.destructive = true
         let title = playedOnly ? L10n.podcastArchiveAllPlayed : L10n.podcastArchiveAll
-        archiveAllConfirm.addDescriptiveActions(title: title, message: L10n.podcastArchivePromptMsg, icon: "options-archiveall", actions: [archiveAllAction])
+        let actionLabel = episodeCount == 1 ? L10n.podcastArchiveEpisodeCountSingular : L10n.podcastArchiveEpisodesCountPluralFormat(episodeCount.localized())
 
-        archiveAllConfirm.show(statusBarStyle: preferredStatusBarStyle)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: title, message: L10n.podcastArchivePromptMsg, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: actionLabel, style: .destructive) { _ in
+                podcastDelegate.archiveAllTapped(playedOnly: playedOnly)
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            present(alert, animated: true)
+        } else {
+            let archiveAllConfirm = OptionsPicker(title: nil)
+            let archiveAllAction = OptionAction(label: actionLabel, icon: nil, action: {
+                podcastDelegate.archiveAllTapped(playedOnly: playedOnly)
+            })
+            archiveAllAction.destructive = true
+            archiveAllConfirm.addDescriptiveActions(title: title, message: L10n.podcastArchivePromptMsg, icon: "options-archiveall", actions: [archiveAllAction])
+            archiveAllConfirm.show(statusBarStyle: preferredStatusBarStyle)
+        }
     }
 
     private func presentSortOptions() {

--- a/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
+++ b/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
@@ -173,7 +173,7 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
 
             if FeatureFlag.liquidGlass.enabled {
                 let onWifi = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
-                let title = onWifi ? L10n.downloadAll : L10n.notOnWifi
+                let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
                 var message = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
                 if !onWifi, !Settings.mobileDataAllowed() {
                     message = L10n.downloadDataWarningAlert + (message.isEmpty ? "" : "\n" + message)
@@ -269,11 +269,12 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
         let actionLabel = episodeCount == 1 ? L10n.podcastArchiveEpisodeCountSingular : L10n.podcastArchiveEpisodesCountPluralFormat(episodeCount.localized())
 
         if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: title, message: L10n.podcastArchivePromptMsg, preferredStyle: .alert)
+            let alertTitle = playedOnly ? L10n.alertArchiveAllPlayed : L10n.alertArchiveAll
+            let alert = UIAlertController(title: alertTitle, message: L10n.podcastArchivePromptMsg, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             alert.addAction(UIAlertAction(title: actionLabel, style: .destructive) { _ in
                 podcastDelegate.archiveAllTapped(playedOnly: playedOnly)
             })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             present(alert, animated: true)
         } else {
             let archiveAllConfirm = OptionsPicker(title: nil)

--- a/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
+++ b/podcasts/Podcasts/Podcast Page/EpisodeListSearchController.swift
@@ -171,54 +171,42 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
             if actualDownloadCount == 0 { return }
             let downloadText = L10n.downloadCountPrompt(actualDownloadCount)
 
-            if FeatureFlag.liquidGlass.enabled {
-                let onWifi = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
-                let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
-                var message = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
-                if !onWifi, !Settings.mobileDataAllowed() {
-                    message = L10n.downloadDataWarningAlert + (message.isEmpty ? "" : "\n" + message)
-                }
-
-                let alert = UIAlertController(title: title, message: message.isEmpty ? nil : message, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: downloadText, style: onWifi ? .default : .destructive) { _ in
-                    delegate.downloadAllTapped()
-                })
-                if !onWifi {
-                    alert.addAction(UIAlertAction(title: L10n.queueForLater, style: .default) { _ in
-                        delegate.queueAllTapped()
-                    })
-                    if !Settings.mobileDataAllowed() {
-                        alert.addAction(UIAlertAction(title: L10n.settings, style: .default) { _ in
-                            if let url = URL(string: "pktc://settings/storage-and-data") {
-                                UIApplication.shared.open(url)
-                            }
-                        })
-                    }
-                }
-                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-                self?.present(alert, animated: true)
-            } else {
-                let downloadAction = OptionAction(label: downloadText, icon: nil) { () in
-                    delegate.downloadAllTapped()
-                }
-                let confirmPicker = OptionsPicker(title: nil)
-                var warningMessage = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
-
-                if NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
-                    confirmPicker.addDescriptiveActions(title: L10n.downloadAll, message: warningMessage, icon: "filter_downloaded", actions: [downloadAction])
-                } else {
-                    downloadAction.destructive = true
-                    let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                        delegate.queueAllTapped()
-                    }
-                    queueAction.outline = true
-                    if !Settings.mobileDataAllowed() {
-                        warningMessage = L10n.downloadDataWarningWithSettingsLink("pktc://settings/storage-and-data") + "\n" + warningMessage
-                    }
-                    confirmPicker.addAttributedDescriptiveActions(title: L10n.notOnWifi, message: warningMessage, icon: "option-alert", actions: [downloadAction, queueAction])
-                }
-                confirmPicker.show(statusBarStyle: self?.preferredStatusBarStyle ?? .default)
+            let onWifi = NetworkUtils.shared.isConnectedToUnexpensiveConnection()
+            let title = onWifi ? L10n.alertDownloadAll : L10n.notOnWifi
+            var message = downloadLimitExceeded ? L10n.bulkDownloadMax : ""
+            if !onWifi, !Settings.mobileDataAllowed() {
+                message = L10n.downloadDataWarningAlert + (message.isEmpty ? "" : "\n" + message)
             }
+
+            let downloadAction = OptionAction(label: downloadText, icon: "filter_downloaded") { () in
+                delegate.downloadAllTapped()
+            }
+            downloadAction.destructive = !onWifi
+
+            var actions: [OptionAction] = [downloadAction]
+            if !onWifi {
+                let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
+                    delegate.queueAllTapped()
+                }
+                queueAction.outline = true
+                actions.append(queueAction)
+                if !Settings.mobileDataAllowed() {
+                    actions.append(OptionAction(label: L10n.settings, icon: nil) {
+                        if let url = URL(string: "pktc://settings/storage-and-data") {
+                            UIApplication.shared.open(url)
+                        }
+                    })
+                }
+            }
+
+            let confirmPicker = OptionsPicker(title: nil)
+            confirmPicker.addDescriptiveActions(
+                title: title,
+                message: message.isEmpty ? nil : message,
+                icon: onWifi ? "filter_downloaded" : "option-alert",
+                actions: actions
+            )
+            confirmPicker.show(statusBarStyle: self?.preferredStatusBarStyle ?? .default)
         }
         optionPicker.addAction(action: downloadAllAction)
 
@@ -268,23 +256,20 @@ class EpisodeListSearchController: SimpleNotificationsViewController, UISearchBa
         let title = playedOnly ? L10n.podcastArchiveAllPlayed : L10n.podcastArchiveAll
         let actionLabel = episodeCount == 1 ? L10n.podcastArchiveEpisodeCountSingular : L10n.podcastArchiveEpisodesCountPluralFormat(episodeCount.localized())
 
-        if FeatureFlag.liquidGlass.enabled {
-            let alertTitle = playedOnly ? L10n.alertArchiveAllPlayed : L10n.alertArchiveAll
-            let alert = UIAlertController(title: alertTitle, message: L10n.podcastArchivePromptMsg, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            alert.addAction(UIAlertAction(title: actionLabel, style: .destructive) { _ in
-                podcastDelegate.archiveAllTapped(playedOnly: playedOnly)
-            })
-            present(alert, animated: true)
-        } else {
-            let archiveAllConfirm = OptionsPicker(title: nil)
-            let archiveAllAction = OptionAction(label: actionLabel, icon: nil, action: {
-                podcastDelegate.archiveAllTapped(playedOnly: playedOnly)
-            })
-            archiveAllAction.destructive = true
-            archiveAllConfirm.addDescriptiveActions(title: title, message: L10n.podcastArchivePromptMsg, icon: "options-archiveall", actions: [archiveAllAction])
-            archiveAllConfirm.show(statusBarStyle: preferredStatusBarStyle)
-        }
+        let alertTitle = playedOnly ? L10n.alertArchiveAllPlayed : L10n.alertArchiveAll
+        let archiveAllAction = OptionAction(label: actionLabel, icon: "options-archiveall", action: {
+            podcastDelegate.archiveAllTapped(playedOnly: playedOnly)
+        })
+        archiveAllAction.destructive = true
+
+        let archiveAllConfirm = OptionsPicker(title: nil)
+        archiveAllConfirm.addDescriptiveActions(
+            title: alertTitle,
+            message: L10n.podcastArchivePromptMsg,
+            icon: "options-archiveall",
+            actions: [archiveAllAction]
+        )
+        archiveAllConfirm.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     private func presentSortOptions() {

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.swift
@@ -101,19 +101,40 @@ class PodcastSettingsViewController: PCViewController {
                 downloadedCount += 1
             }
         }
-        let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
+
         let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
-        let unsubscribeAction = OptionAction(label: label, icon: nil, action: { [weak self] in
-            self?.performUnsubscribe()
-        })
-        if downloadedCount > 0 {
-            unsubscribeAction.destructive = true
-            let message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
-            optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: message, icon: "option-alert", actions: [unsubscribeAction])
+
+        if FeatureFlag.liquidGlass.enabled {
+            let title: String
+            let message: String?
+            if downloadedCount > 0 {
+                title = L10n.downloadedFilesConf(downloadedCount)
+                message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
+            } else {
+                title = L10n.areYouSure
+                message = nil
+            }
+
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
+                self?.performUnsubscribe()
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            present(alert, animated: true)
         } else {
-            optionPicker.addAction(action: unsubscribeAction)
+            let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
+            let unsubscribeAction = OptionAction(label: label, icon: nil, action: { [weak self] in
+                self?.performUnsubscribe()
+            })
+            if downloadedCount > 0 {
+                unsubscribeAction.destructive = true
+                let message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
+                optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: message, icon: "option-alert", actions: [unsubscribeAction])
+            } else {
+                optionPicker.addAction(action: unsubscribeAction)
+            }
+            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
         }
-        optionPicker.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     private func performUnsubscribe() {

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.swift
@@ -111,15 +111,15 @@ class PodcastSettingsViewController: PCViewController {
                 title = L10n.downloadedFilesConf(downloadedCount)
                 message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
             } else {
-                title = L10n.areYouSure
+                title = L10n.alertAreYouSure
                 message = nil
             }
 
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
                 self?.performUnsubscribe()
             })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             present(alert, animated: true)
         } else {
             let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.swift
@@ -104,37 +104,24 @@ class PodcastSettingsViewController: PCViewController {
 
         let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
 
-        if FeatureFlag.liquidGlass.enabled {
-            let title: String
-            let message: String?
-            if downloadedCount > 0 {
-                title = L10n.downloadedFilesConf(downloadedCount)
-                message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
-            } else {
-                title = L10n.alertAreYouSure
-                message = nil
-            }
+        let unsubscribeAction = OptionAction(label: label, icon: "option-alert", action: { [weak self] in
+            self?.performUnsubscribe()
+        })
+        unsubscribeAction.destructive = true
 
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
-                self?.performUnsubscribe()
-            })
-            present(alert, animated: true)
+        let title: String
+        let message: String?
+        if downloadedCount > 0 {
+            title = L10n.downloadedFilesConf(downloadedCount)
+            message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
         } else {
-            let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
-            let unsubscribeAction = OptionAction(label: label, icon: nil, action: { [weak self] in
-                self?.performUnsubscribe()
-            })
-            if downloadedCount > 0 {
-                unsubscribeAction.destructive = true
-                let message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
-                optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: message, icon: "option-alert", actions: [unsubscribeAction])
-            } else {
-                optionPicker.addAction(action: unsubscribeAction)
-            }
-            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+            title = L10n.alertAreYouSure
+            message = nil
         }
+
+        let optionPicker = OptionsPicker(title: nil)
+        optionPicker.addDescriptiveActions(title: title, message: message, icon: "option-alert", actions: [unsubscribeAction])
+        optionPicker.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     private func performUnsubscribe() {

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -760,19 +760,39 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
             }
         }
 
-        let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
         let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
-        let unsubscribeAction = OptionAction(label: label, icon: nil, action: { [weak self] in
-            self?.performUnsubscribe()
-        })
-        if downloadedCount > 0 {
-            unsubscribeAction.destructive = true
-            let message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
-            optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: message, icon: "option-alert", actions: [unsubscribeAction])
+
+        if FeatureFlag.liquidGlass.enabled {
+            let title: String
+            let message: String?
+            if downloadedCount > 0 {
+                title = L10n.downloadedFilesConf(downloadedCount)
+                message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
+            } else {
+                title = L10n.areYouSure
+                message = nil
+            }
+
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
+                self?.performUnsubscribe()
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            present(alert, animated: true)
         } else {
-            optionPicker.addAction(action: unsubscribeAction)
+            let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
+            let unsubscribeAction = OptionAction(label: label, icon: nil, action: { [weak self] in
+                self?.performUnsubscribe()
+            })
+            if downloadedCount > 0 {
+                unsubscribeAction.destructive = true
+                let message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
+                optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: message, icon: "option-alert", actions: [unsubscribeAction])
+            } else {
+                optionPicker.addAction(action: unsubscribeAction)
+            }
+            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
         }
-        optionPicker.show(statusBarStyle: preferredStatusBarStyle)
 
         Analytics.track(.podcastScreenUnsubscribeTapped)
     }

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -769,15 +769,15 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
                 title = L10n.downloadedFilesConf(downloadedCount)
                 message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
             } else {
-                title = L10n.areYouSure
+                title = L10n.alertAreYouSure
                 message = nil
             }
 
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
                 self?.performUnsubscribe()
             })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
             present(alert, animated: true)
         } else {
             let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -762,37 +762,24 @@ class PodcastViewController: FakeNavViewController, PodcastActionsDelegate, Sync
 
         let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
 
-        if FeatureFlag.liquidGlass.enabled {
-            let title: String
-            let message: String?
-            if downloadedCount > 0 {
-                title = L10n.downloadedFilesConf(downloadedCount)
-                message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
-            } else {
-                title = L10n.alertAreYouSure
-                message = nil
-            }
+        let unsubscribeAction = OptionAction(label: label, icon: "option-alert", action: { [weak self] in
+            self?.performUnsubscribe()
+        })
+        unsubscribeAction.destructive = true
 
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
-                self?.performUnsubscribe()
-            })
-            present(alert, animated: true)
+        let title: String
+        let message: String?
+        if downloadedCount > 0 {
+            title = L10n.downloadedFilesConf(downloadedCount)
+            message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
         } else {
-            let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
-            let unsubscribeAction = OptionAction(label: label, icon: nil, action: { [weak self] in
-                self?.performUnsubscribe()
-            })
-            if downloadedCount > 0 {
-                unsubscribeAction.destructive = true
-                let message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
-                optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: message, icon: "option-alert", actions: [unsubscribeAction])
-            } else {
-                optionPicker.addAction(action: unsubscribeAction)
-            }
-            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+            title = L10n.alertAreYouSure
+            message = nil
         }
+
+        let optionPicker = OptionsPicker(title: nil)
+        optionPicker.addDescriptiveActions(title: title, message: message, icon: "option-alert", actions: [unsubscribeAction])
+        optionPicker.show(statusBarStyle: preferredStatusBarStyle)
 
         Analytics.track(.podcastScreenUnsubscribeTapped)
     }

--- a/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.swift
+++ b/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.swift
@@ -79,11 +79,11 @@ class IncomingShareListViewController: PCViewController, UITableViewDelegate, UI
     @IBAction func subscribeToAllTapped(_ sender: AnyObject) {
         if podcasts.count > 2 {
             if FeatureFlag.liquidGlass.enabled {
-                let alert = UIAlertController(title: L10n.sharedListSubscribeConfTitle, message: L10n.sharedListSubscribeConfMsg(podcasts.count.localized()), preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: L10n.sharedListSubscribeConfAction, style: .default) { [weak self] _ in
+                let alert = UIAlertController(title: L10n.alertSharedListSubscribeTitle(podcasts.count.localized()), message: L10n.alertSharedListSubscribeMessage, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+                alert.addAction(UIAlertAction(title: L10n.alertSharedListSubscribeAction, style: .default) { [weak self] _ in
                     self?.performSubscribeAll()
                 })
-                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
                 present(alert, animated: true)
             } else {
                 let optionPicker = OptionsPicker(title: nil)

--- a/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.swift
+++ b/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.swift
@@ -1,4 +1,5 @@
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 
 class IncomingShareListViewController: PCViewController, UITableViewDelegate, UITableViewDataSource {
@@ -77,17 +78,24 @@ class IncomingShareListViewController: PCViewController, UITableViewDelegate, UI
 
     @IBAction func subscribeToAllTapped(_ sender: AnyObject) {
         if podcasts.count > 2 {
-            let optionPicker = OptionsPicker(title: nil)
-
-            let subscribeAction = OptionAction(label: L10n.sharedListSubscribeConfAction, icon: nil, action: { [weak self] in
-                self?.performSubscribeAll()
-            })
-            optionPicker.addDescriptiveActions(title: L10n.sharedListSubscribeConfTitle,
-                                               message: L10n.sharedListSubscribeConfMsg(podcasts.count.localized()),
-                                               icon: "option-podcasts",
-                                               actions: [subscribeAction])
-
-            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+            if FeatureFlag.liquidGlass.enabled {
+                let alert = UIAlertController(title: L10n.sharedListSubscribeConfTitle, message: L10n.sharedListSubscribeConfMsg(podcasts.count.localized()), preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: L10n.sharedListSubscribeConfAction, style: .default) { [weak self] _ in
+                    self?.performSubscribeAll()
+                })
+                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+                present(alert, animated: true)
+            } else {
+                let optionPicker = OptionsPicker(title: nil)
+                let subscribeAction = OptionAction(label: L10n.sharedListSubscribeConfAction, icon: nil, action: { [weak self] in
+                    self?.performSubscribeAll()
+                })
+                optionPicker.addDescriptiveActions(title: L10n.sharedListSubscribeConfTitle,
+                                                   message: L10n.sharedListSubscribeConfMsg(podcasts.count.localized()),
+                                                   icon: "option-podcasts",
+                                                   actions: [subscribeAction])
+                optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+            }
         } else {
             performSubscribeAll()
         }

--- a/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.swift
+++ b/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.swift
@@ -78,24 +78,17 @@ class IncomingShareListViewController: PCViewController, UITableViewDelegate, UI
 
     @IBAction func subscribeToAllTapped(_ sender: AnyObject) {
         if podcasts.count > 2 {
-            if FeatureFlag.liquidGlass.enabled {
-                let alert = UIAlertController(title: L10n.alertSharedListSubscribeTitle(podcasts.count.localized()), message: L10n.alertSharedListSubscribeMessage, preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-                alert.addAction(UIAlertAction(title: L10n.alertSharedListSubscribeAction, style: .default) { [weak self] _ in
-                    self?.performSubscribeAll()
-                })
-                present(alert, animated: true)
-            } else {
-                let optionPicker = OptionsPicker(title: nil)
-                let subscribeAction = OptionAction(label: L10n.sharedListSubscribeConfAction, icon: nil, action: { [weak self] in
-                    self?.performSubscribeAll()
-                })
-                optionPicker.addDescriptiveActions(title: L10n.sharedListSubscribeConfTitle,
-                                                   message: L10n.sharedListSubscribeConfMsg(podcasts.count.localized()),
-                                                   icon: "option-podcasts",
-                                                   actions: [subscribeAction])
-                optionPicker.show(statusBarStyle: preferredStatusBarStyle)
-            }
+            let subscribeAction = OptionAction(label: L10n.alertSharedListSubscribeAction, icon: "option-podcasts", action: { [weak self] in
+                self?.performSubscribeAll()
+            })
+            let optionPicker = OptionsPicker(title: nil)
+            optionPicker.addDescriptiveActions(
+                title: L10n.alertSharedListSubscribeTitle(podcasts.count.localized()),
+                message: L10n.alertSharedListSubscribeMessage,
+                icon: "option-podcasts",
+                actions: [subscribeAction]
+            )
+            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
         } else {
             performSubscribeAll()
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -190,10 +190,10 @@ internal enum L10n {
   internal static var alertDownloadAll: String { return L10n.tr("Localizable", "alert_download_all", fallback: "Download all?") }
   /// Alert title for playing all episodes
   internal static var alertPlayAll: String { return L10n.tr("Localizable", "alert_play_all", fallback: "Play all?") }
-  /// Alert action button for subscribing to all podcasts in a shared list
-  internal static var alertSharedListSubscribeAction: String { return L10n.tr("Localizable", "alert_shared_list_subscribe_action", fallback: "Subscribe to All") }
-  /// Alert message for subscribing to a shared podcast list
-  internal static var alertSharedListSubscribeMessage: String { return L10n.tr("Localizable", "alert_shared_list_subscribe_message", fallback: "They’ll all show up in Your Podcasts.") }
+  /// Alert action button for following all podcasts in a shared list
+  internal static var alertSharedListSubscribeAction: String { return L10n.tr("Localizable", "alert_shared_list_subscribe_action", fallback: "Follow All") }
+  /// Alert message for following all podcasts in a shared list
+  internal static var alertSharedListSubscribeMessage: String { return L10n.tr("Localizable", "alert_shared_list_subscribe_message", fallback: "They’ll be added to your Podcasts.") }
   /// Alert title for subscribing to a shared podcast list. '%1$@' is a placeholder for the number of podcasts.
   internal static func alertSharedListSubscribeTitle(_ p1: Any) -> String {
     return L10n.tr("Localizable", "alert_shared_list_subscribe_title", String(describing: p1), fallback: "%1$@ podcasts incoming.")

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -956,6 +956,10 @@ internal enum L10n {
   }
   /// The episode failed to download but the app wasn't able to determine why. Suggesting to try again after waiting for a bit.
   internal static var downloadErrorTryAgain: String { return L10n.tr("Localizable", "download_error_try_again", fallback: "Unable to download episode. Please try again later.") }
+  /// Alert message showing estimated download size. '%1$@' is a placeholder for the formatted size (e.g. '250 MB').
+  internal static func downloadEstimatedSize(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "download_estimated_size", String(describing: p1), fallback: "This will use approximately %1$@ of storage.")
+  }
   /// A common string used throughout the app. Informs the user the download has failed.
   internal static var downloadFailed: String { return L10n.tr("Localizable", "download_failed", fallback: "Download Failed") }
   /// A common string used throughout the app. Title for screens and prompts related to storage and downloaded files.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -134,6 +134,10 @@ internal enum L10n {
   internal static var accountSelectType: String { return L10n.tr("Localizable", "account_select_type", fallback: "Select Account Type") }
   /// Prompt to allow the user to sign out of their account.
   internal static var accountSignOut: String { return L10n.tr("Localizable", "account_sign_out", fallback: "Sign Out") }
+  /// Message for the sign out confirmation alert
+  internal static var accountSignOutAlertMessage: String { return L10n.tr("Localizable", "account_sign_out_alert_message", fallback: "Your podcasts, progress, and data will be here when you get back.") }
+  /// Title for the sign out confirmation alert
+  internal static var accountSignOutAlertTitle: String { return L10n.tr("Localizable", "account_sign_out_alert_title", fallback: "Sign out?") }
   /// Confirmation dialog informing the user that signing out will remove the given number of supported podcasts. '%1$@' is a placeholder for the number of supported podcasts.
   internal static func accountSignOutSupporterPrompt(_ p1: Any) -> String {
     return L10n.tr("Localizable", "account_sign_out_supporter_prompt", String(describing: p1), fallback: "Signing out will remove %1$@ supported podcasts from this device. Are you sure?")
@@ -162,6 +166,40 @@ internal enum L10n {
   internal static var addToUpNext: String { return L10n.tr("Localizable", "add_to_up_next", fallback: "Add to Up Next") }
   /// A common string used throughout the app. Option that determines the behavior of the app after playing an item.
   internal static var afterPlaying: String { return L10n.tr("Localizable", "after_playing", fallback: "After Playing") }
+  /// Alert title for archiving all episodes
+  internal static var alertArchiveAll: String { return L10n.tr("Localizable", "alert_archive_all", fallback: "Archive all?") }
+  /// Alert title for archiving all played episodes
+  internal static var alertArchiveAllPlayed: String { return L10n.tr("Localizable", "alert_archive_all_played", fallback: "Archive all played?") }
+  /// Alert title for confirming an action
+  internal static var alertAreYouSure: String { return L10n.tr("Localizable", "alert_are_you_sure", fallback: "Are you sure?") }
+  /// Alert title for cleaning up downloaded files
+  internal static var alertCleanUp: String { return L10n.tr("Localizable", "alert_clean_up", fallback: "Clean up?") }
+  /// Alert title for clearing listening history
+  internal static var alertClearListeningHistory: String { return L10n.tr("Localizable", "alert_clear_listening_history", fallback: "Clear listening history?") }
+  /// Alert title for clearing Up Next
+  internal static var alertClearUpNext: String { return L10n.tr("Localizable", "alert_clear_up_next", fallback: "Clear Up Next?") }
+  /// Alert title for deleting a file
+  internal static var alertDeleteFile: String { return L10n.tr("Localizable", "alert_delete_file", fallback: "Delete file?") }
+  /// Alert title for deleting from cloud
+  internal static var alertDeleteFromCloud: String { return L10n.tr("Localizable", "alert_delete_from_cloud", fallback: "Delete from cloud?") }
+  /// Alert title for deleting from device
+  internal static var alertDeleteFromDevice: String { return L10n.tr("Localizable", "alert_delete_from_device", fallback: "Delete from device?") }
+  /// Alert title for deleting a playlist
+  internal static var alertDeletePlaylist: String { return L10n.tr("Localizable", "alert_delete_playlist", fallback: "Delete playlist?") }
+  /// Alert title for downloading all episodes
+  internal static var alertDownloadAll: String { return L10n.tr("Localizable", "alert_download_all", fallback: "Download all?") }
+  /// Alert title for playing all episodes
+  internal static var alertPlayAll: String { return L10n.tr("Localizable", "alert_play_all", fallback: "Play all?") }
+  /// Alert action button for subscribing to all podcasts in a shared list
+  internal static var alertSharedListSubscribeAction: String { return L10n.tr("Localizable", "alert_shared_list_subscribe_action", fallback: "Subscribe to All") }
+  /// Alert message for subscribing to a shared podcast list
+  internal static var alertSharedListSubscribeMessage: String { return L10n.tr("Localizable", "alert_shared_list_subscribe_message", fallback: "They’ll all show up in Your Podcasts.") }
+  /// Alert title for subscribing to a shared podcast list. '%1$@' is a placeholder for the number of podcasts.
+  internal static func alertSharedListSubscribeTitle(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "alert_shared_list_subscribe_title", String(describing: p1), fallback: "%1$@ podcasts incoming.")
+  }
+  /// Alert title for unsubscribing from a podcast
+  internal static var alertUnsubscribe: String { return L10n.tr("Localizable", "alert_unsubscribe", fallback: "Unsubscribe?") }
   /// Search Results filter option
   internal static var allResults: String { return L10n.tr("Localizable", "all_results", fallback: "Top Results") }
   /// Autoplay feature announcement description
@@ -2374,6 +2412,8 @@ internal enum L10n {
   internal static var playerActionTitleUnstarEpisode: String { return L10n.tr("Localizable", "player_action_title_unstar_episode", fallback: "Unstar Episode") }
   /// Title for a page where you can rearrange common actions (eg sort/reorder and move the ones you like more to the top)
   internal static var playerActionsRearrangeTitle: String { return L10n.tr("Localizable", "player_actions_rearrange_title", fallback: "Rearrange Actions") }
+  /// Message for the archive episode confirmation alert
+  internal static var playerArchiveAlertMessage: String { return L10n.tr("Localizable", "player_archive_alert_message", fallback: "Hidden from your feed, not deleted.") }
   /// Confirmation prompt for archiving an episode.
   internal static var playerArchivedConfirmation: String { return L10n.tr("Localizable", "player_archived_confirmation", fallback: "Archive this episode?") }
   /// Accessibility label calling out the current artwork that's being displayed. '%1$@' is a placeholder for either the episode name or the chapter title.
@@ -2410,6 +2450,10 @@ internal enum L10n {
   internal static var playerErrorShortPlaybackError: String { return L10n.tr("Localizable", "player_error_short_playback_error", fallback: "Playback failed, please try again") }
   /// Accessibility label for the player control that fast-forwards the current playback position by a customizable time.
   internal static var playerIncrementTime: String { return L10n.tr("Localizable", "player_increment_time", fallback: "Increment time") }
+  /// Message for the mark as played confirmation alert
+  internal static var playerMarkAsPlayedAlertMessage: String { return L10n.tr("Localizable", "player_mark_as_played_alert_message", fallback: "It’ll move out of Up Next and into your history.") }
+  /// Title for the mark as played confirmation alert
+  internal static var playerMarkAsPlayedAlertTitle: String { return L10n.tr("Localizable", "player_mark_as_played_alert_title", fallback: "Mark as played?") }
   /// Confirmation prompt for marking an episode as played.
   internal static var playerMarkAsPlayedConfirmation: String { return L10n.tr("Localizable", "player_mark_as_played_confirmation", fallback: "Mark this episode as played?") }
   /// Warning that comes along with selecting to play all. Informs the user that their queue will be cleared.
@@ -2843,8 +2887,12 @@ internal enum L10n {
   internal static var podcastDetailsQueued: String { return L10n.tr("Localizable", "podcast_details_queued", fallback: "Queued") }
   /// Confirmation prompt to remove the episode file for the selected podcast episode.
   internal static var podcastDetailsRemoveDownload: String { return L10n.tr("Localizable", "podcast_details_remove_download", fallback: "REMOVE DOWNLOADED FILE?") }
+  /// Message for the remove downloaded file confirmation alert. '%1$@' is a placeholder for the file size (e.g. '42 MB').
+  internal static func podcastDetailsRemoveDownloadAlertMessage(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "podcast_details_remove_download_alert_message", String(describing: p1), fallback: "This frees up %1$@. You can re-download anytime.")
+  }
   /// Alert title for removing the downloaded episode file.
-  internal static var podcastDetailsRemoveDownloadAlertTitle: String { return L10n.tr("Localizable", "podcast_details_remove_download_alert_title", fallback: "Remove Downloaded File?") }
+  internal static var podcastDetailsRemoveDownloadAlertTitle: String { return L10n.tr("Localizable", "podcast_details_remove_download_alert_title", fallback: "Remove downloaded file?") }
   /// Prompt to download the selected podcast now.
   internal static var podcastDownloadNow: String { return L10n.tr("Localizable", "podcast_download_now", fallback: "Download Now") }
   /// Indicates that a file is being downloaded and includes the completed percentage. '%1$@' is a placeholder for percentage that has been downloaded so far.

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -892,6 +892,8 @@ internal enum L10n {
   internal static var downloadAll: String { return L10n.tr("Localizable", "download_all", fallback: "Download All") }
   /// A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi.
   internal static var downloadDataWarning: String { return L10n.tr("Localizable", "download_data_warning", fallback: "Downloading will use data.") }
+  /// Alert message warning the user that downloading will use mobile data.
+  internal static var downloadDataWarningAlert: String { return L10n.tr("Localizable", "download_data_warning_alert", fallback: "This download will use mobile data. You can turn off this warning in Settings.") }
   /// A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. The word Settings will be linked to an internal URL which redirects the user to the correct Settings. The %@ is the placeholder for the URL
   internal static func downloadDataWarningWithSettingsLink(_ p1: Any) -> String {
     return L10n.tr("Localizable", "download_data_warning_with_settings_link", String(describing: p1), fallback: "This download will use mobile data. You can turn off this warning in [Settings](%@).")
@@ -2841,6 +2843,8 @@ internal enum L10n {
   internal static var podcastDetailsQueued: String { return L10n.tr("Localizable", "podcast_details_queued", fallback: "Queued") }
   /// Confirmation prompt to remove the episode file for the selected podcast episode.
   internal static var podcastDetailsRemoveDownload: String { return L10n.tr("Localizable", "podcast_details_remove_download", fallback: "REMOVE DOWNLOADED FILE?") }
+  /// Alert title for removing the downloaded episode file.
+  internal static var podcastDetailsRemoveDownloadAlertTitle: String { return L10n.tr("Localizable", "podcast_details_remove_download_alert_title", fallback: "Remove Downloaded File?") }
   /// Prompt to download the selected podcast now.
   internal static var podcastDownloadNow: String { return L10n.tr("Localizable", "podcast_download_now", fallback: "Download Now") }
   /// Indicates that a file is being downloaded and includes the completed percentage. '%1$@' is a placeholder for percentage that has been downloaded so far.
@@ -2953,6 +2957,8 @@ internal enum L10n {
   internal static var podcastSortOrderTitle: String { return L10n.tr("Localizable", "podcast_sort_order_title", fallback: "SORT ORDER") }
   /// Confirmation option to stream the selected episode. Used in tandem with a notice that the user is not on WiFi.
   internal static var podcastStreamConfirmation: String { return L10n.tr("Localizable", "podcast_stream_confirmation", fallback: "Stream Anyway") }
+  /// Alert message warning the user that streaming will use data.
+  internal static var podcastStreamDataWarningAlert: String { return L10n.tr("Localizable", "podcast_stream_data_warning_alert", fallback: "Streaming this episode will use data. You can turn off this warning in Settings.") }
   /// Prompt to warn the user that continuing with the option to stream will consume data. Used in tandem with a notice that the user is not on WiFi.
   internal static func podcastStreamDataWarningWithSettings(_ p1: Any) -> String {
     return L10n.tr("Localizable", "podcast_stream_data_warning_with_settings", String(describing: p1), fallback: "Streaming this episode will use data. You can turn off this warning in [Settings](%@).")

--- a/podcasts/SupporterPodcastViewController.swift
+++ b/podcasts/SupporterPodcastViewController.swift
@@ -299,19 +299,27 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
 
     private func showCancelPrompt() {
         guard let firstPodcastSubscription = bundleSubscription.podcasts.first, let firstPodcast = DataManager.sharedManager.findPodcast(uuid: firstPodcastSubscription.uuid, includeUnsubscribed: true) else { return }
-        let actionSheet = OptionsPicker(title: nil)
-
-        let cancelAction = OptionAction(label: L10n.paidPodcastCancel, icon: nil) { [weak self] in
-            self?.performCancel()
-        }
-        cancelAction.destructive = true
 
         let expiryDateStr = DateFormatHelper.sharedHelper.longLocalizedFormat(Date(timeIntervalSince1970: TimeInterval(firstPodcastSubscription.expiryDate)))
         let deleteAfterExpiryMessage = isSingleBundleSubscription() ? L10n.paidPodcastCancelMsgSingular(expiryDateStr) : L10n.paidPodcastCancelMsgPlural(expiryDateStr)
         let message = firstPodcast.licensing == PodcastLicensing.deleteEpisodesAfterExpiry.rawValue ? deleteAfterExpiryMessage : L10n.paidPodcastCancelMsgRetainAccess(expiryDateStr)
-        actionSheet.addDescriptiveActions(title: L10n.areYouSure, message: message, icon: "cancelsubscription-large", actions: [cancelAction])
 
-        actionSheet.show(statusBarStyle: preferredStatusBarStyle)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.areYouSure, message: message, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.paidPodcastCancel, style: .destructive) { [weak self] _ in
+                self?.performCancel()
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            present(alert, animated: true)
+        } else {
+            let actionSheet = OptionsPicker(title: nil)
+            let cancelAction = OptionAction(label: L10n.paidPodcastCancel, icon: nil) { [weak self] in
+                self?.performCancel()
+            }
+            cancelAction.destructive = true
+            actionSheet.addDescriptiveActions(title: L10n.areYouSure, message: message, icon: "cancelsubscription-large", actions: [cancelAction])
+            actionSheet.show(statusBarStyle: preferredStatusBarStyle)
+        }
     }
 
     private var progressAlert: ShiftyLoadingAlert?
@@ -461,15 +469,22 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
     }
 
     @objc func unsubscribeWarning() {
-        let optionPicker = OptionsPicker(title: nil)
-        let unsubscribeAction = OptionAction(label: L10n.unsubscribeAll, icon: nil, action: { [weak self] in
-            self?.unsubscribeAll()
-        })
-
-        unsubscribeAction.destructive = true
-        optionPicker.addDescriptiveActions(title: L10n.unsubscribe, message: L10n.paidPodcastUnsubscribeMsg, icon: "option-alert", actions: [unsubscribeAction])
-
-        optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+        if FeatureFlag.liquidGlass.enabled {
+            let alert = UIAlertController(title: L10n.unsubscribe, message: L10n.paidPodcastUnsubscribeMsg, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.unsubscribeAll, style: .destructive) { [weak self] _ in
+                self?.unsubscribeAll()
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            present(alert, animated: true)
+        } else {
+            let optionPicker = OptionsPicker(title: nil)
+            let unsubscribeAction = OptionAction(label: L10n.unsubscribeAll, icon: nil, action: { [weak self] in
+                self?.unsubscribeAll()
+            })
+            unsubscribeAction.destructive = true
+            optionPicker.addDescriptiveActions(title: L10n.unsubscribe, message: L10n.paidPodcastUnsubscribeMsg, icon: "option-alert", actions: [unsubscribeAction])
+            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+        }
     }
 
     private func unsubscribeAll() {

--- a/podcasts/SupporterPodcastViewController.swift
+++ b/podcasts/SupporterPodcastViewController.swift
@@ -305,7 +305,7 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
         let message = firstPodcast.licensing == PodcastLicensing.deleteEpisodesAfterExpiry.rawValue ? deleteAfterExpiryMessage : L10n.paidPodcastCancelMsgRetainAccess(expiryDateStr)
 
         if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.areYouSure, message: message, preferredStyle: .alert)
+            let alert = UIAlertController(title: L10n.alertAreYouSure, message: message, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L10n.paidPodcastCancel, style: .destructive) { [weak self] _ in
                 self?.performCancel()
             })
@@ -470,7 +470,7 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
 
     @objc func unsubscribeWarning() {
         if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.unsubscribe, message: L10n.paidPodcastUnsubscribeMsg, preferredStyle: .alert)
+            let alert = UIAlertController(title: L10n.alertUnsubscribe, message: L10n.paidPodcastUnsubscribeMsg, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L10n.unsubscribeAll, style: .destructive) { [weak self] _ in
                 self?.unsubscribeAll()
             })

--- a/podcasts/SupporterPodcastViewController.swift
+++ b/podcasts/SupporterPodcastViewController.swift
@@ -304,22 +304,19 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
         let deleteAfterExpiryMessage = isSingleBundleSubscription() ? L10n.paidPodcastCancelMsgSingular(expiryDateStr) : L10n.paidPodcastCancelMsgPlural(expiryDateStr)
         let message = firstPodcast.licensing == PodcastLicensing.deleteEpisodesAfterExpiry.rawValue ? deleteAfterExpiryMessage : L10n.paidPodcastCancelMsgRetainAccess(expiryDateStr)
 
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.alertAreYouSure, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.paidPodcastCancel, style: .destructive) { [weak self] _ in
-                self?.performCancel()
-            })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            present(alert, animated: true)
-        } else {
-            let actionSheet = OptionsPicker(title: nil)
-            let cancelAction = OptionAction(label: L10n.paidPodcastCancel, icon: nil) { [weak self] in
-                self?.performCancel()
-            }
-            cancelAction.destructive = true
-            actionSheet.addDescriptiveActions(title: L10n.areYouSure, message: message, icon: "cancelsubscription-large", actions: [cancelAction])
-            actionSheet.show(statusBarStyle: preferredStatusBarStyle)
+        let cancelAction = OptionAction(label: L10n.paidPodcastCancel, icon: "cancelsubscription-large") { [weak self] in
+            self?.performCancel()
         }
+        cancelAction.destructive = true
+
+        let actionSheet = OptionsPicker(title: nil)
+        actionSheet.addDescriptiveActions(
+            title: L10n.alertAreYouSure,
+            message: message,
+            icon: "cancelsubscription-large",
+            actions: [cancelAction]
+        )
+        actionSheet.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     private var progressAlert: ShiftyLoadingAlert?
@@ -469,22 +466,19 @@ class SupporterPodcastViewController: PCViewController, UITableViewDataSource, U
     }
 
     @objc func unsubscribeWarning() {
-        if FeatureFlag.liquidGlass.enabled {
-            let alert = UIAlertController(title: L10n.alertUnsubscribe, message: L10n.paidPodcastUnsubscribeMsg, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.unsubscribeAll, style: .destructive) { [weak self] _ in
-                self?.unsubscribeAll()
-            })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            present(alert, animated: true)
-        } else {
-            let optionPicker = OptionsPicker(title: nil)
-            let unsubscribeAction = OptionAction(label: L10n.unsubscribeAll, icon: nil, action: { [weak self] in
-                self?.unsubscribeAll()
-            })
-            unsubscribeAction.destructive = true
-            optionPicker.addDescriptiveActions(title: L10n.unsubscribe, message: L10n.paidPodcastUnsubscribeMsg, icon: "option-alert", actions: [unsubscribeAction])
-            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
-        }
+        let unsubscribeAction = OptionAction(label: L10n.unsubscribeAll, icon: "option-alert", action: { [weak self] in
+            self?.unsubscribeAll()
+        })
+        unsubscribeAction.destructive = true
+
+        let optionPicker = OptionsPicker(title: nil)
+        optionPicker.addDescriptiveActions(
+            title: L10n.alertUnsubscribe,
+            message: L10n.paidPodcastUnsubscribeMsg,
+            icon: "option-alert",
+            actions: [unsubscribeAction]
+        )
+        optionPicker.show(statusBarStyle: preferredStatusBarStyle)
     }
 
     private func unsubscribeAll() {

--- a/podcasts/UpNextViewController+UserEpisode.swift
+++ b/podcasts/UpNextViewController+UserEpisode.swift
@@ -9,7 +9,6 @@ extension UpNextViewController: UserEpisodeDetailProtocol {
 
     func showDeleteConfirmation(userEpisode: UserEpisode) {
         UserEpisodeManager.presentDeleteOptions(episode: userEpisode, preferredStatusBarStyle: preferredStatusBarStyle, themeOverride: nil)
-        dismiss(animated: true, completion: nil)
     }
 
     func showUpgradeRequired() {

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -239,7 +239,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             performClearAll()
         } else if FeatureFlag.liquidGlass.enabled {
             let actionLabel = actionLabelText(queueCount)
-            let alert = UIAlertController(title: L10n.clearUpNext, message: L10n.clearUpNextMessage, preferredStyle: .alert)
+            let alert = UIAlertController(title: L10n.alertClearUpNext, message: L10n.clearUpNextMessage, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: actionLabel, style: .destructive) { [weak self] _ in
                 self?.performClearAll()
             })

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -237,6 +237,14 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
         if queueCount <= Constants.Limits.upNextClearWithoutWarning && !FeatureFlag.upNextShuffle.enabled {
             performClearAll()
+        } else if FeatureFlag.liquidGlass.enabled {
+            let actionLabel = actionLabelText(queueCount)
+            let alert = UIAlertController(title: L10n.clearUpNext, message: L10n.clearUpNextMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: actionLabel, style: .destructive) { [weak self] _ in
+                self?.performClearAll()
+            })
+            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+            present(alert, animated: true)
         } else {
             let clearOptions = OptionsPicker(title: nil, themeOverride: themeOverride)
             let actionLabel = actionLabelText(queueCount)
@@ -245,7 +253,6 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             })
             clearAllAction.destructive = true
             clearOptions.addDescriptiveActions(title: L10n.clearUpNext, message: L10n.clearUpNextMessage, icon: "option-clear", actions: [clearAllAction])
-
             clearOptions.show(statusBarStyle: preferredStatusBarStyle)
         }
 

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -237,22 +237,20 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
         if queueCount <= Constants.Limits.upNextClearWithoutWarning && !FeatureFlag.upNextShuffle.enabled {
             performClearAll()
-        } else if FeatureFlag.liquidGlass.enabled {
-            let actionLabel = actionLabelText(queueCount)
-            let alert = UIAlertController(title: L10n.alertClearUpNext, message: L10n.clearUpNextMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: actionLabel, style: .destructive) { [weak self] _ in
-                self?.performClearAll()
-            })
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            present(alert, animated: true)
         } else {
-            let clearOptions = OptionsPicker(title: nil, themeOverride: themeOverride)
             let actionLabel = actionLabelText(queueCount)
-            let clearAllAction = OptionAction(label: actionLabel, icon: nil, action: { [weak self] in
+            let clearAllAction = OptionAction(label: actionLabel, icon: "option-clear", action: { [weak self] in
                 self?.performClearAll()
             })
             clearAllAction.destructive = true
-            clearOptions.addDescriptiveActions(title: L10n.clearUpNext, message: L10n.clearUpNextMessage, icon: "option-clear", actions: [clearAllAction])
+
+            let clearOptions = OptionsPicker(title: nil, themeOverride: themeOverride)
+            clearOptions.addDescriptiveActions(
+                title: L10n.alertClearUpNext,
+                message: L10n.clearUpNextMessage,
+                icon: "option-clear",
+                actions: [clearAllAction]
+            )
             clearOptions.show(statusBarStyle: preferredStatusBarStyle)
         }
 

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -323,8 +323,6 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
                 self.reloadLocalFiles()
             }
         }
-
-        dismiss(animated: true, completion: nil)
     }
 
     func showUpgradeRequired() {

--- a/podcasts/UserEpisodeManager.swift
+++ b/podcasts/UserEpisodeManager.swift
@@ -260,7 +260,15 @@ struct UserEpisodeManager {
             }
 
             if FeatureFlag.liquidGlass.enabled {
-                let alert = UIAlertController(title: title, message: L10n.deleteFileMessage, preferredStyle: .alert)
+                let alertTitle: String
+                if episode.uploaded(), !episode.downloaded(pathFinder: DownloadManager.shared) {
+                    alertTitle = L10n.alertDeleteFromCloud
+                } else if !episode.uploaded(), episode.downloaded(pathFinder: DownloadManager.shared) {
+                    alertTitle = L10n.alertDeleteFromDevice
+                } else {
+                    alertTitle = L10n.alertDeleteFile
+                }
+                let alert = UIAlertController(title: alertTitle, message: L10n.deleteFileMessage, preferredStyle: .alert)
 
                 if episode.downloaded(pathFinder: DownloadManager.shared), episode.uploaded() {
                     alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .default) { _ in

--- a/podcasts/UserEpisodeManager.swift
+++ b/podcasts/UserEpisodeManager.swift
@@ -250,41 +250,6 @@ struct UserEpisodeManager {
 
     #if !os(watchOS)
     static func presentDeleteOptions(episode: UserEpisode, preferredStatusBarStyle: UIStatusBarStyle, themeOverride: Theme.ThemeType?, dismissCallback: (() -> ())? = nil, actionCallback: ((Bool, Bool) -> Void)? = nil) {
-            let optionPicker = OptionsPicker(title: "", themeOverride: themeOverride)
-
-            if let dismissCallback {
-                optionPicker.setNoActionCallback(dismissCallback)
-            }
-
-            let deleteCloudAction = OptionAction(label: L10n.deleteFromCloud, icon: nil, action: { [] in
-                UserEpisodeManager.deleteFromCloud(episode: episode)
-                actionCallback?(false, true)
-            })
-
-            let deleteDeviceLabel = episode.uploaded() && episode.downloaded(pathFinder: DownloadManager.shared) ? L10n.deleteFromDeviceOnly : L10n.deleteFromDevice
-            let deleteDeviceAction = OptionAction(label: deleteDeviceLabel, icon: nil, action: { [] in
-                UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                actionCallback?(true, false)
-            })
-            let deleteEverywhereAction = OptionAction(label: L10n.deleteEverywhereShort, icon: nil, action: { [] in
-                UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
-                actionCallback?(true, true)
-            })
-            deleteDeviceAction.destructive = episode.uploaded() && episode.downloaded(pathFinder: DownloadManager.shared) ? false : true
-            deleteCloudAction.destructive = true
-            deleteEverywhereAction.destructive = true
-
-            var actions: [OptionAction]
-            if episode.downloaded(pathFinder: DownloadManager.shared), episode.uploaded() {
-                actions = [deleteDeviceAction, deleteEverywhereAction]
-            } else if episode.downloaded(pathFinder: DownloadManager.shared), !episode.uploaded() {
-                actions = [deleteDeviceAction]
-            } else if !episode.downloaded(pathFinder: DownloadManager.shared), episode.uploaded() {
-                actions = [deleteCloudAction]
-            } else {
-                actions = [deleteDeviceAction]
-            }
-
             let title: String
             if episode.uploaded(), !episode.downloaded(pathFinder: DownloadManager.shared) {
                 title = L10n.deleteFromCloud
@@ -293,9 +258,79 @@ struct UserEpisodeManager {
             } else {
                 title = L10n.deleteFile
             }
-            optionPicker.addDescriptiveActions(title: title, message: L10n.deleteFileMessage, icon: "delete-red", actions: actions)
 
-            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+            if FeatureFlag.liquidGlass.enabled {
+                let alert = UIAlertController(title: title, message: L10n.deleteFileMessage, preferredStyle: .alert)
+
+                if episode.downloaded(pathFinder: DownloadManager.shared), episode.uploaded() {
+                    alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .default) { _ in
+                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
+                        actionCallback?(true, false)
+                    })
+                    alert.addAction(UIAlertAction(title: L10n.deleteEverywhereShort, style: .destructive) { _ in
+                        UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
+                        actionCallback?(true, true)
+                    })
+                } else if episode.downloaded(pathFinder: DownloadManager.shared) {
+                    alert.addAction(UIAlertAction(title: L10n.deleteFromDevice, style: .destructive) { _ in
+                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
+                        actionCallback?(true, false)
+                    })
+                } else if episode.uploaded() {
+                    alert.addAction(UIAlertAction(title: L10n.deleteFromCloud, style: .destructive) { _ in
+                        UserEpisodeManager.deleteFromCloud(episode: episode)
+                        actionCallback?(false, true)
+                    })
+                } else {
+                    alert.addAction(UIAlertAction(title: L10n.deleteFromDevice, style: .destructive) { _ in
+                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
+                        actionCallback?(true, false)
+                    })
+                }
+
+                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
+                    dismissCallback?()
+                })
+
+                SceneHelper.rootViewController()?.present(alert, animated: true)
+            } else {
+                let optionPicker = OptionsPicker(title: "", themeOverride: themeOverride)
+
+                if let dismissCallback {
+                    optionPicker.setNoActionCallback(dismissCallback)
+                }
+
+                let deleteCloudAction = OptionAction(label: L10n.deleteFromCloud, icon: nil, action: {
+                    UserEpisodeManager.deleteFromCloud(episode: episode)
+                    actionCallback?(false, true)
+                })
+                let deleteDeviceLabel = episode.uploaded() && episode.downloaded(pathFinder: DownloadManager.shared) ? L10n.deleteFromDeviceOnly : L10n.deleteFromDevice
+                let deleteDeviceAction = OptionAction(label: deleteDeviceLabel, icon: nil, action: {
+                    UserEpisodeManager.deleteFromDevice(userEpisode: episode)
+                    actionCallback?(true, false)
+                })
+                let deleteEverywhereAction = OptionAction(label: L10n.deleteEverywhereShort, icon: nil, action: {
+                    UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
+                    actionCallback?(true, true)
+                })
+                deleteDeviceAction.destructive = episode.uploaded() && episode.downloaded(pathFinder: DownloadManager.shared) ? false : true
+                deleteCloudAction.destructive = true
+                deleteEverywhereAction.destructive = true
+
+                var actions: [OptionAction]
+                if episode.downloaded(pathFinder: DownloadManager.shared), episode.uploaded() {
+                    actions = [deleteDeviceAction, deleteEverywhereAction]
+                } else if episode.downloaded(pathFinder: DownloadManager.shared), !episode.uploaded() {
+                    actions = [deleteDeviceAction]
+                } else if !episode.downloaded(pathFinder: DownloadManager.shared), episode.uploaded() {
+                    actions = [deleteCloudAction]
+                } else {
+                    actions = [deleteDeviceAction]
+                }
+
+                optionPicker.addDescriptiveActions(title: title, message: L10n.deleteFileMessage, icon: "delete-red", actions: actions)
+                optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+            }
         }
     #endif
 }

--- a/podcasts/UserEpisodeManager.swift
+++ b/podcasts/UserEpisodeManager.swift
@@ -250,95 +250,49 @@ struct UserEpisodeManager {
 
     #if !os(watchOS)
     static func presentDeleteOptions(episode: UserEpisode, preferredStatusBarStyle: UIStatusBarStyle, themeOverride: Theme.ThemeType?, dismissCallback: (() -> ())? = nil, actionCallback: ((Bool, Bool) -> Void)? = nil) {
-            let title: String
+            let alertTitle: String
             if episode.uploaded(), !episode.downloaded(pathFinder: DownloadManager.shared) {
-                title = L10n.deleteFromCloud
+                alertTitle = L10n.alertDeleteFromCloud
             } else if !episode.uploaded(), episode.downloaded(pathFinder: DownloadManager.shared) {
-                title = L10n.deleteFromDevice
+                alertTitle = L10n.alertDeleteFromDevice
             } else {
-                title = L10n.deleteFile
+                alertTitle = L10n.alertDeleteFile
             }
 
-            if FeatureFlag.liquidGlass.enabled {
-                let alertTitle: String
-                if episode.uploaded(), !episode.downloaded(pathFinder: DownloadManager.shared) {
-                    alertTitle = L10n.alertDeleteFromCloud
-                } else if !episode.uploaded(), episode.downloaded(pathFinder: DownloadManager.shared) {
-                    alertTitle = L10n.alertDeleteFromDevice
-                } else {
-                    alertTitle = L10n.alertDeleteFile
-                }
-                let alert = UIAlertController(title: alertTitle, message: L10n.deleteFileMessage, preferredStyle: .alert)
+            let deleteCloudAction = OptionAction(label: L10n.deleteFromCloud, icon: "delete-red", action: {
+                UserEpisodeManager.deleteFromCloud(episode: episode)
+                actionCallback?(false, true)
+            })
+            let deleteDeviceLabel = episode.uploaded() && episode.downloaded(pathFinder: DownloadManager.shared) ? L10n.deleteFromDeviceOnly : L10n.deleteFromDevice
+            let deleteDeviceAction = OptionAction(label: deleteDeviceLabel, icon: "delete-red", action: {
+                UserEpisodeManager.deleteFromDevice(userEpisode: episode)
+                actionCallback?(true, false)
+            })
+            let deleteEverywhereAction = OptionAction(label: L10n.deleteEverywhereShort, icon: "delete-red", action: {
+                UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
+                actionCallback?(true, true)
+            })
+            deleteDeviceAction.destructive = episode.uploaded() && episode.downloaded(pathFinder: DownloadManager.shared) ? false : true
+            deleteCloudAction.destructive = true
+            deleteEverywhereAction.destructive = true
 
-                if episode.downloaded(pathFinder: DownloadManager.shared), episode.uploaded() {
-                    alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .default) { _ in
-                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                        actionCallback?(true, false)
-                    })
-                    alert.addAction(UIAlertAction(title: L10n.deleteEverywhereShort, style: .destructive) { _ in
-                        UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
-                        actionCallback?(true, true)
-                    })
-                } else if episode.downloaded(pathFinder: DownloadManager.shared) {
-                    alert.addAction(UIAlertAction(title: L10n.deleteFromDevice, style: .destructive) { _ in
-                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                        actionCallback?(true, false)
-                    })
-                } else if episode.uploaded() {
-                    alert.addAction(UIAlertAction(title: L10n.deleteFromCloud, style: .destructive) { _ in
-                        UserEpisodeManager.deleteFromCloud(episode: episode)
-                        actionCallback?(false, true)
-                    })
-                } else {
-                    alert.addAction(UIAlertAction(title: L10n.deleteFromDevice, style: .destructive) { _ in
-                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                        actionCallback?(true, false)
-                    })
-                }
-
-                alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel) { _ in
-                    dismissCallback?()
-                })
-
-                SceneHelper.rootViewController()?.present(alert, animated: true)
+            var actions: [OptionAction]
+            if episode.downloaded(pathFinder: DownloadManager.shared), episode.uploaded() {
+                actions = [deleteDeviceAction, deleteEverywhereAction]
+            } else if episode.downloaded(pathFinder: DownloadManager.shared), !episode.uploaded() {
+                actions = [deleteDeviceAction]
+            } else if !episode.downloaded(pathFinder: DownloadManager.shared), episode.uploaded() {
+                actions = [deleteCloudAction]
             } else {
-                let optionPicker = OptionsPicker(title: "", themeOverride: themeOverride)
-
-                if let dismissCallback {
-                    optionPicker.setNoActionCallback(dismissCallback)
-                }
-
-                let deleteCloudAction = OptionAction(label: L10n.deleteFromCloud, icon: nil, action: {
-                    UserEpisodeManager.deleteFromCloud(episode: episode)
-                    actionCallback?(false, true)
-                })
-                let deleteDeviceLabel = episode.uploaded() && episode.downloaded(pathFinder: DownloadManager.shared) ? L10n.deleteFromDeviceOnly : L10n.deleteFromDevice
-                let deleteDeviceAction = OptionAction(label: deleteDeviceLabel, icon: nil, action: {
-                    UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                    actionCallback?(true, false)
-                })
-                let deleteEverywhereAction = OptionAction(label: L10n.deleteEverywhereShort, icon: nil, action: {
-                    UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
-                    actionCallback?(true, true)
-                })
-                deleteDeviceAction.destructive = episode.uploaded() && episode.downloaded(pathFinder: DownloadManager.shared) ? false : true
-                deleteCloudAction.destructive = true
-                deleteEverywhereAction.destructive = true
-
-                var actions: [OptionAction]
-                if episode.downloaded(pathFinder: DownloadManager.shared), episode.uploaded() {
-                    actions = [deleteDeviceAction, deleteEverywhereAction]
-                } else if episode.downloaded(pathFinder: DownloadManager.shared), !episode.uploaded() {
-                    actions = [deleteDeviceAction]
-                } else if !episode.downloaded(pathFinder: DownloadManager.shared), episode.uploaded() {
-                    actions = [deleteCloudAction]
-                } else {
-                    actions = [deleteDeviceAction]
-                }
-
-                optionPicker.addDescriptiveActions(title: title, message: L10n.deleteFileMessage, icon: "delete-red", actions: actions)
-                optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+                actions = [deleteDeviceAction]
             }
+
+            let optionPicker = OptionsPicker(title: "", themeOverride: themeOverride)
+            if let dismissCallback {
+                optionPicker.setNoActionCallback(dismissCallback)
+            }
+            optionPicker.addDescriptiveActions(title: alertTitle, message: L10n.deleteFileMessage, icon: "delete-red", actions: actions)
+            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
         }
     #endif
 }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -3064,11 +3064,11 @@
 /* Alert title for subscribing to a shared podcast list. '%1$@' is a placeholder for the number of podcasts. */
 "alert_shared_list_subscribe_title" = "%1$@ podcasts incoming.";
 
-/* Alert message for subscribing to a shared podcast list */
-"alert_shared_list_subscribe_message" = "They\U2019ll all show up in Your Podcasts.";
+/* Alert message for following all podcasts in a shared list */
+"alert_shared_list_subscribe_message" = "They\U2019ll be added to your Podcasts.";
 
-/* Alert action button for subscribing to all podcasts in a shared list */
-"alert_shared_list_subscribe_action" = "Subscribe to All";
+/* Alert action button for following all podcasts in a shared list */
+"alert_shared_list_subscribe_action" = "Follow All";
 
 /* A common string used throughout the app. Refers to the Notes (show notes) tab in the player. */
 "show_notes" = "Notes";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -811,6 +811,9 @@
 /* Alert message warning the user that downloading will use mobile data. */
 "download_data_warning_alert" = "This download will use mobile data. You can turn off this warning in Settings.";
 
+/* Alert message showing estimated download size. '%1$@' is a placeholder for the formatted size (e.g. '250 MB'). */
+"download_estimated_size" = "This will use approximately %1$@ of storage.";
+
 /* A common string used throughout the app. Prompts the user that they have selected multiple episodes to download. '%1$@' is a placeholder for the count of the selected items, will be more than one. */
 "download_episode_plural_format" = "Download %1$@ Episodes";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -124,6 +124,51 @@
 /* Subtitle to the Confirmation dialog informing the user that signing out will remove the given number of supported podcasts. */
 "account_sign_out_supporter_subtitle" = "You can sign in again to regain access.";
 
+/* Title for the sign out confirmation alert */
+"account_sign_out_alert_title" = "Sign out?";
+
+/* Message for the sign out confirmation alert */
+"account_sign_out_alert_message" = "Your podcasts, progress, and data will be here when you get back.";
+
+/* Alert title for confirming an action */
+"alert_are_you_sure" = "Are you sure?";
+
+/* Alert title for archiving all episodes */
+"alert_archive_all" = "Archive all?";
+
+/* Alert title for archiving all played episodes */
+"alert_archive_all_played" = "Archive all played?";
+
+/* Alert title for cleaning up downloaded files */
+"alert_clean_up" = "Clean up?";
+
+/* Alert title for clearing Up Next */
+"alert_clear_up_next" = "Clear Up Next?";
+
+/* Alert title for clearing listening history */
+"alert_clear_listening_history" = "Clear listening history?";
+
+/* Alert title for deleting a file */
+"alert_delete_file" = "Delete file?";
+
+/* Alert title for deleting from cloud */
+"alert_delete_from_cloud" = "Delete from cloud?";
+
+/* Alert title for deleting from device */
+"alert_delete_from_device" = "Delete from device?";
+
+/* Alert title for deleting a playlist */
+"alert_delete_playlist" = "Delete playlist?";
+
+/* Alert title for downloading all episodes */
+"alert_download_all" = "Download all?";
+
+/* Alert title for playing all episodes */
+"alert_play_all" = "Play all?";
+
+/* Alert title for unsubscribing from a podcast */
+"alert_unsubscribe" = "Unsubscribe?";
+
 /* Error message for when the account registration request has failed. */
 "account_sso_failed" = "Sign in failed. Please try again.";
 
@@ -1537,6 +1582,9 @@
 /* Confirmation prompt for archiving an episode. */
 "player_archived_confirmation" = "Archive this episode?";
 
+/* Message for the archive episode confirmation alert */
+"player_archive_alert_message" = "Hidden from your feed, not deleted.";
+
 /* Accessibility label calling out the current artwork that's being displayed. '%1$@' is a placeholder for either the episode name or the chapter title. */
 "player_artwork" = "%1$@ Artwork";
 
@@ -1563,6 +1611,12 @@
 
 /* Confirmation prompt for marking an episode as played. */
 "player_mark_as_played_confirmation" = "Mark this episode as played?";
+
+/* Title for the mark as played confirmation alert */
+"player_mark_as_played_alert_title" = "Mark as played?";
+
+/* Message for the mark as played confirmation alert */
+"player_mark_as_played_alert_message" = "It\U2019ll move out of Up Next and into your history.";
 
 /* Warning that comes along with selecting to play all. Informs the user that their queue will be cleared. */
 "player_options_play_all_message" = "This will clear your current Up Next queue.";
@@ -1900,7 +1954,10 @@
 "podcast_details_remove_download" = "REMOVE DOWNLOADED FILE?";
 
 /* Alert title for removing the downloaded episode file. */
-"podcast_details_remove_download_alert_title" = "Remove Downloaded File?";
+"podcast_details_remove_download_alert_title" = "Remove downloaded file?";
+
+/* Message for the remove downloaded file confirmation alert. '%1$@' is a placeholder for the file size (e.g. '42 MB'). */
+"podcast_details_remove_download_alert_message" = "This frees up %1$@. You can re-download anytime.";
 
 /* Prompt to download the selected podcast now. */
 "podcast_download_now" = "Download Now";
@@ -3000,6 +3057,15 @@
 
 /* Title for a dialog presented when a user selects to subscribe to all podcasts in a list. */
 "shared_list_subscribe_conf_title" = "That's a lot of podcasts!";
+
+/* Alert title for subscribing to a shared podcast list. '%1$@' is a placeholder for the number of podcasts. */
+"alert_shared_list_subscribe_title" = "%1$@ podcasts incoming.";
+
+/* Alert message for subscribing to a shared podcast list */
+"alert_shared_list_subscribe_message" = "They\U2019ll all show up in Your Podcasts.";
+
+/* Alert action button for subscribing to all podcasts in a shared list */
+"alert_shared_list_subscribe_action" = "Subscribe to All";
 
 /* A common string used throughout the app. Refers to the Notes (show notes) tab in the player. */
 "show_notes" = "Notes";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -763,6 +763,9 @@
 /* A common string used throughout the app. Prompt to warn the user that continuing with the download will consume data. Used in tandem with a notice that the user is not on WiFi. The word Settings will be linked to an internal URL which redirects the user to the correct Settings. The %@ is the placeholder for the URL */
 "download_data_warning_with_settings_link" = "This download will use mobile data. You can turn off this warning in [Settings](%@).";
 
+/* Alert message warning the user that downloading will use mobile data. */
+"download_data_warning_alert" = "This download will use mobile data. You can turn off this warning in Settings.";
+
 /* A common string used throughout the app. Prompts the user that they have selected multiple episodes to download. '%1$@' is a placeholder for the count of the selected items, will be more than one. */
 "download_episode_plural_format" = "Download %1$@ Episodes";
 
@@ -1896,6 +1899,9 @@
 /* Confirmation prompt to remove the episode file for the selected podcast episode. */
 "podcast_details_remove_download" = "REMOVE DOWNLOADED FILE?";
 
+/* Alert title for removing the downloaded episode file. */
+"podcast_details_remove_download_alert_title" = "Remove Downloaded File?";
+
 /* Prompt to download the selected podcast now. */
 "podcast_download_now" = "Download Now";
 
@@ -2012,6 +2018,9 @@
 
 /* Prompt to warn the user that continuing with the option to stream will consume data. Used in tandem with a notice that the user is not on WiFi. */
 "podcast_stream_data_warning_with_settings" = "Streaming this episode will use data. You can turn off this warning in [Settings](%@).";
+
+/* Alert message warning the user that streaming will use data. */
+"podcast_stream_data_warning_alert" = "Streaming this episode will use data. You can turn off this warning in Settings.";
 
 /* Used to reference the episode was published this month. */
 "podcast_this_month" = "This Month";

--- a/podcasts/podcasts-Info.plist
+++ b/podcasts/podcasts-Info.plist
@@ -1087,7 +1087,7 @@
 	<key>UIBrowsableContentSupportsSectionedBrowsing</key>
 	<false/>
 	<key>UIDesignRequiresCompatibility</key>
-	<true/>
+	<false/>
 	<key>UILaunchStoryboardName</key>
 	<string>Launch Screen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/podcasts/podcasts-Info.plist
+++ b/podcasts/podcasts-Info.plist
@@ -1087,7 +1087,7 @@
 	<key>UIBrowsableContentSupportsSectionedBrowsing</key>
 	<false/>
 	<key>UIDesignRequiresCompatibility</key>
-	<false/>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>Launch Screen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
## Summary

Migrates legacy `OptionsPicker`-style confirmation dialogs to native `UIAlertController` alerts, gated under `FeatureFlag.liquidGlass.enabled`. The legacy flow is preserved in the `else` branch so behavior is unchanged when the flag is off.

Covered flows:
- Account: sign out / delete
- Episode actions: archive, mark as played, remove downloaded file
- Bulk multi-select: download all (with estimated size), delete (cloud/device/both), archive, play all
- Playlists: delete playlist, play all, download all
- Up Next: clear queue
- Listening History: clear
- Cellular data warnings: download / stream
- Shared podcast lists: subscribe (now uses "Follow All" terminology)
- Files / user-uploaded episodes: delete confirmations

Also:
- Adds total estimated download size to bulk download confirmation alerts.

## To test

1. Enable the `Liquid Glass` feature flag in the dev menu.
2. Trigger each native alert and confirm copy, button styles, and action behavior:
   - Profile → Sign Out
   - Player → ⋯ → Archive / Mark as played
   - Podcast page → episode ⋯ → Remove from device
   - Multi-select → Download / Delete / Archive
   - Playlist → Delete playlist / Play all
   - Up Next → Clear
   - Profile → Listening History → Clear
   - Profile → Files → swipe to delete (and ⋯ → Delete)
   - Open a shared podcast list link → "Follow All"
3. To test the cellular data warning alerts (Simulator can't fake cellular):
   - Edit `NetworkUtils.isConnectedToUnexpensiveConnection()` to `return false` temporarily
   - Profile → Settings → Storage & Data → turn off "Use Mobile Data"
   - Tap download / play on any non-downloaded episode → both download and stream warning alerts should appear
4. Toggle Liquid Glass off and confirm the legacy OptionsPicker UI still appears for all of the above.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 16 48" src="https://github.com/user-attachments/assets/28943bce-6e07-4a7d-964a-da72d2a989a8" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 15 49" src="https://github.com/user-attachments/assets/c6140740-b58e-4a95-93db-ee0ffa511a9b" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-13 at 21 33 07" src="https://github.com/user-attachments/assets/2ce8cd66-7471-4b2e-8ef6-6a5f08e15c45" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-13 at 21 33 03" src="https://github.com/user-attachments/assets/ff8ce0fb-d6ce-420f-8327-6cb26874fe68" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 20 20" src="https://github.com/user-attachments/assets/793d77a3-470a-4271-a70a-0e2d1bb86d16" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 18 54" src="https://github.com/user-attachments/assets/6329e02b-2db8-46b9-b5c1-efcc2fea9cf7" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 18 50" src="https://github.com/user-attachments/assets/207339b0-8d3f-4bfc-8a6b-c68154124fb5" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 22 19" src="https://github.com/user-attachments/assets/ba954893-5fba-41bb-b53c-15b30ee3d10f" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 22 01" src="https://github.com/user-attachments/assets/928ad2a6-34c3-4789-b27f-4a9e4780dd11" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 21 48" src="https://github.com/user-attachments/assets/ea4f5510-4e1c-4c9b-802b-f9dac29363d3" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 33 45" src="https://github.com/user-attachments/assets/f35eb325-8caa-4d5a-a898-0bf0f34ecdc0" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 29 51" src="https://github.com/user-attachments/assets/d03ecbe4-3f52-44c9-995a-4938129d1481" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 24 55" src="https://github.com/user-attachments/assets/661de32a-33a0-4b57-b313-a24151673273" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 22 54" src="https://github.com/user-attachments/assets/3e68eff8-fe88-48b7-a52d-60e31e37a73a" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 22 30" src="https://github.com/user-attachments/assets/11d868ed-ab9f-49a3-887f-fa80762c8b7a" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 40 50" src="https://github.com/user-attachments/assets/94efcbde-dc09-403c-afd9-34d054f40629" />
<img width="320" height="695" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-14 at 01 37 54" src="https://github.com/user-attachments/assets/54f1a370-9b1f-41ea-a14f-a4d6605de5a2" />



