### PR TITLE
TV: Episode row actions and Up Next refresh

### DIFF
--- a/Pocket Casts TV App/Data/EpisodesQueryBuilder.swift
+++ b/Pocket Casts TV App/Data/EpisodesQueryBuilder.swift
@@ -1,0 +1,30 @@
+import PocketCastsDataModel
+
+class EpisodesQueryBuilder {
+
+    func makeEpisodeQuery(podcast: Podcast) -> String {
+
+        let episodeSortOrder = podcast.podcastSortOrder
+
+        let sortStr: String
+        let sortOrder = episodeSortOrder ?? PodcastEpisodeSortOrder.newestToOldest
+        switch sortOrder {
+        case .titleAtoZ:
+            sortStr = "ORDER BY title ASC, addedDate"
+        case .titleZtoA:
+            sortStr = "ORDER BY title DESC, addedDate"
+        case .newestToOldest:
+            sortStr = "ORDER BY publishedDate DESC, addedDate DESC"
+        case .oldestToNewest:
+            sortStr = "ORDER BY publishedDate ASC, addedDate ASC"
+        case .shortestToLongest:
+            sortStr = "ORDER BY duration ASC, addedDate"
+        case .longestToShortest:
+            sortStr = "ORDER BY duration DESC, addedDate"
+        case .serial:
+            sortStr = "ORDER BY CASE WHEN seasonNumber < 1 THEN 9999 ELSE seasonNumber END, CASE WHEN episodeNumber < 1 THEN 9999 ELSE episodeNumber END ASC, publishedDate ASC"
+        }
+
+        return "podcast_id = \(podcast.id) AND archived = 0 \(sortStr)"
+    }
+}

--- a/Pocket Casts TV App/Data/EpisodesQueryBuilder.swift
+++ b/Pocket Casts TV App/Data/EpisodesQueryBuilder.swift
@@ -1,8 +1,8 @@
 import PocketCastsDataModel
 
-class EpisodesQueryBuilder {
+enum EpisodesQueryBuilder {
 
-    func makeEpisodeQuery(podcast: Podcast) -> String {
+    static func makeEpisodeQuery(podcast: Podcast) -> (query: String, arguments: [Any]) {
 
         let episodeSortOrder = podcast.podcastSortOrder
 
@@ -25,6 +25,6 @@ class EpisodesQueryBuilder {
             sortStr = "ORDER BY CASE WHEN seasonNumber < 1 THEN 9999 ELSE seasonNumber END, CASE WHEN episodeNumber < 1 THEN 9999 ELSE episodeNumber END ASC, publishedDate ASC"
         }
 
-        return "podcast_id = \(podcast.id) AND archived = 0 \(sortStr)"
+        return ("podcast_id = ? AND archived = 0 \(sortStr)", [podcast.id])
     }
 }

--- a/Pocket Casts TV App/Data/EpisodesQueryBuilder.swift
+++ b/Pocket Casts TV App/Data/EpisodesQueryBuilder.swift
@@ -25,6 +25,6 @@ enum EpisodesQueryBuilder {
             sortStr = "ORDER BY CASE WHEN seasonNumber < 1 THEN 9999 ELSE seasonNumber END, CASE WHEN episodeNumber < 1 THEN 9999 ELSE episodeNumber END ASC, publishedDate ASC"
         }
 
-        return ("podcast_id = ? AND archived = 0 \(sortStr)", [podcast.id])
+        return ("podcast_id = ? AND archived = 0 AND wasDeleted = 0 \(sortStr)", [podcast.id])
     }
 }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -66,7 +66,7 @@ struct PlaylistDetailView: View {
                 }
             }
         } else if let first = images.first {
-            Image(first).resizable().aspectRatio(contentMode: .fill)
+            PodcastImage(uuid: first, size: .page).aspectRatio(contentMode: .fill)
         }
     }
 

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -19,10 +19,14 @@ class PlaylistDetailsViewModel {
     var episodes: [Episode] = []
 
     private let dataManager: DataManager
+    private let playbackManager: PlaybackManager
 
-    init(playlist: EpisodeFilter, dataManager: DataManager = DataManager.sharedManager ) {
+    init(playlist: EpisodeFilter,
+         dataManager: DataManager = DataManager.sharedManager,
+         playbackManager: PlaybackManager = PlaybackManager.shared) {
         self.playlist = playlist
         self.dataManager = dataManager
+        self.playbackManager = playbackManager
     }
 
     func load() {
@@ -36,6 +40,7 @@ class PlaylistDetailsViewModel {
     }
 
     func playAll() {
+        playbackManager.play(playlist: playlist)
     }
 
     var playlistName: String {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -141,6 +141,9 @@ struct EpisodeRowWithActions: View {
                 model.play()
             } label: {
                 EpisodeRow(model: model, isActive: isEpisodeFocused)
+                    .containerRelativeFrame([.horizontal], alignment: .leading) { length, _ in
+                        return length - 150
+                    }
             }
             .buttonStyle(EpisodeRowButtonStyle())
             .focused($focusedElement, equals: .episode)

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -25,7 +25,7 @@ struct EpisodeRow: View {
     }
 
     private var isHighlighted: Bool {
-        isActive ?? isFocused
+        isFocused
     }
 
     enum Layout {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -146,11 +146,9 @@ struct EpisodeRowWithActions: View {
             .focused($focusedElement, equals: .episode)
 
             if shouldShowMoreButton {
-                Menu {
-                    actionButtons
-                        .onAppear {
-                            restoreFocus = true
-                        }
+                Button {
+                    restoreFocus = true
+                    isShowingActions = true
                 } label: {
                     Image(systemName: "ellipsis")
                 }
@@ -175,6 +173,9 @@ struct EpisodeRowWithActions: View {
         .fullScreenCover(isPresented: $isPlaying) {
             NowPlayingView()
                 .ignoresSafeArea()
+        }
+        .confirmationDialog(model.displayTitle, isPresented: $isShowingActions) {
+            actionButtons
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -124,13 +124,14 @@ struct EpisodeRowWithActions: View {
             Button(L10n.playNextInUpNext) { model.playNext() }
             Button(L10n.playLastInUpNext) { model.playLast() }
             Button(L10n.markPlayed) { model.markAsPlayed() }
-            Button(L10n.archive) { model.archive() }
+            if model.canArchive {
+                Button(L10n.archive) { model.archive() }
+            }
         case .upNext:
             Button(L10n.playNext) { model.playNext() }
             Button(L10n.playLast) { model.playLast() }
             Button(L10n.removeFromUpNext) { model.removeFromUpNext() }
         }
-        Button(L10n.tvEpisodeInfo) {}
     }
 
     var body: some View {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -110,7 +110,7 @@ struct EpisodeRowWithActions: View {
     }
 
     private var shouldShowMoreButton: Bool {
-        focusedElement != nil || isShowingActions || restoreFocus
+        focusedElement != nil || restoreFocus
     }
 
     private var isEpisodeFocused: Bool {
@@ -146,9 +146,11 @@ struct EpisodeRowWithActions: View {
             .focused($focusedElement, equals: .episode)
 
             if shouldShowMoreButton {
-                Button {
-                    restoreFocus = true
-                    isShowingActions = true
+                Menu {
+                    actionButtons
+                        .onAppear {
+                            restoreFocus = true
+                        }
                 } label: {
                     Image(systemName: "ellipsis")
                 }
@@ -173,10 +175,7 @@ struct EpisodeRowWithActions: View {
         .fullScreenCover(isPresented: $isPlaying) {
             NowPlayingView()
                 .ignoresSafeArea()
-        }
-        .confirmationDialog(model.displayTitle, isPresented: $isShowingActions) {
-            actionButtons
-        }
+        }        
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -175,7 +175,7 @@ struct EpisodeRowWithActions: View {
         .fullScreenCover(isPresented: $isPlaying) {
             NowPlayingView()
                 .ignoresSafeArea()
-        }        
+        }
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -121,14 +121,14 @@ struct EpisodeRowWithActions: View {
     private var actionButtons: some View {
         switch context {
         case .default:
-            Button(L10n.playNextInUpNext) {}
-            Button(L10n.playLastInUpNext) {}
-            Button(L10n.markPlayed) {}
-            Button(L10n.archive) {}
+            Button(L10n.playNextInUpNext) { model.playNext() }
+            Button(L10n.playLastInUpNext) { model.playLast() }
+            Button(L10n.markPlayed) { model.markAsPlayed() }
+            Button(L10n.archive) { model.archive() }
         case .upNext:
-            Button(L10n.playNext) {}
-            Button(L10n.playLast) {}
-            Button(L10n.removeFromUpNext) {}
+            Button(L10n.playNext) { model.playNext() }
+            Button(L10n.playLast) { model.playLast() }
+            Button(L10n.removeFromUpNext) { model.removeFromUpNext() }
         }
         Button(L10n.tvEpisodeInfo) {}
     }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -15,9 +15,12 @@ class EpisodeRowViewModel: Identifiable {
 
     var id: String { episode.uuid }
 
-    init(episode: BaseEpisode, podcast: Podcast?) {
+    private let playbackManager: PlaybackManager
+
+    init(episode: BaseEpisode, podcast: Podcast?, playbackManager: PlaybackManager = PlaybackManager.shared) {
         self.episode = episode
         self.podcast = podcast
+        self.playbackManager = playbackManager
     }
 
     func loadEpisodeArtwork() {
@@ -74,6 +77,36 @@ class EpisodeRowViewModel: Identifiable {
 
     func play() {
         PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
+    }
+
+    func playNext() {
+        if PlaybackManager.shared.inUpNext(episode: episode) {
+            playbackManager.queue.move(episode: episode, to: 0)
+        } else {
+            playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: true, userInitiated: true)
+        }
+    }
+
+    func playLast() {
+        if playbackManager.inUpNext(episode: episode) {
+            let queueCount = PlaybackManager.shared.queue.upNextCount()
+            playbackManager.queue.move(episode: episode, to: max(queueCount - 1, 0))
+        } else {
+            playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: false, userInitiated: true)
+        }
+    }
+
+    func markAsPlayed() {
+        EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
+    }
+
+    func archive() {
+        guard let episode = episode as? Episode else { return }
+        EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
+    }
+
+    func removeFromUpNext() {
+        playbackManager.removeIfPlayingOrQueued(episode: episode, fireNotification: true, userInitiated: true)
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -81,7 +81,7 @@ class EpisodeRowViewModel: Identifiable {
     }
 
     func playNext() {
-        if PlaybackManager.shared.inUpNext(episode: episode) {
+        if playbackManager.inUpNext(episode: episode) {
             playbackManager.queue.move(episode: episode, to: 0)
         } else {
             playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: true, userInitiated: true)
@@ -90,7 +90,7 @@ class EpisodeRowViewModel: Identifiable {
 
     func playLast() {
         if playbackManager.inUpNext(episode: episode) {
-            let queueCount = PlaybackManager.shared.queue.upNextCount()
+            let queueCount = playbackManager.queue.upNextCount()
             playbackManager.queue.move(episode: episode, to: max(queueCount - 1, 0))
         } else {
             playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: false, userInitiated: true)

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -99,6 +99,8 @@ class EpisodeRowViewModel: Identifiable {
 
     func markAsPlayed() {
         EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
+    }
+
     var canArchive: Bool {
         episode is Episode
     }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -99,6 +99,8 @@ class EpisodeRowViewModel: Identifiable {
 
     func markAsPlayed() {
         EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
+    var canArchive: Bool {
+        episode is Episode
     }
 
     func archive() {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 
 @Observable
 class EpisodeRowViewModel: Identifiable {
@@ -45,7 +46,7 @@ class EpisodeRowViewModel: Identifiable {
     }
 
     var displayDate: String {
-        return episode.shortPublishedDate()
+        return DateFormatHelper.sharedHelper.tinyLocalizedFormat(episode.publishedDate).localizedUppercase
     }
 
     var displayDuration: String {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -6,7 +6,6 @@ import PocketCastsServer
 class PodcastDetailViewModel {
 
     private let dataManager: DataManager
-    private let episodesQueryBuilder = EpisodesQueryBuilder()
     private let serverPodcastManager: ServerPodcastManager
     private let podcastManager: PodcastManager
 
@@ -92,8 +91,8 @@ class PodcastDetailViewModel {
         guard let podcast else {
             return []
         }
-        let query = episodesQueryBuilder.makeEpisodeQuery(podcast: podcast)
-        return dataManager.findEpisodesWhere(customWhere: query, arguments: nil)
+        let (query, arguments) = EpisodesQueryBuilder.makeEpisodeQuery(podcast: podcast)
+        return dataManager.findEpisodesWhere(customWhere: query, arguments: arguments)
     }
 
     func subscribe() {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -6,6 +6,7 @@ import PocketCastsServer
 class PodcastDetailViewModel {
 
     private let dataManager: DataManager
+    private let episodesQueryBuilder = EpisodesQueryBuilder()
     private let serverPodcastManager: ServerPodcastManager
     private let podcastManager: PodcastManager
 
@@ -91,7 +92,8 @@ class PodcastDetailViewModel {
         guard let podcast else {
             return []
         }
-        return dataManager.allEpisodesForPodcast(id: podcast.id)
+        let query = episodesQueryBuilder.makeEpisodeQuery(podcast: podcast)
+        return dataManager.findEpisodesWhere(customWhere: query, arguments: nil)
     }
 
     func subscribe() {

--- a/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
@@ -56,7 +56,17 @@ class UpNextViewModel {
     }
 
     fileprivate func observeUpNextChanges() {
-        NotificationCenter.default.publisher(for: Constants.Notifications.upNextQueueChanged)
+        let notificationsToObserve: [Notification.Name] = [
+            Constants.Notifications.upNextQueueChanged,
+            Constants.Notifications.upNextEpisodeRemoved,
+            Constants.Notifications.upNextEpisodeAdded,
+        ]
+
+        let publishers = notificationsToObserve.map {
+            NotificationCenter.default.publisher(for: $0).map { _ in () }.eraseToAnyPublisher()
+        }
+
+        Publishers.MergeMany(publishers)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-675](https://linear.app/a8c/issue/PCIOS-675/implement-episode-actions-for-up-next) <!-- issue number, if applicable -->

Wires up the action menu on `EpisodeRowWithActions` in the tvOS app so the buttons actually do something. Logic lives on `EpisodeRowViewModel` and reuses the existing iOS primitives (`PlaybackManager`, `EpisodeManager`), so behavior matches the phone app.

Also bundles a few small tvOS improvements that came out of the same task:

- New `EpisodesQueryBuilder` so the podcast detail screen lists episodes in the user's chosen sort order (and excludes archived). Uses parameterized SQL.
- `PlaylistDetailsViewModel.playAll()` now actually starts playback of the playlist.
- `UpNextViewModel` now also reacts to `upNextEpisodeAdded` / `upNextEpisodeRemoved` notifications, so the list refreshes when those actions are triggered from elsewhere.
- `EpisodeRowViewModel.displayDate` switched to `DateFormatHelper.tinyLocalizedFormat` for a tighter, uppercase format.
- `PlaybackManager` is now injectable into `EpisodeRowViewModel` and `PlaylistDetailsViewModel` to make the view models testable.
- Archive button is hidden for `UserEpisode` rows (it wouldn't have done anything otherwise).
- Removed the placeholder "Episode info" button — no info screen exists yet, so it was a focusable no-op.

## To test

1. Run the tvOS target on the Apple TV simulator (or a real Apple TV).
2. Open a podcast and focus an episode row, then press select/menu to bring up the action sheet.
3. Verify each action:
   1. **Play next in Up Next** → the episode is added to the top of Up Next (open the Up Next tab to confirm). If already in Up Next, it moves to the top.
   2. **Play last in Up Next** → the episode is added to the end of Up Next. If already in Up Next, it moves to the end.
   3. **Mark played** → the episode disappears from the list (or shows played state) and is removed from Up Next if it was there.
   4. **Archive** → the episode is archived and removed from the list / Up Next.
4. Open the **Up Next** tab and bring up the actions on a queued episode:
   1. **Play next** → moves to the top of the queue.
   2. **Play last** → moves to the bottom of the queue.
   3. **Remove from Up Next** → the episode is removed from the queue immediately (list updates without needing to re-enter the tab).
5. Open a podcast detail page and confirm episodes are listed in the sort order set for that podcast (Newest first, A-Z, Shortest, Serial, etc.) and that archived episodes are not shown.
6. Open a playlist and tap **Play all** — the playlist should start playing from the first episode.
7. Upload a custom file (User Episode) and open its row's action menu — confirm the **Archive** option is not shown.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.