### PR TITLE
[PC TV] Fix an issue with section title animation

### DIFF
--- a/Pocket Casts TV App/UI/Common/FocusStore.swift
+++ b/Pocket Casts TV App/UI/Common/FocusStore.swift
@@ -15,7 +15,9 @@ struct FocusObserving: ViewModifier {
             .focused($isFocused)
             .onChange(of: isFocused) { _, newValue in
                 if newValue {
-                    focusStore.focusedID = section
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        focusStore.focusedID = section
+                    }
                 }
             }
     }

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -218,12 +218,25 @@ struct HomeSection<Content: View>: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 32) {
-            Text(title)
-                .font(isFocusedSection ? .title2 : .headline)
-                .foregroundStyle(Color.pcTextPrimary)
+            titleView
             content
         }
         .focusSection()
+    }
+
+    // Always reserve space for the larger (focused) title so the layout
+    // doesn't jump when the title resizes on focus changes. A hidden copy at
+    // the largest font sizes the slot; the visible title is overlaid and
+    // bottom-aligned so its distance to the content below stays constant.
+    private var titleView: some View {
+        Text(title)
+            .font(.title2)
+            .hidden()
+            .overlay(alignment: .bottomLeading) {
+                Text(title)
+                    .font(isFocusedSection ? .title2 : .headline)
+                    .foregroundStyle(Color.pcTextPrimary)
+            }
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

The layout not longer jumps.

https://github.com/user-attachments/assets/2ef87d82-78ab-4ba3-af43-8392b57230ed


## To test

Follow the steps from the video.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
