### PR TITLE
Oversample fingerprint windows to fix post-ad transcript sync

### DIFF
--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -17,8 +17,18 @@ enum FingerprintConstants {
     /// Duration of each windowed fingerprint produced during live matching, in milliseconds.
     static let windowDurationMs: UInt32 = 8000
 
-    /// Interval between windowed fingerprints produced during live matching, in milliseconds.
-    static let windowIntervalMs: UInt32 = 2000
+    /// Interval between windowed fingerprints emitted during live matching, in
+    /// milliseconds. Deliberately FINER than the reference's 2s checkpoint grid
+    /// (oversampling). A dynamic ad whose duration isn't a 2s multiple phase-shifts
+    /// our windows off that grid, so at a 2s stride every following window straddles
+    /// two checkpoints and matches neither cleanly (the post-mid-roll failure).
+    /// Emitting every 1s guarantees that for any ad offset a window lands within
+    /// ~0.5s of a checkpoint — that well-aligned window scores dominantly and
+    /// commits, while the off-phase ones straddle and are dropped by the existing
+    /// dominance gate. No score inflation, no gate changes, so precision is
+    /// unchanged elsewhere. Cost: ~2x window hashing/matching. Halve again (500) for
+    /// ~0.25s alignment if 1s doesn't score dominantly enough post-ad.
+    static let windowIntervalMs: UInt32 = 1000
 
     /// Seconds of decoded PCM read per AVAudioFile chunk during streaming
     /// fingerprint generation. Smaller = more responsive UI, larger = less per-call overhead.

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -600,11 +600,11 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
-    /// Snap a playback time to the window-interval grid so that the windows we
-    /// emit align with the reference checkpoint timestamps. The reference is
-    /// produced with the same `windowIntervalMs` stride starting at 0, so any
-    /// off-grid start would yield windows whose audio content is shifted
-    /// relative to the reference and would fail to match.
+    /// Snap a playback time to the window-interval grid so emitted window
+    /// timestamps are deterministic (stable across restarts and cache reuse).
+    /// Windows are emitted every `windowIntervalMs`, finer than the reference's
+    /// 2s checkpoint grid, so a correctly-phased window exists for any dynamic-ad
+    /// offset rather than relying on a single phase happening to line up.
     private static func alignToWindowGrid(_ time: Double) -> Double {
         let stride = Double(FingerprintConstants.windowIntervalMs) / 1000.0
         guard stride > 0 else { return max(0, time) }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Dynamic ads whose duration isn't a multiple of the 2s fingerprint window interval phase-shift every following query window off the reference's 2s checkpoint grid. At a 2s stride, each post-ad window straddles two checkpoints and matches neither cleanly — so synced-transcript highlighting went quiet or **desynced for the rest of the episode** after a mid-roll.

This emits query windows every **1s instead of 2s** (finer than the reference grid). For any ad offset, one window now lands within ~0.5s of a checkpoint, scores dominantly, and commits through the **existing** dominance gate; the off-phase windows straddle and are dropped exactly as before.

**Why this approach.** Earlier attempts traded correctness for coverage: raising the matcher's `maxDrift` inflated scores globally and committed wrong-offset anchors (backwards/jittery highlighting); loosening the dominance gate admitted far-away false matches. Oversampling leaves the matcher and every filter **exactly as `trunk`** — so precision in already-aligned regions is unchanged and there's no backwards-anchor risk. It just guarantees a correctly-phased window is always available.

**Cost.** Measured on a physical device: ~3.2% of one core (window hashing); matcher cost negligible (~0.1%). The one knob if 1s isn't dominant enough on some episodes is dropping `windowIntervalMs` to `500` (~0.25s alignment, roughly 2× this cost — still small).

> Draft pending a final on-device confirmation that highlighting stays synced through the mid-roll across a couple of ad-heavy episodes.

## To test

1. Enable the `syncedTranscripts` feature flag (Developer settings) and download an episode that has a dynamic mid-roll ad *and* a server fingerprint — e.g. The Daily, "Popcast: Olivia Rodrigo" (ping me so I can share my file with the dynamic ad that contains residual)
2. Play it and open the transcript; wait for the fingerprint state to reach `active` (debug overlay turns green).
3. Play through the mid-roll ad and confirm the highlight **stays synced with the audio for the rest of the episode** (before this change it went quiet / desynced after the first mid-roll).
4. Confirm pre-ad highlighting is unchanged (still synced, no jitter).
5. (Optional) Watch the debug overlay: the post-ad region should fill in green rather than red.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
