### PR TITLE
PCIOS-462: UI: Remove shadow on nav bar when scrolling and reduce padding to 16px

### DIFF
--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -39,8 +39,6 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
     // Callback to inform an external presenter of the desired action bar state
     var externalActionBarHandler: ((ExternalActionBarState) -> Void)? = nil
 
-    @State private var showShadow = false
-
     init(viewModel: BookmarkListViewModel,
          style: ListStyle,
          showHeader: Bool = true,
@@ -180,29 +178,21 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
 
     @ViewBuilder
     private var scrollView: some View {
-        ZStack(alignment: .top) {
-            ScrollViewWithContentOffset {
-                LazyVStack(spacing: 0) {
-                    ForEach(viewModel.bookmarks) { bookmark in
-                        BookmarkRow(bookmark: bookmark, style: style)
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(viewModel.bookmarks) { bookmark in
+                    BookmarkRow(bookmark: bookmark, style: style)
 
-                        if !viewModel.isLast(item: bookmark) {
-                            divider
-                        }
-                    }
-
-                    // Add padding to the bottom of the list when the action bar is visible so it's not blocking the view
-                    if actionBarVisible && !useExternalActionBar {
-                        Spacer(minLength: BookmarkListConstants.multiSelectionBottomPadding)
+                    if !viewModel.isLast(item: bookmark) {
+                        divider
                     }
                 }
-            }
-            .onContentOffsetChange { contentOffset in
-                showShadow = Int(contentOffset.y) < 0
-            }
 
-            // Shadow overlay
-            shadowView
+                // Add padding to the bottom of the list when the action bar is visible so it's not blocking the view
+                if actionBarVisible && !useExternalActionBar {
+                    Spacer(minLength: BookmarkListConstants.multiSelectionBottomPadding)
+                }
+            }
         }
     }
 
@@ -254,14 +244,6 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
 
     // MARK: - Utility Views
 
-    /// A shadow view that adds depth between the scroll view and the static header
-    private var shadowView: some View {
-        LinearGradient(colors: [.black.opacity(0.2), .black.opacity(0)], startPoint: .top, endPoint: .bottom)
-            .frame(maxWidth: .infinity, maxHeight: BookmarkListConstants.shadowHeight)
-            .opacity(showShadow ? 1 : 0)
-            .animation(.linear(duration: 0.2), value: showShadow)
-    }
-
     /// Styled divider view
     @ViewBuilder
     private var divider: some View {
@@ -296,9 +278,8 @@ struct BookmarkListMultiSelectHeaderView<HeaderStyle: BookmarksStyle>: View {
 }
 
 enum BookmarkListConstants {
-    static let shadowHeight = 20.0
     static let padding = 16.0
-    static let headerPadding = 18.0
+    static let headerPadding = 16.0
     static let headerTransitionOffset = 10.0
     static let multiSelectionBottomPadding = 70.0
     static let searchFieldBottomPadding = 10.0

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
@@ -8,7 +8,7 @@ struct BookmarksProfileListView: View {
     var body: some View {
         VStack(spacing: BookmarkListConstants.padding) {
             searchField
-                .padding([.horizontal], BookmarkListConstants.headerPadding)
+                .padding([.vertical, .horizontal], BookmarkListConstants.headerPadding)
                 .background(style.theme.secondaryUi01)
             bookmarkListView
         }

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
@@ -8,7 +8,7 @@ struct BookmarksProfileListView: View {
     var body: some View {
         VStack(spacing: BookmarkListConstants.padding) {
             searchField
-                .padding([.vertical, .horizontal], BookmarkListConstants.headerPadding)
+                .padding([.horizontal], BookmarkListConstants.headerPadding)
                 .background(style.theme.secondaryUi01)
             bookmarkListView
         }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-462/ui-remove-shadow-on-nav-bar-when-scrolling-and-reduce-padding-to-16px

## Summary
Removes the scroll-triggered shadow overlay on the Bookmarks list and reduces header padding from 18px to 16px for visual consistency with the design spec.

## Changes
- Removed `shadowView` (LinearGradient overlay) and its `showShadow` state from `BookmarksListView`
- Replaced `ScrollViewWithContentOffset` with a standard `ScrollView` (the content offset tracking was only used for the shadow)
- Removed `shadowHeight` constant from `BookmarkListConstants`
- Reduced `headerPadding` from 18px to 16px in `BookmarkListConstants`

## Verification
- **Lint**: PASS
- **Tests**: N/A — UI-only changes, no bookmark test coverage for shadow/padding
- **Build**: Pre-existing CarPlay build failures (unrelated to this change); bookmark files compile cleanly
- **Diff review**: PASS — confirmed single-file change, no unintended modifications
- **Secret scan**: PASS — no credentials in diff

## Confidence
**HIGH** — The shadow removal and padding change are straightforward, self-contained edits to a single SwiftUI view file. The shadow overlay and its supporting state/logic are fully removed with no remaining references.

---
This PR was created autonomously by linear-solver.
Triage complexity: simple | [Linear issue](https://linear.app/a8c/issue/PCIOS-462/ui-remove-shadow-on-nav-bar-when-scrolling-and-reduce-padding-to-16px)