### PR TITLE
Fix safe area usage in Playback Effects

### DIFF
--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController.xib
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController.xib
@@ -22,7 +22,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="64" estimatedRowHeight="64" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="tgC-Bb-blq" customClass="ThemeableTable" customModule="podcasts" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                     <connections>
                         <outlet property="dataSource" destination="-1" id="AFR-ab-MUX"/>
@@ -35,7 +35,7 @@
                 <constraint firstItem="tgC-Bb-blq" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="6rM-NW-2X2"/>
                 <constraint firstItem="tgC-Bb-blq" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="PfI-ki-F1o"/>
                 <constraint firstItem="tgC-Bb-blq" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="hdz-nz-Ka5"/>
-                <constraint firstItem="tgC-Bb-blq" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="topMargin" id="orp-JN-eFo"/>
+                <constraint firstItem="tgC-Bb-blq" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="orp-JN-eFo"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="-207" y="120"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Before

<img width="320"  alt="Screenshot 2026-05-28 at 10 10 12 AM" src="https://github.com/user-attachments/assets/37d76977-1f24-4eb1-aee1-508d91c2dc62" />

After (iOS 26)

<img width="320"  alt="Screenshot 2026-05-28 at 10 16 41 AM" src="https://github.com/user-attachments/assets/e4c5d072-6cca-40b1-a399-897da21670cc" />

After (iOS 18)

<img width="320" alt="Screenshot 2026-05-28 at 10 18 16 AM" src="https://github.com/user-attachments/assets/ff88e527-b6d4-4a98-bd28-5bd5e2ea554d" />



## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
