### PR TITLE
Enable Stats: Heatmap and add info button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix swipe action animations when adding episodes to Up Next [#4366](https://github.com/Automattic/pocket-casts-ios/pull/4366)
 - Update remaining menus to use sheet presentation [#4426](https://github.com/Automattic/pocket-casts-ios/pull/4426)
 - Fix rare crash in Stats [#4445](https://github.com/Automattic/pocket-casts-ios/pull/4445)
+- Add a listening activity heatmap to the Stats screen [#4443](https://github.com/Automattic/pocket-casts-ios/pull/4443)
 
 8.13
 -----

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -526,7 +526,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .trackNetworkDataUsage:
             true
         case .statsHeatmap:
-            false
+            true
         case .watchSentryLogs:
             false
         case .liquidGlass:

--- a/podcasts/Common Components/SettingsTableHeader.swift
+++ b/podcasts/Common Components/SettingsTableHeader.swift
@@ -87,7 +87,7 @@ class SettingsTableHeader: ThemeableView {
     func addInfoButton(selector: Selector, target: Any, accessibilityLabel: String) {
         titleLabel.setContentHuggingPriority(.required, for: .horizontal)
 
-        let infoButton = UIButton(type: .system)
+        let infoButton = HitTargetButton(type: .system)
         infoButton.setImage(UIImage(named: "empty-playlist-info")?.withRenderingMode(.alwaysTemplate), for: .normal)
         infoButton.tintColor = AppTheme.colorForStyle(.primaryText02, themeOverride: themeOverride)
         infoButton.imageView?.contentMode = .scaleAspectFit
@@ -123,5 +123,17 @@ class SettingsTableHeader: ThemeableView {
         let iconMetric = UIFontMetrics(forTextStyle: .largeTitle)
         let iconSize = max(24, iconMetric.scaledValue(for: 24))
         lockImage?.updateSizeConstraints(to: iconSize)
+    }
+}
+
+/// A button whose tappable area is expanded to a minimum size, centered on its
+/// bounds, without affecting its visible layout.
+private final class HitTargetButton: UIButton {
+    var minimumHitTarget = CGSize(width: 44, height: 44)
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        let dx = min(0, (bounds.width - minimumHitTarget.width) / 2)
+        let dy = min(0, (bounds.height - minimumHitTarget.height) / 2)
+        return bounds.insetBy(dx: dx, dy: dy).contains(point)
     }
 }

--- a/podcasts/Common Components/SettingsTableHeader.swift
+++ b/podcasts/Common Components/SettingsTableHeader.swift
@@ -39,12 +39,14 @@ class SettingsTableHeader: ThemeableView {
 
         addSubview(titleLabel)
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        let titleTrailing = titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16)
+        titleTrailing.priority = .defaultHigh
         NSLayoutConstraint.activate([
             titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
             titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
             titleLabel.topAnchor.constraint(equalTo: topAnchor),
             titleLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.Values.tableSectionHeaderHeight),
-            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            titleTrailing,
         ])
 
         if showLockedImage {
@@ -80,6 +82,27 @@ class SettingsTableHeader: ThemeableView {
         }
 
         updateSize()
+    }
+
+    func addInfoButton(selector: Selector, target: Any, accessibilityLabel: String) {
+        titleLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        let infoButton = UIButton(type: .system)
+        infoButton.setImage(UIImage(named: "empty-playlist-info")?.withRenderingMode(.alwaysTemplate), for: .normal)
+        infoButton.tintColor = AppTheme.colorForStyle(.primaryText02, themeOverride: themeOverride)
+        infoButton.imageView?.contentMode = .scaleAspectFit
+        infoButton.translatesAutoresizingMaskIntoConstraints = false
+        infoButton.addTarget(target, action: selector, for: .touchUpInside)
+        infoButton.accessibilityLabel = accessibilityLabel
+        addSubview(infoButton)
+        let iconSize: CGFloat = 18
+        NSLayoutConstraint.activate([
+            infoButton.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor, constant: 6),
+            infoButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor),
+            infoButton.widthAnchor.constraint(equalToConstant: iconSize),
+            infoButton.heightAnchor.constraint(equalToConstant: iconSize),
+            trailingAnchor.constraint(greaterThanOrEqualTo: infoButton.trailingAnchor, constant: 16)
+        ])
     }
 
     override func handleThemeDidChange() {

--- a/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
+++ b/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
@@ -139,7 +139,7 @@ class BottomSheetSwiftUIWrapper<ContentView: View>: UIViewController, UISheetPre
     }
 }
 
-extension UIViewController {
+private extension UIViewController {
     func presentModally(
         in viewController: UIViewController,
         detents: [UISheetPresentationController.Detent] = [.medium()],
@@ -153,7 +153,7 @@ extension UIViewController {
                 sheetController.delegate = sheetDelegate
             }
             sheetController.prefersGrabberVisible = showingGrabber
-            sheetController.preferredCornerRadius = 10
+            sheetController.preferredCornerRadius = LiquidGlass.isEnabled ? 26 : 10
 
             // Prevent sheet from being dismissed by dragging down
             sheetController.prefersScrollingExpandsWhenScrolledToEdge = false

--- a/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
+++ b/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
@@ -153,7 +153,9 @@ private extension UIViewController {
                 sheetController.delegate = sheetDelegate
             }
             sheetController.prefersGrabberVisible = showingGrabber
-            sheetController.preferredCornerRadius = LiquidGlass.isEnabled ? 26 : 10
+            if !LiquidGlass.isEnabled {
+                sheetController.preferredCornerRadius = 10
+            }
 
             // Prevent sheet from being dismissed by dragging down
             sheetController.prefersScrollingExpandsWhenScrolledToEdge = false

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -86,7 +86,9 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
 
         switch sections[section] {
         case .heatmap:
-            return SettingsTableHeader(frame: headerFrame, title: L10n.statsListeningActivitySectionTitle)
+            let header = SettingsTableHeader(frame: headerFrame, title: L10n.statsListeningActivitySectionTitle)
+            header.addInfoButton(selector: #selector(showHeatmapInfo), target: self, accessibilityLabel: L10n.statsListeningActivityInfoAccessibilityLabel)
+            return header
         case .timeSavedBreakdown:
             return SettingsTableHeader(frame: headerFrame, title: L10n.statsTimeSaved)
         case .header, .timeSavedTotal:
@@ -244,6 +246,20 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
 
     private func formatStat(_ stat: Double) -> String {
         stat.localizedTimeDescription ?? L10n.statsTimeZeroSeconds
+    }
+
+    @objc private func showHeatmapInfo() {
+        let view = ModalMessageView(
+            title: L10n.statsListeningActivityInfoTitle,
+            message: L10n.statsListeningActivityInfoMessage,
+            actionTitle: L10n.gotIt
+        )
+        BottomSheetSwiftUIWrapper.present(
+            view.environmentObject(Theme.sharedTheme),
+            autoSize: true,
+            showingGrabber: true,
+            in: self
+        )
     }
 
     private func requestReviewIfPossible() {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4137,6 +4137,12 @@ internal enum L10n {
   internal static func statsListeningActivityAccessibilityLabel(_ p1: Any) -> String {
     return L10n.tr("Localizable", "stats_listening_activity_accessibility_label", String(describing: p1), fallback: "Listening activity heatmap. Days listened: %1$@ of 365.")
   }
+  /// VoiceOver label for the info button next to the listening activity section header.
+  internal static var statsListeningActivityInfoAccessibilityLabel: String { return L10n.tr("Localizable", "stats_listening_activity_info_accessibility_label", fallback: "About listening activity") }
+  /// Body text for the sheet that explains how the listening activity heatmap is calculated.
+  internal static var statsListeningActivityInfoMessage: String { return L10n.tr("Localizable", "stats_listening_activity_info_message", fallback: "An estimate of when you've been listening, based on your playback history. If you finish an episode over a few days, it shows on the last day.") }
+  /// Title for the sheet that explains how the listening activity heatmap is calculated.
+  internal static var statsListeningActivityInfoTitle: String { return L10n.tr("Localizable", "stats_listening_activity_info_title", fallback: "Listening activity") }
   /// Label for the low end of the heatmap legend
   internal static var statsListeningActivityLegendLess: String { return L10n.tr("Localizable", "stats_listening_activity_legend_less", fallback: "Less") }
   /// Label for the high end of the heatmap legend

--- a/podcasts/Utilities/SwiftUI/ModalMessage.swift
+++ b/podcasts/Utilities/SwiftUI/ModalMessage.swift
@@ -4,21 +4,32 @@ struct ModalMessageView: View {
     @Environment(\.dismiss) var dismiss
     @EnvironmentObject var theme: Theme
 
-    let icon: String
+    let icon: String?
     let title: String
     let message: String
     let destructive: Bool
     let actionTitle: String
     let action: (() -> Void)?
 
+    init(icon: String? = nil, title: String, message: String, destructive: Bool = false, actionTitle: String, action: (() -> Void)? = nil) {
+        self.icon = icon
+        self.title = title
+        self.message = message
+        self.destructive = destructive
+        self.actionTitle = actionTitle
+        self.action = action
+    }
+
     var body: some View {
         VStack(spacing: 16) {
             Spacer()
-            Image(icon)
-                .resizable()
-                .renderingMode(.template)
-                .frame(width: 36, height: 36)
-                .foregroundColor(theme.primaryInteractive01)
+            if let icon {
+                Image(icon)
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: 36, height: 36)
+                    .foregroundColor(theme.primaryInteractive01)
+            }
             Group {
                 Text(title)
                     .font(.title2.bold())

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -1249,6 +1249,15 @@
 /* VoiceOver label for the listening activity heatmap. '%1$@' is a placeholder for the number of days with listening activity out of the last 365. */
 "stats_listening_activity_accessibility_label" = "Listening activity heatmap. Days listened: %1$@ of 365.";
 
+/* VoiceOver label for the info button next to the listening activity section header. */
+"stats_listening_activity_info_accessibility_label" = "About listening activity";
+
+/* Title for the sheet that explains how the listening activity heatmap is calculated. */
+"stats_listening_activity_info_title" = "Listening activity";
+
+/* Body text for the sheet that explains how the listening activity heatmap is calculated. */
+"stats_listening_activity_info_message" = "An estimate of when you've been listening, based on your playback history. If you finish an episode over a few days, it shows on the last day.";
+
 /* A common string used throughout the app. Often refers to the Listening History screen. */
 "listening_history" = "Listening History";
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

- Enable FF
- Add Info sheet


<img width="320" alt="Screenshot 2026-05-30 at 2 18 40 PM" src="https://github.com/user-attachments/assets/8e262769-27d1-4e42-8e5d-a5f3c581c03e" />


- Update corner radius for existing sheets (affects a couple of similar popups, minimum affect on layout). Example:

<img width="320"  alt="Screenshot 2026-05-30 at 2 23 11 PM" src="https://github.com/user-attachments/assets/e8d291db-b675-4f50-b448-654b95bee0ee" />



## To test

- Test the new info button

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
