### PR TITLE
Fix an issue with content going under the multi-select bar

### DIFF
--- a/podcasts/Extensions/UIScrollView+MiniPlayer.swift
+++ b/podcasts/Extensions/UIScrollView+MiniPlayer.swift
@@ -12,7 +12,12 @@ extension UIScrollView {
     }
 
     func updateContentInset(multiSelectEnabled: Bool, ignoreMiniPlayer: Bool = false) {
-        guard !LiquidGlass.isEnabled else {return }
+        if LiquidGlass.isEnabled {
+            let multiSelectFooterOffset: CGFloat = multiSelectEnabled ? 60 : 0
+            contentInset.bottom = multiSelectFooterOffset
+            verticalScrollIndicatorInsets.bottom = multiSelectFooterOffset
+            return
+        }
 
         let existingInset = contentInset
         let multiSelectFooterOffset: CGFloat = multiSelectEnabled ? 80 : 0


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

The content no longer goes under the multi-select bar (that doesn't currently contribute to safe area). **Note**: I plan to refactor it later in trunk; this is a quick fix for release using an existing mechanism.

<img width="320" alt="Screenshot 2026-06-01 at 4 58 20 PM" src="https://github.com/user-attachments/assets/3047845d-af3d-49be-b2a5-617364739f00" />

**Known Issue:** In "Up Next", the screen has gray background which is used in the header. It needs to be reworked a bit.

## To test

On screens with multi-select, verify that content doesn't go under the multi-select bar.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
