### PR TITLE
Liquid Glass: Show chapter instead of title when available

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -332,6 +332,9 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         addCustomObserver(Constants.Notifications.themeChanged, selector: #selector(themeChanged))
         addCustomObserver(Constants.Notifications.currentlyPlayingEpisodeUpdated, selector: #selector(updateRequired))
+
+        addCustomObserver(Constants.Notifications.podcastChapterChanged, selector: #selector(chapterDidChange))
+        addCustomObserver(Constants.Notifications.podcastChaptersDidUpdate, selector: #selector(chapterDidChange))
     }
 
     func rootViewController() -> MainTabBarController? {
@@ -363,9 +366,29 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             podcastArtwork.setBaseEpisode(episode: episode, size: .list)
         }
 
-        if let episodeTitleLabel, episodeTitleLabel.text != episode.title {
-            episodeTitleLabel.text = episode.title
+        updateTitle(for: episode)
+    }
+
+    /// Shows the current chapter title when the episode has chapters, falling
+    /// back to the episode title otherwise — matching the full screen player.
+    private func updateTitle(for episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) {
+        guard let episodeTitleLabel, let episode else { return }
+
+        let chapters = PlaybackManager.shared.currentChapters()
+        let newTitle: String?
+        if PlaybackManager.shared.chapterCount() != 0, chapters.visibleChapter != nil, !chapters.title.isEmpty {
+            newTitle = chapters.title
+        } else {
+            newTitle = episode.title
         }
+
+        if episodeTitleLabel.text != newTitle {
+            episodeTitleLabel.text = newTitle
+        }
+    }
+
+    @objc private func chapterDidChange() {
+        updateTitle()
     }
 
     @objc private func playbackStarted() {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

The new behavior matches what full player shows and other apps prioritize.

<img width="360"  alt="Screenshot 2026-05-18 at 1 47 21 PM" src="https://github.com/user-attachments/assets/b85c4e18-1a2e-45b1-9574-ff201ed75003" />
<img width="360" alt="Screenshot 2026-05-18 at 1 47 24 PM" src="https://github.com/user-attachments/assets/5b2771ff-a177-47c0-a7d4-6651f6909f15" />

## To test

- Play a podcast with chapters
- Verify that the mini player shows them

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
