### PR TITLE
Fix visual hierarchy in tab bar

### DIFF
--- a/podcasts/Main/MainTabBarController+Animations.swift
+++ b/podcasts/Main/MainTabBarController+Animations.swift
@@ -7,7 +7,11 @@ import UIKit
 extension MainTabBarController {
     /// The queue count knocked out of a continuous capsule with the "list"
     /// lines beside it, as a template image the tab bar tints like every other item.
-    static func composeUpNextTabImage(count: Int) -> UIImage? {
+    ///
+    /// When `selected` is `true`, the capsule is fully filled and the digits
+    /// are punched out as transparent cutouts so the count reads light against
+    /// the tinted pill — the "active tab" counterpart to the resting badge.
+    static func composeUpNextTabImage(count: Int, isSelected: Bool = false) -> UIImage? {
         let clamped = min(99, max(1, count))
 
         // Fixed at the widest (3-digit) size so the tab image never resizes.
@@ -20,26 +24,29 @@ extension MainTabBarController {
             y: ((canvasSize.height - content.height) / 2).rounded()
         )
         let layout = upNextBadgeLayout(count: clamped, origin: origin)
-        let secondaryShadeAlpha: CGFloat = 0.45
+        let secondaryShadeAlpha: CGFloat = isSelected ? 0.45 : 0.9
+        let capsuleFillAlpha: CGFloat = isSelected ? 0.93 : 0.08
 
         return UIGraphicsImageRenderer(size: canvasSize).image { context in
-            let cg = context.cgContext
-
-            UIColor.black.setFill()
-            UIBezierPath(roundedRect: layout.capsule, cornerRadius: layout.capsule.height).fill()
+            UIColor.black.withAlphaComponent(capsuleFillAlpha).setFill()
+            UIBezierPath(roundedRect: layout.capsule, cornerRadius: layout.capsule.height / 2).fill()
 
             let countAsStr = "\(clamped)" as NSString
             let textAttributes: [NSAttributedString.Key: Any] = [.font: layout.font, .foregroundColor: UIColor.black]
             let textSize = countAsStr.size(withAttributes: textAttributes)
-            cg.saveGState()
-            cg.setBlendMode(.destinationOut)
-            countAsStr.draw(
-                at: CGPoint(
-                    x: layout.capsule.midX - textSize.width / 2,
-                    y: layout.capsule.midY - textSize.height / 2),
-                withAttributes: textAttributes
-            )
-            cg.restoreGState()
+            let textOrigin = CGPoint(
+                x: layout.capsule.midX - textSize.width / 2,
+                y: layout.capsule.midY - textSize.height / 2)
+            if isSelected {
+                // Punch the digits out of the filled capsule so the count reads
+                // as transparent against the tinted pill.
+                context.cgContext.saveGState()
+                context.cgContext.setBlendMode(.destinationOut)
+                countAsStr.draw(at: textOrigin, withAttributes: textAttributes)
+                context.cgContext.restoreGState()
+            } else {
+                countAsStr.draw(at: textOrigin, withAttributes: textAttributes)
+            }
 
             UIColor.black.withAlphaComponent(secondaryShadeAlpha).setFill()
             for line in layout.lines {
@@ -63,7 +70,7 @@ extension MainTabBarController {
         let lineCount = 3
         // The shortest (vertically centered) line; off-center lines stretch
         // further left to track the capsule's rounded cap, see below.
-        let baseLineWidth: CGFloat = 10
+        let baseLineWidth: CGFloat = 8
         let lineThickness: CGFloat = 2
         let lineSpacing: CGFloat = 4
 

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -1247,7 +1247,7 @@ extension MainTabBarController {
 
         // A template image so the tab bar tints it like every other item.
         upNextTabBarItem.image = Self.composeUpNextTabImage(count: count)
-        upNextTabBarItem.selectedImage = nil
+        upNextTabBarItem.selectedImage = Self.composeUpNextTabImage(count: count, isSelected: true)
 
         // Only celebrate the queue growing — a drain (playing/removing) shouldn't pop.
         if previous.map({ count > $0 }) ?? false { pulseUpNextTabButton() }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Worked with David to adjust the tab bar "Up Next" button a bit so it fits better with other items and doesn't fight with "play" for attention.

## To test

In the non-selected state, the colors are now inverted.

<img width="544" alt="Screenshot 2026-06-02 at 1 03 49 PM" src="https://github.com/user-attachments/assets/0f454d77-1a54-4aa4-a23c-dbe8929d1322" />

The selected state looks the same:

<img width="545"  alt="Screenshot 2026-06-02 at 1 03 53 PM" src="https://github.com/user-attachments/assets/751e0ae3-e0e1-4bd4-be5a-0e521a7a34a0" />

Try different themes and dark mode.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
