### PR TITLE
[PC TV] Add unarchive action and refresh episode list on archive changes

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -140,7 +140,7 @@ struct EpisodeRowWithActions: View {
             Button(L10n.playLastInUpNext) { model.playLast() }
             Button(L10n.markPlayed) { model.markAsPlayed() }
             if model.canArchive {
-                Button(L10n.archive) { model.archive() }
+                Button(model.isArchived ? L10n.unarchive : L10n.archive) { model.isArchived ? model.unarchive() : model.archive() }
             }
         case .upNext:
             Button(L10n.playNext) { model.playNext() }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -150,6 +150,11 @@ class EpisodeRowViewModel: Identifiable {
         ToastManager.shared.show(L10n.podcastArchived)
     }
 
+    func unarchive() {
+        guard let episode = episode as? Episode else { return }
+        EpisodeManager.unarchiveEpisode(episode: episode, fireNotification: true)
+    }
+
     func removeFromUpNext() {
         playbackManager.removeIfPlayingOrQueued(episode: episode, fireNotification: true, userInitiated: true)
         ToastManager.shared.show(L10n.removeFromUpNext)
@@ -160,6 +165,20 @@ class EpisodeRowViewModel: Identifiable {
         .receive(on: DispatchQueue.main)
         .sink { [weak self] _ in
             self?.updateProgress()
+        }
+        .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: Constants.Notifications.episodeArchiveStatusChanged)
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] notification in
+            guard let self else {
+                return
+            }
+            if let uuid = notification.object as? String, uuid == episode.uuid {
+                if let newEpisode = DataManager.sharedManager.findBaseEpisode(uuid: uuid) {
+                    episode = newEpisode
+                }
+            }
         }
         .store(in: &cancellables)
     }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
+import Combine
 
 @Observable
 class PodcastDetailViewModel {
@@ -8,6 +9,7 @@ class PodcastDetailViewModel {
     private let dataManager: TVDataManager
     private let serverPodcastManager: ServerPodcastManager
     private let podcastManager: PodcastManager
+    private var cancellables: Set<AnyCancellable> = []
 
     enum State: Equatable, Hashable {
         case loading
@@ -22,9 +24,7 @@ class PodcastDetailViewModel {
     var episodes: [EpisodeRowViewModel] = []
     var recommendedEpisode: EpisodeRowViewModel?
     var isFollowing: Bool = false
-    var showArchived: Bool = false
-
-    private var allEpisodes: [Episode] = []
+    var showArchived: Bool = false    
 
     private static func archiveStorageKey(for podcastUuid: String) -> String {
         "showArchived_podcast_\(podcastUuid)"
@@ -32,7 +32,7 @@ class PodcastDetailViewModel {
 
     func setShowArchived(_ value: Bool) {
         showArchived = value
-        applyArchivedFilter()
+        load()
         UserDefaults.standard.set(value, forKey: Self.archiveStorageKey(for: podcastUuid))
     }
 
@@ -45,6 +45,7 @@ class PodcastDetailViewModel {
         self.serverPodcastManager = serverPodcastManager
         self.podcastManager = podcastManager
         self.showArchived = UserDefaults.standard.bool(forKey: Self.archiveStorageKey(for: podcastUuid))
+        setupObservers()
     }
 
     convenience init(podcast: Podcast,
@@ -68,24 +69,17 @@ class PodcastDetailViewModel {
                 await MainActor.run { state = .failed }
                 return
             }
-            let allEpisodes = dataManager.fetchEpisodes(podcast: podcast, includeArchived: true)
+            let allEpisodes = dataManager.fetchEpisodes(podcast: podcast, includeArchived: showArchived).map {
+                EpisodeRowViewModel(episode: $0, podcast: podcast)
+            }
             await MainActor.run {
                 self.podcast = podcast
                 self.isFollowing = podcast.subscribed != 0
-                self.allEpisodes = allEpisodes
-                self.applyArchivedFilter()
-                self.recommendedEpisode = allEpisodes
-                    .first { !$0.archived }
-                    .map { EpisodeRowViewModel(episode: $0, podcast: podcast) }
+                self.episodes = allEpisodes
+                self.recommendedEpisode = nil
                 self.state = .ready
             }
         }
-    }
-
-    private func applyArchivedFilter() {
-        guard let podcast else { return }
-        let visible = showArchived ? allEpisodes : allEpisodes.filter { !$0.archived }
-        episodes = visible.map { EpisodeRowViewModel(episode: $0, podcast: podcast) }
     }
 
     func subscribe() {
@@ -98,5 +92,24 @@ class PodcastDetailViewModel {
         guard let podcast else { return }
         isFollowing = false
         podcastManager.unsubscribe(podcast: podcast)
+    }
+
+    private func setupObservers() {
+        NotificationCenter.default.publisher(for: Constants.Notifications.episodeArchiveStatusChanged)
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] notification in
+            guard let self else {
+                return
+            }
+            if let uuid = notification.object as? String {
+                let contains = episodes.contains { episode in
+                    episode.id == uuid
+                }
+                if contains {
+                    load()
+                }
+            }
+        }
+        .store(in: &cancellables)
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -24,7 +24,7 @@ class PodcastDetailViewModel {
     var episodes: [EpisodeRowViewModel] = []
     var recommendedEpisode: EpisodeRowViewModel?
     var isFollowing: Bool = false
-    var showArchived: Bool = false    
+    var showArchived: Bool = false
 
     private static func archiveStorageKey(for podcastUuid: String) -> String {
         "showArchived_podcast_\(podcastUuid)"


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

On the TV app's podcast detail screen, episodes could be archived but never unarchived, and the episode list didn't update after an archive action. This PR:

- Adds an **Unarchive** action to the episode context menu. The menu item now toggles between Archive/Unarchive based on the episode's archived state (`EpisodeRow.swift`, `EpisodeRowViewModel.unarchive()`).
- Reloads the episode list when an episode's archive status changes. Both `PodcastDetailViewModel` and `EpisodeRowViewModel` now observe `episodeArchiveStatusChanged` and refresh accordingly, so the list and individual rows stay in sync.
- Simplifies fetching by passing `showArchived` directly to `fetchEpisodes(includeArchived:)` and reloading on toggle, removing the now-redundant client-side `applyArchivedFilter()` and cached `allEpisodes` array. The "recommended episode" (previously the first non-archived episode shown at the top) is no longer surfaced separately.

## To test

1. Open the TV app and navigate to a podcast's detail screen.
2. Focus an episode and open its context menu.
3. Tap **Archive** — confirm the episode is archived and the list updates.
4. Enable "Show archived", focus the archived episode, open the context menu.
5. Confirm the action now reads **Unarchive**; tap it and verify the episode is unarchived and the list refreshes.
6. Toggle "Show archived" on/off and confirm the list reflects the correct set of episodes.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
