### PR TITLE
TV: Add Now Playing row to Home screen

### DIFF
--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -159,6 +159,7 @@ struct MockData {
                 episode.title = episodeTitles[titleIndex]
                 episode.publishedDate = Date.now.weeksAgo(j)
                 episode.duration = Double.random(in: (5.minutes...1.hours))
+                episode.playedUpTo = Double.random(in: (0...episode.duration))
                 episode.podcastUuid = podcast.uuid
                 episode.downloadUrl = sampleMediaURL.absoluteString
                 episodes.append(episode)

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -41,12 +41,12 @@ struct HomeView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 40) {
-                    Text(L10n.tvHomeKeepListeningTitle)
-                        .font(.title2)
-                        .foregroundStyle(Color.textPrimary)
                     if let currentPlaying = model.currentPlaying {
-                        EpisodePlayerButton(model: currentPlaying)
-                            .frame(maxWidth: 864, alignment: .leading)
+                        Text(L10n.tvHomeKeepListeningTitle)
+                            .font(.title2)
+                            .foregroundStyle(Color.textPrimary)
+                        NowPlayingRow(model: currentPlaying)
+                            .frame(maxWidth: 1242, alignment: .leading)
                     }
                     VStack(alignment: .leading, spacing: 24) {
                         Text(L10n.tvHomeRecommendedForYouTitle)
@@ -97,7 +97,7 @@ struct HomeView: View {
     var upNextRow: some View {
         ScrollView(.horizontal) {
             LazyHStack(spacing: 24) {
-                ForEach(model.upNext) { episode in
+                ForEach(model.upNext.dropFirst()) { episode in
                     EpisodePlayerButton(model: episode)
                         .frame(width: 864)
                 }

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -40,13 +40,13 @@ struct HomeView: View {
     var homeView: some View {
         NavigationStack {
             ScrollView {
-                VStack(alignment: .leading, spacing: 40) {
+                VStack(alignment: .leading, spacing: 80) {
                     if let currentPlaying = model.currentPlaying {
                         Text(L10n.tvHomeKeepListeningTitle)
                             .font(.title2)
                             .foregroundStyle(Color.textPrimary)
                         NowPlayingRow(model: currentPlaying)
-                            .frame(maxWidth: 1242, alignment: .leading)
+                            .frame(width: 1242, alignment: .leading)
                     }
                     VStack(alignment: .leading, spacing: 24) {
                         Text(L10n.tvHomeRecommendedForYouTitle)

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -103,7 +103,7 @@ struct HomeView: View {
                     .foregroundStyle(Color.textPrimary)
                 ScrollView(.horizontal) {
                     LazyHStack(spacing: 24) {
-                        ForEach(model.upNext.dropFirst()) { episode in
+                        ForEach(model.upNext) { episode in
                             EpisodePlayerButton(model: episode)
                                 .frame(width: 864)
                         }

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -42,22 +42,21 @@ struct HomeView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 80) {
                     if let currentPlaying = model.currentPlaying {
-                        Text(L10n.tvHomeKeepListeningTitle)
-                            .font(.title2)
-                            .foregroundStyle(Color.textPrimary)
-                        NowPlayingRow(model: currentPlaying)
-                            .frame(width: 1242, alignment: .leading)
+                        VStack(alignment: .leading, spacing: 32) {
+                            Text(L10n.tvHomeKeepListeningTitle)
+                                .font(.title2)
+                                .foregroundStyle(Color.textPrimary)
+                            NowPlayingRow(model: currentPlaying)
+                                .frame(width: 1242, alignment: .leading)
+                        }
                     }
+                    upNextRow
                     VStack(alignment: .leading, spacing: 24) {
                         Text(L10n.tvHomeRecommendedForYouTitle)
                             .font(.title3)
                             .foregroundStyle(Color.textPrimary)
                         discoverCollection
                     }
-                    Text(L10n.tvTabUpNext)
-                        .font(.title3)
-                        .foregroundStyle(Color.textPrimary)
-                    upNextRow
                     VStack(alignment: .leading, spacing: 24) {
                         Text(L10n.tvHomeRecentlyPlayed)
                             .font(.title3)
@@ -94,15 +93,24 @@ struct HomeView: View {
             }
         }
     }
+
+    @ViewBuilder
     var upNextRow: some View {
-        ScrollView(.horizontal) {
-            LazyHStack(spacing: 24) {
-                ForEach(model.upNext.dropFirst()) { episode in
-                    EpisodePlayerButton(model: episode)
-                        .frame(width: 864)
+        if model.upNext.count > 1 {
+            VStack(alignment: .leading, spacing: 24) {
+                Text(L10n.tvTabUpNext)
+                    .font(.title3)
+                    .foregroundStyle(Color.textPrimary)
+                ScrollView(.horizontal) {
+                    LazyHStack(spacing: 24) {
+                        ForEach(model.upNext.dropFirst()) { episode in
+                            EpisodePlayerButton(model: episode)
+                                .frame(width: 864)
+                        }
+                    }
+                    .padding(.horizontal, 24)
                 }
             }
-            .padding(.horizontal, 24)
         }
     }
 

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -7,6 +7,8 @@ struct HomeView: View {
 
     @State private var model = HomeViewModel()
 
+    @State private var showNowPlayingPlayer: Bool = false
+
     enum Layout {
         static let gridSize = CGFloat(250)
     }
@@ -46,8 +48,10 @@ struct HomeView: View {
                             Text(L10n.tvHomeKeepListeningTitle)
                                 .font(.title2)
                                 .foregroundStyle(Color.textPrimary)
-                            NowPlayingRow(model: currentPlaying)
-                                .frame(width: 1242, alignment: .leading)
+                            NowPlayingRow(model: currentPlaying) {
+                                showNowPlayingPlayer = true
+                            }
+                            .frame(width: 1242, alignment: .leading)
                         }
                     }
                     upNextRow
@@ -69,6 +73,10 @@ struct HomeView: View {
                     newReleasesRow
                 }
             }
+        }
+        .fullScreenCover(isPresented: $showNowPlayingPlayer) {
+            NowPlayingView()
+                .ignoresSafeArea()
         }
     }
 

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -112,7 +112,7 @@ struct HomeView: View {
                 ScrollView(.horizontal) {
                     LazyHStack(spacing: 24) {
                         ForEach(model.upNext) { episode in
-                            EpisodePlayerButton(model: episode)
+                            upNextButton(model: episode)
                                 .frame(width: 864)
                         }
                     }
@@ -120,6 +120,16 @@ struct HomeView: View {
                 }
             }
         }
+    }
+
+    func upNextButton(model: EpisodeRowViewModel) -> some View {
+        Button {
+            model.play()
+            showNowPlayingPlayer = true
+        } label: {
+            EpisodeRow(model: model, isActive: false)
+        }
+        .buttonStyle(EpisodeRowButtonStyle())
     }
 
     var recentlyPlayedRow: some View {

--- a/Pocket Casts TV App/UI/Home/HomeViewModel.swift
+++ b/Pocket Casts TV App/UI/Home/HomeViewModel.swift
@@ -23,9 +23,7 @@ class HomeViewModel {
     var state: State = .loading
 
     var podcasts: [Podcast] = []
-    var currentPlaying: EpisodeRowViewModel? {
-        upNext.first
-    }
+    var currentPlaying: EpisodeRowViewModel?
     var upNext: [EpisodeRowViewModel] = []
     var recentlyPlayed: [Podcast] = []
     var newReleases: [EpisodeRowViewModel] = []
@@ -47,8 +45,11 @@ class HomeViewModel {
                 guard let self else { return }
                 recentlyPlayed = Array(podcasts.shuffled().prefix(10))
                 self.podcasts = podcasts
-                upNext = Array(upNextEpisodes.prefix(12)).map { episode in
+                upNext = Array(upNextEpisodes.dropFirst().prefix(12)).map { episode in
                     self.makeRowViewModel(for: episode)
+                }
+                if let currentlyPlaying = upNextEpisodes.first {
+                    currentPlaying = makeRowViewModel(for: currentlyPlaying)
                 }
                 newReleases = newEpisodes
                 state = .ready
@@ -73,7 +74,8 @@ class HomeViewModel {
             Constants.Notifications.upNextQueueChanged,
             Constants.Notifications.manyEpisodesChanged,
             ServerNotifications.podcastsRefreshed,
-            ServerNotifications.syncCompleted
+            ServerNotifications.syncCompleted,
+            Constants.Notifications.playbackTrackChanged
         ]
 
         let publishers = notificationsToObserve.map {

--- a/Pocket Casts TV App/UI/Home/HomeViewModel.swift
+++ b/Pocket Casts TV App/UI/Home/HomeViewModel.swift
@@ -47,7 +47,7 @@ class HomeViewModel {
                 guard let self else { return }
                 recentlyPlayed = Array(podcasts.shuffled().prefix(10))
                 self.podcasts = podcasts
-                upNext = Array(upNextEpisodes.prefix(3)).map { episode in
+                upNext = Array(upNextEpisodes.prefix(12)).map { episode in
                     self.makeRowViewModel(for: episode)
                 }
                 newReleases = newEpisodes

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -14,7 +14,7 @@ struct NowPlayingRowButtonStyle: ButtonStyle {
 
 struct NowPlayingRow: View {
 
-    let model: EpisodeRowViewModel
+    @State var model: EpisodeRowViewModel
     @State var showPlayer: Bool = false
 
     @Environment(\.isFocused) private var isFocused: Bool
@@ -54,7 +54,7 @@ struct NowPlayingRow: View {
                         .font(.title3)
                         .foregroundColor(isFocused ? .textPrimaryActive : .textPrimary)
                         .lineLimit(2)
-                    ProgressView(value: model.playedUpTo, total: model.duration)
+                    ProgressView(value: model.progress)
                         .foregroundStyle(.blue)
                         .tint(model.currentPodcastTintColor)
                         .clipShape(RoundedRectangle(cornerRadius: 100))

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -56,7 +56,7 @@ struct NowPlayingRow: View {
                         .lineLimit(2)
                     ProgressView(value: model.playedUpTo, total: model.duration)
                         .foregroundStyle(.blue)
-                        .tint(.red)
+                        .tint(model.currentPodcastTintColor)
                         .clipShape(RoundedRectangle(cornerRadius: 100))
                     Text(model.timeLeft)
                         .font(.body)

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -2,16 +2,6 @@ import SwiftUI
 import PocketCastsUtils
 import PocketCastsDataModel
 
-struct NowPlayingRowButtonStyle: ButtonStyle {
-    @Environment(\.isFocused) var isFocused: Bool
-
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .scaleEffect(isFocused ? 1.02 : 1.0)
-            .animation(.easeInOut(duration: 0.15), value: isFocused)
-    }
-}
-
 struct NowPlayingRow: View {
 
     @Bindable var model: EpisodeRowViewModel

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -14,14 +14,10 @@ struct NowPlayingRowButtonStyle: ButtonStyle {
 
 struct NowPlayingRow: View {
 
-    @State var model: EpisodeRowViewModel
+    @Bindable var model: EpisodeRowViewModel
     @State var showPlayer: Bool = false
 
     @Environment(\.isFocused) private var isFocused: Bool
-
-    init(model: EpisodeRowViewModel) {
-        self.model = model
-    }
 
     enum Layout {
         static let episodeImageSize = CGFloat(272)
@@ -39,7 +35,7 @@ struct NowPlayingRow: View {
     var body: some View {
         Button {
             model.play()
-            showPlayer.toggle()
+            showPlayer = true
         } label: {
             HStack(spacing: 48) {
                 thumbnail

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import PocketCastsUtils
+import PocketCastsDataModel
+
+struct NowPlayingRowButtonStyle: ButtonStyle {
+    @Environment(\.isFocused) var isFocused: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(isFocused ? 1.02 : 1.0)
+            .animation(.easeInOut(duration: 0.15), value: isFocused)
+    }
+}
+
+struct NowPlayingRow: View {
+
+    let model: EpisodeRowViewModel
+    @State var showPlayer: Bool = false
+
+    @Environment(\.isFocused) private var isFocused: Bool
+
+    init(model: EpisodeRowViewModel) {
+        self.model = model
+    }
+
+    enum Layout {
+        static let episodeImageSize = CGFloat(272)
+    }
+
+    @ViewBuilder
+    private var thumbnail: some View {
+        if let uuid = model.podcastUuid {
+            PodcastImage(uuid: uuid, size: .page)
+        } else {
+            Image(ImageResource.pcLogo)
+        }
+    }
+
+    var body: some View {
+        Button {
+            model.play()
+            showPlayer.toggle()
+        } label: {
+            HStack(spacing: 48) {
+                thumbnail
+                    .frame(width: Layout.episodeImageSize, height: Layout.episodeImageSize)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                VStack(alignment: .leading) {
+                    Text(model.displayDate)
+                        .font(.body)
+                        .foregroundColor(isFocused ? .textSecondaryActive : .textSecondary)
+                    Text(model.episode.displayableTitle())
+                        .font(.title3)
+                        .foregroundColor(isFocused ? .textPrimaryActive : .textPrimary)
+                        .lineLimit(2)
+                    ProgressView(value: model.playedUpTo, total: model.duration)
+                        .foregroundStyle(.blue)
+                        .tint(.red)
+                        .clipShape(RoundedRectangle(cornerRadius: 100))
+                    Text(model.timeLeft)
+                        .font(.body)
+                        .foregroundColor(isFocused ? .textSecondaryActive : .textSecondary)
+                }
+                Spacer()
+            }
+            .padding(32)
+            .background(isFocused ? Color.backgroundActive : Color.backgroundSunken)
+        }
+        .buttonStyle(.card)
+        .fullScreenCover(isPresented: $showPlayer) {
+            NowPlayingView()
+                .ignoresSafeArea()
+        }
+    }
+}
+
+
+#Preview {
+    NowPlayingRow(model: EpisodeRowViewModel(episode: MockData.makeStubEpisodes().first!, podcast: MockData.makeStubPodcasts().first!))
+    .environment(AppCoordinator())
+    .environment(MainTabRouter())
+}

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -46,6 +46,7 @@ struct NowPlayingRow: View {
                     .frame(width: Layout.episodeImageSize, height: Layout.episodeImageSize)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
                 VStack(alignment: .leading) {
+                    Spacer()
                     Text(model.displayDate)
                         .font(.body)
                         .foregroundColor(isFocused ? .textSecondaryActive : .textSecondary)
@@ -60,6 +61,7 @@ struct NowPlayingRow: View {
                     Text(model.timeLeft)
                         .font(.body)
                         .foregroundColor(isFocused ? .textSecondaryActive : .textSecondary)
+                    Spacer()
                 }
                 Spacer()
             }

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -15,7 +15,8 @@ struct NowPlayingRowButtonStyle: ButtonStyle {
 struct NowPlayingRow: View {
 
     @Bindable var model: EpisodeRowViewModel
-    @State var showPlayer: Bool = false
+
+    var callback: (() -> ())?
 
     @Environment(\.isFocused) private var isFocused: Bool
 
@@ -35,7 +36,7 @@ struct NowPlayingRow: View {
     var body: some View {
         Button {
             model.play()
-            showPlayer = true
+            callback?()
         } label: {
             HStack(spacing: 48) {
                 thumbnail
@@ -65,10 +66,6 @@ struct NowPlayingRow: View {
             .background(isFocused ? Color.backgroundActive : Color.backgroundSunken)
         }
         .buttonStyle(.card)
-        .fullScreenCover(isPresented: $showPlayer) {
-            NowPlayingView()
-                .ignoresSafeArea()
-        }
     }
 }
 

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -16,6 +16,7 @@ struct PlaylistDetailView: View {
         static let mosaicTileSize = CGFloat(209)
         static let infoPanelWidth = CGFloat(568)
         static let gutter = CGFloat(24)
+        static let rowInsets = EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16)
     }
 
     var body: some View {
@@ -139,7 +140,7 @@ struct PlaylistDetailView: View {
             ForEach(model.episodes, id: \.uuid) { episode in
                 EpisodeRowWithActions(model: EpisodeRowViewModel(episode: episode, podcast: nil))
                     .prefersDefaultFocus(episode.uuid == model.episodes.first?.uuid, in: episodeListNamespace)
-                    .listRowInsets(EdgeInsets(top: 2, leading: 0, bottom: 2, trailing: 0))
+                    .listRowInsets(Layout.rowInsets)
             }
         }
         .focusScope(episodeListNamespace)

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -148,6 +148,7 @@ struct EpisodeRowWithActions: View {
                         .frame(width: !shouldShowMoreButton ? Layout.spacing + MoreButtonStyle.Layout.size : 0)
                 }
                 .background(isFocused ? Color.backgroundActive : Color.backgroundSunken)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
             }
             .buttonStyle(EpisodeRowButtonStyle())
             .focused($focusedElement, equals: .episode)

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -89,11 +89,8 @@ class EpisodeRowViewModel: Identifiable {
     }
 
     func play() {
-        if PlaybackManager.shared.isActivelyPlaying(episodeUuid: episode.uuid) {
-            return
-        } else {
-            PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
-        }
+        guard !PlaybackManager.shared.isActivelyPlaying(episodeUuid: episode.uuid) else { return }
+        PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
     }
 
     func playNext() {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -15,7 +15,7 @@ class EpisodeRowViewModel: Identifiable {
     var episode: BaseEpisode
     var podcast: Podcast?
     var imageData: Data?
-    var progress: Double = 0
+    var progress: Double
     var id: String { episode.uuid }
 
     private var cancellables: Set<AnyCancellable> = []
@@ -149,6 +149,7 @@ class EpisodeRowViewModel: Identifiable {
 
     private func setupObservers() {
         NotificationCenter.default.publisher(for: Constants.Notifications.playbackProgress)
+        .receive(on: DispatchQueue.main)
         .sink { [weak self] _ in
             self?.updateProgress()
         }
@@ -158,8 +159,9 @@ class EpisodeRowViewModel: Identifiable {
     private func updateProgress() {
         guard let currentEpisode = PlaybackManager.shared.currentEpisode(), episode.uuid == currentEpisode.uuid else {
             return
-        }
-        episode = currentEpisode
+        }     
+        episode.playedUpTo = currentEpisode.playedUpTo
+        episode.duration = currentEpisode.duration
         progress = currentEpisode.playedUpTo / currentEpisode.duration
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -89,7 +89,11 @@ class EpisodeRowViewModel: Identifiable {
     }
 
     func play() {
-        PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
+        if PlaybackManager.shared.isActivelyPlaying(episodeUuid: episode.uuid) {
+            return
+        } else {
+            PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
+        }
     }
 
     func playNext() {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -71,7 +71,7 @@ class EpisodeRowViewModel: Identifiable {
     }
 
     var currentPodcastTintColor: Color? {
-        if let podcast = podcast {
+        if let podcast {
             return Color(ColorManager.darkThemeTintForPodcast(podcast))
         } else if let episode = episode as? UserEpisode, episode.imageColor > 0 {
             return Color(AppTheme.userEpisodeColor(number: Int(episode.imageColor)))

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -159,7 +159,7 @@ class EpisodeRowViewModel: Identifiable {
     private func updateProgress() {
         guard let currentEpisode = playbackManager.currentEpisode(), episode.uuid == currentEpisode.uuid else {
             return
-        }     
+        }
         episode.playedUpTo = currentEpisode.playedUpTo
         episode.duration = currentEpisode.duration
         progress = currentEpisode.playedUpTo / currentEpisode.duration

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -3,6 +3,7 @@ import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 import SwiftUI
+import Combine
 
 @Observable
 class EpisodeRowViewModel: Identifiable {
@@ -14,15 +15,18 @@ class EpisodeRowViewModel: Identifiable {
     var episode: BaseEpisode
     var podcast: Podcast?
     var imageData: Data?
-
+    var progress: Double = 0
     var id: String { episode.uuid }
 
+    private var cancellables: Set<AnyCancellable> = []
     private let playbackManager: PlaybackManager
 
     init(episode: BaseEpisode, podcast: Podcast?, playbackManager: PlaybackManager = PlaybackManager.shared) {
         self.episode = episode
         self.podcast = podcast
         self.playbackManager = playbackManager
+        self.progress = episode.playedUpTo / episode.duration
+        setupObservers()
     }
 
     func loadEpisodeArtwork() {
@@ -141,6 +145,22 @@ class EpisodeRowViewModel: Identifiable {
     func removeFromUpNext() {
         playbackManager.removeIfPlayingOrQueued(episode: episode, fireNotification: true, userInitiated: true)
         ToastManager.shared.show(L10n.removeFromUpNext)
+    }
+
+    private func setupObservers() {
+        NotificationCenter.default.publisher(for: Constants.Notifications.playbackProgress)
+        .sink { [weak self] _ in
+            self?.updateProgress()
+        }
+        .store(in: &cancellables)
+    }
+
+    private func updateProgress() {
+        guard let currentEpisode = PlaybackManager.shared.currentEpisode(), episode.uuid == currentEpisode.uuid else {
+            return
+        }
+        episode = currentEpisode
+        progress = currentEpisode.playedUpTo / currentEpisode.duration
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -157,7 +157,7 @@ class EpisodeRowViewModel: Identifiable {
     }
 
     private func updateProgress() {
-        guard let currentEpisode = PlaybackManager.shared.currentEpisode(), episode.uuid == currentEpisode.uuid else {
+        guard let currentEpisode = playbackManager.currentEpisode(), episode.uuid == currentEpisode.uuid else {
             return
         }     
         episode.playedUpTo = currentEpisode.playedUpTo

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
+import SwiftUI
 
 @Observable
 class EpisodeRowViewModel: Identifiable {
@@ -67,6 +68,16 @@ class EpisodeRowViewModel: Identifiable {
 
     var displayImageData: Data? {
         return imageData
+    }
+
+    var currentPodcastTintColor: Color? {
+        if let podcast = podcast {
+            return Color(ColorManager.darkThemeTintForPodcast(podcast))
+        } else if let episode = episode as? UserEpisode, episode.imageColor > 0 {
+            return Color(AppTheme.userEpisodeColor(number: Int(episode.imageColor)))
+        } else {
+            return Color(AppTheme.userEpisodeColor(number: 1))
+        }
     }
 
     private func loadEpisodeArtworkData() async -> Data? {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -33,6 +33,14 @@ class EpisodeRowViewModel: Identifiable {
         }
     }
 
+    var duration: Double {
+        return episode.duration
+    }
+
+    var playedUpTo: Double {
+        return episode.playedUpTo
+    }
+
     var displayTitle: String {
         return episode.displayableTitle()
     }
@@ -51,6 +59,10 @@ class EpisodeRowViewModel: Identifiable {
 
     var displayDuration: String {
         return episode.displayableDuration
+    }
+
+    var timeLeft: String {
+        return episode.displayableTimeLeft()
     }
 
     var displayImageData: Data? {

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -27,17 +27,20 @@ struct UpNextView: View {
     }
 
     var upNextView: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                HStack {
-                    Text(L10n.tvTabUpNext)
-                        .font(.title2)
-                        .foregroundStyle(Color.textPrimary)
-                    Spacer()
+        List {
+            Section {
+                ForEach(model.episodes) { episode in
+                    EpisodeRowWithActions(model: episode, context: .upNext)
+                        .frame(width: 1160)
+                        .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
                 }
-                upNextListView
-                    .frame(maxWidth: 1160)
+            } header: {
+                Text(L10n.tvTabUpNext)
+                    .font(.title2)
+                    .foregroundStyle(Color.textPrimary)
+                Spacer()
             }
+            .focusScope(rowNamespace)
         }
     }
 
@@ -48,16 +51,6 @@ struct UpNextView: View {
     }
 
     @Namespace private var rowNamespace
-    var upNextListView: some View {
-        LazyVStack(alignment: .leading, spacing: 16) {
-            ForEach(model.episodes) { episode in
-                EpisodeRowWithActions(model: episode, context: .upNext)
-                    .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
-            }
-        }
-        .focusScope(rowNamespace)
-        .padding(24)
-    }
 }
 
 #Preview {

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -44,7 +44,6 @@ struct UpNextView: View {
                 Text(L10n.tvTabUpNext)
                     .font(.title2)
                     .foregroundStyle(Color.textPrimary)
-                Spacer()
             }
             .focusScope(rowNamespace)
         }

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -29,7 +29,13 @@ struct UpNextView: View {
     var upNextView: some View {
         List {
             Section {
-                ForEach(model.episodes) { episode in
+                if let currentPlaying = model.episodes.first {
+                    NowPlayingRow(model: currentPlaying)
+                        .frame(width: 1242, alignment: .leading)
+                }
+            }
+            Section {
+                ForEach(model.episodes.dropFirst()) { episode in
                     EpisodeRowWithActions(model: episode, context: .upNext)
                         .frame(width: 1160)
                         .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4320,7 +4320,7 @@ internal enum L10n {
   /// tv episode action to view episode info
   internal static var tvEpisodeInfo: String { return L10n.tr("Localizable", "tv_episode_info", fallback: "Episode info") }
   /// tv keep listening title
-  internal static var tvHomeKeepListeningTitle: String { return L10n.tr("Localizable", "tv_home_keep_listening_title", fallback: "Keep listening") }
+  internal static var tvHomeKeepListeningTitle: String { return L10n.tr("Localizable", "tv_home_keep_listening_title", fallback: "Picking up where you left off") }
   /// tv home new releases section title
   internal static var tvHomeNewReleases: String { return L10n.tr("Localizable", "tv_home_new_releases", fallback: "New releases") }
   /// tv home recently played section title

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6086,7 +6086,7 @@
 "tv_playlists_empty_action_title" = "Create a playlist";
 
 /* tv keep listening title */
-"tv_home_keep_listening_title" = "Keep listening";
+"tv_home_keep_listening_title" = "Picking up where you left off";
 
 /* tv home recommended for you title */
 "tv_home_recommended_for_you_title" = "Recommended for you";


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

<!-- Fixes PCIOS- -->

## Summary

Adds a Now Playing row at the top of the TV Home screen that surfaces the user's currently playing / last-played episode under a "Keep listening" header. Tapping the row resumes playback (no-op if it's already actively playing) and presents the `NowPlayingView` full-screen.

- New `NowPlayingRow` SwiftUI view — large thumbnail, date, title, progress, and time-left layout tuned for tvOS focus states.
- `HomeView` shows the row when `model.currentPlaying` is set, above the existing Discover / Up Next / Recently Played / New Releases sections.
- `EpisodeRowViewModel` gains `duration`, `playedUpTo`, and `timeLeft` accessors for the row, and `play()` now guards against restarting the episode if it's already actively playing.

<img width="1024"  alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-05-24 at 22 47 21" src="https://github.com/user-attachments/assets/0188d419-4ee1-45f3-89b3-eb9bc5ac0b02" />


## To test

1. Run the TV target on the tvOS simulator.
2. Start playback of any episode, then return to the Home tab.
3. Verify the "Keep listening" row appears at the top with the episode artwork, title, date, progress bar, and time left.
4. Focus the row — confirm the focus styling (background + text colors) updates.
5. Select the row — playback should continue (not restart) and the full-screen `NowPlayingView` should appear.
6. Pause / play other episodes and confirm the row reflects the most recent one.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.