### PR TITLE
Fix an issue with player not dismising when navigating to podcasts

### DIFF
--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -122,7 +122,6 @@ extension MiniPlayerViewController {
 
     func closeUpNextAndFullPlayer(completion: (() -> Void)? = nil) {
         if let fullScreenPlayer {
-            _ = fullScreenPlayer.children.map { $0.dismiss(animated: false, completion: nil) }
             closeFullScreenPlayer(completion: {
                 completion?()
             })


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

**Note**: it is a production issue and reproduces on iOS 18 and iOS 26. The difference is that iOS 26 currently requires the dismiss transition to run.

**RCA:**

This line instantly hides the full player (NOT children) with no animation and without running the dismiss transition:

```
_ = fullScreenPlayer.children.map { $0.dismiss(animated: false, completion: nil) }
```

## To test

- Open full player
- Tap "More" / "Go to Podcast"
- Verify navigation works as expected (player is dismissed with animation, etc)

The other scenario is full player / up next / details / tap on podcat


https://github.com/user-attachments/assets/078880da-ffe3-4024-8a96-f2c370650077



## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
