### PR TITLE
Liquid Glass: Hide tab bar during multi-select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix an issue with diagonal swipes not dismissing the player [#4335](https://github.com/Automattic/pocket-casts-ios/pull/4335)
 - Fix player interactive dismiss gesture interaction with vertical scroll views [#4349](https://github.com/Automattic/pocket-casts-ios/pull/4349)
 - Fix Show Archived toggle in Playlists during search [#4329](https://github.com/Automattic/pocket-casts-ios/pull/4329)
+- Hide the tab bar during multi-select to create more space [#4364](https://github.com/Automattic/pocket-casts-ios/pull/4364) 
 
 8.12
 -----

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -34,7 +34,7 @@ class DownloadsViewController: PCViewController {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.setupNavBar()
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
                 self.downloadsTable.beginUpdates()
                 self.downloadsTable.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -34,6 +34,7 @@ class DownloadsViewController: PCViewController {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.setupNavBar()
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
                 self.downloadsTable.beginUpdates()
                 self.downloadsTable.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled

--- a/podcasts/Extensions/UIViewController+TabBar.swift
+++ b/podcasts/Extensions/UIViewController+TabBar.swift
@@ -5,7 +5,7 @@ extension UIViewController {
     /// On earlier OS versions, or when the view controller isn't inside a
     /// tab bar controller, this is a no-op.
     func setEnclosingTabBarHidden(_ hidden: Bool, animated: Bool) {
-        guard #available(iOS 18.0, *), let tabBarController else { return }
+        guard #available(iOS 26, *), let tabBarController else { return }
         tabBarController.setTabBarHidden(hidden, animated: animated)
     }
 }

--- a/podcasts/Extensions/UIViewController+TabBar.swift
+++ b/podcasts/Extensions/UIViewController+TabBar.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+extension UIViewController {
+    /// Hides or shows the enclosing tab bar using the iOS 18 API.
+    /// On earlier OS versions, or when the view controller isn't inside a
+    /// tab bar controller, this is a no-op.
+    func setEnclosingTabBarHidden(_ hidden: Bool, animated: Bool) {
+        guard #available(iOS 18.0, *), let tabBarController else { return }
+        tabBarController.setTabBarHidden(hidden, animated: animated)
+    }
+}

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -43,6 +43,7 @@ class ListeningHistoryViewController: PCViewController {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.setupNavBar()
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
                 self.listeningHistoryTable.beginUpdates()
                 self.listeningHistoryTable.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.listeningHistoryTable.endUpdates()

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -43,7 +43,7 @@ class ListeningHistoryViewController: PCViewController {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.setupNavBar()
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
                 self.listeningHistoryTable.beginUpdates()
                 self.listeningHistoryTable.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.listeningHistoryTable.endUpdates()

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -68,7 +68,7 @@ class PlaylistDetailViewController: PCViewController, UIScrollViewDelegate {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
 
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
                 self.tableView.beginUpdates()
                 self.tableView.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -68,6 +68,7 @@ class PlaylistDetailViewController: PCViewController, UIScrollViewDelegate {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
 
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
                 self.tableView.beginUpdates()
                 self.tableView.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled

--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -85,7 +85,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
                 guard let self else { return }
 
                 self.setupNavBar()
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
                 self.tableView.beginUpdates()
                 self.tableView.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled

--- a/podcasts/PlaylistViewController.swift
+++ b/podcasts/PlaylistViewController.swift
@@ -85,6 +85,7 @@ class PlaylistViewController: PCViewController, TitleButtonDelegate {
                 guard let self else { return }
 
                 self.setupNavBar()
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
                 self.tableView.beginUpdates()
                 self.tableView.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController+Edit.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController+Edit.swift
@@ -40,7 +40,7 @@ extension PodcastListViewController {
 
         podcastsCollectionView.dragInteractionEnabled = true
         podcastsCollectionView.allowsSelection = false
-        setTabBarHidden(true, animated: true)
+        setEnclosingTabBarHidden(true, animated: true)
 
         for cell in podcastsCollectionView.visibleCells {
             applyEditingTreatment(to: cell)
@@ -50,7 +50,7 @@ extension PodcastListViewController {
     private func exitEditMode() {
         podcastsCollectionView.dragInteractionEnabled = false
         podcastsCollectionView.allowsSelection = true
-        setTabBarHidden(false, animated: true)
+        setEnclosingTabBarHidden(false, animated: true)
 
         setCustomRightBtn(savedRightBarButtonItem, animated: true)
         savedRightBarButtonItem = nil
@@ -58,11 +58,6 @@ extension PodcastListViewController {
         for cell in podcastsCollectionView.visibleCells {
             removeEditingTreatment(from: cell)
         }
-    }
-
-    private func setTabBarHidden(_ hidden: Bool, animated: Bool) {
-        guard #available(iOS 18.0, *), let tabBarController else { return }
-        tabBarController.setTabBarHidden(hidden, animated: animated)
     }
 
     // MARK: Wiggle (grid)

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -153,6 +153,7 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
     @MainActor
     var isMultiSelectEnabled = false {
         didSet {
+            setEnclosingTabBarHidden(isMultiSelectEnabled, animated: true)
             // For non-episode cells we don't enable editing. It needs to be for Bookmarks and already if for You Might Like.
             if currentViewMode == .episodes {
                 self.episodesTable.beginUpdates()

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -153,7 +153,7 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
     @MainActor
     var isMultiSelectEnabled = false {
         didSet {
-            setEnclosingTabBarHidden(isMultiSelectEnabled, animated: true)
+            setEnclosingTabBarHidden(isMultiSelectEnabled, animated: false)
             // For non-episode cells we don't enable editing. It needs to be for Bookmarks and already if for You Might Like.
             if currentViewMode == .episodes {
                 self.episodesTable.beginUpdates()

--- a/podcasts/StarredViewController.swift
+++ b/podcasts/StarredViewController.swift
@@ -31,6 +31,7 @@ class StarredViewController: PCViewController {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.setupNavBar()
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
                 self.starredTable.beginUpdates()
                 self.starredTable.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.starredTable.endUpdates()

--- a/podcasts/StarredViewController.swift
+++ b/podcasts/StarredViewController.swift
@@ -31,7 +31,7 @@ class StarredViewController: PCViewController {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.setupNavBar()
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
                 self.starredTable.beginUpdates()
                 self.starredTable.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.starredTable.endUpdates()

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -34,7 +34,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.updateNavBarButtons()
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
                 contentInseter.isMultiSelectEnabled = isMultiSelectEnabled
                 if !self.isMultiSelectEnabled {
                     self.multiSelectActionBar.isHidden = true

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -34,6 +34,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.updateNavBarButtons()
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
                 contentInseter.isMultiSelectEnabled = isMultiSelectEnabled
                 if !self.isMultiSelectEnabled {
                     self.multiSelectActionBar.isHidden = true

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -63,7 +63,7 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.setupNavBar()
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
                 self.uploadsTable.beginUpdates()
                 self.uploadsTable.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.insetAdjuster.isMultiSelectEnabled = self.isMultiSelectEnabled

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -63,6 +63,7 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
                 self.setupNavBar()
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: true)
                 self.uploadsTable.beginUpdates()
                 self.uploadsTable.setEditing(self.isMultiSelectEnabled, animated: true)
                 self.insetAdjuster.isMultiSelectEnabled = self.isMultiSelectEnabled


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Only for iOS 26 because mini player can't handle it on previous versions.

It gives you more space and eliminates these janky animations on scroll:

https://github.com/user-attachments/assets/9bff1a3b-eebf-4440-aef8-bc23055ad615

I initially tried animating hiding the tab bar and showing the multi-select bar, but it feels much better with no animations. You aren't looking there anyway. The animations are distracting and hard to get in sync.

https://github.com/user-attachments/assets/31037c5b-f028-4864-b33a-c13aa1c0638f

## To test

- Verify that tab bar hides during multi-select and reappears when you cancel it

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
