### PR TITLE
Rename synced_transcript analytics events to synced_transcripts

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -924,13 +924,13 @@ enum AnalyticsEvent: String {
     case episodeTranscriptShown
     case transcriptShared
     case transcriptTextHighlighted
-    case syncedTranscriptSeekUsed
-    case syncedTranscriptPreparationStarted
-    case syncedTranscriptPreparationCompleted
-    case syncedTranscriptPreparationFailed
-    case syncedTranscriptUnavailable
-    case syncedTranscriptSeekFailed
-    case syncedTranscriptAutoScrollResumed
+    case syncedTranscriptsSeekUsed
+    case syncedTranscriptsPreparationStarted
+    case syncedTranscriptsPreparationCompleted
+    case syncedTranscriptsPreparationFailed
+    case syncedTranscriptsUnavailable
+    case syncedTranscriptsSeekFailed
+    case syncedTranscriptsAutoScrollResumed
 
     // MARK: - Widgets
 

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -438,7 +438,7 @@ enum PlusUpgradeViewSource: String {
     case settings
     case referral
     case deselectChapterWhatsNew = "deselect_chapters_whats_new"
-    case transcriptsWhatsNew = "transcripts_whats_new"
+    case syncedTranscripts = "synced_transcripts"
     case bookmarksLocked = "bookmarks_locked"
     case overflowMenu = "overflow_menu"
     case slumber

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -375,13 +375,13 @@ final class FingerprintTimingManager: NSObject {
 
         guard FeatureFlag.syncedTranscripts.enabled else {
             updateState(.unavailable)
-            track(.syncedTranscriptUnavailable, properties: ["reason": "feature_disabled"])
+            track(.syncedTranscriptsUnavailable, properties: ["reason": "feature_disabled"])
             return
         }
 
         guard let episode else {
             updateState(.unavailable)
-            track(.syncedTranscriptUnavailable, properties: ["reason": "no_episode"])
+            track(.syncedTranscriptsUnavailable, properties: ["reason": "no_episode"])
             return
         }
 
@@ -394,7 +394,7 @@ final class FingerprintTimingManager: NSObject {
 
         preparationStartDate = Date()
         updateState(.preparing)
-        track(.syncedTranscriptPreparationStarted, properties: [
+        track(.syncedTranscriptsPreparationStarted, properties: [
             "episode_uuid": uuid,
             "episode_duration_seconds": episode.duration
         ])
@@ -415,7 +415,7 @@ final class FingerprintTimingManager: NSObject {
 
                 guard let data, let reference = ReferenceFingerprint.decode(from: data) else {
                     self.updateState(.unavailable)
-                    self.track(.syncedTranscriptUnavailable, properties: ["reason": "no_reference"])
+                    self.track(.syncedTranscriptsUnavailable, properties: ["reason": "no_reference"])
                     FileLog.shared.addMessage("FingerprintTimingManager: no reference available for \(uuid)")
                     return
                 }
@@ -448,7 +448,7 @@ final class FingerprintTimingManager: NSObject {
         let duration = episode.duration
         guard duration > 0 else {
             updateState(.unavailable)
-            track(.syncedTranscriptUnavailable, properties: ["reason": "invalid_duration"])
+            track(.syncedTranscriptsUnavailable, properties: ["reason": "invalid_duration"])
             return
         }
 
@@ -475,7 +475,7 @@ final class FingerprintTimingManager: NSObject {
 
         guard !libraryCheckpoints.isEmpty else {
             updateState(.unavailable)
-            track(.syncedTranscriptUnavailable, properties: ["reason": "no_reference"])
+            track(.syncedTranscriptsUnavailable, properties: ["reason": "no_reference"])
             FileLog.shared.addMessage("FingerprintTimingManager: reference for \(uuid) has no usable checkpoints")
             return
         }
@@ -508,7 +508,7 @@ final class FingerprintTimingManager: NSObject {
         }
         updateState(.preparing)
         if !hasEmittedPreparationStarted {
-            track(.syncedTranscriptPreparationStarted, properties: [
+            track(.syncedTranscriptsPreparationStarted, properties: [
                 "is_streaming": isStreaming,
                 "episode_duration_seconds": duration
             ])
@@ -545,7 +545,7 @@ final class FingerprintTimingManager: NSObject {
                 updateState(.active(coverage: coverage))
                 if !hasReachedActive {
                     hasReachedActive = true
-                    track(.syncedTranscriptPreparationCompleted, properties: [
+                    track(.syncedTranscriptsPreparationCompleted, properties: [
                         "duration_ms": preparationDurationMs,
                         "is_streaming": isStreaming
                     ])
@@ -618,7 +618,7 @@ final class FingerprintTimingManager: NSObject {
                 switch terminalState {
                 case .failed(let error):
                     let nsError = error as NSError
-                    self.track(.syncedTranscriptPreparationFailed, properties: [
+                    self.track(.syncedTranscriptsPreparationFailed, properties: [
                         "error_code": nsError.code,
                         "error_domain": nsError.domain,
                         "stage": "fingerprint_generation",
@@ -626,7 +626,7 @@ final class FingerprintTimingManager: NSObject {
                     ])
                 case .unavailable:
                     let reason = ctx.isStreaming ? "streaming_unsupported" : "no_matches"
-                    self.track(.syncedTranscriptUnavailable, properties: [
+                    self.track(.syncedTranscriptsUnavailable, properties: [
                         "reason": reason,
                         "is_streaming": ctx.isStreaming
                     ])
@@ -1019,7 +1019,7 @@ final class FingerprintTimingManager: NSObject {
             updateState(.active(coverage: coverage))
             if !hasReachedActive {
                 hasReachedActive = true
-                track(.syncedTranscriptPreparationCompleted, properties: [
+                track(.syncedTranscriptsPreparationCompleted, properties: [
                     "duration_ms": preparationDurationMs,
                     "is_streaming": context?.isStreaming ?? false
                 ])

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -986,7 +986,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         if let suppressedDate = autoScrollSuppressedDate {
             properties["manual_scroll_duration_ms"] = Int(Date().timeIntervalSince(suppressedDate) * 1000)
         }
-        track(.syncedTranscriptAutoScrollResumed, properties: properties)
+        track(.syncedTranscriptsAutoScrollResumed, properties: properties)
     }
 
     @objc private func transcriptTapped(_ gesture: UITapGestureRecognizer) {
@@ -1019,7 +1019,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
         guard let seekTime = FingerprintTimingManager.shared.playbackTime(forReferenceTime: referenceTime) else {
             let syncedState = FingerprintTimingManager.shared.state
-            track(.syncedTranscriptSeekFailed, properties: [
+            track(.syncedTranscriptsSeekFailed, properties: [
                 "reason": "mapping_unavailable",
                 "synced_state": syncedState.analyticsName
             ])
@@ -1035,7 +1035,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         let fromPosition = playbackManager.currentTime()
         playbackManager.seekTo(time: seekTime)
         syncedSeeksCount += 1
-        track(.syncedTranscriptSeekUsed, properties: [
+        track(.syncedTranscriptsSeekUsed, properties: [
             "from_position_seconds": Int(fromPosition),
             "to_position_seconds": Int(seekTime)
         ])

--- a/podcasts/Whats New/TranscriptAnnouncementViewModel.swift
+++ b/podcasts/Whats New/TranscriptAnnouncementViewModel.swift
@@ -28,7 +28,7 @@ class TranscriptAnnouncementViewModel {
                 return
             }
 
-            PaidFeature.syncedTranscripts.presentUpgradeController(from: rootViewController, source: .transcriptsWhatsNew)
+            PaidFeature.syncedTranscripts.presentUpgradeController(from: rootViewController, source: .syncedTranscripts)
         }
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

## Summary

Aligns the synced-transcripts analytics with Android and the shared Tracks event catalog.

- Renames the 7 synced-transcript `AnalyticsEvent` cases so the events sent to Tracks become `synced_transcripts_*` (previously `synced_transcript_*`): seek used/failed, auto-scroll resumed, preparation started/completed/failed, and unavailable.
- Adds a dedicated `synced_transcripts` upgrade source (`PlusUpgradeViewSource`), replacing `transcripts_whats_new`. It is now passed when a Free user subscribes from the highlighted-transcripts What's New. The value matches the existing `synced_transcripts` entry in the shared EventHorizon source enum.

⚠️ Because the event names change, existing dashboards/queries on `synced_transcript_*` must be repointed to `synced_transcripts_*`.

## To test

1. Enable the `syncedTranscripts` feature flag.
2. Open a transcript and confirm synced playback works (tap-to-seek, auto-scroll).
3. With analytics logging on, verify the events are emitted as `synced_transcripts_*`.
4. As a Free user, open the highlighted-transcripts What's New and tap subscribe — confirm the upsell source is `synced_transcripts`.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.