### PR TITLE
Ensure sleep timer set/unset is all done on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix an issue with pull-to-refresh sometimes skipping the refresh on the Smart Playlist screen [#4187](https://github.com/Automattic/pocket-casts-ios/pull/4187)  
 - Improve pull-to-refresh stability and polish on the podcasts list [#4225](https://github.com/Automattic/pocket-casts-ios/pull/4225)
 - Car play progress fix [#4147](https://github.com/Automattic/pocket-casts-ios/pull/4147)
+- Fix an bug where the sleep timer could run at double speed [#4336](https://github.com/Automattic/pocket-casts-ios/pull/4336)
 
 8.11
 -----

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1546,29 +1546,21 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private func startUpdateTimer() {
-        cancelUpdateTimer()
-
         // schedule the timer on a thread that has a run loop, the main thread being a good option
-        if Thread.isMainThread {
-            updateTimer = Timer.scheduledTimer(timeInterval: updateTimerInterval, target: self, selector: #selector(progressTimerFired), userInfo: nil, repeats: true)
-        } else {
-            DispatchQueue.main.sync { [weak self] in
-                guard let self else { return }
-
-                self.updateTimer = Timer.scheduledTimer(timeInterval: self.updateTimerInterval, target: self, selector: #selector(self.progressTimerFired), userInfo: nil, repeats: true)
-            }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            updateTimer?.invalidate()
+            updateTimer = nil
+            self.updateTimer = Timer.scheduledTimer(timeInterval: self.updateTimerInterval, target: self, selector: #selector(self.progressTimerFired), userInfo: nil, repeats: true)
         }
     }
 
     private func cancelUpdateTimer() {
-        if Thread.isMainThread {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
             updateTimer?.invalidate()
-        } else {
-            DispatchQueue.main.sync { [weak self] in
-                self?.updateTimer?.invalidate()
-            }
+            updateTimer = nil
         }
-        updateTimer = nil
     }
 
     @objc private func progressTimerFired() {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-670](https://linear.app/a8c/issue/PCIOS-670/sleep-timer-double-speed-issue) <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
We got reports of sleep timer double counting this fix will ensure that all calls to start and stop timer are done on the main thread and be serial

## To test

1. Start the app
2. Play an episode and set a sleep timer
3. Ensure that time of sleep timer duration to finish is correct.
4. Start and stop playing multiple episodes to check if sleep timer updates are still correct.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
