### PR TITLE
[PC TV] Remove unused episode artwork loader from EpisodeRowViewModel

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -1,6 +1,5 @@
 import Foundation
 import PocketCastsDataModel
-import PocketCastsServer
 import PocketCastsUtils
 import SwiftUI
 import Combine
@@ -14,7 +13,6 @@ class EpisodeRowViewModel: Identifiable {
 
     var episode: BaseEpisode
     var podcast: Podcast?
-    var imageData: Data?
     var progress: Double
     var id: String { episode.uuid }
 
@@ -27,15 +25,6 @@ class EpisodeRowViewModel: Identifiable {
         self.playbackManager = playbackManager
         self.progress = episode.playedUpTo / episode.duration
         setupObservers()
-    }
-
-    func loadEpisodeArtwork() {
-        Task.detached { [weak self] in
-            let data = await self?.loadEpisodeArtworkData()
-            await MainActor.run { [weak self] in
-                self?.imageData = data
-            }
-        }
     }
 
     var duration: Double {
@@ -70,10 +59,6 @@ class EpisodeRowViewModel: Identifiable {
         return episode.displayableTimeLeft()
     }
 
-    var displayImageData: Data? {
-        return imageData
-    }
-
     var currentPodcastTintColor: Color? {
         if let podcast {
             return Color(ColorManager.darkThemeTintForPodcast(podcast))
@@ -82,17 +67,6 @@ class EpisodeRowViewModel: Identifiable {
         } else {
             return Color(AppTheme.userEpisodeColor(number: 1))
         }
-    }
-
-    private func loadEpisodeArtworkData() async -> Data? {
-        let imageUrl = ServerHelper.image(podcastUuid: episode.parentIdentifier(), size: 340)
-        guard let url = URL(string: imageUrl),
-              let (data, _) = try? await URLSession.shared.data(for: URLRequest(url: url)),
-              let uiImage = UIImage(data: data)
-        else {
-            return nil
-        }
-        return uiImage.pngData()
     }
 
     var podcastUuid: String? {


### PR DESCRIPTION
## Summary

`EpisodeRowViewModel.loadEpisodeArtworkData()` hand-rolled a `URLSession.shared.data(for:)` request against `ServerHelper.image(...)`, bypassing the shared `ImageManager`/Kingfisher cache. This code is now removed.

## To test

Artwork rendering is unchanged, but to sanity-check the Apple TV app:

1. Open the Apple TV app and navigate to a Podcast detail screen.
2. Confirm episode rows still show podcast artwork thumbnails.
3. Check Up Next, Listening History, and Starred — episode rows render artwork as before.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)