### PR TITLE
POC-631: Tweak tap to seek

### DIFF
--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -988,13 +988,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
         guard let cue = transcript.cues.first(where: { NSLocationInRange(charIndex, $0.characterRange) }) else { return }
 
-        let fraction: Double
-        if cue.characterRange.length > 0 {
-            fraction = Double(charIndex - cue.characterRange.location) / Double(cue.characterRange.length)
-        } else {
-            fraction = 0
-        }
-        let referenceTime = cue.startTime + fraction * (cue.endTime - cue.startTime)
+        let referenceTime = cue.startTime
 
         guard let seekTime = FingerprintTimingManager.shared.playbackTime(forReferenceTime: referenceTime) else {
             let syncedState = FingerprintTimingManager.shared.state


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/POC-631/tweak-tap-to-seek

## Summary
When tapping a synced transcript cue, always seek to the beginning of the cue instead of guessing timing based on tap position within the cue text.

## Changes
- Removed fraction-based interpolation in `TranscriptViewController.transcriptTapped(_:)` that estimated timing based on where within a cue's text the user tapped
- Now uses `cue.startTime` directly as the reference time for seeking

## Verification
- **Lint**: PASS
- **Tests**: FAIL — pre-existing CarPlay build error on trunk (`CPPlaybackConfiguration` not in scope), unrelated to this change
- **Diff review**: PASS — confirmed minimal, scoped change with no unintended modifications
- **Secret scan**: PASS

## Confidence
**HIGH** — The change is a one-line simplification that directly matches the issue requirement. The fraction calculation is cleanly replaced with `cue.startTime`, and the rest of the seek flow remains unchanged.

---
This PR was created autonomously by linear-solver.
Triage complexity: simple | [Linear issue](https://linear.app/a8c/issue/POC-631/tweak-tap-to-seek)