### PR TITLE
[PC TV] Refine category pill styling and cover animation

### DIFF
--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoriesRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoriesRow.swift
@@ -33,10 +33,10 @@ struct DiscoverCategoriesRow: View {
     var list: some View {
         ScrollView(.horizontal) {
             LazyHStack(spacing: 48, content: {
-                ForEach(model.categories, id: \.id) { category in
+                ForEach(Array(model.categories.enumerated()), id: \.element.id) { index, category in
                     if category.id != nil {
                         NavigationLink(value: category) {
-                            DiscoverCategoryCell(category: category)
+                            DiscoverCategoryCell(category: category, colorIndex: index)
                                 .frame(width: Layout.cellWidth, height: Layout.cellHeight)
                         }
                         .buttonStyle(.card)

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoryCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoryCell.swift
@@ -70,7 +70,7 @@ struct DiscoverCategoryCell: View {
         }
         .padding(.horizontal, 36)
         .frame(height: Layout.cardHeight)
-        .background(style(for: model.category))
+        .background(style(for: colorIndex))
         .clipped()
         .task {
             await model.load()
@@ -78,7 +78,7 @@ struct DiscoverCategoryCell: View {
     }
 
     @ViewBuilder
-    func style(for category: DiscoverCategory) -> some View {
+    func style(for colorIndex: Int) -> some View {
         if !isFocused {
             Color.pcBackgroundOverlay
         } else {

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoryCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoryCell.swift
@@ -5,6 +5,7 @@ import Kingfisher
 
 struct DiscoverCategoryCell: View {
     @State var model: DiscoverCategoryModel
+    let colorIndex: Int
 
     @Environment(\.isFocused) var isFocused: Bool
 
@@ -15,8 +16,9 @@ struct DiscoverCategoryCell: View {
         static let iconSize = CGFloat(48)
     }
 
-    init(category: DiscoverCategory) {
+    init(category: DiscoverCategory, colorIndex: Int) {
         _model = State(wrappedValue: DiscoverCategoryModel(category: category))
+        self.colorIndex = colorIndex
     }
 
     var body: some View {
@@ -46,21 +48,21 @@ struct DiscoverCategoryCell: View {
                     HStack {
                         PodcastImage(uuid: firstPodcast, size: .page)
                             .frame(width: Layout.imageSize, height: Layout.imageSize)
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
                             .shadow(color: .pcShadowLight, radius: 37.5, x: 0, y: 0)
-                            .offset(x: isFocused ? -Layout.imageSize : 0)
-                            .scaleEffect(isFocused ? 1.0 : 0.6)
+                            .offset(x: isFocused ? -Layout.imageSize + 8 : -Layout.imageSize * 2)
+                            .scaleEffect(isFocused ? 1.0 : 0.85)
                             .opacity(isFocused ? 1.0 : 0.0)
-                            .animation(.default, value: isFocused)
+                            .animation(.spring(duration: 0.35, bounce: 0.35), value: isFocused)
                         Spacer()
                         PodcastImage(uuid: lastPodcast, size: .page)
                             .frame(width: Layout.imageSize, height: Layout.imageSize)
-                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
                             .shadow(color: .pcShadowLight, radius: 37.5, x: 0, y: 0)
-                            .offset(x: isFocused ? Layout.imageSize : 0)
-                            .scaleEffect(isFocused ? 1.0 : 0.6)
+                            .offset(x: isFocused ? Layout.imageSize - 8 : Layout.imageSize * 2)
+                            .scaleEffect(isFocused ? 1.0 : 0.85)
                             .opacity(isFocused ? 1.0 : 0.0)
-                            .animation(.default, value: isFocused)
+                            .animation(.spring(duration: 0.35, bounce: 0.35), value: isFocused)
                     }
                 }
             }
@@ -79,16 +81,14 @@ struct DiscoverCategoryCell: View {
     func style(for category: DiscoverCategory) -> some View {
         if !isFocused {
             Color.pcBackgroundOverlay
-        } else if let id = category.id {
-            CategoryStyle.allCases[id % CategoryStyle.allCases.count].gradient
         } else {
-            CategoryStyle.red.tintColor
+            CategoryStyle.assignableCases[colorIndex % CategoryStyle.assignableCases.count].gradient
         }
     }
 }
 
 #Preview {
-    DiscoverCategoryCell(category: DiscoverCategory(id: 1, name: "True Crime"))
+    DiscoverCategoryCell(category: DiscoverCategory(id: 1, name: "True Crime"), colorIndex: 0)
         .environment(AppCoordinator())
         .environment(MainTabRouter())
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
@@ -34,6 +34,7 @@ struct DiscoverPodcastsListView: View {
         .task {
             await model.load()
         }
+        .toolbar(.hidden, for: .tabBar)
         .onAppear { tabRouter.isShowingDetail = true }
         .onDisappear { tabRouter.isShowingDetail = false }
     }

--- a/Pocket Casts TV App/UI/Style/CategoryStyle.swift
+++ b/Pocket Casts TV App/UI/Style/CategoryStyle.swift
@@ -8,6 +8,9 @@ enum CategoryStyle: Int, CaseIterable {
     case blue
     case green
 
+    /// Subset used to color category pills. Yellow/green are excluded by design.
+    static let assignableCases: [CategoryStyle] = [.red, .purple, .blue]
+
     var gradient: LinearGradient {
         switch self {
         case .red:


### PR DESCRIPTION
## Summary

Polishes the styling of category pills on the TV home view:

- **Palette**: removed yellow and green from the pill background rotation; now cycles through red / purple / blue only. Yellow and green cases are kept in `CategoryStyle` for potential reuse elsewhere.
- **No adjacent repeats**: `DiscoverCategoryCell` now takes a `colorIndex` driven by the visual position in the row (via `enumerated()` in `DiscoverCategoriesRow`), so neighboring cells are always different colors regardless of the underlying category `id` ordering.
- **Cover animation refinement**:
  - Covers slide in from outside the pill (start offset = `±imageSize * 2`) to their focused position (`±imageSize ∓ 8`), so more of each cover is visible.
  - Corner radius bumped from 6 → 12dp.
  - Replaced default animation with `.spring(duration: 0.35, bounce: 0.35)` for a subtle bounce on the slide-in.
  - Unfocused scale tightened to `0.85` (was `0.6`) for a less dramatic size change.

## Test plan

- [ ] Open the TV home (logged out) and find the "Browse By Category" row
- [ ] Confirm the focused pill backgrounds cycle red → purple → blue → red → … and never show yellow or green
- [ ] Scroll horizontally and verify no two adjacent pills ever share a color
- [ ] Move focus across pills and confirm:
  - [ ] Covers slide in from outside the pill (not from the center)
  - [ ] Slight bounce at end of slide
  - [ ] Covers end up slightly closer to center (8dp inward) — more cover visible
  - [ ] Cover corner radius is rounder than before

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.