### PR TITLE
TV: Refresh playlists on server sync changes

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
@@ -40,7 +40,7 @@ class PlaylistsViewModel {
             NotificationCenter.default.publisher(for: Constants.Notifications.playlistChanged),
             NotificationCenter.default.publisher(for: ServerNotifications.syncCompleted)
         )
-        .receive(on: DispatchQueue.main)
+        .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
         .sink { [weak self] _ in
             self?.load()
         }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 import Combine
 import PocketCastsDataModel
+import PocketCastsServer
 
 @Observable
 class PlaylistsViewModel {
 
-    private var cancellable: AnyCancellable?
+    private var cancellables: Set<AnyCancellable> = []
 
     enum State: Equatable, Hashable {
         case loading
@@ -19,6 +20,7 @@ class PlaylistsViewModel {
 
     init(dataManager: DataManager = DataManager.sharedManager) {
         self.dataManager = dataManager
+        observePlaylistChanges()
     }
     var playlists: [EpisodeFilter] = []
 
@@ -31,5 +33,17 @@ class PlaylistsViewModel {
                 self.state = playlists.isEmpty ? .empty : .ready
             }
         }
+    }
+
+    private func observePlaylistChanges() {
+        Publishers.Merge(
+            NotificationCenter.default.publisher(for: Constants.Notifications.playlistChanged),
+            NotificationCenter.default.publisher(for: ServerNotifications.syncCompleted)
+        )
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in
+            self?.load()
+        }
+        .store(in: &cancellables)
     }
 }


### PR DESCRIPTION
Fixes PCIOS- <!-- issue number, if applicable -->

The TV `PlaylistsViewModel` only loaded once and never refreshed when playlists changed (created, edited, deleted, or pulled down by sync), so the Playlists tab could show stale data until the screen was rebuilt.

This PR makes `PlaylistsViewModel` observe two notifications and re-run `load()` when either fires:
- `Constants.Notifications.playlistChanged` — posted by `PlaylistManager`/`ServerSyncManager` on any local or sync-driven playlist change.
- `ServerNotifications.syncCompleted` — covers full-sync paths where playlist changes arrive without an explicit `playlistChanged` post.

The observer is wired up in `init` and uses a `Set<AnyCancellable>`, mirroring the pattern already used by `UpNextViewModel`.

## To test

1. Sign in on the TV app and open the Playlists tab.
2. On the iOS app (same account), create a new playlist, then edit/delete an existing one.
3. Return to the TV without backing out of the Playlists tab — the list should update to reflect the changes after sync.
4. Trigger a full sync (e.g. relaunch / pull-to-refresh on iOS) and confirm the TV Playlists tab reflects any server-side playlist changes.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)