### PR TITLE
Track transcript text highlighting

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -922,6 +922,7 @@ enum AnalyticsEvent: String {
     case episodeDetailTranscriptCardTapped
     case episodeTranscriptShown
     case transcriptShared
+    case transcriptTextHighlighted
     case syncedTranscriptSeekUsed
     case syncedTranscriptPreparationStarted
     case syncedTranscriptPreparationCompleted

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -1170,9 +1170,9 @@ extension TranscriptViewController: UIScrollViewDelegate {
 
 extension TranscriptViewController: UITextViewDelegate {
     func textViewDidChangeSelection(_ textView: UITextView) {
-        let wasEmpty = !hadNonEmptySelection
+        let wasEmpty = !hasNonEmptySelection
         let isNonEmpty = textView.selectedRange.length > 0
-        hadNonEmptySelection = isNonEmpty
+        hasNonEmptySelection = isNonEmpty
         if wasEmpty && isNonEmpty {
             track(.transcriptTextHighlighted)
         }

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -14,7 +14,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private var canScrollToDismiss = true
 
     private var isUserScrolling = false
-    private var hadNonEmptySelection = false
+    private var hasNonEmptySelection = false
     // Stays `true` for the entire scroll-back grace period, not just while the
     // user's finger is on the view. `isUserScrolling` flips back to false the
     // instant the drag ends, so without this, the next playback tick would

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -755,6 +755,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         previousRange = nil
         cachedCueIndex = 0
         self.transcript = transcript
+        hasNonEmptySelection = false
         transcriptView.attributedText = styleText(transcript: transcript)
         if resetPosition {
             transcriptView.setContentOffset(.zero, animated: false)

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -14,6 +14,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private var canScrollToDismiss = true
 
     private var isUserScrolling = false
+    private var hadNonEmptySelection = false
     // Stays `true` for the entire scroll-back grace period, not just while the
     // user's finger is on the view. `isUserScrolling` flips back to false the
     // instant the drag ends, so without this, the next playback tick would
@@ -525,7 +526,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         updateColors()
         loadTranscript()
         addObservers()
-        (transcriptView as UIScrollView).delegate = self
+        transcriptView.delegate = self
         #if DEBUG
         let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
             self?.debugOverlay?.update()
@@ -1163,6 +1164,17 @@ extension TranscriptViewController: UIScrollViewDelegate {
     private func userScrollDidEnd() {
         isUserScrolling = false
         scheduleAutoScrollBack()
+    }
+}
+
+extension TranscriptViewController: UITextViewDelegate {
+    func textViewDidChangeSelection(_ textView: UITextView) {
+        let wasEmpty = !hadNonEmptySelection
+        let isNonEmpty = textView.selectedRange.length > 0
+        hadNonEmptySelection = isNonEmpty
+        if wasEmpty && isNonEmpty {
+            track(.transcriptTextHighlighted)
+        }
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: # |  |
|:---:|

Adds an analytics event (`transcriptTextHighlighted`) that fires the first time a user creates a non-empty text selection in the transcript view. This is a measurement-only change to validate whether users highlight transcript text often enough to justify follow-up features (e.g. suggesting a clip/bookmark on highlight, or "popular highlights" overlays). No UI change, no data leaves the device beyond the existing event payload.

The event only fires on the empty→non-empty edge of `textViewDidChangeSelection`, so dragging the selection handles or tapping to clear does not spam events. One event per highlight gesture.

Phase 2 (suggest clip/bookmark on highlight) and Phase 3 ("popular highlights" Kindle-style underlines) are tracked separately and are gated on whatever this event shows over the next few weeks.

## To test

1. Play any episode that has a transcript.
2. Open the transcript view.
3. Long-press on the transcript text until iOS selects a word.
4. Confirm a single `transcript_text_highlighted` event is recorded (via Tracks logging / debug overlay).
5. Drag the selection handles to extend the selection — confirm no additional events fire.
6. Tap elsewhere to clear the selection, then long-press again — confirm a new event fires.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to \`CHANGELOG.md\` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)