### PR TITLE
Liquid Glass: Options Picker Sheet Presentation

### DIFF
--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -546,7 +546,6 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     func errorTapped() {
         guard let episode else { return }
 
-        let statusBarStyle = playlistUuid == nil ? UIStatusBarStyle.lightContent : AppTheme.defaultStatusBarStyle()
         if episode.playbackError() {
             let optionsPicker = OptionsPicker(title: nil)
             let retryAction = OptionAction(label: L10n.retry, icon: nil, action: { [weak self] in
@@ -554,7 +553,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             })
 
             optionsPicker.addDescriptiveActions(title: L10n.playbackFailed, message: episode.playbackErrorDetails, icon: "option-alert", actions: [retryAction])
-            optionsPicker.show(statusBarStyle: statusBarStyle)
+            optionsPicker.present()
         } else {
             let downloadError = episode.readableErrorMessage()
             let optionsPicker = OptionsPicker(title: nil)
@@ -562,7 +561,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
                 self?.downloadTapped()
             })
             optionsPicker.addDescriptiveActions(title: L10n.downloadFailed, message: downloadError, icon: "option-alert", actions: [retryAction])
-            optionsPicker.show(statusBarStyle: statusBarStyle)
+            optionsPicker.present()
         }
     }
 

--- a/podcasts/OptionsPickerRootController.swift
+++ b/podcasts/OptionsPickerRootController.swift
@@ -43,7 +43,9 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
     private weak var dismissView: UIView?
     private(set) var isPresentedAsSheet = false
 
-    private let sheetTopPadding: CGFloat = 12
+    private var sheetTopPadding: CGFloat {
+        stackView.arrangedSubviews.count > 1 ? 12 : 0
+    }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         overrideStatusBarStyle

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -759,7 +759,7 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
         }
         optionsPicker.addAction(action: refreshAction)
 
-        optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
+        optionsPicker.present(from: self)
     }
 
     func unsubscribe() {

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -1086,7 +1086,7 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
             archiveActionForSeason(season)
         ].compactMap(\.self))
 
-        optionPicker.show(statusBarStyle: AppTheme.defaultStatusBarStyle())
+        optionPicker.present(from: self)
     }
 
     private func downloadActionForSeason(_ season: Int) -> OptionAction? {
@@ -1365,7 +1365,7 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
         }
         optionsPicker.addAction(action: goToFolderAction)
 
-        optionsPicker.show(statusBarStyle: preferredStatusBarStyle)
+        optionsPicker.present(from: self)
     }
 
     private func showFolderPickerDialog() {

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -754,7 +754,7 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
         guard let podcast else { return }
 
         let optionsPicker = OptionsPicker(title: nil)
-        let refreshAction = OptionAction(label: L10n.podcastRefreshArtwork, icon: nil) {
+        let refreshAction = OptionAction(label: L10n.podcastRefreshArtwork, icon: "option-download-retry") {
             ImageManager.sharedManager.clearCache(podcastUuid: podcast.uuid, recacheWhenDone: true)
         }
         optionsPicker.addAction(action: refreshAction)

--- a/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.swift
+++ b/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.swift
@@ -87,7 +87,7 @@ class IncomingShareListViewController: PCViewController, UITableViewDelegate, UI
                                                icon: "option-podcasts",
                                                actions: [subscribeAction])
 
-            optionPicker.show(statusBarStyle: preferredStatusBarStyle)
+            optionPicker.present(from: self)
         } else {
             performSubscribeAll()
         }

--- a/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.xib
+++ b/podcasts/Podcasts/Share Podcast List/IncomingShareListViewController.xib
@@ -39,7 +39,7 @@
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                 </textView>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="65" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="gwx-dM-eFY" customClass="ThemeableTable" customModule="podcasts" customModuleProvider="target">
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="87" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="gwx-dM-eFY" customClass="ThemeableTable" customModule="podcasts" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="50" width="375" height="617"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     <connections>
@@ -66,7 +66,7 @@
                 <constraint firstItem="zcY-mH-saN" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="16" id="LwI-Bc-bFD"/>
                 <constraint firstAttribute="trailing" secondItem="gwx-dM-eFY" secondAttribute="trailing" id="VHW-FB-pEb"/>
                 <constraint firstItem="HNS-81-f8m" firstAttribute="top" secondItem="r0l-li-woE" secondAttribute="bottom" constant="4.5" id="dPX-ze-ZeK"/>
-                <constraint firstItem="zcY-mH-saN" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="15" id="eMg-GG-Bq9"/>
+                <constraint firstItem="zcY-mH-saN" firstAttribute="top" secondItem="teP-8L-YoP" secondAttribute="top" constant="15" id="eMg-GG-Bq9"/>
                 <constraint firstAttribute="trailing" secondItem="r0l-li-woE" secondAttribute="trailing" constant="12" id="g0x-KH-1WN"/>
                 <constraint firstItem="gwx-dM-eFY" firstAttribute="top" secondItem="HNS-81-f8m" secondAttribute="bottom" id="g9Y-H0-TTQ"/>
             </constraints>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

There are three changes.

**1. Fix layout when only one item is shown**

In a special case when there is only one item, we don't want to add top padding and want it centered. Here's before and after.

<img width="1092" height="676" alt="Screenshot 2026-05-28 at 5 02 44 PM" src="https://github.com/user-attachments/assets/dfcce9cd-22a9-420d-8896-2b14feb30ce9" />

**2. Fix layout in IncomingShareListViewController

Here's before and after. I believe it's a production issue, which is why I'm adding it to `trunk` only. It's rarely used.

You can apply this patch to test it [incoming-share-list-test.patch](https://github.com/user-attachments/files/28368130/incoming-share-list-test.patch).

<img width="1256" height="971" alt="Screenshot 2026-05-28 at 5 03 48 PM" src="https://github.com/user-attachments/assets/d9e6d5fd-6b34-4479-9c91-12b27e999122" />

**3. Update a few more places to use sheet presentation

<img width="320" alt="Screenshot 2026-05-28 at 4 09 41 PM" src="https://github.com/user-attachments/assets/1619df3b-7081-4c7e-ba81-70019ca9c74e" />
<img width="320"  alt="Screenshot 2026-05-28 at 4 38 05 PM" src="https://github.com/user-attachments/assets/515284d6-4263-4a03-a594-c9a31c056a6f" />
<img width="320"  alt="Screenshot 2026-05-28 at 4 50 01 PM" src="https://github.com/user-attachments/assets/6e68d0ac-97ae-4596-89d4-33cdaf1f7cd2" />



## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
