### PR TITLE
Update Automattic-Tracks-iOS to tvOS store-directory fix

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -42,7 +42,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "revision" : "ce83ea7dc017beb9a3b42710e9da74ac2b7f4913"
+        "revision" : "8e889c30cd8234d5809966f25fd61abbb10d345e"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/ra1028/DifferenceKit", from: "1.2.0"),
         .package(url: "https://github.com/krisk/fuse-swift", from: "1.4.0"),
         .package(url: "https://github.com/shiftyjelly/SwipeCellKit", from: "2.7.6"),
-        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS", revision: "ce83ea7dc017beb9a3b42710e9da74ac2b7f4913"),
+        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS", revision: "8e889c30cd8234d5809966f25fd61abbb10d345e"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.23.0"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", from: "7.1.0"),
         .package(url: "https://github.com/Automattic/Agrume", from: "5.6.12"),


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Updates the `Automattic-Tracks-iOS` dependency to [`8e889c3`](https://github.com/Automattic/Automattic-Tracks-iOS/commit/8e889c30cd8234d5809966f25fd61abbb10d345e), which stores the Tracks Core Data database in **Caches on tvOS**. Application Support is not writable on tvOS, so today the analytics pipeline throws (`TracksApplicationSupportException` / `TracksPersistentStoreException`) at `TracksService` init on real Apple TV hardware.

⚠️ **Depends on [Automattic/Automattic-Tracks-iOS#361](https://github.com/Automattic/Automattic-Tracks-iOS/pull/361).** The revision is pinned to that PR's branch commit, so this should not be merged until #361 lands — at which point the revision should be repointed to the merge commit (or a tagged release).

## To test

1. Run the tvOS target on a **real Apple TV** (the tvOS Simulator inherits the Mac filesystem and masks the bug).
2. Confirm the app launches and analytics initializes without throwing at `TracksService(contextManager:)`.
3. Confirm Tracks analytics events are still recorded normally on iOS (no regression on the Application Support path).

## Checklist

- [x] I have considered if this change warrants user-facing release notes — dependency bump, no user-facing change.
- [x] I have considered adding unit tests — covered in the Tracks repo (`TracksContextManagerTests`, runs on tvOS + macOS).
- [x] I have updated the analytics spreadsheet — no analytics changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
