### PR TITLE
Fix transcript search bar background on iOS 26

### DIFF
--- a/podcasts/TranscriptSearchAccessoryView.swift
+++ b/podcasts/TranscriptSearchAccessoryView.swift
@@ -45,13 +45,18 @@ class TranscriptSearchAccessoryView: UIInputView {
         return stackView
     }()
 
-    private lazy var doneButton: UIButton = createButton(
-        title: L10n.done,
-        action: #selector(done),
-        titleColor: .label,
-        highlightedTitleColor: .systemGray,
-        contentInsets: .init(top: 8, leading: 16, bottom: 8, trailing: 16)
-    )
+    private lazy var doneButton: UIButton = {
+        if #available(iOS 26.0, *) {
+            return createDoneGlassButton()
+        }
+        return createButton(
+            title: L10n.done,
+            action: #selector(done),
+            titleColor: .label,
+            highlightedTitleColor: .systemGray,
+            contentInsets: .init(top: 8, leading: 16, bottom: 8, trailing: 16)
+        )
+    }()
 
     private lazy var downButton: UIButton = createSymbolButton(
         imageName: "chevron.down",
@@ -91,9 +96,36 @@ class TranscriptSearchAccessoryView: UIInputView {
         addSubview(mainStackView)
         mainStackView.addArrangedSubview(innerStackView)
         innerStackView.addArrangedSubview(doneButton)
-        innerStackView.addArrangedSubview(textField)
-        innerStackView.addArrangedSubview(upButton)
-        innerStackView.addArrangedSubview(downButton)
+
+        // On iOS 26 the keyboard input view is transparent, so we float the field
+        // and the navigation buttons as Liquid Glass capsules over the keyboard.
+        // Older versions keep the previous flat layout backed by the keyboard style.
+        if #available(iOS 26.0, *) {
+            innerStackView.spacing = 8
+            // Fill so the field capsule matches the height of the chevron capsule.
+            innerStackView.alignment = .fill
+            mainStackView.layoutMargins = UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16)
+            mainStackView.isLayoutMarginsRelativeArrangement = true
+
+            // Keep the Done checkmark circular by matching its width to its height.
+            doneButton.widthAnchor.constraint(equalTo: doneButton.heightAnchor).isActive = true
+
+            let fieldContainer = makeGlassContainer(wrapping: textField)
+            fieldContainer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            fieldContainer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            innerStackView.addArrangedSubview(fieldContainer)
+
+            let chevronStackView = UIStackView(arrangedSubviews: [upButton, downButton])
+            chevronStackView.axis = .horizontal
+            let chevronContainer = makeGlassContainer(wrapping: chevronStackView)
+            chevronContainer.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+            chevronContainer.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+            innerStackView.addArrangedSubview(chevronContainer)
+        } else {
+            innerStackView.addArrangedSubview(textField)
+            innerStackView.addArrangedSubview(upButton)
+            innerStackView.addArrangedSubview(downButton)
+        }
 
         setupConstraints()
         configureHuggingAndCompressionPriorities()
@@ -154,8 +186,13 @@ private extension TranscriptSearchAccessoryView {
         textField.autocorrectionType = .no
         textField.spellCheckingType = .no
         textField.clearButtonMode = .whileEditing
-        textField.layer.cornerRadius = 8
-        textField.backgroundColor = .systemGray3
+        if #available(iOS 26.0, *) {
+            // The surrounding glass capsule provides the background and shape.
+            textField.backgroundColor = .clear
+        } else {
+            textField.layer.cornerRadius = 8
+            textField.backgroundColor = .systemGray3
+        }
         textField.rightLabel.textColor = .secondaryLabel
         textField.delegate = self
         textField.font = UIFont.font(with: .body, maxSizeCategory: maxContentSizeCategory)
@@ -163,6 +200,36 @@ private extension TranscriptSearchAccessoryView {
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.rightLabel.font = UIFont.font(with: .callout, maxSizeCategory: maxContentSizeCategory)
         textField.rightLabel.adjustsFontForContentSizeCategory = false
+    }
+
+    @available(iOS 26.0, *)
+    func createDoneGlassButton() -> UIButton {
+        var config = UIButton.Configuration.prominentGlass()
+        config.image = UIImage(systemName: "checkmark")
+        config.baseBackgroundColor = .systemBlue
+        config.cornerStyle = .capsule
+        let button = UIButton(configuration: config)
+        button.tintColor = .white
+        button.accessibilityLabel = L10n.done
+        button.addTarget(self, action: #selector(done), for: .touchUpInside)
+        return button
+    }
+
+    @available(iOS 26.0, *)
+    func makeGlassContainer(wrapping content: UIView) -> UIVisualEffectView {
+        let effect = UIGlassEffect()
+        effect.isInteractive = true
+        let container = UIVisualEffectView(effect: effect)
+        container.cornerConfiguration = .capsule()
+        content.translatesAutoresizingMaskIntoConstraints = false
+        container.contentView.addSubview(content)
+        NSLayoutConstraint.activate([
+            content.leadingAnchor.constraint(equalTo: container.contentView.leadingAnchor),
+            content.trailingAnchor.constraint(equalTo: container.contentView.trailingAnchor),
+            content.topAnchor.constraint(equalTo: container.contentView.topAnchor),
+            content.bottomAnchor.constraint(equalTo: container.contentView.bottomAnchor)
+        ])
+        return container
     }
 
     func createButton(title: String, action: Selector, titleColor: UIColor, highlightedTitleColor: UIColor, contentInsets: NSDirectionalEdgeInsets) -> UIButton {


### PR DESCRIPTION
Fixes PCIOS-715

| iOS 26 | iOS 18 |
| ------ | ------- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-04 at 10 45 47" src="https://github.com/user-attachments/assets/96effe98-7f8d-4f39-891d-1c430d0d95ec" /> | <img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2026-06-04 at 10 45 26" src="https://github.com/user-attachments/assets/56f4c6be-8677-447b-bd96-95d33423b115" /> |

The transcript search bar (`TranscriptSearchAccessoryView`) is a `UIInputView` created with `inputViewStyle: .keyboard`, which used to paint its own keyboard-style background. On iOS 26 that style no longer fills the background, so the bar rendered transparent and showed the transcript through it.

This restyles the bar **on iOS 26 only**, matching the native Liquid Glass find bar:

- The search field and the up/down chevrons are each wrapped in a `UIGlassEffect` capsule that floats over the keyboard.
- The field capsule matches the height of the chevron capsule (stack `alignment = .fill`).
- The **Done** button becomes a blue checkmark glass icon (`UIButton.Configuration.prominentGlass()`), with "Done" kept as its accessibility label.

Everything is gated behind `if #available(iOS 26.0, *)`, so older iOS keeps the previous flat layout backed by the keyboard style.

## To test

1. Run on an iOS 26 device/simulator.
2. Open an episode transcript (player or episode detail).
3. Tap **Search**.
4. Verify the search field and chevrons render as glass capsules over the keyboard, the field and chevron capsules are the same height, and the Done control is a blue checkmark.
5. Run on an iOS 18 (or earlier) simulator and confirm the search bar looks/behaves as before.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.