### PR TITLE
Fix top safe area in a couple more screens

### DIFF
--- a/podcasts/Up Next History/UpNextEntryView.swift
+++ b/podcasts/Up Next History/UpNextEntryView.swift
@@ -15,20 +15,44 @@ struct UpNextEntryView: View {
     }
 
     var body: some View {
+        if LiquidGlass.isEnabled, #available(iOS 26.0, *) {
+            liquidGlassBody
+        } else {
+            legacyBody
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private var liquidGlassBody: some View {
+        NavigationStack {
+            episodeList
+                .listStyle(.plain)
+                .navigationTitle("\(entryDate.formatted())")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button(role: .cancel) {
+                            dismiss()
+                        }
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button(L10n.restore) {
+                            showingAlert = true
+                        }
+                    }
+                }
+                .restoreAlert(isPresented: $showingAlert, onRestore: restore)
+        }
+        .applyDefaultThemeOptions()
+    }
+
+    private var legacyBody: some View {
         VStack(spacing: 0) {
             HStack(alignment: .center) {
                 Button(L10n.restore) {
                     showingAlert = true
                 }
-                .alert(L10n.restoreUpNext, isPresented: $showingAlert, actions: {
-                    Button(L10n.restore) {
-                        model.reAddMissingItems(entry: entryDate)
-                        dismiss()
-                    }
-                    Button(L10n.cancel, role: .cancel) { }
-                }, message: {
-                    Text(L10n.restoreUpNextMessage)
-                })
+                .restoreAlert(isPresented: $showingAlert, onRestore: restore)
                 Spacer()
                 Text("\(entryDate.formatted())").bold()
                 Spacer()
@@ -37,31 +61,51 @@ struct UpNextEntryView: View {
                 }
             }.padding()
 
-            List(model.episodes, id: \.uuid) { episode in
-                HStack {
-                    EpisodeImage(episode: episode)
-                        .frame(width: 48, height: 48)
-                    VStack(alignment: .leading) {
-                        Text("\(DateFormatHelper.sharedHelper.tinyLocalizedFormat(episode.publishedDate).localizedUppercase)")
-                            .foregroundStyle(theme.primaryText02)
-                            .font(style: .footnote)
-                        Text("\(episode.title ?? "")")
-                            .lineLimit(1)
-                            .font(style: .body)
-                        Text(episode.displayableInfo(includeSize: false))
-                            .foregroundStyle(theme.primaryText02)
-                            .font(style: .footnote)
-                    }
+            episodeList
+        }
+        .navigationTitle("\(entryDate.formatted())")
+        .background(theme.primaryUi04)
+        .applyDefaultThemeOptions()
+    }
+
+    private var episodeList: some View {
+        List(model.episodes, id: \.uuid) { episode in
+            HStack {
+                EpisodeImage(episode: episode)
+                    .frame(width: 48, height: 48)
+                VStack(alignment: .leading) {
+                    Text("\(DateFormatHelper.sharedHelper.tinyLocalizedFormat(episode.publishedDate).localizedUppercase)")
+                        .foregroundStyle(theme.primaryText02)
+                        .font(style: .footnote)
+                    Text("\(episode.title ?? "")")
+                        .lineLimit(1)
+                        .font(style: .body)
+                    Text(episode.displayableInfo(includeSize: false))
+                        .foregroundStyle(theme.primaryText02)
+                        .font(style: .footnote)
                 }
-                .listRowBackground(theme.primaryUi02)
-                .listRowSeparatorTint(theme.primaryUi05)
             }
+            .listRowBackground(theme.primaryUi02)
+            .listRowSeparatorTint(theme.primaryUi05)
         }
         .modifier(HiddenScrollContentBackground())
-        .background(theme.primaryUi04)
         .onAppear { model.loadEpisodes(for: entryDate) }
-        .navigationTitle("\(entryDate.formatted())")
-        .applyDefaultThemeOptions()
+    }
+
+    private func restore() {
+        model.reAddMissingItems(entry: entryDate)
+        dismiss()
+    }
+}
+
+private extension View {
+    func restoreAlert(isPresented: Binding<Bool>, onRestore: @escaping () -> Void) -> some View {
+        alert(L10n.restoreUpNext, isPresented: isPresented, actions: {
+            Button(L10n.restore, action: onRestore)
+            Button(L10n.cancel, role: .cancel) { }
+        }, message: {
+            Text(L10n.restoreUpNextMessage)
+        })
     }
 }
 

--- a/podcasts/UploadedSettingsViewController.xib
+++ b/podcasts/UploadedSettingsViewController.xib
@@ -32,7 +32,7 @@
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="0eS-Ku-0Pk" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="3r5-hd-OuF"/>
+                <constraint firstItem="0eS-Ku-0Pk" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="3r5-hd-OuF"/>
                 <constraint firstItem="0eS-Ku-0Pk" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="kbM-ZW-5Tb"/>
                 <constraint firstItem="0eS-Ku-0Pk" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="pvD-9T-hIa"/>
                 <constraint firstItem="0eS-Ku-0Pk" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="rBN-Ts-68J"/>

--- a/podcasts/UploadedStorageHeaderView.xib
+++ b/podcasts/UploadedStorageHeaderView.xib
@@ -118,7 +118,7 @@
                 <constraint firstAttribute="bottom" secondItem="6oY-Pd-rYs" secondAttribute="bottom" id="4i7-07-ybP"/>
                 <constraint firstItem="6oY-Pd-rYs" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="8ab-Hg-gxg"/>
                 <constraint firstItem="P40-lj-z0V" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="AzG-jW-f67"/>
-                <constraint firstItem="f3w-Vu-PhP" firstAttribute="top" secondItem="P40-lj-z0V" secondAttribute="bottom" constant="-1" id="JHU-Eh-Msk"/>
+                <constraint firstAttribute="bottom" secondItem="f3w-Vu-PhP" secondAttribute="bottom" id="JHU-Eh-Msk"/>
                 <constraint firstAttribute="trailing" secondItem="f3w-Vu-PhP" secondAttribute="trailing" id="WK3-xZ-K46"/>
                 <constraint firstItem="6oY-Pd-rYs" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="btB-cC-6r1"/>
                 <constraint firstAttribute="bottom" secondItem="P40-lj-z0V" secondAttribute="bottom" id="kPB-9I-Bsu"/>

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -11,6 +11,9 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
     @IBOutlet var uploadsTable: ThemeableTable! {
         didSet {
             registerLongPress()
+            if LiquidGlass.isEnabled {
+                uploadsTable.themeStyle = .primaryUi02
+            }
             uploadsTable.allowsMultipleSelectionDuringEditing = true
             uploadsTable.rowHeight = UITableView.automaticDimension
             uploadsTable.estimatedRowHeight = 80

--- a/podcasts/WatchSettingsViewController.xib
+++ b/podcasts/WatchSettingsViewController.xib
@@ -33,7 +33,7 @@
                 <constraint firstItem="taG-l9-Ybb" firstAttribute="bottom" secondItem="i5M-Pr-FkT" secondAttribute="bottom" id="4VF-88-WsC"/>
                 <constraint firstItem="taG-l9-Ybb" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="I7o-fr-VFm"/>
                 <constraint firstItem="taG-l9-Ybb" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="L9J-GC-pHs"/>
-                <constraint firstItem="taG-l9-Ybb" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="rro-aR-Zfb"/>
+                <constraint firstItem="taG-l9-Ybb" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="rro-aR-Zfb"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="139" y="102"/>


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

- Fix top safe area in "Apple Watch" settings, "Files", "File Settings (under "Files")
- Update "Up Next History" details view to use regular navigation bar (fixes safe area as well)
- Update background color on "Files"

  
<img width="320" alt="Screenshot 2026-06-01 at 5 37 32 PM" src="https://github.com/user-attachments/assets/73601a0f-a8d2-49b8-9197-93e211ebe646" />
<img width="320" alt="Screenshot 2026-06-01 at 5 38 26 PM" src="https://github.com/user-attachments/assets/c7104fa0-9074-42b3-bfc6-20937a6b1040" />

<img width="320" alt="Screenshot 2026-06-01 at 5 39 10 PM" src="https://github.com/user-attachments/assets/8b95ebe6-360e-4792-b299-8f129613bc43" />

## To test

Test the top safe area in the listed screens.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
