### PR TITLE
[PC TV] Add Starred episodes

### DIFF
--- a/Pocket Casts TV App/UI/MainTabRouter.swift
+++ b/Pocket Casts TV App/UI/MainTabRouter.swift
@@ -6,4 +6,5 @@ final class MainTabRouter {
     var selectedTab: MainTab = .home
     var isShowingDetail: Bool = false
     var pendingAuthFlow: ProfileMenuView.AuthDestination?
+    var profileDestination: ProfileMenuView.ProfileDestination?
 }

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -196,8 +196,25 @@ struct MainTabView: View {
             ProfileMenuView(onAuthSelected: { destination in
                 tabSelection.pendingAuthFlow = destination
                 showProfileMenu = false
+            }, onProfileSelected: { destination in
+                tabSelection.profileDestination = destination
+                showProfileMenu = false
             })
             .environment(coordinator)
+        }
+        .fullScreenCover(item: $tabSelection.profileDestination) { destination in
+            ZStack {
+                Color.pcBackgroundSurface.ignoresSafeArea()
+                switch destination {
+                case .starred:
+                    StarredEpisodesView()
+                }
+            }
+            .environment(coordinator)
+            .environment(tabSelection)
+            .onExitCommand {
+                tabSelection.profileDestination = nil
+            }
         }
         .fullScreenCover(item: $tabSelection.pendingAuthFlow) { destination in
             ZStack {

--- a/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
@@ -9,9 +9,19 @@ struct ProfileMenuView: View {
     /// dismissing this menu and showing the destination.
     let onAuthSelected: (AuthDestination) -> Void
 
+    /// Called with the chosen destination when a signed-in user taps one of
+    /// the content actions (e.g. "Starred Episodes"). The presenter is
+    /// responsible for dismissing this menu and showing the destination.
+    let onProfileSelected: (ProfileDestination) -> Void
+
     enum AuthDestination: Hashable, Identifiable {
         case signIn
         case createAccount
+        var id: Self { self }
+    }
+
+    enum ProfileDestination: Hashable, Identifiable {
+        case starred
         var id: Self { self }
     }
 
@@ -55,7 +65,7 @@ struct ProfileMenuView: View {
 
             // Group 2
             Button {
-                // Starred episodes destination not yet implemented for TV
+                onProfileSelected(.starred)
             } label: {
                 Text(L10n.tvProfileMenuStarredEpisodes)
                     .frame(minWidth: 400)
@@ -109,6 +119,6 @@ struct ProfileMenuView: View {
 }
 
 #Preview {
-    ProfileMenuView(onAuthSelected: { _ in })
+    ProfileMenuView(onAuthSelected: { _ in }, onProfileSelected: { _ in })
         .environment(AppCoordinator())
 }

--- a/Pocket Casts TV App/UI/Starred/StarredEpisodesView.swift
+++ b/Pocket Casts TV App/UI/Starred/StarredEpisodesView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct StarredEpisodesView: View {
+
+    @State private var model = StarredEpisodesViewModel()
+    @Namespace private var rowNamespace
+
+    var body: some View {
+        ZStack {
+            switch model.state {
+            case .loading:
+                ProgressView()
+            case .ready:
+                episodeList
+            case .empty:
+                emptyView
+            }
+        }
+        .task {
+            model.load()
+        }
+    }
+
+    private var episodeList: some View {
+        List {
+            Section {
+                ForEach(model.episodes) { episode in
+                    EpisodeRowWithActions(model: episode)
+                        .frame(width: 1160)
+                        .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
+                }
+            } header: {
+                Text(L10n.tvProfileMenuStarredEpisodes)
+                    .font(.title2)
+                    .foregroundStyle(Color.pcTextPrimary)
+            }
+            .focusScope(rowNamespace)
+        }
+    }
+
+    private var emptyView: some View {
+        EmptyDataView(title: L10n.tvStarredEmptyTitle, subtitle: L10n.tvStarredEmptySubtitle)
+    }
+}
+
+#Preview {
+    StarredEpisodesView()
+        .environment(AppCoordinator())
+        .environment(MainTabRouter())
+}

--- a/Pocket Casts TV App/UI/Starred/StarredEpisodesViewModel.swift
+++ b/Pocket Casts TV App/UI/Starred/StarredEpisodesViewModel.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import Combine
+import PocketCastsDataModel
+import PocketCastsServer
+
+@MainActor @Observable
+class StarredEpisodesViewModel {
+
+    enum State: Equatable {
+        case loading
+        case ready
+        case empty
+    }
+
+    private(set) var state: State = .loading
+    private(set) var episodes: [EpisodeRowViewModel] = []
+
+    private let dataManager: DataManager
+    private let apiHandler: ApiServerHandler
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(dataManager: DataManager = DataManager.sharedManager, apiHandler: ApiServerHandler = .shared) {
+        self.dataManager = dataManager
+        self.apiHandler = apiHandler
+        observeStarredChanges()
+    }
+
+    func load() {
+        if SyncManager.isUserLoggedIn() {
+            refreshFromServer()
+        } else {
+            fetchLocalData()
+        }
+    }
+
+    /// Pulls the latest starred list from the server. `RetrieveStarredTask`
+    /// stars the returned episodes locally before completing, so once it
+    /// finishes we simply re-read from the database to get a consistent,
+    /// locally-backed list. On failure (`nil`) we fall back to whatever is
+    /// already stored locally.
+    private func refreshFromServer() {
+        apiHandler.retrieveStarred { [weak self] _ in
+            self?.fetchLocalData()
+        }
+    }
+
+    private func fetchLocalData() {
+        Task {
+            let fetched = fetchStarredEpisodes()
+            let episodes = fetched.map { episode in
+                EpisodeRowViewModel(episode: episode, podcast: episode.parentPodcast(dataManager: dataManager))
+            }
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.episodes = episodes
+                self.state = episodes.isEmpty ? .empty : .ready
+            }
+        }
+    }
+
+    private func fetchStarredEpisodes() -> [Episode] {
+        dataManager.findEpisodesWhere(customWhere: "keepEpisode = 1 ORDER BY starredModified DESC LIMIT 1000", arguments: nil)
+    }
+
+    private func observeStarredChanges() {
+        NotificationCenter.default.publisher(for: Constants.Notifications.episodeStarredChanged)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.fetchLocalData()
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4475,6 +4475,10 @@ internal enum L10n {
   internal static var tvSigningInSubtitle: String { return L10n.tr("Localizable", "tv_signing_in_subtitle", fallback: "Loading your podcasts now.") }
   /// tv signing in title
   internal static var tvSigningInTitle: String { return L10n.tr("Localizable", "tv_signing_in_title", fallback: "Good to see you.") }
+  /// tv starred episodes empty subtitle
+  internal static var tvStarredEmptySubtitle: String { return L10n.tr("Localizable", "tv_starred_empty_subtitle", fallback: "Star episodes to keep them handy, and they'll show up here") }
+  /// tv starred episodes empty title
+  internal static var tvStarredEmptyTitle: String { return L10n.tr("Localizable", "tv_starred_empty_title", fallback: "No starred episodes") }
   /// tv app home tab
   internal static var tvTabHome: String { return L10n.tr("Localizable", "tv_tab_home", fallback: "Home") }
   /// tv app Playlists tab

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6157,6 +6157,12 @@
 /* tv up next empty button action title */
 "tv_up_next_empty_action_title" = "Add episodes";
 
+/* tv starred episodes empty title */
+"tv_starred_empty_title" = "No starred episodes";
+
+/* tv starred episodes empty subtitle */
+"tv_starred_empty_subtitle" = "Star episodes to keep them handy, and they'll show up here";
+
 /* tv User Profile actions title */
 "tv_user_profile_actions" = "User settings";
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-696.

Implements the **Starred Episodes** screen on tvOS, wired into the previously-stubbed Profile menu item. Syncs starred episodes from the server (falling back to local data) and lists them with play / play next / play last / mark played / archive actions.

  ## To test

  1. Sign in on the TV app and star a few episodes (e.g. on iOS).
  2. Open the **Profile** menu (top-left avatar).
  3. Tap **Starred Episodes** → the list appears.
  4. Play an episode and try the more (•••) actions.
  5. With no starred episodes, confirm the empty state shows.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
