### PR TITLE
Fix time label sometimes not legible

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -69,6 +69,22 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         static let skipIconScale: CGFloat = 0.9
     }
 
+    /// Wraps `content` in a vibrancy effect so it blends with the tab accessory's glass.
+    private static func makeVibrancyWrapper(style: UIVibrancyEffectStyle, content: UIView) -> UIVisualEffectView {
+        let vibrancy = UIVibrancyEffect(blurEffect: UIBlurEffect(style: .systemChromeMaterial), style: style)
+        let wrapper = UIVisualEffectView(effect: vibrancy)
+        wrapper.translatesAutoresizingMaskIntoConstraints = false
+        content.translatesAutoresizingMaskIntoConstraints = false
+        wrapper.contentView.addSubview(content)
+        NSLayoutConstraint.activate([
+            content.leadingAnchor.constraint(equalTo: wrapper.contentView.leadingAnchor),
+            content.trailingAnchor.constraint(equalTo: wrapper.contentView.trailingAnchor),
+            content.topAnchor.constraint(equalTo: wrapper.contentView.topAnchor),
+            content.bottomAnchor.constraint(equalTo: wrapper.contentView.bottomAnchor),
+        ])
+        return wrapper
+    }
+
     /// When set, the next time-left value update is wrapped in `withAnimation`
     /// so SwiftUI's numeric-text transition rolls the digits. Set by skip
     /// back/forward and consumed on the first resulting change so only
@@ -142,15 +158,14 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         }
 
         let title = MiniPlayerScrollingTitleView()
-        title.translatesAutoresizingMaskIntoConstraints = false
         title.font = .font(ofSize: 13, weight: .medium, scalingWith: .subheadline)
         episodeTitleLabel = title
+        let titleVibrancy = Self.makeVibrancyWrapper(style: .label, content: title)
 
         // Hosted SwiftUI so the time-left digits can use the native
         // `.numericText` content transition when the user skips.
         let timeLeftModel = MiniPlayerTimeLeftModel()
         let timeLeftHost = UIHostingController(rootView: MiniPlayerTimeLeftView(model: timeLeftModel))
-        timeLeftHost.view.translatesAutoresizingMaskIntoConstraints = false
         timeLeftHost.view.backgroundColor = .clear
         timeLeftHost.sizingOptions = .intrinsicContentSize
         timeLeftHost.safeAreaRegions = []
@@ -159,16 +174,18 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         self.timeLeftModel = timeLeftModel
         self.timeLeftHostingController = timeLeftHost
 
-        let progressView = MiniPlayerGlassProgressView()
-        progressView.translatesAutoresizingMaskIntoConstraints = false
-        glassProgressView = progressView
+        let timeLeftVibrancy = Self.makeVibrancyWrapper(style: .secondaryLabel, content: timeLeftHost.view)
 
-        let bottomRow = UIStackView(arrangedSubviews: [progressView, timeLeftHost.view])
+        let progressView = MiniPlayerGlassProgressView()
+        glassProgressView = progressView
+        let progressVibrancy = Self.makeVibrancyWrapper(style: .fill, content: progressView)
+
+        let bottomRow = UIStackView(arrangedSubviews: [progressVibrancy, timeLeftVibrancy])
         bottomRow.axis = .horizontal
         bottomRow.alignment = .center
         bottomRow.spacing = 6
 
-        let textStack = UIStackView(arrangedSubviews: [title, bottomRow])
+        let textStack = UIStackView(arrangedSubviews: [titleVibrancy, bottomRow])
         textStack.translatesAutoresizingMaskIntoConstraints = false
         textStack.axis = .vertical
         textStack.alignment = .leading
@@ -606,7 +623,8 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         let iconColor = ThemeColor.podcastIcon03(podcastColor: actionColor)
         let bgColor = ThemeColor.primaryUi02()
 
-        episodeTitleLabel?.textColor = ThemeColor.primaryText01()
+        // System color so the vibrancy wrapper can modulate it.
+        episodeTitleLabel?.textColor = .label
         timeLeftModel?.color = Color(ThemeColor.primaryText02())
 
         playPauseBtn.playButtonColor = bgColor


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Fixes by using vibrancy effect on both title and time label (more noticeable in secondary label).

In the previous implementation, you'd occasionally get gray on top of gray.

https://github.com/user-attachments/assets/82af3430-1650-4526-b9e6-6429242c6d9f


## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
