### PR TITLE
Prevent dev team changes to Xcode project file

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -2,6 +2,19 @@
 
 github.dismiss_out_of_range_messages
 
+# Prevent re-pinning DEVELOPMENT_TEAM in the Xcode project. It must live in the
+# xcconfig files so that Prototype builds can switch to the Enterprise team —
+# target-level pbxproj values outrank xcconfig and silently break signing.
+pbxproj = 'podcasts.xcodeproj/project.pbxproj'
+pbxproj_diff = git.diff_for_file(pbxproj)
+if pbxproj_diff && pbxproj_diff.patch =~ /^\+\s*DEVELOPMENT_TEAM\s*=/
+  failure(
+    "`DEVELOPMENT_TEAM` was added to `#{pbxproj}`. Keep it in the xcconfig " \
+    'files under `config/` instead — in Xcode, go to Build Settings → ' \
+    'Signing → Development Team and clear the value so the xcconfig wins.'
+  )
+end
+
 # `files: []` forces rubocop to scan all files, not just the ones modified in the PR
 rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true)
 


### PR DESCRIPTION
Adds a Danger rule to prevent pinning the DEVELOPMENT_TEAM in the Xcode project, which prevents prototypes from building.

PRs where we previously had to revert these changes:
- https://github.com/Automattic/pocket-casts-ios/pull/3540
- https://github.com/Automattic/pocket-casts-ios/pull/4369

## To test

[See test PR](https://github.com/Automattic/pocket-casts-ios/pull/4371)

1. Apply [repin-dev-team.patch](https://github.com/user-attachments/files/28032780/repin-dev-team.patch), commit and push.
2. Expect a [Danger warning](https://github.com/Automattic/pocket-casts-ios/pull/4371#issuecomment-4492618497).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
