### PR TITLE
Enable SwiftLint rule: untyped_error_in_catch

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -112,6 +112,9 @@ only_rules:
   # Lines should not have trailing whitespace.
   - trailing_whitespace
 
+  # `catch` statements should not declare error variables without type casting.
+  - untyped_error_in_catch
+
   # Unused parameters in a closure should be replaced with `_`.
   - unused_closure_parameter
 

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -670,7 +670,7 @@ class PodcastDataManager {
                 WHERE uuid = '\(podcastUuid)'
                 """
                 try db.executeUpdate(query, values: [])
-            } catch let error {
+            } catch {
                 FileLog.shared.addMessage("PodcastDataManager.saveSingleSetting for \(name) error: \(error)")
             }
         }

--- a/Modules/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -187,7 +187,7 @@ class TokenHelper {
 
             let errorResponse = ApiServerHandler.extractErrorResponse(data: responseData, response: response, error: nil)
             throw errorResponse ?? .UNKNOWN
-        } catch let error {
+        } catch {
             FileLog.shared.addMessage("TokenHelper acquireToken failed \(error.localizedDescription)")
             throw error
         }
@@ -202,7 +202,7 @@ class TokenHelper {
                 completion(.success(authenticationResponse))
                 return
             }
-        } catch let error {
+        } catch {
             completion(.failure(error))
             return
         }
@@ -211,7 +211,7 @@ class TokenHelper {
             do {
                 let authenticationResponse = try await acquireIdentityToken()
                 completion(.success(authenticationResponse))
-            } catch let error {
+            } catch {
                 completion(.failure(error))
             }
         }
@@ -244,7 +244,7 @@ class TokenHelper {
             if try ServerSettings.refreshToken() == nil {
                 logMessages.append("no SSO token")
             }
-        } catch let error {
+        } catch {
             if case let KeychainHelper.KeychainError.status(status) = error, status == errSecInteractionNotAllowed {
                 logMessages.append("no SSO token")
                 FileLog.shared.addMessage("Acquire Token was called, however the user has \(logMessages.joined(separator: ", ")).")

--- a/Modules/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
@@ -59,7 +59,7 @@ extension ModifiedDate where Value: RawRepresentable {
     mutating func update<S: ApiSetting>(setting: S) where Value.RawValue == S.ReturnValue.T {
         do {
             try uncaughtUpdate(setting: setting)
-        } catch let error {
+        } catch {
             switch error {
             case ApiUpdateError.representableNotFound(value: let value, representable: let representable):
                 FileLog.shared.addMessage("Failed to represent value: \(value) representing: \(representable)")

--- a/Modules/Sources/PocketCastsUtils/General/ModifiedDate.swift
+++ b/Modules/Sources/PocketCastsUtils/General/ModifiedDate.swift
@@ -37,7 +37,7 @@ extension ModifiedDate {
 
         do {
             value = try container.decode(Value.self, forKey: .value)
-        } catch let error {
+        } catch {
             // Add additional decoding for Int -> Bool due to SQLite type issues
             // "the SQL datatype of the result is NULL for a JSON null, INTEGER or REAL for a JSON numeric value, an INTEGER zero for a JSON false value, an INTEGER one for a JSON true value"
             // See more details on the `json_extract` output here: https://www.sqlite.org/json1.html#jex

--- a/Modules/Tests/PocketCastsDataModelTests/SQLiteValidator.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/SQLiteValidator.swift
@@ -23,7 +23,7 @@ struct SQLiteValidator {
         queue.read { db in
             do {
                 _ = try db.executeQuery(sql, values: values)
-            } catch let inError {
+            } catch {
                 error = inError
             }
         }

--- a/Modules/Tests/PocketCastsDataModelTests/SQLiteValidator.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/SQLiteValidator.swift
@@ -19,17 +19,17 @@ struct SQLiteValidator {
         DatabaseHelper.setup(queue: queue)
 
         // Attempt to prepare the SQL via our database layer
-        var error: Error?
+        var validationError: Error?
         queue.read { db in
             do {
                 _ = try db.executeQuery(sql, values: values)
             } catch {
-                error = inError
+                validationError = error
             }
         }
 
-        if let error {
-            throw error
+        if let validationError {
+            throw validationError
         }
     }
 }

--- a/Modules/Tests/PocketCastsServerTests/MockURLHandler.swift
+++ b/Modules/Tests/PocketCastsServerTests/MockURLHandler.swift
@@ -16,7 +16,7 @@ extension MockRequestHandler: RequestHandler {
         do {
             let (data, response) = try handler(request)
             completion(data, response, nil)
-        } catch let error {
+        } catch {
             completion(nil, nil, error)
         }
     }

--- a/Pocket Casts Watch App/Data & Communication/SessionManager.swift
+++ b/Pocket Casts Watch App/Data & Communication/SessionManager.swift
@@ -54,7 +54,7 @@ class SessionManager: NSObject, WCSessionDelegate {
             let value = flags[flag.rawValue] ?? flag.default
             do {
                 try FeatureFlagOverrideStore().override(flag, withValue: value)
-            } catch let error {
+            } catch {
                 assertionFailure("Failed to override \(flag.rawValue) with \(value): \(error)")
             }
         }

--- a/PocketCastsTests/Mocks/MockURLHandler.swift
+++ b/PocketCastsTests/Mocks/MockURLHandler.swift
@@ -16,7 +16,7 @@ extension MockRequestHandler: RequestHandler {
         do {
             let (data, response) = try handler(request)
             completion(data, response, nil)
-        } catch let error {
+        } catch {
             completion(nil, nil, error)
         }
     }

--- a/PocketCastsTests/Tests/Utilities/TokenHelperTests.swift
+++ b/PocketCastsTests/Tests/Utilities/TokenHelperTests.swift
@@ -37,7 +37,7 @@ class TokenHelperTests: XCTestCase {
             XCTAssertEqual(response?.token, "1234")
             XCTAssertEqual(response?.email, "test@test.com")
             XCTAssertNotNil(response?.uuid, "Should receive UUID")
-        } catch let error {
+        } catch {
             XCTFail("Acquire Password Token shouldn't fail: \(error)")
         }
     }

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -219,7 +219,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         let destinationUrl = URL(fileURLWithPath: pathForUrl(fileUrl: url, uuid: uuid))
         do {
             try StorageManager.moveItem(at: url, to: destinationUrl, options: .overwriteExisting)
-        } catch let error {
+        } catch {
             let nsError = error as NSError
             switch (nsError.domain, nsError.code) {
             case (NSCocoaErrorDomain, 513):

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -162,7 +162,7 @@ fileprivate struct CustomVideoPlayerView: UIViewControllerRepresentable {
         if !PlaybackManager.shared.isPlayingEpisode {
             do {
                 try AVAudioSession.sharedInstance().setActive(false)
-            } catch let error {
+            } catch {
                 FileLog.shared.addMessage("Playback Video Audio Session error: \(error)")
             }
         }

--- a/podcasts/MediaExporter.swift
+++ b/podcasts/MediaExporter.swift
@@ -49,7 +49,7 @@ struct MediaExporter {
         if FileManager.default.fileExists(atPath: outputURL.path) {
             do {
                 try FileManager.default.removeItem(at: outputURL)
-            } catch let error {
+            } catch {
                 FileLog.shared.addMessage("DownloadManager export session: failed to delete file with error -> \(error)")
                 return false
             }

--- a/podcasts/MediaFileHandle.swift
+++ b/podcasts/MediaFileHandle.swift
@@ -116,7 +116,7 @@ extension MediaFileHandle {
     func deleteFile() {
         do {
             try FileManager.default.removeItem(atPath: filePath)
-        } catch let error {
+        } catch {
             FileLog.shared.addMessage("MediaFileHandle: File [\(filePath)] deletion error: \(error)")
         }
     }

--- a/podcasts/Sharing/ShareButton.swift
+++ b/podcasts/Sharing/ShareButton.swift
@@ -23,7 +23,7 @@ struct ShareButton: View {
             shareTask = Task.detached { @MainActor in
                 do {
                     try await destination.share(option, style: style, clipTime: clipTime, clipUUID: clipUUID, progress: $progress, presentFrom: frame, source: source)
-                } catch let error {
+                } catch {
                     if Task.isCancelled { return }
                     await MainActor.run {
                         Toast.show("Failed clip export: \(error.localizedDescription)")

--- a/podcasts/Watch Communication/WatchManager+Send.swift
+++ b/podcasts/Watch Communication/WatchManager+Send.swift
@@ -99,7 +99,7 @@ extension WatchManager {
         rotator.rotateFile(ifSizeExceeds: 100.kilobytes)
         do {
             try contents.write(to: filePath, atomically: false, encoding: .utf8)
-        } catch let error {
+        } catch {
             FileLog.shared.addMessage("Failed to save cached watch log file: \(error.localizedDescription)")
         }
     }


### PR DESCRIPTION
Part of the progressive SwiftLint rules rollout.

This PR enables the [`untyped_error_in_catch`](https://realm.github.io/SwiftLint/untyped_error_in_catch.html) rule and applies its autofix.

The rule flags `catch let error` and `catch var error` clauses that bind the error without specifying a type; Swift already exposes an implicit `error` constant inside `catch` blocks, so the explicit binding is redundant.

The body changes are SwiftLint's autofix output (`make format` on SwiftLint 0.63.2): each `catch let error {` becomes `catch {`.

## To test

- `make lint` passes locally.
- CI is green.