### PR TITLE
Home layout improvements (tvOS)

### DIFF
--- a/Pocket Casts TV App/UI/Common/FocusStore.swift
+++ b/Pocket Casts TV App/UI/Common/FocusStore.swift
@@ -2,13 +2,13 @@ import SwiftUI
 
 @Observable
 class FocusStore {
-    var focusedID: String?
+    var focusedID: AnyHashable?
 }
 
 struct FocusObserving: ViewModifier {
     @Environment(FocusStore.self) var focusStore
     @FocusState private var isFocused: Bool
-    let section: String
+    let section: AnyHashable
 
     func body(content: Content) -> some View {
         content
@@ -24,7 +24,7 @@ struct FocusObserving: ViewModifier {
 }
 
 extension View {
-    func setFocus(section: String) -> some View {
+    func setFocus(section: AnyHashable) -> some View {
         modifier(FocusObserving(section: section))
     }
 }

--- a/Pocket Casts TV App/UI/Common/FocusStore.swift
+++ b/Pocket Casts TV App/UI/Common/FocusStore.swift
@@ -16,6 +16,8 @@ struct FocusObserving: ViewModifier {
             .onChange(of: isFocused) { _, newValue in
                 if newValue {
                     focusStore.focusedID = section
+                } else if focusStore.focusedID == section {
+                    focusStore.focusedID = nil
                 }
             }
     }

--- a/Pocket Casts TV App/UI/Common/FocusStore.swift
+++ b/Pocket Casts TV App/UI/Common/FocusStore.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+@Observable
+class FocusStore {
+    var focusedID: AnyHashable?
+}
+
+struct FocusObserving: ViewModifier {
+    @Environment(FocusStore.self) var focusStore
+    @FocusState private var isFocused: Bool
+    let section: String
+
+    func body(content: Content) -> some View {
+        content
+            .focused($isFocused)
+            .onChange(of: isFocused) { _, newValue in
+                if newValue {
+                    focusStore.focusedID = section
+                }
+            }
+    }
+}
+
+extension View {
+    func setFocus(section: String) -> some View {
+        modifier(FocusObserving(section: section))
+    }
+}

--- a/Pocket Casts TV App/UI/Common/FocusStore.swift
+++ b/Pocket Casts TV App/UI/Common/FocusStore.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 @Observable
 class FocusStore {
-    var focusedID: AnyHashable?
+    var focusedID: String?
 }
 
 struct FocusObserving: ViewModifier {

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -46,7 +46,7 @@ struct DiscoverPodcastRow: View {
                         }
                         .buttonStyle(.card)
                         .padding(.vertical, 24)
-                        .setFocus(section: model.type.rawValue)
+                        .setFocus(section: model.type)
                     }
                 }
             })

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -37,7 +37,7 @@ struct DiscoverPodcastRow: View {
 
     var podcastList: some View {
         ScrollView(.horizontal) {
-            LazyHStack(spacing: 0, content: {
+            LazyHStack(spacing: 48, content: {
                 ForEach(model.podcasts, id: \.uuid) { podcast in
                     if let uuid = podcast.uuid {
                         NavigationLink(value: podcast) {
@@ -45,7 +45,7 @@ struct DiscoverPodcastRow: View {
                                 .frame(width: Layout.gridSize, height: Layout.gridSize)
                         }
                         .buttonStyle(.card)
-                        .padding(24)
+                        .padding(.vertical, 24)
                     }
                 }
             })

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -48,7 +48,7 @@ struct DiscoverPodcastRow: View {
                         .padding(.vertical, 24)
                     }
                 }
-            })            
+            })
         }
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -35,6 +35,9 @@ struct DiscoverPodcastRow: View {
         }
     }
 
+    @Environment(FocusStore.self) var focusStore
+    @FocusState private var isFocused: Bool
+
     var podcastList: some View {
         ScrollView(.horizontal) {
             LazyHStack(spacing: 48, content: {
@@ -46,6 +49,12 @@ struct DiscoverPodcastRow: View {
                         }
                         .buttonStyle(.card)
                         .padding(.vertical, 24)
+                        .focused($isFocused)
+                        .onChange(of: isFocused) { _, newValue in
+                            if newValue {
+                                focusStore.focusedID = model.type.rawValue
+                            }
+                        }
                     }
                 }
             })

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -35,9 +35,6 @@ struct DiscoverPodcastRow: View {
         }
     }
 
-    @Environment(FocusStore.self) var focusStore
-    @FocusState private var isFocused: Bool
-
     var podcastList: some View {
         ScrollView(.horizontal) {
             LazyHStack(spacing: 48, content: {
@@ -49,12 +46,7 @@ struct DiscoverPodcastRow: View {
                         }
                         .buttonStyle(.card)
                         .padding(.vertical, 24)
-                        .focused($isFocused)
-                        .onChange(of: isFocused) { _, newValue in
-                            if newValue {
-                                focusStore.focusedID = model.type.rawValue
-                            }
-                        }
+                        .setFocus(section: model.type.rawValue)
                     }
                 }
             })

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -15,6 +15,12 @@ struct HomeView: View {
         static let sectionSpacing = CGFloat(80)
     }
 
+    enum Section: String {
+        case homeNowPlaying
+        case homeUpNext
+        case homeNewReleases
+    }
+
     var body: some View {
         ZStack {
             switch model.state {
@@ -68,12 +74,12 @@ struct HomeView: View {
     @ViewBuilder
     var nowPlayingRow: some View {
         if let currentPlaying = model.currentPlaying {
-            HomeSection(title: L10n.tvHomeKeepListeningTitle, focusSection: "NowPlaying") {
+            HomeSection(title: L10n.tvHomeKeepListeningTitle, focusSection: Section.homeNowPlaying) {
                 NowPlayingRow(model: currentPlaying) {
                     showNowPlayingPlayer = true
                 }
                 .frame(width: 1242, alignment: .leading)
-                .setFocus(section: "NowPlaying")
+                .setFocus(section: Section.homeNowPlaying)
             }
         } else {
             EmptyView()
@@ -81,7 +87,7 @@ struct HomeView: View {
     }
 
     var youMightLikeRow: some View {
-        HomeSection(title: L10n.tvHomeRecommendedForYouTitle, focusSection: DiscoverType.recommendationsUser.rawValue) {
+        HomeSection(title: L10n.tvHomeRecommendedForYouTitle, focusSection: DiscoverType.recommendationsUser) {
             DiscoverPodcastRow(type: .recommendationsUser)
         }
     }
@@ -89,7 +95,7 @@ struct HomeView: View {
     @State private var sectionPodcast: String?
 
     var lovedByListenersOfRow: some View {
-        HomeSection(title: L10n.tvHomeRecommendUserPodcastSectionTitle(sectionPodcast ?? ""), focusSection: DiscoverType.recommendationsSocial.rawValue) {
+        HomeSection(title: L10n.tvHomeRecommendUserPodcastSectionTitle(sectionPodcast ?? ""), focusSection: DiscoverType.recommendationsSocial) {
             DiscoverPodcastRow(type: .recommendationsSocial) { title in
                 sectionPodcast = title
             }
@@ -97,7 +103,7 @@ struct HomeView: View {
     }
 
     var trendingRow: some View {
-        HomeSection(title: L10n.tvHomeTrendingSectionTitle, focusSection: DiscoverType.trending.rawValue) {
+        HomeSection(title: L10n.tvHomeTrendingSectionTitle, focusSection: DiscoverType.trending) {
             DiscoverPodcastRow(type: .trending)
         }
     }
@@ -105,13 +111,13 @@ struct HomeView: View {
     @ViewBuilder
     var upNextRow: some View {
         if model.upNext.count > 1 {
-            HomeSection(title: L10n.tvTabUpNext, focusSection: "UpNext") {
+            HomeSection(title: L10n.tvTabUpNext, focusSection: Section.homeUpNext) {
                 ScrollView(.horizontal) {
                     LazyHStack(spacing: 24) {
                         ForEach(model.upNext) { episode in
                             upNextButton(model: episode)
                                 .frame(width: 864)
-                                .setFocus(section: "UpNext")
+                                .setFocus(section: Section.homeUpNext)
                         }
                     }
                 }
@@ -130,13 +136,13 @@ struct HomeView: View {
     }
 
     var newReleasesRow: some View {
-        HomeSection(title: L10n.tvHomeNewReleases, focusSection: "NewReleases") {
+        HomeSection(title: L10n.tvHomeNewReleases, focusSection: Section.homeNewReleases) {
             ScrollView(.horizontal) {
                 LazyHStack(spacing: 24) {
                     ForEach(model.newReleases) { episode in
                         EpisodePlayerButton(model: episode)
                             .frame(width: 864)
-                            .setFocus(section: "NewReleases")
+                            .setFocus(section: Section.homeNewReleases)
                     }
                 }
             }
@@ -146,12 +152,12 @@ struct HomeView: View {
 
 struct HomeSection<Content: View>: View {
     private let title: String
-    private let focusSection: String
+    private let focusSection: AnyHashable
     private let content: Content
 
     @Environment(FocusStore.self) var focusStore
 
-    init(title: String, focusSection: String, @ViewBuilder content: () -> Content) {
+    init(title: String, focusSection: AnyHashable, @ViewBuilder content: () -> Content) {
         self.title = title
         self.content = content()
         self.focusSection = focusSection

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -70,26 +70,23 @@ struct HomeView: View {
                 }
                 .frame(width: 1242, alignment: .leading)
             }
+            .focusSection()
         } else {
             EmptyView()
         }
     }
+
     var youMightLikeRow: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            Text(L10n.tvHomeRecommendedForYouTitle)
-                .font(.title3)
-                .foregroundStyle(Color.textPrimary)
+        HomeSection(title: L10n.tvHomeRecommendedForYouTitle) {
             DiscoverPodcastRow(type: .recommendationsUser)
         }
+        .focusSection()
     }
 
     @State private var sectionPodcast: String?
 
     var lovedByListenersOfRow: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            Text(L10n.tvHomeRecommendUserPodcastSectionTitle(sectionPodcast ?? ""))
-                .font(.title3)
-                .foregroundStyle(Color.textPrimary)
+        HomeSection(title: L10n.tvHomeRecommendUserPodcastSectionTitle(sectionPodcast ?? "")) {
             DiscoverPodcastRow(type: .recommendationsSocial) { title in
                 sectionPodcast = title
             }
@@ -97,10 +94,7 @@ struct HomeView: View {
     }
 
     var trendingRow: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            Text(L10n.tvHomeTrendingSectionTitle)
-                .font(.title3)
-                .foregroundStyle(Color.textPrimary)
+        HomeSection(title: L10n.tvHomeTrendingSectionTitle) {
             DiscoverPodcastRow(type: .trending)
         }
     }
@@ -108,10 +102,7 @@ struct HomeView: View {
     @ViewBuilder
     var upNextRow: some View {
         if model.upNext.count > 1 {
-            VStack(alignment: .leading, spacing: 24) {
-                Text(L10n.tvTabUpNext)
-                    .font(.title3)
-                    .foregroundStyle(Color.textPrimary)
+            HomeSection(title: L10n.tvTabUpNext) {
                 ScrollView(.horizontal) {
                     LazyHStack(spacing: 24) {
                         ForEach(model.upNext) { episode in
@@ -119,7 +110,6 @@ struct HomeView: View {
                                 .frame(width: 864)
                         }
                     }
-                    .padding(.horizontal, 24)
                 }
             }
         }
@@ -136,10 +126,7 @@ struct HomeView: View {
     }
 
     var newReleasesRow: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            Text(L10n.tvHomeNewReleases)
-                .font(.title3)
-                .foregroundStyle(Color.textPrimary)
+        HomeSection(title: L10n.tvHomeNewReleases) {
             ScrollView(.horizontal) {
                 LazyHStack(spacing: 24) {
                     ForEach(model.newReleases) { episode in
@@ -147,8 +134,26 @@ struct HomeView: View {
                             .frame(width: 864)
                     }
                 }
-                .padding(.horizontal, 24)
             }
+        }
+    }
+}
+
+struct HomeSection<Content: View>: View {
+    private let title: String
+    private let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 32) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(Color.textPrimary)
+            content
         }
     }
 }

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -5,6 +5,7 @@ import PocketCastsServer
 struct HomeView: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
+    @Environment(FocusStore.self) var focusStore
 
     @State private var model = HomeViewModel()
 
@@ -68,14 +69,12 @@ struct HomeView: View {
     @ViewBuilder
     var nowPlayingRow: some View {
         if let currentPlaying = model.currentPlaying {
-            VStack(alignment: .leading, spacing: 32) {
-                Text(L10n.tvHomeKeepListeningTitle)
-                    .font(.title2)
-                    .foregroundStyle(Color.textPrimary)
+            HomeSection(title: L10n.tvHomeKeepListeningTitle, focusSection: "NowPlaying") {
                 NowPlayingRow(model: currentPlaying) {
                     showNowPlayingPlayer = true
                 }
                 .frame(width: 1242, alignment: .leading)
+                .setFocus(section: "NowPlaying")
             }
             .focusSection()
         } else {
@@ -84,7 +83,7 @@ struct HomeView: View {
     }
 
     var youMightLikeRow: some View {
-        HomeSection(title: L10n.tvHomeRecommendedForYouTitle) {
+        HomeSection(title: L10n.tvHomeRecommendedForYouTitle, focusSection: DiscoverType.recommendationsUser.rawValue) {
             DiscoverPodcastRow(type: .recommendationsUser)
         }
         .focusSection()
@@ -93,7 +92,7 @@ struct HomeView: View {
     @State private var sectionPodcast: String?
 
     var lovedByListenersOfRow: some View {
-        HomeSection(title: L10n.tvHomeRecommendUserPodcastSectionTitle(sectionPodcast ?? "")) {
+        HomeSection(title: L10n.tvHomeRecommendUserPodcastSectionTitle(sectionPodcast ?? ""), focusSection: DiscoverType.recommendationsSocial.rawValue) {
             DiscoverPodcastRow(type: .recommendationsSocial) { title in
                 sectionPodcast = title
             }
@@ -101,7 +100,7 @@ struct HomeView: View {
     }
 
     var trendingRow: some View {
-        HomeSection(title: L10n.tvHomeTrendingSectionTitle) {
+        HomeSection(title: L10n.tvHomeTrendingSectionTitle, focusSection: DiscoverType.trending.rawValue) {
             DiscoverPodcastRow(type: .trending)
         }
     }
@@ -109,12 +108,13 @@ struct HomeView: View {
     @ViewBuilder
     var upNextRow: some View {
         if model.upNext.count > 1 {
-            HomeSection(title: L10n.tvTabUpNext) {
+            HomeSection(title: L10n.tvTabUpNext, focusSection: "UpNext") {
                 ScrollView(.horizontal) {
                     LazyHStack(spacing: 24) {
                         ForEach(model.upNext) { episode in
                             upNextButton(model: episode)
                                 .frame(width: 864)
+                                .setFocus(section: "UpNext")
                         }
                     }
                 }
@@ -133,12 +133,13 @@ struct HomeView: View {
     }
 
     var newReleasesRow: some View {
-        HomeSection(title: L10n.tvHomeNewReleases) {
+        HomeSection(title: L10n.tvHomeNewReleases, focusSection: "NewReleases") {
             ScrollView(.horizontal) {
                 LazyHStack(spacing: 24) {
                     ForEach(model.newReleases) { episode in
                         EpisodePlayerButton(model: episode)
                             .frame(width: 864)
+                            .setFocus(section: "NewReleases")
                     }
                 }
             }
@@ -148,17 +149,25 @@ struct HomeView: View {
 
 struct HomeSection<Content: View>: View {
     private let title: String
+    private let focusSection: String
     private let content: Content
 
-    init(title: String, @ViewBuilder content: () -> Content) {
+    @Environment(FocusStore.self) var focusStore
+
+    init(title: String, focusSection: String, @ViewBuilder content: () -> Content) {
         self.title = title
         self.content = content()
+        self.focusSection = focusSection
+    }
+
+    private var isFocusedSection: Bool {
+        (focusStore.focusedID as? String) == focusSection
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 32) {
             Text(title)
-                .font(.headline)
+                .font(isFocusedSection ? .title2 : .headline)
                 .foregroundStyle(Color.textPrimary)
             content
         }

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -5,7 +5,6 @@ import PocketCastsServer
 struct HomeView: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
-    @Environment(FocusStore.self) var focusStore
 
     @State private var model = HomeViewModel()
 
@@ -76,7 +75,6 @@ struct HomeView: View {
                 .frame(width: 1242, alignment: .leading)
                 .setFocus(section: "NowPlaying")
             }
-            .focusSection()
         } else {
             EmptyView()
         }
@@ -86,7 +84,6 @@ struct HomeView: View {
         HomeSection(title: L10n.tvHomeRecommendedForYouTitle, focusSection: DiscoverType.recommendationsUser.rawValue) {
             DiscoverPodcastRow(type: .recommendationsUser)
         }
-        .focusSection()
     }
 
     @State private var sectionPodcast: String?
@@ -161,7 +158,7 @@ struct HomeSection<Content: View>: View {
     }
 
     private var isFocusedSection: Bool {
-        (focusStore.focusedID as? String) == focusSection
+        focusStore.focusedID == focusSection
     }
 
     var body: some View {
@@ -171,6 +168,7 @@ struct HomeSection<Content: View>: View {
                 .foregroundStyle(Color.textPrimary)
             content
         }
+        .focusSection()
     }
 }
 

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -12,6 +12,7 @@ struct HomeView: View {
 
     enum Layout {
         static let gridSize = CGFloat(250)
+        static let sectionSpacing = CGFloat(80)
     }
 
     var body: some View {
@@ -43,7 +44,7 @@ struct HomeView: View {
     var homeView: some View {
         NavigationStack {
             ScrollView {
-                VStack(alignment: .leading, spacing: 80) {
+                VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
                     nowPlayingRow
                     upNextRow
                     youMightLikeRow

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -51,8 +51,7 @@ struct NowPlayingRow: View {
                     Spacer()
                 }
                 Spacer()
-            }
-            .padding(32)
+            }            
             .background(isFocused ? Color.backgroundActive : Color.backgroundSunken)
         }
         .buttonStyle(.card)

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -51,7 +51,7 @@ struct NowPlayingRow: View {
                     Spacer()
                 }
                 Spacer()
-            }            
+            }
             .background(isFocused ? Color.backgroundActive : Color.backgroundSunken)
         }
         .buttonStyle(.card)

--- a/Pocket Casts TV App/UI/RootView.swift
+++ b/Pocket Casts TV App/UI/RootView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct RootView: View {
     @State private var coordinator = AppCoordinator()
+    @State private var focusStore = FocusStore()
 
     var body: some View {
         ZStack {
@@ -21,6 +22,7 @@ struct RootView: View {
             }
         }
         .environment(coordinator)
+        .environment(focusStore)
         .task {
             await coordinator.load()
         }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

<!-- No tracking issue -->

## Summary

Adjusts the tvOS Home screen layout and adds focus-aware section titles.

- Updates inter-section spacing to the new 80pt rhythm and pulls it into a `Layout.sectionSpacing` constant.
- Removes ad-hoc per-row `VStack` headers and unifies all Home rows under a new `HomeSection` wrapper that renders the title and applies `.focusSection()` for tvOS focus navigation.
- Adds a small `FocusStore` (`@Observable`) plus a `.setFocus(section:)` view modifier so that whichever row currently holds focus gets a larger title (`.title2`) while the others use `.headline`.
- Tweaks padding/spacing on `DiscoverPodcastRow` and `NowPlayingRow` so cards align with the new layout.

## To test

1. Run the tvOS app and open the Home tab.
2. Move focus between sections (Keep Listening, Up Next, Recommended For You, New Releases, Loved By Listeners Of…, Trending).
3. Verify the focused section's title grows (`.title2`) and the other titles use `.headline`.
4. Verify section-to-section navigation feels correct (focus jumps between sections, not between individual cards across sections).
5. Verify Up Next and New Releases rows align with the rest of the Home content.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.