### PR TITLE
Enable SwiftLint rule: collection_alignment

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -27,6 +27,9 @@ only_rules:
   # Colons should be next to the identifier when specifying a type.
   - colon
 
+  # All elements in a collection literal should be vertically aligned.
+  - collection_alignment
+
   # There should be no space before and one after any comma.
   - comma
 

--- a/Pocket Casts Watch App/Data & Communication/SessionManager+Send.swift
+++ b/Pocket Casts Watch App/Data & Communication/SessionManager+Send.swift
@@ -18,7 +18,7 @@ extension SessionManager {
         if !WCSession.default.isReachable { return }
 
         let playEpisodeRequest = [WatchConstants.Messages.messageType: WatchConstants.Messages.PlayEpisodeRequest.type, WatchConstants.Messages.PlayEpisodeRequest.episodeUuid: episode.uuid,
-            WatchConstants.Messages.PlayEpisodeRequest.playlist: (try? JSONEncoder().encode(playlist)) as Any] as [String: Any]
+                                  WatchConstants.Messages.PlayEpisodeRequest.playlist: (try? JSONEncoder().encode(playlist)) as Any] as [String: Any]
         WCSession.default.sendMessage(playEpisodeRequest, replyHandler: nil)
     }
 

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -800,7 +800,7 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     func allTasks() async -> [URLSessionTask] {
         return [await wifiOnlyBackgroundSession.allTasks,
-         await cellularForegroundSession.allTasks,
-         await cellularBackgroundSession.allTasks].flatMap { $0 }
+                await cellularForegroundSession.allTasks,
+                await cellularBackgroundSession.allTasks].flatMap { $0 }
     }
 }

--- a/podcasts/Extensions/View+CVPixelBuffer.swift
+++ b/podcasts/Extensions/View+CVPixelBuffer.swift
@@ -9,7 +9,7 @@ extension View {
     @MainActor
     func pixelBuffer(size: CGSize, scale: CGFloat, pool: CVPixelBufferPool? = nil) throws -> CVPixelBuffer {
         let attrs = [kCVPixelBufferCGImageCompatibilityKey: kCFBooleanTrue,
-             kCVPixelBufferCGBitmapContextCompatibilityKey: kCFBooleanTrue] as CFDictionary
+                     kCVPixelBufferCGBitmapContextCompatibilityKey: kCFBooleanTrue] as CFDictionary
         var pixelBuffer: CVPixelBuffer?
 
         let status: CVReturn

--- a/podcasts/ShortcutManager.swift
+++ b/podcasts/ShortcutManager.swift
@@ -11,15 +11,15 @@ class ShortcutManager: CustomObserver {
         stopListeningForShortcutChanges()
 
         let notifications: [NSNotification.Name] = [Constants.Notifications.playbackStarted,
-                                                     Constants.Notifications.playbackPaused,
-                                                     Constants.Notifications.playbackEnded,
-                                                     Constants.Notifications.playlistChanged,
-                                                     Constants.Notifications.podcastAdded,
-                                                     Constants.Notifications.episodePlayStatusChanged,
-                                                     Constants.Notifications.episodeArchiveStatusChanged,
-                                                     Constants.Notifications.episodeStarredChanged,
-                                                     Constants.Notifications.episodeDownloadStatusChanged,
-                                                     Constants.Notifications.manyEpisodesChanged]
+                                                    Constants.Notifications.playbackPaused,
+                                                    Constants.Notifications.playbackEnded,
+                                                    Constants.Notifications.playlistChanged,
+                                                    Constants.Notifications.podcastAdded,
+                                                    Constants.Notifications.episodePlayStatusChanged,
+                                                    Constants.Notifications.episodeArchiveStatusChanged,
+                                                    Constants.Notifications.episodeStarredChanged,
+                                                    Constants.Notifications.episodeDownloadStatusChanged,
+                                                    Constants.Notifications.manyEpisodesChanged]
 
         let mergedNotifications = notifications
             .map { NotificationCenter.default.publisher(for: $0) }

--- a/podcasts/TranscriptSearchAccessoryView.swift
+++ b/podcasts/TranscriptSearchAccessoryView.swift
@@ -170,7 +170,7 @@ private extension TranscriptSearchAccessoryView {
         button.addTarget(self, action: action, for: .touchUpInside)
         let attributes: [NSAttributedString.Key: Any] = [
             .foregroundColor: titleColor,
-                    .font: UIFont.font(with: .callout, maxSizeCategory: maxContentSizeCategory)
+            .font: UIFont.font(with: .callout, maxSizeCategory: maxContentSizeCategory)
         ]
         button.setAttributedTitle(NSAttributedString(string: title, attributes: attributes), for: .normal)
         button.setTitle(title, for: .normal)


### PR DESCRIPTION
### What

Enables the SwiftLint `collection_alignment` rule, which requires all elements in a multi-line collection literal to be vertically aligned.

### Changes

- 0 auto-fixed violations — `collection_alignment` is not autocorrectable, so `make format` made no source changes.
- 14 agentic (manual) fixes across 5 files: `SessionManager+Send.swift`, `DownloadManager.swift`, `View+CVPixelBuffer.swift`, `ShortcutManager.swift`, `TranscriptSearchAccessoryView.swift`. All are whitespace-only indentation adjustments.
- 0 violations left for human review.

### Notes

Part of the Orchard SwiftLint rollout campaign — enabling opt-in rules progressively, one rule per PR.

### How to test

CI lint must pass. The source changes are indentation-only and do not affect behavior.