### PR TITLE
Remove download failed check from Listening History

### DIFF
--- a/podcasts/ListeningHistoryViewController+Table.swift
+++ b/podcasts/ListeningHistoryViewController+Table.swift
@@ -92,20 +92,7 @@ extension ListeningHistoryViewController: UITableViewDelegate, UITableViewDataSo
         } else {
             tableView.deselectRow(at: indexPath, animated: true)
 
-            if episode.downloadFailed() {
-                let optionsPicker = OptionsPicker(title: nil)
-                let retryAction = OptionAction(label: L10n.retry, icon: nil, action: {
-                    NetworkUtils.shared.downloadEpisodeRequested(autoDownloadStatus: .notSpecified, { later in
-                        if later {
-                            DownloadManager.shared.queueForLaterDownload(episodeUuid: episode.uuid, fireNotification: true, autoDownloadStatus: .notSpecified)
-                        } else {
-                            DownloadManager.shared.addToQueue(episodeUuid: episode.uuid)
-                        }
-                    }, disallowed: nil)
-                })
-                optionsPicker.addDescriptiveActions(title: L10n.downloadFailed, message: episode.readableErrorMessage(), icon: "option-alert", actions: [retryAction])
-                optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
-            } else if let parentPodcast = episode.parentPodcast() {
+            if let parentPodcast = episode.parentPodcast() {
                 let episodeController = EpisodeDetailViewController(episodeUuid: episode.uuid, podcast: parentPodcast, source: .listeningHistory)
                 episodeController.modalPresentationStyle = .formSheet
                 present(episodeController, animated: true, completion: nil)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

The understanding is that it was mistakenly copied from "Downloads". There is no point forcing you to restart the download from Listening History.

## To test

n/a

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
