### PR TITLE
TV: Confirm before Play All overwrites Up Next on playlist detail

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -6,6 +6,8 @@ struct PlaylistDetailView: View {
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
     let model: PlaylistDetailsViewModel
     @FocusState private var focusedSection: FocusSection?
+    @State private var isShowingClearConfirmation = false
+    @State private var isShowingPlayer = false
 
     enum FocusSection: Hashable {
         case episodes
@@ -123,7 +125,11 @@ struct PlaylistDetailView: View {
             }
             if !model.episodes.isEmpty {
                 Button {
-                    model.playAll()
+                    if model.shouldConfirmClearUpNext {
+                        isShowingClearConfirmation = true
+                    } else {
+                        playAllAndShowPlayer()
+                    }
                 } label: {
                     Text(L10n.tvPlaylistDetailPlayAll)
                         .font(.caption2)
@@ -131,6 +137,27 @@ struct PlaylistDetailView: View {
             }
         }
         .focusSection()
+        .confirmationDialog(
+            L10n.tvPlaylistPlayAllConfirmTitle,
+            isPresented: $isShowingClearConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(L10n.tvPlaylistPlayAllConfirmAction, role: .destructive) {
+                playAllAndShowPlayer()
+            }
+            Button(L10n.cancel, role: .cancel) {}
+        } message: {
+            Text(L10n.tvPlaylistPlayAllConfirmMessage(model.upNextCount))
+        }
+        .fullScreenCover(isPresented: $isShowingPlayer) {
+            NowPlayingView()
+                .ignoresSafeArea()
+        }
+    }
+
+    private func playAllAndShowPlayer() {
+        model.playAll()
+        isShowingPlayer = true
     }
 
     @Namespace private var episodeListNamespace

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -43,6 +43,17 @@ class PlaylistDetailsViewModel {
         playbackManager.play(playlist: playlist)
     }
 
+    /// True when Up Next holds at least one episode beyond the currently playing one,
+    /// meaning a Play All would discard that queue.
+    var shouldConfirmClearUpNext: Bool {
+        upNextCount > 0
+    }
+
+    /// Number of episodes in Up Next excluding the currently playing one.
+    var upNextCount: Int {
+        playbackManager.queue.upNextCount()
+    }
+
     var playlistName: String {
         return playlist.playlistName
     }

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4409,6 +4409,14 @@ internal enum L10n {
   }
   /// tv playlist detail play all button title
   internal static var tvPlaylistDetailPlayAll: String { return L10n.tr("Localizable", "tv_playlist_detail_play_all", fallback: "Play all episodes") }
+  /// tv playlist play all confirmation action that wipes Up Next and starts playing the playlist
+  internal static var tvPlaylistPlayAllConfirmAction: String { return L10n.tr("Localizable", "tv_playlist_play_all_confirm_action", fallback: "Clear and play") }
+  /// tv playlist play all confirmation message. '%1$@' is a placeholder for the number of episodes currently in Up Next.
+  internal static func tvPlaylistPlayAllConfirmMessage(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "tv_playlist_play_all_confirm_message", String(describing: p1), fallback: "You currently have %1$@ episodes in Up Next")
+  }
+  /// tv playlist play all confirmation alert title shown when the user already has episodes in Up Next
+  internal static var tvPlaylistPlayAllConfirmTitle: String { return L10n.tr("Localizable", "tv_playlist_play_all_confirm_title", fallback: "This will clear your Up Next") }
   /// tv playlists empty button action title
   internal static var tvPlaylistsEmptyActionTitle: String { return L10n.tr("Localizable", "tv_playlists_empty_action_title", fallback: "Create a playlist") }
   /// tv playlists empty subtitle

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6103,6 +6103,15 @@
 /* tv playlist detail play all button title */
 "tv_playlist_detail_play_all" = "Play all episodes";
 
+/* tv playlist play all confirmation alert title shown when the user already has episodes in Up Next */
+"tv_playlist_play_all_confirm_title" = "This will clear your Up Next";
+
+/* tv playlist play all confirmation action that wipes Up Next and starts playing the playlist */
+"tv_playlist_play_all_confirm_action" = "Clear and play";
+
+/* tv playlist play all confirmation message. '%1$@' is a placeholder for the number of episodes currently in Up Next. */
+"tv_playlist_play_all_confirm_message" = "You currently have %1$@ episodes in Up Next";
+
 /* tv playlists empty title */
 "tv_playlists_empty_title" = "Your playlists live here";
 


### PR DESCRIPTION
## Summary

- "Play all episodes" on a playlist detail now asks for confirmation before discarding the user's existing Up Next.
- Confirmation only appears when Up Next has at least one episode beyond the currently playing one (`PlaybackManager.shared.queue.upNextCount() > 0`). With an empty queue, Play All starts immediately.
- Native `.confirmationDialog` with title "This will clear your Up Next", a message that shows the current Up Next count, a destructive "Clear and play" action, and a "Cancel" action.
- After confirming (or when no confirmation was needed), the fullscreen ``NowPlayingView`` is presented once playback starts.

## Test plan

- [ ] Open a playlist with episodes when Up Next is empty (or only the currently playing track). Tap **Play all episodes** → playback starts immediately and the fullscreen player opens, no alert.
- [ ] Queue up a few episodes in Up Next (e.g. via the long-press More button), then open a playlist and tap **Play all episodes** → confirmation alert appears with title "This will clear your Up Next" and message "You currently have X episodes in Up Next".
- [ ] Tap **Cancel** → alert dismisses, Up Next is unchanged, no playback change.
- [ ] Tap **Clear and play** → Up Next is replaced with the playlist's episodes, first episode plays, fullscreen player slides up.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.