### PR TITLE
Enable SwiftLint rule: period_spacing

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -85,6 +85,9 @@ only_rules:
   # the declaration.
   - opening_brace
 
+  # Periods should not be followed by whitespace inside an expression.
+  - period_spacing
+
   # Prefer `0` over explicit `Int(0)` / `CGFloat(0)` etc.
   - prefer_zero_over_explicit_init
 


### PR DESCRIPTION
Adds `period_spacing` to the SwiftLint opt-in `only_rules`.

The rule flags whitespace immediately after a period inside an expression (e.g. `foo. bar` → `foo.bar`). Auto-fixable.

**Auto-fix count:** 0 — the codebase was already clean.
**Files changed:** 1 (`.swiftlint.yml`)

Part of the progressive SwiftLint rollout campaign — one rule, one PR at a time.

---

*Posted by Claude (Opus 4.7 1M) on behalf of @mokagio with approval.*