### PR TITLE
Replace PodcastImageViewWrapper with PodcastImage on tvOS

### DIFF
--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -47,7 +47,7 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
         ScrollView(.horizontal) {
             HStack(spacing: 24, content: {
                 ForEach(model.podcasts) { podcast in
-                    PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
+                    PodcastImage(uuid: podcast.uuid, size: .page)
                         .frame(width: Layout.gridSize, height: Layout.gridSize)
                 }
             }).ignoresSafeArea()

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -80,7 +80,7 @@ struct HomeView: View {
             LazyHStack(spacing: 0, content: {
                 ForEach(model.podcasts) { podcast in
                     NavigationLink(value: podcast) {
-                        PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
+                        PodcastImage(uuid: podcast.uuid, size: .page)
                             .frame(width: Layout.gridSize, height: Layout.gridSize)
                     }
                     .buttonStyle(.card)
@@ -111,7 +111,7 @@ struct HomeView: View {
             LazyHStack(spacing: 0) {
                 ForEach(model.recentlyPlayed) { podcast in
                     NavigationLink(value: podcast) {
-                        PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
+                        PodcastImage(uuid: podcast.uuid, size: .page)
                             .frame(width: Layout.gridSize, height: Layout.gridSize)
                     }
                     .buttonStyle(.card)

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -57,12 +57,12 @@ struct PlaylistDetailView: View {
         if images.count >= 4 {
             VStack(spacing: 0) {
                 HStack(spacing: 0) {
-                    PodcastImageViewWrapper(podcastUUID: images[0], size: .page)
-                    PodcastImageViewWrapper(podcastUUID: images[1], size: .page)
+                    PodcastImage(uuid: images[0], size: .page)
+                    PodcastImage(uuid: images[1], size: .page)
                 }
                 HStack(spacing: 0) {
-                    PodcastImageViewWrapper(podcastUUID: images[2], size: .page)
-                    PodcastImageViewWrapper(podcastUUID: images[3], size: .page)
+                    PodcastImage(uuid: images[2], size: .page)
+                    PodcastImage(uuid: images[3], size: .page)
                 }
             }
         } else if let first = images.first {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -35,7 +35,7 @@ struct EpisodeRow: View {
     @ViewBuilder
     private var thumbnail: some View {
         if let uuid = model.podcastUuid {
-            PodcastImageViewWrapper(podcastUUID: uuid, size: .list)
+            PodcastImage(uuid: uuid, size: .list)
         } else {
             Image(ImageResource.pcLogo)
         }

--- a/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
@@ -52,7 +52,7 @@ struct FolderCardView: View {
     @ViewBuilder
     private func coverImage(at index: Int) -> some View {
         if index < model.topPodcastsUuids.count {
-            PodcastImageViewWrapper(podcastUUID: model.topPodcastsUuids[index], size: .list)
+            PodcastImage(uuid: model.topPodcastsUuids[index], size: .list)
                 .frame(width: coverSize, height: coverSize)
                 .clipShape(RoundedRectangle(cornerRadius: 6))
         } else {

--- a/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
@@ -28,7 +28,7 @@ struct FolderDetailView: View {
                 LazyVGrid(columns: Self.gridColumns, spacing: 48) {
                     ForEach(model.podcasts) { podcast in
                         NavigationLink(value: podcast) {
-                            PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
+                            PodcastImage(uuid: podcast.uuid, size: .page)
                                 .frame(width: Layout.gridSize, height: Layout.gridSize)
                         }
                         .buttonStyle(.card)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -56,13 +56,13 @@ struct PodcastDetailView: View {
             episodeContent
         }
         .blurredCoverBackground(size: Layout.podcastImageSize) {
-            PodcastImageViewWrapper(podcastUUID: model.podcast.uuid, size: .page)
+            PodcastImage(uuid: model.podcast.uuid, size: .page)
         }
     }
 
     var podcastInfo: some View {
         VStack(alignment: .leading, spacing: 40) {
-            PodcastImageViewWrapper(podcastUUID: model.podcast.uuid, size: .page)
+            PodcastImage(uuid: model.podcast.uuid, size: .page)
                 .frame(width: Layout.podcastImageSize, height: Layout.podcastImageSize)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .shadow(color: .black.opacity(0.6), radius: 40, x: 0, y: 20)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
@@ -9,7 +9,7 @@ struct PodcastMoreInfoView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 48) {
             HStack(alignment: .top, spacing: 40) {
-                PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
+                PodcastImage(uuid: podcast.uuid, size: .page)
                     .frame(width: 240, height: 240)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                 VStack(alignment: .leading, spacing: 8) {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -65,7 +65,7 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
             ForEach(model.items) { item in
                 if let podcast = item.podcast {
                     NavigationLink(value: podcast) {
-                        PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
+                        PodcastImage(uuid: podcast.uuid, size: .page)
                             .frame(width: Layout.gridSize, height: Layout.gridSize)
                     }
                     .buttonStyle(.card)

--- a/Pocket Casts TV App/UI/Search/SearchPodcastResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchPodcastResultsView.swift
@@ -18,7 +18,7 @@ struct SearchPodcastsResultsView: View {
             LazyVGrid(columns: items, spacing: 48, content: {
                 ForEach(podcasts) { podcast in
                     NavigationLink(value: podcast) {
-                        PodcastImageViewWrapper(podcastUUID: podcast.uuid, size: .page)
+                        PodcastImage(uuid: podcast.uuid, size: .page)
                             .frame(width: Layout.cellSize, height: Layout.cellSize)
                     }
                     .buttonStyle(.card)


### PR DESCRIPTION
## Summary

Replaces all usages of `PodcastImageViewWrapper` with `PodcastImage` across the tvOS target. `PodcastImageViewWrapper` is a `UIViewRepresentable` around the legacy UIKit `PodcastImageView`, while `PodcastImage` is the native SwiftUI implementation (Kingfisher-backed) already used elsewhere in the app — including a couple of spots in the TV target. This unifies podcast artwork rendering on tvOS on the SwiftUI path.

The `PodcastImageViewWrapper.swift` definition itself is **not** removed, since it is still used by the iOS target.

## Files changed (tvOS only)

- `Pocket Casts TV App/UI/Home/HomeView.swift`
- `Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift`
- `Pocket Casts TV App/UI/Auth/SigningInView.swift`
- `Pocket Casts TV App/UI/Podcasts/PodcastsView.swift`
- `Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift`
- `Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift`
- `Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift`
- `Pocket Casts TV App/UI/Podcasts/FolderCardView.swift`
- `Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift`
- `Pocket Casts TV App/UI/Search/SearchPodcastResultsView.swift`

The mechanical change is `PodcastImageViewWrapper(podcastUUID: X, size: Y)` → `PodcastImage(uuid: X, size: Y)`.

## To test

1. Build & run the tvOS target.
2. Verify podcast/folder artwork still renders correctly in:
   - Home: discover collection, recently played row
   - Podcasts grid + Folder detail + Folder card mosaics
   - Podcast detail (cover + blurred background)
   - Podcast "More Info" sheet
   - Playlist detail mosaic (1, 1-3, and 4+ podcast cases) and blurred background
   - Episode row thumbnails
   - Search results grid
   - Signing-in screen podcast row

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)