### PR TITLE
Liquid Glass: Minor fixes for iOS 18 nav bar appearance

### DIFF
--- a/podcasts/Common Components/View Controllers/PCViewController.swift
+++ b/podcasts/Common Components/View Controllers/PCViewController.swift
@@ -234,7 +234,7 @@ class PCViewController: SimpleNotificationsViewController {
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()
         if scrolled {
-            appearance.backgroundEffect = UIBlurEffect(style: .regular)
+            appearance.configureWithOpaqueBackground()
         }
         navigationBar.standardAppearance = appearance
         navigationBar.scrollEdgeAppearance = appearance

--- a/podcasts/Common Components/View Controllers/PCViewController.swift
+++ b/podcasts/Common Components/View Controllers/PCViewController.swift
@@ -48,6 +48,8 @@ class PCViewController: SimpleNotificationsViewController {
     private var navTitleColor: UIColor?
     private var navBgColor: UIColor?
 
+    private var isNavBarScrolled = false
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -96,6 +98,11 @@ class PCViewController: SimpleNotificationsViewController {
 
         if let title, !title.isEmpty {
             setupNavBar(animated: animated)
+        } else if useTransparentNavigationBarAppearance {
+            // `setupNavBar` is gated on a non-empty title, but transparent-bar subclasses (which
+            // often use `navigationItem.titleView` and leave `title` empty) still need the bar's
+            // global appearance restored — another VC in the stack may have overwritten it.
+            setTransparentNavBarScrolled(isNavBarScrolled)
         }
         refreshRightButtons()
     }
@@ -214,7 +221,7 @@ class PCViewController: SimpleNotificationsViewController {
     }
 
     private func configureTransparentAppearance() {
-        setTransparentNavBarScrolled(false)
+        setTransparentNavBarScrolled(isNavBarScrolled)
     }
 
     /// Toggles the navigation bar between its at-edge (transparent) and scrolled (blurred) styles,
@@ -224,6 +231,8 @@ class PCViewController: SimpleNotificationsViewController {
     /// UIKit animates the appearance swap. When Liquid Glass is enabled the system handles the
     /// at-edge/scrolled transition on its own, so we just install its default background once.
     func setTransparentNavBarScrolled(_ scrolled: Bool) {
+        isNavBarScrolled = scrolled
+
         guard !LiquidGlass.isEnabled else {
             return // It's a no-op since on iOS 26 we already use default transparent bars
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

- Fix opaque nav bar being nearly transparent during selection
- Fix nav bar state not restoring after the interactive dismiss is cancelled 

**Note**: ideally, the app would use `navigationItem` instead of changing `navigationBar` directly, but that's a bigger change we can't feasibly make not – cutting too close to the release.

https://github.com/user-attachments/assets/409c5d79-25b9-442f-a136-350c3e853044



## To test

- Follow the steps from the recording

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
