### PR TITLE
Fix an issue with time left label displaying under the skip buttons

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -192,7 +192,11 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
             textStack.leadingAnchor.constraint(equalTo: podcastArtwork.trailingAnchor, constant: 8),
             textStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: 2),
+            {
+                let constraint = textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: 2)
+                constraint.priority = UILayoutPriority(999)
+                return constraint
+            }(),
 
             progressView.heightAnchor.constraint(equalToConstant: 5),
 
@@ -675,6 +679,5 @@ struct MiniPlayerTimeLeftView: View {
             .foregroundColor(model.color)
             .contentTransition(.numericText(countsDown: model.countsDown))
             .lineLimit(1)
-            .fixedSize()
     }
 }

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -155,6 +155,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         timeLeftHost.sizingOptions = .intrinsicContentSize
         timeLeftHost.safeAreaRegions = []
         addChild(timeLeftHost)
+
         self.timeLeftModel = timeLeftModel
         self.timeLeftHostingController = timeLeftHost
 
@@ -189,7 +190,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             podcastArtwork.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
             podcastArtwork.centerYAnchor.constraint(equalTo: view.centerYAnchor),
 
-            textStack.leadingAnchor.constraint(equalTo: podcastArtwork.trailingAnchor, constant: 10),
+            textStack.leadingAnchor.constraint(equalTo: podcastArtwork.trailingAnchor, constant: 8),
             textStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             textStack.trailingAnchor.constraint(lessThanOrEqualTo: buttonStack.leadingAnchor, constant: 2),
 
@@ -221,6 +222,19 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             NSLayoutConstraint.activate(accessoryEnvironmentConstraints)
         }
         super.updateViewConstraints()
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        guard let timeLeftHost = timeLeftHostingController?.view else {
+            return
+        }
+
+        let timeLeftMaxX = timeLeftHost.convert(timeLeftHost.bounds, to: view).maxX
+        let buttonSkipMinX = skipBackBtn.convert(skipBackBtn.bounds, to: view).minX
+
+        timeLeftHost.alpha = timeLeftMaxX > buttonSkipMinX + 12 ? 0 : 1
     }
 
     deinit {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Fixes an issue where "time left" was under the buttons visually.

https://github.com/user-attachments/assets/b15fc49b-013b-44cf-8852-49671717ca50


Note: It's inevitable on Display Zoom that the label will show very little – other apps do the same.


## To test

- Set "Display Zoom" to "Larger Text" in "Display & Brightness" 

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
