### PR TITLE
TV: Polish login screen layout and copy

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+DeviceAuth.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+DeviceAuth.swift
@@ -46,7 +46,7 @@ public extension ApiServerHandler {
                 }
 
                 do {
-                    let response = try Api_DeviceAuthorizeResponse(jsonUTF8Data: responseData)
+                    let response = try Api_DeviceAuthorizeResponse(serializedBytes: responseData)
                     let externalResponse = DeviceAuthorizationResponse(deviceCode: response.deviceCode, userCode: response.userCode, verificationURI: response.verificationUri, verificationURIComplete: response.verificationUriComplete)
                     completion(.success(externalResponse))
                 } catch {

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -14,8 +14,8 @@ struct SignInView: View {
         static let qrSize = CGFloat(240)
     }
 
-    var attributed: AttributedString {
-        let baseString = L10n.tvSignInEnterCodeGoUrl(model.pairURLPretty, model.pairURLString)
+    var enterCodePrompt: AttributedString {
+        let baseString = L10n.tvSignInEnterCodeInUrl(model.pairURLPretty, model.pairURLString)
         var attributedString = (try? AttributedString(markdown: baseString)) ?? AttributedString(baseString)
 
         var linkStyle = AttributeContainer()
@@ -45,13 +45,9 @@ struct SignInView: View {
     var body: some View {
         ZStack(alignment: .top) {
             VStack(spacing: 32) {
-                Spacer()
                 Image(ImageResource.pcLogo)
                 Text(L10n.tvSignInTitle)
                     .font(.title)
-                Text(L10n.tvSignInSubtitle)
-                    .font(.headline)
-                    .foregroundStyle(Color.textSecondary)
                 Picker(L10n.tvUserSignInLoginType, selection: $loginType) {
                     ForEach(LoginType.allCases, id: \.self) { type in
                         Text(type.description).tag(type)
@@ -59,22 +55,29 @@ struct SignInView: View {
                 }
                 .pickerStyle(.segmented)
                 .frame(width: 500)
-                switch loginType {
-                case .manual:
-                    usernamePasswordLogin
-                case .qr:
-                    QRCodeView(url: model.pairURLString)
-                    separator
-                    Text(L10n.tvSignInEnterCode)
-                        .font(.headline)
-                        .foregroundStyle(Color.textSecondary)
-                    qrCodeDigits
-                    Text(attributed)
-                        .font(.headline)
-                        .foregroundStyle(Color.textSecondary)
+                // Mode-specific content area, fixed height so the logo,
+                // title, and picker above never shift when switching modes.
+                VStack(spacing: 32) {
+                    switch loginType {
+                    case .manual:
+                        usernamePasswordLogin
+                            .padding(.top, 64)
+                    case .qr:
+                        Text(L10n.tvSignInSubtitle)
+                            .font(.headline)
+                            .foregroundStyle(Color.textSecondary)
+                        QRCodeView(url: model.pairURLString)
+                        separator
+                        Text(enterCodePrompt)
+                            .font(.headline)
+                            .foregroundStyle(Color.textSecondary)
+                        qrCodeDigits
+                    }
                 }
-                Spacer()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
+            .padding(.top, 80)
+            .offset(y: -64)
         }
         .task {
             switch loginType {

--- a/Pocket Casts TV App/UI/WelcomeView.swift
+++ b/Pocket Casts TV App/UI/WelcomeView.swift
@@ -48,18 +48,18 @@ struct WelcomeView: View {
                     }
                 }
             }
+            .background {
+                ZStack {
+                    podcastGrid
+                    gradientView
+                }
+            }
             .navigationDestination(for: Destination.self) { destination in
                 switch destination {
                 case .signIn:
                     SignInView()
                 case .createAccount:
                     CreateAccountView()
-                }
-            }
-            .background {
-                ZStack {
-                    podcastGrid
-                    gradientView
                 }
             }
         }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4411,10 +4411,14 @@ internal enum L10n {
   internal static func tvSignInEnterCodeGoUrl(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "tv_sign_in_enter_code_go_url", String(describing: p1), String(describing: p2), fallback: "going to [%1$@](%2$@)")
   }
+  /// tv sign enter code. '%1$@' is the visible (white, underlined) pair URL, '%2$@' is the full URL to navigate to.
+  internal static func tvSignInEnterCodeInUrl(_ p1: Any, _ p2: Any) -> String {
+    return L10n.tr("Localizable", "tv_sign_in_enter_code_in_url", String(describing: p1), String(describing: p2), fallback: "or enter this code in [%1$@](%2$@)")
+  }
   /// tv sign in subtitle
   internal static var tvSignInSubtitle: String { return L10n.tr("Localizable", "tv_sign_in_subtitle", fallback: "Open your camera and point to this QR code") }
   /// tv sign in title
-  internal static var tvSignInTitle: String { return L10n.tr("Localizable", "tv_sign_in_title", fallback: "Sign in with your phone") }
+  internal static var tvSignInTitle: String { return L10n.tr("Localizable", "tv_sign_in_title", fallback: "Log in to Pocket Casts") }
   /// tv signing in subtitle
   internal static var tvSigningInSubtitle: String { return L10n.tr("Localizable", "tv_signing_in_subtitle", fallback: "Your podcasts are syncing, we’ll sign you in soon!") }
   /// tv signing in title

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5996,10 +5996,13 @@
 "tv_welcome_browse_without_account" = "Browse without an account";
 
 /* tv sign in title */
-"tv_sign_in_title" = "Sign in with your phone";
+"tv_sign_in_title" = "Log in to Pocket Casts";
 
 /* tv sign in subtitle */
 "tv_sign_in_subtitle" = "Open your camera and point to this QR code";
+
+/* tv sign enter code. '%1$@' is the visible (white, underlined) pair URL, '%2$@' is the full URL to navigate to. */
+"tv_sign_in_enter_code_in_url" = "or enter this code in [%1$@](%2$@)";
 
 /* tv sign enter code */
 "tv_sign_in_enter_code" = "or enter the following code";


### PR DESCRIPTION
Change the sign-in title to "Log in to Pocket Casts" and move the QR/manual picker above the subtitle so the logo, title, and picker stay anchored when switching modes. Combine the QR pair URL into a single "or enter this code in [url]" line, removing the separate "going to" line.


## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

https://github.com/user-attachments/assets/c1fa6a6d-8b04-48f5-bd0c-90ee648e69b0

