### PR TITLE
Fix typos in comments and docs

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Refresh/RefreshManager.swift
@@ -16,7 +16,7 @@ public class RefreshManager {
         return queue
     }()
 
-    // the watch has less resources than a phone, so be a bit more agressive about not refreshing constantly
+    // the watch has less resources than a phone, so be a bit more aggressive about not refreshing constantly
     #if os(watchOS)
         private static let minTimeBetweenRefreshes = 1.minute
     #else

--- a/Modules/Sources/PocketCastsServer/Public/ServerEnums.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ServerEnums.swift
@@ -79,7 +79,7 @@ public enum HeadphoneControl: Int32, Codable {
     case previousChapter = 4
 }
 
-/// Android uses different numberic values for these, thus the specific numbers specified here. See `Old` for the original values we used.
+/// Android uses different numeric values for these, thus the specific numbers specified here. See `Old` for the original values we used.
 public enum ThemeType: Int32, CaseIterable, Codable {
     case light = 0
     case dark = 1

--- a/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -413,7 +413,7 @@ class UpNextSyncTask: ApiBaseTask {
     }
 
     private func convertToProto(action: UpNextChanges) -> Api_UpNextChanges.Change? {
-        // a replace involves multiple episodes and a slightly different format, so handle that seperately
+        // a replace involves multiple episodes and a slightly different format, so handle that separately
         if action.type == UpNextChanges.Actions.replace.rawValue {
             guard let uuids = action.uuids else { return nil }
 

--- a/Modules/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
+++ b/Modules/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
@@ -72,7 +72,7 @@ final class LogBufferTests: XCTestCase {
             await logBuffer.append("Log Message \(messageNum)", date: Date())
         }
 
-        // THEN the flushed messages are seperated by newlines.
+        // THEN the flushed messages are separated by newlines.
         XCTAssertTrue(fileWriteSpy.textWrittenToLog)
         XCTAssertNotNil(fileWriteSpy.lastWrittenChunk)
         let lineCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count

--- a/Pocket Casts App Clip/AppClipAppDelegate.swift
+++ b/Pocket Casts App Clip/AppClipAppDelegate.swift
@@ -14,7 +14,7 @@ enum AppClipNotification {
 class AppClipAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-        // This is where we register this device to recieve push notifications from Apple
+        // This is where we register this device to receive push notifications from Apple
         // All this function does is register the device with APNs, it doesn't set up push notifications by itself
         application.registerForRemoteNotifications()
 

--- a/podcasts/CustomSegmentedControl.swift
+++ b/podcasts/CustomSegmentedControl.swift
@@ -190,7 +190,7 @@ class CustomSegmentedControl: UIControl {
             }
             actionViews.append(segmentView)
 
-            // add seperator if required
+            // add separator if required
             if willHaveTrailingSeperator {
                 let separator = UIView()
                 separator.translatesAutoresizingMaskIntoConstraints = false

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1134,7 +1134,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             cancelSleepTimer()
             return
         }
-        // once playback is over iOS can be agressive about killing off our app, so start a short lived background task to let it know we're doing stuff
+        // once playback is over iOS can be aggressive about killing off our app, so start a short lived background task to let it know we're doing stuff
         startBackgroundTask()
         defer {
             endBackgroundTask()

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1134,7 +1134,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             cancelSleepTimer()
             return
         }
-        // once playback is over iOS can be aggressive about killing off our app, so start a short lived background task to let it know we're doing stuff
+        // once playback is over iOS can be aggressive about killing off our app, so start a short-lived background task to let it know we're doing stuff
         startBackgroundTask()
         defer {
             endBackgroundTask()

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2621,7 +2621,7 @@ internal enum L10n {
   internal static var plusCancelTerms: String { return L10n.tr("Localizable", "plus_cancel_terms", fallback: "Can be canceled at any time") }
   /// Account detail message informing the user that they have been granted a lifetime membership, don't translate "Pocket Casts Champion"
   internal static var plusChampion: String { return L10n.tr("Localizable", "plus_champion", fallback: "Pocket Casts Champion") }
-  /// Message displayed when teh user tap "Pocket Casts Champion" button
+  /// Message displayed when the user tap "Pocket Casts Champion" button
   internal static var plusChampionMessage: String { return L10n.tr("Localizable", "plus_champion_message", fallback: "Thanks for being with Pocket Casts from the start. You're a real champion!") }
   /// The available cloud storage limit available to Pocket Casts Plus Subscribers. '%1$@' is a placeholder for the available storage.
   internal static func plusCloudStorageLimitFormat(_ p1: Any) -> String {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2621,7 +2621,7 @@ internal enum L10n {
   internal static var plusCancelTerms: String { return L10n.tr("Localizable", "plus_cancel_terms", fallback: "Can be canceled at any time") }
   /// Account detail message informing the user that they have been granted a lifetime membership, don't translate "Pocket Casts Champion"
   internal static var plusChampion: String { return L10n.tr("Localizable", "plus_champion", fallback: "Pocket Casts Champion") }
-  /// Message displayed when the user tap "Pocket Casts Champion" button
+  /// Message displayed when the user taps "Pocket Casts Champion" button
   internal static var plusChampionMessage: String { return L10n.tr("Localizable", "plus_champion_message", fallback: "Thanks for being with Pocket Casts from the start. You're a real champion!") }
   /// The available cloud storage limit available to Pocket Casts Plus Subscribers. '%1$@' is a placeholder for the available storage.
   internal static func plusCloudStorageLimitFormat(_ p1: Any) -> String {

--- a/podcasts/ThemeableLabel.swift
+++ b/podcasts/ThemeableLabel.swift
@@ -46,7 +46,7 @@ class ThemeableLabel: UILabel {
         handleThemeDidChange()
     }
 
-    // can be overriden by sub-classes to do more when the theme changes
+    // can be overridden by sub-classes to do more when the theme changes
     func handleThemeDidChange() {}
 
     private func updateTextColor() {

--- a/podcasts/ThemeableUIButton.swift
+++ b/podcasts/ThemeableUIButton.swift
@@ -40,7 +40,7 @@ class ThemeableUIButton: UIButton {
         handleThemeDidChange()
     }
 
-    // can be overriden by sub-classes to do more when the theme changes
+    // can be overridden by sub-classes to do more when the theme changes
     func handleThemeDidChange() {}
 
     private func updateColors() {

--- a/podcasts/Utilities/AVFileUtil.swift
+++ b/podcasts/Utilities/AVFileUtil.swift
@@ -29,7 +29,7 @@ class AVFileUtil: NSObject {
             }
         }
 
-        // do duration seperately as it takes longer. the load function calls the closure
+        // do duration separately as it takes longer. the load function calls the closure
         // only when all keys are available
         asset.loadValuesAsynchronously(forKeys: ["duration"]) {
             let durationStatus = self.asset.statusOfValue(forKey: "duration", error: nil)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1672,7 +1672,7 @@
 /* Account detail message informing the user that they have been granted a lifetime membership, don't translate "Pocket Casts Champion" */
 "plus_champion" = "Pocket Casts Champion";
 
-/* Message displayed when the user tap "Pocket Casts Champion" button */
+/* Message displayed when the user taps "Pocket Casts Champion" button */
 "plus_champion_message" = "Thanks for being with Pocket Casts from the start. You're a real champion!";
 
 /* Pocket Casts Plus marketing page, description of generated transcriptsg */

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1672,7 +1672,7 @@
 /* Account detail message informing the user that they have been granted a lifetime membership, don't translate "Pocket Casts Champion" */
 "plus_champion" = "Pocket Casts Champion";
 
-/* Message displayed when teh user tap "Pocket Casts Champion" button */
+/* Message displayed when the user tap "Pocket Casts Champion" button */
 "plus_champion_message" = "Thanks for being with Pocket Casts from the start. You're a real champion!";
 
 /* Pocket Casts Plus marketing page, description of generated transcriptsg */


### PR DESCRIPTION
Mechanical typo fixes in code comments, doc-comments, and one comment in `Localizable.strings`.
No behavior changes; no user-facing strings touched.

Each commit fixes typos in a single file so the diff can be reviewed file-by-file.

## To test

- Skim the diff; verify each replacement is the obvious correction.
- CI should be green.

## Checklist

- [x] No user-facing changes — no release notes needed.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*