### PR TITLE
[tvOS] Add error handling for QR code

### DIFF
--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -84,7 +84,9 @@ struct SignInView: View {
             .padding(.top, 80)
             .offset(y: -64)
         }
-        .task {
+        .task(id: loginType) {
+            // Clear any leftover error so it doesn't leak across login modes.
+            model.state = .start
             switch loginType {
             case .qr:
                 await model.thirdPartyApprovalSignin()

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -64,15 +64,19 @@ struct SignInView: View {
                         usernamePasswordLogin
                             .padding(.top, 64)
                     case .qr:
-                        Text(L10n.tvSignInSubtitle)
-                            .font(.headline)
-                            .foregroundStyle(Color.pcTextSecondary)
-                        QRCodeView(url: model.pairURLString)
-                        separator
-                        Text(enterCodePrompt)
-                            .font(.headline)
-                            .foregroundStyle(Color.pcTextSecondary)
-                        qrCodeDigits
+                        if case .error(_, let message) = model.state {
+                            qrCodeError(message: message)
+                        } else {
+                            Text(L10n.tvSignInSubtitle)
+                                .font(.headline)
+                                .foregroundStyle(Color.pcTextSecondary)
+                            QRCodeView(url: model.pairURLString)
+                            separator
+                            Text(enterCodePrompt)
+                                .font(.headline)
+                                .foregroundStyle(Color.pcTextSecondary)
+                            qrCodeDigits
+                        }
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -95,6 +99,24 @@ struct SignInView: View {
             }
         }
         .background(Color.pcBackgroundBase)
+    }
+
+    func qrCodeError(message: String) -> some View {
+        ContentUnavailableView {
+            Label(L10n.tvSignInQrCodeErrorTitle, systemImage: "wifi.exclamationmark")
+        } description: {
+            Text(message)
+        } actions: {
+            Button {
+                Task {
+                    await model.thirdPartyApprovalSignin()
+                }
+            } label: {
+                Text(L10n.tryAgain)
+                    .frame(minWidth: 300)
+            }
+        }
+        .padding(.top, 64)
     }
 
     var qrCodeDigits: some View {

--- a/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
@@ -42,6 +42,7 @@ class SignInViewModel {
 
         var tryAgain = true
         while tryAgain {
+            if Task.isCancelled { return }
             do {
                 let authorizeResponse = try await AuthenticationHelper.deviceAuthorizeCode()
                 codes = authorizeResponse.userCode.map({ char in
@@ -57,11 +58,15 @@ class SignInViewModel {
                     tryAgain = true
                 } else {
                     tryAgain = false
-                    state = .error(error, error.localizedDescription)
+                    if !Task.isCancelled {
+                        state = .error(error, error.localizedDescription)
+                    }
                 }
             } catch {
                 tryAgain = false
-                state = .error(error, error.localizedDescription)
+                if !Task.isCancelled {
+                    state = .error(error, error.localizedDescription)
+                }
             }
         }
     }

--- a/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
@@ -37,6 +37,9 @@ class SignInViewModel {
     var pairURLComplete: String?
 
     func thirdPartyApprovalSignin() async {
+        codes = []
+        state = .start
+
         var tryAgain = true
         while tryAgain {
             do {

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4467,6 +4467,8 @@ internal enum L10n {
   internal static func tvSignInEnterCodeInUrl(_ p1: Any, _ p2: Any) -> String {
     return L10n.tr("Localizable", "tv_sign_in_enter_code_in_url", String(describing: p1), String(describing: p2), fallback: "or enter this code in [%1$@](%2$@)")
   }
+  /// tv sign in error title shown when the app fails to fetch the QR sign in code
+  internal static var tvSignInQrCodeErrorTitle: String { return L10n.tr("Localizable", "tv_sign_in_qr_code_error_title", fallback: "Couldn't get your sign in code") }
   /// tv sign in subtitle
   internal static var tvSignInSubtitle: String { return L10n.tr("Localizable", "tv_sign_in_subtitle", fallback: "Open your camera and point to this QR code") }
   /// tv sign in title

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6025,6 +6025,9 @@
 /* tv sign enter code go url.  %1$@ is the visible url and %2$@ the full url to enter the code*/
 "tv_sign_in_enter_code_go_url" = "going to [%1$@](%2$@)";
 
+/* tv sign in error title shown when the app fails to fetch the QR sign in code */
+"tv_sign_in_qr_code_error_title" = "Couldn't get your sign in code";
+
 /* tv create account title */
 "tv_create_account_title" = "Create your free account";
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-684.

- Show a `ContentUnavailableView` with the error message and a "Try Again" button when fetching the QR sign-in code
  fails, instead of hanging on a spinner.
- Scope the QR polling to the login tab via `.task(id:)` so it cancels (and resets state) when switching to Password,
  preventing the QR error from leaking across modes.

**Note**: the original ticket also included retry attempts. Do we really need them? Is the server known to initially fail but recovered quickly and we are working something around? If not, I'd suggest to keep it simple.

<img width="620"  alt="Screenshot 2026-06-04 at 1 58 38 PM" src="https://github.com/user-attachments/assets/c6b76a8b-5539-4046-9660-23081f75e9a8" />

## To test

1. On Apple TV, open Sign In with QR selected, go offline (or otherwise force the code request to fail), and confirm the error view appears with a focused "Try Again" button that retries successfully once back online.
2. Trigger the QR error, switch to the Password tab, and confirm no error is shown there; switch back to QR and confirm a fresh code/flow starts.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
