### PR TITLE
Only highlight transcript on matched content (skip ads & unmatched audio)

### DIFF
--- a/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
@@ -269,4 +269,126 @@ final class FingerprintTimingManagerTests: XCTestCase {
         XCTAssertEqual(first, 100.0, accuracy: 0.001)
         XCTAssertEqual(last, 200.0, accuracy: 0.001)
     }
+
+    // MARK: - Ad detection
+
+    // Dense anchors on real content (every ~2s) → no gap wide enough to be an ad.
+    private static let denseContent: [Entry] = stride(from: 0.0, through: 60.0, by: 2.0)
+        .map { Entry(playbackTime: $0, referenceTime: $0) }
+
+    func testAdRegionNilOnDenselyMappedContent() {
+        let region = FingerprintTimingManager.adRegion(
+            forPlaybackTime: 30,
+            in: Self.denseContent,
+            processedStart: 0,
+            processedFrontier: 60
+        )
+        XCTAssertNil(region)
+    }
+
+    func testAdRegionNilWhenNotYetProcessed() {
+        // Frontier hasn't reached the queried time: it's un-fingerprinted content,
+        // not an ad, even though there's no anchor here.
+        let entries = [Entry(playbackTime: 0, referenceTime: 0), Entry(playbackTime: 2, referenceTime: 2)]
+        let region = FingerprintTimingManager.adRegion(
+            forPlaybackTime: 40,
+            in: entries,
+            processedStart: 0,
+            processedFrontier: 5
+        )
+        XCTAssertNil(region)
+    }
+
+    func testAdRegionDetectsLeadingAdBeforeFirstAnchor() throws {
+        // All committed anchors sit after the ad; playback is in the processed-but-
+        // uncommitted stretch ahead of them — the case the first implementation missed.
+        let entries = [Entry(playbackTime: 50, referenceTime: 30), Entry(playbackTime: 52, referenceTime: 32)]
+        let region = try XCTUnwrap(FingerprintTimingManager.adRegion(
+            forPlaybackTime: 40,
+            in: entries,
+            processedStart: 20,
+            processedFrontier: 55
+        ))
+        XCTAssertEqual(region.lowerBound, 20, accuracy: 0.001)
+        XCTAssertEqual(region.upperBound, 50, accuracy: 0.001)
+    }
+
+    func testAdRegionDetectsInteriorAdBetweenAnchors() throws {
+        // Reference barely advances (30→31) while playback jumps 20→50: a 30s ad.
+        let entries = [
+            Entry(playbackTime: 18, referenceTime: 29),
+            Entry(playbackTime: 20, referenceTime: 30),
+            Entry(playbackTime: 50, referenceTime: 31),
+            Entry(playbackTime: 52, referenceTime: 33)
+        ]
+        let region = try XCTUnwrap(FingerprintTimingManager.adRegion(
+            forPlaybackTime: 35,
+            in: entries,
+            processedStart: 0,
+            processedFrontier: 60
+        ))
+        XCTAssertEqual(region.lowerBound, 20, accuracy: 0.001)
+        XCTAssertEqual(region.upperBound, 50, accuracy: 0.001)
+    }
+
+    func testAdRegionDetectsTrailingAdPastLastAnchor() throws {
+        // Playback has run past the newest anchor into audio the matcher walked
+        // (frontier 60) but committed nothing for.
+        let entries = [Entry(playbackTime: 18, referenceTime: 18), Entry(playbackTime: 20, referenceTime: 20)]
+        let region = try XCTUnwrap(FingerprintTimingManager.adRegion(
+            forPlaybackTime: 40,
+            in: entries,
+            processedStart: 0,
+            processedFrontier: 60
+        ))
+        XCTAssertEqual(region.lowerBound, 20, accuracy: 0.001)
+        XCTAssertEqual(region.upperBound, 60, accuracy: 0.001)
+    }
+
+    func testAdRegionNilForShortGapBelowThreshold() {
+        // A 4s commit gap (e.g. the matcher's normal latency confirming a run) is
+        // below `adMinimumGapSeconds` and must not be flagged.
+        let entries = [Entry(playbackTime: 20, referenceTime: 20), Entry(playbackTime: 24, referenceTime: 24)]
+        let region = FingerprintTimingManager.adRegion(
+            forPlaybackTime: 22,
+            in: entries,
+            processedStart: 0,
+            processedFrontier: 30
+        )
+        XCTAssertNil(region)
+    }
+
+    func testAdRegionNilForUnanchoredProcessedWindowAfterSeek() {
+        // Just after a seek the matcher has processed a stretch (40→54) but not yet
+        // confirmed its first anchor there; the only anchors are stale ones from
+        // before the seek. A gap bounded solely by the processed-window edges must
+        // not be flagged, or tapping around content would fire spurious ad toasts.
+        let entries = [Entry(playbackTime: 0, referenceTime: 0), Entry(playbackTime: 5, referenceTime: 5)]
+        let region = FingerprintTimingManager.adRegion(
+            forPlaybackTime: 45,
+            in: entries,
+            processedStart: 40,
+            processedFrontier: 54
+        )
+        XCTAssertNil(region)
+    }
+
+    func testAdRegionIgnoresStaleAnchorsOutsideProcessedWindow() throws {
+        // Anchors before a seek (at 0/5) shouldn't shrink the gap measured in the
+        // post-seek processed window [40, 80]; the ad spans the whole new window.
+        let entries = [
+            Entry(playbackTime: 0, referenceTime: 0),
+            Entry(playbackTime: 5, referenceTime: 5),
+            Entry(playbackTime: 70, referenceTime: 8),
+            Entry(playbackTime: 72, referenceTime: 10)
+        ]
+        let region = try XCTUnwrap(FingerprintTimingManager.adRegion(
+            forPlaybackTime: 50,
+            in: entries,
+            processedStart: 40,
+            processedFrontier: 80
+        ))
+        XCTAssertEqual(region.lowerBound, 40, accuracy: 0.001)
+        XCTAssertEqual(region.upperBound, 70, accuracy: 0.001)
+    }
 }

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
@@ -270,125 +270,56 @@ final class FingerprintTimingManagerTests: XCTestCase {
         XCTAssertEqual(last, 200.0, accuracy: 0.001)
     }
 
-    // MARK: - Ad detection
+    // MARK: - Matched-content gate (highlight opt-in)
 
-    // Dense anchors on real content (every ~2s) → no gap wide enough to be an ad.
+    // Dense anchors on real content (every ~2s) → always within matched content.
     private static let denseContent: [Entry] = stride(from: 0.0, through: 60.0, by: 2.0)
         .map { Entry(playbackTime: $0, referenceTime: $0) }
 
-    func testAdRegionNilOnDenselyMappedContent() {
-        let region = FingerprintTimingManager.adRegion(
-            forPlaybackTime: 30,
-            in: Self.denseContent,
-            processedStart: 0,
-            processedFrontier: 60
-        )
-        XCTAssertNil(region)
+    func testMatchedOnDenselyMappedContent() {
+        XCTAssertTrue(FingerprintTimingManager.isWithinMatchedContent(forPlaybackTime: 30, in: Self.denseContent))
     }
 
-    func testAdRegionNilWhenNotYetProcessed() {
-        // Frontier hasn't reached the queried time: it's un-fingerprinted content,
-        // not an ad, even though there's no anchor here.
-        let entries = [Entry(playbackTime: 0, referenceTime: 0), Entry(playbackTime: 2, referenceTime: 2)]
-        let region = FingerprintTimingManager.adRegion(
-            forPlaybackTime: 40,
-            in: entries,
-            processedStart: 0,
-            processedFrontier: 5
-        )
-        XCTAssertNil(region)
+    func testMatchedBridgesQuickGapBetweenAnchors() {
+        // A short sparse stretch (a "quick red" the matcher couldn't anchor) still
+        // sits between two close committed anchors, so it counts as matched.
+        let entries = [Entry(playbackTime: 20, referenceTime: 20), Entry(playbackTime: 26, referenceTime: 26)]
+        XCTAssertTrue(FingerprintTimingManager.isWithinMatchedContent(forPlaybackTime: 23, in: entries))
     }
 
-    func testAdRegionDetectsLeadingAdBeforeFirstAnchor() throws {
-        // All committed anchors sit after the ad; playback is in the processed-but-
-        // uncommitted stretch ahead of them — the case the first implementation missed.
-        let entries = [Entry(playbackTime: 50, referenceTime: 30), Entry(playbackTime: 52, referenceTime: 32)]
-        let region = try XCTUnwrap(FingerprintTimingManager.adRegion(
-            forPlaybackTime: 40,
-            in: entries,
-            processedStart: 20,
-            processedFrontier: 55
-        ))
-        XCTAssertEqual(region.lowerBound, 20, accuracy: 0.001)
-        XCTAssertEqual(region.upperBound, 50, accuracy: 0.001)
+    func testNotMatchedInWideGap() {
+        // A 30s gap between anchors is an ad break: not matched content.
+        let entries = [Entry(playbackTime: 20, referenceTime: 20), Entry(playbackTime: 50, referenceTime: 21)]
+        XCTAssertFalse(FingerprintTimingManager.isWithinMatchedContent(forPlaybackTime: 35, in: entries))
     }
 
-    func testAdRegionDetectsInteriorAdBetweenAnchors() throws {
-        // Reference barely advances (30→31) while playback jumps 20→50: a 30s ad.
-        let entries = [
-            Entry(playbackTime: 18, referenceTime: 29),
-            Entry(playbackTime: 20, referenceTime: 30),
-            Entry(playbackTime: 50, referenceTime: 31),
-            Entry(playbackTime: 52, referenceTime: 33)
-        ]
-        let region = try XCTUnwrap(FingerprintTimingManager.adRegion(
-            forPlaybackTime: 35,
-            in: entries,
-            processedStart: 0,
-            processedFrontier: 60
-        ))
-        XCTAssertEqual(region.lowerBound, 20, accuracy: 0.001)
-        XCTAssertEqual(region.upperBound, 50, accuracy: 0.001)
-    }
-
-    func testAdRegionDetectsTrailingAdPastLastAnchor() throws {
-        // Playback has run past the newest anchor into audio the matcher walked
-        // (frontier 60) but committed nothing for.
+    func testNotMatchedPastLastAnchor() {
+        // Playback has run past the newest anchor (e.g. into an ad whose far side
+        // isn't anchored yet) — no anchor ahead, so don't highlight.
         let entries = [Entry(playbackTime: 18, referenceTime: 18), Entry(playbackTime: 20, referenceTime: 20)]
-        let region = try XCTUnwrap(FingerprintTimingManager.adRegion(
-            forPlaybackTime: 40,
-            in: entries,
-            processedStart: 0,
-            processedFrontier: 60
-        ))
-        XCTAssertEqual(region.lowerBound, 20, accuracy: 0.001)
-        XCTAssertEqual(region.upperBound, 60, accuracy: 0.001)
+        XCTAssertFalse(FingerprintTimingManager.isWithinMatchedContent(forPlaybackTime: 40, in: entries))
     }
 
-    func testAdRegionNilForShortGapBelowThreshold() {
-        // A 4s commit gap (e.g. the matcher's normal latency confirming a run) is
-        // below `adMinimumGapSeconds` and must not be flagged.
-        let entries = [Entry(playbackTime: 20, referenceTime: 20), Entry(playbackTime: 24, referenceTime: 24)]
-        let region = FingerprintTimingManager.adRegion(
-            forPlaybackTime: 22,
-            in: entries,
-            processedStart: 0,
-            processedFrontier: 30
-        )
-        XCTAssertNil(region)
+    func testNotMatchedBeforeFirstAnchor() {
+        let entries = [Entry(playbackTime: 18, referenceTime: 18), Entry(playbackTime: 20, referenceTime: 20)]
+        XCTAssertFalse(FingerprintTimingManager.isWithinMatchedContent(forPlaybackTime: 5, in: entries))
     }
 
-    func testAdRegionNilForUnanchoredProcessedWindowAfterSeek() {
-        // Just after a seek the matcher has processed a stretch (40→54) but not yet
-        // confirmed its first anchor there; the only anchors are stale ones from
-        // before the seek. A gap bounded solely by the processed-window edges must
-        // not be flagged, or tapping around content would fire spurious ad toasts.
-        let entries = [Entry(playbackTime: 0, referenceTime: 0), Entry(playbackTime: 5, referenceTime: 5)]
-        let region = FingerprintTimingManager.adRegion(
-            forPlaybackTime: 45,
-            in: entries,
-            processedStart: 40,
-            processedFrontier: 54
-        )
-        XCTAssertNil(region)
+    func testNotMatchedWithEmptyMapping() {
+        XCTAssertFalse(FingerprintTimingManager.isWithinMatchedContent(forPlaybackTime: 10, in: []))
     }
 
-    func testAdRegionIgnoresStaleAnchorsOutsideProcessedWindow() throws {
-        // Anchors before a seek (at 0/5) shouldn't shrink the gap measured in the
-        // post-seek processed window [40, 80]; the ad spans the whole new window.
+    func testMatchedFlipsImmediatelyAtLastAnchorBeforeAd() {
+        // Anchors up to 14 (ad start), next committed anchor only after the ad at 44.
+        // Just before 14 we're matched; the instant we cross it the bracket widens
+        // to 14→44 and we stop — no lag.
         let entries = [
-            Entry(playbackTime: 0, referenceTime: 0),
-            Entry(playbackTime: 5, referenceTime: 5),
-            Entry(playbackTime: 70, referenceTime: 8),
-            Entry(playbackTime: 72, referenceTime: 10)
+            Entry(playbackTime: 12, referenceTime: 12),
+            Entry(playbackTime: 14, referenceTime: 14),
+            Entry(playbackTime: 44, referenceTime: 15),
+            Entry(playbackTime: 45, referenceTime: 16)
         ]
-        let region = try XCTUnwrap(FingerprintTimingManager.adRegion(
-            forPlaybackTime: 50,
-            in: entries,
-            processedStart: 40,
-            processedFrontier: 80
-        ))
-        XCTAssertEqual(region.lowerBound, 40, accuracy: 0.001)
-        XCTAssertEqual(region.upperBound, 70, accuracy: 0.001)
+        XCTAssertTrue(FingerprintTimingManager.isWithinMatchedContent(forPlaybackTime: 13.9, in: entries))
+        XCTAssertFalse(FingerprintTimingManager.isWithinMatchedContent(forPlaybackTime: 14.1, in: entries))
     }
 }

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -101,4 +101,14 @@ enum FingerprintConstants {
     /// Persistent cache schema version. Bump when the on-disk shape changes so
     /// older files are silently discarded on the next load.
     static let mappingCacheSchemaVersion: Int = 2
+
+    /// A dynamically-inserted ad is audio present in the playback timeline but
+    /// absent from the reference fingerprint, so the matcher walks over it yet
+    /// commits no anchors (those candidates show as red rejections in the debug
+    /// overlay). It surfaces as a stretch of *processed* audio with no committed
+    /// anchor. A gap must span at least this many seconds to count as an ad —
+    /// comfortably above the matcher's normal commit latency over real content
+    /// (a few seconds to confirm the first anchor of a run) so ordinary playback
+    /// is never mistaken for an ad, while real ads (≥15s) are caught.
+    static let adMinimumGapSeconds: Double = 8
 }

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -102,13 +102,13 @@ enum FingerprintConstants {
     /// older files are silently discarded on the next load.
     static let mappingCacheSchemaVersion: Int = 2
 
-    /// A dynamically-inserted ad is audio present in the playback timeline but
-    /// absent from the reference fingerprint, so the matcher walks over it yet
-    /// commits no anchors (those candidates show as red rejections in the debug
-    /// overlay). It surfaces as a stretch of *processed* audio with no committed
-    /// anchor. A gap must span at least this many seconds to count as an ad —
-    /// comfortably above the matcher's normal commit latency over real content
-    /// (a few seconds to confirm the first anchor of a run) so ordinary playback
-    /// is never mistaken for an ad, while real ads (≥15s) are caught.
-    static let adMinimumGapSeconds: Double = 8
+    /// Highlighting is opt-in: a transcript word is only highlighted while playback
+    /// sits between two committed anchors no further apart than this. Real content
+    /// commits anchors every second or two, and sparse "quick red" gaps within
+    /// matched audio stay under this bound, so highlighting tracks continuously.
+    /// Dynamic ads and other unmatched audio open a much wider gap (or leave no
+    /// committed anchor ahead at all), so the instant playback crosses the last
+    /// matched anchor the gap jumps past this and highlighting stops — no ad
+    /// detection, no lag. Comfortably below a typical ad break (≥15s).
+    static let highlightMaxGapSeconds: Double = 8
 }

--- a/podcasts/Fingerprint/FingerprintDebugOverlay.swift
+++ b/podcasts/Fingerprint/FingerprintDebugOverlay.swift
@@ -7,7 +7,7 @@ class FingerprintDebugOverlay: UIView {
     private var rejections: [FingerprintTimingManager.TimeMappingEntry] = []
     private var totalDuration: Double = 0
     private var playbackPosition: Double = 0
-    private var adRange: ClosedRange<Double>?
+    private var isHighlighting = false
 
     private let statusLabel: UILabel = {
         let label = UILabel()
@@ -48,8 +48,8 @@ class FingerprintDebugOverlay: UIView {
         let fingerprintDuration = FingerprintTimingManager.shared.totalDuration ?? 0
         totalDuration = fingerprintDuration > 0 ? fingerprintDuration : PlaybackManager.shared.duration()
         playbackPosition = PlaybackManager.shared.currentTime()
-        adRange = FingerprintTimingManager.shared.adRegion(forPlaybackTime: playbackPosition)
-        statusLabel.text = describe(state: FingerprintTimingManager.shared.state)
+        isHighlighting = FingerprintTimingManager.shared.isWithinMatchedContent(forPlaybackTime: playbackPosition)
+        statusLabel.text = "\(describe(state: FingerprintTimingManager.shared.state)) · \(isHighlighting ? "🟢 highlighting" : "🔴 suppressed")"
         setNeedsDisplay()
     }
 
@@ -85,16 +85,6 @@ class FingerprintDebugOverlay: UIView {
             let segmentWidth = max(CGFloat(2.0 / totalDuration) * rect.width, 2)
             ctx?.setFillColor(UIColor.systemGreen.cgColor)
             ctx?.fill(CGRect(x: x, y: 0, width: segmentWidth, height: rect.height))
-        }
-
-        // Currently-detected dynamic ad — the span over which highlighting is
-        // suppressed. Vivid, opaque yellow so it's unmistakable against the
-        // red/green ticks.
-        if let adRange {
-            let startX = CGFloat(adRange.lowerBound / totalDuration) * rect.width
-            let endX = CGFloat(adRange.upperBound / totalDuration) * rect.width
-            ctx?.setFillColor(UIColor.yellow.cgColor)
-            ctx?.fill(CGRect(x: startX, y: 0, width: max(endX - startX, 2), height: rect.height))
         }
 
         if playbackPosition > 0 {

--- a/podcasts/Fingerprint/FingerprintDebugOverlay.swift
+++ b/podcasts/Fingerprint/FingerprintDebugOverlay.swift
@@ -7,6 +7,7 @@ class FingerprintDebugOverlay: UIView {
     private var rejections: [FingerprintTimingManager.TimeMappingEntry] = []
     private var totalDuration: Double = 0
     private var playbackPosition: Double = 0
+    private var adRange: ClosedRange<Double>?
 
     private let statusLabel: UILabel = {
         let label = UILabel()
@@ -47,6 +48,7 @@ class FingerprintDebugOverlay: UIView {
         let fingerprintDuration = FingerprintTimingManager.shared.totalDuration ?? 0
         totalDuration = fingerprintDuration > 0 ? fingerprintDuration : PlaybackManager.shared.duration()
         playbackPosition = PlaybackManager.shared.currentTime()
+        adRange = FingerprintTimingManager.shared.adRegion(forPlaybackTime: playbackPosition)
         statusLabel.text = describe(state: FingerprintTimingManager.shared.state)
         setNeedsDisplay()
     }
@@ -83,6 +85,16 @@ class FingerprintDebugOverlay: UIView {
             let segmentWidth = max(CGFloat(2.0 / totalDuration) * rect.width, 2)
             ctx?.setFillColor(UIColor.systemGreen.cgColor)
             ctx?.fill(CGRect(x: x, y: 0, width: segmentWidth, height: rect.height))
+        }
+
+        // Currently-detected dynamic ad — the span over which highlighting is
+        // suppressed. Vivid, opaque yellow so it's unmistakable against the
+        // red/green ticks.
+        if let adRange {
+            let startX = CGFloat(adRange.lowerBound / totalDuration) * rect.width
+            let endX = CGFloat(adRange.upperBound / totalDuration) * rect.width
+            ctx?.setFillColor(UIColor.yellow.cgColor)
+            ctx?.fill(CGRect(x: startX, y: 0, width: max(endX - startX, 2), height: rect.height))
         }
 
         if playbackPosition > 0 {

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -83,6 +83,14 @@ final class FingerprintTimingManager: NSObject {
     private var referenceToPlayback: [TimeMappingEntry] = []
     private var lastProgressPosition: Double = -1
 
+    /// Playback-time span the matcher has consumed in the current stream, whether
+    /// or not it committed anchors there. Lets ad detection tell "matcher walked
+    /// over here and committed nothing" (an ad / non-matching audio) from "matcher
+    /// hasn't reached here yet" (un-fingerprinted content). Both reset on every
+    /// (re)start so they describe only the active stream's processed window.
+    private var processedPlaybackStart: Double = -1
+    private var processedPlaybackFrontier: Double = -1
+
     private var preparationStartDate: Date?
     private var hasReachedActive = false
     private var hasEmittedPreparationStarted = false
@@ -267,6 +275,29 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
+    /// Returns the playback-time range of a dynamically-inserted ad containing
+    /// `playbackTime`, or nil when playback is on mapped content.
+    ///
+    /// Dynamic ads aren't in the reference fingerprint, so the matcher walks over
+    /// them but commits no anchors (they show as the red rejection chunks in the
+    /// debug overlay). An ad is therefore any stretch the matcher has *processed*
+    /// — bounded by `processedPlaybackStart`/`processedPlaybackFrontier` — that has
+    /// no committed anchor for at least `adMinimumGapSeconds`. This covers an ad
+    /// before the first anchor, between two anchors, or past the last anchor alike;
+    /// the only thing that disqualifies a gap is the matcher not having reached it
+    /// yet (un-fingerprinted content), which the processed window excludes.
+    func adRegion(forPlaybackTime playbackTime: Double) -> ClosedRange<Double>? {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+        return queue.sync {
+            Self.adRegion(
+                forPlaybackTime: playbackTime,
+                in: playbackToReference,
+                processedStart: processedPlaybackStart,
+                processedFrontier: processedPlaybackFrontier
+            )
+        }
+    }
+
     #if DEBUG
     var totalDuration: Double? {
         dispatchPrecondition(condition: .notOnQueue(queue))
@@ -310,6 +341,8 @@ final class FingerprintTimingManager: NSObject {
     private func resetFilterState() {
         filterLastTrusted = nil
         filterCandidatePool.removeAll()
+        processedPlaybackStart = -1
+        processedPlaybackFrontier = -1
     }
 
     private func track(_ event: AnalyticsEvent, properties: [String: Sendable] = [:]) {
@@ -504,6 +537,11 @@ final class FingerprintTimingManager: NSObject {
 
             if isWithinMappedRange(currentTime) {
                 filterLastTrusted = cached.entries.last
+                // A full cache means the whole file was fingerprinted in a prior
+                // session, so treat the entire timeline as processed — ad gaps
+                // already baked into the cached mapping are then detectable.
+                processedPlaybackStart = 0
+                processedPlaybackFrontier = duration
                 let coverage = cached.entries.count
                 updateState(.active(coverage: coverage))
                 if !hasReachedActive {
@@ -977,6 +1015,18 @@ final class FingerprintTimingManager: NSObject {
             inserted += consider(candidate: candidate)
         }
 
+        // Record the playback span we just walked — including windows that matched
+        // nothing — so ad detection knows this stretch was processed and left
+        // uncommitted on purpose, rather than simply not reached yet.
+        if let firstWindow = windows.first {
+            let start = startOffset + Double(firstWindow.timestampMs) / 1000.0
+            processedPlaybackStart = processedPlaybackStart < 0 ? start : min(processedPlaybackStart, start)
+        }
+        if let lastWindow = windows.last {
+            let frontier = startOffset + Double(lastWindow.timestampMs) / 1000.0
+            processedPlaybackFrontier = max(processedPlaybackFrontier, frontier)
+        }
+
         let coverage = playbackToReference.count
         if coverage >= FingerprintConstants.minimumCoverageForActive {
             updateState(.active(coverage: coverage))
@@ -1175,6 +1225,65 @@ final class FingerprintTimingManager: NSObject {
 
         let fraction = (t1 > t0) ? (time - t0) / (t1 - t0) : 0
         return v0 + fraction * (v1 - v0)
+    }
+
+    /// Finds the commit-gap of processed audio containing `playbackTime` and
+    /// returns it when it's wide enough to be a dynamic ad. See
+    /// `adRegion(forPlaybackTime:)`.
+    static func adRegion(
+        forPlaybackTime playbackTime: Double,
+        in entries: [TimeMappingEntry],
+        processedStart: Double,
+        processedFrontier: Double
+    ) -> ClosedRange<Double>? {
+        // Outside the matcher's processed window we can't tell an ad from audio
+        // that simply hasn't been fingerprinted yet.
+        guard processedStart >= 0,
+              playbackTime >= processedStart,
+              playbackTime <= processedFrontier else { return nil }
+
+        // Binary search for the anchors bracketing `playbackTime`. `hi` is the
+        // first anchor strictly after it; `hi - 1` the last at or before it.
+        var lo = 0
+        var hi = entries.count
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if entries[mid].playbackTime <= playbackTime {
+                lo = mid + 1
+            } else {
+                hi = mid
+            }
+        }
+
+        // Bound the gap by the bracketing anchors, but never beyond the processed
+        // window — anchors outside it belong to a different region (e.g. before a
+        // seek) and mustn't shrink the gap we're measuring here. Track whether
+        // each bound came from a real committed anchor versus the processed-window
+        // edge.
+        var lower = processedStart
+        var lowerIsAnchor = false
+        if hi - 1 >= 0, entries[hi - 1].playbackTime > lower {
+            lower = entries[hi - 1].playbackTime
+            lowerIsAnchor = true
+        }
+        var upper = processedFrontier
+        var upperIsAnchor = false
+        if hi < entries.count, entries[hi].playbackTime < upper {
+            upper = entries[hi].playbackTime
+            upperIsAnchor = true
+        }
+
+        guard upper - lower >= FingerprintConstants.adMinimumGapSeconds else { return nil }
+
+        // The gap must be anchored by committed content on at least one side. A
+        // gap bounded only by the processed-window edges is a region the matcher
+        // has walked but not yet anchored anywhere near — the transient state
+        // right after a seek, before the first anchor confirms. Flagging it would
+        // fire spurious "ad started / ended" toasts while tapping around content
+        // that has no ads.
+        guard lowerIsAnchor || upperIsAnchor else { return nil }
+
+        return lower...upper
     }
 
     // MARK: - Helpers

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -284,6 +284,26 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
+    /// The reference time for `playbackTime`, but only when it's on matched content
+    /// (see `isWithinMatchedContent`). Combines the gate and the interpolation into
+    /// a single `queue.sync` so the highlight tick — driven by the display link at
+    /// ~60Hz — pays one lock per frame and can't see the two disagree if the mapping
+    /// mutates between them.
+    func matchedReferenceTime(forPlaybackTime playbackTime: Double) -> Double? {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+        return queue.sync {
+            guard Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: playbackToReference) else {
+                return nil
+            }
+            return Self.interpolate(
+                time: playbackTime,
+                in: playbackToReference,
+                keyPath: \.playbackTime,
+                valuePath: \.referenceTime
+            )
+        }
+    }
+
     #if DEBUG
     var totalDuration: Double? {
         dispatchPrecondition(condition: .notOnQueue(queue))

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -83,14 +83,6 @@ final class FingerprintTimingManager: NSObject {
     private var referenceToPlayback: [TimeMappingEntry] = []
     private var lastProgressPosition: Double = -1
 
-    /// Playback-time span the matcher has consumed in the current stream, whether
-    /// or not it committed anchors there. Lets ad detection tell "matcher walked
-    /// over here and committed nothing" (an ad / non-matching audio) from "matcher
-    /// hasn't reached here yet" (un-fingerprinted content). Both reset on every
-    /// (re)start so they describe only the active stream's processed window.
-    private var processedPlaybackStart: Double = -1
-    private var processedPlaybackFrontier: Double = -1
-
     private var preparationStartDate: Date?
     private var hasReachedActive = false
     private var hasEmittedPreparationStarted = false
@@ -275,26 +267,20 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
-    /// Returns the playback-time range of a dynamically-inserted ad containing
-    /// `playbackTime`, or nil when playback is on mapped content.
+    /// Whether `playbackTime` sits on confidently-matched content — bracketed by
+    /// committed anchors no more than `highlightMaxGapSeconds` apart.
     ///
-    /// Dynamic ads aren't in the reference fingerprint, so the matcher walks over
-    /// them but commits no anchors (they show as the red rejection chunks in the
-    /// debug overlay). An ad is therefore any stretch the matcher has *processed*
-    /// — bounded by `processedPlaybackStart`/`processedPlaybackFrontier` — that has
-    /// no committed anchor for at least `adMinimumGapSeconds`. This covers an ad
-    /// before the first anchor, between two anchors, or past the last anchor alike;
-    /// the only thing that disqualifies a gap is the matcher not having reached it
-    /// yet (un-fingerprinted content), which the processed window excludes.
-    func adRegion(forPlaybackTime playbackTime: Double) -> ClosedRange<Double>? {
+    /// Highlighting keys off this so it only ever runs while we're sure where we
+    /// are. Real content commits anchors every second or two, so a sparse "quick
+    /// red" gap stays under the bound and still counts as matched. A dynamic ad
+    /// (absent from the reference fingerprint, so no anchors commit across it)
+    /// opens a wide gap — or leaves no committed anchor ahead of the play-head at
+    /// all — so the instant playback crosses the last matched anchor this returns
+    /// false and highlighting stops, with no ad-detection step to lag behind.
+    func isWithinMatchedContent(forPlaybackTime playbackTime: Double) -> Bool {
         dispatchPrecondition(condition: .notOnQueue(queue))
         return queue.sync {
-            Self.adRegion(
-                forPlaybackTime: playbackTime,
-                in: playbackToReference,
-                processedStart: processedPlaybackStart,
-                processedFrontier: processedPlaybackFrontier
-            )
+            Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: playbackToReference)
         }
     }
 
@@ -341,8 +327,6 @@ final class FingerprintTimingManager: NSObject {
     private func resetFilterState() {
         filterLastTrusted = nil
         filterCandidatePool.removeAll()
-        processedPlaybackStart = -1
-        processedPlaybackFrontier = -1
     }
 
     private func track(_ event: AnalyticsEvent, properties: [String: Sendable] = [:]) {
@@ -537,11 +521,6 @@ final class FingerprintTimingManager: NSObject {
 
             if isWithinMappedRange(currentTime) {
                 filterLastTrusted = cached.entries.last
-                // A full cache means the whole file was fingerprinted in a prior
-                // session, so treat the entire timeline as processed — ad gaps
-                // already baked into the cached mapping are then detectable.
-                processedPlaybackStart = 0
-                processedPlaybackFrontier = duration
                 let coverage = cached.entries.count
                 updateState(.active(coverage: coverage))
                 if !hasReachedActive {
@@ -1015,18 +994,6 @@ final class FingerprintTimingManager: NSObject {
             inserted += consider(candidate: candidate)
         }
 
-        // Record the playback span we just walked — including windows that matched
-        // nothing — so ad detection knows this stretch was processed and left
-        // uncommitted on purpose, rather than simply not reached yet.
-        if let firstWindow = windows.first {
-            let start = startOffset + Double(firstWindow.timestampMs) / 1000.0
-            processedPlaybackStart = processedPlaybackStart < 0 ? start : min(processedPlaybackStart, start)
-        }
-        if let lastWindow = windows.last {
-            let frontier = startOffset + Double(lastWindow.timestampMs) / 1000.0
-            processedPlaybackFrontier = max(processedPlaybackFrontier, frontier)
-        }
-
         let coverage = playbackToReference.count
         if coverage >= FingerprintConstants.minimumCoverageForActive {
             updateState(.active(coverage: coverage))
@@ -1227,21 +1194,12 @@ final class FingerprintTimingManager: NSObject {
         return v0 + fraction * (v1 - v0)
     }
 
-    /// Finds the commit-gap of processed audio containing `playbackTime` and
-    /// returns it when it's wide enough to be a dynamic ad. See
-    /// `adRegion(forPlaybackTime:)`.
-    static func adRegion(
+    /// Whether `playbackTime` is bracketed by two committed anchors no further
+    /// apart than `highlightMaxGapSeconds`. See `isWithinMatchedContent(forPlaybackTime:)`.
+    static func isWithinMatchedContent(
         forPlaybackTime playbackTime: Double,
-        in entries: [TimeMappingEntry],
-        processedStart: Double,
-        processedFrontier: Double
-    ) -> ClosedRange<Double>? {
-        // Outside the matcher's processed window we can't tell an ad from audio
-        // that simply hasn't been fingerprinted yet.
-        guard processedStart >= 0,
-              playbackTime >= processedStart,
-              playbackTime <= processedFrontier else { return nil }
-
+        in entries: [TimeMappingEntry]
+    ) -> Bool {
         // Binary search for the anchors bracketing `playbackTime`. `hi` is the
         // first anchor strictly after it; `hi - 1` the last at or before it.
         var lo = 0
@@ -1255,35 +1213,12 @@ final class FingerprintTimingManager: NSObject {
             }
         }
 
-        // Bound the gap by the bracketing anchors, but never beyond the processed
-        // window — anchors outside it belong to a different region (e.g. before a
-        // seek) and mustn't shrink the gap we're measuring here. Track whether
-        // each bound came from a real committed anchor versus the processed-window
-        // edge.
-        var lower = processedStart
-        var lowerIsAnchor = false
-        if hi - 1 >= 0, entries[hi - 1].playbackTime > lower {
-            lower = entries[hi - 1].playbackTime
-            lowerIsAnchor = true
-        }
-        var upper = processedFrontier
-        var upperIsAnchor = false
-        if hi < entries.count, entries[hi].playbackTime < upper {
-            upper = entries[hi].playbackTime
-            upperIsAnchor = true
-        }
+        // Need a committed anchor on each side: before the first or past the last
+        // we aren't confidently on matched content, so don't highlight.
+        guard hi - 1 >= 0, hi < entries.count else { return false }
 
-        guard upper - lower >= FingerprintConstants.adMinimumGapSeconds else { return nil }
-
-        // The gap must be anchored by committed content on at least one side. A
-        // gap bounded only by the processed-window edges is a region the matcher
-        // has walked but not yet anchored anywhere near — the transient state
-        // right after a seek, before the first anchor confirms. Flagging it would
-        // fire spurious "ad started / ended" toasts while tapping around content
-        // that has no ads.
-        guard lowerIsAnchor || upperIsAnchor else { return nil }
-
-        return lower...upper
+        let gap = entries[hi].playbackTime - entries[hi - 1].playbackTime
+        return gap <= FingerprintConstants.highlightMaxGapSeconds
     }
 
     // MARK: - Helpers

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -897,7 +897,10 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
             )
             #endif
         } else if let startTime = transcript.cues.first?.startTime, position < startTime {
-            previousRange = nil
+            // Before the first cue there's nothing to highlight — clear any rendered
+            // highlight rather than just nil'ing `previousRange`, which would leave a
+            // painted range on screen.
+            clearHighlight(transcript: transcript)
             if !isUserScrolling, !isSearching, !isAutoScrollSuppressed {
                 transcriptView.scrollRangeToVisible(NSRange(location: 0, length: 0))
             }

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -11,6 +11,11 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private var transcript: TranscriptModel?
     private var previousRange: NSRange?
 
+    // True while a dynamically-inserted ad is playing. The reference timeline
+    // doesn't advance through ad audio, so highlighting is suppressed and the
+    // listener is toasted at the ad's start and end.
+    private var isInDynamicAd = false
+
     private var canScrollToDismiss = true
 
     private var isUserScrolling = false
@@ -758,6 +763,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         setupShowTranscriptState()
         previousRange = nil
         cachedCueIndex = 0
+        isInDynamicAd = false
         self.transcript = transcript
         hasNonEmptySelection = false
         transcriptView.attributedText = styleText(transcript: transcript)
@@ -858,10 +864,17 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     @objc private func updateTranscriptPosition() {
         guard let transcript else { return }
 
+        let rawTime = playbackManager.currentTime()
+
+        // Dynamically-inserted ads aren't in the reference fingerprint, so any cue
+        // we'd pick while one plays is wrong. Suppress highlighting and toast the
+        // ad's start/end instead.
+        updateDynamicAdState(playbackTime: rawTime, transcript: transcript)
+        guard !isInDynamicAd else { return }
+
         // Only highlight when the fingerprint flow has an actual mapping for this
         // playback time. Without that, falling back to raw playback time would
         // highlight arbitrary VTT lines during ads and other non-matching audio.
-        let rawTime = playbackManager.currentTime()
         guard case .active = FingerprintTimingManager.shared.state,
               let position = FingerprintTimingManager.shared.referenceTime(forPlaybackTime: rawTime) else {
             if previousRange != nil {
@@ -895,6 +908,33 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 transcriptView.scrollRangeToVisible(NSRange(location: 0, length: 0))
             }
         }
+    }
+
+    /// Detects whether `playbackTime` falls inside a dynamically-inserted ad and,
+    /// on entering one, clears the highlight (it stays cleared until the ad ends,
+    /// when the normal highlight loop resumes on the next tick).
+    private func updateDynamicAdState(playbackTime: Double, transcript: TranscriptModel) {
+        let inAd: Bool
+        if case .active = FingerprintTimingManager.shared.state {
+            inAd = FingerprintTimingManager.shared.adRegion(forPlaybackTime: playbackTime) != nil
+        } else {
+            // No mapping to classify against — assume we're not in an ad.
+            inAd = false
+        }
+
+        guard inAd != isInDynamicAd else { return }
+        isInDynamicAd = inAd
+        guard inAd else { return }
+
+        // Drop any highlight for the duration of the ad. Restyle unconditionally —
+        // `previousRange` can already be nil while a stale highlight is still
+        // rendered (e.g. after seeking into the ad), so gating on it would leave
+        // that highlight stuck on screen. Mutate `textStorage` in place rather than
+        // assigning `attributedText`: the latter resets the text view's scroll
+        // position on the next layout pass, yanking the transcript. The content is
+        // identical bar colour, so an in-place attribute swap keeps the scroll put.
+        previousRange = nil
+        transcriptView.textStorage.setAttributedString(styleText(transcript: transcript))
     }
 
     // Resolves the cue containing `position` in O(1) amortized for normal

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -11,10 +11,10 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private var transcript: TranscriptModel?
     private var previousRange: NSRange?
 
-    // True while a dynamically-inserted ad is playing. The reference timeline
-    // doesn't advance through ad audio, so highlighting is suppressed and the
-    // listener is toasted at the ad's start and end.
-    private var isInDynamicAd = false
+    // Whether a highlight is currently rendered. Tracked separately from
+    // `previousRange` because that can be nilled without restyling, leaving a
+    // highlight on screen that still needs clearing when we leave matched content.
+    private var hasRenderedHighlight = false
 
     private var canScrollToDismiss = true
 
@@ -763,7 +763,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         setupShowTranscriptState()
         previousRange = nil
         cachedCueIndex = 0
-        isInDynamicAd = false
+        hasRenderedHighlight = false
         self.transcript = transcript
         hasNonEmptySelection = false
         transcriptView.attributedText = styleText(transcript: transcript)
@@ -866,21 +866,15 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
         let rawTime = playbackManager.currentTime()
 
-        // Dynamically-inserted ads aren't in the reference fingerprint, so any cue
-        // we'd pick while one plays is wrong. Suppress highlighting and toast the
-        // ad's start/end instead.
-        updateDynamicAdState(playbackTime: rawTime, transcript: transcript)
-        guard !isInDynamicAd else { return }
-
-        // Only highlight when the fingerprint flow has an actual mapping for this
-        // playback time. Without that, falling back to raw playback time would
-        // highlight arbitrary VTT lines during ads and other non-matching audio.
+        // Highlighting is opt-in: only paint while playback is confidently on
+        // matched content. Off it — dynamic ads, unmatched audio, regions not yet
+        // fingerprinted, or before/after the mapped range — we clear and leave it
+        // cleared. Crossing the last matched anchor flips this immediately, so we
+        // never highlight ad words first and retract them.
         guard case .active = FingerprintTimingManager.shared.state,
+              FingerprintTimingManager.shared.isWithinMatchedContent(forPlaybackTime: rawTime),
               let position = FingerprintTimingManager.shared.referenceTime(forPlaybackTime: rawTime) else {
-            if previousRange != nil {
-                previousRange = nil
-                transcriptView.attributedText = styleText(transcript: transcript)
-            }
+            clearHighlight(transcript: transcript)
             return
         }
 
@@ -889,6 +883,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         if let cue = currentCue, cue.characterRange != previousRange {
             let range = cue.characterRange
             previousRange = range
+            hasRenderedHighlight = true
             transcriptView.attributedText = styleText(transcript: transcript, position: position)
             if !isUserScrolling, !isSearching, !isAutoScrollSuppressed {
                 transcriptView.scrollToRange(range, verticalAnchor: Self.highlightVerticalAnchor)
@@ -910,30 +905,15 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         }
     }
 
-    /// Detects whether `playbackTime` falls inside a dynamically-inserted ad and,
-    /// on entering one, clears the highlight (it stays cleared until the ad ends,
-    /// when the normal highlight loop resumes on the next tick).
-    private func updateDynamicAdState(playbackTime: Double, transcript: TranscriptModel) {
-        let inAd: Bool
-        if case .active = FingerprintTimingManager.shared.state {
-            inAd = FingerprintTimingManager.shared.adRegion(forPlaybackTime: playbackTime) != nil
-        } else {
-            // No mapping to classify against — assume we're not in an ad.
-            inAd = false
-        }
-
-        guard inAd != isInDynamicAd else { return }
-        isInDynamicAd = inAd
-        guard inAd else { return }
-
-        // Drop any highlight for the duration of the ad. Restyle unconditionally —
-        // `previousRange` can already be nil while a stale highlight is still
-        // rendered (e.g. after seeking into the ad), so gating on it would leave
-        // that highlight stuck on screen. Mutate `textStorage` in place rather than
-        // assigning `attributedText`: the latter resets the text view's scroll
-        // position on the next layout pass, yanking the transcript. The content is
-        // identical bar colour, so an in-place attribute swap keeps the scroll put.
+    /// Remove any rendered highlight while leaving the scroll position untouched.
+    /// Mutates `textStorage` in place rather than reassigning `attributedText`
+    /// (which resets the text view's scroll on the next layout pass), and keys off
+    /// `hasRenderedHighlight` rather than `previousRange` since the latter can be
+    /// nilled elsewhere without restyling, leaving a highlight on screen.
+    private func clearHighlight(transcript: TranscriptModel) {
+        guard hasRenderedHighlight else { return }
         previousRange = nil
+        hasRenderedHighlight = false
         transcriptView.textStorage.setAttributedString(styleText(transcript: transcript))
     }
 

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -872,8 +872,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         // cleared. Crossing the last matched anchor flips this immediately, so we
         // never highlight ad words first and retract them.
         guard case .active = FingerprintTimingManager.shared.state,
-              FingerprintTimingManager.shared.isWithinMatchedContent(forPlaybackTime: rawTime),
-              let position = FingerprintTimingManager.shared.referenceTime(forPlaybackTime: rawTime) else {
+              let position = FingerprintTimingManager.shared.matchedReferenceTime(forPlaybackTime: rawTime) else {
             clearHighlight(transcript: transcript)
             return
         }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

Synced (highlighted) transcripts drove the highlight off a fingerprint mapping that **interpolates across every gap**, so across a dynamically-inserted ad (which has no committed anchors) the highlight kept advancing through ad audio and landed on the wrong words.

This **inverts the logic to opt-in**: a word is highlighted only while playback sits between two committed anchors no further apart than `highlightMaxGapSeconds` (8s).

- **Green / dense matches** → bracketed by close anchors → highlight.
- **Quick red between greens** (sparse but matched audio) → still bracketed within the bound → highlight.
- **Dynamic ad / unmatched audio / not-yet-fingerprinted / outside the mapped range** → no close bracket → no highlight.

The key property: the instant playback crosses the **last matched anchor before an ad**, the bracketing gap jumps wide (or there's no anchor ahead at all), so highlighting stops *immediately* — there's no ad-detection step to lag behind, so ad words are never painted and then retracted. Off matched content the highlight is cleared **in place via `textStorage`** (not by reassigning `attributedText`, which resets the text view's scroll), so the transcript stays put.

### Changes
- `FingerprintTimingManager.isWithinMatchedContent(forPlaybackTime:)` — the opt-in gate; returns true only when the play-head is bracketed by committed anchors within the gap bound.
- `TranscriptViewController` — highlight guard requires the gate; clears in place with a `hasRenderedHighlight` flag so a stale highlight can't get stuck.
- `FingerprintConstants.highlightMaxGapSeconds` — the single tuning knob.
- Debug overlay — status label shows the live `🟢 highlighting` / `🔴 suppressed` decision.

All gated behind the existing `FeatureFlag.syncedTranscripts`.

## To test

1. Play any recently The Daily episode
2. Let playback reach the ad — the highlight stops the moment playback enters the ad and resumes on the content after it (overlay shows 🔴 during the ad, 🟢 on content).
3. Rewind/seek into the ad — confirm no highlight appears, and seeking does not scroll the transcript.
4. Tap around ad-free content — confirm highlighting stays continuous with no flicker.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.