### PR TITLE
PCIOS-452: Auto Add To Up Next settings screen shows orphan title if no podcasts chosen

### DIFF
--- a/podcasts/AutoAddToUpNextViewController.swift
+++ b/podcasts/AutoAddToUpNextViewController.swift
@@ -111,7 +111,7 @@ class AutoAddToUpNextViewController: PCViewController, UITableViewDelegate, UITa
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        section == 0 ? nil : L10n.settingsAutoAddPodcasts
+        section == 0 || autoDownloadPodcasts.isEmpty ? nil : L10n.settingsAutoAddPodcasts
     }
 
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-452/auto-add-to-up-next-settings-screen-shows-orphan-title-if-no-podcasts

## Summary
Hide the "AUTO-ADD PODCASTS" section header on the Auto Add to Up Next settings screen when no podcasts have been selected for auto-adding.

## Changes
- Modified `titleForHeaderInSection` in `AutoAddToUpNextViewController.swift` to return `nil` for section 1 when `autoDownloadPodcasts` is empty, preventing the orphan header from displaying.

## Verification
- **Lint**: PASS — `make format` ran cleanly
- **Tests**: SKIPPED — build has pre-existing failures in `CarPlaySceneDelegate+Convert.swift` (unrelated CarPlay API availability issue); the changed file compiled successfully
- **Diff review**: PASS — single-line change, no unintended modifications
- **Secret scan**: PASS — no secrets in diff

## Confidence
**HIGH** — The fix is a one-line conditional that hides the section header when the podcast list is empty. The logic is straightforward and matches the existing pattern in the file.

---
This PR was created autonomously by linear-solver.
Triage complexity: simple | [Linear issue](https://linear.app/a8c/issue/PCIOS-452/auto-add-to-up-next-settings-screen-shows-orphan-title-if-no-podcasts)