### PR TITLE
Enable SwiftLint rule: explicit_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -65,6 +65,9 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
+  # Prefer explicit `.init` when creating a value of a known type.
+  - explicit_init
+
   # Prefer `first(where:)` over `filter { }.first`.
   - first_where
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -65,7 +65,7 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
-  # Prefer explicit `.init` when creating a value of a known type.
+  # Prefer `Type()` over `Type.init()` when creating a value of a known type.
   - explicit_init
 
   # Prefer `first(where:)` over `filter { }.first`.

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -199,7 +199,7 @@ public class YearListeningHistory {
             dispatchGroup.enter()
 
             DispatchQueue.global(qos: .userInitiated).async {
-                let syncYearListeningHistory = SyncYearListeningHistoryTask.init(year: yearToSync)
+                let syncYearListeningHistory = SyncYearListeningHistoryTask(year: yearToSync)
 
                 syncYearListeningHistory.start()
 

--- a/Modules/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
+++ b/Modules/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
@@ -82,7 +82,7 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
         let uuid = bookmark.uuid
         let updatedTitle = "hello"
         let updatedTime = 321.0
-        let updatedDate = Date.init(timeIntervalSince1970: 99999)
+        let updatedDate = Date(timeIntervalSince1970: 99999)
 
         let apiBookmark = Api_SyncUserBookmark(uuid: uuid,
                                                episode: bookmark.episodeUuid,
@@ -150,8 +150,8 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
 
         let allBookmarks = bookmarkManager.allBookmarks()
 
-        XCTAssertEqual(allBookmarks.map(\.title), Array.init(repeating: newTitle, count: bookmarks.count))
-        XCTAssertEqual(allBookmarks.map(\.created), Array.init(repeating: created, count: bookmarks.count))
+        XCTAssertEqual(allBookmarks.map(\.title), Array(repeating: newTitle, count: bookmarks.count))
+        XCTAssertEqual(allBookmarks.map(\.created), Array(repeating: created, count: bookmarks.count))
     }
 
     func testFullSyncImportsDataCorrectly() {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -56,7 +56,7 @@ class EpisodeRowViewModel: Identifiable {
     private func loadEpisodeArtworkData() async -> Data? {
         let imageUrl = ServerHelper.image(podcastUuid: episode.parentIdentifier(), size: 340)
         guard let url = URL(string: imageUrl),
-              let (data, _) = try? await URLSession.shared.data(for: URLRequest.init(url: url)),
+              let (data, _) = try? await URLSession.shared.data(for: URLRequest(url: url)),
               let uiImage = UIImage(data: data)
         else {
             return nil

--- a/WidgetExtension/Now Playing/NowPlayingEntryView.swift
+++ b/WidgetExtension/Now Playing/NowPlayingEntryView.swift
@@ -291,12 +291,12 @@ struct NowPlayingWidgetEntryView: View {
 struct NowPlayingEntryView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            NowPlayingWidgetEntryView(entry: .init(date: Date(), episode: WidgetEpisode(commonItem: CommonUpNextItem.init(episodeUuid: "foo", imageUrl: "", episodeTitle: "foo", podcastName: "foo", podcastColor: "#999999", duration: 400, isPlaying: true)), isPlaying: true), widgetColorSchemeLight: .bold,
+            NowPlayingWidgetEntryView(entry: .init(date: Date(), episode: WidgetEpisode(commonItem: CommonUpNextItem(episodeUuid: "foo", imageUrl: "", episodeTitle: "foo", podcastName: "foo", podcastColor: "#999999", duration: 400, isPlaying: true)), isPlaying: true), widgetColorSchemeLight: .bold,
                 widgetColorSchemeDark: .bold)
                 .previewContext(WidgetPreviewContext(family: .systemSmall))
                 .previewDisplayName("Episode Playing")
 
-            NowPlayingWidgetEntryView(entry: .init(date: Date(), episode: WidgetEpisode(commonItem: CommonUpNextItem.init(episodeUuid: "foo", imageUrl: "", episodeTitle: "foo", podcastName: "foo", podcastColor: "#999999", duration: 400, isPlaying: true)), isPlaying: false), widgetColorSchemeLight: .bold,
+            NowPlayingWidgetEntryView(entry: .init(date: Date(), episode: WidgetEpisode(commonItem: CommonUpNextItem(episodeUuid: "foo", imageUrl: "", episodeTitle: "foo", podcastName: "foo", podcastColor: "#999999", duration: 400, isPlaying: true)), isPlaying: false), widgetColorSchemeLight: .bold,
                 widgetColorSchemeDark: .bold)
                 .previewContext(WidgetPreviewContext(family: .systemSmall))
                 .previewDisplayName("Episode Paused")

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -100,7 +100,7 @@ class BookmarksPlayerTabController: PlayerItemViewController {
         guard isNew else { return }
 
         if canceled {
-            Task.init {
+            Task {
                 let _ = await bookmarkManager.remove([bookmark])
                 viewModel.reload()
             }

--- a/podcasts/End of Year/StoriesModel.swift
+++ b/podcasts/End of Year/StoriesModel.swift
@@ -108,7 +108,7 @@ class StoriesModel: ObservableObject {
     func refresh() {
         isReady = false
 
-        Task.init {
+        Task {
             if self.configuration.loadingIsTheFirstStory {
                 loadingStart()
             }

--- a/podcasts/Episode+Transcript.swift
+++ b/podcasts/Episode+Transcript.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 
 extension Episode {
     func checkTranscriptAvailability() {
-        Task.init {
+        Task {
             if let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier(), episodeUuid: uuid) {
                 let transcriptsAvailable = !metadata.transcripts.isEmpty
                 let hasGeneratedTranscripts = metadata.hasGeneratedTranscripts

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
@@ -142,7 +142,7 @@ class UpgradeAccountViewModel: PlusPurchaseModel {
         track(.plusPromotionUpgradeButtonTapped)
 
         guard SyncManager.isUserLoggedIn() else {
-            presentLogin(with: ProductInfo.init(plan: upgradeTier.plan, frequency: selectedFrequency))
+            presentLogin(with: ProductInfo(plan: upgradeTier.plan, frequency: selectedFrequency))
             return
         }
         purchase(product: selectedProduct)

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -174,6 +174,6 @@ extension PlusLandingViewModel {
     @ViewBuilder
     private static func defaultPaywall(with viewModel: PlusLandingViewModel, headline: String? = nil) -> some View {
             UpgradeLandingView(viewModel: viewModel)
-                .setupDefaultEnvironment(theme: Theme.init(previewTheme: .light))
+                .setupDefaultEnvironment(theme: Theme(previewTheme: .light))
     }
 }

--- a/podcasts/Referrals/ReferralSendPassVC.swift
+++ b/podcasts/Referrals/ReferralSendPassVC.swift
@@ -154,7 +154,7 @@ class ImageShareSource: NSObject, UIActivityItemSource {
         metadata.originalURL = URL(string: ServerConstants.Urls.pocketcastsDotCom)
         metadata.url = URL(string: ServerConstants.Urls.pocketcastsDotCom)
         metadata.title = title
-        metadata.imageProvider = NSItemProvider.init(contentsOf: url)
+        metadata.imageProvider = NSItemProvider(contentsOf: url)
 
         return metadata
     }


### PR DESCRIPTION
## What

Enables the SwiftLint `explicit_init` rule, which flags redundant `.init` calls when the type is obvious from context (e.g. `Task.init { ... }`, `Date.init(timeIntervalSince1970:)`, `Array.init(repeating:count:)`).

## Why

Part of the Orchard SwiftLint rollout campaign — progressively enabling more rules across our iOS repos to keep style consistent and catch common nits at lint time instead of review time.

## Changes

- 13 violations auto-fixed via `make format`
- 0 manual (agentic) fixes
- 0 violations left for human review

## To test

CI should be green.

## Checklist

- [x] Considered release notes — N/A (lint-only, no behaviour change).
- [x] Considered unit tests — N/A (no production logic change).
- [x] Considered analytics — N/A.