### PR TITLE
[PC TV] Implement re-sync if local DB is missing

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -2,12 +2,18 @@ import Foundation
 import PocketCastsUtils
 
 class DatabaseHelper {
-    class func setup(queue: PCDBQueue) {
+    /// Sets up the database schema, running any required migrations.
+    /// - Returns: `true` if the database was created from scratch this call (starting
+    ///   schema version 0) — i.e. there were no tables to begin with.
+    @discardableResult
+    class func setup(queue: PCDBQueue) -> Bool {
+        var databaseWasCreated = false
         queue.write { db in
             do {
                 try db.executeQuery("PRAGMA busy_timeout = 10000", values: nil).close()
 
                 let startingSchemaVersion = db.pragmaUserVersion() ?? 0
+                databaseWasCreated = startingSchemaVersion < 1
 
                 var newSchemaVersion = startingSchemaVersion
                 upgradeIfRequired(schemaVersion: &newSchemaVersion, db: db)
@@ -21,6 +27,7 @@ class DatabaseHelper {
                 FileLog.shared.addMessage("Failed to setup database \(db.lastErrorCode()): \(db.lastErrorMessage()) actual error: \(error)")
             }
         }
+        return databaseWasCreated
     }
 
     private class func upgradeIfRequired(schemaVersion: inout Int32, db: PCDatabase) {

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -30,6 +30,11 @@ public class DataManager {
 
     let dbQueue: PCDBQueue
 
+    /// `true` if the database was created from scratch during init (no tables existed).
+    /// On tvOS, where the database lives in the purgeable Caches directory, a logged-in
+    /// user seeing this means their data was wiped and a full resync is required.
+    public let databaseWasCreated: Bool
+
     public internal(set) static var sharedManager = DataManager()
 
     public static var logger: ErrorLogger?
@@ -82,7 +87,7 @@ public class DataManager {
     public init(dbQueue: PCDBQueue) {
         self.dbQueue = dbQueue
 
-        DatabaseHelper.setup(queue: dbQueue)
+        self.databaseWasCreated = DatabaseHelper.setup(queue: dbQueue)
 
         // closing it above won't affect these calls, since they will re-open it
         podcastManager.setup(dbQueue: dbQueue)
@@ -1152,6 +1157,12 @@ public class DataManager {
         let folderPath = pathToDbFolder() as NSString
 
         return folderPath.appendingPathComponent("podcast_newDB_backup.sqlite3")
+    }
+
+    /// The database file plus its WAL/SHM sidecars — the full on-disk file set.
+    public static func databaseFilePaths() -> [String] {
+        let dbPath = pathToDb()
+        return [dbPath, "\(dbPath)-wal", "\(dbPath)-shm"]
     }
 
     private static func pathToDbFolder() -> String {

--- a/Modules/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -187,6 +187,10 @@ public class ServerSettings {
         UserDefaults.standard.string(forKey: filesUsageLastModifiedKey)
     }
 
+    public class func removeFilesUsageLastModifiedKey() {
+        UserDefaults.standard.removeObject(forKey: filesUsageLastModifiedKey)
+    }
+
     // MARK: Custom Storage limit from user
 
     public class func setCustomStorageUserLimit(_ value: Int) {

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncManager.swift
@@ -71,6 +71,27 @@ public class SyncManager {
         KeychainHelper.removeKey(ServerConstants.Values.refreshTokenKey)
         KeychainHelper.removeKey(ServerConstants.Values.appleAuthUserIDKey)
     }
+
+    /// Clears the server "last modified" watermarks so the next sync is a full re-fetch,
+    /// without signing the user out. Needed when the database was lost but these
+    /// UserDefaults watermarks survived — otherwise the server returns "not modified"
+    /// and the empty database stays empty.
+    public class func clearSyncWatermarksForFullResync() {
+        FileLog.shared.addMessage("SyncManager.clearSyncWatermarksForFullResync")
+
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: ServerConstants.UserDefaults.lastModifiedServerDate)
+        defaults.removeObject(forKey: ServerConstants.UserDefaults.lastSyncStartDate)
+        defaults.removeObject(forKey: ServerConstants.UserDefaults.lastSyncTime)
+        defaults.removeObject(forKey: ServerConstants.UserDefaults.historyServerLastModified)
+        defaults.removeObject(forKey: ServerConstants.UserDefaults.upNextServerLastModified)
+        // Drop the pending history-clear marker too, else SyncHistoryTask would re-send a
+        // stale clearAll during what should be a pull-only recovery.
+        defaults.removeObject(forKey: ServerConstants.UserDefaults.lastClearHistoryDate)
+
+        ServerSettings.removeFilesLastModifiedKey()
+        ServerSettings.removeFilesUsageLastModifiedKey()
+    }
 }
 
 // MARK: - Sync Reason

--- a/Pocket Casts TV App/Data/DataLossSimulator.swift
+++ b/Pocket Casts TV App/Data/DataLossSimulator.swift
@@ -1,0 +1,30 @@
+import Foundation
+import PocketCastsDataModel
+import PocketCastsUtils
+
+/// Reproduces the tvOS "system purged our files" scenario for testing. Launch with the
+/// `-PCSimulateDataLoss` argument (Xcode ▸ Edit Scheme ▸ Run ▸ Arguments) to delete the
+/// database files while leaving the keychain login and sync watermarks intact, just as
+/// tvOS reclaiming the Caches directory would. Run once normally first, then relaunch
+/// with the argument set to trigger the resync.
+enum DataLossSimulator {
+    static let launchArgument = "-PCSimulateDataLoss"
+
+    static func simulateIfRequested() {
+        // Non-App Store builds only, to keep it out of release paths.
+        guard BuildEnvironment.current == .debug else { return }
+        guard ProcessInfo.processInfo.arguments.contains(launchArgument) else { return }
+
+        FileLog.shared.addMessage("⚠️ DataLossSimulator: \(launchArgument) is set — wiping the database to simulate a tvOS file purge")
+
+        // Remove the database file set so a clean one is recreated on first access.
+        for path in DataManager.databaseFilePaths() where FileManager.default.fileExists(atPath: path) {
+            do {
+                try FileManager.default.removeItem(atPath: path)
+                FileLog.shared.addMessage("DataLossSimulator: removed \(path)")
+            } catch {
+                FileLog.shared.addMessage("DataLossSimulator: failed to remove \(path): \(error)")
+            }
+        }
+    }
+}

--- a/Pocket Casts TV App/PocketCastsTVApp.swift
+++ b/Pocket Casts TV App/PocketCastsTVApp.swift
@@ -7,6 +7,9 @@ struct PocketCastsTVApp: App {
     private let appLifecycleAnalytics = AppLifecycleAnalytics()
 
     init() {
+        // Before anything opens the database, so a requested wipe hits a closed file.
+        DataLossSimulator.simulateIfRequested()
+
         AnalyticsSetup.setupIfNeeded()
         _ = appLifecycleAnalytics.checkApplicationInstalledOrUpgraded()
     }

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -11,6 +11,7 @@ class AppCoordinator {
         case browsing
         case signedIn
         case userSync
+        case dataLossResync
     }
 
     var state: State = .loading
@@ -30,15 +31,20 @@ class AppCoordinator {
 
         setupFirebase()
 
+        // Fresh database + still logged in (keychain survived) = the system purged our
+        // data; re-fetch everything behind a spinner first.
+        let needsDataLossResync = DataManager.sharedManager.databaseWasCreated && SyncManager.isUserLoggedIn()
+
         await MainActor.run {
             userState.refresh()
             if userState.isLoggedIn {
-                state = .signedIn
+                state = needsDataLossResync ? .dataLossResync : .signedIn
             } else {
                 state = .welcome
             }
         }
-        if userState.isLoggedIn {
+        // The resync screen drives its own full sync.
+        if userState.isLoggedIn, !needsDataLossResync {
             RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)
             RefreshManager.shared.syncUpNext()
         }

--- a/Pocket Casts TV App/UI/Auth/DataLossResyncView.swift
+++ b/Pocket Casts TV App/UI/Auth/DataLossResyncView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import PocketCastsServer
+
+/// Shown when the local database was wiped while the user stayed logged in. Re-fetches
+/// everything behind a spinner, then hands off to the main app.
+struct DataLossResyncView: View {
+    @Environment(AppCoordinator.self) private var coordinator
+    @State private var model = DataLossResyncViewModel()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            ProgressView()
+                .scaleEffect(1.5)
+            Text(L10n.tvResyncFetchingEpisodes)
+                .font(.headline)
+                .foregroundStyle(Color.pcTextSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.pcBackgroundSurface)
+        .ignoresSafeArea()
+        .task {
+            await model.resync()
+            coordinator.state = .signedIn
+        }
+    }
+}
+
+@MainActor
+final class DataLossResyncViewModel {
+    /// Upper bound so a failed or stalled sync never traps the user on the spinner.
+    private static let timeout: TimeInterval = 60
+
+    /// Clears the sync watermarks, kicks off a full resync, and returns once it finishes
+    /// (success or failure) or the timeout elapses.
+    func resync() async {
+        // Force a full re-fetch, and pull as if we'd just logged in so the empty local
+        // Up Next / history is never pushed up and used to wipe the server's copy.
+        SyncManager.clearSyncWatermarksForFullResync()
+        SyncManager.syncReason = .login
+
+        await waitForSyncToFinish()
+    }
+
+    private func waitForSyncToFinish() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let center = NotificationCenter.default
+            var observers: [NSObjectProtocol] = []
+            var didFinish = false
+
+            let finish = {
+                guard !didFinish else { return }
+                didFinish = true
+                observers.forEach { center.removeObserver($0) }
+                continuation.resume()
+            }
+
+            // syncCompleted/syncFailed end the sync chain; podcastRefreshFailed covers a
+            // refresh that can't reach the server (which emits no sync notification).
+            let names: [Notification.Name] = [
+                ServerNotifications.syncCompleted,
+                ServerNotifications.syncFailed,
+                ServerNotifications.podcastRefreshFailed
+            ]
+            observers = names.map { name in
+                center.addObserver(forName: name, object: nil, queue: .main) { _ in finish() }
+            }
+
+            // Safety net so a stalled sync never traps the user on the spinner.
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.timeout) { finish() }
+
+            RefreshManager.shared.refreshPodcasts(forceEvenIfRefreshedRecently: true)
+        }
+    }
+}
+
+#Preview {
+    DataLossResyncView()
+        .environment(AppCoordinator())
+}

--- a/Pocket Casts TV App/UI/RootView.swift
+++ b/Pocket Casts TV App/UI/RootView.swift
@@ -19,6 +19,8 @@ struct RootView: View {
                 MainTabView()
             case .userSync:
                 SigningInView()
+            case .dataLossResync:
+                DataLossResyncView()
             }
         }
         .environment(coordinator)

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
@@ -51,6 +51,12 @@
             ReferencedContainer = "container:podcasts.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-PCSimulateDataLoss"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6064,6 +6064,9 @@
 /* tv signing in subtitle */
 "tv_signing_in_subtitle" = "Loading your podcasts now.";
 
+/* tv data loss resync — subtle spinner label shown when the local database was purged (e.g. by tvOS) and we re-fetch everything before entering the app */
+"tv_resync_fetching_episodes" = "Fetching latest episodes";
+
 /* tv podcasts empty title */
 "tv_podcasts_empty_title" = "Time to fill this up.";
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-697.

On tvOS the app database lives in the system-purgeable Caches directory, so the OS can reclaim it under storage pressure. When that happens the keychain login and the UserDefaults sync watermarks survive, but the database is empty – and because the watermarks are still set, the next sync goes incremental ("not modified"), leaving the app permanently empty.

This adds detection and recovery: at launch, if the database was created from scratch but the user is still logged in, we clear the sync watermarks, pull everything from the server as a full sync (treated like a fresh login so the empty local Up Next/history is never pushed up and used to wipe the server copy), and show a subtle "Fetching latest episodes" spinner until it completes (with a 60s safety timeout) before entering the app.

 ## To test

  1. Run the Pocket Casts TV App on a tvOS simulator/device and sign in; let it finish syncing so the home screen shows your podcasts.
  2. Edit Scheme → Run → Arguments, add -PCSimulateDataLoss (enabled).
  3. Relaunch. Expected: the "Fetching latest episodes" spinner appears, then the app enters with all podcasts/Up Next/history restored from the server.
  4. Confirm the server side is untouched — your Up Next queue and listening history are intact (the empty local state was not pushed up).
  5. Disable the launch argument and relaunch → normal startup, no spinner.
  6. Regression: a normal first sign-in still shows the existing cover-stack SigningInView, not the resync spinner.

Alternative (no launch arg): delete Library/Caches/Pocket Casts/podcast_newDB.sqlite3* from the simulator's data container (xcrun simctl get_app_container booted au.com.shiftyjelly.podcasts data) between launches.

<img width="960" height="592" alt="Screenshot 2026-06-09 at 5 51 05 PM" src="https://github.com/user-attachments/assets/df887b6f-a6fd-44b6-a772-6de325d196ff" />
<img width="2560" height="1410" alt="Screenshot 2026-06-09 at 5 51 09 PM" src="https://github.com/user-attachments/assets/1e95d6ad-adf6-46a5-bb73-9a499990bbaf" />


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
