### PR TITLE
Use artwork thumbnail when available when showing full player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix an issue with diagonal swipes not dismissing the player [#4335](https://github.com/Automattic/pocket-casts-ios/pull/4335)
 - Fix player interactive dismiss gesture interaction with vertical scroll views [#4349](https://github.com/Automattic/pocket-casts-ios/pull/4349)
 - Fix Show Archived toggle in Playlists during search [#4329](https://github.com/Automattic/pocket-casts-ios/pull/4329)
+- Fix an issue where full player will occasionally show generic placeholder for artwork instead of using available smaller actual artwork thumbnail [#4391](https://github.com/Automattic/pocket-casts-ios/pull/4391)
 - Hide the tab bar during multi-select to create more space [#4364](https://github.com/Automattic/pocket-casts-ios/pull/4364) 
 
 8.12

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -69,6 +69,8 @@ extension MiniPlayerViewController {
             return
         }
 
+        fullScreenPlayer.nowPlayingItem.placeholderArtwork = podcastArtwork.imageView?.image
+
         playerOpenState = .animating
 
         presentFromRootController(fullScreenPlayer, animated: true) {

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -12,6 +12,10 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     var showingCustomImage = false
     var lastChapterIndexRendered = -1
 
+    /// Low-res artwork handed over from the mini player when opening the full
+    /// screen player.
+    var placeholderArtwork: UIImage?
+
     private var bannerTask: Task<Void, Never>? = nil
 
     // Detect Display Zoom (zoomed display makes UI elements appear larger).
@@ -357,6 +361,10 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     }
 
     override func willBeAddedToPlayer() {
+        if episodeImage.image == nil, let placeholderArtwork {
+            episodeImage.image = placeholderArtwork
+            self.placeholderArtwork = nil
+        }
         update(notification: nil)
         addObservers()
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->



## To test

- Start playing an epsiode
- Simulate memory warning
- Tap mini player


Before 

https://github.com/user-attachments/assets/50876fe0-b03a-45ee-bf2a-3ca8269c4b00

After

https://github.com/user-attachments/assets/27ddab6b-a89c-4dcf-96b2-c31ab6d0c414



## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
