### PR TITLE
Fix episode transcript layout and enable highlight

### DIFF
--- a/podcasts/TranscriptPlaybackManaging.swift
+++ b/podcasts/TranscriptPlaybackManaging.swift
@@ -47,12 +47,18 @@ struct TranscriptEpisodeInfoProvider: TranscriptPlaybackManaging {
     }
 
     func currentTime() -> TimeInterval {
-        0
+        guard PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episodeUUID) else {
+            return 0
+        }
+        return PlaybackManager.shared.currentTime()
     }
 
-    func seekTo(time: TimeInterval) {}
+    func seekTo(time: TimeInterval) {
+        guard PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episodeUUID) else { return }
+        PlaybackManager.shared.seekTo(time: time)
+    }
 
-    var canSeek: Bool { false }
+    var canSeek: Bool { PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episodeUUID) }
 
     var isPlayingEpisode: Bool {
         PlaybackManager.shared.isActivelyPlaying(episodeUuid: episodeUUID)

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -635,7 +635,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 await MainActor.run {
                     self.setHasGeneratedTranscripts(hasGeneratedTranscripts)
                     if isDisplayingGenerated {
-                        if FeatureFlag.syncedTranscripts.enabled, !self.showFromEpisode {
+                        if FeatureFlag.syncedTranscripts.enabled, !self.showFromEpisode || PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: self.playbackManager.episodeUUID) {
                             FingerprintTimingManager.shared.prepareForCurrentEpisode()
                         }
                         self.startHighlightDisplayLink()

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -160,7 +160,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     }
 
     func setHasGeneratedTranscripts(_ value: Bool) {
-        let topMargin = showFromEpisode ? 24.0 : 0.0
+        let topMargin = showFromEpisode ? 8.0 : 0.0
 
         if FeatureFlag.generatedTranscripts.enabled, value {
             transcriptViewTopConstraint?.constant = 80.0 + topMargin
@@ -284,7 +284,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
         view.addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        let topMargin = showFromEpisode ? 24.0 : 0.0
+        let topMargin = showFromEpisode ? 8.0 : 0.0
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: topMargin),
             stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12),

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -442,17 +442,19 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private lazy var closeButton: TintableImageButton! = {
         let closeButton = TintableImageButton()
         closeButton.setImage(UIImage(named: "close"), for: .normal)
-        closeButton.tintColor = showFromEpisode ? ThemeColor.primaryText01() : ThemeColor.primaryIcon02()
+        closeButton.tintColor = showFromEpisode ? ThemeColor.primaryInteractive01() : ThemeColor.primaryIcon02()
         closeButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
         return closeButton
     }()
 
     private lazy var searchButton: RoundButton = {
-        let titleColor = showFromEpisode ? ThemeColor.primaryText01() : .white
-        let tintColor = showFromEpisode ? ThemeColor.primaryUi05() : .white.withAlphaComponent(0.2)
+        let titleColor = showFromEpisode ? ThemeColor.primaryInteractive01() : .white
+        let tintColor = showFromEpisode ? ThemeColor.primaryInteractive01().withAlphaComponent(0.1) : .white.withAlphaComponent(0.2)
 
         var configuration = UIButton.Configuration.filled()
         configuration.contentInsets = .init(top: 4, leading: 12, bottom: 4, trailing: 12)
+        configuration.baseForegroundColor = titleColor
+        configuration.baseBackgroundColor = tintColor
 
         let searchButton = RoundButton(type: .system)
         let attributes: [NSAttributedString.Key: Any] = [
@@ -476,11 +478,13 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     }()
 
     private lazy var shareButton: RoundButton = {
-        let titleColor = showFromEpisode ? ThemeColor.primaryText01() : .white
-        let tintColor = showFromEpisode ? ThemeColor.primaryUi05() : .white.withAlphaComponent(0.2)
+        let titleColor = showFromEpisode ? ThemeColor.primaryInteractive01() : .white
+        let tintColor = showFromEpisode ? ThemeColor.primaryInteractive01().withAlphaComponent(0.1) : .white.withAlphaComponent(0.2)
 
         var configuration = UIButton.Configuration.filled()
         configuration.contentInsets = .init(top: 4, leading: 12, bottom: 4, trailing: 12)
+        configuration.baseForegroundColor = titleColor
+        configuration.baseBackgroundColor = tintColor
 
         let shareButton = RoundButton(type: .system)
         let attributes: [NSAttributedString.Key: Any] = [
@@ -791,7 +795,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         formattedText.beginEditing()
         let normalStyle = makeStyle()
         var highlightStyle = normalStyle
-        highlightStyle[.foregroundColor] = showFromEpisode ? ThemeColor.primaryText01() : ThemeColor.playerContrast01()
+        highlightStyle[.foregroundColor] = showFromEpisode ? ThemeColor.primaryInteractive01() : ThemeColor.playerContrast01()
 
         let fullLength = NSRange(location: 0, length: formattedText.length)
         formattedText.addAttributes(normalStyle, range: fullLength)
@@ -1271,7 +1275,7 @@ fileprivate class RoundPlayPauseButton: RoundButton {
 
     var buttonState: ButtonState = .play {
         didSet {
-            let config = UIImage.SymbolConfiguration(pointSize: 15, weight: .medium)
+            let config = UIImage.SymbolConfiguration(pointSize: 12, weight: .medium)
             let image = UIImage(systemName: buttonState.imageName, withConfiguration: config)?
                 .withRenderingMode(.alwaysTemplate)
             let attributes: [NSAttributedString.Key: Any] = [
@@ -1290,8 +1294,8 @@ fileprivate class RoundPlayPauseButton: RoundButton {
     }
 
     static func makeButton(playbackManager: TranscriptPlaybackManaging) -> RoundPlayPauseButton {
-        let titleColor = ThemeColor.primaryText01()
-        let tintColor = ThemeColor.primaryUi05()
+        let titleColor = ThemeColor.primaryInteractive01()
+        let tintColor = ThemeColor.primaryInteractive01().withAlphaComponent(0.1)
 
         var  bg = UIBackgroundConfiguration.clear()
         bg.backgroundColor = tintColor
@@ -1299,7 +1303,7 @@ fileprivate class RoundPlayPauseButton: RoundButton {
         configuration.contentInsets = .init(top: 4, leading: 12, bottom: 4, trailing: 12)
         configuration.imagePadding = 8.0
         configuration.background = bg
-        configuration.baseForegroundColor = ThemeColor.primaryIcon03()
+        configuration.baseForegroundColor = ThemeColor.primaryInteractive01()
 
         let playButton = RoundPlayPauseButton(type: .system)
         playButton.playbackManager = playbackManager


### PR DESCRIPTION
Fixes PCIOS-716

<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-06-04 at 11 22 59" src="https://github.com/user-attachments/assets/2196693a-87a8-4307-a575-b1f997e35dc6" />

Improves the episode transcript screen (the transcript opened from an episode, not the player):

- **Restyles the top controls to match Android.** The Close (X), Share, Play, and Search buttons now use the interactive accent color (`primaryInteractive01`): a light-blue pill background with solid blue text/icons, fixing the poor contrast where the controls were nearly invisible. The currently-playing line highlight also uses the accent color so it stands out from normal text.
- **Slightly reduces the Play/Pause glyph size** (15 → 12 pt) so it sits better in the pill.
- **Enables transcript highlighting from the episode screen** when that episode is the now-playing episode (re-applies the changes from the previously closed #4315):
  - `TranscriptEpisodeInfoProvider` now returns the real playback position, supports `seekTo(time:)`, and reports `canSeek` — all gated on the episode being the now-playing episode.
  - The fingerprint timing setup gate now also fires when the episode screen shows the now-playing episode (`!showFromEpisode || isNowPlayingEpisode(...)`).

Highlighting remains gated behind `FeatureFlag.syncedTranscripts`. The player transcript appearance is unchanged.

## To test

1. Subscribe to Plus (transcripts are Plus-only) and enable the `syncedTranscripts` feature flag.
2. Open an episode that has an auto-generated transcript and tap the transcript.
3. Verify the Close, Share, Play, and Search buttons have light-blue backgrounds with blue text/icons and good contrast (matching Android).
4. Start playing the episode and confirm the current line is highlighted in blue and follows playback.
5. Tap a transcript line and confirm playback seeks to that position.
6. Confirm the transcript opened from the **player** looks unchanged.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
