### PR TITLE
Fix an issue with podcast header loaded late during screen presentation

### DIFF
--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -339,6 +339,12 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
             }
         }
 
+        if podcast != nil, episodeInfo.isEmpty {
+            let searchHeader = ListHeader(headerTitle: L10n.search, isSectionHeader: true, sectionNumber: -1)
+            episodeInfo = [ArraySection(model: searchHeader.headerTitle, elements: [searchHeader])]
+            reloadData()
+        }
+
         loadPodcastInfo()
 
         NotificationCenter.default.addObserver(self, selector: #selector(podcastUpdated(_:)), name: Constants.Notifications.podcastUpdated, object: nil)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Fix an issue with podcast header loaded late during screen presentation. 

## To test

- Same as https://github.com/Automattic/pocket-casts-ios/pull/4305

I wasn't sure about it at first, but seems good. There is still a bit of delays presumable due to SwiftUI, but it's an improvement.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
