### PR TITLE
PCIOS-649: Smart Folders Suggestion: Navigation bar visible

### DIFF
--- a/podcasts/Folders/Create & Edit/Views/SuggestedFoldersView.swift
+++ b/podcasts/Folders/Create & Edit/Views/SuggestedFoldersView.swift
@@ -38,18 +38,7 @@ struct SuggestedFoldersView: View {
             case .loaded:
                 NavigationContainer {
                     mainBody
-                        .toolbar {
-                            ToolbarItem(placement: .navigationBarLeading) {
-                                Button {
-                                    track(.suggestedFoldersPageDismissed)
-                                    onCompletion(.dismiss)
-                                } label: {
-                                    Image("close")
-                                        .foregroundColor(ThemeColor.primaryInteractive01(for: theme.activeTheme).color)
-                                }
-                                .accessibilityLabel(L10n.close)
-                            }
-                        }
+                        .navigationBarHidden(true)
                 }
                 .navigationViewStyle(.stack)
                 .tint(ThemeColor.primaryInteractive01(for: theme.activeTheme).color)
@@ -83,6 +72,17 @@ struct SuggestedFoldersView: View {
 
     var mainBody: some View {
         VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Button {
+                    track(.suggestedFoldersPageDismissed)
+                    onCompletion(.dismiss)
+                } label: {
+                    Image("close")
+                        .foregroundColor(ThemeColor.primaryInteractive01(for: theme.activeTheme).color)
+                }
+                .accessibilityLabel(L10n.close)
+                Spacer()
+            }
             Group {
                 Text(L10n.suggestedFoldersTitle)
                     .textStyle(PrimaryText())
@@ -130,7 +130,6 @@ struct SuggestedFoldersView: View {
             Spacer()
         }
         .padding(.horizontal, Constants.margin)
-        .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             track(.suggestedFoldersPageShown)
         }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-649/smart-folders-suggestion-navigation-bar-visible

## Summary
Hide the navigation bar in `SuggestedFoldersView` and move the close button from the navigation toolbar into the view body.

## Changes
- Added `.navigationBarHidden(true)` to hide the empty navigation bar on the suggested folders screen
- Moved the close button from a `ToolbarItem` into an `HStack` at the top of the view body
- Removed the now-unnecessary `.navigationBarTitleDisplayMode(.inline)` modifier

## Verification
- **Lint**: PASS
- **Tests**: N/A — pre-existing CarPlay build errors unrelated to this change
- **Diff review**: PASS — confirmed changes are scoped to the single file

## Confidence
**HIGH** — Straightforward UI modifier change. The navigation bar was the only source of the empty bar, and the close button has been relocated to maintain functionality.

---
This PR was created autonomously by linear-solver.
Triage complexity: simple | [Linear issue](https://linear.app/a8c/issue/PCIOS-649/smart-folders-suggestion-navigation-bar-visible)