### PR TITLE
[PC TV] Localize hardcoded strings in the tvOS app

### DIFF
--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -166,13 +166,13 @@ struct SignInView: View {
 
     var usernamePasswordLogin: some View {
         VStack {
-            TextField("Username", text: $username)
+            TextField(L10n.tvUserSignInUsernamePlaceholder, text: $username)
                 .textContentType(.username)
                 .focused($focusedField, equals: .username)
                 .submitLabel(.next)
                 .onSubmit { focusedField = .password }
 
-            SecureField("Password", text: $password)
+            SecureField(L10n.signInPasswordPrompt, text: $password)
                 .textContentType(.password)
                 .focused($focusedField, equals: .password)
                 .submitLabel(.done)
@@ -191,7 +191,7 @@ struct SignInView: View {
             } label: {
                 switch model.state {
                 case .start, .error:
-                    Text("Sign In")
+                    Text(L10n.signIn)
                         .frame(minWidth: 300)
                 case .waiting:
                     ProgressView()

--- a/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
@@ -41,7 +41,7 @@ class SignInViewModel {
         } catch let error as APIError {
             state = .error(error, error.localizedDescription)
         } catch {
-            state = .error(error, "Please try again")
+            state = .error(error, L10n.pleaseTryAgain)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -121,7 +121,7 @@ struct PodcastDetailView: View {
             if let podcast = model.podcast {
                 PodcastMoreInfoView(podcast: podcast)
             } else {
-                Text("Loading Info")
+                Text(L10n.loading)
             }
         }
     }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6259,6 +6259,9 @@
 /* tv Sign In Option Username and Password */
 "tv_user_sign_in_option_manual" = "User/Pass";
 
+/* tv Sign In manual login username text field placeholder */
+"tv_user_sign_in_username_placeholder" = "Username";
+
 /* tv search field placeholder prompt */
 "tv_search_prompt" = "Podcasts, shows, authors";
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

A small cleanup of hardcoded English strings in the tvOS app that were bypassing the `L10n` localization system and would have shipped untranslated. The codebase is otherwise consistent about routing all user-facing copy through `L10n.*`, so these stood out.

### What changed

| Location | Before | After |
|---|---|---|
| `SignInView.swift` (manual login) | `TextField("Username", …)` | `L10n.tvUserSignInUsernamePlaceholder` (new key) |
| `SignInView.swift` (manual login) | `SecureField("Password", …)` | `L10n.signInPasswordPrompt` (existing key) |
| `SignInView.swift` (sign-in button) | `Text("Sign In")` | `L10n.signIn` (existing key) |
| `SignInViewModel.swift` (sign-in error fallback) | `.error(error, "Please try again")` | `L10n.pleaseTryAgain` (existing key) |
| `PodcastDetailView.swift` (more-info sheet fallback) | `Text("Loading Info")` | `L10n.loading` (existing key) |

Only one new string key was added — `tv_user_sign_in_username_placeholder` = `"Username"` (no existing equivalent; the iOS flow uses "Email Address" while tvOS manual login is username-based). The rest reuse existing keys, consistent with how this view already reuses generic keys like `L10n.tryAgain` and `L10n.podcastErrorMessage`.

The `SignInViewModel` error fallback was caught by a full sweep of all 83 tvOS source files (it lives in a view model rather than a View, so it isn't obvious from a quick scan of the screens).

## To test

1. Build and run the **Pocket Casts TV App** scheme on a tvOS Simulator.
2. From the welcome screen, choose **Sign in**, then switch the login type to **User/Pass**.
3. Confirm the **Username** and **Password** fields and the **Sign In** button render correctly.
4. Enter invalid credentials and submit — confirm the error fallback ("Please try again") appears.
5. Open any podcast's detail screen and tap **More info** — confirm the sheet loads (the localized "Loading…" fallback shows only if the podcast hasn't loaded yet).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
