### PR TITLE
[PC TV] Add light mode support

### DIFF
--- a/Pocket Casts TV App/PocketCastsTVApp.swift
+++ b/Pocket Casts TV App/PocketCastsTVApp.swift
@@ -14,7 +14,6 @@ struct PocketCastsTVApp: App {
     var body: some Scene {
         WindowGroup {
             RootView()
-                .preferredColorScheme(.dark)
         }
         .onChange(of: scenePhase) { _, newPhase in
             appLifecycleAnalytics.handle(scenePhase: newPhase)

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -132,7 +132,7 @@ struct SignInView: View {
                             .font(.caption2)
                             .foregroundStyle(Color.pcTextSecondary)
                             .padding()
-                            .background(Color.pcBackgroundActive50)
+                            .background(Color.pcBackgroundActive20)
                             .clipShape(RoundedRectangle(cornerRadius: 12))
                     }
                 }

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -68,7 +68,7 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
                 podcastGrid
                 Spacer()
             }
-            Color.black
+            Color.pcBackgroundSunken
                 .opacity(blackOverlayOpaque ? 1 : 0)
                 .animation(reduceMotion ? nil : .easeInOut(duration: Pacing.fadeDuration), value: blackOverlayOpaque)
                 .allowsHitTesting(false)

--- a/Pocket Casts TV App/UI/Common/Toast/ToastWindow.swift
+++ b/Pocket Casts TV App/UI/Common/Toast/ToastWindow.swift
@@ -50,12 +50,12 @@ class ToastView: UIView {
     required init?(coder: NSCoder) { fatalError() }
 
     private func setupUI(message: String) {
-        backgroundColor = UIColor(Color.pcBackgroundOverlay)
+        backgroundColor = .pcBackgroundOverlay
         layer.cornerRadius = 10
         translatesAutoresizingMaskIntoConstraints = false
 
         messageLabel.text = message
-        messageLabel.textColor = UIColor(Color.pcTextPrimary)
+        messageLabel.textColor = .pcTextPrimary
         messageLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
         messageLabel.numberOfLines = 0
         messageLabel.textAlignment = .center

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -51,5 +51,6 @@ struct DiscoverPodcastRow: View {
                 }
             })
         }
+        .scrollClipDisabled()
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -135,6 +135,10 @@ struct DiscoverVideoEpisodeCell: View {
             }
             Spacer()
         }
+        // These buttons always sit over the card's black gradient overlay, so force the
+        // dark color scheme to keep the default tvOS button readable (light label / bright
+        // focus pill) in light mode too.
+        .environment(\.colorScheme, .dark)
         .transition(.opacity.combined(with: .scale(scale: 0.95)))
     }
 
@@ -150,13 +154,13 @@ struct DiscoverVideoEpisodeCell: View {
                     if let title = model.episode.podcastTitle {
                         Text(title)
                             .font(.caption)
-                            .foregroundColor(.pcTextSecondary)
+                            .foregroundColor(.pcTextOnColorSecondary)
                     }
                     if let description = model.episode.title {
                         Text(description)
                             .lineLimit(1)
                             .font(.caption)
-                            .foregroundColor(.pcTextPrimary)
+                            .foregroundColor(.pcTextOnColorPrimary)
                     }
                 }
                 Spacer()

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -176,11 +176,11 @@ struct MainTabView: View {
                 }
             }
             .frame(width: 64, height: 64)
-            .background(Color.white.opacity(0.15), in: Circle())
+            .background(Color.pcTextPrimary.opacity(0.15), in: Circle())
             .clipShape(Circle())
             .overlay(
                 Circle()
-                    .stroke(Color.white, lineWidth: profileFocused ? 4 : 0)
+                    .stroke(Color.pcTextPrimary, lineWidth: profileFocused ? 4 : 0)
             )
         }
         .buttonStyle(ChromelessButtonStyle())

--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -9,6 +9,7 @@ struct PlaylistCell: View {
     }
 
     @Environment(\.isFocused) var isFocused: Bool
+    @Environment(\.colorScheme) var colorScheme
 
     enum Layout {
         static let imageSize = CGFloat(156)
@@ -35,6 +36,9 @@ struct PlaylistCell: View {
                     Spacer()
                 }
             }
+            // In light mode, use variable for light more over artwork (except for focus state)
+            .environment(\.colorScheme, colorScheme == .light ? (isFocused ? .light : .dark) : colorScheme)
+
             .padding(.vertical, 24)
             ZStack {
                 if model.state == .ready {

--- a/Pocket Casts TV App/UI/Style/Color+Style.swift
+++ b/Pocket Casts TV App/UI/Style/Color+Style.swift
@@ -1,36 +1,85 @@
 import SwiftUI
+import UIKit
+import PocketCastsUtils
+
+// Values come from the tvOS design tokens (Figma "Light mode" / "Dark mode" sets).
+// Each token resolves dynamically on the active user interface style; see `appearance(light:dark:)`.
 
 extension Color {
 
-    static let pcTextPrimary = Color(red: 0.98, green: 0.98, blue: 0.98)
+    static let pcTextPrimary = Color(uiColor: .pcTextPrimary)
 
-    static let pcTextPrimaryActive = Color(red: 0.09, green: 0.09, blue: 0.09)
+    // The "-active" tokens style content shown *on* the focused surface, which inverts relative to
+    // the page: the focused surface is near-white in dark mode (so active text is dark) and near-black
+    // in light mode (so active text is light). See `pcBackgroundActive`.
+    static let pcTextPrimaryActive = Color(uiColor: .appearance(light: "#FBFBFC", dark: "#161718"))
 
-    static let pcTextSecondary = Color(red: 0.69, green: 0.7, blue: 0.72)
+    static let pcTextSecondary = Color(uiColor: .appearance(light: "#5A5D62", dark: "#B0B3B8"))
 
-    static let pcTextSecondaryActive = Color(red: 0.24, green: 0.25, blue: 0.27)
+    static let pcTextSecondaryActive = Color(uiColor: .appearance(light: "#C8CACE", dark: "#3D4044"))
 
-    static let pcTextTertiary = Color(red: 0.48, green: 0.49, blue: 0.51)
+    static let pcTextTertiary = Color(uiColor: .appearance(light: "#909398", dark: "#7A7D82"))
 
-    static let pcTextTertiaryActive = Color(red: 0.48, green: 0.49, blue: 0.51)
+    static let pcTextTertiaryActive = Color(uiColor: .appearance(light: "#909398", dark: "#7A7D82"))
 
-    static let pcTextDisabled = Color(red: 0.29, green: 0.3, blue: 0.32)
+    static let pcTextDisabled = Color(uiColor: .appearance(light: "#C0C2C6", dark: "#4A4D51"))
 
-    static let pcTextDisabledActive = Color(red: 0.69, green: 0.70, blue: 0.72)
+    static let pcTextDisabledActive = Color(uiColor: .appearance(light: "#5A5D62", dark: "#B0B3B8"))
 
-    static let pcBackgroundSunken = Color(red: 0.09, green: 0.09, blue: 0.09)
+    // Text drawn over artwork or fixed-color cards (e.g. playlist colors), which stay dark in
+    // both appearances. These never flip, so the text stays readable on those surfaces.
+    static let pcTextOnColorPrimary = Color(uiColor: UIColor(hex: "#FBFBFC"))
 
-    static let pcBackgroundSurface = Color(red: 0.12, green: 0.13, blue: 0.14)
+    static let pcTextOnColorSecondary = Color(uiColor: UIColor(hex: "#B0B3B8"))
 
-    static let pcBackgroundBase = Color(red: 0.16, green: 0.17, blue: 0.18)
+    static let pcBackgroundSunken = Color(uiColor: .appearance(light: "#E8E9EA", dark: "#161718"))
 
-    static let pcBackgroundOverlay = Color(red: 0.2, green: 0.21, blue: 0.22)
+    static let pcBackgroundSurface = Color(uiColor: .appearance(light: "#F0F1F2", dark: "#1F2123"))
 
-    static let pcBackgroundActive = Color(red: 0.98, green: 0.98, blue: 0.99)
+    static let pcBackgroundBase = Color(uiColor: .appearance(light: "#F7F7F8", dark: "#292B2E"))
 
-    static let pcBackgroundActive50 = Color(red: 0.98, green: 0.98, blue: 0.99).opacity(0.2)
+    static let pcBackgroundOverlay = Color(uiColor: .pcBackgroundOverlay)
 
-    static let pcShadowLight = black.opacity(0.2)
+    // Focus highlight (`bg-active`). The focused surface inverts against the page: near-white in dark
+    // mode, near-black in light mode. Paired with `pcShadowFocus` to lift it off the page.
+    static let pcBackgroundActive = Color(uiColor: .appearance(light: "#161718", dark: "#FBFBFC"))
 
-    static let pcShadowStrong = black.opacity(0.6)
+    // `bg-active-20` token: the active color at 20% opacity. Alpha is applied inside each branch so
+    // the color still re-resolves between light and dark (calling `withAlphaComponent` on a dynamic
+    // color would flatten it to a single appearance).
+    static let pcBackgroundActive20 = Color(uiColor: .appearance(
+        light: UIColor(hex: "#161718").withAlphaComponent(0.2),
+        dark: UIColor(hex: "#FBFBFC").withAlphaComponent(0.2)
+    ))
+
+    // Shadows stay black but are much softer in light mode, where a heavy drop shadow looks harsh.
+    static let pcShadowLight = Color(uiColor: .appearance(light: .black.withAlphaComponent(0.1), dark: .black.withAlphaComponent(0.2)))
+
+    static let pcShadowStrong = Color(uiColor: .appearance(light: .black.withAlphaComponent(0.18), dark: .black.withAlphaComponent(0.6)))
+
+    // Soft lift under a focused card. Only present in light mode — in dark mode the focus already
+    // pops as a bright card on a dark background, so no shadow is needed (and it would just darken
+    // the dark page).
+    static let pcShadowFocus = Color(uiColor: .appearance(light: .black.withAlphaComponent(0.18), dark: .clear))
+}
+
+extension UIColor {
+
+    // Tokens also consumed from UIKit (e.g. `ToastView`) are defined here as genuine
+    // dynamic `UIColor`s so they re-resolve with the view's traits. The `Color`
+    // counterparts above wrap these, keeping a single source of truth.
+
+    static let pcTextPrimary = appearance(light: "#161718", dark: "#FBFBFC")
+
+    static let pcBackgroundOverlay = appearance(light: "#FFFFFF", dark: "#323538")
+
+    /// Resolves to `light` in light mode, otherwise `dark`.
+    /// An unspecified user interface style falls back to `dark`, preserving the original behavior.
+    fileprivate static func appearance(light: UIColor, dark: UIColor) -> UIColor {
+        UIColor { $0.userInterfaceStyle == .light ? light : dark }
+    }
+
+    fileprivate static func appearance(light: String, dark: String) -> UIColor {
+        appearance(light: UIColor(hex: light), dark: UIColor(hex: dark))
+    }
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-701.

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

<img width="968" height="623" alt="Screenshot 2026-06-08 at 3 11 59 PM" src="https://github.com/user-attachments/assets/c4cdd1fa-60b0-45be-89e5-8ceefe55b7b3" />
<img width="968" height="623" alt="Screenshot 2026-06-08 at 3 12 04 PM" src="https://github.com/user-attachments/assets/dcd9162a-7044-4dca-8cbe-ae57cc3f6818" />
<img width="968" height="623" alt="Screenshot 2026-06-08 at 3 12 39 PM" src="https://github.com/user-attachments/assets/c110bba7-2118-4ed8-8fc4-515cac500f6f" />
<img width="968" height="623" alt="Screenshot 2026-06-08 at 3 12 40 PM" src="https://github.com/user-attachments/assets/5903754a-7b86-47dd-ab55-e97f2ff50e80" />
<img width="968" height="623" alt="Screenshot 2026-06-08 at 3 12 48 PM" src="https://github.com/user-attachments/assets/44aba4b4-f1f9-41b4-ba4f-3696c50df977" />
<img width="968" height="623" alt="Screenshot 2026-06-08 at 3 12 49 PM" src="https://github.com/user-attachments/assets/4bc2e50d-b4f6-4efd-a737-cf09b84edbc9" />
<img width="968" height="623" alt="Screenshot 2026-06-08 at 3 12 54 PM" src="https://github.com/user-attachments/assets/0445325b-696b-4a6c-97f4-4c04d4c88a42" />
<img width="968" height="623" alt="Screenshot 2026-06-08 at 3 13 31 PM" src="https://github.com/user-attachments/assets/d135f634-a767-4d0d-ac6d-07236a412c67" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
