### PR TITLE
Liquid Glass: Connect buffering

### DIFF
--- a/podcasts/Common Components/Progress Views/ProgressLine.swift
+++ b/podcasts/Common Components/Progress Views/ProgressLine.swift
@@ -21,7 +21,7 @@ class ProgressLine: UIView {
         }
     }
 
-    var buferredAmount: CGFloat = 0 {
+    var bufferedAmount: CGFloat = 0 {
         didSet {
             recalculatePositionRects(true)
         }
@@ -60,10 +60,10 @@ class ProgressLine: UIView {
 
         progressLayer().bgRect = CGRect(x: 0, y: 0, width: availableWidth, height: lineHeight)
         progressLayer().progressRect = CGRect(x: 0, y: 0, width: progressSize, height: lineHeight)
-        if buferredAmount == 0 {
+        if bufferedAmount == 0 {
             progressLayer().bufferRect = CGRect.zero
         } else {
-            progressLayer().bufferRect = CGRect(x: progressSize, y: 0, width: (availableWidth - progressSize) * buferredAmount, height: lineHeight)
+            progressLayer().bufferRect = CGRect(x: progressSize, y: 0, width: (availableWidth - progressSize) * bufferedAmount, height: lineHeight)
         }
 
         if !animated {

--- a/podcasts/MiniPlayerGlassProgressView.swift
+++ b/podcasts/MiniPlayerGlassProgressView.swift
@@ -54,8 +54,8 @@ final class MiniPlayerGlassProgressView: UIView {
         applyTintColor()
     }
 
-    private static let trackColor = UIColor.gray.withAlphaComponent(0.27)
-    private static let bufferColor = UIColor.gray.withAlphaComponent(0.32)
+    private static let trackColor = UIColor.gray.withAlphaComponent(0.28)
+    private static let bufferColor = UIColor.gray.withAlphaComponent(0.30)
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -445,6 +445,14 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         glassProgressView?.playbackProgress = progress
         glassProgressView?.indeterminate = isIndeterminate
+        // ProgressLine draws the buffer relative to the remaining track, but the
+        // glass view's buffer layer is an absolute 0...1 fraction of the whole
+        // track, so express how far buffering reaches from the start instead.
+        if amountBuferred > 0, duration > 0 {
+            glassProgressView?.bufferedAmount = CGFloat((currentTime + amountBuferred) / duration)
+        } else {
+            glassProgressView?.bufferedAmount = 0
+        }
 
         if let episodeTimeLeftLabel {
             let remaining = max(0, duration - currentTime)

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -445,13 +445,9 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         glassProgressView?.playbackProgress = progress
         glassProgressView?.indeterminate = isIndeterminate
-        // ProgressLine draws the buffer relative to the remaining track, but the
-        // glass view's buffer layer is an absolute 0...1 fraction of the whole
-        // track, so express how far buffering reaches from the start instead.
-        if amountBuferred > 0, duration > 0 {
-            glassProgressView?.bufferedAmount = CGFloat((currentTime + amountBuferred) / duration)
-        } else {
-            glassProgressView?.bufferedAmount = 0
+
+        if amountBuferred > 0 {
+            glassProgressView?.bufferedAmount = CGFloat(amountBuferred / (duration - currentTime))
         }
 
         if let episodeTimeLeftLabel {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -438,16 +438,16 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         playbackProgressView.progress = progress
         playbackProgressView.indeterminant = isIndeterminate
 
-        let amountBuferred = PlaybackManager.shared.futureBufferAvailable()
-        if amountBuferred > 0 {
-            playbackProgressView.buferredAmount = CGFloat(amountBuferred / (duration - currentTime))
+        let amountBuffered = PlaybackManager.shared.futureBufferAvailable()
+        if amountBuffered > 0 {
+            playbackProgressView.bufferedAmount = CGFloat(amountBuffered / (duration - currentTime))
         }
 
         glassProgressView?.playbackProgress = progress
         glassProgressView?.indeterminate = isIndeterminate
 
-        if amountBuferred > 0 {
-            glassProgressView?.bufferedAmount = CGFloat(amountBuferred / (duration - currentTime))
+        if amountBuffered > 0 {
+            glassProgressView?.bufferedAmount = CGFloat(amountBuffered / (duration - currentTime))
         }
 
         if let episodeTimeLeftLabel {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Enables showing buffering in the mini player. 

**Note**: it might be a bit misleading as it shows what `AVPlayer` buffered and not what was actually downloaded, but it's consistent with how the current mini player works, and can be improved later.

https://github.com/user-attachments/assets/814d516b-1e3b-4a3e-816a-c9ea0153b2e9


## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
