### PR TITLE
Enable SwiftLint rule: return_value_from_void_function

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -101,6 +101,9 @@ only_rules:
   # Type annotations are redundant when the type can be inferred.
   - redundant_type_annotation
 
+  # Don't `return` a value from a function whose return type is `Void`.
+  - return_value_from_void_function
+
   # Prefer shorthand optional binding `if let foo {` over `if let foo = foo {`.
   - shorthand_optional_binding
 

--- a/podcasts/Common Components/RoundedLabel.swift
+++ b/podcasts/Common Components/RoundedLabel.swift
@@ -23,7 +23,8 @@ class RoundedLabel: ThemeableLabel {
     override func drawText(in rect: CGRect) {
         let insets = UIEdgeInsets(top: topInset, left: leftInset, bottom: bottomInset, right: rightInset)
         setNeedsLayout()
-        return super.drawText(in: rect.inset(by: insets))
+        super.drawText(in: rect.inset(by: insets))
+        return
     }
 
     override var intrinsicContentSize: CGSize {

--- a/podcasts/Common Components/View Controllers/PCViewController.swift
+++ b/podcasts/Common Components/View Controllers/PCViewController.swift
@@ -229,7 +229,8 @@ class PCViewController: SimpleNotificationsViewController {
         }
 
         guard let navigationBar = navigationController?.navigationBar else {
-            return assertionFailure("navigationBar is missing")
+            assertionFailure("navigationBar is missing")
+            return
         }
         let appearance = UINavigationBarAppearance()
         appearance.configureWithTransparentBackground()

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -609,7 +609,8 @@ class Settings: NSObject {
 
     class func setUserEpisodeAutoAddToUpNext(_ value: Bool) {
         if FeatureFlag.newSettingsStorage.enabled {
-            return SettingsStore.appSettings.filesAutoUpNext = value
+            SettingsStore.appSettings.filesAutoUpNext = value
+            return
         }
         UserDefaults.standard.set(value, forKey: userEpisodeAutoAddToUpNextKey)
         trackValueToggled(.settingsFilesAutoAddUpNextToggled, enabled: value)


### PR DESCRIPTION
Part of the progressive SwiftLint rules rollout.

This PR enables the [`return_value_from_void_function`](https://realm.github.io/SwiftLint/return_value_from_void_function.html) rule and applies its autofix.

The rule flags statements like `return foo()` where `foo()` returns `Void` — the `return` keyword there is misleading because there is no value to return. The autofix splits each occurrence onto two lines: `foo()` followed by a bare `return`.

The body changes are SwiftLint's autofix output (`make format` on SwiftLint 0.63.2), applied to 3 sites:

- `podcasts/Settings.swift`
- `podcasts/Common Components/RoundedLabel.swift`
- `podcasts/Common Components/View Controllers/PCViewController.swift`

## To test

- `make lint` passes locally.
- CI is green.

---

*Posted by Claude (Opus 4.7 1M context) on behalf of @mokagio with approval.*