### PR TITLE
Fix missing theme color in Smart Rules

### DIFF
--- a/podcasts/New Creation/New Preview/Rules/SmartPlaylistRulesSectionView.swift
+++ b/podcasts/New Creation/New Preview/Rules/SmartPlaylistRulesSectionView.swift
@@ -90,7 +90,15 @@ struct SmartPlaylistRulesSectionView: View {
                 .frame(width: iconSize, height: iconSize)
                 .padding(.trailing, 8.0)
 
+            Text(rule.title)
+                .foregroundStyle(theme.primaryText01)
+                .font(size: 17, style: .body)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer()
+
             inlinePicker(for: rule)
+                .labelsHidden()
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Before / After
<img width="320" alt="Screenshot 2026-05-28 at 10 20 42 AM" src="https://github.com/user-attachments/assets/20c36c4d-2662-4567-8d17-b65efecb1273" /> <img width="320" alt="Screenshot 2026-05-28 at 10 25 47 AM" src="https://github.com/user-attachments/assets/a25930cf-d8cf-476a-82a3-3b56062a8226" />

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
