### PR TITLE
Liquid Glass: Options Picker Sheet Presentation - Part 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 8.14
 -----
-- Fix swipe action animations when adding episodes to Up Next [#4366](https://github.com/Automattic/pocket-casts-ios/pull/4366) 
+- Fix swipe action animations when adding episodes to Up Next [#4366](https://github.com/Automattic/pocket-casts-ios/pull/4366)
+- Update remaining menus to use sheet presentation [#4426](https://github.com/Automattic/pocket-casts-ios/pull/4426)
 
 8.13
 -----

--- a/podcasts/AutoAddToUpNextViewController.swift
+++ b/podcasts/AutoAddToUpNextViewController.swift
@@ -85,13 +85,13 @@ class AutoAddToUpNextViewController: PCViewController, UITableViewDelegate, UITa
                 addAutoAddLimit(amount: 500, to: options)
                 addAutoAddLimit(amount: 1000, to: options)
 
-                options.show(statusBarStyle: preferredStatusBarStyle)
+                options.present(from: self)
             case .ifLimitReached:
                 let options = OptionsPicker(title: L10n.settingsAutoAddLimitReached)
                 addOnLimitReached(action: .addToTopOnly, to: options)
                 addOnLimitReached(action: .stopAdding, to: options)
 
-                options.show(statusBarStyle: preferredStatusBarStyle)
+                options.present(from: self)
             case .selectPodcasts:
                 let podcastSelectViewController = PodcastChooserViewController()
                 podcastSelectViewController.analyticsSource = .autoAdd
@@ -106,7 +106,7 @@ class AutoAddToUpNextViewController: PCViewController, UITableViewDelegate, UITa
             addActionForPodcast(podcast: podcast, setting: .addFirst, label: L10n.top, to: options)
             addActionForPodcast(podcast: podcast, setting: .addLast, label: L10n.bottom, to: options)
 
-            options.show(statusBarStyle: preferredStatusBarStyle)
+            options.present(from: self)
         }
     }
 

--- a/podcasts/AutoArchiveViewController.swift
+++ b/podcasts/AutoArchiveViewController.swift
@@ -82,7 +82,7 @@ class AutoArchiveViewController: PCViewController, UITableViewDelegate, UITableV
                 addArchivePlayedAction(time: 2.days, to: options)
                 addArchivePlayedAction(time: 1.week, to: options)
 
-                options.show(statusBarStyle: preferredStatusBarStyle)
+                options.present(from: self)
             } else if indexPath.row == 1 {
                 let options = OptionsPicker(title: L10n.settingsArchiveInactiveTitle)
 
@@ -92,7 +92,7 @@ class AutoArchiveViewController: PCViewController, UITableViewDelegate, UITableV
                 addArchiveInactiveAction(time: 30.days, to: options)
                 addArchiveInactiveAction(time: 90.days, to: options)
 
-                options.show(statusBarStyle: preferredStatusBarStyle)
+                options.present(from: self)
             }
         }
     }

--- a/podcasts/DownloadSettingsViewController.swift
+++ b/podcasts/DownloadSettingsViewController.swift
@@ -211,7 +211,7 @@ class DownloadSettingsViewController: PCViewController, UITableViewDataSource, U
                 }
                 picker.addAction(action: selectAction)
             }
-            picker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
+            picker.present(from: self)
         default:
             break
         }

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -346,7 +346,7 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
                 tableView.reloadData()
             }
             options.addAction(action: downloadAction)
-            options.show(statusBarStyle: preferredStatusBarStyle)
+            options.present(from: self)
         } else if row == .defaultGrouping {
             let currentGrouping = Settings.defaultPodcastGrouping()
 
@@ -391,7 +391,7 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
             }
             options.addAction(action: starredAction)
 
-            options.show(statusBarStyle: preferredStatusBarStyle)
+            options.present(from: self)
         } else if row == .defaultArchive {
             let currentlyShowingArchived = Settings.showArchivedDefault()
 
@@ -412,7 +412,7 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
             }
             options.addAction(action: showAction)
 
-            options.show(statusBarStyle: preferredStatusBarStyle)
+            options.present(from: self)
         } else if row == .defaultAddToUpNextSwipe {
             let currentAction = Settings.primaryUpNextSwipeAction()
 
@@ -428,7 +428,7 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
                 tableView.reloadData()
             }
             options.addAction(action: playLastAction)
-            options.show(statusBarStyle: preferredStatusBarStyle)
+            options.present(from: self)
         }
     }
 
@@ -494,7 +494,7 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
         let groupingMessage = grouping == .none ? L10n.settingsGeneralRemoveGroupsApplyAll : L10n.settingsGeneralSelectedGroupApplyAll(grouping.description.localizedLowercase)
         groupingPrompt.addDescriptiveActions(title: L10n.settingsGeneralApplyAllTitle, message: groupingMessage, icon: "option-podcasts", actions: [applyToAllAction, noAction])
 
-        groupingPrompt.show(statusBarStyle: preferredStatusBarStyle)
+        groupingPrompt.present(from: self)
     }
 
     private func promptToApplyShowArchiveToAll(_ showArchived: Bool) {
@@ -513,7 +513,7 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
         let groupingMessage = L10n.settingsGeneralArchivedEpisodesPromptFormat((showArchived ? L10n.settingsGeneralShow : L10n.settingsGeneralHide).localizedLowercase)
         groupingPrompt.addDescriptiveActions(title: L10n.settingsGeneralApplyAllTitle, message: groupingMessage, icon: "option-podcasts", actions: [applyToAllAction, noAction])
 
-        groupingPrompt.show(statusBarStyle: preferredStatusBarStyle)
+        groupingPrompt.present(from: self)
     }
 
     @objc private func screenLockToggled(_ sender: UISwitch) {

--- a/podcasts/HeadphoneSettingsViewController.swift
+++ b/podcasts/HeadphoneSettingsViewController.swift
@@ -211,7 +211,7 @@ private extension HeadphoneSettingsViewController {
                 onChange(option)
             }
         })
-        picker.show(statusBarStyle: preferredStatusBarStyle)
+        picker.present(from: self)
     }
 }
 

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastArchiveViewController+Table.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastArchiveViewController+Table.swift
@@ -1,3 +1,4 @@
+import UIKit
 import PocketCastsDataModel
 
 extension PodcastArchiveViewController: UITableViewDataSource, UITableViewDelegate {
@@ -73,7 +74,7 @@ extension PodcastArchiveViewController: UITableViewDataSource, UITableViewDelega
             addArchivePlayedAction(time: 2.days, to: options)
             addArchivePlayedAction(time: 1.week, to: options)
 
-            options.show(statusBarStyle: preferredStatusBarStyle)
+            options.present(from: self)
         } else if row == .inactiveEpisodes {
             let options = OptionsPicker(title: L10n.settingsArchiveInactiveTitle)
 
@@ -85,7 +86,7 @@ extension PodcastArchiveViewController: UITableViewDataSource, UITableViewDelega
             addArchiveInactiveAction(time: 30.days, to: options)
             addArchiveInactiveAction(time: 90.days, to: options)
 
-            options.show(statusBarStyle: preferredStatusBarStyle)
+            options.present(from: self)
         } else if row == .episodeLimit {
             let options = OptionsPicker(title: L10n.settingsEpisodeLimit)
             addEpisodeLimitAction(limit: 0, to: options)
@@ -94,7 +95,7 @@ extension PodcastArchiveViewController: UITableViewDataSource, UITableViewDelega
             addEpisodeLimitAction(limit: 5, to: options)
             addEpisodeLimitAction(limit: 10, to: options)
 
-            options.show(statusBarStyle: preferredStatusBarStyle)
+            options.present(from: self)
         }
     }
 

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController+Table.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController+Table.swift
@@ -128,7 +128,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
             addTrimLevelAction(level: .medium, to: options)
             addTrimLevelAction(level: .high, to: options)
 
-            options.show(statusBarStyle: preferredStatusBarStyle)
+            options.present(from: self)
         }
     }
 

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController+Table.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController+Table.swift
@@ -331,7 +331,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
         }
         positionPicker.addAction(action: bottomAction)
 
-        positionPicker.show(statusBarStyle: preferredStatusBarStyle)
+        positionPicker.present(from: self)
     }
 
     private func setUpNext(_ setting: AutoAddToUpNextSetting) {

--- a/podcasts/WatchSettingsViewController.swift
+++ b/podcasts/WatchSettingsViewController.swift
@@ -201,7 +201,7 @@ class WatchSettingsViewController: PCViewController, UITableViewDelegate, UITabl
 
                 upNextPicker.addAction(action: action)
             }
-            upNextPicker.show(statusBarStyle: preferredStatusBarStyle)
+            upNextPicker.present(from: self)
         case .autoDownloadUpNext:
             if let cell = settingsTable.cellForRow(at: indexPath) as? SwitchCell {
                 upNextToggled(cell.cellSwitch)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Update (and tested) multiple more places with sheet presentation for `OptionsPicker`.

## To test

<img width="320" alt="Screenshot 2026-05-27 at 4 34 26 PM" src="https://github.com/user-attachments/assets/9c9c277a-e25e-4079-910c-8462f13ace09" />
<img width="320" alt="Screenshot 2026-05-27 at 4 36 59 PM" src="https://github.com/user-attachments/assets/61d1cb33-ced2-4e93-b478-476030cdb7c6" />
<img width="320" alt="Screenshot 2026-05-27 at 4 37 09 PM" src="https://github.com/user-attachments/assets/035d99c3-1fb6-4db5-9988-a92d966aeb9d" />
<img width="320" alt="Screenshot 2026-05-27 at 4 38 18 PM" src="https://github.com/user-attachments/assets/febe4b4e-db9f-4393-9080-7a046c2ed1f0" />
<img width="320" alt="Screenshot 2026-05-27 at 4 39 11 PM" src="https://github.com/user-attachments/assets/d16a696d-a19d-46a7-8108-59ca7f42e336" />
<img width="320" alt="Screenshot 2026-05-27 at 4 44 38 PM" src="https://github.com/user-attachments/assets/34d0d23a-8467-45ff-9c98-f4915cc908da" />
<img width="320" alt="Screenshot 2026-05-27 at 4 46 24 PM" src="https://github.com/user-attachments/assets/2ee403d8-dd9d-4f6c-bf08-96634f7cb74f" />
<img width="320" alt="Screenshot 2026-05-27 at 4 47 09 PM" src="https://github.com/user-attachments/assets/0c4c7e86-6428-4f04-aae9-59d96f1df537" />
<img width="320" alt="Screenshot 2026-05-27 at 4 48 48 PM" src="https://github.com/user-attachments/assets/5a38c66b-ea7d-4940-a97e-36844083182a" />
<img width="320" alt="Screenshot 2026-05-27 at 4 48 54 PM" src="https://github.com/user-attachments/assets/8f5b1aab-0447-46de-b161-9a882ac0d22c" />

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
