### PR TITLE
[PC TV] Fix rows occasionally losing focus on reload

### DIFF
--- a/podcasts/HomeGridItem.swift
+++ b/podcasts/HomeGridItem.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 
-class HomeGridItem: Identifiable {
+struct HomeGridItem: Identifiable {
     let podcast: Podcast?
     let folder: Folder?
 

--- a/podcasts/HomeGridItem.swift
+++ b/podcasts/HomeGridItem.swift
@@ -5,6 +5,21 @@ class HomeGridItem: Identifiable {
     let podcast: Podcast?
     let folder: Folder?
 
+    enum ID: Hashable {
+        case podcast(String)
+        case folder(String)
+        case empty
+    }
+
+    var id: ID {
+        if let podcast {
+            return .podcast(podcast.uuid)
+        } else if let folder {
+            return .folder(folder.uuid)
+        }
+        return .empty
+    }
+
     init(podcast: Podcast) {
         self.podcast = podcast
         folder = nil


### PR DESCRIPTION
Fixes a tvOS bug where the "Your Podcasts" grid loses keyboard/remote focus shortly after the screen appears — focus jumps off the grid (typically up to the tab bar) on its own, interrupting the user.

**Root cause**

`HomeGridItem` is a class that conforms to `Identifiable` without an explicit id, so SwiftUI falls back to `ObjectIdentifier(self)` – i.e. the item's identity is tied to its memory instance, not its content.

 **To test**

  1. Run the Pocket Casts TV App on the tvOS simulator (or an Apple TV) signed into an account with several subscribed podcasts.
  2. Open the "Your Podcasts" tab.
  3. Move focus onto a podcast in the grid (not the first one) and leave the remote idle.
  4. Wait through the on-appear refresh / let a sync complete (or background and foreground the app to trigger a refresh).
  5. Expected: focus stays on the same podcast cell throughout the refresh — it no longer jumps to the tab bar or resets.
  6. Sanity-check the empty state still works (account with no subscriptions) and that navigating into a podcast/folder and back behaves normally.
  7. Regression-check watchOS "Podcasts" list still renders/scrolls correctly, since HomeGridItem is shared.

**Checklist**

  - [x] I have considered if this change warrants user-facing release notes and have added them to CHANGELOG.md if necessary.
  - [x] I have considered adding unit tests for my changes.
  - [x] No analytics changes.


