### PR TITLE
[PC TV] Fix sign in animation

### DIFF
--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -116,6 +116,43 @@ struct MockData {
         return self.stubPodcasts
     }
 
+    /// Real Pocket Casts podcast UUIDs, so mock podcasts render real artwork from
+    /// the image CDN instead of blank placeholders in previews and demos.
+    static let artworkUUIDs = [
+        "e7a6f7d0-02f2-0133-1c51-059c869cc4eb",
+        "da3271a0-69e7-0132-d9fd-5f4c86fd3263",
+        "3782b780-0bc5-012e-fb02-00163e1b201c",
+        "9349e8d0-a87f-013a-d8af-0acc26574db2",
+        "82e37e80-755d-0138-eddc-0acc26574db2",
+        "9478cc80-7c42-0138-edfe-0acc26574db2",
+        "37082d70-e945-0137-b6eb-0acc26574db2",
+        "62200ab0-b7ec-0139-f606-0acc26574db2",
+        "b0689300-ecd3-012e-e054-525400c11844",
+        "68504d20-dc2b-012e-da14-525400c11844",
+        "43e949f0-60ec-0131-7415-723c91aeae46"
+    ]
+
+    static var stubArtworkPodcasts: [Podcast] = []
+
+    /// Stub podcasts whose `uuid` resolves to real artwork on the image CDN.
+    /// Use these where the mock should look populated (e.g. the signing-in animation).
+    static func makeStubArtworkPodcasts() -> [Podcast] {
+        guard stubArtworkPodcasts.isEmpty else {
+            return stubArtworkPodcasts
+        }
+        var results = [Podcast]()
+        for (i, uuid) in artworkUUIDs.enumerated() {
+            let podcast = Podcast()
+            podcast.id = Int64(i)
+            podcast.uuid = uuid
+            podcast.title = podcastNames[i % podcastNames.count]
+            podcast.author = authorNames[i % authorNames.count]
+            results.append(podcast)
+        }
+        stubArtworkPodcasts = results
+        return results
+    }
+
     private static func makeStubFolder(name: String, podcastCount: Int, from allPodcasts: [Podcast], startIndex: Int) -> Folder {
         let folderPodcasts = Array(allPodcasts[startIndex..<min(startIndex + podcastCount, allPodcasts.count)])
         let folder = Folder()

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Observation
 import PocketCastsDataModel
+import Kingfisher
 
 fileprivate enum Layout {
     static let coverSize = CGFloat(272)
@@ -10,16 +11,30 @@ fileprivate enum Layout {
 }
 
 fileprivate enum Pacing {
-    static let totalCoversToShow = 8
+    /// Minimum covers shown before we hand off, so a fast sync still reads as an animation.
+    static let minCoversToShow = 6
     static let maxSimultaneous = 2
     static let stepInterval: Double = 0.8
+    /// Fine-grained poll used before the first podcast has synced, so the first cover lands ASAP.
+    static let warmUpInterval: Double = 0.1
     static let fadeDuration: Double = 0.6
+    /// How many upcoming covers to keep mounted (hidden, loading) ahead of being shown.
+    static let prefetchAhead = 3
+    /// Upper bound on waiting for a cover's artwork, so a slow image never stalls the stack.
+    static let maxPreloadWait: Double = 1.5
 }
 
 fileprivate struct StackedCover: Identifiable {
+    /// Monotonic insertion id so the same podcast can appear more than once
+    /// (when a small library is recycled) without colliding in `ForEach`.
+    let id: Int
     let podcast: Podcast
     let rotation: Double
-    var id: String { podcast.uuid }
+    /// Set once the artwork finishes loading (reported by the image view).
+    var isLoaded = false
+    /// Covers are mounted (and start loading) while hidden, then revealed once
+    /// their artwork is ready.
+    var isRevealed = false
 }
 
 struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
@@ -27,8 +42,11 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var model: ViewModel
-    @State private var displayedCovers: [StackedCover] = []
-    @State private var nextIndex: Int = 0
+    /// Mounted covers — both those warming up (hidden, loading) and those revealed.
+    @State private var covers: [StackedCover] = []
+    @State private var nextCoverID: Int = 0
+    @State private var podcastCursor: Int = 0
+    @State private var revealedCount: Int = 0
     @State private var blackOverlayOpaque = true
 
     init(model: ViewModel = SigningInViewModel()) {
@@ -68,81 +86,164 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
         // Fade in from black so the QR/sign-in screen doesn't flash through.
         blackOverlayOpaque = false
 
-        let stepNanoseconds = UInt64(Pacing.stepInterval * 1_000_000_000)
+        // Keep revealing covers until the underlying sync finishes. For large
+        // libraries this runs well past the first batch, so the stack keeps
+        // moving instead of freezing while the sync continues in the background.
+        while !Task.isCancelled {
+            // Mount the next few covers hidden so their artwork starts loading
+            // ahead of being shown.
+            replenishWarmingCovers()
 
-        for _ in 0..<Pacing.totalCoversToShow {
-            try? await Task.sleep(nanoseconds: stepNanoseconds)
-            if Task.isCancelled { return }
-            guard nextIndex < model.podcasts.count else { continue }
-            let podcast = model.podcasts[nextIndex]
-            let sign: Double = nextIndex.isMultiple(of: 2) ? -1 : 1
-            let rotation = sign * Double.random(in: Layout.minRotation...Layout.maxRotation)
-            nextIndex += 1
-            if displayedCovers.count >= Pacing.maxSimultaneous {
-                displayedCovers.removeFirst()
+            let next = covers.first(where: { !$0.isRevealed })
+            let syncFinished = model.state == .finished
+            let shownEnough = revealedCount >= Pacing.minCoversToShow
+
+            // Done once the sync has finished and we've either shown enough covers
+            // or run out of podcasts to reveal — the latter covers an empty account
+            // and libraries smaller than `minCoversToShow`, which can never reach it.
+            if syncFinished && (shownEnough || next == nil) {
+                break
             }
-            displayedCovers.append(StackedCover(podcast: podcast, rotation: rotation))
-        }
 
-        // Wait for the underlying sync to finish before moving on.
-        await waitForSyncCompletion()
+            guard let next else {
+                // Podcasts are still syncing in — poll quickly so the first cover
+                // appears as soon as one is available rather than after a full step.
+                try? await Task.sleep(for: .seconds(Pacing.warmUpInterval))
+                continue
+            }
+
+            // The cover view is already mounted and loading; reveal it once its
+            // artwork is ready so it animates in fully loaded instead of flashing
+            // the placeholder, or after a timeout so a slow image never stalls us.
+            await waitUntilLoaded(next.id)
+            if Task.isCancelled { return }
+            reveal(next.id)
+            try? await Task.sleep(for: .seconds(Pacing.stepInterval))
+        }
         if Task.isCancelled { return }
 
         // Fade the whole screen to black before handing off to the home view.
         blackOverlayOpaque = true
-        try? await Task.sleep(nanoseconds: UInt64(Pacing.fadeDuration * 1_000_000_000))
+        try? await Task.sleep(for: .seconds(Pacing.fadeDuration))
         if Task.isCancelled { return }
 
         coordinator.state = .signedIn
     }
 
-    @MainActor
-    private func waitForSyncCompletion() async {
-        guard model.state != .finished else { return }
-
-        await withCheckedContinuation { continuation in
-            observeSyncState(continuation: continuation)
+    /// Mounts upcoming covers (hidden) so they begin loading before they're shown,
+    /// cycling back through already-synced podcasts when the sync hasn't produced
+    /// new ones yet so the stack never stalls.
+    private func replenishWarmingCovers() {
+        let podcasts = model.podcasts
+        guard !podcasts.isEmpty else { return }
+        var needed = Pacing.prefetchAhead - covers.filter { !$0.isRevealed }.count
+        while needed > 0, let podcast = takeNextDistinctPodcast(from: podcasts) {
+            let sign: Double = nextCoverID.isMultiple(of: 2) ? -1 : 1
+            let rotation = sign * Double.random(in: Layout.minRotation...Layout.maxRotation)
+            covers.append(StackedCover(id: nextCoverID, podcast: podcast, rotation: rotation))
+            nextCoverID += 1
+            needed -= 1
         }
     }
 
-    @MainActor
-    private func observeSyncState(continuation: CheckedContinuation<Void, Never>) {
-        withObservationTracking {
-            _ = model.state
-        } onChange: {
-            Task { @MainActor in
-                if model.state == .finished {
-                    continuation.resume()
-                } else {
-                    observeSyncState(continuation: continuation)
-                }
+    /// Advances the cursor to the next podcast that isn't already on screen, cycling
+    /// through the list so covers progress and never duplicate a visible one. Returns
+    /// nil when every synced podcast is currently mounted (e.g. a tiny library that
+    /// hasn't finished syncing), in which case we simply wait for more to arrive.
+    private func takeNextDistinctPodcast(from podcasts: [Podcast]) -> Podcast? {
+        let mounted = Set(covers.map { $0.podcast.uuid })
+        for _ in 0..<podcasts.count {
+            let candidate = podcasts[podcastCursor % podcasts.count]
+            podcastCursor += 1
+            if !mounted.contains(candidate.uuid) {
+                return candidate
             }
         }
+        return nil
+    }
+
+    /// Waits until the cover's artwork has loaded (reported by the image view),
+    /// or until `maxPreloadWait` elapses so a slow image never freezes the stack.
+    private func waitUntilLoaded(_ id: Int) async {
+        var elapsed = 0.0
+        while covers.first(where: { $0.id == id })?.isLoaded != true,
+              elapsed < Pacing.maxPreloadWait,
+              !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(Pacing.warmUpInterval))
+            elapsed += Pacing.warmUpInterval
+        }
+    }
+
+    private func markLoaded(_ id: Int) {
+        guard let index = covers.firstIndex(where: { $0.id == id }) else { return }
+        covers[index].isLoaded = true
+    }
+
+    /// Reveals the cover and retires the oldest ones beyond `maxSimultaneous`.
+    private func reveal(_ id: Int) {
+        guard let index = covers.firstIndex(where: { $0.id == id }) else { return }
+        covers[index].isRevealed = true
+        revealedCount += 1
+
+        let revealed = covers.filter(\.isRevealed)
+        guard revealed.count > Pacing.maxSimultaneous else { return }
+        let stale = Set(revealed.dropLast(Pacing.maxSimultaneous).map(\.id))
+        covers.removeAll { stale.contains($0.id) }
+    }
+
+    private func imageURL(for podcast: Podcast) -> URL {
+        ImageManager.sharedManager.podcastUrl(imageSize: .page, uuid: podcast.uuid)
     }
 
     var podcastGrid: some View {
         ZStack {
-            ForEach(displayedCovers) { cover in
-                PodcastImage(uuid: cover.podcast.uuid, size: .page)
+            ForEach(covers) { cover in
+                coverImage(for: cover)
                     .frame(width: Layout.coverSize, height: Layout.coverSize)
                     .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
-                    .rotationEffect(.degrees(cover.rotation))
-                    .transition(coverTransition)
+                    .scaleEffect(scale(for: cover))
+                    .rotationEffect(.degrees(rotation(for: cover)))
+                    .opacity(cover.isRevealed ? 1 : 0)
+                    .animation(revealAnimation, value: cover.isRevealed)
+                    // Covers are revealed in place; only their removal needs a transition.
+                    .transition(.asymmetric(insertion: .identity, removal: .opacity.animation(.easeOut(duration: 0.5))))
+                    .accessibilityHidden(true)
             }
         }
         .frame(width: Layout.coverSize, height: Layout.coverSize)
     }
 
-    private var coverTransition: AnyTransition {
-        if reduceMotion {
-            return .opacity
-        }
-        return .asymmetric(
-            insertion: .scale(scale: 0.6)
-                .combined(with: .opacity)
-                .animation(.interpolatingSpring(stiffness: 220, damping: 14)),
-            removal: .opacity.animation(.easeOut(duration: 0.5))
-        )
+    /// The displayed image view also drives loading: it starts fetching as soon as
+    /// the cover is mounted (while hidden) and reports completion so the cover can
+    /// be revealed once its artwork is ready.
+    private func coverImage(for cover: StackedCover) -> some View {
+        KFImage(imageURL(for: cover.podcast))
+            .placeholder { _ in
+                if let placeholder = ImageManager.sharedManager.placeHolderImage(.page) {
+                    Image(uiImage: placeholder)
+                        .resizable()
+                }
+            }
+            .onSuccess { _ in markLoaded(cover.id) }
+            .onFailure { _ in markLoaded(cover.id) }
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+    }
+
+    private func scale(for cover: StackedCover) -> CGFloat {
+        if reduceMotion { return 1 }
+        return cover.isRevealed ? 1 : 0.6
+    }
+
+    private func rotation(for cover: StackedCover) -> Double {
+        if reduceMotion { return cover.rotation }
+        return cover.isRevealed ? cover.rotation : 0
+    }
+
+    private var revealAnimation: Animation {
+        reduceMotion
+            ? .easeInOut(duration: 0.4)
+            : .interpolatingSpring(stiffness: 220, damping: 14)
     }
 }
 

--- a/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInViewModel.swift
@@ -163,7 +163,7 @@ class SigningInViewModelMock: SigningInViewModelProtocol {
 
     var state: SigningInState = .waitingForPodcastsSync
 
-    var totalPodcastsToImport: Int = MockData.makeStubPodcasts().count
+    var totalPodcastsToImport: Int = MockData.makeStubArtworkPodcasts().count
 
     var totalPodcastsImported: Int = 0
 
@@ -174,7 +174,8 @@ class SigningInViewModelMock: SigningInViewModelProtocol {
     var podcasts: [Podcast] = []
 
     func sync() {
-        cancellable = Timer.publish(every: 1.0, on: .main, in: .common)
+        let allPodcasts = MockData.makeStubArtworkPodcasts()
+        cancellable = Timer.publish(every: 0.7, on: .main, in: .common)
                     .autoconnect()
                     .sink { [weak self] _ in
                         guard let self else { return }
@@ -184,7 +185,7 @@ class SigningInViewModelMock: SigningInViewModelProtocol {
                         } else {
                             state = .finished
                         }
-                        podcasts = Array(MockData.makeStubPodcasts().prefix(totalPodcastsImported))
+                        podcasts = Array(allPodcasts.prefix(totalPodcastsImported))
                         progress = CGFloat(totalPodcastsImported) / CGFloat(totalPodcastsToImport)
                     }
     }


### PR DESCRIPTION
Fixes PCIOS-721.

Improves the tvOS "Signing in" sync animation. The covers now load before they appear, start sooner, keep moving through a large sync, and never get stuck.

## What we improved

- Starts sooner. The first cover now appears as soon as a podcast is available (fine-grained poll) instead of after
  a fixed ~0.8s dead delay.
- No more placeholder flash. Each cover is mounted hidden and starts loading via its own image view; it's only
  revealed once its artwork has loaded (with a timeout backstop so a slow image never stalls the stack).
- Keeps moving during large syncs. Replaced the fixed 8-cover cap with a loop that runs until the sync finishes, so
  the stack no longer freezes mid-sync on big libraries.
- No duplicate covers. Covers progress through distinct podcasts and only recycle ones that have scrolled off
  screen, so you never see the same icon twice at once.
- Fixed a hang on tiny libraries. Accounts with 1–2 podcasts previously never left the signing-in screen (the
  minimum-cover threshold was unreachable); it now finishes once sync completes.

https://github.com/user-attachments/assets/c4095e28-cb0e-4703-9ea9-20471c569142


## To test

  1. Sign out of the Pocket Casts tvOS app (or use a fresh account) and sign back in.
  2. On the "Signing in" screen, confirm: covers fade in promptly, each appears with its artwork already loaded (no
  placeholder→pop), and the stack keeps animating until sync completes, then fades to the home screen.
  3. Sign in with an account that has a large library and confirm the covers keep cycling for the whole sync (no
  mid-sync freeze) and show distinct podcasts.
  4. Sign in with an account that has 1–2 subscribed podcasts and confirm it reaches the home screen (does not hang
  on the signing-in screen).
  5. Open SigningInView.swift in Xcode and run the SwiftUI Preview — confirm real cover artwork loads and no icon is
  duplicated on screen at once.
  6. Enable Settings → Accessibility → Reduce Motion and re-run sign-in; confirm covers cross-fade without the
  scale/spring.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
