### PR TITLE
[PC TV] Fix bottom inset in podcast lists

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -145,7 +145,7 @@ struct PlaylistDetailView: View {
         }
         .focusScope(episodeListNamespace)
         .padding(.horizontal, 24)
-        .padding(.bottom, 24)
+        .contentMargins(.bottom, 24, for: .scrollContent)
         .focused($focusedSection, equals: .episodes)
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -160,7 +160,7 @@ struct PodcastDetailView: View {
         }
         .focusScope(episodeListNamespace)
         .padding(.horizontal, 24)
-        .padding(.bottom, 24)
+        .contentMargins(.bottom, 24, for: .scrollContent)
         .focused($focusedSection, equals: .episodes)
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

Before: a large chunk of dead space at the bottom:

<img width="968" height="623" alt="Screenshot 2026-06-04 at 9 57 17 AM" src="https://github.com/user-attachments/assets/9ebf5315-ee05-4d18-bc85-0ca28dabc9b8" />

After: the entire screen is usable

<img width="968" height="623" alt="Screenshot 2026-06-04 at 10 16 47 AM" src="https://github.com/user-attachments/assets/6a8e8b83-d017-4b9a-8eac-f2030ea1dfe4" />

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
