### PR TITLE
Use archive swatch for "Add to playlist" swipe in contrast themes

### DIFF
--- a/podcasts/Episode Cells/SwipeActionsHelper.swift
+++ b/podcasts/Episode Cells/SwipeActionsHelper.swift
@@ -44,6 +44,18 @@ protocol SwipeHandler: AnyObject {
 }
 
 enum SwipeActionsHelper {
+    // Contrast themes prioritise readability; the green `support02` background
+    // doesn't pass against the white "+" icon, so fall back to `support06` (the
+    // archive swatch) in those themes.
+    static var addToPlaylistSwipeBackground: UIColor {
+        switch Theme.sharedTheme.activeTheme {
+        case .contrastLight, .contrastDark:
+            return ThemeColor.support06()
+        default:
+            return ThemeColor.support02()
+        }
+    }
+
     static func createLeftActionsForEpisode(_ episode: BaseEpisode, tableView: UITableView, indexPath: IndexPath, swipeHandler: SwipeHandler) -> TableSwipeActions {
         let tableSwipeActions = TableSwipeActions()
         let storedUuid = episode.uuid
@@ -142,7 +154,7 @@ enum SwipeActionsHelper {
 
             if FeatureFlag.playlistsRebranding.enabled {
                 if swipeHandler.swipeSourceType.canAddEpisodeToManualPlaylist {
-                    let shareAction = TableSwipeAction(indexPath: indexPath, title: L10n.playlistManualAddEpisodes, removesFromList: false, backgroundColor: ThemeColor.support02(), icon: UIImage(named: "playlist-add-episode"), tableView: tableView, hidesWhenSelected: true, handler: { indexPath -> Bool in
+                    let shareAction = TableSwipeAction(indexPath: indexPath, title: L10n.playlistManualAddEpisodes, removesFromList: false, backgroundColor: addToPlaylistSwipeBackground, icon: UIImage(named: "playlist-add-episode"), tableView: tableView, hidesWhenSelected: true, handler: { indexPath -> Bool in
                         swipeHandler.addToManualPlaylist(episode: episode, at: indexPath)
                         Self.performAction(.addToManualPlaylist, handler: swipeHandler, willBeRemoved: false)
                         return true

--- a/podcasts/UpNextViewController+Swipe.swift
+++ b/podcasts/UpNextViewController+Swipe.swift
@@ -95,7 +95,7 @@ extension UpNextViewController: SwipeTableViewCellDelegate {
                     }
                 }
                 shareAction.hidesWhenSelected = true
-                shareAction.backgroundColor = ThemeColor.support02()
+                shareAction.backgroundColor = SwipeActionsHelper.addToPlaylistSwipeBackground
                 shareAction.image = UIImage(named: "playlist-add-episode")
                 shareAction.accessibilityLabel = L10n.playlistManualAddEpisodes
                 return [deleteAction, shareAction]


### PR DESCRIPTION
Fixes low-contrast white "+" on green for the "Add to playlist" swipe in Dark Contrast / Light Contrast themes by reusing the archive swatch (support06). All other themes unchanged.

Fixes PCIOS-567

## To test

• In Dark Contrast & Light Contrast: swipe an episode in any episode list (Podcast view, Playlist details, Downloads, etc.) → "+" button is dark.
• In any other theme: "+" still green.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.


<img width="320" height="696" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-19 at 18 11 14" src="https://github.com/user-attachments/assets/fa6db7a7-1b26-43b8-9cdd-a3432a64f60e" />
<img width="320" height="696" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-19 at 18 10 54" src="https://github.com/user-attachments/assets/bb45101b-d65d-4b50-943e-9c6002779762" />
<img width="320" height="696" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-19 at 18 10 42" src="https://github.com/user-attachments/assets/28c86d68-3c9c-4d1e-9bb4-4a6261c669c4" />
<img width="320" height="696" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-19 at 18 10 34" src="https://github.com/user-attachments/assets/dff7dc96-ba86-42c3-acf1-60490e60664c" />
