### PR TITLE
TV: Refresh podcasts on update notifications and server refresh on entry

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
@@ -31,19 +31,41 @@ class PodcastsViewModel: PodcastsViewModelProtocol {
 
     init(dataManager: DataManager = DataManager.sharedManager) {
         self.dataManager = dataManager
+        observePodcastUpdates()
     }
 
     func load() async {
         await fetchPodcasts()
+        RefreshManager.shared.refreshPodcasts()
     }
 
     private func fetchPodcasts() async {
-        Task {
-            let gridItems = HomeGridDataHelper.gridItems(orderedBy: .titleAtoZ)
-            await MainActor.run {
-                self.items = gridItems
-                self.state = .ready
-            }
+        let gridItems = await Task.detached {
+            HomeGridDataHelper.gridItems(orderedBy: .titleAtoZ)
+        }.value
+
+        await MainActor.run {
+            self.items = gridItems
+            self.state = gridItems.isEmpty ? .empty : .ready
+        }
+    }
+
+    private func observePodcastUpdates() {
+        let notificationsToObserve: [Notification.Name] = [
+            Constants.Notifications.podcastUpdated,
+            Constants.Notifications.podcastAdded,
+            Constants.Notifications.podcastDeleted,
+            ServerNotifications.podcastsRefreshed
+        ]
+
+        for name in notificationsToObserve {
+            NotificationCenter.default.publisher(for: name)
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in
+                    guard let self else { return }
+                    Task { await self.fetchPodcasts() }
+                }
+                .store(in: &cancellables)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
@@ -55,7 +55,8 @@ class PodcastsViewModel: PodcastsViewModelProtocol {
             Constants.Notifications.podcastUpdated,
             Constants.Notifications.podcastAdded,
             Constants.Notifications.podcastDeleted,
-            ServerNotifications.podcastsRefreshed
+            ServerNotifications.podcastsRefreshed,
+            ServerNotifications.syncCompleted
         ]
 
         let publishers = notificationsToObserve.map {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
@@ -40,7 +40,7 @@ class PodcastsViewModel: PodcastsViewModelProtocol {
     }
 
     private func fetchPodcasts() async {
-        let gridItems = await Task.detached {
+        let gridItems = await Task {
             HomeGridDataHelper.gridItems(orderedBy: .titleAtoZ)
         }.value
 

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsViewModel.swift
@@ -58,15 +58,17 @@ class PodcastsViewModel: PodcastsViewModelProtocol {
             ServerNotifications.podcastsRefreshed
         ]
 
-        for name in notificationsToObserve {
-            NotificationCenter.default.publisher(for: name)
-                .receive(on: DispatchQueue.main)
-                .sink { [weak self] _ in
-                    guard let self else { return }
-                    Task { await self.fetchPodcasts() }
-                }
-                .store(in: &cancellables)
+        let publishers = notificationsToObserve.map {
+            NotificationCenter.default.publisher(for: $0).map { _ in () }.eraseToAnyPublisher()
         }
+
+        Publishers.MergeMany(publishers)
+            .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                Task { await self.fetchPodcasts() }
+            }
+            .store(in: &cancellables)
     }
 }
 


### PR DESCRIPTION
## Summary

On the tvOS app's Podcasts screen:

- **React to podcast update notifications.** `PodcastsViewModel` now subscribes to `Constants.Notifications.podcastUpdated`, `podcastAdded`, `podcastDeleted` and `ServerNotifications.podcastsRefreshed`, re-fetching the grid via `HomeGridDataHelper` whenever any of them fire so the UI stays in sync with database changes (e.g. after a sync, subscribe/unsubscribe, or background refresh).
- **Trigger a server data refresh when entering the screen.** `load()` (called from the view's `.task`) now calls `RefreshManager.shared.refreshPodcasts()` after the initial local fetch. `RefreshManager` already throttles to a 15s minimum between refreshes, so re-entering the tab quickly is safe.

While in here, two small correctness fixes in `fetchPodcasts()`:
- The original used a fire-and-forget inner `Task`, which meant the `async` function returned before the data was loaded. Switched to `Task.detached { ... }.value` so callers (including the notification handlers) can serialize properly.
- State now becomes `.empty` when there are no items, matching the existing `.empty` UI branch in `PodcastsView`.

The mock view model is unchanged.

## To test

1. Run the **Pocket Casts TV App** target on an Apple TV simulator (or device) while signed in.
2. Open the **Podcasts** tab — confirm the grid populates.
3. Trigger a server refresh from another device (or wait for the refresh to complete) and confirm the grid updates without leaving the tab.
4. Subscribe / unsubscribe to a podcast from another device — confirm `podcastAdded` / `podcastDeleted` notifications cause the grid to update.
5. Leave the Podcasts tab and come back — confirm a server refresh is triggered each time (subject to the 15s throttle in `RefreshManager`).
6. Sign out and back in — confirm no crashes and the grid loads.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)