### PR TITLE
Liquid Glass: Update dividers in Up Next cells

### DIFF
--- a/podcasts/PlayerCell.swift
+++ b/podcasts/PlayerCell.swift
@@ -55,6 +55,12 @@ class PlayerCell: ThemeableSwipeCell {
         }
     }
 
+    @IBOutlet var bottomDividerHeightConstraint: NSLayoutConstraint! {
+        didSet {
+            bottomDividerHeightConstraint.constant = 1.0 / UIScreen.main.scale
+        }
+    }
+
     @IBOutlet var podcastImageToSelectViewConstraint: NSLayoutConstraint!
     @IBOutlet var selectViewLeadingConstraint: NSLayoutConstraint!
     @IBOutlet var selectTickImageView: UIImageView!

--- a/podcasts/PlayerCell.xib
+++ b/podcasts/PlayerCell.xib
@@ -47,48 +47,48 @@
                         </constraints>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="TxV-st-0Vt" userLabel="Text Stack View">
-                        <rect key="frame" x="84" y="10.5" width="228" height="51"/>
+                        <rect key="frame" x="84" y="8" width="228" height="64"/>
                         <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="250" text="DAY NAME" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vxd-V8-but" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="80" y="15" width="232" height="13.5"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
-                        <color key="textColor" white="1" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="749" text="Glow In The Dark Sharks can be real snarks" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wE1-9S-69I" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                        <rect key="frame" x="80" y="30.5" width="232" height="15.5"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
-                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="oRM-hc-IES">
-                        <rect key="frame" x="80" y="50" width="240" height="16"/>
-                        <subviews>
-                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="5GB-f2-YaE">
-                                <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="16" id="VxE-oZ-M1d"/>
-                                    <constraint firstAttribute="height" constant="16" id="e8b-sa-A6K"/>
-                                </constraints>
-                            </activityIndicatorView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="list_downloaded" translatesAutoresizingMaskIntoConstraints="NO" id="Ng8-Au-jkV" userLabel="Status Indicator">
-                                <rect key="frame" x="24" y="0.0" width="16" height="16"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="16" id="CAS-eL-8vT"/>
-                                    <constraint firstAttribute="width" constant="16" id="Y3Q-rK-Oi7"/>
-                                </constraints>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="32 minutes left" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PPM-dn-LHr" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                                <rect key="frame" x="48" y="0.0" width="192" height="16"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                <color key="textColor" red="1" green="1" blue="1" alpha="0.69999999999999996" colorSpace="calibratedRGB"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" horizontalCompressionResistancePriority="250" text="DAY NAME" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vxd-V8-but" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="228" height="13.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                <color key="textColor" white="1" alpha="0.69999999999999996" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="749" text="Glow In The Dark Sharks can be real snarks" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wE1-9S-69I" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="16.5" width="228" height="28.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="oRM-hc-IES">
+                                <rect key="frame" x="0.0" y="48" width="228" height="16"/>
+                                <subviews>
+                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="5GB-f2-YaE">
+                                        <rect key="frame" x="0.0" y="0.0" width="16" height="16"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="16" id="VxE-oZ-M1d"/>
+                                            <constraint firstAttribute="height" constant="16" id="e8b-sa-A6K"/>
+                                        </constraints>
+                                    </activityIndicatorView>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="list_downloaded" translatesAutoresizingMaskIntoConstraints="NO" id="Ng8-Au-jkV" userLabel="Status Indicator">
+                                        <rect key="frame" x="24" y="0.0" width="16" height="16"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="CAS-eL-8vT"/>
+                                            <constraint firstAttribute="width" constant="16" id="Y3Q-rK-Oi7"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="32 minutes left" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PPM-dn-LHr" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                                        <rect key="frame" x="48" y="0.0" width="180" height="16"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <color key="textColor" red="1" green="1" blue="1" alpha="0.69999999999999996" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
                         </subviews>
                     </stackView>
-                        </subviews>
-                    </stackView>
-                    <view alpha="0.20000000000000001" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SPL-EK-QpB" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SPL-EK-QpB" customClass="ThemeableView" customModule="podcasts" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="79" width="320" height="1"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
@@ -99,23 +99,26 @@
                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstItem="IaQ-ms-xZi" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="7mz-gA-2Vu"/>
-                    <constraint firstItem="IaQ-ms-xZi" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="-24" id="W6l-JH-2df"/>
-                    <constraint firstItem="IaQ-ms-xZi" firstAttribute="trailing" secondItem="OJf-Is-8tF" secondAttribute="leading" constant="-16" id="dAg-4g-2db"/>
-                    <constraint firstItem="OJf-Is-8tF" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="Z0H-Az-83U"/>
-                    <constraint firstItem="OJf-Is-8tF" firstAttribute="top" relation="greaterThanOrEqual" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="img-tp-006"/>
-                    <constraint firstItem="TxV-st-0Vt" firstAttribute="leading" secondItem="OJf-Is-8tF" secondAttribute="trailing" constant="12" id="txt-le-001"/>
-                    <constraint firstItem="TxV-st-0Vt" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="txt-cy-002"/>
-                    <constraint firstAttribute="trailing" secondItem="TxV-st-0Vt" secondAttribute="trailing" constant="8" id="txt-tr-003"/>
-                    <constraint firstItem="TxV-st-0Vt" firstAttribute="top" relation="greaterThanOrEqual" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="txt-tp-004"/>
-                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="TxV-st-0Vt" secondAttribute="bottom" constant="8" id="txt-bt-005"/>
                     <constraint firstItem="SPL-EK-QpB" firstAttribute="top" relation="greaterThanOrEqual" secondItem="OJf-Is-8tF" secondAttribute="bottom" constant="6" id="FT0-GR-4aw"/>
-                    <constraint firstItem="SPL-EK-QpB" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="THB-Gv-8b2"/>
-                    <constraint firstAttribute="trailing" secondItem="SPL-EK-QpB" secondAttribute="trailing" id="FRd-Je-Vth"/>
+                    <constraint firstItem="IaQ-ms-xZi" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="-24" id="W6l-JH-2df"/>
+                    <constraint firstItem="OJf-Is-8tF" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="Z0H-Az-83U"/>
+                    <constraint firstItem="IaQ-ms-xZi" firstAttribute="trailing" secondItem="OJf-Is-8tF" secondAttribute="leading" constant="-16" id="dAg-4g-2db"/>
+                    <constraint firstItem="OJf-Is-8tF" firstAttribute="top" relation="greaterThanOrEqual" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="img-tp-006"/>
                     <constraint firstItem="SPL-EK-QpB" firstAttribute="bottom" secondItem="H2p-sc-9uM" secondAttribute="bottom" id="ixX-SD-QBc"/>
+                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="TxV-st-0Vt" secondAttribute="bottom" constant="8" id="txt-bt-005"/>
+                    <constraint firstItem="TxV-st-0Vt" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="txt-cy-002"/>
+                    <constraint firstItem="TxV-st-0Vt" firstAttribute="leading" secondItem="OJf-Is-8tF" secondAttribute="trailing" constant="12" id="txt-le-001"/>
+                    <constraint firstItem="TxV-st-0Vt" firstAttribute="top" relation="greaterThanOrEqual" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="txt-tp-004"/>
+                    <constraint firstAttribute="trailing" secondItem="TxV-st-0Vt" secondAttribute="trailing" constant="8" id="txt-tr-003"/>
                 </constraints>
             </tableViewCellContentView>
+            <constraints>
+                <constraint firstItem="SPL-EK-QpB" firstAttribute="leading" secondItem="KGk-i7-Jjw" secondAttribute="leading" id="THB-Gv-8b2"/>
+                <constraint firstItem="KGk-i7-Jjw" firstAttribute="trailing" secondItem="SPL-EK-QpB" secondAttribute="trailing" id="FRd-Je-Vth"/>
+            </constraints>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="bottomDividerHeightConstraint" destination="Yg3-Y0-GSr" id="bdH-Pc-Hgt"/>
                 <outlet property="dayName" destination="vxd-V8-but" id="kbJ-Lr-CTk"/>
                 <outlet property="dividerView" destination="SPL-EK-QpB" id="qCw-qE-k2o"/>
                 <outlet property="downloadedIndicator" destination="Ng8-Au-jkV" id="98F-lX-CmF"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Update the divides so they also match the `EpisodeCell`:
- Remove 0.2 alpha
- Reduce height to match EpisodeCell
- Extend edge to edge

Before / After

<img width="320"  alt="Screenshot 2026-05-22 at 11 49 48 AM" src="https://github.com/user-attachments/assets/3088ecb3-f85d-45da-90bc-5ac60c172c31" /> <img width="320" alt="Screenshot 2026-05-22 at 12 00 58 PM" src="https://github.com/user-attachments/assets/e9a01239-d2d5-42bb-9c05-54952c09599e" />

The are more inconsistencies with divides, but this one was the most visible. The plan is to review everything else in the next release.

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
