### PR TITLE
[PC TV] Clear all local data and cache on logout

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -89,16 +89,21 @@ public class DataManager {
 
         self.databaseWasCreated = DatabaseHelper.setup(queue: dbQueue)
 
-        // closing it above won't affect these calls, since they will re-open it
-        podcastManager.setup(dbQueue: dbQueue)
-        folderManager.setup(dbQueue: dbQueue)
-        upNextManager.setup(dbQueue: dbQueue)
-
         autoAddCandidates = AutoAddCandidatesDataManager(dbQueue: dbQueue)
         bookmarks = BookmarkDataManager(dbQueue: dbQueue)
         ratings = RatingsDataManager()
         // Force unwrap is safe here as dbQueue is always a GRDBQueue at runtime
         networkDataUsageManager = NetworkDataUsageManager(dbQueue: dbQueue as! GRDBQueue)
+
+        setupInMemoryCaches()
+    }
+
+    /// (Re)loads the in-memory caches that mirror database tables. Keep in sync when adding a
+    /// new cached manager.
+    private func setupInMemoryCaches() {
+        podcastManager.setup(dbQueue: dbQueue)
+        folderManager.setup(dbQueue: dbQueue)
+        upNextManager.setup(dbQueue: dbQueue)
     }
 
     convenience init(endOfYearManager: EndOfYearDataManager) {
@@ -1380,5 +1385,27 @@ extension DataManager {
         }
 
         try? sourceDbQueue.close()
+    }
+}
+
+// MARK: - Full data wipe
+
+extension DataManager {
+    /// Deletes every row from every table, leaving the schema and the live database connection
+    /// intact so objects already holding a `DataManager` reference keep working. Used by tvOS
+    /// logout; a later login repopulates the database via a full sync.
+    public func deleteAllData() {
+        do {
+            try (dbQueue as? GRDBQueue)?.dbPool.write { db in
+                let tableNames = try String.fetchAll(db, sql: "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
+                for tableName in tableNames {
+                    try db.execute(sql: "DELETE FROM \(tableName.quotedDatabaseIdentifier)")
+                }
+            }
+        } catch {
+            FileLog.shared.addMessage("DataManager.deleteAllData failed: \(error)")
+        }
+
+        setupInMemoryCaches()
     }
 }

--- a/Modules/Tests/PocketCastsDataModelTests/DataManagerDeleteAllDataTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/DataManagerDeleteAllDataTests.swift
@@ -1,5 +1,4 @@
 import XCTest
-import GRDB
 @testable import PocketCastsDataModel
 @testable import PocketCastsUtils
 

--- a/Modules/Tests/PocketCastsDataModelTests/DataManagerDeleteAllDataTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/DataManagerDeleteAllDataTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import GRDB
+@testable import PocketCastsDataModel
+@testable import PocketCastsUtils
+
+/// Tests for `DataManager.deleteAllData`, the full local-data wipe used by tvOS logout.
+final class DataManagerDeleteAllDataTests: DataManagerTestCase {
+
+    func testDeleteAllDataClearsEveryTable() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let podcast = self.createTestPodcast(uuid: "podcast-1", dataManager: dataManager)
+            let episode = self.createTestEpisode(uuid: "episode-1", podcast: podcast, dataManager: dataManager)
+            _ = self.createTestUserEpisode(uuid: "user-episode-1", dataManager: dataManager)
+            _ = self.createTestPlaylist(dataManager: dataManager)
+            _ = self.createTestFolder(dataManager: dataManager)
+            self.addToUpNextBottom(episodeUuid: episode.uuid, podcastUuid: podcast.uuid, dataManager: dataManager)
+
+            XCTAssertFalse(dataManager.allPodcasts(includeUnsubscribed: true).isEmpty, "\(impl): expected podcasts before wipe")
+            XCTAssertNotNil(dataManager.findEpisode(uuid: "episode-1"), "\(impl): expected episode before wipe")
+            XCTAssertFalse(dataManager.allUpNextEpisodes().isEmpty, "\(impl): expected up next before wipe")
+
+            dataManager.deleteAllData()
+
+            XCTAssertTrue(dataManager.allPodcasts(includeUnsubscribed: true).isEmpty, "\(impl): podcasts should be cleared")
+            XCTAssertNil(dataManager.findEpisode(uuid: "episode-1"), "\(impl): episodes should be cleared")
+            XCTAssertNil(dataManager.findUserEpisode(uuid: "user-episode-1"), "\(impl): user episodes should be cleared")
+            XCTAssertTrue(dataManager.allPlaylists(includeDeleted: true).isEmpty, "\(impl): playlists should be cleared")
+            XCTAssertTrue(dataManager.allFolders(includeDeleted: true).isEmpty, "\(impl): folders should be cleared")
+            XCTAssertTrue(dataManager.allUpNextEpisodes().isEmpty, "\(impl): up next should be cleared")
+        }
+    }
+
+    func testDeleteAllDataLeavesDatabaseUsable() throws {
+        try runWithBothImplementations { dataManager, impl in
+            _ = self.createTestPodcast(uuid: "before-wipe", dataManager: dataManager)
+
+            dataManager.deleteAllData()
+
+            _ = self.createTestPodcast(uuid: "after-wipe", title: "After Wipe", dataManager: dataManager)
+
+            let podcasts = dataManager.allPodcasts(includeUnsubscribed: true)
+            XCTAssertEqual(podcasts.count, 1, "\(impl): database should be usable after the wipe")
+            XCTAssertEqual(podcasts.first?.uuid, "after-wipe", "\(impl): only the post-wipe podcast should remain")
+        }
+    }
+}

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -56,6 +56,54 @@ class AppCoordinator {
         state = .welcome
     }
 
+    /// Logs the user out and removes all local data and cache, returning to the signed-out
+    /// experience. Unlike iOS, tvOS keeps nothing locally once signed out.
+    func logout() {
+        Task {
+            // Clear credentials first so anything below can't push the about-to-be-wiped data
+            // up to the server.
+            SignOutHelper.signout()
+
+            // Stop audio and clear the queue before its backing data is removed (main actor).
+            await MainActor.run {
+                PlaybackManager.shared.endPlayback(saveCurrentEpisode: false)
+            }
+
+            DataManager.sharedManager.deleteAllData()
+            DownloadManager.shared.removeAllDownloadedFiles()
+            ImageManager.sharedManager.clearAllImageCaches()
+            clearUserDefaults()
+
+            await MainActor.run {
+                userState.refresh()
+                state = .welcome
+            }
+        }
+    }
+
+    /// Wipes `UserDefaults` apart from device-level keys, so the next account to sign in on a
+    /// shared Apple TV doesn't inherit the previous user's preferences (playback speed, theme, …).
+    private func clearUserDefaults() {
+        let defaults = UserDefaults.standard
+
+        let preservedKeys = [
+            Constants.UserDefaults.appId,
+            Constants.UserDefaults.analyticsOptOut,
+            Constants.UserDefaults.reviewRequestDates
+        ]
+        let preserved = preservedKeys.reduce(into: [String: Any]()) { result, key in
+            result[key] = defaults.object(forKey: key)
+        }
+
+        if let bundleId = Bundle.main.bundleIdentifier {
+            defaults.removePersistentDomain(forName: bundleId)
+        }
+
+        for (key, value) in preserved {
+            defaults.set(value, forKey: key)
+        }
+    }
+
     private func setupCredentials() {
         ServerCredentials.sharing = ApiCredentials.sharingServerSecret
     }

--- a/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
@@ -4,6 +4,8 @@ struct ProfileMenuView: View {
     @Environment(AppCoordinator.self) private var coordinator
     @Environment(\.dismiss) private var dismiss
 
+    @State private var isShowingLogoutConfirmation = false
+
     /// Called with the chosen destination when the signed-out user taps
     /// "Log in" or "Create account". The presenter is responsible for
     /// dismissing this menu and showing the destination.
@@ -37,6 +39,19 @@ struct ProfileMenuView: View {
         .padding(80)
         .frame(width: 862, alignment: .center)
         .fixedSize(horizontal: true, vertical: false)
+        .confirmationDialog(
+            L10n.tvProfileMenuLogOutConfirmationTitle,
+            isPresented: $isShowingLogoutConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button(L10n.tvProfileMenuLogOut, role: .destructive) {
+                coordinator.logout()
+                dismiss()
+            }
+            Button(L10n.cancel, role: .cancel) {}
+        } message: {
+            Text(L10n.tvProfileMenuLogOutConfirmationMessage)
+        }
     }
 
     // MARK: - Signed-in
@@ -89,8 +104,7 @@ struct ProfileMenuView: View {
 
             // Group 3
             Button {
-                coordinator.userState.logout()
-                dismiss()
+                isShowingLogoutConfirmation = true
             } label: {
                 Label(L10n.tvProfileMenuLogOut, systemImage: "rectangle.portrait.and.arrow.right")
                     .foregroundStyle(.red)

--- a/Pocket Casts TV App/UI/UserStateModel.swift
+++ b/Pocket Casts TV App/UI/UserStateModel.swift
@@ -42,11 +42,4 @@ class UserStateModel {
         }
         .store(in: &cancellables)
     }
-
-    func logout() {
-        Task {
-            SignOutHelper.signout()
-            refresh()
-        }
-    }
 }

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -215,6 +215,18 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
     }
 
+    /// Deletes the contents of the download, buffer, and temp folders (keeping the folders). Used by tvOS logout.
+    func removeAllDownloadedFiles() {
+        let folders = [podcastsDirectory, streamingBufferDirectory, tempDownloadFolder]
+        for folder in folders where !folder.isEmpty {
+            guard let contents = try? FileManager.default.contentsOfDirectory(atPath: folder) else { continue }
+            for file in contents {
+                let path = (folder as NSString).appendingPathComponent(file)
+                try? FileManager.default.removeItem(atPath: path)
+            }
+        }
+    }
+
     func addLocalFile(url: URL, uuid: String) throws -> URL? {
         let destinationUrl = URL(fileURLWithPath: pathForUrl(fileUrl: url, uuid: uuid))
         do {

--- a/podcasts/ImageManager.swift
+++ b/podcasts/ImageManager.swift
@@ -435,6 +435,15 @@ class ImageManager {
 
     // MARK: - Cleanup
 
+    /// Clears every image cache, memory and disk. Used by tvOS logout.
+    func clearAllImageCaches() {
+        let caches = [networkImageCache, searchImageCache, subscribedPodcastsCache, userEpisodeCache, discoverCache, discoverVideoThumbnailCache]
+        for cache in caches {
+            cache.clearMemoryCache()
+            cache.clearDiskCache()
+        }
+    }
+
     func clearPodcastCache(recacheWhenDone: Bool) {
         // clear out all the saved colors, since they might change when the images do
         DataManager.sharedManager.setAllPodcastImageVersions(to: 0)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6244,6 +6244,12 @@
 /* tv Profile menu — log out action */
 "tv_profile_menu_log_out" = "Log out";
 
+/* tv Profile menu — title of the confirmation shown before logging out */
+"tv_profile_menu_log_out_confirmation_title" = "Log out?";
+
+/* tv Profile menu — message warning that logging out erases all locally stored data from this Apple TV */
+"tv_profile_menu_log_out_confirmation_message" = "This removes all downloaded podcasts and data from this Apple TV. You can sign in again to restore them.";
+
 /* tv Profile menu — log in action (signed-out state) */
 "tv_profile_menu_log_in" = "Log in";
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-720.

On tvOS, logging out now removes **all** locally cached data from the device and asks for confirmation first.

Unlike iOS — which keeps your local library so a returning/anonymous user can keep browsing — an Apple TV is often shared, so signing out should leave nothing behind. Logout now:

- Shows a **"Log out?"** confirmation dialog before doing anything destructive.
- Stops playback and clears the now-playing / Up Next queue.
- Clears credentials and sync watermarks (existing `SignOutHelper.signout()`).
- Wipes the local database (`DataManager.deleteAllData()`).
- Deletes downloaded/buffered media (`DownloadManager.removeAllDownloadedFiles()`).
- Clears every image cache (`ImageManager.clearAllImageCaches()`).
- Wipes `UserDefaults`, preserving only device-level keys (`appId`, `analyticsOptOut`, `reviewRequestDates`).
- Returns the app to the welcome screen.

A later sign-in repopulates everything via a normal full sync.

**Implementation note — why truncate instead of deleting the DB file?** `DataManager.sharedManager` has an internal setter and is captured by long-lived singletons (`TVDataManager`, `PodcastManager`, `DownloadManager`). Reassigning it would leave them pointing at a closed pool, and deleting an open SQLite file just orphans the data. `deleteAllData()` instead truncates every table through the one live connection (the schema version lives in `PRAGMA user_version`, not a table), so every existing reference stays valid. All changes are tvOS-only — iOS `SignOutHelper` behavior is unchanged.

## To test

1. On an Apple TV or tvOS simulator, sign in and let podcasts, Up Next, and history sync.
2. Start playing an episode.
3. Open the profile menu → tap **Log out**, and confirm the **"Log out?"** dialog appears.
4. Tap **Cancel** — nothing changes and playback continues.
5. Tap **Log out** again, then tap **Log out** in the dialog.
6. Confirm playback stops and the app returns to the welcome screen.
7. Sign in again with the **same** account and confirm everything re-syncs from scratch.
8. Sign in with a **different** account and confirm none of the previous user's podcasts, Up Next, history, or playback settings (e.g. playback speed) remain.

<img width="960" height="592" alt="Screenshot 2026-06-10 at 1 06 41 PM" src="https://github.com/user-attachments/assets/795bc86c-d12a-4cb4-9b05-3965486332b1" />


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
