### PR TITLE
[PC TV] Playlist – "Play All"

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -39,7 +39,7 @@ struct PlaylistDetailView: View {
             titleVisibility: .visible
         ) {
             Button(L10n.playlistPlayAllSheetButtonTitle, role: .confirm) {
-                model.playAllEpisodes()
+                model.buttonConfirmPlayPlaylistTapped()
             }
             Button(L10n.cancel, role: .cancel) {}
         } message: {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -20,6 +20,7 @@ struct PlaylistDetailView: View {
     }
 
     var body: some View {
+        @Bindable var model = model
         ZStack {
             switch model.state {
             case .loading:
@@ -32,6 +33,22 @@ struct PlaylistDetailView: View {
         .defaultFocus($focusedSection, .episodes)
         .onAppear { tabRouter.isShowingDetail = true }
         .onDisappear { tabRouter.isShowingDetail = false }
+        .confirmationDialog(
+            L10n.playlistPlayAllSheetTitle,
+            isPresented: $model.isShowingReplaceUpNextConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(L10n.playlistPlayAllSheetButtonTitle, role: .confirm) {
+                model.playAllEpisodes()
+            }
+            Button(L10n.cancel, role: .cancel) {}
+        } message: {
+            Text(L10n.playlistPlayAllSheetDescription)
+        }
+        .fullScreenCover(isPresented: $model.isShowingNowPlaying) {
+            NowPlayingView()
+                .ignoresSafeArea()
+        }
         .task {
             model.load()
         }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -15,6 +15,12 @@ class PlaylistDetailsViewModel {
 
     var state: State = .loading
 
+    /// Drives the "Replace your Up Next?" confirmation dialog before playing all episodes.
+    var isShowingReplaceUpNextConfirmation = false
+
+    /// Drives the full-screen Now Playing presentation once playback starts.
+    var isShowingNowPlaying = false
+
     let playlist: EpisodeFilter
     var episodes: [Episode] = []
 
@@ -40,7 +46,22 @@ class PlaylistDetailsViewModel {
     }
 
     func playAll() {
+        guard !episodes.isEmpty else { return }
+
+        switch playbackManager.playAllAction(forPlaylistEpisodeIDs: episodes.map(\.uuid)) {
+        case .play:
+            playAllEpisodes()
+        case .confirmReplaceUpNext:
+            isShowingReplaceUpNextConfirmation = true
+        case .resumeCurrent:
+            playbackManager.resumeIfPaused()
+            isShowingNowPlaying = true
+        }
+    }
+
+    func playAllEpisodes() {
         playbackManager.play(playlist: playlist)
+        isShowingNowPlaying = true
     }
 
     var playlistName: String {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -15,10 +15,7 @@ class PlaylistDetailsViewModel {
 
     var state: State = .loading
 
-    /// Drives the "Replace your Up Next?" confirmation dialog before playing all episodes.
     var isShowingReplaceUpNextConfirmation = false
-
-    /// Drives the full-screen Now Playing presentation once playback starts.
     var isShowingNowPlaying = false
 
     let playlist: EpisodeFilter
@@ -48,18 +45,14 @@ class PlaylistDetailsViewModel {
     func playAll() {
         guard !episodes.isEmpty else { return }
 
-        switch playbackManager.playAllAction(forPlaylistEpisodeIDs: episodes.map(\.uuid)) {
-        case .play:
-            playAllEpisodes()
-        case .confirmReplaceUpNext:
-            isShowingReplaceUpNextConfirmation = true
-        case .resumeCurrent:
-            playbackManager.resumeIfPaused()
+        if playbackManager.playIfSafe(playlist: playlist, episodeIDs: episodes.map(\.uuid)) {
             isShowingNowPlaying = true
+        } else {
+            isShowingReplaceUpNextConfirmation = true
         }
     }
 
-    func playAllEpisodes() {
+    func buttonConfirmPlayPlaylistTapped() {
         playbackManager.play(playlist: playlist)
         isShowingNowPlaying = true
     }

--- a/podcasts/New Detail/PlaylistDetailViewController+PlayAll.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+PlayAll.swift
@@ -7,49 +7,16 @@ extension PlaylistDetailViewController: UISheetPresentationControllerDelegate, P
 
         track(.filterPlayAllTapped)
 
-        Task { [weak self] in
-            guard let self else { return }
-            let hasDifferencesWithUpNext = await self.checkDifferencesWithUpNext()
-            if hasDifferencesWithUpNext {
-                if PlaybackManager.shared.queue.upNextCount() == 0 {
-                    // there's nothing to over-write, so nothing to confirm either
-                    await MainActor.run {
-                        self.viewModel.playAllEpisodes()
-                    }
-                    return
-                }
-                await MainActor.run {
-                    let sheet = PlaylistPlayAllSheetHost(delegate: self)
-                    self.present(sheet, animated: true)
-                }
-            } else if !PlaybackManager.shared.playing() {
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackStarting)
-                PlaybackManager.shared.play()
-            }
+        let playlistEpisodeIDs = viewModel.episodes.map { $0.episode.uuid }
+        switch PlaybackManager.shared.playAllAction(forPlaylistEpisodeIDs: playlistEpisodeIDs) {
+        case .play:
+            viewModel.playAllEpisodes()
+        case .confirmReplaceUpNext:
+            let sheet = PlaylistPlayAllSheetHost(delegate: self)
+            present(sheet, animated: true)
+        case .resumeCurrent:
+            PlaybackManager.shared.resumeIfPaused()
         }
-    }
-
-    private func checkDifferencesWithUpNext() async -> Bool {
-        let playlistEpisodeUuids = viewModel.episodes.map { $0.episode.uuid }
-        let upNextEpisodeUuids = viewModel.dataManager.allUpNextEpisodeUuids().compactMap(\.uuid)
-
-        if playlistEpisodeUuids.count != upNextEpisodeUuids.count {
-            return true
-        }
-
-        if playlistEpisodeUuids != upNextEpisodeUuids {
-            return true
-        }
-
-        guard let firstPlaylistUuid = playlistEpisodeUuids.first else {
-            return false
-        }
-
-        guard let currentUuid = PlaybackManager.shared.currentEpisode()?.uuid else {
-            return true
-        }
-
-        return currentUuid != firstPlaylistUuid
     }
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {

--- a/podcasts/New Detail/PlaylistDetailViewController+PlayAll.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+PlayAll.swift
@@ -8,14 +8,9 @@ extension PlaylistDetailViewController: UISheetPresentationControllerDelegate, P
         track(.filterPlayAllTapped)
 
         let playlistEpisodeIDs = viewModel.episodes.map { $0.episode.uuid }
-        switch PlaybackManager.shared.playAllAction(forPlaylistEpisodeIDs: playlistEpisodeIDs) {
-        case .play:
-            viewModel.playAllEpisodes()
-        case .confirmReplaceUpNext:
+        if !PlaybackManager.shared.playIfSafe(playlist: viewModel.playlist, episodeIDs: playlistEpisodeIDs) {
             let sheet = PlaylistPlayAllSheetHost(delegate: self)
             present(sheet, animated: true)
-        case .resumeCurrent:
-            PlaybackManager.shared.resumeIfPaused()
         }
     }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -691,6 +691,56 @@ class PlaybackManager: ServerPlaybackDelegate {
         uuidOfPlayingList = playlist.uuid
     }
 
+    /// The action to take when the user asks to play every episode of a playlist, based on how the
+    /// playlist's episodes compare to the current Up Next queue and playback state.
+    enum PlayAllAction {
+        /// The playlist differs from Up Next and there's nothing queued to overwrite — start playing.
+        case play
+        /// The playlist differs from a non-empty Up Next — confirm replacing it before playing.
+        case confirmReplaceUpNext
+        /// The playlist already matches the current Up Next — resume the existing playback.
+        case resumeCurrent
+    }
+
+    func playAllAction(forPlaylistEpisodeIDs playlistEpisodeIDs: [String]) -> PlayAllAction {
+        let upNextEpisodeIDs = DataManager.sharedManager
+            .allUpNextEpisodeUuids()
+            .compactMap(\.uuid)
+        guard Self.playlistDiffersFromUpNext(playlistEpisodeIDs: playlistEpisodeIDs, upNextEpisodeIDs: upNextEpisodeIDs, currentEpisodeID: currentEpisode()?.uuid) else {
+            return .resumeCurrent
+        }
+        return queue.upNextCount() == 0 ? .play : .confirmReplaceUpNext
+    }
+
+    /// Whether playing `playlistEpisodeIDs` would change the current Up Next queue or the episode being played.
+    private static func playlistDiffersFromUpNext(
+        playlistEpisodeIDs: [String],
+        upNextEpisodeIDs: [String],
+        currentEpisodeID: String?
+    ) -> Bool {
+        if playlistEpisodeIDs != upNextEpisodeIDs {
+            return true
+        }
+
+        guard let firstPlaylistID = playlistEpisodeIDs.first else {
+            return false
+        }
+
+        guard let currentID = currentEpisodeID else {
+            return true
+        }
+
+        return currentID != firstPlaylistID
+    }
+
+    /// Resumes playback when it's currently paused. Used by the playlist "Play All" flow when the
+    /// Up Next queue already matches the playlist being played.
+    func resumeIfPaused() {
+        guard !playing() else { return }
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackStarting)
+        play()
+    }
+
     func internalPlayerForVideoPlayback() -> AVPlayer? {
         if let episode = currentEpisode(), player == nil {
             load(episode: episode, autoPlay: false, overrideUpNext: false)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1311,17 +1311,15 @@ class PlaybackManager: ServerPlaybackDelegate {
             // the user has chosen to play a single episode, and they have an up next list, so add this episode into up next and push the rest down
             switchTo(episodeToPlay: startingAtEpisode, moveExistingToUpNext: true, autoPlay: true)
         } else {
-            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                // there's a new list of episodes to play, so clear what's currently playing and play that
-                self?.load(episode: startingAtEpisode, autoPlay: true, overrideUpNext: true)
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
+            // there's a new list of episodes to play, so clear what's currently playing and play that
+            load(episode: startingAtEpisode, autoPlay: true, overrideUpNext: true)
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
 
-                let filteredEpisodes = episodes!.filter { $0.uuid != startingAtEpisode.uuid }
-                if filteredEpisodes.isEmpty {
-                    return
-                }
-                self?.queue.bulkAdd(filteredEpisodes)
+            let filteredEpisodes = episodes!.filter { $0.uuid != startingAtEpisode.uuid }
+            if filteredEpisodes.isEmpty {
+                return
             }
+            queue.bulkAdd(filteredEpisodes)
         }
     }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -691,33 +691,26 @@ class PlaybackManager: ServerPlaybackDelegate {
         uuidOfPlayingList = playlist.uuid
     }
 
-    /// The action to take when the user asks to play every episode of a playlist, based on how the
-    /// playlist's episodes compare to the current Up Next queue and playback state.
-    enum PlayAllAction {
-        /// The playlist differs from Up Next and there's nothing queued to overwrite — start playing.
-        case play
-        /// The playlist differs from a non-empty Up Next — confirm replacing it before playing.
-        case confirmReplaceUpNext
-        /// The playlist already matches the current Up Next — resume the existing playback.
-        case resumeCurrent
-    }
-
-    func playAllAction(forPlaylistEpisodeIDs playlistEpisodeIDs: [String]) -> PlayAllAction {
-        let upNextEpisodeIDs = DataManager.sharedManager
-            .allUpNextEpisodeUuids()
-            .compactMap(\.uuid)
-        guard Self.playlistDiffersFromUpNext(playlistEpisodeIDs: playlistEpisodeIDs, upNextEpisodeIDs: upNextEpisodeIDs, currentEpisodeID: currentEpisode()?.uuid) else {
-            return .resumeCurrent
+    /// Plays every episode of `playlist`, or resumes the current playback when the Up Next queue
+    /// already matches it. Returns `false` without playing anything when a non-empty Up Next queue
+    /// would be replaced, so the caller can confirm the replacement before playback starts.
+    func playIfSafe(playlist: EpisodeFilter, episodeIDs: [String]) -> Bool {
+        guard isPlaylistDifferentFromUpNext(playlistEpisodeIDs: episodeIDs) else {
+            resumeIfPaused()
+            return true
         }
-        return queue.upNextCount() == 0 ? .play : .confirmReplaceUpNext
+        guard queue.upNextCount() == 0 else {
+            return false
+        }
+        play(playlist: playlist)
+        return true
     }
 
     /// Whether playing `playlistEpisodeIDs` would change the current Up Next queue or the episode being played.
-    private static func playlistDiffersFromUpNext(
-        playlistEpisodeIDs: [String],
-        upNextEpisodeIDs: [String],
-        currentEpisodeID: String?
-    ) -> Bool {
+    private func isPlaylistDifferentFromUpNext(playlistEpisodeIDs: [String]) -> Bool {
+        let upNextEpisodeIDs = DataManager.sharedManager
+            .allUpNextEpisodeUuids()
+            .compactMap(\.uuid)
         if playlistEpisodeIDs != upNextEpisodeIDs {
             return true
         }
@@ -726,7 +719,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             return false
         }
 
-        guard let currentID = currentEpisodeID else {
+        guard let currentID = currentEpisode()?.uuid else {
             return true
         }
 
@@ -735,7 +728,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     /// Resumes playback when it's currently paused. Used by the playlist "Play All" flow when the
     /// Up Next queue already matches the playlist being played.
-    func resumeIfPaused() {
+    private func resumeIfPaused() {
         guard !playing() else { return }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackStarting)
         play()


### PR DESCRIPTION
Fixes PCIOS-691.

## Summary

- Extracts the "what should Play All do?" decision into `PlaybackManager.playAllAction(forPlaylistEpisodeIDs:)`. iOS `PlaylistDetailViewController+PlayAll` now uses it, dropping its private Up Next diffing logic.
- Wires Play All into the tvOS playlist detail screen (replace-Up-Next confirmation dialog + full-screen Now Playing).

## To test

  **Play All (iOS)**
  1. Filters tab → open a filter → Play All.
  2. With an empty Up Next: playback starts immediately.
  3. With a different non-empty Up Next: confirm the "Replace Up Next?" sheet appears, and confirming plays the filter.
  4. With Up Next already matching the filter and playback paused: confirm it just resumes (no sheet).

  **Play All (tvOS)**
  1. Open a playlist → Play All; verify the same three outcomes, with the confirmation dialog and Now Playing screen.


https://github.com/user-attachments/assets/ed99e661-7880-47b9-af0b-60c2c29bfb8d



## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
