### PR TITLE
Enable SwiftLint rule: literal_expression_end_indentation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -71,6 +71,10 @@ only_rules:
   # Prefer `last(where:)` over `filter { }.last`.
   - last_where
 
+  # Closing brackets/braces of literal expressions should be at the same indent
+  # level as the opening.
+  - literal_expression_end_indentation
+
   # MARK comment should be in valid format.
   - mark
 

--- a/podcasts/Analytics/AnalyticsAppThemeProvider.swift
+++ b/podcasts/Analytics/AnalyticsAppThemeProvider.swift
@@ -11,6 +11,6 @@ struct AnalyticsAppThemeProvider: AnalyticsAppThemeProviding {
             "theme_dark_preference": Theme.preferredDarkTheme().analyticsDescription,
             "theme_light_preference": Theme.preferredLightTheme().analyticsDescription,
             "theme_use_system_settings": Settings.shouldFollowSystemTheme()
-            ]
+        ]
     }
 }

--- a/podcasts/Common SwiftUI/Toast/ToastView.swift
+++ b/podcasts/Common SwiftUI/Toast/ToastView.swift
@@ -204,8 +204,8 @@ struct ToastView_Previews: PreviewProvider {
         ToastView(viewModel: .init(coordinator: PreviewCoordinator(), title: "Hello World", actions: [
             .init(title: "Tap Me", action: {
                 print("Tapped")
-            })], dismissPolicy: .never), style: .defaultTheme)
-    }
+        ], dismissPolicy: .never), style: .defaultTheme)
+        }
 
     private class PreviewCoordinator: ToastDelegate {
         func toastDismissed() {

--- a/podcasts/Common SwiftUI/Toast/ToastView.swift
+++ b/podcasts/Common SwiftUI/Toast/ToastView.swift
@@ -204,8 +204,9 @@ struct ToastView_Previews: PreviewProvider {
         ToastView(viewModel: .init(coordinator: PreviewCoordinator(), title: "Hello World", actions: [
             .init(title: "Tap Me", action: {
                 print("Tapped")
+            })
         ], dismissPolicy: .never), style: .defaultTheme)
-        }
+    }
 
     private class PreviewCoordinator: ToastDelegate {
         func toastDismissed() {

--- a/podcasts/DownloadManager+Logging.swift
+++ b/podcasts/DownloadManager+Logging.swift
@@ -64,7 +64,7 @@ extension DownloadManager {
             "expected_content_length": expectedContentLength,
             "response_body_bytes_received": responseBodyBytesReceived,
             "in_background": inBackground
-        ])
+                    ])
 
         let url = metrics.transactionMetrics.last?.request.url?.absoluteString ?? "unknown"
         FileLog.shared.addMessage("DownloadManager: Failed download \(episode.uuid) \(url) statusCode:\(String(describing: statusCode)) isCell:\(isCellular) isProxy: \(isProxy) errorCode:\(String(describing: errorCode)) errorDomain:\(String(describing: errorDomain))")

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -151,7 +151,7 @@ class DownloadsViewController: PCViewController {
             banner.trailingAnchor.constraint(equalTo: wrapperView.trailingAnchor, constant: -16),
             banner.topAnchor.constraint(equalTo: wrapperView.topAnchor, constant: 16),
             banner.bottomAnchor.constraint(equalTo: wrapperView.bottomAnchor, constant: 0),
-            ])
+        ])
         return wrapperView
     }
 

--- a/podcasts/New Detail/PlaylistDetailViewController+EmptyState.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+EmptyState.swift
@@ -53,7 +53,7 @@ extension PlaylistDetailViewController {
                         self?.emptyStateAction()
                     }
                 )
-            ])
+                ])
         }
         set(configuration: config)
     }

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -358,7 +358,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
                     self?.addNewFilter()
                     }
                 )
-            ])
+                ])
         }
         set(configuration: config)
     }

--- a/podcasts/UpNextViewController+Table.swift
+++ b/podcasts/UpNextViewController+Table.swift
@@ -74,7 +74,7 @@ extension UpNextViewController: UITableViewDelegate, UITableViewDataSource {
                         Analytics.shared.track(.upNextDiscoverButtonTapped)
                         NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey)
                     }
-            ])
+                ])
             return emptyCell
         }
 


### PR DESCRIPTION
Enables the SwiftLint rule [`literal_expression_end_indentation`](https://realm.github.io/SwiftLint/literal_expression_end_indentation.html) — closing brackets/braces of literal expressions match the indentation of the opening.

- **Auto-fixed violations**: all (via `make format`)
- **Agentic fixes**: 0
- **Left for human review**: 0
- **Files touched**: 7 source files (indentation only)

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)