### PR TITLE
PCIOS-671: Options Picker colors are not updated when system color scheme changes

### DIFF
--- a/podcasts/DescriptiveActionView.swift
+++ b/podcasts/DescriptiveActionView.swift
@@ -35,6 +35,10 @@ class DescriptiveActionView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     func actionWasAdded(vc: UIViewController) {
         // add icon
         let image = UIImage(named: icon)?.tintedImage(AppTheme.colorForStyle(iconTintStyle, themeOverride: themeOverride))
@@ -148,7 +152,7 @@ class DescriptiveActionView: UIView {
     }
 
     private func makeStandardButton(for action: OptionAction) -> UIView {
-        let actionColor = action.destructive ? AppTheme.destructiveTextColor() : ThemeColor.primaryIcon01(for: themeOverride)
+        let actionColor = action.destructive ? AppTheme.destructiveTextColor(for: themeOverride) : ThemeColor.primaryIcon01(for: themeOverride)
 
         var config = UIButton.Configuration.filled()
         var title = AttributedString(action.label)
@@ -220,7 +224,7 @@ class DescriptiveActionView: UIView {
         for (index, button) in actionButtons.enumerated() {
             guard index < actions.count else { continue }
             let action = actions[index]
-            let actionColor = action.destructive ? AppTheme.destructiveTextColor() : ThemeColor.primaryIcon01(for: themeOverride)
+            let actionColor = action.destructive ? AppTheme.destructiveTextColor(for: themeOverride) : ThemeColor.primaryIcon01(for: themeOverride)
 
             var config = button.configuration
             config?.baseBackgroundColor = action.outline ? .clear : actionColor

--- a/podcasts/DescriptiveActionView.swift
+++ b/podcasts/DescriptiveActionView.swift
@@ -11,6 +11,9 @@ class DescriptiveActionView: UIView {
     private let onLinkTap: (() -> Void)?
 
     private weak var iconView: UIImageView?
+    private weak var titleLabel: UILabel?
+    private weak var messageLabel: UILabel?
+    private var actionButtons: [UIButton] = []
 
     private weak var delegate: OptionsPickerRootController?
 
@@ -24,6 +27,7 @@ class DescriptiveActionView: UIView {
         self.iconTintStyle = iconTintStyle
         self.onLinkTap = onLinkTap
         super.init(frame: frame)
+        NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
     }
 
     @available(*, unavailable)
@@ -59,6 +63,7 @@ class DescriptiveActionView: UIView {
         titleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
 
         addSubview(titleLabel)
+        self.titleLabel = titleLabel
 
         NSLayoutConstraint.activate([
             titleLabel.topAnchor.constraint(equalTo: iconView.bottomAnchor, constant: 20),
@@ -99,6 +104,7 @@ class DescriptiveActionView: UIView {
             messageLabel.textAlignment = .center
             messageLabel.numberOfLines = 0
             addSubview(messageLabel)
+            self.messageLabel = messageLabel
 
             NSLayoutConstraint.activate([
                 messageLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
@@ -114,6 +120,9 @@ class DescriptiveActionView: UIView {
 
         for (index, action) in actions.enumerated() {
             let actionButton = makeStandardButton(for: action)
+            if let button = actionButton as? UIButton {
+                actionButtons.append(button)
+            }
 
             actionButton.accessibilityIdentifier = "action_\(index)"
             actionButton.translatesAutoresizingMaskIntoConstraints = false
@@ -201,6 +210,26 @@ class DescriptiveActionView: UIView {
             }
         }
         return actionButton
+    }
+
+    @objc private func themeDidChange() {
+        iconView?.image = UIImage(named: icon)?.tintedImage(AppTheme.colorForStyle(iconTintStyle, themeOverride: themeOverride))
+        titleLabel?.textColor = AppTheme.mainTextColor(for: themeOverride)
+        messageLabel?.textColor = AppTheme.mainTextColor(for: themeOverride)
+
+        for (index, button) in actionButtons.enumerated() {
+            guard index < actions.count else { continue }
+            let action = actions[index]
+            let actionColor = action.destructive ? AppTheme.destructiveTextColor() : ThemeColor.primaryIcon01(for: themeOverride)
+
+            var config = button.configuration
+            config?.baseBackgroundColor = action.outline ? .clear : actionColor
+            config?.baseForegroundColor = action.outline ? actionColor : ThemeColor.primaryInteractive02(for: themeOverride)
+            if action.outline {
+                config?.background.strokeColor = actionColor
+            }
+            button.configuration = config
+        }
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/MultipleActionView.swift
+++ b/podcasts/MultipleActionView.swift
@@ -26,6 +26,10 @@ class MultipleActionView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     func actionWasAdded() {
         let label = UILabel()
         label.font = UIFont.font(ofSize: 18, weight: .semibold, scalingWith: .headline)

--- a/podcasts/MultipleActionView.swift
+++ b/podcasts/MultipleActionView.swift
@@ -5,6 +5,8 @@ class MultipleActionView: UIView {
     private let icon: String?
     private let actions: [OptionAction]
     private let themeOverride: Theme.ThemeType?
+    private weak var label: UILabel?
+    private weak var segmentedControl: CustomSegmentedControl?
     private var imageView: UIImageView?
     private let iconActionWidth: CGFloat = 45
     private let componentHeight: CGFloat = 44
@@ -16,6 +18,7 @@ class MultipleActionView: UIView {
         self.themeOverride = themeOverride
 
         super.init(frame: frame)
+        NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
     }
 
     @available(*, unavailable)
@@ -32,6 +35,7 @@ class MultipleActionView: UIView {
         label.textColor = AppTheme.mainTextColor(for: themeOverride)
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)
+        self.label = label
 
         if let icon, let image = UIImage(named: icon)?.tintedImage(ThemeColor.primaryIcon01(for: themeOverride)) {
             let imageView = UIImageView(image: image)
@@ -71,6 +75,7 @@ class MultipleActionView: UIView {
         segmentedControl.selectedItemColor = ThemeColor.primaryInteractive02(for: themeOverride)
         segmentedControl.unselectedBgColor = UIColor.clear
         addSubview(segmentedControl)
+        self.segmentedControl = segmentedControl
 
         NSLayoutConstraint.activate([
             trailingAnchor.constraint(equalTo: segmentedControl.trailingAnchor, constant: 20),
@@ -96,6 +101,19 @@ class MultipleActionView: UIView {
             let imageSize = max(24, metric.scaledValue(for: 24))
             imageView.updateSizeConstraints(to: imageSize)
         }
+    }
+
+    @objc private func themeDidChange() {
+        label?.textColor = AppTheme.mainTextColor(for: themeOverride)
+
+        if let icon, let image = UIImage(named: icon) {
+            imageView?.image = image.tintedImage(ThemeColor.primaryIcon01(for: themeOverride))
+        }
+
+        segmentedControl?.lineColor = ThemeColor.primaryInteractive01(for: themeOverride)
+        segmentedControl?.unselectedItemColor = ThemeColor.primaryInteractive01(for: themeOverride)
+        segmentedControl?.selectedBgColor = ThemeColor.primaryInteractive01(for: themeOverride)
+        segmentedControl?.selectedItemColor = ThemeColor.primaryInteractive02(for: themeOverride)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/OptionsPickerRootController.swift
+++ b/podcasts/OptionsPickerRootController.swift
@@ -51,6 +51,10 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         overrideStatusBarStyle
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     func setup(title: String?, themeOverride: Theme.ThemeType? = nil, iconTintStyle: ThemeStyle, colors: Colors? = nil) {
         let colors = colors ?? Colors(theme: themeOverride ?? Theme.sharedTheme.activeTheme)
 

--- a/podcasts/OptionsPickerRootController.swift
+++ b/podcasts/OptionsPickerRootController.swift
@@ -27,6 +27,8 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
     private var actionHeight: CGFloat = 72
     private let layoutHorizontalMargin = CGFloat(20)
     private var actionsAdded = 0
+    private var titleLabel: UILabel?
+    private var dividerViews: [UIView] = []
 
     private var themeOverride: Theme.ThemeType?
     private var iconTintStyle: ThemeStyle = .primaryIcon01
@@ -134,6 +136,8 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         if view.bounds.height < 600 {
             actionHeight = 64
         }
+
+        NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
     }
 
     func addAction(action: OptionAction) {
@@ -325,6 +329,7 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         label.textColor = titleColor
         label.translatesAutoresizingMaskIntoConstraints = false
         containerView.addSubview(label)
+        self.titleLabel = label
         NSLayoutConstraint.activate([
             containerView.leadingAnchor.constraint(equalTo: stackView.layoutMarginsGuide.leadingAnchor),
             containerView.trailingAnchor.constraint(equalTo: stackView.layoutMarginsGuide.trailingAnchor),
@@ -350,6 +355,7 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         dividerView.translatesAutoresizingMaskIntoConstraints = false
 
         containerView.addSubview(dividerView)
+        dividerViews.append(dividerView)
         NSLayoutConstraint.activate([
             containerView.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
             containerView.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
@@ -358,6 +364,27 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
             dividerView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
             dividerView.topAnchor.constraint(equalTo: containerView.topAnchor)
         ])
+    }
+
+    @objc private func themeDidChange() {
+        let colors = Colors(theme: themeOverride ?? Theme.sharedTheme.activeTheme)
+
+        if isPresentedAsSheet {
+            if LiquidGlass.isEnabled {
+                view.backgroundColor = colors.background.withAlphaComponent(0.85)
+            } else {
+                view.backgroundColor = colors.background
+                scrollView.backgroundColor = colors.background
+            }
+        } else {
+            scrollView.backgroundColor = colors.background
+        }
+
+        titleLabel?.textColor = colors.title
+
+        for divider in dividerViews {
+            divider.backgroundColor = AppTheme.tableDividerColor(for: themeOverride)
+        }
     }
 
     // MARK: - Orientation

--- a/podcasts/SimpleActionView.swift
+++ b/podcasts/SimpleActionView.swift
@@ -26,6 +26,10 @@ class SimpleActionView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
     func actionWasAdded() {
         let label = UILabel()
         label.font = UIFont.font(ofSize: 18, weight: .semibold, scalingWith: .headline)

--- a/podcasts/SimpleActionView.swift
+++ b/podcasts/SimpleActionView.swift
@@ -7,6 +7,8 @@ class SimpleActionView: UIView {
 
     private weak var delegate: OptionsPickerRootController?
     private var onOffSwitch: UISwitch?
+    private weak var label: UILabel?
+    private weak var secondaryLabel: UILabel?
     private var imageView: UIImageView?
     private var selectedView: UIImageView?
 
@@ -16,6 +18,7 @@ class SimpleActionView: UIView {
         self.themeOverride = themeOverride
         self.iconTintStyle = iconTintStyle
         super.init(frame: frame)
+        NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
     }
 
     @available(*, unavailable)
@@ -32,6 +35,7 @@ class SimpleActionView: UIView {
         label.textColor = action.destructive ? AppTheme.destructiveTextColor(for: themeOverride) : AppTheme.mainTextColor(for: themeOverride)
         label.translatesAutoresizingMaskIntoConstraints = false
         addSubview(label)
+        self.label = label
         label.setContentHuggingPriority(.defaultLow, for: .vertical)
         label.setContentCompressionResistancePriority(.required, for: .vertical)
         let iconTintColor = action.destructive ? AppTheme.destructiveTextColor(for: themeOverride) : AppTheme.colorForStyle(iconTintStyle, themeOverride: themeOverride)
@@ -77,6 +81,7 @@ class SimpleActionView: UIView {
             secondaryLabel.textColor = ThemeColor.primaryText02(for: themeOverride)
             secondaryLabel.translatesAutoresizingMaskIntoConstraints = false
             addSubview(secondaryLabel)
+            self.secondaryLabel = secondaryLabel
 
             NSLayoutConstraint.activate([
                 secondaryLabel.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
@@ -190,6 +195,20 @@ class SimpleActionView: UIView {
         }
     }
 
+
+    @objc private func themeDidChange() {
+        label?.textColor = action.destructive ? AppTheme.destructiveTextColor(for: themeOverride) : AppTheme.mainTextColor(for: themeOverride)
+        secondaryLabel?.textColor = ThemeColor.primaryText02(for: themeOverride)
+
+        let iconTintColor = action.destructive ? AppTheme.destructiveTextColor(for: themeOverride) : AppTheme.colorForStyle(iconTintStyle, themeOverride: themeOverride)
+        if action.tintIcon, let iconName = action.icon, let image = UIImage(named: iconName) {
+            imageView?.image = image.tintedImage(iconTintColor)
+        }
+
+        if action.selected && !action.onOffAction {
+            selectedView?.image = UIImage(named: "small-tick")?.tintedImage(ThemeColor.primaryIcon01(for: themeOverride))
+        }
+    }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-671/options-picker-colors-are-not-updated-when-system-color-scheme-changes

## Summary
When the system color scheme changes while an OptionsPicker sheet is open, the picker's colors (background, text, icons, dividers) now update dynamically instead of remaining stale from the initial presentation.

## Changes
- `OptionsPickerRootController` — Observe `themeChanged` notification; update scroll view/view background, title label color, and divider colors
- `SimpleActionView` — Observe `themeChanged`; update label, secondary label, icon tint, and checkmark colors
- `MultipleActionView` — Observe `themeChanged`; update label, icon tint, and segmented control colors
- `DescriptiveActionView` — Observe `themeChanged`; update icon, title, message, and button colors

## Verification
- **Lint**: PASS
- **Tests**: SKIP — no unit tests for this UI component
- **Build**: Pre-existing failure in CarPlaySceneDelegate+Convert.swift (unrelated); no errors in modified files
- **Diff review**: PASS

## Confidence
**HIGH** — The fix follows the same themeChanged observer pattern used by 40+ other components in the codebase.

---
This PR was created autonomously by linear-solver.
Triage complexity: simple | [Linear issue](https://linear.app/a8c/issue/PCIOS-671/options-picker-colors-are-not-updated-when-system-color-scheme-changes)