### PR TITLE
Stop transcript highlighting during ads

### DIFF
--- a/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
@@ -335,6 +335,22 @@ final class FingerprintTimingManagerTests: XCTestCase {
         XCTAssertFalse(manager.evaluateAdStateForTesting(playbackTime: 25, processedStart: 10, processedFrontier: 40, hasReachedActive: false))
     }
 
+    func testSeekForwardAheadOfFingerprintingNotFlaggedAsAd() {
+        let manager = FingerprintTimingManager()
+        // Anchors from before a forward seek, all clustered near the start.
+        [0, 2, 4].forEach { manager.insert(mapping: Entry(playbackTime: Double($0), referenceTime: Double($0))) }
+
+        // The listener seeks far ahead to 300 s; the stream re-anchors there and
+        // has only examined a few seconds past it. The nearest anchor at-or-before
+        // is the stale one at 4 s — without clamping the bounds to the examined
+        // range, the gap (4 → 305) reads as a 300 s ad. It must not.
+        XCTAssertFalse(manager.evaluateAdStateForTesting(playbackTime: 300, processedStart: 300, processedFrontier: 305))
+
+        // Once the loop has examined well past the resume point with nothing
+        // matching, it genuinely is unmatched audio (a post-seek ad) and flags.
+        XCTAssertTrue(manager.evaluateAdStateForTesting(playbackTime: 300, processedStart: 300, processedFrontier: 320))
+    }
+
     func testGapWidthUsesStrictThreshold() {
         // Exactly adCoverageGapSeconds (12) wide → not an ad (strict greater-than).
         let atThreshold = FingerprintTimingManager()

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
@@ -269,4 +269,81 @@ final class FingerprintTimingManagerTests: XCTestCase {
         XCTAssertEqual(first, 100.0, accuracy: 0.001)
         XCTAssertEqual(last, 200.0, accuracy: 0.001)
     }
+
+    // MARK: - Ad detection
+
+    /// adCoverageGapSeconds is 12; anchors land roughly every window interval, so
+    /// these scenarios space anchors apart to model the unmatched stretches the
+    /// detector treats as dynamically inserted ads.
+
+    func testPreRollFlaggedAsAd() {
+        let manager = FingerprintTimingManager()
+        // First matched content starts at playback=30; nothing matched below it.
+        [30, 32, 34].forEach { manager.insert(mapping: Entry(playbackTime: Double($0), referenceTime: Double($0))) }
+
+        // Inside the pre-roll: bounded below by processedStart (0) and above by the
+        // first anchor (30) → a 30 s gap, well over the 12 s threshold.
+        XCTAssertTrue(manager.evaluateAdStateForTesting(playbackTime: 10, processedStart: 0, processedFrontier: 34))
+
+        // Once playback reaches matched content the surrounding anchors are ~2 s
+        // apart, so the same position range is no longer an ad.
+        XCTAssertFalse(manager.evaluateAdStateForTesting(playbackTime: 31, processedStart: 0, processedFrontier: 34))
+    }
+
+    func testMidRollGapBetweenTwoAnchorsFlaggedAsAd() {
+        let manager = FingerprintTimingManager()
+        // Two tight clusters of content with a 16 s unmatched gap (4 → 20) between.
+        [0, 2, 4, 20, 22, 24].forEach { manager.insert(mapping: Entry(playbackTime: Double($0), referenceTime: Double($0))) }
+
+        // Inside the gap: bounded by anchors 4 and 20 → 16 s > 12 s.
+        XCTAssertTrue(manager.evaluateAdStateForTesting(playbackTime: 12, processedStart: 0, processedFrontier: 24))
+
+        // Before the gap, surrounded by 2 s-apart anchors → not an ad.
+        XCTAssertFalse(manager.evaluateAdStateForTesting(playbackTime: 2, processedStart: 0, processedFrontier: 24))
+
+        // The ad clears exactly when playback reaches the next matched anchor (20),
+        // not partway through the gap.
+        XCTAssertFalse(manager.evaluateAdStateForTesting(playbackTime: 22, processedStart: 0, processedFrontier: 24))
+    }
+
+    func testPostRollFlaggedAsAdBoundedByFrontier() {
+        let manager = FingerprintTimingManager()
+        // Last matched content is at playback=4; the loop has confirmed audio out
+        // to the frontier at 30 with nothing matching beyond 4.
+        [0, 2, 4].forEach { manager.insert(mapping: Entry(playbackTime: Double($0), referenceTime: Double($0))) }
+
+        // Past the final anchor: bounded above by processedFrontier (30) → 26 s gap.
+        XCTAssertTrue(manager.evaluateAdStateForTesting(playbackTime: 20, processedStart: 0, processedFrontier: 30))
+
+        // Still inside matched content → not an ad.
+        XCTAssertFalse(manager.evaluateAdStateForTesting(playbackTime: 2, processedStart: 0, processedFrontier: 30))
+    }
+
+    func testPositionsOutsideProcessedRangeNotFlagged() {
+        let manager = FingerprintTimingManager()
+        // A huge 50 s gap between the only two anchors — tempting to flag — but the
+        // examined range is just [10, 40].
+        [0, 50].forEach { manager.insert(mapping: Entry(playbackTime: Double($0), referenceTime: Double($0))) }
+
+        // Below processedStart: coverage there hasn't been generated, so not an ad.
+        XCTAssertFalse(manager.evaluateAdStateForTesting(playbackTime: 5, processedStart: 10, processedFrontier: 40))
+
+        // Above processedFrontier (the live-streaming edge): likewise not an ad.
+        XCTAssertFalse(manager.evaluateAdStateForTesting(playbackTime: 60, processedStart: 10, processedFrontier: 40))
+
+        // Even inside the range, nothing is flagged until the manager is active.
+        XCTAssertFalse(manager.evaluateAdStateForTesting(playbackTime: 25, processedStart: 10, processedFrontier: 40, hasReachedActive: false))
+    }
+
+    func testGapWidthUsesStrictThreshold() {
+        // Exactly adCoverageGapSeconds (12) wide → not an ad (strict greater-than).
+        let atThreshold = FingerprintTimingManager()
+        [0, 12].forEach { atThreshold.insert(mapping: Entry(playbackTime: Double($0), referenceTime: Double($0))) }
+        XCTAssertFalse(atThreshold.evaluateAdStateForTesting(playbackTime: 6, processedStart: 0, processedFrontier: 12))
+
+        // Just over the threshold → an ad.
+        let overThreshold = FingerprintTimingManager()
+        [0, 12.5].forEach { overThreshold.insert(mapping: Entry(playbackTime: $0, referenceTime: $0)) }
+        XCTAssertTrue(overThreshold.evaluateAdStateForTesting(playbackTime: 6, processedStart: 0, processedFrontier: 12.5))
+    }
 }

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -25,6 +25,7 @@ struct Constants {
         static let dimmingViewTapped = NSNotification.Name(rawValue: "SJDimViewTapped")
         static let downloadProgress = NSNotification.Name(rawValue: "SJDwnProg")
         static let podcastImageReCacheRequired = NSNotification.Name(rawValue: "PCPodcastImageReCacheRequired")
+        static let fingerprintAdStateChanged = NSNotification.Name(rawValue: "PCFingerprintAdStateChanged")
 
         static let skipTimesChanged = NSNotification.Name(rawValue: "SJSkipTimesChanged")
         static let subscribeRequestedFromCell = NSNotification.Name(rawValue: "SJSubscribeRequestFromCell")

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -101,4 +101,15 @@ enum FingerprintConstants {
     /// Persistent cache schema version. Bump when the on-disk shape changes so
     /// older files are silently discarded on the next load.
     static let mappingCacheSchemaVersion: Int = 2
+
+    /// Widest unmatched stretch, in seconds on the playback axis, allowed before
+    /// it counts as an ad. During matched playback the drift filter commits
+    /// anchors every window interval or so, so a stretch wider than this — bounded
+    /// by the surrounding anchors, or by the examined range at the timeline edges
+    /// (pre/post-roll) — is content the matcher refused, in practice a
+    /// dynamically inserted ad. Used to stop transcript highlighting across the
+    /// stretch instead of extrapolating through it. Measured as the full bounded
+    /// width (not distance to the nearest anchor) so the ad clears exactly when
+    /// playback reaches the next matched anchor.
+    static let adCoverageGapSeconds: Double = 12
 }

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -1254,6 +1254,27 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
+    /// Test seam: configures the processed range plus the active flag and runs
+    /// the ad-detection evaluation synchronously on the manager's serial queue —
+    /// the way `processProgress` does each tick — returning the resulting
+    /// queue-confined ad state. The public `isAdInProgress` mirror is updated
+    /// asynchronously on the main thread, so tests read this return value to stay
+    /// deterministic. Set up the anchor mapping first via `insert(mapping:)`.
+    func evaluateAdStateForTesting(
+        playbackTime: Double,
+        processedStart: Double,
+        processedFrontier: Double,
+        hasReachedActive: Bool = true
+    ) -> Bool {
+        queue.sync {
+            self.hasReachedActive = hasReachedActive
+            self.processedStart = processedStart
+            self.processedFrontier = processedFrontier
+            evaluateAdState(playbackTime: playbackTime)
+            return adInProgress
+        }
+    }
+
     private func insertMapping(_ entry: TimeMappingEntry) {
         let pbIdx = playbackToReference.sortedInsertionIndex { $0.playbackTime < entry.playbackTime }
         playbackToReference.insert(entry, at: pbIdx)

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -257,7 +257,10 @@ final class FingerprintTimingManager: NSObject {
     /// Only positions the loop has actually examined are judged. Outside
     /// `[processedStart, processedFrontier]` coverage simply hasn't been generated
     /// yet (notably the live-streaming edge), and flagging an ad there would
-    /// suppress legitimate highlighting.
+    /// suppress legitimate highlighting. For the same reason the bounding anchors
+    /// are clamped to that range — an anchor left behind by a pre-seek stream
+    /// segment must not stretch the measured gap across audio this stream never
+    /// examined.
     private func evaluateAdState(playbackTime: Double) {
         guard hasReachedActive,
               playbackTime >= processedStart,
@@ -277,8 +280,15 @@ final class FingerprintTimingManager: NSObject {
             above = playbackToReference.isEmpty ? nil : 0
         }
 
-        let lowerBound = below.map { playbackToReference[$0].playbackTime } ?? processedStart
-        let upperBound = above.map { playbackToReference[$0].playbackTime } ?? processedFrontier
+        // Clamp the bounding anchors to the examined range. Only
+        // `[processedStart, processedFrontier]` was actually fingerprinted by the
+        // current stream; an anchor outside it belongs to an earlier segment with
+        // unexamined audio in between. Without this clamp, seeking forward — which
+        // keeps the pre-seek anchors far behind the freshly re-anchored resume
+        // point — would measure the entire skipped span as one unmatched stretch
+        // and false-flag an ad while the loop is merely catching up.
+        let lowerBound = max(below.map { playbackToReference[$0].playbackTime } ?? processedStart, processedStart)
+        let upperBound = min(above.map { playbackToReference[$0].playbackTime } ?? processedFrontier, processedFrontier)
 
         setAdInProgress(upperBound - lowerBound > FingerprintConstants.adCoverageGapSeconds)
     }

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -1043,8 +1043,12 @@ final class FingerprintTimingManager: NSObject {
         // whether anything matched — windows are emitted continuously, so a
         // stretch examined here that commits no anchor is confirmed unmatched
         // audio (an ad), which is exactly what ad detection needs to know.
+        // `timestampMs` is the window's start, so add its duration to reach the
+        // audio actually examined; otherwise the frontier trails by up to one
+        // window and ad detection would briefly treat positions near it as
+        // unprocessed, flickering highlighting back on right behind the edge.
         if let lastWindow = windows.last {
-            let batchEnd = startOffset + Double(lastWindow.timestampMs) / 1000.0
+            let batchEnd = startOffset + Double(lastWindow.timestampMs + lastWindow.durationMs) / 1000.0
             processedFrontier = max(processedFrontier, batchEnd)
         }
 

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -34,6 +34,12 @@ final class FingerprintTimingManager: NSObject {
 
     private(set) var state: State = .idle
 
+    /// True while the listener is inside a stretch of audio the matcher no longer
+    /// recognises — typically a dynamically inserted mid-roll ad. Updated on the
+    /// main thread; read it from the transcript UI to stop highlighting during
+    /// ads. Transitions also post `Constants.Notifications.fingerprintAdStateChanged`.
+    private(set) var isAdInProgress = false
+
     // MARK: - Internal Types
 
     private struct GenerationContext {
@@ -86,6 +92,19 @@ final class FingerprintTimingManager: NSObject {
     private var preparationStartDate: Date?
     private var hasReachedActive = false
     private var hasEmittedPreparationStarted = false
+
+    /// Queue-confined mirror of `isAdInProgress` used to detect transitions
+    /// without hopping to the main thread on every progress tick.
+    private var adInProgress = false
+
+    /// Playback-axis range, in seconds, the fingerprint loop has actually
+    /// examined for the current stream. Anything inside this range that produced
+    /// no matched anchor is genuinely unmatched audio (an ad); anything outside
+    /// it simply hasn't been generated yet, so we can't call it. `start` is where
+    /// the current stream was anchored, `frontier` is the furthest window matched
+    /// so far. Default ordering (start > frontier) means "nothing processed yet".
+    private var processedStart: Double = .greatestFiniteMagnitude
+    private var processedFrontier: Double = -1
 
     // Drift-filter state — see `consider(candidate:)`.
     private var filterLastTrusted: TimeMappingEntry?
@@ -177,6 +196,8 @@ final class FingerprintTimingManager: NSObject {
     private func processProgress(playbackTime: Double, episodeUuid: String?) {
         guard let ctx = context, ctx.episodeUuid == episodeUuid else { return }
 
+        evaluateAdState(playbackTime: playbackTime)
+
         if lastProgressPosition >= 0 {
             let delta = abs(playbackTime - lastProgressPosition)
             if delta > FingerprintConstants.restartDeltaSeconds {
@@ -208,6 +229,88 @@ final class FingerprintTimingManager: NSObject {
         )
         #endif
         restart(from: playbackTime, context: ctx)
+    }
+
+    // MARK: - Ad Detection
+
+    /// Decide whether the current playback position sits in an ad and flip
+    /// `isAdInProgress` accordingly.
+    ///
+    /// The position is an ad when it falls inside an unmatched stretch wider than
+    /// `adCoverageGapSeconds`. During matched playback anchors land roughly every
+    /// window interval, so a stretch this wide is content the matcher refused.
+    /// The stretch is bounded by:
+    /// - below: the nearest anchor at or before the position, or — when there's
+    ///   none (the position is before the first anchor, i.e. a pre-roll) — the
+    ///   point where the loop began examining audio (`processedStart`);
+    /// - above: the nearest anchor at or after the position, or — when there's
+    ///   none (the position is beyond the last anchor, i.e. a post-roll or
+    ///   mid-roll not yet exited) — how far the loop has confirmed unmatched
+    ///   (`processedFrontier`).
+    ///
+    /// Measuring the full bounded width, rather than the distance to the nearest
+    /// anchor, matters because the first anchor after an ad sits exactly where
+    /// real content resumes and is usually committed (the loop runs ahead) while
+    /// the listener is still in the ad; distance-to-nearest would clear the ad up
+    /// to `adCoverageGapSeconds` early as playback merely approached it.
+    ///
+    /// Only positions the loop has actually examined are judged. Outside
+    /// `[processedStart, processedFrontier]` coverage simply hasn't been generated
+    /// yet (notably the live-streaming edge), and flagging an ad there would
+    /// suppress legitimate highlighting.
+    private func evaluateAdState(playbackTime: Double) {
+        guard hasReachedActive,
+              playbackTime >= processedStart,
+              playbackTime <= processedFrontier else {
+            setAdInProgress(false)
+            return
+        }
+
+        let below = lastAnchorIndex(atOrBefore: playbackTime)
+        // The anchor bounding the position from above: the one after `below`, or
+        // the very first anchor when the position precedes them all (pre-roll).
+        let above: Int?
+        if let below {
+            let next = below + 1
+            above = playbackToReference.indices.contains(next) ? next : nil
+        } else {
+            above = playbackToReference.isEmpty ? nil : 0
+        }
+
+        let lowerBound = below.map { playbackToReference[$0].playbackTime } ?? processedStart
+        let upperBound = above.map { playbackToReference[$0].playbackTime } ?? processedFrontier
+
+        setAdInProgress(upperBound - lowerBound > FingerprintConstants.adCoverageGapSeconds)
+    }
+
+    /// Index of the last anchor whose `playbackTime` is `<= playbackTime`, or nil
+    /// if the position is before every anchor.
+    private func lastAnchorIndex(atOrBefore playbackTime: Double) -> Int? {
+        guard let first = playbackToReference.first, playbackTime >= first.playbackTime else { return nil }
+        var lo = 0
+        var hi = playbackToReference.count - 1
+        while lo < hi {
+            let mid = (lo + hi + 1) / 2
+            if playbackToReference[mid].playbackTime <= playbackTime {
+                lo = mid
+            } else {
+                hi = mid - 1
+            }
+        }
+        return lo
+    }
+
+    private func setAdInProgress(_ inAd: Bool) {
+        guard inAd != adInProgress else { return }
+        adInProgress = inAd
+        #if DEBUG
+        FileLog.shared.addMessage("FingerprintTimingManager: ad \(inAd ? "started" : "ended")")
+        #endif
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.isAdInProgress = inAd
+            NotificationCenter.default.post(name: Constants.Notifications.fingerprintAdStateChanged, object: nil)
+        }
     }
 
     private func isWithinMappedRange(_ playbackTime: Double) -> Bool {
@@ -301,6 +404,9 @@ final class FingerprintTimingManager: NSObject {
         preparationStartDate = nil
         hasReachedActive = false
         hasEmittedPreparationStarted = false
+        processedStart = .greatestFiniteMagnitude
+        processedFrontier = -1
+        setAdInProgress(false)
         resetFilterState()
         #if DEBUG
         debugRejections.removeAll()
@@ -501,6 +607,11 @@ final class FingerprintTimingManager: NSObject {
             // entry through `insertMapping`'s per-entry `Array.insert`.
             playbackToReference = cached.entries
             referenceToPlayback = cached.entries.sorted { $0.referenceTime < $1.referenceTime }
+            // A full-coverage cache is only written after a prior session
+            // fingerprinted the entire file, so the whole timeline counts as
+            // processed — gaps in it are real ads, including pre/post-roll.
+            processedStart = 0
+            processedFrontier = duration
 
             if isWithinMappedRange(currentTime) {
                 filterLastTrusted = cached.entries.last
@@ -538,6 +649,11 @@ final class FingerprintTimingManager: NSObject {
     /// actually hearing — without waiting for the entire file to be processed.
     private func startStream(context ctx: GenerationContext, fromPosition position: Double) {
         let aligned = Self.alignToWindowGrid(position)
+        // A (re)started stream re-examines the audio from `aligned` forward, so
+        // the confirmed-processed range collapses to that point and grows again
+        // as windows are matched. Ad detection only trusts this range.
+        processedStart = aligned
+        processedFrontier = aligned
         generationQueue.async { [weak self] in
             guard let self else { return }
             do {
@@ -923,6 +1039,15 @@ final class FingerprintTimingManager: NSObject {
         startOffset: Double,
         context ctx: GenerationContext
     ) {
+        // Advance the processed frontier to the end of this batch regardless of
+        // whether anything matched — windows are emitted continuously, so a
+        // stretch examined here that commits no anchor is confirmed unmatched
+        // audio (an ad), which is exactly what ad detection needs to know.
+        if let lastWindow = windows.last {
+            let batchEnd = startOffset + Double(lastWindow.timestampMs) / 1000.0
+            processedFrontier = max(processedFrontier, batchEnd)
+        }
+
         var inserted = 0
         #if DEBUG
         var bestScoreOverall: Float = 0

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -848,7 +848,17 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             addCustomObserver(Constants.Notifications.playbackStarted, selector: #selector(updateHighlightDisplayLinkPauseState))
             addCustomObserver(Constants.Notifications.playbackPaused, selector: #selector(updateHighlightDisplayLinkPauseState))
             addCustomObserver(Constants.Notifications.playbackEnded, selector: #selector(updateHighlightDisplayLinkPauseState))
+            addCustomObserver(Constants.Notifications.fingerprintAdStateChanged, selector: #selector(adStateChanged))
         }
+    }
+
+    @objc private func adStateChanged() {
+        // Clear or restore the highlight immediately rather than waiting for the
+        // next display-link tick.
+        updateTranscriptPosition()
+        #if DEBUG
+        Toast.show(FingerprintTimingManager.shared.isAdInProgress ? "Ad in progress" : "Ad finished")
+        #endif
     }
 
     @objc private func updateTranscriptPosition() {
@@ -859,6 +869,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         // highlight arbitrary VTT lines during ads and other non-matching audio.
         let rawTime = playbackManager.currentTime()
         guard case .active = FingerprintTimingManager.shared.state,
+              !FingerprintTimingManager.shared.isAdInProgress,
               let position = FingerprintTimingManager.shared.referenceTime(forPlaybackTime: rawTime) else {
             if previousRange != nil {
                 previousRange = nil


### PR DESCRIPTION
Synced-transcript highlighting kept advancing **during ads**: the playback→reference time mapping interpolates (and extrapolates) across stretches the fingerprint matcher never matched, so the highlight either crept forward or froze on a line while an ad played. The existing `.active` guard didn't catch this because the manager stays `.active` and `referenceTime(_:)` still returns a value across the gap.

This PR detects unmatched stretches and pauses highlighting until matched content resumes — for **pre-, mid- and post-roll** ads.

**How it works**
- `FingerprintTimingManager` tracks the playback range the loop has actually examined, `[processedStart, processedFrontier]`. The frontier advances for every matched batch *whether or not it committed an anchor*, so a stretch examined-but-unmatched is confirmed ad audio.
- `isAdInProgress` is set when the playhead sits inside an unmatched stretch wider than `adCoverageGapSeconds` (12s), bounded by the surrounding anchors or — at the timeline edges — the examined range. Positions outside the examined range are never flagged (that's the live-streaming edge, where coverage just hasn't been generated yet).
- The stretch is measured as a full bounded width, not distance-to-nearest-anchor, so the ad clears exactly when playback **reaches** the next matched anchor rather than ~12s early.
- `TranscriptViewController` reads the flag to clear/restore the highlight, and **debug builds** show an "Ad in progress" / "Ad finished" toast on each transition.

Branched off `fix/synced-transcript-window-oversampling` and targets it (the oversampling change makes the matcher recover faster *after* an ad; this one stops the highlight *during* it).

## To test

1. Build a debug/staging build and enable the `syncedTranscripts` feature flag.
2. Play an episode (ideally downloaded) that contains a dynamically inserted **mid-roll** ad, and open the transcript.
3. When the ad starts, confirm highlighting **stops** and an "Ad in progress" toast appears.
4. When the ad ends, confirm highlighting **resumes on the correct line** as the real audio returns, and an "Ad finished" toast appears (it should land as the audio resumes, not seconds early).
5. Repeat with an episode that has a **pre-roll** and one with a **post-roll** ad; highlighting should not run during either.
6. Sanity check a clean (ad-free) episode: highlighting tracks normally with no toasts.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.