### PR TITLE
[PC TV] Update "Keep listening" card design

### DIFF
--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -8,6 +8,21 @@ struct NowPlayingRow: View {
 
     var callback: (() -> ())?
 
+    var body: some View {
+        Button {
+            model.play()
+            callback?()
+        } label: {
+            NowPlayingRowLabel(model: model)
+        }
+        .buttonStyle(EpisodeRowButtonStyle())
+    }
+}
+
+private struct NowPlayingRowLabel: View {
+
+    @Bindable var model: EpisodeRowViewModel
+
     @Environment(\.isFocused) private var isFocused: Bool
 
     enum Layout {
@@ -24,37 +39,33 @@ struct NowPlayingRow: View {
     }
 
     var body: some View {
-        Button {
-            model.play()
-            callback?()
-        } label: {
-            HStack(spacing: 48) {
-                thumbnail
-                    .frame(width: Layout.episodeImageSize, height: Layout.episodeImageSize)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                VStack(alignment: .leading) {
-                    Spacer()
-                    Text(model.displayDate)
-                        .font(.body)
-                        .foregroundColor(isFocused ? .pcTextSecondaryActive : .pcTextSecondary)
-                    Text(model.episode.displayableTitle())
-                        .font(.title3)
-                        .foregroundColor(isFocused ? .pcTextPrimaryActive : .pcTextPrimary)
-                        .lineLimit(2)
-                    ProgressView(value: model.progress)
-                        .foregroundStyle(.blue)
-                        .tint(model.currentPodcastTintColor)
-                        .clipShape(RoundedRectangle(cornerRadius: 100))
-                    Text(model.timeLeft)
-                        .font(.body)
-                        .foregroundColor(isFocused ? .pcTextSecondaryActive : .pcTextSecondary)
-                    Spacer()
-                }
+        HStack(spacing: 48) {
+            thumbnail
+                .frame(width: Layout.episodeImageSize, height: Layout.episodeImageSize)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            VStack(alignment: .leading) {
+                Spacer()
+                Text(model.displayDate)
+                    .font(.body)
+                    .foregroundColor(isFocused ? .pcTextSecondaryActive : .pcTextSecondary)
+                Text(model.episode.displayableTitle())
+                    .font(.title3)
+                    .foregroundColor(isFocused ? .pcTextPrimaryActive : .pcTextPrimary)
+                    .lineLimit(2)
+                ProgressView(value: model.progress)
+                    .foregroundStyle(.blue)
+                    .tint(model.currentPodcastTintColor)
+                    .clipShape(RoundedRectangle(cornerRadius: 100))
+                Text(model.timeLeft)
+                    .font(.body)
+                    .foregroundColor(isFocused ? .pcTextSecondaryActive : .pcTextSecondary)
                 Spacer()
             }
-            .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
+            Spacer()
         }
-        .buttonStyle(.card)
+        .padding(32)
+        .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -24,10 +24,6 @@ struct EpisodeRow: View {
         self.isActive = isActive
     }
 
-    private var isHighlighted: Bool {
-        isFocused
-    }
-
     enum Layout {
         static let episodeImageSize = CGFloat(124)
     }
@@ -51,25 +47,25 @@ struct EpisodeRow: View {
                     if model.isVideo {
                         Image(systemName: "play.rectangle.fill")
                             .font(.caption)
-                            .foregroundColor(isHighlighted ? .pcTextSecondaryActive : .pcTextSecondary)
+                            .foregroundColor(isFocused ? .pcTextSecondaryActive : .pcTextSecondary)
                             .accessibilityLabel(L10n.filterMediaTypeVideo)
                     }
                     Text(model.displayDate)
                         .font(.caption)
-                        .foregroundColor(isHighlighted ? .pcTextSecondaryActive : .pcTextSecondary)
+                        .foregroundColor(isFocused ? .pcTextSecondaryActive : .pcTextSecondary)
                 }
                 Text(model.episode.displayableTitle())
                     .font(.body)
-                    .foregroundColor(isHighlighted ? .pcTextPrimaryActive : .pcTextPrimary)
+                    .foregroundColor(isFocused ? .pcTextPrimaryActive : .pcTextPrimary)
                     .lineLimit(2)
                 Text(model.displayDuration)
                     .font(.caption)
-                    .foregroundColor(isHighlighted ? .pcTextSecondaryActive : .pcTextSecondary)
+                    .foregroundColor(isFocused ? .pcTextSecondaryActive : .pcTextSecondary)
             }
             Spacer()
         }
-        .padding(24)
-        .background(isHighlighted ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
+        .padding(32)
+        .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .opacity(archivedOpacity)
         .animation(.easeInOut(duration: 0.15), value: archivedOpacity)
@@ -77,7 +73,7 @@ struct EpisodeRow: View {
 
     private var archivedOpacity: Double {
         guard model.isArchived else { return 1.0 }
-        return isHighlighted ? 1.0 : 0.3
+        return isFocused ? 1.0 : 0.3
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-724.

Updates the design of the **"Keep listening"** (now playing) card on the tvOS Home screen so it matches the other episode cards.

- Inset the artwork with **32** padding and round the card corners.
- Keep the **48** spacing between the artwork and the labels.
- Add the focus-state **contrast** used by the other episode cards: on focus the background swaps from `pcBackgroundSunken` to `pcBackgroundActive` and the text uses the active colors.

Under the hood this swaps the system `.card` button style for the flat `EpisodeRowButtonStyle`. Because `@Environment(\.isFocused)` reflects the nearest focusable *ancestor*, the card content was moved into the button's label (`NowPlayingRowLabel`) so focus is actually detected — previously the `isFocused` colour swaps never fired and the system `.card` style was masking it.

`EpisodeRow`'s padding was also bumped `24` → `32` for consistency across the cards.

## To test

1. Sign in and open the **Home** tab on the Apple TV app.
2. Make sure you have an in-progress episode so the **"Keep listening"** card appears at the top.
3. Move focus onto the card: confirm the background lightens (active) and the title/subtitle/time-left text gains contrast, and the card scales slightly.
4. Move focus away: confirm the card returns to the dark (sunken) background.
5. Confirm the artwork is inset (32 padding) with clear spacing to the labels, and the card has rounded corners.
6. Scroll to the **Up Next** / **New Releases** rows and confirm those episode cards still look correct with the 32 padding.

<img width="960" height="592" alt="Screenshot 2026-06-10 at 11 47 24 AM" src="https://github.com/user-attachments/assets/2fa1bc16-a49d-49f2-9ab4-5b1bb81e626d" />

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)