### PR TITLE
tvOS: refresh Home tab when data changes

### DIFF
--- a/Pocket Casts TV App/UI/Home/HomeViewModel.swift
+++ b/Pocket Casts TV App/UI/Home/HomeViewModel.swift
@@ -31,7 +31,6 @@ class HomeViewModel {
     func load() {
         Task {
             let podcasts = fetchPodcasts()
-            recentlyPlayed = Array(podcasts.shuffled().prefix(10))
             let upNextEpisodes = dataManager.allUpNextEpisodes()
             var newEpisodes = [EpisodeRowViewModel]()
             for podcast in podcasts.prefix(8) {
@@ -44,14 +43,13 @@ class HomeViewModel {
 
             await MainActor.run { [weak self] in
                 guard let self else { return }
+                recentlyPlayed = Array(podcasts.shuffled().prefix(10))
                 self.podcasts = podcasts
                 upNext = Array(upNextEpisodes.prefix(3)).map { episode in
                     self.makeRowViewModel(for: episode)
                 }
                 currentPlaying = upNext.first
-
                 newReleases = newEpisodes
-
                 state = .ready
             }
         }

--- a/Pocket Casts TV App/UI/Home/HomeViewModel.swift
+++ b/Pocket Casts TV App/UI/Home/HomeViewModel.swift
@@ -1,14 +1,17 @@
 import SwiftUI
 import Combine
 import PocketCastsDataModel
+import PocketCastsServer
 
 @Observable
 class HomeViewModel {
 
+    private var cancellables: Set<AnyCancellable> = []
     private let dataManager: DataManager
 
     init(dataManager: DataManager = DataManager.sharedManager) {
         self.dataManager = dataManager
+        observeDataChanges()
     }
 
     enum State: Equatable, Hashable {
@@ -61,5 +64,28 @@ class HomeViewModel {
     private func makeRowViewModel(for episode: BaseEpisode) -> EpisodeRowViewModel {
         let podcast = (episode as? Episode).flatMap { $0.parentPodcast(dataManager: dataManager) }
         return EpisodeRowViewModel(episode: episode, podcast: podcast)
+    }
+
+    private func observeDataChanges() {
+        let notificationsToObserve: [Notification.Name] = [
+            Constants.Notifications.podcastUpdated,
+            Constants.Notifications.podcastAdded,
+            Constants.Notifications.podcastDeleted,
+            Constants.Notifications.upNextQueueChanged,
+            Constants.Notifications.manyEpisodesChanged,
+            ServerNotifications.podcastsRefreshed,
+            ServerNotifications.syncCompleted
+        ]
+
+        let publishers = notificationsToObserve.map {
+            NotificationCenter.default.publisher(for: $0).map { _ in () }.eraseToAnyPublisher()
+        }
+
+        Publishers.MergeMany(publishers)
+            .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.load()
+            }
+            .store(in: &cancellables)
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

The tvOS `HomeViewModel` only refreshed its sections when `load()` was called explicitly (e.g. on appear), so podcast subscribe/unsubscribe, Up Next edits, episode changes, and server syncs would leave the Home tab stale until the user navigated away and back.

This change makes `HomeViewModel` observe the same notifications already used by `PodcastsViewModel` and `UpNextViewModel`, debounces them, and re-runs `load()` so the four Home sections (podcasts, recently played, current playing / Up Next, new releases) stay in sync with the rest of the app.

Observed notifications:
- `Constants.Notifications.podcastUpdated` / `podcastAdded` / `podcastDeleted`
- `Constants.Notifications.upNextQueueChanged`
- `Constants.Notifications.manyEpisodesChanged`
- `ServerNotifications.podcastsRefreshed`
- `ServerNotifications.syncCompleted`

## To test

1. Run the **Pocket Casts TV App** scheme on a tvOS simulator and sign in to an account with podcasts.
2. Open the **Home** tab and confirm it populates.
3. From the iOS app (or another logged-in client) signed in to the same account:
   - Subscribe to a new podcast → the new podcast appears in the tvOS Home sections after the next sync without leaving the tab.
   - Unsubscribe from a podcast → it disappears from Home sections without leaving the tab.
   - Add an episode to Up Next / reorder Up Next → the current playing + Up Next rows on Home update.
4. Trigger a server sync from the tvOS app (e.g. by relaunching or letting periodic sync run) and confirm Home reloads automatically.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.