### PR TITLE
Update Player to use alerts for Mark as Played and Archive

### DIFF
--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -460,15 +460,13 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     private func markPlayed() {
         guard let episode = PlaybackManager.shared.currentEpisode() else { return }
 
-        let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)
-
-        let markPlayedAction = OptionAction(label: L10n.markPlayedShort, icon: nil) {
+        let alert = UIAlertController(title: L10n.playerMarkAsPlayedConfirmation, message: L10n.playerMarkAsPlayedConfirmationMessage, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: L10n.markPlayedShort, style: .destructive) { _ in
             AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
             EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
-        }
-        markPlayedAction.destructive = true
-        optionsPicker.addDescriptiveActions(title: L10n.playerMarkAsPlayedConfirmation, message: nil, icon: "shelf_played", actions: [markPlayedAction])
-        optionsPicker.present(from: self)
+        })
+        present(alert, animated: true)
     }
 
     private func delete() {
@@ -483,14 +481,12 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
 
-        let optionsPicker = OptionsPicker(title: nil, themeOverride: .dark)
-
-        let archiveAction = OptionAction(label: L10n.archive, icon: nil) {
+        let alert = UIAlertController(title: L10n.playerArchivedConfirmation, message: L10n.playerArchivedConfirmationMessage, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: L10n.archive, style: .destructive) { _ in
             EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
-        }
-        archiveAction.destructive = true
-        optionsPicker.addDescriptiveActions(title: L10n.playerArchivedConfirmation, message: nil, icon: "shelf_archive", actions: [archiveAction])
-        optionsPicker.present(from: self)
+        })
+        present(alert, animated: true)
     }
     #endif
 

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -2388,6 +2388,8 @@ internal enum L10n {
   internal static var playerActionsRearrangeTitle: String { return L10n.tr("Localizable", "player_actions_rearrange_title", fallback: "Rearrange Actions") }
   /// Confirmation prompt for archiving an episode.
   internal static var playerArchivedConfirmation: String { return L10n.tr("Localizable", "player_archived_confirmation", fallback: "Archive this episode?") }
+  /// Message body shown in the confirmation prompt for archiving an episode.
+  internal static var playerArchivedConfirmationMessage: String { return L10n.tr("Localizable", "player_archived_confirmation_message", fallback: "Hidden from your feed, not deleted.") }
   /// Accessibility label calling out the current artwork that's being displayed. '%1$@' is a placeholder for either the episode name or the chapter title.
   internal static func playerArtwork(_ p1: Any) -> String {
     return L10n.tr("Localizable", "player_artwork", String(describing: p1), fallback: "%1$@ Artwork")
@@ -2424,6 +2426,8 @@ internal enum L10n {
   internal static var playerIncrementTime: String { return L10n.tr("Localizable", "player_increment_time", fallback: "Increment time") }
   /// Confirmation prompt for marking an episode as played.
   internal static var playerMarkAsPlayedConfirmation: String { return L10n.tr("Localizable", "player_mark_as_played_confirmation", fallback: "Mark this episode as played?") }
+  /// Message body shown in the confirmation prompt for marking an episode as played.
+  internal static var playerMarkAsPlayedConfirmationMessage: String { return L10n.tr("Localizable", "player_mark_as_played_confirmation_message", fallback: "It'll move out of Up Next and into your history.") }
   /// Warning that comes along with selecting to play all. Informs the user that their queue will be cleared.
   internal static var playerOptionsPlayAllMessage: String { return L10n.tr("Localizable", "player_options_play_all_message", fallback: "This will clear your current Up Next queue.") }
   /// Prompt to play a single episode from a multi-select screen.

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1552,6 +1552,9 @@
 /* Confirmation prompt for archiving an episode. */
 "player_archived_confirmation" = "Archive this episode?";
 
+/* Message body shown in the confirmation prompt for archiving an episode. */
+"player_archived_confirmation_message" = "Hidden from your feed, not deleted.";
+
 /* Accessibility label calling out the current artwork that's being displayed. '%1$@' is a placeholder for either the episode name or the chapter title. */
 "player_artwork" = "%1$@ Artwork";
 
@@ -1578,6 +1581,9 @@
 
 /* Confirmation prompt for marking an episode as played. */
 "player_mark_as_played_confirmation" = "Mark this episode as played?";
+
+/* Message body shown in the confirmation prompt for marking an episode as played. */
+"player_mark_as_played_confirmation_message" = "It'll move out of Up Next and into your history.";
 
 /* Warning that comes along with selecting to play all. Informs the user that their queue will be cleared. */
 "player_options_play_all_message" = "This will clear your current Up Next queue.";


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

By David's request, switching to the native sheets for these two scenarios and updating copy.


<img width="320" alt="Screenshot 2026-05-28 at 11 59 33 AM" src="https://github.com/user-attachments/assets/f9278952-b386-4b4b-b3c1-f7d798dcf6c1" /> <img width="320" alt="Screenshot 2026-05-28 at 11 59 41 AM" src="https://github.com/user-attachments/assets/2d1db11a-21a0-46ba-b65e-5d8a9a456e01" />



## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
