### PR TITLE
Fix top spacing in PlaylistHeaderView

### DIFF
--- a/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
+++ b/podcasts/New Detail/Playlist Header/PlaylistHeaderView.swift
@@ -31,7 +31,7 @@ struct PlaylistHeaderView: View {
                     Spacer()
                     PlaylistArtworkView(items: viewModel.images, cornerRadius: 8)
                         .frame(width: 192.0, height: 192.0)
-                        .padding(.top, 15.0)
+                        .padding(.top, LiquidGlass.isEnabled ? 0 : 15.0)
                         .shadow(color: .black.opacity(0.2), radius: 30, x: 0, y: 2)
                     Spacer()
                 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Since the app now uses standard navigation bar, it adds safe area at the top, which moved the Playlist header about 15pt below. This PR fixes is, so the header appears visually on the same top offset as the production version.

<img width="1018" height="1029" alt="Screenshot 2026-06-02 at 10 47 19 AM" src="https://github.com/user-attachments/assets/e9627b1d-745a-4026-a872-b09f05936000" />


## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
