### PR TITLE
fix: respect RTL text direction in show notes and podcast description

### DIFF
--- a/podcasts/Common Components/RichExpandableDescriptionView.swift
+++ b/podcasts/Common Components/RichExpandableDescriptionView.swift
@@ -148,8 +148,8 @@ class RichExpandableLabel: WKWebView {
         }
         </style>
         </head>
-        <body>
-        <div id="container">
+        <body dir="auto">
+        <div id="container" dir="auto">
         \(html)
         </div>
         </body>

--- a/podcasts/ShowNotesFormatter.swift
+++ b/podcasts/ShowNotesFormatter.swift
@@ -32,7 +32,7 @@ class ShowNotesFormatter {
             "</style>"
 
         let cleanedShowNotes = removeHtml(string: showNotes)
-        styledShowNotes = styledShowNotes + "</head><body>"
+        styledShowNotes = styledShowNotes + "</head><body dir=\"auto\">"
 
         if let customTitle {
             styledShowNotes = styledShowNotes + "<p><customTitle>\(customTitle)</customTitle></p>"


### PR DESCRIPTION
Fixes PCIOS-592

Hebrew (and other RTL) text in the podcast Details tab is left-aligned because the HTML rendered by `ShowNotesFormatter` and `RichExpandableLabel` doesn't declare a text direction, so WebKit falls back to LTR. Adding `dir="auto"` lets WebKit apply the HTML5 first-strong-character heuristic per paragraph, so Hebrew/Arabic content right-aligns automatically while LTR content is unaffected.

### Changes

- `ShowNotesFormatter.swift`: render show notes inside `<body dir="auto">`.
- `RichExpandableDescriptionView.swift`: render the expandable podcast description inside `<body dir="auto">` and add `dir="auto"` to the inner container `<div>`.

## To test

1. Follow a podcast whose description / episode show notes are in Hebrew or Arabic (the ticket references one in the screenshot; any RTL-language podcast works).
2. Open the podcast and check the collapsible podcast description in the header.
3. - [x] Verify the RTL text is right-aligned and reads from right to left.
4. Open an episode and view the Details / show notes tab.
5. - [x] Verify the RTL show notes text is right-aligned.
6. Tap to expand the podcast description.
7. - [x] Verify both collapsed and expanded states render with correct RTL alignment.
8. Open a podcast with an English (LTR) description.
9. - [x] Verify LTR text is still left-aligned and renders unchanged.
10. Open a podcast/episode whose description mixes LTR and RTL paragraphs.
11. - [ ] Verify each paragraph aligns according to its own first-strong character (RTL paragraphs right, LTR paragraphs left).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
