### PR TITLE
Enable SwiftLint rule: comma_inheritance

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -33,6 +33,10 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # Commas in protocol/superclass inheritance lists should be followed by a
+  # single space (e.g., prefer `class Foo: Bar, Baz` over `class Foo: Bar,Baz`).
+  - comma_inheritance
+
   # Prefer `contains` over `filter(where:).count`.
   - contains_over_filter_count
 


### PR DESCRIPTION
## What

Adds `comma_inheritance` to `only_rules` in `.swiftlint.yml`.

The rule enforces a single space after commas in protocol and superclass inheritance lists (e.g., `class Foo: Bar, Baz` over `class Foo: Bar,Baz`).

## Numbers

- Auto-fixed violations: 0
- Agentic (manual) fixes: 0
- Left for human review: 0

The codebase was already compliant; this PR only opts the rule in.

## Context

Part of the [Orchard SwiftLint rollout](https://github.com/Automattic/orchard) campaign — enabling one rule at a time across mobile repos.