### PR TITLE
Fix crash in Up Next when changing isMultiSelectEnabled from background

### DIFF
--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -29,23 +29,27 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     var isMultiSelectEnabled = false {
         didSet {
-            guard oldValue != isMultiSelectEnabled else { return }
+            let didChange = oldValue != isMultiSelectEnabled
 
-            self.updateNavBarButtons()
-            self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
-            contentInseter.isMultiSelectEnabled = isMultiSelectEnabled
-            if !self.isMultiSelectEnabled {
-                self.multiSelectActionBar.isHidden = true
-                self.selectedPlayListEpisodes.removeAll()
-                self.track(.upNextMultiSelectExited)
-            } else {
-                self.track(.upNextMultiSelectEntered)
+            DispatchQueue.main.async { [weak self] in
+                guard let self, didChange else { return }
+
+                self.updateNavBarButtons()
+                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
+                contentInseter.isMultiSelectEnabled = isMultiSelectEnabled
+                if !self.isMultiSelectEnabled {
+                    self.multiSelectActionBar.isHidden = true
+                    self.selectedPlayListEpisodes.removeAll()
+                    self.track(.upNextMultiSelectExited)
+                } else {
+                    self.track(.upNextMultiSelectEntered)
+                }
+                self.updateNavBarButtons(animated: true)
+                if self.showingInTab {
+                    self.multiSelectActionBarBottomConstraint.constant = Constants.effectiveMiniPlayerOffset + Self.bottomMargin
+                }
+                self.animateMultiSelectChange()
             }
-            self.updateNavBarButtons(animated: true)
-            if self.showingInTab {
-                self.multiSelectActionBarBottomConstraint.constant = Constants.effectiveMiniPlayerOffset + Self.bottomMargin
-            }
-            self.animateMultiSelectChange()
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Fixes https://a8c.sentry.io/issues/7505429815/?environment=appStore&project=4503921846583296&query=release%3A%22au.com.shiftyjelly.podcasts%408.13%2B8.13.0.0%22&referrer=release-issue-stream

Turns out, `isMultiSelectEnabled` does get called from the background, and even adding `@MainActor` does not help. This is a hotfix for the release branch. I'll prepare a more comprehensive fix for `trunk`.

## To test

- Start multi-select
- Tap "Mark as Played" from the more menu

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
