### PR TITLE
[PC TV] Add empty state view to Podcast Details

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -169,7 +169,25 @@ struct PodcastDetailView: View {
 
     @Namespace private var episodeListNamespace
 
+    @ViewBuilder
     var episodeContent: some View {
+        if model.episodes.isEmpty {
+            noEpisodesView
+        } else {
+            episodeList
+        }
+    }
+
+    var noEpisodesView: some View {
+        ContentUnavailableView(
+            L10n.tvPodcastDetailNoEpisodesTitle,
+            systemImage: "list.bullet",
+            description: Text(L10n.tvPodcastDetailNoEpisodesSubtitle)
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    var episodeList: some View {
         List {
             if let recommended = model.recommendedEpisode {
                 Section {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6115,6 +6115,12 @@
 /* tv podcast detail option to show archived episodes in the list */
 "tv_podcast_detail_show_archived" = "Show archived";
 
+/* tv podcast detail empty state title shown when a podcast has no episodes */
+"tv_podcast_detail_no_episodes_title" = "No Episodes";
+
+/* tv podcast detail empty state subtitle shown when a podcast has no episodes */
+"tv_podcast_detail_no_episodes_subtitle" = "Episodes from this podcast will show up here.";
+
 /* tv episode action to view episode info */
 "tv_episode_info" = "Episode info";
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-702.

## To test

I hardcoded "show empty state" for testing purposes.

<img width="968" height="623" alt="Screenshot 2026-06-08 at 6 11 52 PM" src="https://github.com/user-attachments/assets/7c46b786-5591-4e04-ac85-e664d3111d2f" />

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
