### PR TITLE
Add Sleep Timer Live Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 - Add context menus for Podcasts [#4297](https://github.com/Automattic/pocket-casts-ios/pull/4297)
 - Show chapter art in mini player [#4382](https://github.com/Automattic/pocket-casts-ios/pull/4382)
 - Update "Up Next" episode cells to show up to two lines of episode title [4398](https://github.com/Automattic/pocket-casts-ios/pull/4398)
+- Add a Live Activity for sleep timers
 - Fix an issue with diagonal swipes not dismissing the player [#4335](https://github.com/Automattic/pocket-casts-ios/pull/4335)
 - Allow podcast images in Widget to be tinted [#4206](https://github.com/Automattic/pocket-casts-ios/pull/4206)
 - Fix player interactive dismiss gesture interaction with vertical scroll views [#4349](https://github.com/Automattic/pocket-casts-ios/pull/4349)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
+- Add a Live Activity for sleep timers
 
 
 8.18
@@ -109,7 +110,6 @@
 - Add context menus for Podcasts [#4297](https://github.com/Automattic/pocket-casts-ios/pull/4297)
 - Show chapter art in mini player [#4382](https://github.com/Automattic/pocket-casts-ios/pull/4382)
 - Update "Up Next" episode cells to show up to two lines of episode title [4398](https://github.com/Automattic/pocket-casts-ios/pull/4398)
-- Add a Live Activity for sleep timers
 - Fix an issue with diagonal swipes not dismissing the player [#4335](https://github.com/Automattic/pocket-casts-ios/pull/4335)
 - Allow podcast images in Widget to be tinted [#4206](https://github.com/Automattic/pocket-casts-ios/pull/4206)
 - Fix player interactive dismiss gesture interaction with vertical scroll views [#4349](https://github.com/Automattic/pocket-casts-ios/pull/4349)

--- a/WidgetExtension/PocketCastsWidgetBundle.swift
+++ b/WidgetExtension/PocketCastsWidgetBundle.swift
@@ -11,5 +11,8 @@ struct PocketCastsWidgetBundle: WidgetBundle {
         NowPlayingLockScreenWidget()
         AppIconWidget()
         UpNextLockScreenWidget()
+        if #available(iOSApplicationExtension 17.0, *) {
+            SleepTimerLiveActivityWidget()
+        }
     }
 }

--- a/WidgetExtension/Sleep Timer/SleepTimerLiveActivityWidget.swift
+++ b/WidgetExtension/Sleep Timer/SleepTimerLiveActivityWidget.swift
@@ -1,0 +1,162 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+@available(iOSApplicationExtension 17.0, *)
+struct SleepTimerLiveActivityWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: SleepTimerActivityAttributes.self) { context in
+            SleepTimerLockScreenView(context: context)
+                .activityBackgroundTint(SleepTimerLiveActivityStyle.backgroundColor)
+                .activitySystemActionForegroundColor(SleepTimerLiveActivityStyle.primaryTextColor)
+                .widgetURL(URL(string: "pktc://show_player"))
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    SleepTimerIcon(size: 24)
+                        .padding(.leading, 4)
+                }
+
+                DynamicIslandExpandedRegion(.center) {
+                    VStack(alignment: .center, spacing: 2) {
+                        Text(L10n.sleepTimer)
+                            .font(.caption)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(SleepTimerLiveActivityStyle.secondaryTextColor)
+                        SleepTimerCountdown(endDate: context.state.timerEndDate, font: .title3.monospacedDigit().weight(.semibold))
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+
+                DynamicIslandExpandedRegion(.bottom) {
+                    HStack(spacing: 12) {
+                        SleepTimerEpisodeText(
+                            episodeTitle: context.attributes.episodeTitle,
+                            podcastTitle: context.attributes.podcastTitle
+                        )
+                        Spacer(minLength: 8)
+                        SleepTimerExtendButton()
+                    }
+                }
+            } compactLeading: {
+                SleepTimerIcon(size: 19)
+                    .frame(width: 28, height: 28)
+                    .padding(.leading, 4)
+            } compactTrailing: {
+                SleepTimerCountdown(endDate: context.state.timerEndDate, font: .caption2.monospacedDigit().weight(.semibold))
+                    .frame(width: 48, alignment: .center)
+                    .padding(.trailing, 4)
+            } minimal: {
+                SleepTimerIcon(size: 16)
+            }
+            .widgetURL(URL(string: "pktc://show_player"))
+            .keylineTint(SleepTimerLiveActivityStyle.accentColor)
+        }
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+private struct SleepTimerLockScreenView: View {
+    let context: ActivityViewContext<SleepTimerActivityAttributes>
+
+    var body: some View {
+        HStack(spacing: 14) {
+            SleepTimerIcon(size: 40)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(L10n.sleepTimer)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .textCase(.uppercase)
+                    .foregroundStyle(SleepTimerLiveActivityStyle.secondaryTextColor)
+
+                SleepTimerCountdown(endDate: context.state.timerEndDate, font: .title2.monospacedDigit().weight(.bold))
+            }
+            .lineLimit(1)
+
+            Spacer(minLength: 8)
+
+            SleepTimerExtendButton()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+private struct SleepTimerCountdown: View {
+    let endDate: Date
+    let font: Font
+
+    var body: some View {
+        let startDate = min(Date(), endDate)
+
+        Text(timerInterval: startDate ... endDate, countsDown: true)
+            .font(font)
+            .foregroundStyle(SleepTimerLiveActivityStyle.primaryTextColor)
+            .multilineTextAlignment(.leading)
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+private struct SleepTimerEpisodeText: View {
+    let episodeTitle: String?
+    let podcastTitle: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            if let episodeTitle, !episodeTitle.isEmpty {
+                Text(episodeTitle)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .foregroundStyle(SleepTimerLiveActivityStyle.primaryTextColor)
+                    .lineLimit(1)
+            }
+
+            if let podcastTitle, !podcastTitle.isEmpty {
+                Text(podcastTitle)
+                    .font(.caption2)
+                    .foregroundStyle(SleepTimerLiveActivityStyle.secondaryTextColor)
+                    .lineLimit(1)
+            }
+        }
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+private struct SleepTimerExtendButton: View {
+    var body: some View {
+        Button(intent: ExtendSleepTimerLiveActivityIntent()) {
+            Text(L10n.sleepTimerAdd5Mins)
+                .font(.caption)
+                .fontWeight(.bold)
+                .lineLimit(1)
+                .foregroundStyle(SleepTimerLiveActivityStyle.buttonTextColor)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(SleepTimerLiveActivityStyle.buttonBackgroundColor, in: Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+@available(iOSApplicationExtension 17.0, *)
+private struct SleepTimerIcon: View {
+    var size: CGFloat = 28
+
+    var body: some View {
+        Image("logo_white_small_transparent")
+            .resizable()
+            .scaledToFit()
+            .frame(width: size, height: size)
+    }
+}
+
+private enum SleepTimerLiveActivityStyle {
+    static let backgroundColor = Color.widgetBlack
+    static let accentColor = Color.widgetRedLight
+    static let primaryTextColor = Color.white
+    static let secondaryTextColor = Color.white.opacity(0.68)
+    static let buttonBackgroundColor = Color.widgetRedLight
+    static let buttonTextColor = Color.white
+}

--- a/WidgetExtension/Sleep Timer/SleepTimerLiveActivityWidget.swift
+++ b/WidgetExtension/Sleep Timer/SleepTimerLiveActivityWidget.swift
@@ -1,4 +1,5 @@
 import ActivityKit
+import PocketCastsUtils
 import SwiftUI
 import WidgetKit
 
@@ -7,7 +8,9 @@ struct SleepTimerLiveActivityWidget: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: SleepTimerActivityAttributes.self) { context in
             SleepTimerLockScreenView(context: context)
-                .activityBackgroundTint(SleepTimerLiveActivityStyle.backgroundColor)
+                // No tint, so the system draws its default (glass) background, matching
+                // the clear background the other widgets use via `clearBackground()`.
+                .activityBackgroundTint(nil)
                 .activitySystemActionForegroundColor(SleepTimerLiveActivityStyle.primaryTextColor)
                 .widgetURL(URL(string: "pktc://show_player"))
         } dynamicIsland: { context in
@@ -23,7 +26,7 @@ struct SleepTimerLiveActivityWidget: Widget {
                             .font(.caption)
                             .fontWeight(.semibold)
                             .foregroundStyle(SleepTimerLiveActivityStyle.secondaryTextColor)
-                        SleepTimerCountdown(endDate: context.state.timerEndDate, font: .title3.monospacedDigit().weight(.semibold))
+                        SleepTimerCountdown(state: context.state, font: .title3.monospacedDigit().weight(.semibold))
                     }
                     .frame(maxWidth: .infinity)
                 }
@@ -31,8 +34,8 @@ struct SleepTimerLiveActivityWidget: Widget {
                 DynamicIslandExpandedRegion(.bottom) {
                     HStack(spacing: 12) {
                         SleepTimerEpisodeText(
-                            episodeTitle: context.attributes.episodeTitle,
-                            podcastTitle: context.attributes.podcastTitle
+                            episodeTitle: context.state.episodeTitle,
+                            podcastTitle: context.state.podcastTitle
                         )
                         Spacer(minLength: 8)
                         SleepTimerExtendButton()
@@ -43,7 +46,7 @@ struct SleepTimerLiveActivityWidget: Widget {
                     .frame(width: 28, height: 28)
                     .padding(.leading, 4)
             } compactTrailing: {
-                SleepTimerCountdown(endDate: context.state.timerEndDate, font: .caption2.monospacedDigit().weight(.semibold))
+                SleepTimerCountdown(state: context.state, font: .caption2.monospacedDigit().weight(.semibold))
                     .frame(width: 48, alignment: .center)
                     .padding(.trailing, 4)
             } minimal: {
@@ -60,8 +63,8 @@ private struct SleepTimerLockScreenView: View {
     let context: ActivityViewContext<SleepTimerActivityAttributes>
 
     var body: some View {
-        HStack(spacing: 14) {
-            SleepTimerIcon(size: 40)
+        HStack(spacing: 12) {
+            SleepTimerIcon(size: CommonWidgetHelper.iconSize)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(L10n.sleepTimer)
@@ -70,7 +73,7 @@ private struct SleepTimerLockScreenView: View {
                     .textCase(.uppercase)
                     .foregroundStyle(SleepTimerLiveActivityStyle.secondaryTextColor)
 
-                SleepTimerCountdown(endDate: context.state.timerEndDate, font: .title2.monospacedDigit().weight(.bold))
+                SleepTimerCountdown(state: context.state, font: .title2.monospacedDigit().weight(.bold))
             }
             .lineLimit(1)
 
@@ -85,16 +88,23 @@ private struct SleepTimerLockScreenView: View {
 
 @available(iOSApplicationExtension 17.0, *)
 private struct SleepTimerCountdown: View {
-    let endDate: Date
+    let state: SleepTimerActivityAttributes.ContentState
     let font: Font
 
     var body: some View {
-        let startDate = min(Date(), endDate)
-
-        Text(timerInterval: startDate ... endDate, countsDown: true)
-            .font(font)
-            .foregroundStyle(SleepTimerLiveActivityStyle.primaryTextColor)
-            .multilineTextAlignment(.leading)
+        Group {
+            if state.isPaused {
+                // The sleep timer doesn't tick while playback is paused, so show a fixed
+                // time rather than letting the system run the countdown down to zero.
+                Text(TimeFormatter.shared.playTimeFormat(time: state.remaining))
+            } else {
+                let startDate = min(Date(), state.timerEndDate)
+                Text(timerInterval: startDate ... state.timerEndDate, countsDown: true)
+            }
+        }
+        .font(font)
+        .foregroundStyle(SleepTimerLiveActivityStyle.primaryTextColor)
+        .multilineTextAlignment(.leading)
     }
 }
 
@@ -153,10 +163,10 @@ private struct SleepTimerIcon: View {
 }
 
 private enum SleepTimerLiveActivityStyle {
-    static let backgroundColor = Color.widgetBlack
     static let accentColor = Color.widgetRedLight
-    static let primaryTextColor = Color.white
-    static let secondaryTextColor = Color.white.opacity(0.68)
+    // The activity sits on the system's own material, so the text has to adapt to it.
+    static let primaryTextColor = Color.primary
+    static let secondaryTextColor = Color.secondary
     static let buttonBackgroundColor = Color.widgetRedLight
     static let buttonTextColor = Color.white
 }

--- a/WidgetExtension/Sleep Timer/SleepTimerLiveActivityWidget.swift
+++ b/WidgetExtension/Sleep Timer/SleepTimerLiveActivityWidget.swift
@@ -63,7 +63,7 @@ private struct SleepTimerLockScreenView: View {
         HStack(spacing: 14) {
             SleepTimerIcon(size: 40)
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 2) {
                 Text(L10n.sleepTimer)
                     .font(.caption)
                     .fontWeight(.semibold)

--- a/WidgetExtension/Sleep Timer/WidgetExtendSleepTimerLiveActivityIntentExtension.swift
+++ b/WidgetExtension/Sleep Timer/WidgetExtendSleepTimerLiveActivityIntentExtension.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+@available(iOS 17.0, *)
+extension ExtendSleepTimerLiveActivityIntent {
+    func extendSleepTimer(by duration: TimeInterval) {}
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -354,12 +354,12 @@
 		8BC060092AB1FA0D00A4FEC6 /* PlayEpisodeIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC060072AB1FA0400A4FEC6 /* PlayEpisodeIntent.swift */; };
 		8BC0600B2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC0600A2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift */; };
 		8BC0600E2AB2219700A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC0600C2AB2218300A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift */; };
-		8BC061002FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061102FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift */; };
-		8BC061012FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061102FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift */; };
-		8BC061022FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061112FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift */; };
-		8BC061032FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061112FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift */; };
-		8BC061042FB6212400A4FEC6 /* AppExtendSleepTimerLiveActivityIntentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061122FB6212400A4FEC6 /* AppExtendSleepTimerLiveActivityIntentExtension.swift */; };
-		8BC061052FB6212400A4FEC6 /* SleepTimerLiveActivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061132FB6212400A4FEC6 /* SleepTimerLiveActivityController.swift */; };
+		8BC061002FB6212400A4FEC6 /* LiveActivity/SleepTimerActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061102FB6212400A4FEC6 /* LiveActivity/SleepTimerActivityAttributes.swift */; };
+		8BC061012FB6212400A4FEC6 /* LiveActivity/SleepTimerActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061102FB6212400A4FEC6 /* LiveActivity/SleepTimerActivityAttributes.swift */; };
+		8BC061022FB6212400A4FEC6 /* LiveActivity/ExtendSleepTimerLiveActivityIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061112FB6212400A4FEC6 /* LiveActivity/ExtendSleepTimerLiveActivityIntent.swift */; };
+		8BC061032FB6212400A4FEC6 /* LiveActivity/ExtendSleepTimerLiveActivityIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061112FB6212400A4FEC6 /* LiveActivity/ExtendSleepTimerLiveActivityIntent.swift */; };
+		8BC061042FB6212400A4FEC6 /* LiveActivity/AppExtendSleepTimerLiveActivityIntentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061122FB6212400A4FEC6 /* LiveActivity/AppExtendSleepTimerLiveActivityIntentExtension.swift */; };
+		8BC061052FB6212400A4FEC6 /* LiveActivity/SleepTimerLiveActivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061132FB6212400A4FEC6 /* LiveActivity/SleepTimerLiveActivityController.swift */; };
 		8BD256D22A5C7090006648BE /* SharingHelper+swipeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD256D12A5C7090006648BE /* SharingHelper+swipeButton.swift */; };
 		8BD5A4E42A1E844D00F473C6 /* StatusPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD5A4E32A1E844D00F473C6 /* StatusPageView.swift */; };
 		8BD5A4FF2A1F96C200F473C6 /* AppIcon-Pride76x76@2x~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = 8BD5A4EE2A1F96BD00F473C6 /* AppIcon-Pride76x76@2x~ipad.png */; };
@@ -1946,10 +1946,10 @@
 		8BC060072AB1FA0400A4FEC6 /* PlayEpisodeIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayEpisodeIntent.swift; sourceTree = "<group>"; };
 		8BC0600A2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPlayEpisodeIntentExtension.swift; sourceTree = "<group>"; };
 		8BC0600C2AB2218300A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetPlayEpisodeIntentExtension.swift; sourceTree = "<group>"; };
-		8BC061102FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/SleepTimerActivityAttributes.swift; sourceTree = "<group>"; };
-		8BC061112FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/ExtendSleepTimerLiveActivityIntent.swift; sourceTree = "<group>"; };
-		8BC061122FB6212400A4FEC6 /* AppExtendSleepTimerLiveActivityIntentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/AppExtendSleepTimerLiveActivityIntentExtension.swift; sourceTree = "<group>"; };
-		8BC061132FB6212400A4FEC6 /* SleepTimerLiveActivityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/SleepTimerLiveActivityController.swift; sourceTree = "<group>"; };
+		8BC061102FB6212400A4FEC6 /* LiveActivity/SleepTimerActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/SleepTimerActivityAttributes.swift; sourceTree = "<group>"; };
+		8BC061112FB6212400A4FEC6 /* LiveActivity/ExtendSleepTimerLiveActivityIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/ExtendSleepTimerLiveActivityIntent.swift; sourceTree = "<group>"; };
+		8BC061122FB6212400A4FEC6 /* LiveActivity/AppExtendSleepTimerLiveActivityIntentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/AppExtendSleepTimerLiveActivityIntentExtension.swift; sourceTree = "<group>"; };
+		8BC061132FB6212400A4FEC6 /* LiveActivity/SleepTimerLiveActivityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/SleepTimerLiveActivityController.swift; sourceTree = "<group>"; };
 		8BD256D12A5C7090006648BE /* SharingHelper+swipeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingHelper+swipeButton.swift"; sourceTree = "<group>"; };
 		8BD5A4E32A1E844D00F473C6 /* StatusPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPageView.swift; sourceTree = "<group>"; };
 		8BD5A4EE2A1F96BD00F473C6 /* AppIcon-Pride76x76@2x~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Pride76x76@2x~ipad.png"; sourceTree = "<group>"; };
@@ -3863,13 +3863,13 @@
 			isa = PBXGroup;
 			children = (
 				8BC0600A2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift */,
-				8BC061122FB6212400A4FEC6 /* AppExtendSleepTimerLiveActivityIntentExtension.swift */,
-				8BC061112FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift */,
+				8BC061122FB6212400A4FEC6 /* LiveActivity/AppExtendSleepTimerLiveActivityIntentExtension.swift */,
+				8BC061112FB6212400A4FEC6 /* LiveActivity/ExtendSleepTimerLiveActivityIntent.swift */,
 				8BC060072AB1FA0400A4FEC6 /* PlayEpisodeIntent.swift */,
 				BD054A791E3EDEB300D9195B /* SharedConstants.swift */,
 				40043F0A23FBC6B1004A9B57 /* SiriPodcastItem.swift */,
-				8BC061102FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift */,
-				8BC061132FB6212400A4FEC6 /* SleepTimerLiveActivityController.swift */,
+				8BC061102FB6212400A4FEC6 /* LiveActivity/SleepTimerActivityAttributes.swift */,
+				8BC061132FB6212400A4FEC6 /* LiveActivity/SleepTimerLiveActivityController.swift */,
 				8BC0600C2AB2218300A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift */,
 			);
 			name = "Shared with Extension";
@@ -6924,8 +6924,8 @@
 				467DF6EB26E10AFD00AC290C /* Strings+Generated.swift in Sources */,
 				4036B06E25240CC600AE08E6 /* SharedConstants.swift in Sources */,
 				467BB04726CC07C900A73BAF /* Constants.swift in Sources */,
-				8BC061012FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift in Sources */,
-				8BC061032FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift in Sources */,
+				8BC061012FB6212400A4FEC6 /* LiveActivity/SleepTimerActivityAttributes.swift in Sources */,
+				8BC061032FB6212400A4FEC6 /* LiveActivity/ExtendSleepTimerLiveActivityIntent.swift in Sources */,
 				8BC0600E2AB2219700A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift in Sources */,
 				8BC060092AB1FA0D00A4FEC6 /* PlayEpisodeIntent.swift in Sources */,
 				463538F526F2415300BA9D35 /* Strings+L10n.swift in Sources */,
@@ -7066,7 +7066,7 @@
 				F5BA5C9C2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift in Sources */,
 				40422D96251AF10500C80BE4 /* BundlePodcastCell.swift in Sources */,
 				9A466E402E8C26C1005D9E07 /* ManualPlaylistsChooserViewController.swift in Sources */,
-				8BC061052FB6212400A4FEC6 /* SleepTimerLiveActivityController.swift in Sources */,
+				8BC061052FB6212400A4FEC6 /* LiveActivity/SleepTimerLiveActivityController.swift in Sources */,
 				FF68E8BE2DF33D6100114FC7 /* HorizontalCollectionListViewController.swift in Sources */,
 				8B317BA028906A8900A26A13 /* main.swift in Sources */,
 				BDC86830238251B0004C998F /* NowPlayingPlayerItemViewController+UpNextPan.swift in Sources */,
@@ -7100,10 +7100,9 @@
 				BDEAA1861BB144AD001097D9 /* DisclosureCell.swift in Sources */,
 				BDD40A1A1FA1AF7900A53AE1 /* TintableImageView.swift in Sources */,
 				8BC060082AB1FA0400A4FEC6 /* PlayEpisodeIntent.swift in Sources */,
-				8BC061002FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift in Sources */,
-				8BC061022FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift in Sources */,
-				8BC061042FB6212400A4FEC6 /* AppExtendSleepTimerLiveActivityIntentExtension.swift in Sources */,
-				40DD88ED215DB18300277A4E /* PlaylistIconChooserCell.swift in Sources */,
+				8BC061002FB6212400A4FEC6 /* LiveActivity/SleepTimerActivityAttributes.swift in Sources */,
+				8BC061022FB6212400A4FEC6 /* LiveActivity/ExtendSleepTimerLiveActivityIntent.swift in Sources */,
+				8BC061042FB6212400A4FEC6 /* LiveActivity/AppExtendSleepTimerLiveActivityIntentExtension.swift in Sources */,
 				BD1F977C1FD7894C00F89CCD /* MiniPlayerShadowView.swift in Sources */,
 				FF26A9924A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift in Sources */,
 				FF26A99A4A1B5C2D00000004 /* MiniPlayerScrollingTitleView.swift in Sources */,

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -354,6 +354,12 @@
 		8BC060092AB1FA0D00A4FEC6 /* PlayEpisodeIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC060072AB1FA0400A4FEC6 /* PlayEpisodeIntent.swift */; };
 		8BC0600B2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC0600A2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift */; };
 		8BC0600E2AB2219700A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC0600C2AB2218300A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift */; };
+		8BC061002FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061102FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift */; };
+		8BC061012FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061102FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift */; };
+		8BC061022FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061112FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift */; };
+		8BC061032FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061112FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift */; };
+		8BC061042FB6212400A4FEC6 /* AppExtendSleepTimerLiveActivityIntentExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061122FB6212400A4FEC6 /* AppExtendSleepTimerLiveActivityIntentExtension.swift */; };
+		8BC061052FB6212400A4FEC6 /* SleepTimerLiveActivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC061132FB6212400A4FEC6 /* SleepTimerLiveActivityController.swift */; };
 		8BD256D22A5C7090006648BE /* SharingHelper+swipeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD256D12A5C7090006648BE /* SharingHelper+swipeButton.swift */; };
 		8BD5A4E42A1E844D00F473C6 /* StatusPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BD5A4E32A1E844D00F473C6 /* StatusPageView.swift */; };
 		8BD5A4FF2A1F96C200F473C6 /* AppIcon-Pride76x76@2x~ipad.png in Resources */ = {isa = PBXBuildFile; fileRef = 8BD5A4EE2A1F96BD00F473C6 /* AppIcon-Pride76x76@2x~ipad.png */; };
@@ -1940,6 +1946,10 @@
 		8BC060072AB1FA0400A4FEC6 /* PlayEpisodeIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayEpisodeIntent.swift; sourceTree = "<group>"; };
 		8BC0600A2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPlayEpisodeIntentExtension.swift; sourceTree = "<group>"; };
 		8BC0600C2AB2218300A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetPlayEpisodeIntentExtension.swift; sourceTree = "<group>"; };
+		8BC061102FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/SleepTimerActivityAttributes.swift; sourceTree = "<group>"; };
+		8BC061112FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/ExtendSleepTimerLiveActivityIntent.swift; sourceTree = "<group>"; };
+		8BC061122FB6212400A4FEC6 /* AppExtendSleepTimerLiveActivityIntentExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/AppExtendSleepTimerLiveActivityIntentExtension.swift; sourceTree = "<group>"; };
+		8BC061132FB6212400A4FEC6 /* SleepTimerLiveActivityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivity/SleepTimerLiveActivityController.swift; sourceTree = "<group>"; };
 		8BD256D12A5C7090006648BE /* SharingHelper+swipeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingHelper+swipeButton.swift"; sourceTree = "<group>"; };
 		8BD5A4E32A1E844D00F473C6 /* StatusPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPageView.swift; sourceTree = "<group>"; };
 		8BD5A4EE2A1F96BD00F473C6 /* AppIcon-Pride76x76@2x~ipad.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "AppIcon-Pride76x76@2x~ipad.png"; sourceTree = "<group>"; };
@@ -3853,9 +3863,13 @@
 			isa = PBXGroup;
 			children = (
 				8BC0600A2AB1FB8100A4FEC6 /* AppPlayEpisodeIntentExtension.swift */,
+				8BC061122FB6212400A4FEC6 /* AppExtendSleepTimerLiveActivityIntentExtension.swift */,
+				8BC061112FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift */,
 				8BC060072AB1FA0400A4FEC6 /* PlayEpisodeIntent.swift */,
 				BD054A791E3EDEB300D9195B /* SharedConstants.swift */,
 				40043F0A23FBC6B1004A9B57 /* SiriPodcastItem.swift */,
+				8BC061102FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift */,
+				8BC061132FB6212400A4FEC6 /* SleepTimerLiveActivityController.swift */,
 				8BC0600C2AB2218300A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift */,
 			);
 			name = "Shared with Extension";
@@ -6910,6 +6924,8 @@
 				467DF6EB26E10AFD00AC290C /* Strings+Generated.swift in Sources */,
 				4036B06E25240CC600AE08E6 /* SharedConstants.swift in Sources */,
 				467BB04726CC07C900A73BAF /* Constants.swift in Sources */,
+				8BC061012FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift in Sources */,
+				8BC061032FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift in Sources */,
 				8BC0600E2AB2219700A4FEC6 /* WidgetPlayEpisodeIntentExtension.swift in Sources */,
 				8BC060092AB1FA0D00A4FEC6 /* PlayEpisodeIntent.swift in Sources */,
 				463538F526F2415300BA9D35 /* Strings+L10n.swift in Sources */,
@@ -7050,6 +7066,7 @@
 				F5BA5C9C2C80F38200BDA5B9 /* UIViewControllerContentConfiguration.swift in Sources */,
 				40422D96251AF10500C80BE4 /* BundlePodcastCell.swift in Sources */,
 				9A466E402E8C26C1005D9E07 /* ManualPlaylistsChooserViewController.swift in Sources */,
+				8BC061052FB6212400A4FEC6 /* SleepTimerLiveActivityController.swift in Sources */,
 				FF68E8BE2DF33D6100114FC7 /* HorizontalCollectionListViewController.swift in Sources */,
 				8B317BA028906A8900A26A13 /* main.swift in Sources */,
 				BDC86830238251B0004C998F /* NowPlayingPlayerItemViewController+UpNextPan.swift in Sources */,
@@ -7083,6 +7100,10 @@
 				BDEAA1861BB144AD001097D9 /* DisclosureCell.swift in Sources */,
 				BDD40A1A1FA1AF7900A53AE1 /* TintableImageView.swift in Sources */,
 				8BC060082AB1FA0400A4FEC6 /* PlayEpisodeIntent.swift in Sources */,
+				8BC061002FB6212400A4FEC6 /* SleepTimerActivityAttributes.swift in Sources */,
+				8BC061022FB6212400A4FEC6 /* ExtendSleepTimerLiveActivityIntent.swift in Sources */,
+				8BC061042FB6212400A4FEC6 /* AppExtendSleepTimerLiveActivityIntentExtension.swift in Sources */,
+				40DD88ED215DB18300277A4E /* PlaylistIconChooserCell.swift in Sources */,
 				BD1F977C1FD7894C00F89CCD /* MiniPlayerShadowView.swift in Sources */,
 				FF26A9924A1B5C2D00000002 /* MiniPlayerGlassProgressView.swift in Sources */,
 				FF26A99A4A1B5C2D00000004 /* MiniPlayerScrollingTitleView.swift in Sources */,

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -169,6 +169,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
         }
         PlaybackManager.shared.updateIdleTimer()
+        PlaybackManager.shared.reconcileSleepTimerLiveActivity()
     }
 
     func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {

--- a/podcasts/LiveActivity/AppExtendSleepTimerLiveActivityIntentExtension.swift
+++ b/podcasts/LiveActivity/AppExtendSleepTimerLiveActivityIntentExtension.swift
@@ -1,0 +1,9 @@
+import PocketCastsUtils
+
+@available(iOS 17.0, *)
+extension ExtendSleepTimerLiveActivityIntent {
+    @MainActor
+    func extendSleepTimer(by duration: TimeInterval) {
+        PlaybackManager.shared.extendSleepTimer(by: duration)
+    }
+}

--- a/podcasts/LiveActivity/ExtendSleepTimerLiveActivityIntent.swift
+++ b/podcasts/LiveActivity/ExtendSleepTimerLiveActivityIntent.swift
@@ -1,0 +1,19 @@
+import AppIntents
+import PocketCastsUtils
+
+@available(iOS 17.0, *)
+struct ExtendSleepTimerLiveActivityIntent: LiveActivityIntent {
+    static var title: LocalizedStringResource = "Add 5 Minutes"
+    static var isDiscoverable = false
+    static var openAppWhenRun: Bool { false }
+
+    @available(iOS 26.0, *)
+    static var supportedModes: IntentModes { [.background] }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        extendSleepTimer(by: 5.minutes)
+
+        return .result()
+    }
+}

--- a/podcasts/LiveActivity/SleepTimerActivityAttributes.swift
+++ b/podcasts/LiveActivity/SleepTimerActivityAttributes.swift
@@ -1,0 +1,13 @@
+import ActivityKit
+import Foundation
+
+@available(iOS 16.1, *)
+struct SleepTimerActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        let timerEndDate: Date
+    }
+
+    let startedAt: Date
+    let episodeTitle: String?
+    let podcastTitle: String?
+}

--- a/podcasts/LiveActivity/SleepTimerActivityAttributes.swift
+++ b/podcasts/LiveActivity/SleepTimerActivityAttributes.swift
@@ -4,10 +4,21 @@ import Foundation
 @available(iOS 16.1, *)
 struct SleepTimerActivityAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
+        /// When the timer will fire. While paused this is only used to derive nothing:
+        /// `remaining` is the source of truth and the UI renders it statically.
         let timerEndDate: Date
+
+        /// How much time is left on the timer. The sleep timer only counts down while
+        /// playback is running, so this lets the widget freeze rather than run to zero.
+        let remaining: TimeInterval
+
+        let isPaused: Bool
+
+        /// These live here rather than in the attributes so they can follow the episode
+        /// while the timer runs. `ActivityAttributes` are fixed for the life of an activity.
+        let episodeTitle: String?
+        let podcastTitle: String?
     }
 
     let startedAt: Date
-    let episodeTitle: String?
-    let podcastTitle: String?
 }

--- a/podcasts/LiveActivity/SleepTimerLiveActivityController.swift
+++ b/podcasts/LiveActivity/SleepTimerLiveActivityController.swift
@@ -1,0 +1,64 @@
+import ActivityKit
+import Foundation
+import PocketCastsDataModel
+import PocketCastsUtils
+
+@available(iOS 17.0, *)
+final class SleepTimerLiveActivityController {
+    static let shared = SleepTimerLiveActivityController()
+
+    private init() {}
+
+    func startTimer(duration: TimeInterval, episode: BaseEpisode?) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+
+        let timerEndDate = Date().addingTimeInterval(duration)
+        let attributes = SleepTimerActivityAttributes(
+            startedAt: Date(),
+            episodeTitle: episode?.displayableTitle(),
+            podcastTitle: episode?.subTitle()
+        )
+        let content = ActivityContent(
+            state: SleepTimerActivityAttributes.ContentState(timerEndDate: timerEndDate),
+            staleDate: timerEndDate,
+            relevanceScore: 1
+        )
+
+        Task {
+            await endAllActivities(dismissalPolicy: .immediate)
+
+            do {
+                _ = try Activity.request(attributes: attributes, content: content, pushType: nil)
+            } catch {
+                FileLog.shared.addMessage("Sleep Timer Live Activity: unable to start activity: \(error)")
+            }
+        }
+    }
+
+    func updateTimer(durationRemaining: TimeInterval) {
+        let timerEndDate = Date().addingTimeInterval(durationRemaining)
+        let content = ActivityContent(
+            state: SleepTimerActivityAttributes.ContentState(timerEndDate: timerEndDate),
+            staleDate: timerEndDate,
+            relevanceScore: 1
+        )
+
+        Task {
+            for activity in Activity<SleepTimerActivityAttributes>.activities {
+                await activity.update(content)
+            }
+        }
+    }
+
+    func endAll(dismissalPolicy: ActivityUIDismissalPolicy = .default) {
+        Task {
+            await endAllActivities(dismissalPolicy: dismissalPolicy)
+        }
+    }
+
+    private func endAllActivities(dismissalPolicy: ActivityUIDismissalPolicy) async {
+        for activity in Activity<SleepTimerActivityAttributes>.activities {
+            await activity.end(nil, dismissalPolicy: dismissalPolicy)
+        }
+    }
+}

--- a/podcasts/LiveActivity/SleepTimerLiveActivityController.swift
+++ b/podcasts/LiveActivity/SleepTimerLiveActivityController.swift
@@ -12,17 +12,8 @@ final class SleepTimerLiveActivityController {
     func startTimer(duration: TimeInterval, episode: BaseEpisode?) {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
 
-        let timerEndDate = Date().addingTimeInterval(duration)
-        let attributes = SleepTimerActivityAttributes(
-            startedAt: Date(),
-            episodeTitle: episode?.displayableTitle(),
-            podcastTitle: episode?.subTitle()
-        )
-        let content = ActivityContent(
-            state: SleepTimerActivityAttributes.ContentState(timerEndDate: timerEndDate),
-            staleDate: timerEndDate,
-            relevanceScore: 1
-        )
+        let attributes = SleepTimerActivityAttributes(startedAt: Date())
+        let content = content(remaining: duration, isPaused: false, episode: episode)
 
         Task {
             await endAllActivities(dismissalPolicy: .immediate)
@@ -35,13 +26,10 @@ final class SleepTimerLiveActivityController {
         }
     }
 
-    func updateTimer(durationRemaining: TimeInterval) {
-        let timerEndDate = Date().addingTimeInterval(durationRemaining)
-        let content = ActivityContent(
-            state: SleepTimerActivityAttributes.ContentState(timerEndDate: timerEndDate),
-            staleDate: timerEndDate,
-            relevanceScore: 1
-        )
+    /// Pushes the current state of the sleep timer to any running activity. Called whenever
+    /// playback pauses or resumes, the episode changes, or the timer is extended.
+    func sync(remaining: TimeInterval, isPaused: Bool, episode: BaseEpisode?) {
+        let content = content(remaining: remaining, isPaused: isPaused, episode: episode)
 
         Task {
             for activity in Activity<SleepTimerActivityAttributes>.activities {
@@ -50,10 +38,35 @@ final class SleepTimerLiveActivityController {
         }
     }
 
-    func endAll(dismissalPolicy: ActivityUIDismissalPolicy = .default) {
+    /// The sleep timer only lives in memory, so an activity can outlive it if the app is
+    /// force quit. Reap anything that no longer matches the app's state.
+    func reconcile(isTimerRunning: Bool, remaining: TimeInterval, isPaused: Bool, episode: BaseEpisode?) {
+        guard isTimerRunning else {
+            endAll()
+            return
+        }
+
+        sync(remaining: remaining, isPaused: isPaused, episode: episode)
+    }
+
+    func endAll(dismissalPolicy: ActivityUIDismissalPolicy = .immediate) {
         Task {
             await endAllActivities(dismissalPolicy: dismissalPolicy)
         }
+    }
+
+    private func content(remaining: TimeInterval, isPaused: Bool, episode: BaseEpisode?) -> ActivityContent<SleepTimerActivityAttributes.ContentState> {
+        let timerEndDate = Date().addingTimeInterval(remaining)
+        let state = SleepTimerActivityAttributes.ContentState(
+            timerEndDate: timerEndDate,
+            remaining: remaining,
+            isPaused: isPaused,
+            episodeTitle: episode?.displayableTitle(),
+            podcastTitle: episode?.subTitle()
+        )
+
+        // A paused timer never goes stale, it's just waiting for playback to resume.
+        return ActivityContent(state: state, staleDate: isPaused ? nil : timerEndDate, relevanceScore: 1)
     }
 
     private func endAllActivities(dismissalPolicy: ActivityUIDismissalPolicy) async {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -343,6 +343,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             self.updateIdleTimer()
 
             self.sleepTimerManager.restartSleepTimerIfNeeded()
+            self.syncSleepTimerLiveActivity(isPaused: false)
         })
     }
 
@@ -369,6 +370,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         catchUpHelper.playbackDidPause(of: episode)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackPaused)
         cancelUpdateTimer()
+        syncSleepTimerLiveActivity(isPaused: true)
         deactiveAudioSession()
 
         updateIdleTimer()
@@ -776,6 +778,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
 
         numberOfEpisodesToSleepAfter -= 1
+        syncSleepTimerLiveActivity()
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
     }
 
@@ -790,6 +793,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         load(episode: episodeToPlay, autoPlay: autoPlay, overrideUpNext: false, completion: completion)
         switchingToDifferentUpNextEpisode = false
 
+        syncSleepTimerLiveActivity()
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.upNextQueueChanged)
     }
@@ -1497,6 +1501,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         DataManager.sharedManager.saveEpisode(playedUpTo: upTo, episode: currEpisode, updateSyncFlag: SyncManager.isUserLoggedIn())
 
         cleanupCurrentPlayer(permanent: true)
+        endSleepTimerLiveActivity()
 
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackPositionSaved, object: currEpisode.uuid)
         updateNowPlayingInfo()
@@ -2006,7 +2011,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard sleepTimeRemaining >= 0, duration > 0 else { return }
 
         sleepTimeRemaining += duration
-        updateSleepTimerLiveActivity()
+        syncSleepTimerLiveActivity()
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.sleepTimerChanged)
     }
 
@@ -2029,10 +2034,34 @@ class PlaybackManager: ServerPlaybackDelegate {
         #endif
     }
 
-    private func updateSleepTimerLiveActivity() {
+    /// Pushes the current sleep timer state to the Live Activity. The timer only counts down
+    /// while playback is running, so the activity needs to know when we're paused, otherwise
+    /// it keeps counting to zero and sits there showing an expired timer.
+    func syncSleepTimerLiveActivity(isPaused: Bool? = nil) {
+        #if !APPCLIP && !os(watchOS) && !os(tvOS)
+            guard sleepTimeRemaining >= 0 else { return }
+
+            if #available(iOS 17.0, *) {
+                SleepTimerLiveActivityController.shared.sync(
+                    remaining: sleepTimeRemaining,
+                    isPaused: isPaused ?? !playing(),
+                    episode: currentEpisode()
+                )
+            }
+        #endif
+    }
+
+    /// Ends any Live Activity that has outlived the sleep timer, which happens when the app is
+    /// force quit while a timer is running. Called when the app becomes active.
+    func reconcileSleepTimerLiveActivity() {
         #if !APPCLIP && !os(watchOS) && !os(tvOS)
             if #available(iOS 17.0, *) {
-                SleepTimerLiveActivityController.shared.updateTimer(durationRemaining: sleepTimeRemaining)
+                SleepTimerLiveActivityController.shared.reconcile(
+                    isTimerRunning: sleepTimeRemaining >= 0,
+                    remaining: sleepTimeRemaining,
+                    isPaused: !playing(),
+                    episode: currentEpisode()
+                )
             }
         #endif
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -27,6 +27,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 sleepTimeRemaining = -1
                 sleepTimerManager.recordSleepTimerDuration(duration: nil, onEpisodeEnd: true)
                 FileLog.shared.addMessage("Sleep Timer: starting with \(numberOfEpisodesToSleepAfter) episodes")
+                endSleepTimerLiveActivity()
             }
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.sleepTimerChanged)
         }
@@ -1863,6 +1864,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     private func pauseAndRecordSleepTimerFinished() {
         sleepTimerManager.recordSleepTimerFinished()
+        endSleepTimerLiveActivity()
         pause()
     }
 
@@ -1983,6 +1985,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         sleepTimerManager.cancelSleepTimer(userInitiated: userInitiated)
         sleepTimeRemaining = -1
         numberOfEpisodesToSleepAfter = 0
+        endSleepTimerLiveActivity()
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.sleepTimerChanged)
     }
 
@@ -1994,8 +1997,17 @@ class PlaybackManager: ServerPlaybackDelegate {
         FileLog.shared.addMessage("Sleep Timer: starting with \(stopIn)")
         sleepTimerManager.recordSleepTimerDuration(duration: stopIn, onEpisodeEnd: nil)
         sleepTimeRemaining = stopIn
+        startSleepTimerLiveActivity(duration: stopIn)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.sleepTimerChanged)
         Analytics.track(.playerSleepTimerEnabled, properties: ["time": Int(stopIn)])
+    }
+
+    func extendSleepTimer(by duration: TimeInterval) {
+        guard sleepTimeRemaining >= 0, duration > 0 else { return }
+
+        sleepTimeRemaining += duration
+        updateSleepTimerLiveActivity()
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.sleepTimerChanged)
     }
 
     func restartSleepTimer() {
@@ -2007,6 +2019,30 @@ class PlaybackManager: ServerPlaybackDelegate {
         Toast.show(L10n.deviceShakeSleepTimer)
         #endif
         sleepTimerManager.restartSleepTimer()
+    }
+
+    private func startSleepTimerLiveActivity(duration: TimeInterval) {
+        #if !APPCLIP && !os(watchOS) && !os(tvOS)
+            if #available(iOS 17.0, *) {
+                SleepTimerLiveActivityController.shared.startTimer(duration: duration, episode: currentEpisode())
+            }
+        #endif
+    }
+
+    private func updateSleepTimerLiveActivity() {
+        #if !APPCLIP && !os(watchOS) && !os(tvOS)
+            if #available(iOS 17.0, *) {
+                SleepTimerLiveActivityController.shared.updateTimer(durationRemaining: sleepTimeRemaining)
+            }
+        #endif
+    }
+
+    private func endSleepTimerLiveActivity() {
+        #if !APPCLIP && !os(watchOS) && !os(tvOS)
+            if #available(iOS 17.0, *) {
+                SleepTimerLiveActivityController.shared.endAll()
+            }
+        #endif
     }
 
     // MARK: - Remote Control support

--- a/podcasts/SiriShortcutsManager.swift
+++ b/podcasts/SiriShortcutsManager.swift
@@ -436,7 +436,7 @@ class SiriShortcutsManager: CustomObserver {
         guard let minutes = TimeInterval(exactly: addTime) else { return false }
         let sixtySeconds: TimeInterval = 1.minutes
         let addSeconds = sixtySeconds * minutes
-        PlaybackManager.shared.sleepTimeRemaining += addSeconds
+        PlaybackManager.shared.extendSleepTimer(by: addSeconds)
         return true
     }
 

--- a/podcasts/SleepTimerViewController.swift
+++ b/podcasts/SleepTimerViewController.swift
@@ -360,7 +360,7 @@ class SleepTimerViewController: SimpleNotificationsViewController {
     }
 
     @IBAction func plusFiveTapped(_ sender: Any) {
-        PlaybackManager.shared.sleepTimeRemaining += 5.minutes
+        PlaybackManager.shared.extendSleepTimer(by: 5.minutes)
         updateSleepRemainingTime()
         Analytics.track(.playerSleepTimerExtended, properties: ["amount": Int(5.minutes)])
     }

--- a/podcasts/podcasts-Info.plist
+++ b/podcasts/podcasts-Info.plist
@@ -1030,6 +1030,8 @@
 	<string>Pocket Casts needs permission to save this image to your photo library.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Pocket Casts needs permission to save this image to your photo library.</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>ChapterIntent</string>


### PR DESCRIPTION
Adds a Sleep Timer Live Activity so users can see the remaining sleep timer countdown from the Lock Screen and Dynamic Island.

The Live Activity starts when a timed sleep timer is enabled, updates when the timer is extended, and ends when the timer finishes or is cancelled. It also includes a `+ 5 Minutes` action so users can extend the
timer directly from the Live Activity. The Lock Screen presentation intentionally keeps the timer card focused on the countdown, since episode details are already shown in the system Now Playing card.

## To test

1. Build and run the app on an iOS 17+ simulator or device.
2. Start playing an episode.
3. Open the sleep timer and choose a timed duration, for example 30 minutes.
4. Lock the device.
5. Confirm the Sleep Timer Live Activity appears on the Lock Screen with the countdown.
6. Tap `+ 5 Minutes`.
7. Confirm the countdown increases by 5 minutes.
8. Unlock the device and cancel the sleep timer.
9. Lock the device again and confirm the Live Activity is dismissed.
10. Repeat with the Dynamic Island expanded and compact states on a supported simulator/device.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes. (not necessary)
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed
analytics.

No new analytics were added.