### PR TITLE
Present file episode details as a native sheet

### DIFF
--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -362,7 +362,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
                 userEpisodeDetailVC = UserEpisodeDetailViewController(episode: fullEpisode)
                 userEpisodeDetailVC?.delegate = self
                 userEpisodeDetailVC?.themeOverride = themeOverride
-                userEpisodeDetailVC?.animateIn()
+                userEpisodeDetailVC?.present(from: self)
             }
         }
     }

--- a/podcasts/UploadedViewController+Table.swift
+++ b/podcasts/UploadedViewController+Table.swift
@@ -69,7 +69,7 @@ extension UploadedViewController: UITableViewDataSource, UITableViewDelegate {
             userEpisodeDetailVC = UserEpisodeDetailViewController(episodeUuid: episode.uuid)
             userEpisodeDetailVC?.playlist = .files
             userEpisodeDetailVC?.delegate = self
-            userEpisodeDetailVC?.animateIn()
+            userEpisodeDetailVC?.present(from: self)
         }
     }
 

--- a/podcasts/UploadedViewController.swift
+++ b/podcasts/UploadedViewController.swift
@@ -332,7 +332,7 @@ class UploadedViewController: PCViewController, UserEpisodeDetailProtocol {
             openAddFilesVC.cancelTapped()
         }
         if let openUserEpiosdeDetails = userEpisodeDetailVC {
-            openUserEpiosdeDetails.animateOut()
+            openUserEpiosdeDetails.close()
         }
     }
 

--- a/podcasts/UserEpisodeActionCell.xib
+++ b/podcasts/UserEpisodeActionCell.xib
@@ -42,7 +42,7 @@
                     </imageView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="TqZ-tP-wzo" firstAttribute="leading" secondItem="qBR-tJ-Mzf" secondAttribute="trailing" constant="30" id="GUz-Z7-rCG"/>
+                    <constraint firstItem="TqZ-tP-wzo" firstAttribute="leading" secondItem="qBR-tJ-Mzf" secondAttribute="trailing" constant="16" id="GUz-Z7-rCG"/>
                     <constraint firstItem="3U3-HS-2I2" firstAttribute="leading" secondItem="TqZ-tP-wzo" secondAttribute="trailing" constant="8" id="Lpa-Og-3am"/>
                     <constraint firstItem="TqZ-tP-wzo" firstAttribute="centerY" secondItem="qBR-tJ-Mzf" secondAttribute="centerY" id="PCC-lx-E89"/>
                     <constraint firstItem="3U3-HS-2I2" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="g44-zE-ZiY"/>

--- a/podcasts/UserEpisodeDetailViewController+Table.swift
+++ b/podcasts/UserEpisodeDetailViewController+Table.swift
@@ -62,7 +62,7 @@ extension UserEpisodeDetailViewController: UITableViewDelegate, UITableViewDataS
             cell.titleLabel.text = L10n.delete
             cell.titleLabel.style = .support05
             cell.actionImage?.image = UIImage(named: "delete")
-            cell.actionImage?.tintColor = ThemeColor.primaryIcon01()
+            cell.actionImage?.tintColor = ThemeColor.support05(for: themeOverride)
         case .cancelUpload:
             cell.titleLabel.text = L10n.customEpisodeCancelUpload
             cell.titleLabel.style = .primaryText01
@@ -83,39 +83,40 @@ extension UserEpisodeDetailViewController: UITableViewDelegate, UITableViewDataS
 
         switch tableRow {
         case .bookmarks:
+            close()
             delegate?.showBookmarks(userEpisode: episode)
-            animateOut()
 
         case .download:
             Analytics.track(.userFileDetailOptionTapped, properties: ["option": "download"])
             PlaybackActionHelper.download(episodeUuid: episode.uuid)
-            animateOut()
+            close()
         case .cancelDownload:
             Analytics.track(.userFileDetailOptionTapped, properties: ["option": "cancel_download"])
             PlaybackActionHelper.stopDownload(episodeUuid: episode.uuid)
-            animateOut()
+            close()
         case .upload:
             if SubscriptionHelper.hasActiveSubscription() {
                 Analytics.track(.userFileDetailOptionTapped, properties: ["option": "upload"])
                 PlaybackActionHelper.upload(episodeUuid: episode.uuid)
-                animateOut()
+                close()
             } else {
-                animateOut()
-                delegate?.showUpgradeRequired()
                 Analytics.track(.userFileDetailOptionTapped, properties: ["option": "upload_upgrade_required"])
+                close()
+                delegate?.showUpgradeRequired()
             }
         case .cancelUpload:
             PlaybackActionHelper.stopUpload(episodeUuid: episode.uuid)
             Analytics.track(.userFileDetailOptionTapped, properties: ["option": "cancel_upload"])
-            animateOut()
+            close()
         case .removeFromCloud:
             UserEpisodeManager.deleteFromCloud(episode: episode)
             Analytics.track(.userFileDetailOptionTapped, properties: ["option": "delete_from_cloud"])
-            animateOut()
+            close()
         case .upNext:
             if PlaybackManager.shared.inUpNext(episode: episode) {
                 Analytics.track(.userFileDetailOptionTapped, properties: ["option": "up_next_delete"])
                 PlaybackManager.shared.removeIfPlayingOrQueued(episode: episode, fireNotification: true, userInitiated: true)
+                close()
             } else {
                 let addToUpNextPicker = OptionsPicker(title: L10n.addToUpNext.localizedUppercase)
                 let playNextAction = OptionAction(label: L10n.playNext, icon: "list_playnext") {
@@ -130,9 +131,14 @@ extension UserEpisodeDetailViewController: UITableViewDelegate, UITableViewDataS
                 }
                 addToUpNextPicker.addAction(action: playLastAction)
 
-                addToUpNextPicker.show(statusBarStyle: preferredStatusBarStyle)
+                let presentingVC = presentingViewController
+                close()
+                if let presentingVC {
+                    addToUpNextPicker.present(from: presentingVC)
+                } else {
+                    assertionFailure("Missing presenting view controller")
+                }
             }
-            animateOut()
         case .markAsPlayed:
             AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
 
@@ -143,15 +149,15 @@ extension UserEpisodeDetailViewController: UITableViewDelegate, UITableViewDataS
                 Analytics.track(.userFileDetailOptionTapped, properties: ["option": "mark_played"])
                 EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
             }
-            animateOut()
+            close()
         case .editDetails:
-            animateOut()
-            delegate?.showEdit(userEpisode: episode)
             Analytics.track(.userFileDetailOptionTapped, properties: ["option": "edit"])
+            close()
+            delegate?.showEdit(userEpisode: episode)
         case .delete:
-            animateOut()
-            delegate?.showDeleteConfirmation(userEpisode: episode)
             Analytics.track(.userFileDetailOptionTapped, properties: ["option": "delete"])
+            close()
+            delegate?.showDeleteConfirmation(userEpisode: episode)
         }
     }
 
@@ -183,13 +189,13 @@ extension UserEpisodeDetailViewController: UITableViewDelegate, UITableViewDataS
         if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
             // dismiss the dialog if the user hit play
             if !PlaybackManager.shared.playing() {
-                animateOut()
+                close()
             }
 
             PlaybackActionHelper.playPause()
         } else {
             PlaybackActionHelper.play(episode: episode, playlist: playlist)
-            animateOut()
+            close()
         }
     }
 }

--- a/podcasts/UserEpisodeDetailViewController.swift
+++ b/podcasts/UserEpisodeDetailViewController.swift
@@ -21,7 +21,6 @@ class UserEpisodeDetailViewController: UIViewController {
     @IBOutlet var containerView: ThemeableView! {
         didSet {
             containerView.style = .primaryUi01
-            containerView.layer.cornerRadius = 8
         }
     }
 
@@ -51,7 +50,7 @@ class UserEpisodeDetailViewController: UIViewController {
 
     @IBOutlet var playPauseButton: PlayPauseButton!
 
-    @IBOutlet var containerViewHeight: NSLayoutConstraint!
+    @IBOutlet var errorContainerHeight: NSLayoutConstraint!
     @IBOutlet var containerViewBottomConstraint: NSLayoutConstraint!
     @IBOutlet var actionTable: ThemeableTable! {
         didSet {
@@ -97,9 +96,9 @@ class UserEpisodeDetailViewController: UIViewController {
 
     var playlist: AutoplayHelper.Playlist?
 
-    private var window: UIWindow?
-    private static let containerHeightWithError: CGFloat = 534
-    private static let containerHeightWithoutError: CGFloat = 430
+    /// Height of the error banner when shown. The sheet's own height is derived
+    /// from the content, so this is the only fixed dimension we toggle.
+    private static let errorBannerHeight: CGFloat = 100
 
     enum TableRow { case download, bookmarks, removeFromCloud, upload, upNext, markAsPlayed, editDetails, delete, cancelUpload, cancelDownload }
     let actionCellId = "UserEpisodeActionCell"
@@ -134,21 +133,16 @@ class UserEpisodeDetailViewController: UIViewController {
         downloadStatusImage.image = UIImage(named: "episode-downloaded")
         registerCells()
 
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(hide))
-        greyBackgroundView.addGestureRecognizer(tapGesture)
-        let swipeDown = UISwipeGestureRecognizer(target: self, action: #selector(hide))
-        swipeDown.direction = .down
-        containerView.addGestureRecognizer(swipeDown)
-
         playPauseButton.isPlaying = PlaybackManager.shared.isActivelyPlaying(episodeUuid: episode.uuid)
 
         actionTable.backgroundColor = UIColor.clear
-        greyBackgroundView.backgroundColor = UIColor.clear
+
+        greyBackgroundView.isHidden = true
+        barView.isHidden = true
 
         hasError = episode.playbackError() || episode.uploadFailed() || episode.downloadFailed()
         errorContainerView.isHidden = !hasError
-        containerViewHeight.constant = hasError ? UserEpisodeDetailViewController.containerHeightWithError : UserEpisodeDetailViewController.containerHeightWithoutError
-        containerViewBottomConstraint.constant = -containerViewHeight.constant
+        errorContainerHeight.constant = hasError ? UserEpisodeDetailViewController.errorBannerHeight : 0
         updateStatus()
         Analytics.track(.userFileDetailShown)
     }
@@ -164,6 +158,7 @@ class UserEpisodeDetailViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        isAnimatingIn = false
         addObservers()
     }
 
@@ -217,6 +212,7 @@ class UserEpisodeDetailViewController: UIViewController {
     }
 
     private func updateColors() {
+        view.backgroundColor = ThemeColor.primaryUi01(for: themeOverride)
         titleLabel.themeOverride = themeOverride
         containerView.themeOverride = themeOverride
         infoLabel.themeOverride = themeOverride
@@ -303,103 +299,88 @@ class UserEpisodeDetailViewController: UIViewController {
         }
     }
 
-    // MARK: Actions
-
-    @objc func hide() {
-        Analytics.track(.userFileDetailDismissed)
-        animateOut()
-    }
-
-    // MARK: - Animate in/out
+    // MARK: - Presentation
 
     private var isAnimatingIn = true
     private var isAnimatingOut = false
-    func animateIn() {
-        window = SceneHelper.newMainScreenWindow()
-        guard let window else { return }
 
-        window.rootViewController = self
-        window.windowLevel = UIWindow.Level.alert
-        window.makeKeyAndVisible()
+    /// Presents the detail options as a native sheet sized to fit its content.
+    func present(from presenter: UIViewController) {
+        modalPresentationStyle = .formSheet
+        if let sheet = sheetPresentationController {
+            sheet.detents = [contentDetent()]
+            sheet.prefersGrabberVisible = true
+            sheet.delegate = self
+        }
+        presenter.present(self, animated: true)
+    }
 
-        containerViewBottomConstraint.constant = -containerHeight()
-        view.layoutIfNeeded()
-        UIView.animate(withDuration: Constants.Animation.bottomCardAnimationTime, delay: 0, options: .curveEaseOut, animations: { [weak self] in
-            guard let self else { return }
-
-            self.containerViewBottomConstraint.constant = 0
-            self.greyBackgroundView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
-
-            self.view.layoutIfNeeded()
-        }) { [weak self] _ in
-            self?.containerViewBottomConstraint.constant = 0
-            self?.view.layoutIfNeeded()
-            self?.isAnimatingIn = false
+    /// A custom detent that sizes the sheet to fit the content. The container's
+    /// height is driven by its content (Auto Layout), so we measure it rather
+    /// than rely on a fixed value.
+    private func contentDetent() -> UISheetPresentationController.Detent {
+        .custom(identifier: .userEpisodeDetail) { [weak self] context in
+            guard let self else { return context.maximumDetentValue }
+            let fittingHeight = self.containerView.systemLayoutSizeFitting(
+                CGSize(width: self.view.bounds.width, height: 0),
+                withHorizontalFittingPriority: .required,
+                verticalFittingPriority: .fittingSizeLevel
+            ).height
+            return min(fittingHeight, context.maximumDetentValue)
         }
     }
 
-    func animateOut() {
+    /// Dismisses the sheet. A follow-up screen may be presented from the
+    /// delegate immediately after calling this; UIKit serializes the dismissal
+    /// and the subsequent presentation. Pass `completion` to present something
+    /// on the top-most controller once this sheet has fully left the hierarchy.
+    func close(completion: (() -> Void)? = nil) {
         isAnimatingOut = true
-        view?.layoutIfNeeded()
-        UIView.animate(withDuration: Constants.Animation.bottomCardAnimationTime, animations: { [weak self] in
-            guard let self else { return }
-
-            self.greyBackgroundView.backgroundColor = UIColor.clear
-            self.containerViewBottomConstraint.constant = -self.containerHeight()
-            self.view.layoutIfNeeded()
-        }) { [weak self] _ in
-            self?.delegate?.userEpisodeDetailClosed()
-            self?.window?.resignKey()
-            self?.window = nil
-        }
+        dismiss(animated: true, completion: completion)
+        delegate?.userEpisodeDetailClosed()
     }
+
+    // MARK: - Error state
 
     func animateInError() {
         errorContainerView.alpha = 0
         errorContainerView.isHidden = false
+        errorContainerHeight.constant = UserEpisodeDetailViewController.errorBannerHeight
 
-        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime / 2, animations: { [weak self] in
-            guard let self else { return }
-            self.containerViewHeight.constant = UserEpisodeDetailViewController.containerHeightWithError
-            self.view.layoutIfNeeded()
-        }) { [weak self] _ in
-            self?.containerViewHeight.constant = UserEpisodeDetailViewController.containerHeightWithError
-            UIView.animate(withDuration: Constants.Animation.defaultAnimationTime / 2, animations: { [weak self] in
-                guard let self else { return }
-                self.errorContainerView.alpha = 1
-            }) { [weak self] _ in
-                self?.errorContainerView.alpha = 1
-                self?.containerViewHeight.constant = UserEpisodeDetailViewController.containerHeightWithError
-            }
+        sheetPresentationController?.animateChanges { [weak self] in
+            self?.sheetPresentationController?.invalidateDetents()
+            self?.view.layoutIfNeeded()
+        }
+        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime) { [weak self] in
+            self?.errorContainerView.alpha = 1
         }
     }
 
     func animateOutError() {
-        errorContainerView.alpha = 1
-        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime / 2, animations: { [weak self] in
-            guard let self else { return }
-            self.errorContainerView.alpha = 0
-        }) { [weak self] _ in
+        errorContainerHeight.constant = 0
 
-            UIView.animate(withDuration: Constants.Animation.defaultAnimationTime / 2, animations: { [weak self] in
-                guard let self else { return }
-                self.containerViewHeight.constant = UserEpisodeDetailViewController.containerHeightWithoutError
-                self.view.layoutIfNeeded()
-            }) { [weak self] _ in
-                self?.errorContainerView.alpha = 0
-                self?.errorContainerView.isHidden = true
-                self?.containerViewHeight.constant = UserEpisodeDetailViewController.containerHeightWithoutError
-            }
+        UIView.animate(withDuration: Constants.Animation.defaultAnimationTime / 2, animations: { [weak self] in
+            self?.errorContainerView.alpha = 0
+        }) { [weak self] _ in
+            self?.errorContainerView.isHidden = true
+        }
+        sheetPresentationController?.animateChanges { [weak self] in
+            self?.sheetPresentationController?.invalidateDetents()
+            self?.view.layoutIfNeeded()
         }
     }
+}
 
-    private func containerHeight() -> CGFloat {
-        containerViewHeight?.constant ?? 500
+extension UserEpisodeDetailViewController: UISheetPresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        // Fired on interactive (swipe) dismissal only.
+        Analytics.track(.userFileDetailDismissed)
+        delegate?.userEpisodeDetailClosed()
     }
+}
 
-    @objc private func backgroundTapped() {
-        animateOut()
-    }
+private extension UISheetPresentationController.Detent.Identifier {
+    static let userEpisodeDetail = UISheetPresentationController.Detent.Identifier("userEpisodeDetail")
 }
 
 extension UserEpisodeDetailViewController: AnalyticsSourceProvider {

--- a/podcasts/UserEpisodeDetailViewController.xib
+++ b/podcasts/UserEpisodeDetailViewController.xib
@@ -14,7 +14,7 @@
                 <outlet property="barView" destination="Lgm-04-Vea" id="xLZ-RY-pZI"/>
                 <outlet property="containerView" destination="rPk-NC-Zbc" id="Sbv-ag-cXW"/>
                 <outlet property="containerViewBottomConstraint" destination="QRi-zN-N1y" id="8PP-VR-ghA"/>
-                <outlet property="containerViewHeight" destination="K5Z-lB-6vg" id="kRT-8I-qUl"/>
+                <outlet property="errorContainerHeight" destination="bUh-eZ-DTR" id="eCH-He-ght"/>
                 <outlet property="dividerView" destination="lvd-qJ-KlQ" id="W5T-bU-gXy"/>
                 <outlet property="downloadStatusImage" destination="LQy-mY-4LR" id="mkV-fT-GZY"/>
                 <outlet property="downloadingIndicator" destination="d0a-H5-oSK" id="3ro-7b-PSx"/>
@@ -202,7 +202,8 @@
                         <constraint firstItem="lvd-qJ-KlQ" firstAttribute="leading" secondItem="rPk-NC-Zbc" secondAttribute="leading" id="9Zo-l0-Twi"/>
                         <constraint firstItem="9yI-6F-r4n" firstAttribute="top" secondItem="5vT-2y-mAd" secondAttribute="bottom" constant="24" id="FCD-PL-Jh5"/>
                         <constraint firstItem="3MH-20-muf" firstAttribute="leading" secondItem="9yI-6F-r4n" secondAttribute="trailing" constant="16" id="JuV-ru-6uu"/>
-                        <constraint firstAttribute="height" constant="410" id="K5Z-lB-6vg"/>
+                        <constraint firstItem="5vT-2y-mAd" firstAttribute="top" secondItem="rPk-NC-Zbc" secondAttribute="top" constant="16" id="eCt-To-pin"/>
+                        <constraint firstItem="rPk-NC-Zbc" firstAttribute="bottom" secondItem="blI-8r-cU7" secondAttribute="bottom" id="i7y-Cs-8Mg"/>
                         <constraint firstAttribute="trailing" secondItem="mS3-CC-CaQ" secondAttribute="trailing" constant="16" id="MVt-VS-OF3"/>
                         <constraint firstAttribute="trailing" secondItem="lvd-qJ-KlQ" secondAttribute="trailing" id="c9B-G4-E6s"/>
                         <constraint firstItem="5vT-2y-mAd" firstAttribute="leading" secondItem="rPk-NC-Zbc" secondAttribute="leading" constant="16" id="ffo-mF-O0a"/>
@@ -228,7 +229,7 @@
                 <constraint firstItem="bbX-qh-cTr" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="CeC-ut-8Ak"/>
                 <constraint firstAttribute="bottom" secondItem="rPk-NC-Zbc" secondAttribute="bottom" priority="750" id="QRi-zN-N1y"/>
                 <constraint firstAttribute="trailing" secondItem="rPk-NC-Zbc" secondAttribute="trailing" id="arz-w8-fAy"/>
-                <constraint firstItem="rPk-NC-Zbc" firstAttribute="bottom" secondItem="blI-8r-cU7" secondAttribute="bottom" id="i7y-Cs-8Mg"/>
+                <constraint firstItem="rPk-NC-Zbc" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="rPk-To-pRt"/>
                 <constraint firstAttribute="trailing" secondItem="bbX-qh-cTr" secondAttribute="trailing" id="tBD-i1-T7e"/>
             </constraints>
             <point key="canvasLocation" x="138" y="153"/>


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

<!-- Fixes PCIOS- -->

Reworks the **file (uploaded) episode details** dialog to use a native `UISheetPresentationController` instead of the custom window-based animated bottom card.

This is the last screen using the deprecated window-based `OptionsPicker.show(statusBarStyle:)`.

### What changed

- **Native sheet presentation** — `UserEpisodeDetailViewController` is now presented as a self-sizing `.formSheet`. `animateIn()`/`animateOut()` (which spun up their own `UIWindow` and hand-rolled the slide animation) are replaced by `present(from:)`/`close()`. A custom detent measures the container's fitting height so the sheet hugs its content. The legacy dimming view and custom grabber are dropped in favor of the system sheet chrome. Call sites in `UpNextViewController`, `UploadedViewController`, and `UploadedViewController+Table` are updated.
- **Error banner** — the error state now toggles a single banner-height constraint and animates via `sheetPresentationController.animateChanges`/`invalidateDetents()` instead of swapping fixed container heights.
- **Action cell icon spacing** — the icon was hugging the left edge with an oversized gap before the title; the gap is tightened so the icon sits centered between the edge and the title.
- **Destructive action** — the entire Delete row (icon + label) is now red, not just the label.
- **Corner radius** — removed the custom corner radius; the system sheet's native radius is used.

## To test

1. Go to the **Files** tab (Profile → Files) and open an uploaded file's **details** (tap the episode / overflow).
2. Confirm the details appear as a native sheet sized to its content, with the system grabber and corner radius.
3. Swipe the sheet down and confirm it dismisses.
5. Tap **Add to Up Next** → confirm the Play Next / Play Last options picker appears (no crash) after the details sheet closes.
6. Tap **Edit**, **Delete**, **Bookmarks**, and (without Plus) **Upload** → confirm each follow-up screen presents correctly after the sheet closes.
7. Open the details for a file with a playback/upload/download error and confirm the error banner shows and the sheet resizes to fit it.

I tested these scenarios, including the error banner presentation, which is a bit complex but works.

<img width="340" alt="Screenshot 2026-06-10 at 6 43 14 PM" src="https://github.com/user-attachments/assets/fffb6fdb-5aaf-4c54-93ae-1f8d5c9ed890" />
<img width="340" alt="Screenshot 2026-06-10 at 6 44 57 PM" src="https://github.com/user-attachments/assets/62a9e97b-9356-44e2-86a5-849c496dbb2a" />


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)