### PR TITLE
Add diagnostic logging to in-app support form submission

### DIFF
--- a/PocketCastsTests/Tests/Zendesk/ZendeskSupportServiceTests.swift
+++ b/PocketCastsTests/Tests/Zendesk/ZendeskSupportServiceTests.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import PocketCastsUtils
 import XCTest
 @testable import podcasts
 
@@ -60,12 +61,79 @@ final class ZendeskSupportServiceTests: XCTestCase {
     }
 }
 
+final class MessageSupportViewModelTests: XCTestCase {
+    private var cancellables = Set<AnyCancellable>()
+
+    override func tearDown() {
+        ZendeskURLProtocol.requestHandler = nil
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    func testWatchLogPreflightFailureDoesNotSubmitOrRetry() {
+        var requestCount = 0
+        ZendeskURLProtocol.requestHandler = { request in
+            requestCount += 1
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data())
+        }
+
+        let completionExpectation = expectation(description: "Preflight failure is surfaced")
+        let viewModel = MessageSupportViewModel(
+            config: WatchLogMissingConfig(),
+            requesterName: "Test User",
+            requesterEmail: "test@example.com",
+            comment: "My watch is not working",
+            session: makeSession(),
+            isUserSignedIn: false
+        )
+
+        viewModel.$completion
+            .compactMap { $0 }
+            .sink { completion in
+                guard case let .failure(error) = completion,
+                      case MessageSupportViewModel.MessageSupportFailure.watchLogMissing = error
+                else {
+                    XCTFail("Expected a missing Watch log failure")
+                    return
+                }
+                completionExpectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        viewModel.submitRequest()
+
+        wait(for: [completionExpectation], timeout: 1)
+        XCTAssertEqual(requestCount, 0)
+        XCTAssertFalse(viewModel.isWorking)
+    }
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ZendeskURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+}
+
 private struct ZendeskTestConfig: ZDConfig {
     let apiKey = "api-key"
     let baseURL = "https://example.com"
     let newBaseURL = "https://retry.example.com"
     let subject = "Support"
     let type = ZDType.support
+}
+
+private struct WatchLogMissingConfig: ZDConfig {
+    let apiKey = "api-key"
+    let baseURL = "https://example.com"
+    let newBaseURL = "https://retry.example.com"
+    let subject = "Support"
+    let type = ZDType.support
+
+    func customFields(forDisplay: Bool, optOut: Bool) -> AnyPublisher<[ZDCustomField], Never> {
+        Just([ZDCustomField(id: 0, value: FileLog.noWearableLogsAvailable)])
+            .eraseToAnyPublisher()
+    }
 }
 
 private final class ZendeskURLProtocol: URLProtocol {

--- a/PocketCastsTests/Tests/Zendesk/ZendeskSupportServiceTests.swift
+++ b/PocketCastsTests/Tests/Zendesk/ZendeskSupportServiceTests.swift
@@ -98,6 +98,19 @@ final class ZendeskSupportServiceTests: XCTestCase {
         XCTAssertEqual(bodyExcerpt, "<non-JSON response omitted>")
     }
 
+    func testOfflineErrorMapsToNoInternetConnection() {
+        ZendeskURLProtocol.requestHandler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let receivedError = submitRequestAndWait()
+
+        guard case .noInternetConnection = receivedError else {
+            XCTFail("Expected a no-internet-connection error")
+            return
+        }
+    }
+
     private func submitRequestAndWait() -> ZendeskSupportService.SupportRequestError? {
         let completionExpectation = expectation(description: "Request completes")
         var receivedError: ZendeskSupportService.SupportRequestError?

--- a/PocketCastsTests/Tests/Zendesk/ZendeskSupportServiceTests.swift
+++ b/PocketCastsTests/Tests/Zendesk/ZendeskSupportServiceTests.swift
@@ -51,7 +51,13 @@ final class ZendeskSupportServiceTests: XCTestCase {
         {
           "error": "RecordInvalid",
           "description": "Contact user@example.com\\nfor help",
-          "details": {"email": "second@example.com", "type": "invalid"},
+          "details": {
+            "value": [{
+              "type": "invalid",
+              "description": "Contact second@example.com",
+              "submitted_value": "private user text"
+            }]
+          },
           "requester": {"email": "private@example.com"}
         }
         """
@@ -69,10 +75,11 @@ final class ZendeskSupportServiceTests: XCTestCase {
         XCTAssertEqual(statusCode, 422)
         XCTAssertEqual(
             bodyExcerpt,
-            #"error: RecordInvalid, description: Contact <redacted-email> for help, details: {"email":"<redacted-email>","type":"invalid"}"#
+            #"error: RecordInvalid, description: Contact <redacted-email> for help, details: {"value":[{"description":"Contact <redacted-email>","type":"invalid"}]}"#
         )
         XCTAssertFalse(bodyExcerpt?.contains("requester") == true)
         XCTAssertFalse(bodyExcerpt?.contains("private@example.com") == true)
+        XCTAssertFalse(bodyExcerpt?.contains("private user text") == true)
         XCTAssertFalse(bodyExcerpt?.contains("\n") == true)
     }
 

--- a/PocketCastsTests/Tests/Zendesk/ZendeskSupportServiceTests.swift
+++ b/PocketCastsTests/Tests/Zendesk/ZendeskSupportServiceTests.swift
@@ -1,0 +1,99 @@
+import Combine
+import Foundation
+import XCTest
+@testable import podcasts
+
+final class ZendeskSupportServiceTests: XCTestCase {
+    private var cancellables = Set<AnyCancellable>()
+
+    override func tearDown() {
+        ZendeskURLProtocol.requestHandler = nil
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    func testServerErrorPreservesUTF8WhenExcerptLimitSplitsScalarBytes() {
+        let body = String(repeating: "a", count: 255) + "é"
+        ZendeskURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 400, httpVersion: nil, headerFields: nil)!
+            return (response, Data(body.utf8))
+        }
+
+        let completionExpectation = expectation(description: "Request completes")
+        var receivedError: ZendeskSupportService.SupportRequestError?
+
+        makeService()
+            .submitSupportRequest(makeSupportRequest())
+            .sink(receiveCompletion: { completion in
+                if case let .failure(error) = completion {
+                    receivedError = error as? ZendeskSupportService.SupportRequestError
+                }
+                completionExpectation.fulfill()
+            }, receiveValue: { _ in
+                XCTFail("Expected the request to fail")
+            })
+            .store(in: &cancellables)
+
+        wait(for: [completionExpectation], timeout: 1)
+
+        guard case let .serverError(statusCode, bodyExcerpt) = receivedError else {
+            XCTFail("Expected a server error")
+            return
+        }
+        XCTAssertEqual(statusCode, 400)
+        XCTAssertEqual(bodyExcerpt, body)
+    }
+
+    private func makeService() -> ZendeskSupportService {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ZendeskURLProtocol.self]
+        return ZendeskSupportService(config: ZendeskTestConfig(), session: URLSession(configuration: configuration))
+    }
+
+    private func makeSupportRequest() -> ZDSupportRequest {
+        ZDSupportRequest(
+            subject: "Support",
+            name: "Test User",
+            email: "test@example.com",
+            comment: "Help"
+        )
+    }
+}
+
+private struct ZendeskTestConfig: ZDConfig {
+    let apiKey = "api-key"
+    let baseURL = "https://example.com"
+    let newBaseURL = "https://retry.example.com"
+    let subject = "Support"
+    let type = ZDType.support
+}
+
+private final class ZendeskURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let requestHandler = Self.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+
+        do {
+            let (response, data) = try requestHandler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/PocketCastsTests/Tests/Zendesk/ZendeskSupportServiceTests.swift
+++ b/PocketCastsTests/Tests/Zendesk/ZendeskSupportServiceTests.swift
@@ -14,7 +14,8 @@ final class ZendeskSupportServiceTests: XCTestCase {
     }
 
     func testServerErrorPreservesUTF8WhenExcerptLimitSplitsScalarBytes() {
-        let body = String(repeating: "a", count: 255) + "é"
+        let expectedExcerpt = "description: " + String(repeating: "a", count: 242) + "é"
+        let body = #"{"description":"\#(String(repeating: "a", count: 242))é"}"#
         ZendeskURLProtocol.requestHandler = { request in
             let response = HTTPURLResponse(url: request.url!, statusCode: 400, httpVersion: nil, headerFields: nil)!
             return (response, Data(body.utf8))
@@ -42,7 +43,72 @@ final class ZendeskSupportServiceTests: XCTestCase {
             return
         }
         XCTAssertEqual(statusCode, 400)
-        XCTAssertEqual(bodyExcerpt, body)
+        XCTAssertEqual(bodyExcerpt, expectedExcerpt)
+    }
+
+    func testServerErrorOnlyIncludesSanitizedDocumentedJSONFields() {
+        let body = """
+        {
+          "error": "RecordInvalid",
+          "description": "Contact user@example.com\\nfor help",
+          "details": {"email": "second@example.com", "type": "invalid"},
+          "requester": {"email": "private@example.com"}
+        }
+        """
+        ZendeskURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 422, httpVersion: nil, headerFields: nil)!
+            return (response, Data(body.utf8))
+        }
+
+        let receivedError = submitRequestAndWait()
+
+        guard case let .serverError(statusCode, bodyExcerpt) = receivedError else {
+            XCTFail("Expected a server error")
+            return
+        }
+        XCTAssertEqual(statusCode, 422)
+        XCTAssertEqual(
+            bodyExcerpt,
+            #"error: RecordInvalid, description: Contact <redacted-email> for help, details: {"email":"<redacted-email>","type":"invalid"}"#
+        )
+        XCTAssertFalse(bodyExcerpt?.contains("requester") == true)
+        XCTAssertFalse(bodyExcerpt?.contains("private@example.com") == true)
+        XCTAssertFalse(bodyExcerpt?.contains("\n") == true)
+    }
+
+    func testServerErrorOmitsArbitraryPlainTextBody() {
+        ZendeskURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 400, httpVersion: nil, headerFields: nil)!
+            return (response, Data("private user text".utf8))
+        }
+
+        let receivedError = submitRequestAndWait()
+
+        guard case let .serverError(_, bodyExcerpt) = receivedError else {
+            XCTFail("Expected a server error")
+            return
+        }
+        XCTAssertEqual(bodyExcerpt, "<non-JSON response omitted>")
+    }
+
+    private func submitRequestAndWait() -> ZendeskSupportService.SupportRequestError? {
+        let completionExpectation = expectation(description: "Request completes")
+        var receivedError: ZendeskSupportService.SupportRequestError?
+
+        makeService()
+            .submitSupportRequest(makeSupportRequest())
+            .sink(receiveCompletion: { completion in
+                if case let .failure(error) = completion {
+                    receivedError = error as? ZendeskSupportService.SupportRequestError
+                }
+                completionExpectation.fulfill()
+            }, receiveValue: { _ in
+                XCTFail("Expected the request to fail")
+            })
+            .store(in: &cancellables)
+
+        wait(for: [completionExpectation], timeout: 1)
+        return receivedError
     }
 
     private func makeService() -> ZendeskSupportService {

--- a/podcasts/Zendesk/MessageSupportViewModel.swift
+++ b/podcasts/Zendesk/MessageSupportViewModel.swift
@@ -135,6 +135,8 @@ class MessageSupportViewModel: ObservableObject {
     open func submitRequest(ignoreUnavailableWatchLogs: Bool = false) {
         isWorking.toggle()
 
+        FileLog.shared.addMessage("MessageSupportViewModel: submitRequest — isRetrying: \(isRetrying), ignoreUnavailableWatchLogs: \(ignoreUnavailableWatchLogs)")
+
         config.customFields(forDisplay: false, optOut: UserDefaults.standard.debugOptedOut)
             .flatMap { [unowned self] customFields -> AnyPublisher<String, Error> in
 
@@ -166,9 +168,11 @@ class MessageSupportViewModel: ObservableObject {
                 switch completion {
                 case let .failure(error):
                     if self.isRetrying {
+                        FileLog.shared.addMessage("MessageSupportViewModel: submit failed after retry — surfacing error: \(error)")
                         self.isRetrying = false
                         self.completion = .failure(error: error)
                     } else {
+                        FileLog.shared.addMessage("MessageSupportViewModel: submit failed on first attempt — retrying via newBaseURL. Error: \(error)")
                         self.isRetrying = true
                         self.submitRequest(ignoreUnavailableWatchLogs: ignoreUnavailableWatchLogs)
                     }

--- a/podcasts/Zendesk/MessageSupportViewModel.swift
+++ b/podcasts/Zendesk/MessageSupportViewModel.swift
@@ -167,7 +167,11 @@ class MessageSupportViewModel: ObservableObject {
                 isWorking.toggle()
                 switch completion {
                 case let .failure(error):
-                    if self.isRetrying {
+                    if case MessageSupportFailure.watchLogMissing = error {
+                        FileLog.shared.addMessage("MessageSupportViewModel: preflight failed — no support request sent: \(error)")
+                        self.isRetrying = false
+                        self.completion = .failure(error: error)
+                    } else if self.isRetrying {
                         FileLog.shared.addMessage("MessageSupportViewModel: submit failed after retry — surfacing error: \(error)")
                         self.isRetrying = false
                         self.completion = .failure(error: error)

--- a/podcasts/Zendesk/ZendeskSupportService.swift
+++ b/podcasts/Zendesk/ZendeskSupportService.swift
@@ -80,6 +80,9 @@ class ZendeskSupportService {
                 }
                 if let urlError = error as? URLError {
                     FileLog.shared.addMessage("ZendeskSupportService: \(urlLabel) submit failed — URLError \(urlError.code.rawValue) \(urlError.localizedDescription)")
+                    if urlError.code == .notConnectedToInternet {
+                        return SupportRequestError.noInternetConnection
+                    }
                 } else {
                     FileLog.shared.addMessage("ZendeskSupportService: \(urlLabel) submit failed — \(error)")
                 }

--- a/podcasts/Zendesk/ZendeskSupportService.swift
+++ b/podcasts/Zendesk/ZendeskSupportService.swift
@@ -14,7 +14,30 @@ class ZendeskSupportService {
     private let config: ZDConfig
 
     private static let responseExcerptCharacterLimit = 256
-    private static let documentedErrorKeys = ["error", "description", "details"]
+
+    private struct ZendeskErrorResponse: Decodable {
+        let error: String?
+        let description: String?
+        let details: [String: [ZendeskErrorDetail]]?
+
+        private enum CodingKeys: String, CodingKey {
+            case error
+            case description
+            case details
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            error = try? container.decode(String.self, forKey: .error)
+            description = try? container.decode(String.self, forKey: .description)
+            details = try? container.decode([String: [ZendeskErrorDetail]].self, forKey: .details)
+        }
+    }
+
+    private struct ZendeskErrorDetail: Codable {
+        let type: String?
+        let description: String?
+    }
 
     init(config: ZDConfig, session: URLSession = URLSession.shared) {
         self.session = session
@@ -70,19 +93,24 @@ class ZendeskSupportService {
             return nil
         }
 
-        guard let response = try? JSONSerialization.jsonObject(with: data),
-              let response = response as? [String: Any]
+        guard let response = try? JSONDecoder().decode(ZendeskErrorResponse.self, from: data)
         else {
             return "<non-JSON response omitted>"
         }
 
-        let fields = documentedErrorKeys.compactMap { key -> String? in
-            guard let value = response[key],
-                  let value = stringValue(for: value)
-            else {
-                return nil
+        var fields = [String]()
+        if let error = response.error {
+            fields.append("error: \(error)")
+        }
+        if let description = response.description {
+            fields.append("description: \(description)")
+        }
+        if let details = response.details {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            if let data = try? encoder.encode(details) {
+                fields.append("details: \(String(decoding: data, as: UTF8.self))")
             }
-            return "\(key): \(value)"
         }
 
         guard !fields.isEmpty else {
@@ -90,20 +118,6 @@ class ZendeskSupportService {
         }
 
         return sanitizedExcerpt(fields.joined(separator: ", "))
-    }
-
-    private static func stringValue(for value: Any) -> String? {
-        if let value = value as? String {
-            return value
-        }
-
-        guard JSONSerialization.isValidJSONObject(value),
-              let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
-        else {
-            return nil
-        }
-
-        return String(decoding: data, as: UTF8.self)
     }
 
     private static func sanitizedExcerpt(_ value: String) -> String {

--- a/podcasts/Zendesk/ZendeskSupportService.swift
+++ b/podcasts/Zendesk/ZendeskSupportService.swift
@@ -1,11 +1,13 @@
 import Combine
 import Foundation
+import PocketCastsUtils
 
 class ZendeskSupportService {
     enum SupportRequestError: Error {
-        case serverError
+        case serverError(statusCode: Int, bodyExcerpt: String?)
         case badRequest
         case noInternetConnection
+        case invalidResponse
     }
 
     private let session: URLSession
@@ -21,19 +23,41 @@ class ZendeskSupportService {
         do {
             request = try generateSupportRequest(supportRequest, isRetrying: isRetrying)
         } catch {
+            FileLog.shared.addMessage("ZendeskSupportService: failed to build request (isRetrying: \(isRetrying)): \(error)")
             return Fail(error: error).eraseToAnyPublisher()
         }
 
+        let urlLabel = isRetrying ? "newBaseURL" : "baseURL"
+        let requestURL = request.url?.absoluteString ?? "<nil>"
+        FileLog.shared.addMessage("ZendeskSupportService: POST \(requestURL) (\(urlLabel))")
+
         return session.dataTaskPublisher(for: request)
-            .tryMap { _, response in
-                guard
-                    let httpResponse = response as? HTTPURLResponse,
-                    200 ..< 300 ~= httpResponse.statusCode
-                else {
-                    throw SupportRequestError.serverError
+            .tryMap { data, response in
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    FileLog.shared.addMessage("ZendeskSupportService: \(urlLabel) submit failed — non-HTTP response")
+                    throw SupportRequestError.invalidResponse
                 }
 
+                let status = httpResponse.statusCode
+                guard 200 ..< 300 ~= status else {
+                    let bodyExcerpt = String(data: data.prefix(256), encoding: .utf8)
+                    FileLog.shared.addMessage("ZendeskSupportService: \(urlLabel) submit failed — HTTP \(status), body: \(bodyExcerpt ?? "<non-utf8>")")
+                    throw SupportRequestError.serverError(statusCode: status, bodyExcerpt: bodyExcerpt)
+                }
+
+                FileLog.shared.addMessage("ZendeskSupportService: \(urlLabel) submit succeeded — HTTP \(status)")
                 return ""
+            }
+            .mapError { error -> Error in
+                if let supportError = error as? SupportRequestError {
+                    return supportError
+                }
+                if let urlError = error as? URLError {
+                    FileLog.shared.addMessage("ZendeskSupportService: \(urlLabel) submit failed — URLError \(urlError.code.rawValue) \(urlError.localizedDescription)")
+                } else {
+                    FileLog.shared.addMessage("ZendeskSupportService: \(urlLabel) submit failed — \(error)")
+                }
+                return error
             }
             .eraseToAnyPublisher()
     }

--- a/podcasts/Zendesk/ZendeskSupportService.swift
+++ b/podcasts/Zendesk/ZendeskSupportService.swift
@@ -13,6 +13,9 @@ class ZendeskSupportService {
     private let session: URLSession
     private let config: ZDConfig
 
+    private static let responseExcerptCharacterLimit = 256
+    private static let documentedErrorKeys = ["error", "description", "details"]
+
     init(config: ZDConfig, session: URLSession = URLSession.shared) {
         self.session = session
         self.config = config
@@ -40,8 +43,8 @@ class ZendeskSupportService {
 
                 let status = httpResponse.statusCode
                 guard 200 ..< 300 ~= status else {
-                    let bodyExcerpt = String(data: data, encoding: .utf8).map { String($0.prefix(256)) }
-                    FileLog.shared.addMessage("ZendeskSupportService: \(urlLabel) submit failed — HTTP \(status), body: \(bodyExcerpt ?? "<non-utf8>")")
+                    let bodyExcerpt = Self.responseBodyExcerpt(from: data)
+                    FileLog.shared.addMessage("ZendeskSupportService: \(urlLabel) submit failed — HTTP \(status), body: \(bodyExcerpt ?? "<empty>")")
                     throw SupportRequestError.serverError(statusCode: status, bodyExcerpt: bodyExcerpt)
                 }
 
@@ -60,6 +63,60 @@ class ZendeskSupportService {
                 return error
             }
             .eraseToAnyPublisher()
+    }
+
+    private static func responseBodyExcerpt(from data: Data) -> String? {
+        guard !data.isEmpty else {
+            return nil
+        }
+
+        guard let response = try? JSONSerialization.jsonObject(with: data),
+              let response = response as? [String: Any]
+        else {
+            return "<non-JSON response omitted>"
+        }
+
+        let fields = documentedErrorKeys.compactMap { key -> String? in
+            guard let value = response[key],
+                  let value = stringValue(for: value)
+            else {
+                return nil
+            }
+            return "\(key): \(value)"
+        }
+
+        guard !fields.isEmpty else {
+            return "<unrecognized JSON response omitted>"
+        }
+
+        return sanitizedExcerpt(fields.joined(separator: ", "))
+    }
+
+    private static func stringValue(for value: Any) -> String? {
+        if let value = value as? String {
+            return value
+        }
+
+        guard JSONSerialization.isValidJSONObject(value),
+              let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+        else {
+            return nil
+        }
+
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func sanitizedExcerpt(_ value: String) -> String {
+        let withoutControlCharacters = value.unicodeScalars
+            .map { CharacterSet.controlCharacters.contains($0) ? " " : String($0) }
+            .joined()
+        let redacted = withoutControlCharacters.replacingOccurrences(
+            of: #"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"#,
+            with: "<redacted-email>",
+            options: [.regularExpression, .caseInsensitive]
+        )
+        let singleLine = redacted.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        return String(singleLine.prefix(responseExcerptCharacterLimit))
     }
 
     private func generateSupportRequest(_ supportRequest: ZDSupportRequest, isRetrying: Bool = false) throws -> URLRequest {

--- a/podcasts/Zendesk/ZendeskSupportService.swift
+++ b/podcasts/Zendesk/ZendeskSupportService.swift
@@ -40,7 +40,7 @@ class ZendeskSupportService {
 
                 let status = httpResponse.statusCode
                 guard 200 ..< 300 ~= status else {
-                    let bodyExcerpt = String(data: data.prefix(256), encoding: .utf8)
+                    let bodyExcerpt = String(data: data, encoding: .utf8).map { String($0.prefix(256)) }
                     FileLog.shared.addMessage("ZendeskSupportService: \(urlLabel) submit failed — HTTP \(status), body: \(bodyExcerpt ?? "<non-utf8>")")
                     throw SupportRequestError.serverError(statusCode: status, bodyExcerpt: bodyExcerpt)
                 }


### PR DESCRIPTION
Refs PCIOS-686

The in-app Support form (Profile → Help & Feedback → Contact Support) shows the "Oops something went wrong" alert when both submit attempts fail. The submit code path currently emits **zero** log entries — HTTP status, response body, and `URLError` details are all discarded before the alert fires. Customer-reported failures (e.g. Zendesk #11265549, #11173685) are therefore impossible to diagnose from exported logs.

This PR is **strictly additive diagnostics**. Retry behaviour, alert copy, and the public API used by views are unchanged.

### Changes

- [`ZendeskSupportService`](https://github.com/Automattic/pocket-casts-ios/blob/fix/pcios-686-support-form-diagnostic-logging/podcasts/Zendesk/ZendeskSupportService.swift)
  - `import PocketCastsUtils` for `FileLog`
  - Log POST URL on every attempt (with `baseURL` / `newBaseURL` label)
  - Log HTTP status + response-body excerpt (≤256 bytes) on non-2xx
  - Log `URLError` code + description on transport failures
  - Log "submit succeeded" on success
  - Enrich `SupportRequestError.serverError` to carry `statusCode` and `bodyExcerpt`; add `.invalidResponse` for non-HTTPURLResponse
- [`MessageSupportViewModel`](https://github.com/Automattic/pocket-casts-ios/blob/fix/pcios-686-support-form-diagnostic-logging/podcasts/Zendesk/MessageSupportViewModel.swift)
  - Log every `submitRequest` entry (with `isRetrying` flag)
  - Log the recursive retry trigger and the final user-visible failure

### Why this matters

Today, when a customer reports "submit failed", we have nothing actionable — no status code to tell auth/rate-limit/server-down apart, no body to surface a Zendesk validation message, no signal whether both URLs failed or just one. After this change, a single exported log file pinpoints which Zendesk endpoint failed and why.

### To test

1. Build & run on a simulator/device.
2. Open Profile → Help & Feedback → Contact Support, fill in the form, tap Submit.
3. Profile → Help & Feedback → Logs — confirm new entries appear:
   - `ZendeskSupportService: POST https://… (baseURL)`
   - `ZendeskSupportService: baseURL submit succeeded — HTTP 201` (or similar)
4. To exercise the failure path, temporarily point `baseURL` and `newBaseURL` at an invalid host (in the relevant `ZDConfig`), submit again, and confirm:
   - `MessageSupportViewModel: submitRequest — isRetrying: false, …`
   - `ZendeskSupportService: baseURL submit failed — …`
   - `MessageSupportViewModel: submit failed on first attempt — retrying via newBaseURL. …`
   - `MessageSupportViewModel: submit failed after retry — surfacing error: …`
   - The "Oops something went wrong" alert appears.

### Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. *(Diagnostic-only — not user-facing; CHANGELOG entry skipped.)*
- [ ] I have considered adding unit tests for my changes. *(No existing tests for `ZendeskSupportService`; the behaviour change is purely logging output.)*
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. *(N/A — no analytics changes.)*

> Note: I couldn't run a full Xcode build locally (only Command Line Tools installed). `swiftc -parse` passes; CI will provide the real type-check signal.