### PR TITLE
Enable SwiftLint rule: modifier_order

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -81,6 +81,9 @@ only_rules:
   # MARK comment should be in valid format.
   - mark
 
+  # Modifiers (e.g. `public`, `final`, `lazy`) should be specified in a consistent order.
+  - modifier_order
+
   # Opening braces should be preceded by a single space and on the same line as
   # the declaration.
   - opening_brace

--- a/Modules/Sources/EndOfYear/Animations/PlayPauseAnimatableModifier.swift
+++ b/Modules/Sources/EndOfYear/Animations/PlayPauseAnimatableModifier.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 public class PlayPauseAnimationViewModel: ObservableObject {
-    @Published private(set) public var paused = true
+    @Published public private(set) var paused = true
 
     private var duration: TimeInterval
 

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -30,7 +30,7 @@ public class DataManager {
 
     let dbQueue: PCDBQueue
 
-    public static internal(set) var sharedManager = DataManager()
+    public internal(set) static var sharedManager = DataManager()
 
     public static var logger: ErrorLogger?
 

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -176,7 +176,7 @@ extension TrimSilence {
 }
 
 extension Podcast {
-    public override var debugDescription: String {
+    override public var debugDescription: String {
         "Podcast: \(uuid) - \(title ?? "missing title")"
     }
 }

--- a/Modules/Sources/PocketCastsDataModel/Public/NetworkDataUsage/NetworkDataUsageRecord.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/NetworkDataUsage/NetworkDataUsageRecord.swift
@@ -32,7 +32,7 @@ public class NetworkDataUsageRecord: NSObject {
     @GRDBColumn("session_type")
     @objc public var sessionType: String?
 
-    public override init() {
+    override public init() {
         super.init()
     }
 }

--- a/Modules/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
@@ -44,7 +44,7 @@ extension ModifiedDate where Value: RawRepresentable {
 
     /// Updates the ModifiedDate instance with values from an ApiSetting
     /// - Parameter setting: An `ApiSetting` instance which contains a value and (optional) modified date to set on this `ModifiedDate`
-    mutating private func uncaughtUpdate<S: ApiSetting>(setting: S) throws where Value.RawValue == S.ReturnValue.T {
+    private mutating func uncaughtUpdate<S: ApiSetting>(setting: S) throws where Value.RawValue == S.ReturnValue.T {
         let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
         if setting.modifiedAt.date > modifiedAt ?? referenceDate {
             guard let value = Value(rawValue: setting.value.value) else {

--- a/Modules/Sources/PocketCastsServer/Public/AppSettings.swift
+++ b/Modules/Sources/PocketCastsServer/Public/AppSettings.swift
@@ -108,5 +108,5 @@ public struct AppSettings: JSONCodable {
 }
 
 extension SettingsStore<AppSettings> {
-    public static internal(set) var appSettings = SettingsStore(key: "app_settings", value: AppSettings.defaults)
+    public internal(set) static var appSettings = SettingsStore(key: "app_settings", value: AppSettings.defaults)
 }

--- a/Modules/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -78,7 +78,7 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
         case podcast, folder
     }
 
-    static public func ==(lhs: PodcastFolderSearchResult, rhs: PodcastFolderSearchResult) -> Bool {
+    public static func ==(lhs: PodcastFolderSearchResult, rhs: PodcastFolderSearchResult) -> Bool {
         lhs.kind == rhs.kind && lhs.uuid == rhs.uuid
     }
 }

--- a/Modules/Sources/PocketCastsUtils/Extensions/UI/CustomTextView.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/UI/CustomTextView.swift
@@ -29,7 +29,7 @@ public class CustomTextField: UITextField {
         addSubview(rightLabel)
     }
 
-    public override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
 
         let clearButtonWidth: CGFloat = clearButtonRect(forBounds: bounds).width
@@ -47,15 +47,15 @@ public class CustomTextField: UITextField {
         )
     }
 
-    public override func textRect(forBounds bounds: CGRect) -> CGRect {
+    override public func textRect(forBounds bounds: CGRect) -> CGRect {
         return adjustRect(forBounds: bounds)
     }
 
-    public override func editingRect(forBounds bounds: CGRect) -> CGRect {
+    override public func editingRect(forBounds bounds: CGRect) -> CGRect {
         return adjustRect(forBounds: bounds)
     }
 
-    public override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
+    override public func placeholderRect(forBounds bounds: CGRect) -> CGRect {
         return adjustRect(forBounds: bounds)
     }
 

--- a/Modules/Sources/PocketCastsUtils/Extensions/UI/DismissableNestedScrollView.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/UI/DismissableNestedScrollView.swift
@@ -3,7 +3,7 @@ import UIKit
 
 /// A UIScrollView subclass that allows the swipe to dismiss in a presented view when its contained in a parent UIScrollView
 public class DismissableNestedScrollView: UIScrollView, UIGestureRecognizerDelegate {
-    public override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+    override public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         return (contentOffset.y + contentInset.top) - panGestureRecognizer.translation(in: self).y > 0
     }
 }

--- a/Modules/Sources/PocketCastsUtils/Extensions/UI/GradientView.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/UI/GradientView.swift
@@ -49,7 +49,7 @@ public class GradientView: UIView {
         layer.addSublayer(gradientLayer)
     }
 
-    public override func layoutSubviews() {
+    override public func layoutSubviews() {
         super.layoutSubviews()
 
         gradientLayer?.frame = bounds

--- a/Modules/Tests/PocketCastsServerTests/SyncTaskPlaylistOrderingTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/SyncTaskPlaylistOrderingTests.swift
@@ -93,7 +93,7 @@ private final class CapturingDataManager: DataManager {
         storedPlaylists[uuid]
     }
 
-    public override func playlistEpisodes(for playlist: EpisodeFilter, limit: Int? = nil, sortType: PlaylistSort? = nil) -> [Episode] {
+    override public func playlistEpisodes(for playlist: EpisodeFilter, limit: Int? = nil, sortType: PlaylistSort? = nil) -> [Episode] {
         let episodes = stubbedPlaylistEpisodes[playlist.uuid] ?? []
         if let limit {
             return Array(episodes.prefix(limit))

--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -168,7 +168,7 @@ struct MockData {
         return stubEpisodes
     }
 
-    static private var stubPlaylists: [EpisodeFilter] = []
+    private static var stubPlaylists: [EpisodeFilter] = []
 
     static let playlistsSpec: [(String, Bool, Color)] = [
         ("New releases", true, Color(red: 0.15, green: 0.25, blue: 0.5)),

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -40,7 +40,7 @@ class BookmarkEditTitleViewController: ThemedHostingController<BookmarkEditTitle
         }
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -32,7 +32,7 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
         viewModel.router = self
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
@@ -26,7 +26,7 @@ class BookmarksPodcastListController: ThemedHostingController<BookmarksPodcastLi
         viewModel.router = self
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
@@ -29,7 +29,7 @@ class BookmarksProfileListController: ThemedHostingController<BookmarksProfileLi
         Analytics.track(.profileBookmarksShow)
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/podcasts/End of Year/Stories/2025/ListeningTime2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/ListeningTime2025Story.swift
@@ -95,7 +95,7 @@ struct ListeningTime2025Story: ShareableStory {
     }
 }
 
-final private class LottieTextProvider: AnimationKeypathTextProvider {
+private final class LottieTextProvider: AnimationKeypathTextProvider {
 
     private var startTime: Double
     private var endTime: Double

--- a/podcasts/End of Year/Stories/2025/Ratings2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/Ratings2025Story.swift
@@ -235,7 +235,7 @@ fileprivate struct ChartColumn: View {
     }
 }
 
-final private class LottieTextProvider: LegacyAnimationTextProvider, Equatable {
+private final class LottieTextProvider: LegacyAnimationTextProvider, Equatable {
     private let index: Int
 
     private static func formatted(hours: Int) -> String {

--- a/podcasts/End of Year/Stories/2025/YearOverYearCompare2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/YearOverYearCompare2025Story.swift
@@ -162,7 +162,7 @@ struct YearOverYearCompare2025Story: ShareableStory {
     }
 }
 
-final private class LottieTextProvider: LegacyAnimationTextProvider, Equatable {
+private final class LottieTextProvider: LegacyAnimationTextProvider, Equatable {
     private let dict: [String: String]
     private let prevYear: Int
     private let currentYear: Int

--- a/podcasts/Episode/EpisodeLoadingController.swift
+++ b/podcasts/Episode/EpisodeLoadingController.swift
@@ -111,7 +111,7 @@ class EpisodeLoadingController: UIHostingController<AnyView> {
         }
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/podcasts/HorizontalCollectionListViewController.swift
+++ b/podcasts/HorizontalCollectionListViewController.swift
@@ -10,7 +10,7 @@ class HorizontalCollectionListViewController: ThemedHostingController<Horizontal
         super.init(rootView: HorizontalCollectionList(model: model))
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/podcasts/Kids Profile/KidsProfileSheetHost.swift
+++ b/podcasts/Kids Profile/KidsProfileSheetHost.swift
@@ -11,7 +11,7 @@ class KidsProfileSheetHost: ThemedHostingController<KidsProfileSheet> {
         super.init(rootView: screen)
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -22,7 +22,7 @@ class ListeningHistoryViewController: PCViewController {
     private let episodesDataManager = EpisodesDataManager()
     private var searchController: PCSearchBarController?
 
-    lazy private var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
+    private lazy var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
         let viewModel = InformationalBannerViewModel(bannerType: .listeningHistory)
         return InformationalBannerViewCoordinator(viewModel: viewModel)
     }()

--- a/podcasts/LogsViewController.swift
+++ b/podcasts/LogsViewController.swift
@@ -12,7 +12,7 @@ class LogsViewController: ThemedHostingController<LogsView> {
         model.presenter = self
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -20,7 +20,7 @@ class PlaylistDetailViewController: PCViewController, UIScrollViewDelegate {
         }
     }
 
-    lazy private(set) var searchHeaderView: UIView = {
+    private(set) lazy var searchHeaderView: UIView = {
         let header = UIView(frame: .zero)
         header.backgroundColor = AppTheme.colorForStyle(.primaryUi02)
         return header

--- a/podcasts/New Detail/PlaylistPlayAllHelper/PlaylistPlayAllSheetHost.swift
+++ b/podcasts/New Detail/PlaylistPlayAllHelper/PlaylistPlayAllSheetHost.swift
@@ -22,7 +22,7 @@ class PlaylistPlayAllSheetHost: ThemedHostingController<PlaylistPlayAllSheet> {
         super.init(rootView: screen)
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/podcasts/Onboarding/Encourage Account Creation/Banner/InformationalProfileBannerCell.swift
+++ b/podcasts/Onboarding/Encourage Account Creation/Banner/InformationalProfileBannerCell.swift
@@ -3,7 +3,7 @@ import UIKit
 class InformationalProfileBannerCell: ThemeableCell {
     static var identifier = "InformationalBannerIdentifier"
 
-    lazy private var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
+    private lazy var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
         let viewModel = InformationalBannerViewModel(bannerType: .profile)
         return InformationalBannerViewCoordinator(viewModel: viewModel)
     }()

--- a/podcasts/PCHostingController.swift
+++ b/podcasts/PCHostingController.swift
@@ -19,7 +19,7 @@ class ModifedHostingController<Content: View, Modifier: ViewModifier>: UIHosting
         }
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }
@@ -56,7 +56,7 @@ class ThemedHostingController<Content>: ModifedHostingController<Content, Themed
         }
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }

--- a/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
+++ b/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
@@ -40,7 +40,7 @@ actor PlaylistMetadataLoader {
     /// Thread-safe subject for publishing metadata updates.
     /// Access via `updatesPublisher` for subscribing to changes.
     /// Marked nonisolated(unsafe) because PassthroughSubject is internally thread-safe.
-    private nonisolated(unsafe) let updatesSubject = PassthroughSubject<MetadataUpdate, Never>()
+    nonisolated(unsafe) private let updatesSubject = PassthroughSubject<MetadataUpdate, Never>()
 
     /// Publisher that emits metadata updates when counts or images change.
     /// Subscribe to receive updates for specific playlists.
@@ -75,7 +75,7 @@ actor PlaylistMetadataLoader {
 
     /// Subject for publishing when playlists become stale and need refresh.
     /// Marked nonisolated(unsafe) because PassthroughSubject is internally thread-safe.
-    private nonisolated(unsafe) let stalePlaylistsSubject = PassthroughSubject<Set<String>, Never>()
+    nonisolated(unsafe) private let stalePlaylistsSubject = PassthroughSubject<Set<String>, Never>()
 
     /// Publisher that emits sets of playlist IDs that have become stale.
     /// Subscribe to trigger refresh of visible playlists.

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -89,7 +89,7 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
     enum TableRow { case informationalBanner, kidsProfile, referralsClaim, allStats, downloaded, starred, listeningHistory, help, uploadedFiles, endOfYearPrompt, bookmarks }
 
-    lazy private var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
+    private lazy var informationalBannerCoordinator: InformationalBannerViewCoordinator = {
         let viewModel = InformationalBannerViewModel(bannerType: .profile)
         return InformationalBannerViewCoordinator(viewModel: viewModel)
     }()

--- a/podcasts/Referrals/ReferralClaimPassVC.swift
+++ b/podcasts/Referrals/ReferralClaimPassVC.swift
@@ -11,7 +11,7 @@ class ReferralClaimPassVC: ThemedHostingController<ReferralClaimPassView> {
         viewModel.presentationController = self
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/podcasts/Referrals/ReferralSendPassVC.swift
+++ b/podcasts/Referrals/ReferralSendPassVC.swift
@@ -14,7 +14,7 @@ class ReferralSendPassVC: ThemedHostingController<ReferralSendPassView> {
         super.init(rootView: screen)
     }
 
-    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -85,7 +85,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         fatalError("init(coder:) has not been implemented")
     }
 
-    public override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
         if FeatureFlag.generatedTranscripts.enabled {
@@ -717,7 +717,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         bannerLabel.font = .font(ofSize: 13, weight: .medium, scalingWith: .footnote, maxSizeCategory: .extraExtraExtraLarge)
     }
 
-    public override func viewDidLayoutSubviews() {
+    override public func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         updateTextMargins()
     }


### PR DESCRIPTION
Enables the SwiftLint rule [`modifier_order`](https://realm.github.io/SwiftLint/modifier_order.html) — modifiers (e.g. `public`, `final`, `lazy`) should be specified in a consistent order.

- **Auto-fixed violations**: 39 (via `make format`)
- **Agentic fixes**: 0
- **Left for human review**: 0
- **Files touched**: 33 source files (pure modifier reorderings, no multiline rewrites)

Local lint is clean (0 violations) after the fix.
Build deferred to CI — local `make build_staging` was prohibitively slow in this environment and the diff is syntactically narrow (modifier token reordering only).

Part of the Orchard SwiftLint rollout campaign.

---

Generated with the help of Claude Code, https://claude.ai/code