### PR TITLE
[PC TV] Fix folders locations for caches on tvOS

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1160,6 +1160,7 @@ public class DataManager {
 
     private static func pathToDbFolder() -> String {
         #if os(tvOS)
+        //tvOS does not allow the use of the application support or documents directory on a real device so we need to use the caches directory.
         let typeOfDirectory: FileManager.SearchPathDirectory = .cachesDirectory
         #else
         let typeOfDirectory: FileManager.SearchPathDirectory = .applicationSupportDirectory

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1174,7 +1174,7 @@ public class DataManager {
         do {
             try FileManager.default.createDirectory(atPath: pathToDbFolder(), withIntermediateDirectories: true, attributes: nil)
         } catch {
-            print("Unable to create database folder: \(error)")
+            FileLog.shared.addMessage("Unable to create database folder: \(error)")
         }
     }
 

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1159,7 +1159,12 @@ public class DataManager {
     }
 
     private static func pathToDbFolder() -> String {
-        let documentsPath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).last as NSString?
+        #if os(tvOS)
+        let typeOfDirectory: FileManager.SearchPathDirectory = .cachesDirectory
+        #else
+        let typeOfDirectory: FileManager.SearchPathDirectory = .applicationSupportDirectory
+        #endif
+        let documentsPath = NSSearchPathForDirectoriesInDomains(typeOfDirectory, .userDomainMask, true).last as NSString?
         let mainFolder = documentsPath?.appendingPathComponent("Pocket Casts")
 
         return mainFolder!
@@ -1169,7 +1174,7 @@ public class DataManager {
         do {
             try FileManager.default.createDirectory(atPath: pathToDbFolder(), withIntermediateDirectories: true, attributes: nil)
         } catch {
-            print("Unable to create database folder")
+            print("Unable to create database folder: \(error)")
         }
     }
 

--- a/Modules/Sources/PocketCastsUtils/Logging/LogFilePaths.swift
+++ b/Modules/Sources/PocketCastsUtils/Logging/LogFilePaths.swift
@@ -11,7 +11,11 @@ public enum LogFilePaths {
     static var backupLogFilePath: String { logDirectory + "/old.log" }
 
     static var logDirectory: String {
+        #if os(tvOS)
+        let directory = (NSTemporaryDirectory() as NSString).appendingPathComponent("Documents/debug_log")
+        #else
         let directory = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/debug_log")
+        #endif
         return directory
     }
 }

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -146,14 +146,20 @@ class DownloadManager: NSObject, FilePathProtocol {
     }
 
     lazy var podcastsDirectory: String = {
+#if os(tvOS)
+        let directory = (NSTemporaryDirectory() as NSString).appendingPathComponent("Documents/podcasts_non_backed_up")
+#else
         let directory = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/podcasts_non_backed_up")
-
+#endif
         return directory
     }()
 
     private lazy var streamingBufferDirectory: String = {
+#if os(tvOS)
+        let directory = (NSTemporaryDirectory() as NSString).appendingPathComponent("Documents/podcasts_buffered")
+#else
         let directory = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/podcasts_buffered")
-
+#endif
         return directory
     }()
 

--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -16,10 +16,18 @@ class ImageManager {
 
     // subscribed image cache, these we want to store for a longer period of time
     lazy var subscribedPodcastsCache: ImageCache = {
+        #if os(tvOS)
+        let path = (NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).last! as NSString).appendingPathComponent("artworkv3")
+        #else
         let path = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/artworkv3")
+        #endif
         let url = URL(fileURLWithPath: path)
         subscribedPodcastsCache = try! ImageCache(name: "subscribedPodcastsCache", cacheDirectoryURL: url)
+#if os(tvOS)
+        subscribedPodcastsCache.diskStorage.config.sizeLimit = UInt(50.megabytes)
+#else
         subscribedPodcastsCache.diskStorage.config.sizeLimit = UInt(400.megabytes)
+#endif
         subscribedPodcastsCache.diskStorage.config.expiration = .days(365) // cache artwork for a full year, so that users don't have their artwork disappeared
         return subscribedPodcastsCache
     }()

--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -17,17 +17,17 @@ class ImageManager {
     // subscribed image cache, these we want to store for a longer period of time
     lazy var subscribedPodcastsCache: ImageCache = {
         #if os(tvOS)
-        let path = (NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).last! as NSString).appendingPathComponent("artworkv3")
+        let path = ((NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).last ?? NSTemporaryDirectory()) as NSString).appendingPathComponent("artworkv3")
         #else
         let path = (NSHomeDirectory() as NSString).appendingPathComponent("Documents/artworkv3")
         #endif
         let url = URL(fileURLWithPath: path)
         subscribedPodcastsCache = try! ImageCache(name: "subscribedPodcastsCache", cacheDirectoryURL: url)
-#if os(tvOS)
-        subscribedPodcastsCache.diskStorage.config.sizeLimit = UInt(50.megabytes)
-#else
+        #if os(tvOS)
+        subscribedPodcastsCache.diskStorage.config.sizeLimit = UInt(200.megabytes)
+        #else
         subscribedPodcastsCache.diskStorage.config.sizeLimit = UInt(400.megabytes)
-#endif
+        #endif
         subscribedPodcastsCache.diskStorage.config.expiration = .days(365) // cache artwork for a full year, so that users don't have their artwork disappeared
         return subscribedPodcastsCache
     }()

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -3783,6 +3783,8 @@ internal enum L10n {
   internal static var settingsStorageMobileData: String { return L10n.tr("Localizable", "settings_storage_mobile_data", fallback: "MOBILE DATA") }
   /// Section header for information about storage space used.
   internal static var settingsStorageUsage: String { return L10n.tr("Localizable", "settings_storage_usage", fallback: "USAGE") }
+  /// Footer note on the Storage & Data Use screen explaining why iOS may report higher storage than the app does.
+  internal static var settingsStorageUsageFooter: String { return L10n.tr("Localizable", "settings_storage_usage_footer", fallback: "This may differ from the storage shown in your iPhone Settings. iOS manages cached data automatically and frees it up when needed.") }
   /// Label displayed next to the toggle to opt-in/out for First-Party Analytics tracking
   internal static var settingsThirdPartyAnalytics: String { return L10n.tr("Localizable", "settings_third_party_analytics", fallback: "Third-party analytics") }
   /// Title for the settings screen


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
tvOS has limitations regarding disk caches and folders locations.
All the storage used needs to be in the caches folder, other location will fail when trying to create files on it.
This PR moves the database folder and the image cache folder to the application caches folder so they can be created.

This was only noticed now, because the simulator for tvOS doesn't enforce those limitation this is only detected on a real device.

## To test

1. Start the app on a real device
2. Check if database creation is done. ( app should launch)
3. Login with an user
4. Check if image cache for podcast is working

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
