### PR TITLE
PCIOS-683: CarPlay reconnect leaves EffectsPlayer silent — UI position counter advances, no audio

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2025,7 +2025,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             load(episode: currEpisode, autoPlay: autoPlay, overrideUpNext: false)
         } else if reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue {
             player?.routeDidChange(shouldPause: true)
-        } else if reason == AVAudioSession.RouteChangeReason.newDeviceAvailable.rawValue || reason == AVAudioSession.RouteChangeReason.override.rawValue {
+        } else if reason == AVAudioSession.RouteChangeReason.newDeviceAvailable.rawValue || reason == AVAudioSession.RouteChangeReason.override.rawValue || reason == AVAudioSession.RouteChangeReason.categoryChange.rawValue {
             player?.routeDidChange(shouldPause: false)
             updateAllNowPlayingData()
         }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-683/carplay-reconnect-leaves-effectsplayer-silent-ui-position-counter

## Summary
When CarPlay reconnects, the audio route-change reason can be `.categoryChange` (rawValue 3) instead of `.newDeviceAvailable` (rawValue 1). The route-change handler in `PlaybackManager` only handled `.newDeviceAvailable` and `.override`, so `.categoryChange` fell through silently — leaving the EffectsPlayer's AVAudioEngine stale and producing no audio despite the position counter advancing.

## Changes
- Added `.categoryChange` to the route-change reasons that trigger `player?.routeDidChange(shouldPause: false)` in `PlaybackManager.handleRouteChanged(_:)`. This ensures the EffectsPlayer performs its full pause → play restart cycle (tearing down and recreating the AVAudioEngine) when a CarPlay reconnect fires a `.categoryChange` route notification.

## Verification
- **Lint**: PASS — `make format` produced no changes
- **Tests**: FAIL — pre-existing build failure in `CarPlaySceneDelegate+Convert.swift` (`CPPlaybackConfiguration` not found in SDK). Same failure on trunk; unrelated to this change.
- **Diff review**: PASS — single-line change, no unintended modifications
- **Secret scan**: PASS — no secrets in diff

## Confidence
**MEDIUM** — The fix directly addresses the gap identified in the log analysis (`.categoryChange` not handled), and the EffectsPlayer's `routeDidChange` implementation already performs the correct teardown-restart sequence. However, this is a CarPlay audio-routing issue that requires physical hardware to fully verify, and one of the two failure cases in the logs (Failure 2 with reason 1) may involve a separate race condition not addressed here.

## Known Issues
- Build and tests fail on trunk due to `CPPlaybackConfiguration` API not available in the current Xcode SDK — this is a pre-existing issue unrelated to this PR.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/PCIOS-683/carplay-reconnect-leaves-effectsplayer-silent-ui-position-counter)