### PR TITLE
Fix floating section headers in "Listening History" and "Downloads"

### DIFF
--- a/podcasts/DownloadsViewController+Table.swift
+++ b/podcasts/DownloadsViewController+Table.swift
@@ -4,7 +4,6 @@ import UIKit
 
 extension DownloadsViewController: UITableViewDelegate, UITableViewDataSource {
     private static let cellId = "EpisodeCell"
-    private static let topDividerTag = 9821
 
     func registerTableCells() {
         downloadsTable.register(UINib(nibName: "EpisodeCell", bundle: nil), forCellReuseIdentifier: DownloadsViewController.cellId)
@@ -55,32 +54,9 @@ extension DownloadsViewController: UITableViewDelegate, UITableViewDataSource {
             }
         }
 
-        configureTopDivider(on: cell, isFirstInSection: indexPath.row == 0)
+        cell.showsTopDivider = indexPath.row == 0
 
         return cell
-    }
-
-    // The section header (DateHeadingView) can't host the top divider for the first cell
-    // because plain-style headers stick during scroll, which would detach the divider from
-    // the cell. Adding it to the cell instead keeps it anchored.
-    private func configureTopDivider(on cell: EpisodeCell, isFirstInSection: Bool) {
-        let existing = cell.contentView.viewWithTag(DownloadsViewController.topDividerTag)
-        guard isFirstInSection else {
-            existing?.removeFromSuperview()
-            return
-        }
-        if existing != nil { return }
-
-        let divider = ThemeDividerView()
-        divider.tag = DownloadsViewController.topDividerTag
-        divider.translatesAutoresizingMaskIntoConstraints = false
-        cell.contentView.addSubview(divider)
-        NSLayoutConstraint.activate([
-            divider.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale),
-            divider.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
-            divider.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor),
-            divider.topAnchor.constraint(equalTo: cell.contentView.topAnchor)
-        ])
     }
 
     // MARK: - Selection

--- a/podcasts/DownloadsViewController+Table.swift
+++ b/podcasts/DownloadsViewController+Table.swift
@@ -54,7 +54,7 @@ extension DownloadsViewController: UITableViewDelegate, UITableViewDataSource {
             }
         }
 
-        cell.showsTopDivider = indexPath.row == 0
+        cell.showsTopDivider = LiquidGlass.isEnabled && indexPath.row == 0
 
         return cell
     }

--- a/podcasts/DownloadsViewController+Table.swift
+++ b/podcasts/DownloadsViewController+Table.swift
@@ -4,6 +4,7 @@ import UIKit
 
 extension DownloadsViewController: UITableViewDelegate, UITableViewDataSource {
     private static let cellId = "EpisodeCell"
+    private static let topDividerTag = 9821
 
     func registerTableCells() {
         downloadsTable.register(UINib(nibName: "EpisodeCell", bundle: nil), forCellReuseIdentifier: DownloadsViewController.cellId)
@@ -54,7 +55,32 @@ extension DownloadsViewController: UITableViewDelegate, UITableViewDataSource {
             }
         }
 
+        configureTopDivider(on: cell, isFirstInSection: indexPath.row == 0)
+
         return cell
+    }
+
+    // The section header (DateHeadingView) can't host the top divider for the first cell
+    // because plain-style headers stick during scroll, which would detach the divider from
+    // the cell. Adding it to the cell instead keeps it anchored.
+    private func configureTopDivider(on cell: EpisodeCell, isFirstInSection: Bool) {
+        let existing = cell.contentView.viewWithTag(DownloadsViewController.topDividerTag)
+        guard isFirstInSection else {
+            existing?.removeFromSuperview()
+            return
+        }
+        if existing != nil { return }
+
+        let divider = ThemeDividerView()
+        divider.tag = DownloadsViewController.topDividerTag
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        cell.contentView.addSubview(divider)
+        NSLayoutConstraint.activate([
+            divider.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale),
+            divider.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor),
+            divider.topAnchor.constraint(equalTo: cell.contentView.topAnchor)
+        ])
     }
 
     // MARK: - Selection

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -28,8 +28,6 @@ class DownloadsViewController: PCViewController {
             downloadsTable.allowsMultipleSelectionDuringEditing = true
             if LiquidGlass.isEnabled {
                 downloadsTable.themeStyle = .primaryUi02
-                downloadsTable.sectionHeaderHeight = 32
-                downloadsTable.estimatedSectionHeaderHeight = 32
             }
         }
     }

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -21,11 +21,16 @@ class DownloadsViewController: PCViewController {
         return queue
     }()
 
-    @IBOutlet var downloadsTable: UITableView! {
+    @IBOutlet var downloadsTable: ThemeableTable! {
         didSet {
             registerTableCells()
             registerLongPress()
             downloadsTable.allowsMultipleSelectionDuringEditing = true
+            if LiquidGlass.isEnabled {
+                downloadsTable.themeStyle = .primaryUi02
+                downloadsTable.sectionHeaderHeight = 32
+                downloadsTable.estimatedSectionHeaderHeight = 32
+            }
         }
     }
 

--- a/podcasts/Episode Cells/DateHeadingView.swift
+++ b/podcasts/Episode Cells/DateHeadingView.swift
@@ -1,4 +1,3 @@
-
 import UIKit
 
 class DateHeadingView: UIView {
@@ -17,31 +16,39 @@ class DateHeadingView: UIView {
     }
 
     private func setup() {
-        // add the label and dividers
-        let dividerHeight = 1 / UIScreen.main.scale
-        let topDivider = ThemeDividerView(frame: CGRect(x: 0, y: 0, width: bounds.width, height: dividerHeight))
-        topDivider.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(topDivider)
+        let label: UILabel
 
-        titleLabel = ThemeableLabel()
-        titleLabel?.textAlignment = .natural
-        titleLabel?.text = title
-        titleLabel?.font = UIFont.font(ofSize: 22, weight: UIFont.Weight.bold, scalingWith: .largeTitle)
-        titleLabel?.adjustsFontForContentSizeCategory = true
-        addSubview(titleLabel!)
-        titleLabel?.translatesAutoresizingMaskIntoConstraints = false
+        if LiquidGlass.isEnabled {
+            label = UILabel()
+        } else {
+            let dividerHeight = 1 / UIScreen.main.scale
+            let topDivider = ThemeDividerView(frame: CGRect(x: 0, y: 0, width: bounds.width, height: dividerHeight))
+            topDivider.translatesAutoresizingMaskIntoConstraints = false
+            addSubview(topDivider)
 
-        // setup constraints so that they are all in the right place
+            NSLayoutConstraint.activate([
+                topDivider.heightAnchor.constraint(equalToConstant: dividerHeight),
+                topDivider.leadingAnchor.constraint(equalTo: leadingAnchor),
+                topDivider.trailingAnchor.constraint(equalTo: trailingAnchor),
+                topDivider.topAnchor.constraint(equalTo: topAnchor)
+            ])
+
+            label = ThemeableLabel()
+        }
+
+        label.textAlignment = .natural
+        label.text = title
+        label.font = UIFont.font(ofSize: 22, weight: UIFont.Weight.bold, scalingWith: .largeTitle)
+        label.adjustsFontForContentSizeCategory = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        titleLabel = label
+
         NSLayoutConstraint.activate([
-            topDivider.heightAnchor.constraint(equalToConstant: dividerHeight),
-            topDivider.leadingAnchor.constraint(equalTo: leadingAnchor),
-            topDivider.trailingAnchor.constraint(equalTo: trailingAnchor),
-            topDivider.topAnchor.constraint(equalTo: topAnchor),
-
-            titleLabel!.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            titleLabel!.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-            titleLabel!.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0),
-            titleLabel!.topAnchor.constraint(equalTo: topAnchor, constant: 0)
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
+            label.bottomAnchor.constraint(equalTo: bottomAnchor),
+            label.topAnchor.constraint(equalTo: topAnchor)
         ])
 
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
@@ -57,6 +64,6 @@ class DateHeadingView: UIView {
     }
 
     private func setBgColorForTheme() {
-        backgroundColor = ThemeColor.primaryUi02()
+        backgroundColor = LiquidGlass.isEnabled ? .clear : ThemeColor.primaryUi02()
     }
 }

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -42,6 +42,30 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
         }
     }
 
+    private var topDivider: ThemeDividerView?
+
+    /// Shows a hairline divider along the top edge of the cell. Used by lists where the
+    /// section header is transparent (e.g. plain-style sticky headers under Liquid Glass)
+    /// and can't host the divider itself.
+    var showsTopDivider = false {
+        didSet {
+            guard showsTopDivider != oldValue else { return }
+            if showsTopDivider, topDivider == nil {
+                let divider = ThemeDividerView()
+                divider.translatesAutoresizingMaskIntoConstraints = false
+                contentView.addSubview(divider)
+                NSLayoutConstraint.activate([
+                    divider.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale),
+                    divider.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                    divider.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                    divider.topAnchor.constraint(equalTo: contentView.topAnchor)
+                ])
+                topDivider = divider
+            }
+            topDivider?.isHidden = !showsTopDivider
+        }
+    }
+
     @IBOutlet var dayName: ThemeableLabel! {
         didSet {
             dayName.style = .primaryText02

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -45,8 +45,8 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     private var topDivider: ThemeDividerView?
 
     /// Shows a hairline divider along the top edge of the cell. Used by lists where the
-    /// section header is transparent (e.g. plain-style sticky headers under Liquid Glass)
-    /// and can't host the divider itself.
+    /// section header is transparent (Liquid Glass plain-style sticky headers) and can't
+    /// host the divider itself.
     var showsTopDivider = false {
         didSet {
             guard showsTopDivider != oldValue else { return }

--- a/podcasts/ListeningHistoryViewController+Table.swift
+++ b/podcasts/ListeningHistoryViewController+Table.swift
@@ -4,7 +4,6 @@ import UIKit
 
 extension ListeningHistoryViewController: UITableViewDelegate, UITableViewDataSource {
     private static let episodeCellId = "EpisodeCellID"
-    private static let topDividerTag = 9821
 
     func registerCells() {
         listeningHistoryTable.register(UINib(nibName: "EpisodeCell", bundle: nil), forCellReuseIdentifier: ListeningHistoryViewController.episodeCellId)
@@ -54,32 +53,9 @@ extension ListeningHistoryViewController: UITableViewDelegate, UITableViewDataSo
             }
         }
 
-        configureTopDivider(on: cell, isFirstInSection: indexPath.row == 0)
+        cell.showsTopDivider = indexPath.row == 0
 
         return cell
-    }
-
-    // The section header (DateHeadingView) can't host the top divider for the first cell
-    // because plain-style headers stick during scroll, which would detach the divider from
-    // the cell. Adding it to the cell instead keeps it anchored.
-    private func configureTopDivider(on cell: EpisodeCell, isFirstInSection: Bool) {
-        let existing = cell.contentView.viewWithTag(ListeningHistoryViewController.topDividerTag)
-        guard isFirstInSection else {
-            existing?.removeFromSuperview()
-            return
-        }
-        if existing != nil { return }
-
-        let divider = ThemeDividerView()
-        divider.tag = ListeningHistoryViewController.topDividerTag
-        divider.translatesAutoresizingMaskIntoConstraints = false
-        cell.contentView.addSubview(divider)
-        NSLayoutConstraint.activate([
-            divider.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale),
-            divider.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
-            divider.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor),
-            divider.topAnchor.constraint(equalTo: cell.contentView.topAnchor)
-        ])
     }
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {

--- a/podcasts/ListeningHistoryViewController+Table.swift
+++ b/podcasts/ListeningHistoryViewController+Table.swift
@@ -4,6 +4,7 @@ import UIKit
 
 extension ListeningHistoryViewController: UITableViewDelegate, UITableViewDataSource {
     private static let episodeCellId = "EpisodeCellID"
+    private static let topDividerTag = 9821
 
     func registerCells() {
         listeningHistoryTable.register(UINib(nibName: "EpisodeCell", bundle: nil), forCellReuseIdentifier: ListeningHistoryViewController.episodeCellId)
@@ -53,7 +54,32 @@ extension ListeningHistoryViewController: UITableViewDelegate, UITableViewDataSo
             }
         }
 
+        configureTopDivider(on: cell, isFirstInSection: indexPath.row == 0)
+
         return cell
+    }
+
+    // The section header (DateHeadingView) can't host the top divider for the first cell
+    // because plain-style headers stick during scroll, which would detach the divider from
+    // the cell. Adding it to the cell instead keeps it anchored.
+    private func configureTopDivider(on cell: EpisodeCell, isFirstInSection: Bool) {
+        let existing = cell.contentView.viewWithTag(ListeningHistoryViewController.topDividerTag)
+        guard isFirstInSection else {
+            existing?.removeFromSuperview()
+            return
+        }
+        if existing != nil { return }
+
+        let divider = ThemeDividerView()
+        divider.tag = ListeningHistoryViewController.topDividerTag
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        cell.contentView.addSubview(divider)
+        NSLayoutConstraint.activate([
+            divider.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale),
+            divider.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor),
+            divider.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor),
+            divider.topAnchor.constraint(equalTo: cell.contentView.topAnchor)
+        ])
     }
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {

--- a/podcasts/ListeningHistoryViewController+Table.swift
+++ b/podcasts/ListeningHistoryViewController+Table.swift
@@ -53,7 +53,7 @@ extension ListeningHistoryViewController: UITableViewDelegate, UITableViewDataSo
             }
         }
 
-        cell.showsTopDivider = indexPath.row == 0
+        cell.showsTopDivider = LiquidGlass.isEnabled && indexPath.row == 0
 
         return cell
     }

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -234,7 +234,7 @@ class ListeningHistoryViewController: PCViewController {
         var config: UIContentConfiguration?
 
         listeningHistoryTable.backgroundView = UIView()
-        listeningHistoryTable.themeStyle = .primaryUi02
+        listeningHistoryTable.themeStyle = LiquidGlass.isEnabled ? .primaryUi02 : .primaryUi04
 
         if episodes.isEmpty {
             if searchController?.searchTextField.text?.isEmpty == false {

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -34,13 +34,6 @@ class ListeningHistoryViewController: PCViewController {
             listeningHistoryTable.rowHeight = UITableView.automaticDimension
             listeningHistoryTable.allowsMultipleSelection = true
             listeningHistoryTable.allowsMultipleSelectionDuringEditing = true
-            // EpisodeCell draws its own bottom divider, so disable the table's
-            // built-in separator to avoid stacking them into a thicker line.
-            listeningHistoryTable.separatorStyle = .none
-            if LiquidGlass.isEnabled {
-                listeningHistoryTable.sectionHeaderHeight = 32
-                listeningHistoryTable.estimatedSectionHeaderHeight = 32
-            }
             registerLongPress()
         }
     }

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -34,6 +34,13 @@ class ListeningHistoryViewController: PCViewController {
             listeningHistoryTable.rowHeight = UITableView.automaticDimension
             listeningHistoryTable.allowsMultipleSelection = true
             listeningHistoryTable.allowsMultipleSelectionDuringEditing = true
+            // EpisodeCell draws its own bottom divider, so disable the table's
+            // built-in separator to avoid stacking them into a thicker line.
+            listeningHistoryTable.separatorStyle = .none
+            if LiquidGlass.isEnabled {
+                listeningHistoryTable.sectionHeaderHeight = 32
+                listeningHistoryTable.estimatedSectionHeaderHeight = 32
+            }
             registerLongPress()
         }
     }
@@ -227,7 +234,7 @@ class ListeningHistoryViewController: PCViewController {
         var config: UIContentConfiguration?
 
         listeningHistoryTable.backgroundView = UIView()
-        listeningHistoryTable.themeStyle = .primaryUi04
+        listeningHistoryTable.themeStyle = .primaryUi02
 
         if episodes.isEmpty {
             if searchController?.searchTextField.text?.isEmpty == false {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Fix floating section headers in "Listening History" and "Downloads":

- Make the background clear (Apple extend the top blur automatically)
- Remove dividers
- Add top dividers to episode cells and fix "Listening History" using wrong dividers style not matching other screens
- Update background color to match other screens with episodes (02)
<img width="684" height="561" alt="Screenshot 2026-06-01 at 3 37 08 PM" src="https://github.com/user-attachments/assets/3d5e4937-bfee-4fdc-950b-849bf414dc2d" />


## To test

- Verify that iOS 18 and earlier is unchanged
- Verify that sections are rendered "well" in "Listening History" and "Downloads"

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
