### PR TITLE
[Liquid Glass] Fix background not extending beyond safe area on podcast details

### DIFF
--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -281,6 +281,8 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
 
         super.viewDidLoad()
 
+        view.backgroundColor = ThemeColor.primaryUi01()
+
         if FeatureFlag.podcastFeedUpdate.enabled {
             podcastFeedViewModel = PodcastFeedViewModel(uuid: podcast?.uuid ?? podcastInfo?.uuid)
 
@@ -589,6 +591,7 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
     }
 
     private func updateColors() {
+        view.backgroundColor = ThemeColor.primaryUi01()
         reloadData()
         navTitleLabel.textColor = ThemeColor.primaryText01()
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Fixes an issue with the "Podcast Details" screen background not extending beyond the bottom safe area during loading. It's most noticeable if you are testing it in dark mode.

## To test

- Open Discover
- Open a podcast you haven't loaded previously
- Verify there is not brief wide white gap at the bottom during loading

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
