### PR TITLE
Liquid Glass: Multi-Select P2

### DIFF
--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -86,7 +86,7 @@ class PlaylistDetailViewController: PCViewController, UIScrollViewDelegate {
                         self.tableView.selectIndexPath(selectedIndexPath)
                         self.longPressMultiSelectIndexPath = nil
                     }
-                    self.multiSelectFooterBottomConstraint.constant = Constants.effectiveMiniPlayerOffset + 16
+                    self.multiSelectFooterBottomConstraint.constant = Constants.effectiveFooterViewPadding
                 } else {
                     self.track(.filterMultiSelectExited)
                     self.multiSelectFooter.isHidden = true

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -169,7 +169,7 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
                     self.tableView().selectIndexPath(selectedIndexPath)
                     self.longPressMultiSelectIndexPath = nil
                 }
-                self.multiSelectFooterBottomConstraint.constant = Constants.effectiveMiniPlayerOffset + 16
+                self.multiSelectFooterBottomConstraint.constant = Constants.effectiveFooterViewPadding
             } else {
                 self.selectedEpisodes.removeAll()
             }

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -156,10 +156,7 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
             // For non-episode cells we don't enable editing. It needs to be for Bookmarks and already if for You Might Like.
             if currentViewMode == .episodes {
                 self.episodesTable.beginUpdates()
-                self.episodesTable.setEditing(self.isMultiSelectEnabled, animated: true)
-                if self.episodesTable.numberOfSections > 0 {
-                    self.episodesTable.reloadSections(IndexSet(integersIn: 0..<self.episodesTable.numberOfSections), with: .none)
-                }
+                self.episodesTable.setEditing(isMultiSelectEnabled, animated: true)
                 self.episodesTable.endUpdates()
             }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

- Fix an issue with cells not animating on Podcasts when existing mutli-select
- Fix multi select footer bottom padding on Podcasts and Playlists

More fixes to come.

## To test

- **Verify** that when you "Cancel" multi-select on "Podcast Details", the cells are animated

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
