### PR TITLE
Fix missing nav bar appearance override in player

### DIFF
--- a/podcasts/PCNavigationController.swift
+++ b/podcasts/PCNavigationController.swift
@@ -46,7 +46,17 @@ class PCNavigationController: UINavigationController, UIGestureRecognizerDelegat
     }
 
     private func updateNavColors() {
-        guard !LiquidGlass.isEnabled else { return }
+        guard !LiquidGlass.isEnabled else {
+            // Under Liquid Glass we rely on the system glass nav bar, which derives its
+            // title/button colors from the interface style. Force it to match the nav
+            // controller's theme override so an always-dark screen like Up Next keeps a
+            // light title even after content scrolls under the bar (otherwise the glass
+            // renders with the ambient appearance and the title flips to black on scroll).
+            if let themeOverride {
+                overrideUserInterfaceStyle = themeOverride.isDark ? .dark : .light
+            }
+            return
+        }
 
         let appearance = UINavigationBarAppearance()
         appearance.configureWithOpaqueBackground()


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Fix missing nav bar appearance override in player

## To test

- Device on light mode
- In Settings / Appearance enable "Up Next Dark Mode in Player"
- Open Player / Up Next
- Scroll
- Verify that nav bar title is always visible

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
