### PR TITLE
[PC TV] Require account for Up Next / mark played / archive actions

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -110,6 +110,7 @@ struct EpisodeRowWithActions: View {
     let model: EpisodeRowViewModel
     var context: Context = .default
 
+    @Environment(\.requireAccount) private var requireAccount
     @FocusState private var focusedElement: FocusElement?
     @State private var isPlaying = false
     @State private var isShowingActions = false
@@ -136,15 +137,15 @@ struct EpisodeRowWithActions: View {
     private var actionButtons: some View {
         switch context {
         case .default:
-            Button(L10n.playNextInUpNext) { model.playNext() }
-            Button(L10n.playLastInUpNext) { model.playLast() }
-            Button(L10n.markPlayed) { model.markAsPlayed() }
+            Button(L10n.playNextInUpNext) { requireAccount { model.playNext() } }
+            Button(L10n.playLastInUpNext) { requireAccount { model.playLast() } }
+            Button(L10n.markPlayed) { requireAccount { model.markAsPlayed() } }
             if model.canArchive {
-                Button(model.isArchived ? L10n.unarchive : L10n.archive) { model.isArchived ? model.unarchive() : model.archive() }
+                Button(model.isArchived ? L10n.unarchive : L10n.archive) { requireAccount { model.isArchived ? model.unarchive() : model.archive() } }
             }
         case .upNext:
-            Button(L10n.playNext) { model.playNext() }
-            Button(L10n.playLast) { model.playLast() }
+            Button(L10n.playNext) { requireAccount { model.playNext() } }
+            Button(L10n.playLast) { requireAccount { model.playLast() } }
             Button(L10n.removeFromUpNext) { model.removeFromUpNext() }
         }
     }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-692.

Extends the tvOS `requireAccount` gate — previously only on **Follow podcast** — to the remaining episode actions that mutate account-bound state synced to the server. Logged out, these would silently fail to sync (and in some cases never sync even after a later sign-in), so they now prompt account creation instead.

### Actions now gated behind account creation
- **Play Next in Up Next** (`.default` + `.upNext` menus)
- **Play Last in Up Next** (`.default` + `.upNext` menus)
- **Mark as Played**
- **Archive / Unarchive**

All live in the shared `EpisodeRowWithActions` menu, so the gate now applies consistently across Podcast detail, Up Next, Playlists, Starred, and History.

## To test
1. Sign out of the tvOS app.
2. Open a podcast, focus an episode, and press the **…** (more) button.
3. Select **Mark as Played**, **Archive**, or **Play Next/Last in Up Next** → the Create Account flow should appear instead of the action running.
4. Sign in, repeat → the action runs normally.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)