### PR TITLE
Signing in animation

### DIFF
--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -3,7 +3,6 @@ import PocketCastsDataModel
 
 fileprivate enum Layout {
     static let coverSize = CGFloat(272)
-    static let qrSize = CGFloat(240)
     static let cornerRadius = CGFloat(16)
     static let minRotation = 2.0
     static let maxRotation = 10.0
@@ -24,6 +23,7 @@ fileprivate struct StackedCover: Identifiable {
 
 struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
     @Environment(AppCoordinator.self) var coordinator
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var model: ViewModel
     @State private var displayedCovers: [StackedCover] = []
@@ -51,7 +51,7 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
             }
             Color.black
                 .opacity(blackOverlayOpaque ? 1 : 0)
-                .animation(.easeInOut(duration: Pacing.fadeDuration), value: blackOverlayOpaque)
+                .animation(reduceMotion ? nil : .easeInOut(duration: Pacing.fadeDuration), value: blackOverlayOpaque)
                 .allowsHitTesting(false)
                 .ignoresSafeArea()
         }
@@ -60,6 +60,7 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
         }
     }
 
+    @MainActor
     private func runSyncAnimation() async {
         model.sync()
 
@@ -70,6 +71,7 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
 
         for _ in 0..<Pacing.totalCoversToShow {
             try? await Task.sleep(nanoseconds: stepNanoseconds)
+            if Task.isCancelled { return }
             guard nextIndex < model.podcasts.count else { continue }
             let podcast = model.podcasts[nextIndex]
             let sign: Double = nextIndex.isMultiple(of: 2) ? -1 : 1
@@ -84,11 +86,13 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
         // Wait for the underlying sync to finish before moving on.
         while model.state != .finished {
             try? await Task.sleep(nanoseconds: 100_000_000)
+            if Task.isCancelled { return }
         }
 
         // Fade the whole screen to black before handing off to the home view.
         blackOverlayOpaque = true
         try? await Task.sleep(nanoseconds: UInt64(Pacing.fadeDuration * 1_000_000_000))
+        if Task.isCancelled { return }
 
         coordinator.state = .signedIn
     }
@@ -100,15 +104,22 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
                     .frame(width: Layout.coverSize, height: Layout.coverSize)
                     .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
                     .rotationEffect(.degrees(cover.rotation))
-                    .transition(.asymmetric(
-                        insertion: .scale(scale: 0.6)
-                            .combined(with: .opacity)
-                            .animation(.interpolatingSpring(stiffness: 220, damping: 14)),
-                        removal: .opacity.animation(.easeOut(duration: 0.5))
-                    ))
+                    .transition(coverTransition)
             }
         }
         .frame(width: Layout.coverSize, height: Layout.coverSize)
+    }
+
+    private var coverTransition: AnyTransition {
+        if reduceMotion {
+            return .opacity
+        }
+        return .asymmetric(
+            insertion: .scale(scale: 0.6)
+                .combined(with: .opacity)
+                .animation(.interpolatingSpring(stiffness: 220, damping: 14)),
+            removal: .opacity.animation(.easeOut(duration: 0.5))
+        )
     }
 }
 

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -4,6 +4,9 @@ import PocketCastsDataModel
 fileprivate enum Layout {
     static let gridSize = CGFloat(272)
     static let qrSize = CGFloat(240)
+    static let gridSpacing = CGFloat(24)
+    static let cornerRadius = CGFloat(16)
+    static let fadeDuration = 0.8
 }
 
 struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
@@ -19,19 +22,20 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
         VStack(spacing: 32) {
             Spacer()
             Image(ImageResource.pcLogo)
-            Text(L10n.tvSigningInTitle)
-                .font(.title)
-                .foregroundStyle(Color.textPrimary)
-            Text(L10n.tvSigningInSubtitle)
-                .font(.headline)
-                .foregroundStyle(Color.textSecondary)
+            VStack(spacing: 16) {
+                Text(L10n.tvSigningInTitle)
+                    .font(.title)
+                    .foregroundStyle(Color.textPrimary)
+                Text(L10n.tvSigningInSubtitle)
+                    .font(.headline)
+                    .foregroundStyle(Color.textSecondary)
+            }
             if let title = model.title {
                 Text(title)
             }
-            ProgressView(value: model.progress)
             Spacer()
             podcastGrid
-            Spacer().frame(height: 100)
+            Spacer().frame(height: 220)
         }
         .task {
             model.sync()
@@ -44,14 +48,25 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
     }
 
     var podcastGrid: some View {
-        ScrollView(.horizontal) {
-            HStack(spacing: 24, content: {
-                ForEach(model.podcasts) { podcast in
-                    PodcastImage(uuid: podcast.uuid, size: .page)
-                        .frame(width: Layout.gridSize, height: Layout.gridSize)
-                }
-            }).ignoresSafeArea()
+        HStack(spacing: Layout.gridSpacing) {
+            ForEach(0..<max(model.totalPodcastsToImport, 0), id: \.self) { index in
+                podcastSlot(at: index)
+            }
         }
+    }
+
+    @ViewBuilder
+    private func podcastSlot(at index: Int) -> some View {
+        let isLoaded = index < model.podcasts.count
+        ZStack {
+            Color.clear
+            if isLoaded {
+                PodcastImage(uuid: model.podcasts[index].uuid, size: .page)
+                    .transition(.opacity.animation(.easeInOut(duration: Layout.fadeDuration)))
+            }
+        }
+        .frame(width: Layout.gridSize, height: Layout.gridSize)
+        .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
     }
 }
 

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Observation
 import PocketCastsDataModel
 
 fileprivate enum Layout {
@@ -84,10 +85,8 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
         }
 
         // Wait for the underlying sync to finish before moving on.
-        while model.state != .finished {
-            try? await Task.sleep(nanoseconds: 100_000_000)
-            if Task.isCancelled { return }
-        }
+        await waitForSyncCompletion()
+        if Task.isCancelled { return }
 
         // Fade the whole screen to black before handing off to the home view.
         blackOverlayOpaque = true
@@ -95,6 +94,30 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
         if Task.isCancelled { return }
 
         coordinator.state = .signedIn
+    }
+
+    @MainActor
+    private func waitForSyncCompletion() async {
+        guard model.state != .finished else { return }
+
+        await withCheckedContinuation { continuation in
+            observeSyncState(continuation: continuation)
+        }
+    }
+
+    @MainActor
+    private func observeSyncState(continuation: CheckedContinuation<Void, Never>) {
+        withObservationTracking {
+            _ = model.state
+        } onChange: {
+            Task { @MainActor in
+                if model.state == .finished {
+                    continuation.resume()
+                } else {
+                    observeSyncState(continuation: continuation)
+                }
+            }
+        }
     }
 
     var podcastGrid: some View {

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -59,10 +59,15 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
     private func podcastSlot(at index: Int) -> some View {
         let isLoaded = index < model.podcasts.count
         ZStack {
-            Color.clear
+            Color.backgroundBase.opacity(0.2)
             if isLoaded {
                 PodcastImage(uuid: model.podcasts[index].uuid, size: .page)
-                    .transition(.opacity.animation(.easeInOut(duration: Layout.fadeDuration)))
+                    .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
+                    .transition(
+                        .scale(scale: 0.6)
+                            .combined(with: .opacity)
+                            .animation(.interpolatingSpring(stiffness: 220, damping: 7))
+                    )
             }
         }
         .frame(width: Layout.gridSize, height: Layout.gridSize)

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -2,76 +2,113 @@ import SwiftUI
 import PocketCastsDataModel
 
 fileprivate enum Layout {
-    static let gridSize = CGFloat(272)
+    static let coverSize = CGFloat(272)
     static let qrSize = CGFloat(240)
-    static let gridSpacing = CGFloat(24)
     static let cornerRadius = CGFloat(16)
-    static let fadeDuration = 0.8
+    static let minRotation = 2.0
+    static let maxRotation = 10.0
+}
+
+fileprivate enum Pacing {
+    static let totalCoversToShow = 8
+    static let maxSimultaneous = 2
+    static let stepInterval: Double = 0.8
+    static let fadeDuration: Double = 0.6
+}
+
+fileprivate struct StackedCover: Identifiable {
+    let podcast: Podcast
+    let rotation: Double
+    var id: String { podcast.uuid }
 }
 
 struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
     @Environment(AppCoordinator.self) var coordinator
 
     @State private var model: ViewModel
+    @State private var displayedCovers: [StackedCover] = []
+    @State private var nextIndex: Int = 0
+    @State private var blackOverlayOpaque = true
 
     init(model: ViewModel = SigningInViewModel()) {
         self.model = model
     }
 
     var body: some View {
-        VStack(spacing: 32) {
-            Spacer()
-            Image(ImageResource.pcLogo)
-            VStack(spacing: 16) {
-                Text(L10n.tvSigningInTitle)
-                    .font(.title)
-                    .foregroundStyle(Color.textPrimary)
-                Text(L10n.tvSigningInSubtitle)
-                    .font(.headline)
-                    .foregroundStyle(Color.textSecondary)
+        ZStack {
+            VStack(spacing: 96) {
+                Spacer()
+                VStack(spacing: 16) {
+                    Text(L10n.tvSigningInTitle)
+                        .font(.title)
+                        .foregroundStyle(Color.textPrimary)
+                    Text(L10n.tvSigningInSubtitle)
+                        .font(.headline)
+                        .foregroundStyle(Color.textSecondary)
+                }
+                podcastGrid
+                Spacer()
             }
-            if let title = model.title {
-                Text(title)
-            }
-            Spacer()
-            podcastGrid
-            Spacer().frame(height: 220)
+            Color.black
+                .opacity(blackOverlayOpaque ? 1 : 0)
+                .animation(.easeInOut(duration: Pacing.fadeDuration), value: blackOverlayOpaque)
+                .allowsHitTesting(false)
+                .ignoresSafeArea()
         }
         .task {
-            model.sync()
+            await runSyncAnimation()
         }
-        .onChange(of: model.state) {
-            if model.state == .finished {
-                coordinator.state = .signedIn
+    }
+
+    private func runSyncAnimation() async {
+        model.sync()
+
+        // Fade in from black so the QR/sign-in screen doesn't flash through.
+        blackOverlayOpaque = false
+
+        let stepNanoseconds = UInt64(Pacing.stepInterval * 1_000_000_000)
+
+        for _ in 0..<Pacing.totalCoversToShow {
+            try? await Task.sleep(nanoseconds: stepNanoseconds)
+            guard nextIndex < model.podcasts.count else { continue }
+            let podcast = model.podcasts[nextIndex]
+            let sign: Double = nextIndex.isMultiple(of: 2) ? -1 : 1
+            let rotation = sign * Double.random(in: Layout.minRotation...Layout.maxRotation)
+            nextIndex += 1
+            if displayedCovers.count >= Pacing.maxSimultaneous {
+                displayedCovers.removeFirst()
             }
+            displayedCovers.append(StackedCover(podcast: podcast, rotation: rotation))
         }
+
+        // Wait for the underlying sync to finish before moving on.
+        while model.state != .finished {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        // Fade the whole screen to black before handing off to the home view.
+        blackOverlayOpaque = true
+        try? await Task.sleep(nanoseconds: UInt64(Pacing.fadeDuration * 1_000_000_000))
+
+        coordinator.state = .signedIn
     }
 
     var podcastGrid: some View {
-        HStack(spacing: Layout.gridSpacing) {
-            ForEach(0..<max(model.totalPodcastsToImport, 0), id: \.self) { index in
-                podcastSlot(at: index)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func podcastSlot(at index: Int) -> some View {
-        let isLoaded = index < model.podcasts.count
         ZStack {
-            Color.backgroundBase.opacity(0.2)
-            if isLoaded {
-                PodcastImage(uuid: model.podcasts[index].uuid, size: .page)
+            ForEach(displayedCovers) { cover in
+                PodcastImage(uuid: cover.podcast.uuid, size: .page)
+                    .frame(width: Layout.coverSize, height: Layout.coverSize)
                     .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
-                    .transition(
-                        .scale(scale: 0.6)
+                    .rotationEffect(.degrees(cover.rotation))
+                    .transition(.asymmetric(
+                        insertion: .scale(scale: 0.6)
                             .combined(with: .opacity)
-                            .animation(.interpolatingSpring(stiffness: 220, damping: 7))
-                    )
+                            .animation(.interpolatingSpring(stiffness: 220, damping: 14)),
+                        removal: .opacity.animation(.easeOut(duration: 0.5))
+                    ))
             }
         }
-        .frame(width: Layout.gridSize, height: Layout.gridSize)
-        .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
+        .frame(width: Layout.coverSize, height: Layout.coverSize)
     }
 }
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4432,7 +4432,7 @@ internal enum L10n {
   /// tv sign in title
   internal static var tvSignInTitle: String { return L10n.tr("Localizable", "tv_sign_in_title", fallback: "Log in to Pocket Casts") }
   /// tv signing in subtitle
-  internal static var tvSigningInSubtitle: String { return L10n.tr("Localizable", "tv_signing_in_subtitle", fallback: "Your podcasts are syncing, we’ll sign you in soon!") }
+  internal static var tvSigningInSubtitle: String { return L10n.tr("Localizable", "tv_signing_in_subtitle", fallback: "Your podcasts are syncing, we’ll log you in soon!") }
   /// tv signing in title
   internal static var tvSigningInTitle: String { return L10n.tr("Localizable", "tv_signing_in_title", fallback: "Welcome back!") }
   /// tv app home tab

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4432,9 +4432,9 @@ internal enum L10n {
   /// tv sign in title
   internal static var tvSignInTitle: String { return L10n.tr("Localizable", "tv_sign_in_title", fallback: "Log in to Pocket Casts") }
   /// tv signing in subtitle
-  internal static var tvSigningInSubtitle: String { return L10n.tr("Localizable", "tv_signing_in_subtitle", fallback: "Your podcasts are syncing, we’ll log you in soon!") }
+  internal static var tvSigningInSubtitle: String { return L10n.tr("Localizable", "tv_signing_in_subtitle", fallback: "Loading your podcasts now.") }
   /// tv signing in title
-  internal static var tvSigningInTitle: String { return L10n.tr("Localizable", "tv_signing_in_title", fallback: "Welcome back!") }
+  internal static var tvSigningInTitle: String { return L10n.tr("Localizable", "tv_signing_in_title", fallback: "Good to see you.") }
   /// tv app home tab
   internal static var tvTabHome: String { return L10n.tr("Localizable", "tv_tab_home", fallback: "Home") }
   /// tv app Playlists tab

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6020,10 +6020,10 @@
 "tv_create_account_come_back" = "Once you’ve created your account, come back and sign in";
 
 /* tv signing in title */
-"tv_signing_in_title" = "Welcome back!";
+"tv_signing_in_title" = "Good to see you.";
 
 /* tv signing in subtitle */
-"tv_signing_in_subtitle" = "Your podcasts are syncing, we’ll log you in soon!";
+"tv_signing_in_subtitle" = "Loading your podcasts now.";
 
 /* tv podcasts empty title */
 "tv_podcasts_empty_title" = "Time to fill this up.";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6023,7 +6023,7 @@
 "tv_signing_in_title" = "Welcome back!";
 
 /* tv signing in subtitle */
-"tv_signing_in_subtitle" = "Your podcasts are syncing, we’ll sign you in soon!";
+"tv_signing_in_subtitle" = "Your podcasts are syncing, we’ll log you in soon!";
 
 /* tv podcasts empty title */
 "tv_podcasts_empty_title" = "Time to fill this up.";


### PR DESCRIPTION
Replaced the old progress-bar + cover row with a centered stack of at most two tilted podcast covers that bounce in / fade out as the sync runs, plus a full-screen black fade in and out to mask the rough transitions in and out of the screen. New copy: "Good to see you." / "Loading your podcasts now."

## To test

• Fresh QR sign-in fades in from black, no flash.
• Covers rotate through two at a time, ~8 total, screen lasts ≥6s.
• Screen fades to black before home appears.
• Works with a small library (<8 podcasts) too.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
