### PR TITLE
Add support for showing OptionsPicker as a native sheet

### DIFF
--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1294,7 +1294,6 @@
 		FF32F3CB2FAB7CDF00226E58 /* ColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9A43ED1D067AF20012FD9B /* ColorManager.swift */; };
 		FF32F3CD2FAB7E1F00226E58 /* PlaybackActionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD6297E200EE26200168DF7 /* PlaybackActionHelper.swift */; };
 		FF32F3CE2FAB7F8E00226E58 /* HapticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD48D5A5216DB26A00391F9E /* HapticsHelper.swift */; };
-		FF32F3D52FAB80F200226E58 /* OptionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB5F0C42045036200437669 /* OptionAction.swift */; };
 		FF32F3D82FAB830100226E58 /* PlaylistArtworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9004BD2E27A2A1005879CB /* PlaylistArtworkView.swift */; };
 		FF32F3DA2FAB834500226E58 /* PlaylistDetailViewModel+Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A66BE602E968794007516A5 /* PlaylistDetailViewModel+Archive.swift */; };
 		FF32F3DB2FAB838900226E58 /* PlaylistDetailFetchOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD809AE2EA12D850050649B /* PlaylistDetailFetchOperation.swift */; };
@@ -7796,7 +7795,6 @@
 				FF6033FD2FAB4C9700EB3AD5 /* EpisodesDataManager.swift in Sources */,
 				FF8FFE612FAA63750086A867 /* Enumerations.swift in Sources */,
 				FF8FFE652FAA8E5B0086A867 /* PodcastChapterParser.swift in Sources */,
-				FF32F3D52FAB80F200226E58 /* OptionAction.swift in Sources */,
 				FF8FFE6B2FAA8EA00086A867 /* Chapters.swift in Sources */,
 				FF32F3CE2FAB7F8E00226E58 /* HapticsHelper.swift in Sources */,
 				FF8FFE4A2FAA4B6D0086A867 /* FileTypeUtil.swift in Sources */,

--- a/podcasts/DescriptiveActionView.swift
+++ b/podcasts/DescriptiveActionView.swift
@@ -155,8 +155,15 @@ class DescriptiveActionView: UIView {
         config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 24, bottom: 12, trailing: 24)
 
         let actionButton = UIButton(configuration: config, primaryAction: UIAction(title: action.label, handler: { [weak self] _ in
-            action.action()
-            self?.delegate?.animateOut(optionChosen: true)
+            if self?.delegate?.isPresentedAsSheet == true {
+                // Dismiss the sheet before running the action so an action that
+                // presents another screen doesn't hit "already presenting".
+                self?.delegate?.animateOut(optionChosen: true)
+                action.action()
+            } else {
+                action.action()
+                self?.delegate?.animateOut(optionChosen: true)
+            }
         }))
         actionButton.configurationUpdateHandler = { button in
             var config = button.configuration
@@ -183,8 +190,15 @@ class DescriptiveActionView: UIView {
         actionButton.isOn = !action.outline
         actionButton.setup()
         actionButton.buttonTapped = { [weak self] in
-            action.action()
-            self?.delegate?.animateOut(optionChosen: true)
+            if self?.delegate?.isPresentedAsSheet == true {
+                // Dismiss the sheet before running the action so an action that
+                // presents another screen doesn't hit "already presenting".
+                self?.delegate?.animateOut(optionChosen: true)
+                action.action()
+            } else {
+                action.action()
+                self?.delegate?.animateOut(optionChosen: true)
+            }
         }
         return actionButton
     }

--- a/podcasts/OptionAction.swift
+++ b/podcasts/OptionAction.swift
@@ -10,6 +10,10 @@ class OptionAction {
     var outline = false
     var onOffAction = false
     var tintIcon: Bool = true
+    /// When set, tapping the action presents the returned picker as a submenu
+    /// on top of the current one. Choosing an option in the submenu dismisses
+    /// both. The closure is evaluated lazily, only when the action is tapped.
+    var submenu: (() -> OptionsPicker?)?
 
     init(label: String, secondaryLabel: String? = nil, icon: String? = nil, tintIcon: Bool = true, selected: Bool = false, action: @escaping (() -> Void)) {
         self.label = label

--- a/podcasts/OptionsPicker.swift
+++ b/podcasts/OptionsPicker.swift
@@ -63,6 +63,26 @@ class OptionsPicker {
         rootController.animateIn()
     }
 
+    /// Presents the options using a native, self-sizing sheet from the given
+    /// view controller. The sheet's height is adjusted to fit the available
+    /// options, capped at the screen height. If `presentingViewController`
+    /// already has something presented (e.g. another options sheet), this is
+    /// stacked on top of it rather than replacing it.
+    func present(from presentingViewController: UIViewController) {
+        guard let optionsController else { return }
+        optionsController.modalPresentationStyle = .formSheet
+        if let sheet = optionsController.sheetPresentationController {
+            optionsController.configureForSheetPresentation()
+            sheet.delegate = optionsController
+            sheet.prefersGrabberVisible = true
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+            sheet.detents = [.custom { [weak optionsController] context in
+                optionsController?.preferredSheetHeight(limitedTo: context.maximumDetentValue, traitCollection: context.containerTraitCollection) ?? context.maximumDetentValue
+            }]
+        }
+        presentingViewController.present(optionsController, animated: true)
+    }
+
     func controllerDidAnimateOut(optionChosen: Bool) {
         if let noActionCallback, !optionChosen {
             noActionCallback()

--- a/podcasts/OptionsPicker.swift
+++ b/podcasts/OptionsPicker.swift
@@ -65,9 +65,7 @@ class OptionsPicker {
 
     /// Presents the options using a native, self-sizing sheet from the given
     /// view controller. The sheet's height is adjusted to fit the available
-    /// options, capped at the screen height. If `presentingViewController`
-    /// already has something presented (e.g. another options sheet), this is
-    /// stacked on top of it rather than replacing it.
+    /// options, capped at the screen height.
     func present(from presentingViewController: UIViewController) {
         guard let optionsController else { return }
         optionsController.modalPresentationStyle = .formSheet

--- a/podcasts/OptionsPickerRootController.swift
+++ b/podcasts/OptionsPickerRootController.swift
@@ -43,7 +43,7 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
     private weak var dismissView: UIView?
     private(set) var isPresentedAsSheet = false
 
-    private let sheetTopPadding: CGFloat = 20
+    private let sheetTopPadding: CGFloat = LiquidGlass.isEnabled ? 20 : 12
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         overrideStatusBarStyle
@@ -215,8 +215,12 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
     func configureForSheetPresentation() {
         isPresentedAsSheet = true
 
-        view.backgroundColor = scrollView.backgroundColor?.withAlphaComponent(0.85)
-        scrollView.backgroundColor = .clear
+        if LiquidGlass.isEnabled {
+            view.backgroundColor = scrollView.backgroundColor?.withAlphaComponent(0.85)
+            scrollView.backgroundColor = .clear
+        } else {
+            view.backgroundColor = scrollView.backgroundColor
+        }
         view.layer.cornerRadius = 0
         dismissView?.isHidden = true
 

--- a/podcasts/OptionsPickerRootController.swift
+++ b/podcasts/OptionsPickerRootController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate {
+class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate, UISheetPresentationControllerDelegate {
 
     struct Colors {
         let title: UIColor
@@ -38,6 +38,12 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
     private var scrollViewBottomAnchor: NSLayoutConstraint?
     private var scrollViewTopAnchor: NSLayoutConstraint?
     private var scrollViewHeightConstraint: NSLayoutConstraint?
+    private var scrollViewMaxHeightConstraint: NSLayoutConstraint?
+
+    private weak var dismissView: UIView?
+    private(set) var isPresentedAsSheet = false
+
+    private let sheetTopPadding: CGFloat = 20
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         overrideStatusBarStyle
@@ -83,6 +89,7 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         // but is capped at the available vertical space so it never overflows.
         let maxHeightConstraint = scrollView.heightAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.heightAnchor, constant: -75)
         maxHeightConstraint.priority = .required
+        scrollViewMaxHeightConstraint = maxHeightConstraint
 
         // A lower-priority constraint makes the scroll view shrink-wrap its content
         // so it doesn't scroll when all content fits on screen.
@@ -103,6 +110,7 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         dismissView.backgroundColor = UIColor.clear
         dismissView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(dismissView)
+        self.dismissView = dismissView
 
         dismissView.isAccessibilityElement = true
         dismissView.accessibilityLabel = L10n.accessibilityDismiss
@@ -200,6 +208,44 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         ])
     }
 
+    // MARK: - Native Sheet Presentation
+
+    /// Reconfigures the layout so the content fills a natively-presented sheet
+    /// instead of animating in as a bottom card over a dimmed window.
+    func configureForSheetPresentation() {
+        isPresentedAsSheet = true
+
+        view.backgroundColor = scrollView.backgroundColor?.withAlphaComponent(0.85)
+        scrollView.backgroundColor = .clear
+        view.layer.cornerRadius = 0
+        dismissView?.isHidden = true
+
+        scrollViewTopAnchor?.isActive = false
+        scrollViewMaxHeightConstraint?.isActive = false
+        scrollViewHeightConstraint?.isActive = false
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor, constant: sheetTopPadding),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    /// The height needed to show every option without scrolling, capped at `maxHeight`.
+    func preferredSheetHeight(limitedTo maxHeight: CGFloat, traitCollection: UITraitCollection) -> CGFloat {
+        let contentHeight = stackView.systemLayoutSizeFitting(
+            CGSize(width: 320, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        ).height
+        return min(contentHeight + sheetTopPadding, maxHeight)
+    }
+
+    // MARK: - UISheetPresentationControllerDelegate
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        delegate?.controllerDidAnimateOut(optionChosen: false)
+    }
+
     // MARK: - Animate in/out
 
     func animateIn() {
@@ -215,6 +261,25 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
     }
 
     func animateOut(optionChosen: Bool) {
+        if isPresentedAsSheet {
+            // Collect this picker and any parent pickers it was stacked on
+            // (e.g. the root menu under a submenu). Dismissing the bottom-most
+            // one collapses the whole stack in a single animation, so choosing
+            // a submenu option closes both sheets.
+            var pickers = [self]
+            var presenter = presentingViewController
+            while let parentPicker = presenter as? OptionsPickerRootController {
+                pickers.append(parentPicker)
+                presenter = parentPicker.presentingViewController
+            }
+            presenter?.dismiss(animated: true) {
+                for picker in pickers {
+                    picker.delegate?.controllerDidAnimateOut(optionChosen: optionChosen)
+                }
+            }
+            return
+        }
+
         view?.layoutIfNeeded()
         UIView.animate(withDuration: Constants.Animation.bottomCardAnimationTime, animations: { [weak self] in
             self?.scrollViewBottomAnchor?.isActive = false

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController+Search.swift
@@ -41,7 +41,7 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
         searchController.searchDelegate = self
     }
 
-    func showSortOrderOptions() {
+    func makeSortOrderOptionsPicker() -> OptionsPicker {
         let options = OptionsPicker(title: L10n.sortBy.localizedUppercase)
 
         let sortOption: LibrarySort
@@ -105,7 +105,7 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
             options.addAction(action: dragAndDropAction)
         }
 
-        options.show(statusBarStyle: preferredStatusBarStyle)
+        return options
     }
 
     // MARK: - PCSearchBarDelegate

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -356,10 +356,10 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         } else {
             Settings.homeFolderSortOrder()
         }
-        let sortAction = OptionAction(label: L10n.sortBy, secondaryLabel: sortOption.description, icon: "podcast-sort") { [weak self] in
-            self?.showSortOrderOptions()
+        let sortAction = OptionAction(label: L10n.sortBy, secondaryLabel: sortOption.description, icon: "podcast-sort") {
             Analytics.track(.podcastsListModalOptionTapped, properties: ["option": "sort_by"])
         }
+        sortAction.submenu = { [weak self] in self?.makeSortOrderOptionsPicker() }
         optionsPicker.addAction(action: sortAction)
 
         let largeGridAction = OptionAction(label: L10n.podcastsLargeGrid, icon: "podcastlist_largegrid", selected: Settings.libraryType() == .threeByThree) { [weak self] in
@@ -383,10 +383,10 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         optionsPicker.addSegmentedAction(name: L10n.podcastsLayout, icon: "podcastlist_largegrid", actions: [largeGridAction, smallGridAction, listGridAction])
 
         let badgeType = Settings.podcastBadgeType()
-        let badgesAction = OptionAction(label: L10n.podcastsBadges, secondaryLabel: badgeType.description, icon: "badges") { [weak self] in
-            self?.showBadgeOptions()
+        let badgesAction = OptionAction(label: L10n.podcastsBadges, secondaryLabel: badgeType.description, icon: "badges") {
             Analytics.track(.podcastsListModalOptionTapped, properties: ["option": "badges"])
         }
+        badgesAction.submenu = { [weak self] in self?.makeBadgeOptionsPicker() }
         optionsPicker.addAction(action: badgesAction)
 
         let shareAction = OptionAction(label: L10n.podcastsShare, icon: "podcast-share") {
@@ -404,7 +404,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         }
         optionsPicker.addAction(action: editAction)
 
-        optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
+        optionsPicker.present(from: self)
 
         Analytics.track(.podcastsListOptionsButtonTapped)
     }
@@ -436,7 +436,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         adjustSettingsForGridType()
     }
 
-    private func showBadgeOptions() {
+    private func makeBadgeOptionsPicker() -> OptionsPicker {
         let options = OptionsPicker(title: L10n.podcastsBadges.localizedUppercase)
 
         let badgeOption = Settings.podcastBadgeType()
@@ -468,7 +468,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         }
         options.addAction(action: unplayedCountAction)
 
-        options.show(statusBarStyle: preferredStatusBarStyle)
+        return options
     }
 
     override func handleThemeChanged() {

--- a/podcasts/SimpleActionView.swift
+++ b/podcasts/SimpleActionView.swift
@@ -156,13 +156,23 @@ class SimpleActionView: UIView {
     }
 
     @objc private func actionTapped() {
-        action.action()
-
         if action.onOffAction {
+            action.action()
             guard let onOffSwitch else { return }
 
             onOffSwitch.isOn = !onOffSwitch.isOn
+        } else if let submenu = action.submenu?(), let delegate {
+            action.action()
+            submenu.present(from: delegate)
+        } else if delegate?.isPresentedAsSheet == true {
+            // The sheet is a real presented view controller. Start its
+            // dismissal *before* running the action so that an action which
+            // presents another screen doesn't hit "already presenting" — this
+            // lets UIKit serialize the dismiss and the new presentation.
+            delegate?.animateOut(optionChosen: true)
+            action.action()
         } else {
+            action.action()
             delegate?.animateOut(optionChosen: true)
         }
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Add support for showing `OptionsPicker` as a native sheet and integrate it on the "Podcasts" screen ("more" menu).

There are a couple of advantages:

- Nicer visual appearance and animations, feel more native
- Submenus are presented faster as they no longer need to wait for the dismissal of the parent menu
- The system automatically disabled the glass buttons in the presenting view controller so they don’t stick out
- No longer need to pass the status bar appearance

I plan to adopt it one at a time because due to the changes to presentation, not every action might translate well and continue to work.

## To test

- In "Podcasts" tap "More"
- Verify that ALL actions still work

## Screenshots

https://github.com/user-attachments/assets/59c9d936-41a4-4f67-ab61-80f0e7f966f4


==

The menu retains the custom themable style and the custom controls.

<img width="340"  alt="Screenshot 2026-05-18 at 10 56 29 AM" src="https://github.com/user-attachments/assets/bd8affdf-e5b0-442a-a643-18599d2314e4" />

The iPad version is also a slight improvement over production. Ideally, should be a popover, but limiting the scope for now.

<img width="360" alt="Screenshot 2026-05-18 at 10 24 06 AM" src="https://github.com/user-attachments/assets/a8cf7d25-00f3-486a-abac-7b9fd93fbe3d" />
<img width="360" alt="Screenshot 2026-05-18 at 10 26 45 AM" src="https://github.com/user-attachments/assets/0ff5d675-e90f-4bd2-8be9-1b05dbe3f5bc" />


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
