### PR TITLE
Update delete confirmation in MultiSelect to use UIAlertController

### DIFF
--- a/podcasts/Common Components/MultiSelect/MultiSelectActionProtocol.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectActionProtocol.swift
@@ -1,6 +1,8 @@
 import Foundation
 import PocketCastsDataModel
-protocol MultiSelectActionDelegate: AnyObject {
+
+@MainActor
+protocol MultiSelectActionDelegate: AnyObject, Sendable {
     func multiSelectPresentingViewController() -> UIViewController
     func multiSelectedBaseEpisodes() -> [BaseEpisode]
     func multiSelectedPlayListEpisodes() -> [PlaylistEpisode]?

--- a/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
@@ -72,63 +72,49 @@ class MultiSelectHelper {
         let downloadedEpisodes = selectedEpisodes.filter { $0.downloaded(pathFinder: DownloadManager.shared) }
         let uploadedEpisodes = selectedEpisodes.filter { $0.uploaded() }
 
-        let confirmPicker: OptionsPicker
+        let alert: UIAlertController
         if downloadedEpisodes.isEmpty {
-            confirmPicker = OptionsPicker(title: nil)
-            let deleteFromCloudAction = OptionAction(label: L10n.deleteFromCloud, icon: nil) { () in
+            alert = UIAlertController(title: L10n.deleteFromCloud, message: deleteFileMessage(uploadedEpisodes.count), preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.deleteFromCloud, style: .destructive) { _ in
                 DispatchQueue.global().async {
                     for episode in uploadedEpisodes {
                         UserEpisodeManager.deleteFromCloud(episode: episode)
                     }
-
                     actionDelegate.multiSelectActionCompleted()
                 }
-            }
-
-            let warningMessage = deleteFileMessage(uploadedEpisodes.count)
-            confirmPicker.addDescriptiveActions(title: L10n.deleteFromCloud, message: warningMessage, icon: "episode-delete", actions: [deleteFromCloudAction])
+            })
         } else if uploadedEpisodes.isEmpty {
-            confirmPicker = OptionsPicker(title: nil)
-            let deleteFromDeviceAction = OptionAction(label: L10n.deleteFromDeviceOnly, icon: nil) { () in
+            alert = UIAlertController(title: L10n.deleteFromDevice, message: deleteFileMessage(downloadedEpisodes.count), preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .destructive) { _ in
                 DispatchQueue.global().async {
                     for episode in downloadedEpisodes {
                         UserEpisodeManager.deleteFromDevice(userEpisode: episode)
                     }
-
                     actionDelegate.multiSelectActionCompleted()
                 }
-            }
-
-            let warningMessage = deleteFileMessage(downloadedEpisodes.count)
-            confirmPicker.addDescriptiveActions(title: L10n.deleteFromDevice, message: warningMessage, icon: "episode-delete", actions: [deleteFromDeviceAction])
+            })
         } else {
-            confirmPicker = OptionsPicker(title: nil)
-            let deleteEverwhereAction = OptionAction(label: L10n.deleteEverywhere, icon: nil) { () in
+            alert = UIAlertController(title: L10n.deleteFile, message: deleteFileMessage(downloadedEpisodes.count), preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .default) { _ in
+                DispatchQueue.global().async {
+                    for episode in downloadedEpisodes {
+                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
+                    }
+                    actionDelegate.multiSelectActionCompleted()
+                }
+            })
+            alert.addAction(UIAlertAction(title: L10n.deleteEverywhere, style: .destructive) { _ in
                 DispatchQueue.global().async {
                     for episode in selectedEpisodes {
                         UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
                     }
-
                     actionDelegate.multiSelectActionCompleted()
                 }
-            }
-
-            let deleteFromDeviceAction = OptionAction(label: L10n.deleteFromDeviceOnly, icon: nil) { () in
-                DispatchQueue.global().async {
-                    for episode in downloadedEpisodes {
-                        UserEpisodeManager.deleteFromDevice(userEpisode: episode)
-                    }
-
-                    actionDelegate.multiSelectActionCompleted()
-                }
-            }
-            deleteFromDeviceAction.outline = true
-
-            let warningMessage = deleteFileMessage(downloadedEpisodes.count)
-            confirmPicker.addDescriptiveActions(title: L10n.deleteFile, message: warningMessage, icon: "episode-delete", actions: [deleteFromDeviceAction, deleteEverwhereAction])
+            })
         }
 
-        confirmPicker.show(statusBarStyle: actionDelegate.multiSelectPreferredStatusBarStyle())
+        alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+        actionDelegate.multiSelectPresentingViewController().present(alert, animated: true)
     }
 
     private class func archiveEpisodes(actionDelegate: MultiSelectActionDelegate) {

--- a/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
@@ -207,10 +207,8 @@ class MultiSelectHelper {
 
         let downloadText = L10n.downloadCountPrompt(selectedEpisodes.count).localizedUppercase
         let downloadAction = OptionAction(label: downloadText, icon: nil) {
-            MainActor.assumeIsolated {
-                MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
-                actionDelegate.multiSelectActionCompleted()
-            }
+            MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
+            actionDelegate.multiSelectActionCompleted()
         }
 
         let confirmPicker = OptionsPicker(title: nil)
@@ -227,11 +225,9 @@ class MultiSelectHelper {
             }
         } else {
             let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                MainActor.assumeIsolated {
-                    let status = L10n.multiSelectQueuingEpisodesFormat(selectedEpisodes.count.localized())
-                    actionDelegate.multiSelectActionBegan(status: status)
-                    queueEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
-                }
+                let status = L10n.multiSelectQueuingEpisodesFormat(selectedEpisodes.count.localized())
+                actionDelegate.multiSelectActionBegan(status: status)
+                queueEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
             }
             queueAction.outline = true
 

--- a/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectHelper.swift
@@ -1,8 +1,9 @@
 import Foundation
-import PocketCastsDataModel
+@preconcurrency import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 
+@MainActor
 class MultiSelectHelper {
     // MARK: - Action Helpers
 
@@ -56,9 +57,9 @@ class MultiSelectHelper {
             let status = selectedEpisodes.count == 1 ? L10n.multiSelectUnstarringEpisodesSingular : L10n.multiSelectUnstarringEpisodesPluralFormat(selectedEpisodes.count.localized())
             actionDelegate.multiSelectActionBegan(status: status)
         }
-        DispatchQueue.global().async {
+        Task.detached {
             EpisodeManager.bulkSetStarred(star, episodes: selectedEpisodes, updateSyncStatus: SyncManager.isUserLoggedIn())
-            actionDelegate.multiSelectActionCompleted()
+            await actionDelegate.multiSelectActionCompleted()
         }
     }
 
@@ -76,39 +77,39 @@ class MultiSelectHelper {
         if downloadedEpisodes.isEmpty {
             alert = UIAlertController(title: L10n.deleteFromCloud, message: deleteFileMessage(uploadedEpisodes.count), preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L10n.deleteFromCloud, style: .destructive) { _ in
-                DispatchQueue.global().async {
+                Task.detached {
                     for episode in uploadedEpisodes {
                         UserEpisodeManager.deleteFromCloud(episode: episode)
                     }
-                    actionDelegate.multiSelectActionCompleted()
+                    await actionDelegate.multiSelectActionCompleted()
                 }
             })
         } else if uploadedEpisodes.isEmpty {
             alert = UIAlertController(title: L10n.deleteFromDevice, message: deleteFileMessage(downloadedEpisodes.count), preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .destructive) { _ in
-                DispatchQueue.global().async {
+                Task.detached {
                     for episode in downloadedEpisodes {
                         UserEpisodeManager.deleteFromDevice(userEpisode: episode)
                     }
-                    actionDelegate.multiSelectActionCompleted()
+                    await actionDelegate.multiSelectActionCompleted()
                 }
             })
         } else {
             alert = UIAlertController(title: L10n.deleteFile, message: deleteFileMessage(downloadedEpisodes.count), preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L10n.deleteFromDeviceOnly, style: .default) { _ in
-                DispatchQueue.global().async {
+                Task.detached {
                     for episode in downloadedEpisodes {
                         UserEpisodeManager.deleteFromDevice(userEpisode: episode)
                     }
-                    actionDelegate.multiSelectActionCompleted()
+                    await actionDelegate.multiSelectActionCompleted()
                 }
             })
             alert.addAction(UIAlertAction(title: L10n.deleteEverywhere, style: .destructive) { _ in
-                DispatchQueue.global().async {
+                Task.detached {
                     for episode in selectedEpisodes {
                         UserEpisodeManager.deleteFromEverywhere(userEpisode: episode)
                     }
-                    actionDelegate.multiSelectActionCompleted()
+                    await actionDelegate.multiSelectActionCompleted()
                 }
             })
         }
@@ -122,10 +123,10 @@ class MultiSelectHelper {
         let selectedUserEpisodes = actionDelegate.multiSelectedBaseEpisodes().compactMap { $0 as? UserEpisode }
         let status = selectedEpisodes.count == 1 ? L10n.multiSelectArchivingEpisodesSingular : L10n.multiSelectArchivingEpisodesPluralFormat(selectedEpisodes.count.localized())
         actionDelegate.multiSelectActionBegan(status: status)
-        DispatchQueue.global().async {
+        Task.detached {
             EpisodeManager.bulkArchive(episodes: selectedEpisodes, removeFromPlayer: true, updateSyncFlag: SyncManager.isUserLoggedIn())
             EpisodeManager.bulkMarkAsPlayed(episodes: selectedUserEpisodes, updateSyncFlag: SyncManager.isUserLoggedIn())
-            actionDelegate.multiSelectActionCompleted()
+            await actionDelegate.multiSelectActionCompleted()
         }
     }
 
@@ -133,9 +134,9 @@ class MultiSelectHelper {
         let selectedEpisodes = actionDelegate.multiSelectedBaseEpisodes().compactMap { $0 as? Episode }
         let status = selectedEpisodes.count == 1 ? L10n.multiSelectUnarchivingEpisodesSingular : L10n.multiSelectUnarchivingEpisodesPluralFormat(selectedEpisodes.count.localized())
         actionDelegate.multiSelectActionBegan(status: status)
-        DispatchQueue.global().async {
+        Task.detached {
             EpisodeManager.bulkUnarchive(episodes: selectedEpisodes)
-            actionDelegate.multiSelectActionCompleted()
+            await actionDelegate.multiSelectActionCompleted()
         }
     }
 
@@ -154,19 +155,16 @@ class MultiSelectHelper {
             let status = selectedEpisodes.count == 1 ? L10n.multiSelectAddingEpisodesSingular : L10n.multiSelectAddingEpisodesPluralFormat(selectedEpisodes.count.localized())
             actionDelegate.multiSelectActionBegan(status: status)
         }
-        DispatchQueue.global().async {
+        Task.detached {
             PlaybackManager.shared.bulkAdd(episodesToAdd, toTop: toTop)
             if showDelayedCompletionMessage {
                 let timeSinceStatusDisplayed = 0 - statusTime.timeIntervalSinceNow
                 if timeSinceStatusDisplayed < Constants.Animation.multiSelectStatusDelayTime {
                     let delay = Constants.Animation.multiSelectStatusDelayTime - timeSinceStatusDisplayed
-                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + delay) { () in
-                        actionDelegate.multiSelectActionCompleted()
-                    }
-                    return
+                    try? await Task.sleep(for: .seconds(delay))
                 }
             }
-            actionDelegate.multiSelectActionCompleted()
+            await actionDelegate.multiSelectActionCompleted()
         }
     }
 
@@ -175,9 +173,9 @@ class MultiSelectHelper {
         let status = selectedEpisodes.count == 1 ? L10n.multiSelectMarkEpisodesPlayedSingular : L10n.multiSelectMarkEpisodesPlayedPluralFormat(selectedEpisodes.count.localized())
         actionDelegate.multiSelectActionBegan(status: status)
 
-        DispatchQueue.global().async {
+        Task.detached {
             EpisodeManager.bulkMarkAsPlayed(episodes: selectedEpisodes, updateSyncFlag: SyncManager.isUserLoggedIn())
-            actionDelegate.multiSelectActionCompleted()
+            await actionDelegate.multiSelectActionCompleted()
         }
     }
 
@@ -187,10 +185,10 @@ class MultiSelectHelper {
         let status = selectedEpisodes.count == 1 ? L10n.multiSelectMarkEpisodesUnplayedSingular : L10n.multiSelectMarkEpisodesUnplayedPluralFormat(selectedEpisodes.count.localized())
         actionDelegate.multiSelectActionBegan(status: status)
 
-        DispatchQueue.global().async {
+        Task.detached {
             EpisodeManager.bulkMarkAsUnPlayed(selectedEpisodes)
             EpisodeManager.bulkUnarchive(episodes: selectedArchiveEpisodes)
-            actionDelegate.multiSelectActionCompleted()
+            await actionDelegate.multiSelectActionCompleted()
         }
     }
 
@@ -208,9 +206,11 @@ class MultiSelectHelper {
         }
 
         let downloadText = L10n.downloadCountPrompt(selectedEpisodes.count).localizedUppercase
-        let downloadAction = OptionAction(label: downloadText, icon: nil) { () in
-            MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
-            actionDelegate.multiSelectActionCompleted()
+        let downloadAction = OptionAction(label: downloadText, icon: nil) {
+            MainActor.assumeIsolated {
+                MultiSelectHelper.downloadEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
+                actionDelegate.multiSelectActionCompleted()
+            }
         }
 
         let confirmPicker = OptionsPicker(title: nil)
@@ -227,9 +227,11 @@ class MultiSelectHelper {
             }
         } else {
             let queueAction = OptionAction(label: L10n.queueForLater, icon: nil) {
-                let status = L10n.multiSelectQueuingEpisodesFormat(selectedEpisodes.count.localized())
-                actionDelegate.multiSelectActionBegan(status: status)
-                queueEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
+                MainActor.assumeIsolated {
+                    let status = L10n.multiSelectQueuingEpisodesFormat(selectedEpisodes.count.localized())
+                    actionDelegate.multiSelectActionBegan(status: status)
+                    queueEpisodes(downloadableEpisodes, actionDelegate: actionDelegate)
+                }
             }
             queueAction.outline = true
 
@@ -244,7 +246,7 @@ class MultiSelectHelper {
     }
 
     private class func downloadEpisodes(_ episodes: [BaseEpisode], actionDelegate: MultiSelectActionDelegate) {
-        DispatchQueue.global().async {
+        Task.detached {
             var queuedEpisodes = 0
             for episode in episodes {
                 DownloadManager.shared.addToQueue(episodeUuid: episode.uuid, fireNotification: true, autoDownloadStatus: .notSpecified)
@@ -253,14 +255,14 @@ class MultiSelectHelper {
                     return
                 }
             }
-            actionDelegate.multiSelectActionCompleted()
+            await actionDelegate.multiSelectActionCompleted()
         }
 
         AnalyticsEpisodeHelper.shared.bulkDownloadEpisodes(episodes: episodes)
     }
 
     private class func queueEpisodes(_ episodes: [BaseEpisode], actionDelegate: MultiSelectActionDelegate) {
-        DispatchQueue.global().async {
+        Task.detached {
             var queuedEpisodes = 0
             for episode in episodes {
                 DownloadManager.shared.queueForLaterDownload(episodeUuid: episode.uuid, fireNotification: true, autoDownloadStatus: .notSpecified)
@@ -269,7 +271,7 @@ class MultiSelectHelper {
                     return
                 }
             }
-            actionDelegate.multiSelectActionCompleted()
+            await actionDelegate.multiSelectActionCompleted()
         }
 
         AnalyticsEpisodeHelper.shared.bulkDownloadEpisodes(episodes: episodes)
@@ -280,9 +282,9 @@ class MultiSelectHelper {
         let status = selectedEpisodes.count == 1 ? L10n.multiSelectRemoveDownloadSingular : L10n.multiSelectRemoveDownloadsPluralFormat(selectedEpisodes.count.localized())
         actionDelegate.multiSelectActionBegan(status: status)
 
-        DispatchQueue.global().async {
+        Task.detached {
             EpisodeManager.removeDownloadForEpisodes(selectedEpisodes)
-            actionDelegate.multiSelectActionCompleted()
+            await actionDelegate.multiSelectActionCompleted()
         }
     }
 
@@ -354,9 +356,7 @@ class MultiSelectHelper {
         let presentingVC = actionDelegate.multiSelectPresentingViewController()
         let chooser = ManualPlaylistsChooserViewController(episodes: episodes, analyticsSource: "multi_select")
         let navController = UINavigationController(rootViewController: chooser)
-        DispatchQueue.main.async {
-            presentingVC.present(navController, animated: true)
-        }
+        presentingVC.present(navController, animated: true)
     }
 
     private class func removeListeningHistory(actionDelegate: MultiSelectActionDelegate) {

--- a/podcasts/DownloadsViewController+MultiSelect.swift
+++ b/podcasts/DownloadsViewController+MultiSelect.swift
@@ -23,15 +23,13 @@ extension DownloadsViewController: MultiSelectActionDelegate {
     }
 
     func multiSelectActionCompleted() {
-        DispatchQueue.main.async {
+        view.layoutIfNeeded()
+        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
+            self.multiSelectFooterBottomConstraint.constant = 0
             self.view.layoutIfNeeded()
-            UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
-                self.multiSelectFooterBottomConstraint.constant = 0
-                self.view.layoutIfNeeded()
-            }, completion: { _ in
-                self.isMultiSelectEnabled = false
-            })
-        }
+        }, completion: { _ in
+            self.isMultiSelectEnabled = false
+        })
     }
 
     func multiSelectPreferredStatusBarStyle() -> UIStatusBarStyle {

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -29,29 +29,27 @@ class DownloadsViewController: PCViewController {
         }
     }
 
+    @MainActor
     var isMultiSelectEnabled = false {
         didSet {
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                self.setupNavBar()
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
-                self.downloadsTable.beginUpdates()
-                self.downloadsTable.setEditing(self.isMultiSelectEnabled, animated: true)
-                self.insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled
-                self.downloadsTable.endUpdates()
+            setupNavBar()
+            setEnclosingTabBarHidden(isMultiSelectEnabled, animated: false)
+            downloadsTable.beginUpdates()
+            downloadsTable.setEditing(isMultiSelectEnabled, animated: true)
+            insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled
+            downloadsTable.endUpdates()
 
-                if self.isMultiSelectEnabled {
-                    Analytics.track(.downloadsMultiSelectEntered)
-                    self.multiSelectFooter.setSelectedCount(count: self.selectedEpisodes.count)
-                    self.multiSelectFooterBottomConstraint.constant = Constants.effectiveFooterViewPadding
-                    if let selectedIndexPath = self.longPressMultiSelectIndexPath {
-                        self.downloadsTable.selectIndexPath(selectedIndexPath)
-                        self.longPressMultiSelectIndexPath = nil
-                    }
-                } else {
-                    Analytics.track(.downloadsMultiSelectExited)
-                    self.selectedEpisodes.removeAll()
+            if isMultiSelectEnabled {
+                Analytics.track(.downloadsMultiSelectEntered)
+                multiSelectFooter.setSelectedCount(count: selectedEpisodes.count)
+                multiSelectFooterBottomConstraint.constant = Constants.effectiveFooterViewPadding
+                if let selectedIndexPath = longPressMultiSelectIndexPath {
+                    downloadsTable.selectIndexPath(selectedIndexPath)
+                    longPressMultiSelectIndexPath = nil
                 }
+            } else {
+                Analytics.track(.downloadsMultiSelectExited)
+                selectedEpisodes.removeAll()
             }
         }
     }

--- a/podcasts/ListeningHistoryViewController+MultiSelect.swift
+++ b/podcasts/ListeningHistoryViewController+MultiSelect.swift
@@ -23,15 +23,13 @@ extension ListeningHistoryViewController: MultiSelectActionDelegate {
     }
 
     func multiSelectActionCompleted() {
-        DispatchQueue.main.async {
+        view.layoutIfNeeded()
+        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
+            self.multiSelectFooterBottomConstraint.constant = 0
             self.view.layoutIfNeeded()
-            UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
-                self.multiSelectFooterBottomConstraint.constant = 0
-                self.view.layoutIfNeeded()
-            }, completion: { _ in
-                self.isMultiSelectEnabled = false
-            })
-        }
+        }, completion: { _ in
+            self.isMultiSelectEnabled = false
+        })
     }
 
     func multiSelectPreferredStatusBarStyle() -> UIStatusBarStyle {

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -38,28 +38,26 @@ class ListeningHistoryViewController: PCViewController {
         }
     }
 
+    @MainActor
     var isMultiSelectEnabled = false {
         didSet {
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                self.setupNavBar()
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
-                self.listeningHistoryTable.beginUpdates()
-                self.listeningHistoryTable.setEditing(self.isMultiSelectEnabled, animated: true)
-                self.listeningHistoryTable.endUpdates()
-                self.insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled
-                if self.isMultiSelectEnabled {
-                    Analytics.track(.listeningHistoryMultiSelectEntered)
-                    self.multiSelectFooter.setSelectedCount(count: self.selectedEpisodes.count)
-                    self.multiSelectFooterBottomConstraint.constant = Constants.effectiveFooterViewPadding
-                    if let selectedIndexPath = self.longPressMultiSelectIndexPath {
-                        self.listeningHistoryTable.selectIndexPath(selectedIndexPath)
-                        self.longPressMultiSelectIndexPath = nil
-                    }
-                } else {
-                    Analytics.track(.listeningHistoryMultiSelectExited)
-                    self.selectedEpisodes.removeAll()
+            setupNavBar()
+            setEnclosingTabBarHidden(isMultiSelectEnabled, animated: false)
+            listeningHistoryTable.beginUpdates()
+            listeningHistoryTable.setEditing(isMultiSelectEnabled, animated: true)
+            listeningHistoryTable.endUpdates()
+            insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled
+            if isMultiSelectEnabled {
+                Analytics.track(.listeningHistoryMultiSelectEntered)
+                multiSelectFooter.setSelectedCount(count: selectedEpisodes.count)
+                multiSelectFooterBottomConstraint.constant = Constants.effectiveFooterViewPadding
+                if let selectedIndexPath = longPressMultiSelectIndexPath {
+                    listeningHistoryTable.selectIndexPath(selectedIndexPath)
+                    longPressMultiSelectIndexPath = nil
                 }
+            } else {
+                Analytics.track(.listeningHistoryMultiSelectExited)
+                selectedEpisodes.removeAll()
             }
         }
     }

--- a/podcasts/New Detail/PlaylistDetailViewController+MultiSelect.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+MultiSelect.swift
@@ -24,16 +24,14 @@ extension PlaylistDetailViewController: MultiSelectActionDelegate {
         }
 
         func multiSelectActionCompleted() {
-            DispatchQueue.main.async {
+            view.layoutIfNeeded()
+            UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
+                self.multiSelectFooterBottomConstraint.constant = 0
                 self.view.layoutIfNeeded()
-                UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
-                    self.multiSelectFooterBottomConstraint.constant = 0
-                    self.view.layoutIfNeeded()
-                }, completion: { _ in
-                    self.multiSelectActionInProgress = false
-                    self.isMultiSelectEnabled = false
-                })
-            }
+            }, completion: { _ in
+                self.multiSelectActionInProgress = false
+                self.isMultiSelectEnabled = false
+            })
         }
 
         func multiSelectPreferredStatusBarStyle() -> UIStatusBarStyle {

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -63,38 +63,35 @@ class PlaylistDetailViewController: PCViewController, UIScrollViewDelegate {
 
     private var refreshControl: CustomRefreshControl?
 
+    @MainActor
     var isMultiSelectEnabled = false {
         didSet {
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
+            setEnclosingTabBarHidden(isMultiSelectEnabled, animated: false)
+            tableView.beginUpdates()
+            tableView.setEditing(isMultiSelectEnabled, animated: true)
+            insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled
+            tableView.endUpdates()
 
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
-                self.tableView.beginUpdates()
-                self.tableView.setEditing(self.isMultiSelectEnabled, animated: true)
-                self.insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled
-                self.tableView.endUpdates()
-
-                if self.isMultiSelectEnabled {
-                    if self.viewModel.isSearching {
-                        self.searchController.searchTextField.resignFirstResponder()
-                    }
-                    self.track(.filterMultiSelectEntered)
-                    if self.selectedEpisodes.isEmpty, self.longPressMultiSelectIndexPath == nil, !self.multiSelectGestureInProgress {
-                        self.tableView.scrollToRow(at: IndexPath(row: NSNotFound, section: 1), at: .top, animated: true)
-                    }
-                    self.multiSelectFooter.setSelectedCount(count: self.selectedEpisodes.count)
-                    if let selectedIndexPath = self.longPressMultiSelectIndexPath {
-                        self.tableView.selectIndexPath(selectedIndexPath)
-                        self.longPressMultiSelectIndexPath = nil
-                    }
-                    self.multiSelectFooterBottomConstraint.constant = Constants.effectiveFooterViewPadding
-                } else {
-                    self.track(.filterMultiSelectExited)
-                    self.multiSelectFooter.isHidden = true
-                    self.selectedEpisodes.removeAll()
+            if isMultiSelectEnabled {
+                if viewModel.isSearching {
+                    searchController.searchTextField.resignFirstResponder()
                 }
-                self.updateMultiSelectNavBar()
+                track(.filterMultiSelectEntered)
+                if selectedEpisodes.isEmpty, longPressMultiSelectIndexPath == nil, !multiSelectGestureInProgress {
+                    tableView.scrollToRow(at: IndexPath(row: NSNotFound, section: 1), at: .top, animated: true)
+                }
+                multiSelectFooter.setSelectedCount(count: selectedEpisodes.count)
+                if let selectedIndexPath = longPressMultiSelectIndexPath {
+                    tableView.selectIndexPath(selectedIndexPath)
+                    longPressMultiSelectIndexPath = nil
+                }
+                multiSelectFooterBottomConstraint.constant = Constants.effectiveFooterViewPadding
+            } else {
+                track(.filterMultiSelectExited)
+                multiSelectFooter.isHidden = true
+                selectedEpisodes.removeAll()
             }
+            updateMultiSelectNavBar()
         }
     }
 

--- a/podcasts/OptionAction.swift
+++ b/podcasts/OptionAction.swift
@@ -4,7 +4,7 @@ class OptionAction {
     let label: String
     let secondaryLabel: String?
     let icon: String?
-    let action: () -> Void
+    let action: @MainActor () -> Void
     let selected: Bool
     var destructive = false
     var outline = false
@@ -13,9 +13,9 @@ class OptionAction {
     /// When set, tapping the action presents the returned picker as a submenu
     /// on top of the current one. Choosing an option in the submenu dismisses
     /// both. The closure is evaluated lazily, only when the action is tapped.
-    var submenu: (() -> OptionsPicker?)?
+    var submenu: (@MainActor () -> OptionsPicker?)?
 
-    init(label: String, secondaryLabel: String? = nil, icon: String? = nil, tintIcon: Bool = true, selected: Bool = false, action: @escaping (() -> Void)) {
+    init(label: String, secondaryLabel: String? = nil, icon: String? = nil, tintIcon: Bool = true, selected: Bool = false, action: @escaping @MainActor () -> Void) {
         self.label = label
         self.secondaryLabel = secondaryLabel
         self.icon = icon
@@ -24,7 +24,7 @@ class OptionAction {
         self.selected = selected
     }
 
-    init(label: String, icon: String, tintIcon: Bool = true, selected: Bool, onOffAction: Bool, action: @escaping (() -> Void)) {
+    init(label: String, icon: String, tintIcon: Bool = true, selected: Bool, onOffAction: Bool, action: @escaping @MainActor () -> Void) {
         self.label = label
         self.icon = icon
         self.tintIcon = tintIcon

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController+MultiSelect.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController+MultiSelect.swift
@@ -26,15 +26,13 @@ extension PodcastViewController {
     }
 
     func multiSelectActionCompleted() {
-        DispatchQueue.main.async {
+        view.layoutIfNeeded()
+        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
+            self.multiSelectFooterBottomConstraint.constant = 0
             self.view.layoutIfNeeded()
-            UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
-                self.multiSelectFooterBottomConstraint.constant = 0
-                self.view.layoutIfNeeded()
-            }, completion: { _ in
-                self.isMultiSelectEnabled = false
-            })
-        }
+        }, completion: { _ in
+            self.isMultiSelectEnabled = false
+        })
     }
 
     func multiSelectPreferredStatusBarStyle() -> UIStatusBarStyle {

--- a/podcasts/StarredViewController+Multiselect.swift
+++ b/podcasts/StarredViewController+Multiselect.swift
@@ -23,15 +23,13 @@ extension StarredViewController: MultiSelectActionDelegate {
     }
 
     func multiSelectActionCompleted() {
-        DispatchQueue.main.async {
+        view.layoutIfNeeded()
+        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
+            self.multiSelectFooterBottomConstraint.constant = 0
             self.view.layoutIfNeeded()
-            UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
-                self.multiSelectFooterBottomConstraint.constant = 0
-                self.view.layoutIfNeeded()
-            }, completion: { _ in
-                self.isMultiSelectEnabled = false
-            })
-        }
+        }, completion: { _ in
+            self.isMultiSelectEnabled = false
+        })
     }
 
     func multiSelectPreferredStatusBarStyle() -> UIStatusBarStyle {

--- a/podcasts/StarredViewController.swift
+++ b/podcasts/StarredViewController.swift
@@ -26,28 +26,26 @@ class StarredViewController: PCViewController {
     }
     private let refreshQueue = OperationQueue()
     var cellHeights: [IndexPath: CGFloat] = [:]
+    @MainActor
     var isMultiSelectEnabled: Bool = false {
         didSet {
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                self.setupNavBar()
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
-                self.starredTable.beginUpdates()
-                self.starredTable.setEditing(self.isMultiSelectEnabled, animated: true)
-                self.starredTable.endUpdates()
-                self.insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled
-                if self.isMultiSelectEnabled {
-                    Analytics.track(.starredMultiSelectEntered)
-                    self.multiSelectFooter.setSelectedCount(count: self.selectedEpisodes.count)
-                    self.multiSelectFooterBottomConstraint.constant = Constants.effectiveFooterViewPadding
-                    if let selectedIndexPath = self.longPressMultiSelectIndexPath {
-                        self.starredTable.selectIndexPath(selectedIndexPath)
-                        self.longPressMultiSelectIndexPath = nil
-                    }
-                } else {
-                    Analytics.track(.starredMultiSelectExited)
-                    self.selectedEpisodes.removeAll()
+            setupNavBar()
+            setEnclosingTabBarHidden(isMultiSelectEnabled, animated: false)
+            starredTable.beginUpdates()
+            starredTable.setEditing(isMultiSelectEnabled, animated: true)
+            starredTable.endUpdates()
+            insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled
+            if isMultiSelectEnabled {
+                Analytics.track(.starredMultiSelectEntered)
+                multiSelectFooter.setSelectedCount(count: selectedEpisodes.count)
+                multiSelectFooterBottomConstraint.constant = Constants.effectiveFooterViewPadding
+                if let selectedIndexPath = longPressMultiSelectIndexPath {
+                    starredTable.selectIndexPath(selectedIndexPath)
+                    longPressMultiSelectIndexPath = nil
                 }
+            } else {
+                Analytics.track(.starredMultiSelectExited)
+                selectedEpisodes.removeAll()
             }
         }
     }

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -27,29 +27,26 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         InsetAdjuster(ignoreMiniPlayer: !self.showingInTab)
     }()
 
+    @MainActor
     var isMultiSelectEnabled = false {
         didSet {
-            let didChange = oldValue != isMultiSelectEnabled
+            guard oldValue != isMultiSelectEnabled else { return }
 
-            DispatchQueue.main.async { [weak self] in
-                guard let self, didChange else { return }
-
-                self.updateNavBarButtons()
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
-                contentInseter.isMultiSelectEnabled = isMultiSelectEnabled
-                if !self.isMultiSelectEnabled {
-                    self.multiSelectActionBar.isHidden = true
-                    self.selectedPlayListEpisodes.removeAll()
-                    self.track(.upNextMultiSelectExited)
-                } else {
-                    self.track(.upNextMultiSelectEntered)
-                }
-                self.updateNavBarButtons(animated: true)
-                if self.showingInTab {
-                    self.multiSelectActionBarBottomConstraint.constant = Constants.effectiveMiniPlayerOffset + Self.bottomMargin
-                }
-                self.animateMultiSelectChange()
+            updateNavBarButtons()
+            setEnclosingTabBarHidden(isMultiSelectEnabled, animated: false)
+            contentInseter.isMultiSelectEnabled = isMultiSelectEnabled
+            if !isMultiSelectEnabled {
+                multiSelectActionBar.isHidden = true
+                selectedPlayListEpisodes.removeAll()
+                track(.upNextMultiSelectExited)
+            } else {
+                track(.upNextMultiSelectEntered)
             }
+            updateNavBarButtons(animated: true)
+            if showingInTab {
+                multiSelectActionBarBottomConstraint.constant = Constants.effectiveMiniPlayerOffset + Self.bottomMargin
+            }
+            animateMultiSelectChange()
         }
     }
 

--- a/podcasts/UploadedViewController.+MultiSelect.swift
+++ b/podcasts/UploadedViewController.+MultiSelect.swift
@@ -23,15 +23,13 @@ extension UploadedViewController: MultiSelectActionDelegate {
     }
 
     func multiSelectActionCompleted() {
-        DispatchQueue.main.async {
+        view.layoutIfNeeded()
+        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
+            self.multiSelectActionBarBottomConstraint.constant = 0
             self.view.layoutIfNeeded()
-            UIView.animate(withDuration: Constants.Animation.defaultAnimationTime, animations: {
-                self.multiSelectActionBarBottomConstraint.constant = 0
-                self.view.layoutIfNeeded()
-            }, completion: { _ in
-                self.isMultiSelectEnabled = false
-            })
-        }
+        }, completion: { _ in
+            self.isMultiSelectEnabled = false
+        })
     }
 
     func multiSelectPreferredStatusBarStyle() -> UIStatusBarStyle {

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -58,29 +58,27 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
         }
     }
 
+    @MainActor
     var isMultiSelectEnabled = false {
         didSet {
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                self.setupNavBar()
-                self.setEnclosingTabBarHidden(self.isMultiSelectEnabled, animated: false)
-                self.uploadsTable.beginUpdates()
-                self.uploadsTable.setEditing(self.isMultiSelectEnabled, animated: true)
-                self.insetAdjuster.isMultiSelectEnabled = self.isMultiSelectEnabled
-                self.uploadsTable.endUpdates()
+            setupNavBar()
+            setEnclosingTabBarHidden(isMultiSelectEnabled, animated: false)
+            uploadsTable.beginUpdates()
+            uploadsTable.setEditing(isMultiSelectEnabled, animated: true)
+            insetAdjuster.isMultiSelectEnabled = isMultiSelectEnabled
+            uploadsTable.endUpdates()
 
-                if self.isMultiSelectEnabled {
-                    Analytics.track(.uploadedFilesMultiSelectEntered)
-                    self.multiSelectActionBar.setSelectedCount(count: self.selectedEpisodes.count)
-                    self.multiSelectActionBarBottomConstraint.constant = Constants.effectiveFooterViewPadding
-                    if let selectedIndexPath = self.longPressMultiSelectIndexPath {
-                        self.uploadsTable.selectIndexPath(selectedIndexPath)
-                        self.longPressMultiSelectIndexPath = nil
-                    }
-                } else {
-                    Analytics.track(.uploadedFilesMultiSelectExited)
-                    self.selectedEpisodes.removeAll()
+            if isMultiSelectEnabled {
+                Analytics.track(.uploadedFilesMultiSelectEntered)
+                multiSelectActionBar.setSelectedCount(count: selectedEpisodes.count)
+                multiSelectActionBarBottomConstraint.constant = Constants.effectiveFooterViewPadding
+                if let selectedIndexPath = longPressMultiSelectIndexPath {
+                    uploadsTable.selectIndexPath(selectedIndexPath)
+                    longPressMultiSelectIndexPath = nil
                 }
+            } else {
+                Analytics.track(.uploadedFilesMultiSelectExited)
+                selectedEpisodes.removeAll()
             }
         }
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

We already use `UIAlertController` for swipe actions. It adds it for multi select as well.

<img width="456" height="972" alt="Screenshot 2026-05-28 at 5 13 26 PM" src="https://github.com/user-attachments/assets/17e719eb-5309-41cb-b3c0-a594acd6dd59" />


## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
