### PR TITLE
Liquid Glass: Add Up Next animations

### DIFF
--- a/podcasts/Main/MainTabBarController+Alert.swift
+++ b/podcasts/Main/MainTabBarController+Alert.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension MainTabBarController {
     func presentLoader() {
         DispatchQueue.main.async { [weak self] in

--- a/podcasts/Main/MainTabBarController+Animations.swift
+++ b/podcasts/Main/MainTabBarController+Animations.swift
@@ -8,11 +8,11 @@ extension MainTabBarController {
     /// The queue count knocked out of a continuous capsule with the "list"
     /// lines beside it, as a template image the tab bar tints like every other item.
     static func composeUpNextTabImage(count: Int) -> UIImage? {
-        let clamped = min(999, max(1, count))
+        let clamped = min(99, max(1, count))
 
         // Fixed at the widest (3-digit) size so the tab image never resizes.
         let canvasSize = CGSize(
-            width: ceil(upNextBadgeLayout(count: 100, origin: .zero).size.width),
+            width: ceil(upNextBadgeLayout(count: 99, origin: .zero).size.width),
             height: 26)
         let content = upNextBadgeLayout(count: clamped, origin: .zero).size
         let origin = CGPoint(

--- a/podcasts/Main/MainTabBarController+Animations.swift
+++ b/podcasts/Main/MainTabBarController+Animations.swift
@@ -26,7 +26,7 @@ extension MainTabBarController {
             let cg = context.cgContext
 
             UIColor.black.setFill()
-            UIBezierPath(roundedRect: layout.capsule, cornerRadius: layout.capsule.height / 2).fill()
+            UIBezierPath(roundedRect: layout.capsule, cornerRadius: layout.capsule.height).fill()
 
             let countAsStr = "\(clamped)" as NSString
             let textAttributes: [NSAttributedString.Key: Any] = [.font: layout.font, .foregroundColor: UIColor.black]
@@ -57,8 +57,8 @@ extension MainTabBarController {
     }
 
     private static func upNextBadgeLayout(count: Int, origin: CGPoint) -> UpNextBadgeLayout {
-        let height: CGFloat = 22
-        let horizontalPadding: CGFloat = 7
+        let height: CGFloat = 20
+        let horizontalPadding: CGFloat = 5
         let gap: CGFloat = 2
         let lineCount = 3
         // The shortest (vertically centered) line; off-center lines stretch
@@ -67,7 +67,9 @@ extension MainTabBarController {
         let lineThickness: CGFloat = 2
         let lineSpacing: CGFloat = 4
 
-        let font = UIFont.monospacedDigitSystemFont(ofSize: count > 99 ? 10 : 11, weight: .bold)
+        // Matches the full player's Up Next button (UpNextButton): 13pt for
+        // 1–2 digits, 11pt once it spills to 3.
+        let font = UIFont.monospacedDigitSystemFont(ofSize: count > 99 ? 11 : 13, weight: .bold)
         let textWidth = ("\(count)" as NSString).size(withAttributes: [.font: font]).width
         // A stadium shape: floor at a circle for a single digit, but let two or
         // more digits stretch into the oblong pill the design calls for.
@@ -140,7 +142,7 @@ extension MainTabBarController {
         }
 
         // No target, or an animation already in flight: just update the count.
-        guard let targetFrame = upNextTabButtonFrame(in: view),
+        guard let targetFrame = upNextTabTargetFrame(in: view),
               view.viewWithTag(Self.upNextGenieViewTag) == nil else {
             refreshUpNextTabBadge()
             return
@@ -179,7 +181,7 @@ extension MainTabBarController {
         // Phase 1: pop in, hovering just above the Up Next tab.
         container.alpha = 0
         container.transform = CGAffineTransform(scaleX: 0.6, y: 0.6)
-        UIView.animate(withDuration: 0.28, delay: 0, usingSpringWithDamping: 0.68, initialSpringVelocity: 0.4, options: [.allowUserInteraction, .curveEaseOut], animations: {
+        UIView.animate(withDuration: 0.2, delay: 0, usingSpringWithDamping: 0.68, initialSpringVelocity: 0.4, options: [.allowUserInteraction, .curveEaseOut], animations: {
             container.alpha = 1
             container.transform = .identity
         }, completion: { _ in
@@ -189,7 +191,7 @@ extension MainTabBarController {
     }
 
     func runUpNextGenieSuck(on container: UIView, from start: CGPoint, to target: CGPoint) {
-        let duration: CFTimeInterval = 0.45
+        let duration: CFTimeInterval = 0.32
 
         let path = UIBezierPath()
         path.move(to: start)
@@ -232,6 +234,25 @@ extension MainTabBarController {
         }
     }
 
+    /// The on-screen frame of the Up Next tab in `target`'s coordinate space,
+    /// measured from the real (private) tab-button views so the genie lands
+    /// exactly where `pulseUpNextTabButton` fires. Falls back to an even split
+    /// of the tab bar only when those views can't be located.
+    func upNextTabTargetFrame(in target: UIView) -> CGRect? {
+        if #available(iOS 26.0, *) {
+            let buttons = upNextTabButtonViews()
+            if let first = buttons.first {
+                let frame = buttons.dropFirst().reduce(first.convert(first.bounds, to: target)) {
+                    $0.union($1.convert($1.bounds, to: target))
+                }
+                if !frame.isNull, frame.width > 0, frame.height > 0 {
+                    return frame
+                }
+            }
+        }
+        return upNextTabButtonFrame(in: target)
+    }
+
     func upNextTabButtonFrame(in target: UIView) -> CGRect? {
         guard let index = pcTabs.firstIndex(of: .upNext) else { return nil }
 
@@ -248,8 +269,12 @@ extension MainTabBarController {
     /// just silently re-rendered.
     @available(iOS 26.0, *)
     func pulseUpNextTabButton() {
+        // A burst of rapid adds shouldn't stack overlapping springs on the
+        // (private) button views — one pop already conveys "queue grew".
+        guard !isPulsingUpNextTab else { return }
         let buttons = upNextTabButtonViews()
         guard !buttons.isEmpty else { return }
+        isPulsingUpNextTab = true
 
         // A snappy, bounce-free grow, then a single softly springy settle.
         // The grow is short enough that the peak isn't visibly held, and one
@@ -257,10 +282,12 @@ extension MainTabBarController {
         UIView.animate(springDuration: 0.15, bounce: 0, initialSpringVelocity: 0,
                        options: [.allowUserInteraction]) {
             buttons.forEach { $0.transform = CGAffineTransform(scaleX: 1.15, y: 1.15) }
-        } completion: { _ in
+        } completion: { [weak self] _ in
             UIView.animate(springDuration: 0.45, bounce: 0.28, initialSpringVelocity: 0,
                            options: [.allowUserInteraction]) {
                 buttons.forEach { $0.transform = .identity }
+            } completion: { _ in
+                self?.isPulsingUpNextTab = false
             }
         }
     }

--- a/podcasts/Main/MainTabBarController+Animations.swift
+++ b/podcasts/Main/MainTabBarController+Animations.swift
@@ -122,7 +122,23 @@ extension MainTabBarController {
         }
     }
 
+    /// `true` while the iOS 26 liquid-glass tab bar is collapsed into its
+    /// compact pill. There's no public "is minimized" API, but UIKit sets the
+    /// bottom accessory's `tabAccessoryEnvironment` trait to `.inline` exactly
+    /// while the tab bar is minimized, so we read it back off the mini player.
+    private var isTabBarMinimized: Bool {
+        guard #available(iOS 26.0, *) else { return false }
+        return bottomAccessory?.contentView.traitCollection.tabAccessoryEnvironment == .inline
+    }
+
     func playUpNextAddedGenieAnimation(for episode: BaseEpisode) {
+        // Tab bar collapsed into its pill: there's no Up Next tab on screen to
+        // fly into, so skip the animation and just keep the count current.
+        guard !isTabBarMinimized else {
+            refreshUpNextTabBadge()
+            return
+        }
+
         // No target, or an animation already in flight: just update the count.
         guard let targetFrame = upNextTabButtonFrame(in: view),
               view.viewWithTag(Self.upNextGenieViewTag) == nil else {

--- a/podcasts/Main/MainTabBarController+Animations.swift
+++ b/podcasts/Main/MainTabBarController+Animations.swift
@@ -1,0 +1,295 @@
+import PocketCastsDataModel
+import PocketCastsUtils
+import UIKit
+
+// MARK: - Up Next tab image
+
+extension MainTabBarController {
+    /// The queue count knocked out of a continuous capsule with the "list"
+    /// lines beside it, as a template image the tab bar tints like every other item.
+    static func composeUpNextTabImage(count: Int) -> UIImage? {
+        let clamped = min(999, max(1, count))
+
+        // Fixed at the widest (3-digit) size so the tab image never resizes.
+        let canvasSize = CGSize(
+            width: ceil(upNextBadgeLayout(count: 100, origin: .zero).size.width),
+            height: 26)
+        let content = upNextBadgeLayout(count: clamped, origin: .zero).size
+        let origin = CGPoint(
+            x: ((canvasSize.width - content.width) / 2).rounded(),
+            y: ((canvasSize.height - content.height) / 2).rounded()
+        )
+        let layout = upNextBadgeLayout(count: clamped, origin: origin)
+        let secondaryShadeAlpha: CGFloat = 0.45
+
+        return UIGraphicsImageRenderer(size: canvasSize).image { context in
+            let cg = context.cgContext
+
+            UIColor.black.setFill()
+            UIBezierPath(roundedRect: layout.capsule, cornerRadius: layout.capsule.height / 2).fill()
+
+            let countAsStr = "\(clamped)" as NSString
+            let textAttributes: [NSAttributedString.Key: Any] = [.font: layout.font, .foregroundColor: UIColor.black]
+            let textSize = countAsStr.size(withAttributes: textAttributes)
+            cg.saveGState()
+            cg.setBlendMode(.destinationOut)
+            countAsStr.draw(
+                at: CGPoint(
+                    x: layout.capsule.midX - textSize.width / 2,
+                    y: layout.capsule.midY - textSize.height / 2),
+                withAttributes: textAttributes
+            )
+            cg.restoreGState()
+
+            UIColor.black.withAlphaComponent(secondaryShadeAlpha).setFill()
+            for line in layout.lines {
+                UIBezierPath(roundedRect: line, cornerRadius: line.height / 2).fill()
+            }
+        }
+        .withRenderingMode(.alwaysTemplate)
+    }
+
+    private struct UpNextBadgeLayout {
+        let font: UIFont
+        let capsule: CGRect
+        let lines: [CGRect]
+        let size: CGSize
+    }
+
+    private static func upNextBadgeLayout(count: Int, origin: CGPoint) -> UpNextBadgeLayout {
+        let height: CGFloat = 22
+        let horizontalPadding: CGFloat = 7
+        let gap: CGFloat = 2
+        let lineCount = 3
+        // The shortest (vertically centered) line; off-center lines stretch
+        // further left to track the capsule's rounded cap, see below.
+        let baseLineWidth: CGFloat = 10
+        let lineThickness: CGFloat = 2
+        let lineSpacing: CGFloat = 4
+
+        let font = UIFont.monospacedDigitSystemFont(ofSize: count > 99 ? 10 : 11, weight: .bold)
+        let textWidth = ("\(count)" as NSString).size(withAttributes: [.font: font]).width
+        // A stadium shape: floor at a circle for a single digit, but let two or
+        // more digits stretch into the oblong pill the design calls for.
+        let capsuleWidth = max(height, (textWidth + horizontalPadding * 2).rounded())
+        let capsule = CGRect(x: origin.x, y: origin.y, width: capsuleWidth, height: height)
+
+        let linesBlockHeight = lineThickness * CGFloat(lineCount) + lineSpacing * CGFloat(lineCount - 1)
+        let firstLineY = (origin.y + (height - linesBlockHeight) / 2).rounded()
+
+        // The capsule's right end is a semicircular cap, so a line stacked
+        // above or below center meets the badge further left than the middle
+        // one does. Walk each line's start out along that arc and stretch it to
+        // a shared right edge, so every line keeps the same visual gap from the
+        // curved badge (middle line shortest, top and bottom longer).
+        let capRadius = height / 2
+        let capSpineX = capsule.maxX - capRadius
+        let rightEdge = capsule.maxX + gap + baseLineWidth
+        var lines: [CGRect] = []
+        for index in 0..<lineCount {
+            let lineY = firstLineY + CGFloat(index) * (lineThickness + lineSpacing)
+            let dy = min(capRadius, abs(lineY + lineThickness / 2 - capsule.midY))
+            let pillEdgeX = capSpineX + (capRadius * capRadius - dy * dy).squareRoot()
+            let lineX = pillEdgeX + gap
+            lines.append(CGRect(x: lineX, y: lineY, width: rightEdge - lineX, height: lineThickness))
+        }
+
+        return UpNextBadgeLayout(
+            font: font,
+            capsule: capsule,
+            lines: lines,
+            size: CGSize(width: capsuleWidth + gap + baseLineWidth, height: height)
+        )
+    }
+}
+
+// MARK: - Up Next "genie" add animation
+
+extension MainTabBarController {
+    static let upNextGenieViewTag = 776_611
+
+    @objc func animateEpisodeAddedToUpNext(_ notification: Notification) {
+        guard FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) else { return }
+        guard let episodeUuid = notification.object as? String,
+              let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else {
+            // Nothing to animate — just keep the count current.
+            DispatchQueue.main.async { [weak self] in self?.refreshUpNextTabBadge() }
+            return
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.playUpNextAddedGenieAnimation(for: episode)
+        }
+    }
+
+    func playUpNextAddedGenieAnimation(for episode: BaseEpisode) {
+        // No target, or an animation already in flight: just update the count.
+        guard let targetFrame = upNextTabButtonFrame(in: view),
+              view.viewWithTag(Self.upNextGenieViewTag) == nil else {
+            refreshUpNextTabBadge()
+            return
+        }
+
+        let artworkSize: CGFloat = 64
+        let cornerRadius: CGFloat = 14
+        let target = CGPoint(x: targetFrame.midX, y: targetFrame.midY)
+        let start = CGPoint(x: target.x, y: targetFrame.minY - 24)
+
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: artworkSize, height: artworkSize))
+        container.tag = Self.upNextGenieViewTag
+        container.center = start
+        container.isUserInteractionEnabled = false
+        container.layer.cornerRadius = cornerRadius
+        container.layer.cornerCurve = .continuous
+        container.layer.shadowColor = UIColor.black.cgColor
+        container.layer.shadowOpacity = 0.3
+        container.layer.shadowRadius = 12
+        container.layer.shadowOffset = CGSize(width: 0, height: 6)
+
+        // A plain image view, not `PodcastImageView`, which re-rounds its inner
+        // image view with a circular curve and clobbers the continuous corner.
+        let artwork = UIImageView(frame: container.bounds)
+        artwork.contentMode = .scaleAspectFill
+        artwork.clipsToBounds = true
+        artwork.layer.cornerRadius = cornerRadius
+        artwork.layer.cornerCurve = .continuous
+        artwork.layer.borderWidth = 1
+        artwork.layer.borderColor = UIColor.white.withAlphaComponent(0.25).cgColor
+        ImageManager.sharedManager.loadImage(episode: episode, imageView: artwork, size: .list)
+        container.addSubview(artwork)
+
+        view.addSubview(container)
+
+        // Phase 1: pop in, hovering just above the Up Next tab.
+        container.alpha = 0
+        container.transform = CGAffineTransform(scaleX: 0.6, y: 0.6)
+        UIView.animate(withDuration: 0.28, delay: 0, usingSpringWithDamping: 0.68, initialSpringVelocity: 0.4, options: [.allowUserInteraction, .curveEaseOut], animations: {
+            container.alpha = 1
+            container.transform = .identity
+        }, completion: { _ in
+            // Phase 2: genie-suck down into the Up Next tab along a curve.
+            self.runUpNextGenieSuck(on: container, from: start, to: target)
+        })
+    }
+
+    func runUpNextGenieSuck(on container: UIView, from start: CGPoint, to target: CGPoint) {
+        let duration: CFTimeInterval = 0.45
+
+        let path = UIBezierPath()
+        path.move(to: start)
+        // A subtle sideways swoop that accelerates into the tab, echoing the
+        // macOS genie effect.
+        let control = CGPoint(x: start.x + (target.x - start.x) * 0.5 - 28,
+                              y: (start.y + target.y) / 2)
+        path.addQuadCurve(to: target, controlPoint: control)
+
+        let positionAnim = CAKeyframeAnimation(keyPath: "position")
+        positionAnim.path = path.cgPath
+        positionAnim.calculationMode = .cubicPaced
+
+        let scaleAnim = CABasicAnimation(keyPath: "transform.scale")
+        scaleAnim.fromValue = 1.0
+        scaleAnim.toValue = 0.06
+
+        let fadeAnim = CABasicAnimation(keyPath: "opacity")
+        fadeAnim.fromValue = 1.0
+        fadeAnim.toValue = 0.0
+        fadeAnim.beginTime = duration * 0.55
+
+        let group = CAAnimationGroup()
+        group.animations = [positionAnim, scaleAnim, fadeAnim]
+        group.duration = duration
+        group.timingFunction = CAMediaTimingFunction(name: .easeIn)
+        group.isRemovedOnCompletion = false
+        group.fillMode = .forwards
+
+        CATransaction.begin()
+        CATransaction.setCompletionBlock { [weak container] in
+            container?.removeFromSuperview()
+        }
+        container.layer.add(group, forKey: "upNextGenie")
+        CATransaction.commit()
+
+        // Near the end of the suck, swap in the new count so it reads as the artwork landing.
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration * 0.8) { [weak self] in
+            self?.refreshUpNextTabBadge()
+        }
+    }
+
+    func upNextTabButtonFrame(in target: UIView) -> CGRect? {
+        guard let index = pcTabs.firstIndex(of: .upNext) else { return nil }
+
+        // Fallback: even split of the tab bar so the animation still targets
+        // roughly the right place if the button view can't be located.
+        let count = max(pcTabs.count, 1)
+        guard tabBar.bounds.width > 0 else { return nil }
+        let itemWidth = tabBar.bounds.width / CGFloat(count)
+        let itemRect = CGRect(x: itemWidth * CGFloat(index), y: 0, width: itemWidth, height: tabBar.bounds.height)
+        return target.convert(itemRect, from: tabBar)
+    }
+
+    /// A quick spring "pop" on the Up Next tab so a queue change is felt, not
+    /// just silently re-rendered.
+    @available(iOS 26.0, *)
+    func pulseUpNextTabButton() {
+        let buttons = upNextTabButtonViews()
+        guard !buttons.isEmpty else { return }
+
+        // A snappy, bounce-free grow, then a single softly springy settle.
+        // The grow is short enough that the peak isn't visibly held, and one
+        // gentle bounce on the way back reads as lively rather than jittery.
+        UIView.animate(springDuration: 0.15, bounce: 0, initialSpringVelocity: 0,
+                       options: [.allowUserInteraction]) {
+            buttons.forEach { $0.transform = CGAffineTransform(scaleX: 1.15, y: 1.15) }
+        } completion: { _ in
+            UIView.animate(springDuration: 0.45, bounce: 0.28, initialSpringVelocity: 0,
+                           options: [.allowUserInteraction]) {
+                buttons.forEach { $0.transform = .identity }
+            }
+        }
+    }
+
+    /// The button views for the Up Next tab slot, or empty if they can't be
+    /// located.
+    ///
+    /// The iOS 26 liquid-glass tab bar uses private `_UITabButton` views nested
+    /// well below `UITabBar`, and renders each tab more than once (a content
+    /// copy plus the glass-lens copy). We walk the whole subtree, cluster the
+    /// buttons into per-tab slots by horizontal position, and return every
+    /// button in the Up Next slot so the overlapping copies animate together.
+    private func upNextTabButtonViews() -> [UIView] {
+        guard let index = pcTabs.firstIndex(of: .upNext) else { return [] }
+
+        var buttons: [UIView] = []
+        var stack = Array(tabBar.subviews)
+        while let view = stack.popLast() {
+            if String(describing: type(of: view)).contains("TabButton") {
+                buttons.append(view)
+            }
+            stack.append(contentsOf: view.subviews)
+        }
+        guard !buttons.isEmpty else { return [] }
+
+        let positioned = buttons
+            .map { ($0, $0.convert($0.bounds, to: tabBar).midX) }
+            .sorted { $0.1 < $1.1 }
+
+        var slots: [(x: CGFloat, views: [UIView])] = []
+        for (button, x) in positioned {
+            if let last = slots.indices.last, abs(slots[last].x - x) < 20 {
+                slots[last].views.append(button)
+            } else {
+                slots.append((x, [button]))
+            }
+        }
+
+        if slots.indices.contains(index) {
+            return slots[index].views
+        }
+
+        // Slot count doesn't line up with the tab list (e.g. a "More" tab):
+        // animate whichever slot sits nearest the expected Up Next position.
+        guard let expected = upNextTabButtonFrame(in: tabBar) else { return [] }
+        return slots.min { abs($0.x - expected.midX) < abs($1.x - expected.midX) }?.views ?? []
+    }
+}

--- a/podcasts/Main/MainTabBarController+Animations.swift
+++ b/podcasts/Main/MainTabBarController+Animations.swift
@@ -134,15 +134,20 @@ extension MainTabBarController {
     }
 
     func playUpNextAddedGenieAnimation(for episode: BaseEpisode) {
-        // Tab bar collapsed into its pill: there's no Up Next tab on screen to
-        // fly into, so skip the animation and just keep the count current.
-        guard !isTabBarMinimized else {
-            refreshUpNextTabBadge()
-            return
-        }
-
-        // No target, or an animation already in flight: just update the count.
-        guard let targetFrame = upNextTabTargetFrame(in: view),
+        // Skip the animation (and just keep the count current) when there's no
+        // visible Up Next tab to fly into: tab bar collapsed into its pill, the
+        // bar isn't on screen, the landing point would be off-screen, or
+        // another genie is already in flight. When minimized, UIKit keeps the
+        // private tab-button views laid out at their original positions even
+        // though they aren't visible, so a frame check alone isn't enough —
+        // the trait-based `isTabBarMinimized` is the reliable signal.
+        guard !isTabBarMinimized,
+              view.window != nil,
+              !tabBar.isHidden,
+              tabBar.alpha > 0.01,
+              tabBar.window != nil,
+              let targetFrame = upNextTabTargetFrame(in: view),
+              view.bounds.contains(CGPoint(x: targetFrame.midX, y: targetFrame.midY)),
               view.viewWithTag(Self.upNextGenieViewTag) == nil else {
             refreshUpNextTabBadge()
             return

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -21,6 +21,10 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     private lazy var upNextTabBarItem = UITabBarItem(title: L10n.upNext, image: UIImage(named: "upnext_tab"), tag: pcTabs.firstIndex(of: .upNext) ?? -1)
 
+    /// The last Up Next count rendered into the tab, used to pulse the tab only
+    /// when the queue actually changes (not on every refresh notification).
+    private var previousUpNextCount: Int?
+
 
     /// The viewDidAppear can trigger more than once per lifecycle, setting this flag on the first did appear prevents use from prompting more than once per lifecycle. But still wait until the tab bar has appeared to do so.
     var viewDidAppearBefore: Bool = false
@@ -134,9 +138,9 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         refreshProfileTabAvatar()
 
         NotificationCenter.default.addObserver(self, selector: #selector(refreshUpNextTabBadge), name: Constants.Notifications.upNextQueueChanged, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(refreshUpNextTabBadge), name: Constants.Notifications.upNextEpisodeAdded, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(refreshUpNextTabBadge), name: Constants.Notifications.upNextEpisodeRemoved, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(refreshUpNextTabBadge), name: Constants.Notifications.playbackTrackChanged, object: nil)
+        // `upNextEpisodeAdded` refreshes the badge via the genie animation's tail, not here.
         NotificationCenter.default.addObserver(self, selector: #selector(animateEpisodeAddedToUpNext(_:)), name: Constants.Notifications.upNextEpisodeAdded, object: nil)
         refreshUpNextTabBadge()
 
@@ -1221,254 +1225,28 @@ private extension MainTabBarController {
 
 // MARK: - Up Next tab badge
 
-private extension MainTabBarController {
-    static let upNextTabNumberFont = UIFont.monospacedDigitSystemFont(ofSize: 13, weight: .bold)
-    static let upNextTabOverOneHundredNumberFont = UIFont.monospacedDigitSystemFont(ofSize: 11, weight: .bold)
-
+extension MainTabBarController {
     @objc func refreshUpNextTabBadge() {
         guard FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) else { return }
 
         let count = min(999, PlaybackManager.shared.queue.upNextCount())
+        // Only celebrate the queue growing — a drain (playing/removing) shouldn't pop.
+        let countIncreased = previousUpNextCount.map { count > $0 } ?? false
+        previousUpNextCount = count
+
         guard count > 0 else {
             resetUpNextTabImage()
             return
         }
 
-        // A single template image: the tab bar tints it for the
-        // unselected/selected states (and Liquid Glass vibrancy) exactly like
-        // every other tab item, so the colors always match.
-        upNextTabBarItem.image = composeUpNextTabImage(count: count)
+        // A template image so the tab bar tints it like every other item.
+        upNextTabBarItem.image = Self.composeUpNextTabImage(count: count)
         upNextTabBarItem.selectedImage = nil
+        if countIncreased { pulseUpNextTabButton() }
     }
 
     func resetUpNextTabImage() {
         upNextTabBarItem.image = UIImage(named: "upnext_tab")
         upNextTabBarItem.selectedImage = nil
-    }
-
-    /// Composes the queue count into the tab image with the number on the left,
-    /// mirroring how the full player draws it in `UpNextButton`. The circle is
-    /// drawn at full alpha and the list lines at reduced alpha, so once
-    /// templated the tab bar tints the circle in the full primary colour and
-    /// the lines in a lighter "secondary" shade of it (still adapting to
-    /// selected/unselected and Liquid Glass like every other item). The number
-    /// is knocked out of the circle so it reads as a transparent cutout.
-    func composeUpNextTabImage(count: Int) -> UIImage? {
-        let bgImageName: String
-        let canvasSize: CGSize
-        // `splitX` falls in the empty gap between the circle and the list
-        // lines in each asset, so the two regions can be drawn separately.
-        let splitX: CGFloat
-        if count < 10 {
-            bgImageName = "icon-upnext-circle"
-            canvasSize = CGSize(width: 36, height: 26)
-            splitX = 28
-        } else if count < 100 {
-            bgImageName = "icon-upnext-circle-wide"
-            canvasSize = CGSize(width: 43, height: 24)
-            splitX = 33
-        } else {
-            bgImageName = "icon-upnext-circle-wide-wide"
-            canvasSize = CGSize(width: 45, height: 24)
-            splitX = 34
-        }
-
-        guard let bgImage = UIImage(named: bgImageName) else { return nil }
-
-        let imageFrame = CGRect(origin: .zero, size: canvasSize)
-        let secondaryShadeAlpha: CGFloat = 0.45
-
-        let image = UIGraphicsImageRenderer(size: canvasSize).image { context in
-            let cg = context.cgContext
-
-            // Circle (left) at full strength → full primary tint.
-            cg.saveGState()
-            cg.clip(to: CGRect(x: 0, y: 0, width: splitX, height: canvasSize.height))
-            bgImage.draw(in: imageFrame)
-            cg.restoreGState()
-
-            // List lines (right) at reduced alpha → a lighter secondary shade
-            // of the same tint once templated.
-            cg.saveGState()
-            cg.clip(to: CGRect(x: splitX, y: 0, width: canvasSize.width - splitX, height: canvasSize.height))
-            cg.setAlpha(secondaryShadeAlpha)
-            bgImage.draw(in: imageFrame)
-            cg.restoreGState()
-
-            // Erase the count from the circle so it reads as a transparent
-            // cutout, letting the tinted circle define the number's color.
-            let countAsStr = "\(count)" as NSString
-            let font = count > 99 ? Self.upNextTabOverOneHundredNumberFont : Self.upNextTabNumberFont
-            let textFontAttributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: UIColor.black]
-            cg.setBlendMode(.destinationOut)
-            let textSize = countAsStr.size(withAttributes: textFontAttributes)
-            // x matches `UpNextButton`; y is the player's y minus the badge's 9pt offset.
-            let textPoint: CGPoint
-            if count < 10 {
-                textPoint = CGPoint(x: (textSize.width / 2) + 3, y: 6)
-            } else if count < 100 {
-                textPoint = CGPoint(x: (textSize.width / 2) - 2, y: 4)
-            } else {
-                textPoint = CGPoint(x: (textSize.width / 2) - 7, y: 5)
-            }
-            countAsStr.draw(at: textPoint, withAttributes: textFontAttributes)
-        }
-
-        return image.withRenderingMode(.alwaysTemplate)
-    }
-}
-
-// MARK: - Up Next "genie" add animation
-
-private extension MainTabBarController {
-    static let upNextGenieViewTag = 776_611
-
-    @objc func animateEpisodeAddedToUpNext(_ notification: Notification) {
-        guard FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) else { return }
-        guard let episodeUuid = notification.object as? String,
-              let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else { return }
-
-        DispatchQueue.main.async { [weak self] in
-            self?.playUpNextAddedGenieAnimation(for: episode)
-        }
-    }
-
-    func playUpNextAddedGenieAnimation(for episode: BaseEpisode) {
-        guard let targetFrame = upNextTabButtonFrame(in: view) else { return }
-        // Don't stack animations when several episodes are added at once.
-        guard view.viewWithTag(Self.upNextGenieViewTag) == nil else { return }
-
-        let artworkSize: CGFloat = 64
-        let target = CGPoint(x: targetFrame.midX, y: targetFrame.midY)
-        let start = CGPoint(x: target.x, y: targetFrame.minY - 96)
-
-        let container = UIView(frame: CGRect(x: 0, y: 0, width: artworkSize, height: artworkSize))
-        container.tag = Self.upNextGenieViewTag
-        container.center = start
-        container.isUserInteractionEnabled = false
-        container.layer.cornerRadius = 12
-        container.layer.cornerCurve = .continuous
-        container.layer.shadowColor = UIColor.black.cgColor
-        container.layer.shadowOpacity = 0.3
-        container.layer.shadowRadius = 12
-        container.layer.shadowOffset = CGSize(width: 0, height: 6)
-
-        let artwork = PodcastImageView(frame: container.bounds)
-        artwork.setBaseEpisode(episode: episode, size: .list)
-        artwork.layer.cornerRadius = 12
-        artwork.layer.cornerCurve = .continuous
-        artwork.layer.masksToBounds = true
-        artwork.layer.borderWidth = 1
-        artwork.layer.borderColor = UIColor.white.withAlphaComponent(0.25).cgColor
-        container.addSubview(artwork)
-
-        view.addSubview(container)
-
-        // Phase 1: pop in, hovering just above the Up Next tab.
-        container.alpha = 0
-        container.transform = CGAffineTransform(scaleX: 0.6, y: 0.6)
-        UIView.animate(withDuration: 0.28, delay: 0, usingSpringWithDamping: 0.68, initialSpringVelocity: 0.4, options: [.allowUserInteraction, .curveEaseOut], animations: {
-            container.alpha = 1
-            container.transform = .identity
-        }, completion: { _ in
-            // Phase 2: genie-suck down into the Up Next tab along a curve.
-            self.runUpNextGenieSuck(on: container, from: start, to: target)
-        })
-    }
-
-    func runUpNextGenieSuck(on container: UIView, from start: CGPoint, to target: CGPoint) {
-        let duration: CFTimeInterval = 0.5
-
-        let path = UIBezierPath()
-        path.move(to: start)
-        // A subtle sideways swoop that accelerates into the tab, echoing the
-        // macOS genie effect.
-        let control = CGPoint(x: start.x + (target.x - start.x) * 0.5 - 28,
-                              y: (start.y + target.y) / 2)
-        path.addQuadCurve(to: target, controlPoint: control)
-
-        let positionAnim = CAKeyframeAnimation(keyPath: "position")
-        positionAnim.path = path.cgPath
-        positionAnim.calculationMode = .cubicPaced
-
-        let scaleAnim = CABasicAnimation(keyPath: "transform.scale")
-        scaleAnim.fromValue = 1.0
-        scaleAnim.toValue = 0.06
-
-        let fadeAnim = CABasicAnimation(keyPath: "opacity")
-        fadeAnim.fromValue = 1.0
-        fadeAnim.toValue = 0.0
-        fadeAnim.beginTime = duration * 0.55
-
-        let group = CAAnimationGroup()
-        group.animations = [positionAnim, scaleAnim, fadeAnim]
-        group.duration = duration
-        group.timingFunction = CAMediaTimingFunction(name: .easeIn)
-        group.isRemovedOnCompletion = false
-        group.fillMode = .forwards
-
-        CATransaction.begin()
-        CATransaction.setCompletionBlock { [weak self, weak container] in
-            container?.removeFromSuperview()
-            self?.pulseUpNextTabItem()
-        }
-        container.layer.add(group, forKey: "upNextGenie")
-        CATransaction.commit()
-    }
-
-    /// A quick pop on the Up Next tab as the artwork lands.
-    func pulseUpNextTabItem() {
-        guard let button = upNextTabButtonView() else { return }
-        UIView.animate(withDuration: 0.14, delay: 0, options: [.allowUserInteraction, .curveEaseOut], animations: {
-            button.transform = CGAffineTransform(scaleX: 1.22, y: 1.22)
-        }, completion: { _ in
-            UIView.animate(withDuration: 0.22, delay: 0, usingSpringWithDamping: 0.55, initialSpringVelocity: 0.3, options: [.allowUserInteraction], animations: {
-                button.transform = .identity
-            })
-        })
-    }
-
-    /// The Up Next tab's button view, searched at any depth since the tab bar's
-    /// internal hierarchy differs across iOS versions (notably iOS 26).
-    func upNextTabButtonView() -> UIView? {
-        guard let index = pcTabs.firstIndex(of: .upNext) else { return nil }
-
-        func collectButtons(_ view: UIView) -> [UIView] {
-            var result: [UIView] = []
-            for sub in view.subviews {
-                if NSStringFromClass(type(of: sub)).contains("TabBarButton") {
-                    result.append(sub)
-                } else {
-                    result.append(contentsOf: collectButtons(sub))
-                }
-            }
-            return result
-        }
-
-        var buttons = collectButtons(tabBar)
-        if buttons.isEmpty {
-            // Fall back to any control-like leaf (covers class-name changes).
-            buttons = tabBar.subviews.flatMap { $0 is UIControl ? [$0] : $0.subviews.filter { $0 is UIControl } }
-        }
-        buttons.sort { $0.convert($0.bounds, to: tabBar).minX < $1.convert($1.bounds, to: tabBar).minX }
-
-        guard buttons.indices.contains(index) else { return nil }
-        return buttons[index]
-    }
-
-    func upNextTabButtonFrame(in target: UIView) -> CGRect? {
-        guard let index = pcTabs.firstIndex(of: .upNext) else { return nil }
-
-        if let button = upNextTabButtonView() {
-            return target.convert(button.bounds, from: button)
-        }
-
-        // Fallback: even split of the tab bar so the animation still targets
-        // roughly the right place if the button view can't be located.
-        let count = max(pcTabs.count, 1)
-        guard tabBar.bounds.width > 0 else { return nil }
-        let itemWidth = tabBar.bounds.width / CGFloat(count)
-        let itemRect = CGRect(x: itemWidth * CGFloat(index), y: 0, width: itemWidth, height: tabBar.bounds.height)
-        return target.convert(itemRect, from: tabBar)
     }
 }

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -19,6 +19,8 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     private lazy var profileTabBarItem = UITabBarItem(title: L10n.profile, image: UIImage(named: "profile_tab"), tag: pcTabs.firstIndex(of: .profile) ?? -1)
 
+    private lazy var upNextTabBarItem = UITabBarItem(title: L10n.upNext, image: UIImage(named: "upnext_tab"), tag: pcTabs.firstIndex(of: .upNext) ?? -1)
+
 
     /// The viewDidAppear can trigger more than once per lifecycle, setting this flag on the first did appear prevents use from prompting more than once per lifecycle. But still wait until the tab bar has appeared to do so.
     var viewDidAppearBefore: Bool = false
@@ -105,7 +107,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         profileViewController.tabBarItem = profileTabBarItem
 
         let upNextViewController = UpNextViewController(source: .tabBar, showingInTab: true)
-        upNextViewController.tabBarItem = UITabBarItem(title: L10n.upNext, image: UIImage(named: "upnext_tab"), tag: pcTabs.firstIndex(of: .upNext)!)
+        upNextViewController.tabBarItem = upNextTabBarItem
         vcsInTab = [podcastsController, filtersViewController, discoverViewController, upNextViewController, profileViewController]
 
         displayEndOfYearBadgeIfNeeded()
@@ -130,6 +132,12 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         NotificationCenter.default.addObserver(self, selector: #selector(refreshProfileTabAvatar), name: .userLoginDidChange, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(refreshProfileTabAvatarForcingReload), name: Constants.Notifications.avatarNeedsRefreshing, object: nil)
         refreshProfileTabAvatar()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshUpNextTabBadge), name: Constants.Notifications.upNextQueueChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshUpNextTabBadge), name: Constants.Notifications.upNextEpisodeAdded, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshUpNextTabBadge), name: Constants.Notifications.upNextEpisodeRemoved, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshUpNextTabBadge), name: Constants.Notifications.playbackTrackChanged, object: nil)
+        refreshUpNextTabBadge()
 
         observersForEndOfYearStats()
         addBookmarkCreatedToastHandler()
@@ -261,6 +269,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         updateTabBarColor()
         updateErrorColor()
         setNeedsStatusBarAppearanceUpdate()
+        refreshUpNextTabBadge()
     }
 
     private func setupMiniPlayer() {
@@ -1206,5 +1215,80 @@ private extension MainTabBarController {
     func resetProfileTabImage() {
         profileTabBarItem.image = UIImage(named: "profile_tab")
         profileTabBarItem.selectedImage = nil
+    }
+}
+
+// MARK: - Up Next tab badge
+
+private extension MainTabBarController {
+    static let upNextTabNumberFont = UIFont.monospacedDigitSystemFont(ofSize: 13, weight: .bold)
+    static let upNextTabOverOneHundredNumberFont = UIFont.monospacedDigitSystemFont(ofSize: 11, weight: .bold)
+
+    @objc func refreshUpNextTabBadge() {
+        guard FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) else { return }
+
+        let count = min(999, PlaybackManager.shared.queue.upNextCount())
+        guard count > 0 else {
+            resetUpNextTabImage()
+            return
+        }
+
+        // A single template image: the tab bar tints it for the
+        // unselected/selected states (and Liquid Glass vibrancy) exactly like
+        // every other tab item, so the colors always match.
+        upNextTabBarItem.image = composeUpNextTabImage(count: count)
+        upNextTabBarItem.selectedImage = nil
+    }
+
+    func resetUpNextTabImage() {
+        upNextTabBarItem.image = UIImage(named: "upnext_tab")
+        upNextTabBarItem.selectedImage = nil
+    }
+
+    /// Composes the queue count into the tab image with the number on the left,
+    /// mirroring how the full player draws it in `UpNextButton`. The number is
+    /// knocked out of the circle so the result is a single template image the
+    /// tab bar tints like every other item.
+    func composeUpNextTabImage(count: Int) -> UIImage? {
+        let bgImageName: String
+        if count < 10 {
+            bgImageName = "icon-upnext-circle"
+        } else if count < 100 {
+            bgImageName = "icon-upnext-circle-wide"
+        } else {
+            bgImageName = "icon-upnext-circle-wide-wide"
+        }
+
+        guard let bgImage = UIImage(named: bgImageName) else { return nil }
+
+        // Same badge dimensions as `UpNextButton`, with the badge drawn at the
+        // canvas origin (the player offsets it by y:9 within the 44pt button).
+        let canvasSize = count < 10 ? CGSize(width: 36, height: 26) : CGSize(width: 43, height: 24)
+        let imageFrame = CGRect(origin: .zero, size: canvasSize)
+
+        let image = UIGraphicsImageRenderer(size: canvasSize).image { context in
+            // Opaque circle silhouette — only its alpha matters once templated.
+            bgImage.draw(in: imageFrame)
+
+            // Erase the count from the circle so it reads as a transparent
+            // cutout, letting the tinted circle define the number's color.
+            let countAsStr = "\(count)" as NSString
+            let font = count > 99 ? Self.upNextTabOverOneHundredNumberFont : Self.upNextTabNumberFont
+            let textFontAttributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: UIColor.black]
+            context.cgContext.setBlendMode(.destinationOut)
+            let textSize = countAsStr.size(withAttributes: textFontAttributes)
+            // x matches `UpNextButton`; y is the player's y minus the badge's 9pt offset.
+            let textPoint: CGPoint
+            if count < 10 {
+                textPoint = CGPoint(x: (textSize.width / 2) + 3, y: 6)
+            } else if count < 100 {
+                textPoint = CGPoint(x: (textSize.width / 2) - 2, y: 4)
+            } else {
+                textPoint = CGPoint(x: (textSize.width / 2) - 7, y: 5)
+            }
+            countAsStr.draw(at: textPoint, withAttributes: textFontAttributes)
+        }
+
+        return image.withRenderingMode(.alwaysTemplate)
     }
 }

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -25,6 +25,11 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     /// when the queue actually changes (not on every refresh notification).
     private var previousUpNextCount: Int?
 
+    /// `true` while the Up Next tab "pulse" spring is in flight, so a burst of
+    /// rapid adds doesn't stack overlapping transforms on the tab button.
+    /// Not `private`: set from the pulse code in `+Animations`.
+    var isPulsingUpNextTab = false
+
 
     /// The viewDidAppear can trigger more than once per lifecycle, setting this flag on the first did appear prevents use from prompting more than once per lifecycle. But still wait until the tab bar has appeared to do so.
     var viewDidAppearBefore: Bool = false
@@ -1229,10 +1234,15 @@ extension MainTabBarController {
     @objc func refreshUpNextTabBadge() {
         guard FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) else { return }
 
-        let count = min(999, PlaybackManager.shared.queue.upNextCount())
-        // Only celebrate the queue growing — a drain (playing/removing) shouldn't pop.
-        let countIncreased = previousUpNextCount.map { count > $0 } ?? false
+        // Clamping lives in `composeUpNextTabImage`; track the true count here.
+        let count = PlaybackManager.shared.queue.upNextCount()
+        let previous = previousUpNextCount
         previousUpNextCount = count
+
+        // Nothing to redraw if the count didn't move. The composed image is a
+        // template, so the tab bar re-tints it on theme changes for free — no
+        // rebuild needed there either.
+        guard count != previous else { return }
 
         guard count > 0 else {
             resetUpNextTabImage()
@@ -1242,7 +1252,9 @@ extension MainTabBarController {
         // A template image so the tab bar tints it like every other item.
         upNextTabBarItem.image = Self.composeUpNextTabImage(count: count)
         upNextTabBarItem.selectedImage = nil
-        if countIncreased { pulseUpNextTabButton() }
+
+        // Only celebrate the queue growing — a drain (playing/removing) shouldn't pop.
+        if previous.map({ count > $0 }) ?? false { pulseUpNextTabButton() }
     }
 
     func resetUpNextTabImage() {

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -137,6 +137,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
         NotificationCenter.default.addObserver(self, selector: #selector(refreshUpNextTabBadge), name: Constants.Notifications.upNextEpisodeAdded, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(refreshUpNextTabBadge), name: Constants.Notifications.upNextEpisodeRemoved, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(refreshUpNextTabBadge), name: Constants.Notifications.playbackTrackChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(animateEpisodeAddedToUpNext(_:)), name: Constants.Notifications.upNextEpisodeAdded, object: nil)
         refreshUpNextTabBadge()
 
         observersForEndOfYearStats()
@@ -1246,36 +1247,60 @@ private extension MainTabBarController {
     }
 
     /// Composes the queue count into the tab image with the number on the left,
-    /// mirroring how the full player draws it in `UpNextButton`. The number is
-    /// knocked out of the circle so the result is a single template image the
-    /// tab bar tints like every other item.
+    /// mirroring how the full player draws it in `UpNextButton`. The circle is
+    /// drawn at full alpha and the list lines at reduced alpha, so once
+    /// templated the tab bar tints the circle in the full primary colour and
+    /// the lines in a lighter "secondary" shade of it (still adapting to
+    /// selected/unselected and Liquid Glass like every other item). The number
+    /// is knocked out of the circle so it reads as a transparent cutout.
     func composeUpNextTabImage(count: Int) -> UIImage? {
         let bgImageName: String
+        let canvasSize: CGSize
+        // `splitX` falls in the empty gap between the circle and the list
+        // lines in each asset, so the two regions can be drawn separately.
+        let splitX: CGFloat
         if count < 10 {
             bgImageName = "icon-upnext-circle"
+            canvasSize = CGSize(width: 36, height: 26)
+            splitX = 28
         } else if count < 100 {
             bgImageName = "icon-upnext-circle-wide"
+            canvasSize = CGSize(width: 43, height: 24)
+            splitX = 33
         } else {
             bgImageName = "icon-upnext-circle-wide-wide"
+            canvasSize = CGSize(width: 45, height: 24)
+            splitX = 34
         }
 
         guard let bgImage = UIImage(named: bgImageName) else { return nil }
 
-        // Same badge dimensions as `UpNextButton`, with the badge drawn at the
-        // canvas origin (the player offsets it by y:9 within the 44pt button).
-        let canvasSize = count < 10 ? CGSize(width: 36, height: 26) : CGSize(width: 43, height: 24)
         let imageFrame = CGRect(origin: .zero, size: canvasSize)
+        let secondaryShadeAlpha: CGFloat = 0.45
 
         let image = UIGraphicsImageRenderer(size: canvasSize).image { context in
-            // Opaque circle silhouette — only its alpha matters once templated.
+            let cg = context.cgContext
+
+            // Circle (left) at full strength → full primary tint.
+            cg.saveGState()
+            cg.clip(to: CGRect(x: 0, y: 0, width: splitX, height: canvasSize.height))
             bgImage.draw(in: imageFrame)
+            cg.restoreGState()
+
+            // List lines (right) at reduced alpha → a lighter secondary shade
+            // of the same tint once templated.
+            cg.saveGState()
+            cg.clip(to: CGRect(x: splitX, y: 0, width: canvasSize.width - splitX, height: canvasSize.height))
+            cg.setAlpha(secondaryShadeAlpha)
+            bgImage.draw(in: imageFrame)
+            cg.restoreGState()
 
             // Erase the count from the circle so it reads as a transparent
             // cutout, letting the tinted circle define the number's color.
             let countAsStr = "\(count)" as NSString
             let font = count > 99 ? Self.upNextTabOverOneHundredNumberFont : Self.upNextTabNumberFont
             let textFontAttributes: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: UIColor.black]
-            context.cgContext.setBlendMode(.destinationOut)
+            cg.setBlendMode(.destinationOut)
             let textSize = countAsStr.size(withAttributes: textFontAttributes)
             // x matches `UpNextButton`; y is the player's y minus the badge's 9pt offset.
             let textPoint: CGPoint
@@ -1290,5 +1315,160 @@ private extension MainTabBarController {
         }
 
         return image.withRenderingMode(.alwaysTemplate)
+    }
+}
+
+// MARK: - Up Next "genie" add animation
+
+private extension MainTabBarController {
+    static let upNextGenieViewTag = 776_611
+
+    @objc func animateEpisodeAddedToUpNext(_ notification: Notification) {
+        guard FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) else { return }
+        guard let episodeUuid = notification.object as? String,
+              let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.playUpNextAddedGenieAnimation(for: episode)
+        }
+    }
+
+    func playUpNextAddedGenieAnimation(for episode: BaseEpisode) {
+        guard let targetFrame = upNextTabButtonFrame(in: view) else { return }
+        // Don't stack animations when several episodes are added at once.
+        guard view.viewWithTag(Self.upNextGenieViewTag) == nil else { return }
+
+        let artworkSize: CGFloat = 64
+        let target = CGPoint(x: targetFrame.midX, y: targetFrame.midY)
+        let start = CGPoint(x: target.x, y: targetFrame.minY - 96)
+
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: artworkSize, height: artworkSize))
+        container.tag = Self.upNextGenieViewTag
+        container.center = start
+        container.isUserInteractionEnabled = false
+        container.layer.cornerRadius = 12
+        container.layer.cornerCurve = .continuous
+        container.layer.shadowColor = UIColor.black.cgColor
+        container.layer.shadowOpacity = 0.3
+        container.layer.shadowRadius = 12
+        container.layer.shadowOffset = CGSize(width: 0, height: 6)
+
+        let artwork = PodcastImageView(frame: container.bounds)
+        artwork.setBaseEpisode(episode: episode, size: .list)
+        artwork.layer.cornerRadius = 12
+        artwork.layer.cornerCurve = .continuous
+        artwork.layer.masksToBounds = true
+        artwork.layer.borderWidth = 1
+        artwork.layer.borderColor = UIColor.white.withAlphaComponent(0.25).cgColor
+        container.addSubview(artwork)
+
+        view.addSubview(container)
+
+        // Phase 1: pop in, hovering just above the Up Next tab.
+        container.alpha = 0
+        container.transform = CGAffineTransform(scaleX: 0.6, y: 0.6)
+        UIView.animate(withDuration: 0.28, delay: 0, usingSpringWithDamping: 0.68, initialSpringVelocity: 0.4, options: [.allowUserInteraction, .curveEaseOut], animations: {
+            container.alpha = 1
+            container.transform = .identity
+        }, completion: { _ in
+            // Phase 2: genie-suck down into the Up Next tab along a curve.
+            self.runUpNextGenieSuck(on: container, from: start, to: target)
+        })
+    }
+
+    func runUpNextGenieSuck(on container: UIView, from start: CGPoint, to target: CGPoint) {
+        let duration: CFTimeInterval = 0.5
+
+        let path = UIBezierPath()
+        path.move(to: start)
+        // A subtle sideways swoop that accelerates into the tab, echoing the
+        // macOS genie effect.
+        let control = CGPoint(x: start.x + (target.x - start.x) * 0.5 - 28,
+                              y: (start.y + target.y) / 2)
+        path.addQuadCurve(to: target, controlPoint: control)
+
+        let positionAnim = CAKeyframeAnimation(keyPath: "position")
+        positionAnim.path = path.cgPath
+        positionAnim.calculationMode = .cubicPaced
+
+        let scaleAnim = CABasicAnimation(keyPath: "transform.scale")
+        scaleAnim.fromValue = 1.0
+        scaleAnim.toValue = 0.06
+
+        let fadeAnim = CABasicAnimation(keyPath: "opacity")
+        fadeAnim.fromValue = 1.0
+        fadeAnim.toValue = 0.0
+        fadeAnim.beginTime = duration * 0.55
+
+        let group = CAAnimationGroup()
+        group.animations = [positionAnim, scaleAnim, fadeAnim]
+        group.duration = duration
+        group.timingFunction = CAMediaTimingFunction(name: .easeIn)
+        group.isRemovedOnCompletion = false
+        group.fillMode = .forwards
+
+        CATransaction.begin()
+        CATransaction.setCompletionBlock { [weak self, weak container] in
+            container?.removeFromSuperview()
+            self?.pulseUpNextTabItem()
+        }
+        container.layer.add(group, forKey: "upNextGenie")
+        CATransaction.commit()
+    }
+
+    /// A quick pop on the Up Next tab as the artwork lands.
+    func pulseUpNextTabItem() {
+        guard let button = upNextTabButtonView() else { return }
+        UIView.animate(withDuration: 0.14, delay: 0, options: [.allowUserInteraction, .curveEaseOut], animations: {
+            button.transform = CGAffineTransform(scaleX: 1.22, y: 1.22)
+        }, completion: { _ in
+            UIView.animate(withDuration: 0.22, delay: 0, usingSpringWithDamping: 0.55, initialSpringVelocity: 0.3, options: [.allowUserInteraction], animations: {
+                button.transform = .identity
+            })
+        })
+    }
+
+    /// The Up Next tab's button view, searched at any depth since the tab bar's
+    /// internal hierarchy differs across iOS versions (notably iOS 26).
+    func upNextTabButtonView() -> UIView? {
+        guard let index = pcTabs.firstIndex(of: .upNext) else { return nil }
+
+        func collectButtons(_ view: UIView) -> [UIView] {
+            var result: [UIView] = []
+            for sub in view.subviews {
+                if NSStringFromClass(type(of: sub)).contains("TabBarButton") {
+                    result.append(sub)
+                } else {
+                    result.append(contentsOf: collectButtons(sub))
+                }
+            }
+            return result
+        }
+
+        var buttons = collectButtons(tabBar)
+        if buttons.isEmpty {
+            // Fall back to any control-like leaf (covers class-name changes).
+            buttons = tabBar.subviews.flatMap { $0 is UIControl ? [$0] : $0.subviews.filter { $0 is UIControl } }
+        }
+        buttons.sort { $0.convert($0.bounds, to: tabBar).minX < $1.convert($1.bounds, to: tabBar).minX }
+
+        guard buttons.indices.contains(index) else { return nil }
+        return buttons[index]
+    }
+
+    func upNextTabButtonFrame(in target: UIView) -> CGRect? {
+        guard let index = pcTabs.firstIndex(of: .upNext) else { return nil }
+
+        if let button = upNextTabButtonView() {
+            return target.convert(button.bounds, from: button)
+        }
+
+        // Fallback: even split of the tab bar so the animation still targets
+        // roughly the right place if the button view can't be located.
+        let count = max(pcTabs.count, 1)
+        guard tabBar.bounds.width > 0 else { return nil }
+        let itemWidth = tabBar.bounds.width / CGFloat(count)
+        let itemRect = CGRect(x: itemWidth * CGFloat(index), y: 0, width: itemWidth, height: tabBar.bounds.height)
+        return target.convert(itemRect, from: tabBar)
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

- Add "Up Next" badge showing how many items are in the queue directly in the tab bar (backed in the image)
- Add animation (hacks on top of hacks, but it works)

https://github.com/user-attachments/assets/f4939c1c-dda0-44ba-8614-3e29868a6cf3


## To test

- Verify that when tab bar is minimized, the animation does not run

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
