### PR TITLE
Liquid Glass: Native Alerts - Part 3

### DIFF
--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController+ContextMenu.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController+ContextMenu.swift
@@ -107,15 +107,14 @@ extension PodcastListViewController {
     // MARK: Action handlers
 
     private func confirmUnsubscribe(podcast: Podcast) {
-        let optionPicker = OptionsPicker(title: L10n.areYouSure)
         let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
-        let action = OptionAction(label: label, icon: nil) { [weak self] in
+        let alert = UIAlertController(title: L10n.areYouSure, message: nil, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
             PodcastManager.shared.unsubscribe(podcast: podcast)
             Analytics.track(.podcastUnsubscribed, properties: ["source": self?.analyticsSource ?? AnalyticsSource.podcastsList, "uuid": podcast.uuid])
-        }
-        action.destructive = true
-        optionPicker.addAction(action: action)
-        optionPicker.present(from: self)
+        })
+        present(alert, animated: true)
     }
 
     private func showFolderPicker(for podcast: Podcast) {

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController+ContextMenu.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController+ContextMenu.swift
@@ -115,7 +115,7 @@ extension PodcastListViewController {
         }
         action.destructive = true
         optionPicker.addAction(action: action)
-        optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+        optionPicker.present(from: self)
     }
 
     private func showFolderPicker(for podcast: Podcast) {

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.swift
@@ -101,19 +101,22 @@ class PodcastSettingsViewController: PCViewController {
                 downloadedCount += 1
             }
         }
-        let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
         let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
-        let unsubscribeAction = OptionAction(label: label, icon: nil, action: { [weak self] in
+        let title: String
+        let message: String?
+        if downloadedCount > 0 {
+            title = L10n.downloadedFilesConf(downloadedCount)
+            message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
+        } else {
+            title = L10n.areYouSure
+            message = nil
+        }
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
             self?.performUnsubscribe()
         })
-        if downloadedCount > 0 {
-            unsubscribeAction.destructive = true
-            let message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
-            optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: message, icon: "option-alert", actions: [unsubscribeAction])
-        } else {
-            optionPicker.addAction(action: unsubscribeAction)
-        }
-        optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+        present(alert, animated: true)
     }
 
     private func performUnsubscribe() {

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -765,19 +765,22 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
             }
         }
 
-        let optionPicker = OptionsPicker(title: downloadedCount > 0 ? nil : L10n.areYouSure)
         let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
-        let unsubscribeAction = OptionAction(label: label, icon: nil, action: { [weak self] in
+        let title: String
+        let message: String?
+        if downloadedCount > 0 {
+            title = L10n.downloadedFilesConf(downloadedCount)
+            message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
+        } else {
+            title = L10n.areYouSure
+            message = nil
+        }
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
             self?.performUnsubscribe()
         })
-        if downloadedCount > 0 {
-            unsubscribeAction.destructive = true
-            let message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
-            optionPicker.addDescriptiveActions(title: L10n.downloadedFilesConf(downloadedCount), message: message, icon: "option-alert", actions: [unsubscribeAction])
-        } else {
-            optionPicker.addAction(action: unsubscribeAction)
-        }
-        optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+        present(alert, animated: true)
 
         Analytics.track(.podcastScreenUnsubscribeTapped)
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

One more place with destructive actions I found and updated when working on something else:

<img width="340"  alt="Screenshot 2026-05-19 at 3 49 37 PM" src="https://github.com/user-attachments/assets/f495f192-9598-4b98-9ce7-ca6ef9808a29" />
<img width="340"  alt="Screenshot 2026-05-19 at 3 50 31 PM" src="https://github.com/user-attachments/assets/7b27673c-4a31-43d3-9a89-52075a27e9b5" />

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
