### PR TITLE
[PC TV] Add analytics events for non-Home screens

### DIFF
--- a/Pocket Casts TV App/Analytics/AnalyticsSetup.swift
+++ b/Pocket Casts TV App/Analytics/AnalyticsSetup.swift
@@ -15,9 +15,9 @@ enum AnalyticsSetup {
             adapters.append(AnalyticsOSLogAdapter())
 #endif
         }
-        
+
         adapters.append(LiveAnalyticsStreamer())
-        
+
         Analytics.register(adapters: adapters)
     }
 }

--- a/Pocket Casts TV App/Analytics/AnalyticsSetup.swift
+++ b/Pocket Casts TV App/Analytics/AnalyticsSetup.swift
@@ -10,11 +10,14 @@ enum AnalyticsSetup {
         var adapters: [AnalyticsAdapter] = []
 
         if !Settings.analyticsOptOut() {
-            adapters = [AnalyticsLoggingAdapter(), AnalyticsOSLogAdapter(), TracksAdapter()]
+            adapters = [AnalyticsLoggingAdapter(), TracksAdapter()]
+#if DEBUG
+            adapters.append(AnalyticsOSLogAdapter())
+#endif
         }
-
+        
         adapters.append(LiveAnalyticsStreamer())
-
+        
         Analytics.register(adapters: adapters)
     }
 }

--- a/Pocket Casts TV App/Analytics/AnalyticsSetup.swift
+++ b/Pocket Casts TV App/Analytics/AnalyticsSetup.swift
@@ -10,7 +10,7 @@ enum AnalyticsSetup {
         var adapters: [AnalyticsAdapter] = []
 
         if !Settings.analyticsOptOut() {
-            adapters = [AnalyticsLoggingAdapter(), TracksAdapter()]
+            adapters = [AnalyticsLoggingAdapter(), AnalyticsOSLogAdapter(), TracksAdapter()]
         }
 
         adapters.append(LiveAnalyticsStreamer())

--- a/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
+++ b/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
@@ -29,6 +29,7 @@ struct CreateAccountView: View {
     var body: some View {
         layout
             .task {
+                Analytics.track(.createAccountShown)
                 await pairing.start()
             }
             .onChange(of: pairing.state) {
@@ -48,6 +49,7 @@ struct CreateAccountView: View {
     }
 
     private func finish() {
+        Analytics.track(.userAccountCreated, properties: ["source": "qr_code"])
         dismiss()
         coordinator.state = .userSync
     }

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -95,18 +95,22 @@ struct SignInView: View {
         }
         .onChange(of: model.state) {
             if case .finished = model.state {
-                finishSignIn()
+                finishSignIn(source: "password")
             }
         }
         .onChange(of: model.pairing.state) {
             if case .finished = model.pairing.state {
-                finishSignIn()
+                finishSignIn(source: "qr_code")
             }
+        }
+        .onAppear {
+            Analytics.track(.signInShown)
         }
         .background(Color.pcBackgroundBase)
     }
 
-    private func finishSignIn() {
+    private func finishSignIn(source: String) {
+        Analytics.track(.userSignedIn, properties: ["source": source])
         dismiss()
         coordinator.state = .userSync
     }

--- a/Pocket Casts TV App/UI/History/ListeningHistoryView.swift
+++ b/Pocket Casts TV App/UI/History/ListeningHistoryView.swift
@@ -17,6 +17,7 @@ struct ListeningHistoryView: View {
             }
         }
         .task {
+            Analytics.track(.listeningHistoryShown)
             model.load()
         }
     }

--- a/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
@@ -16,6 +16,7 @@ struct NowPlayingTab: View {
             }
             .animation(.easeIn, value: isFocused)
             .onAppear {
+                Analytics.track(.playerShown)
                 //This is to force the player to load the current episode
                 if !PlaybackManager.shared.playing() {
                     DispatchQueue.main.async {

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -98,6 +98,7 @@ struct NowPlayingView: UIViewControllerRepresentable {
                 state: speed == model.playbackSpeed ? .on : .off
             ) { action in
                 model.playbackSpeed = speed
+                AnalyticsPlaybackHelper.shared.playbackSpeedChanged(to: speed)
                 if let menu = action.sender as? UIMenu {
                     menu.children.compactMap { $0 as? UIAction }.forEach { $0.state = .off }
                 }
@@ -116,10 +117,12 @@ struct NowPlayingView: UIViewControllerRepresentable {
         let volumeBoostOff = UIAction(title: L10n.off, state: model.volumeBoost ? .off : .on) { _ in
             ToastManager.shared.show(L10n.tvPlayerVolumeBoostOff)
             model.volumeBoost = false
+            AnalyticsPlaybackHelper.shared.volumeBoostToggled(enabled: false)
         }
         let volumeBoostOn = UIAction(title: L10n.on, state: model.volumeBoost ? .on : .off) { _ in
             ToastManager.shared.show(L10n.tvPlayerVolumeBoostOn)
             model.volumeBoost = true
+            AnalyticsPlaybackHelper.shared.volumeBoostToggled(enabled: true)
         }
         let volumeBoostSection = UIMenu(
             title: L10n.tvPlayerVolumeBoost,
@@ -129,6 +132,8 @@ struct NowPlayingView: UIViewControllerRepresentable {
 
         let trimActions = TrimSilenceAmount.allCases.map { option in
             UIAction(title: option.description, state: model.trimSilence == option ? .on : .off) { _ in
+                model.trimSilence = option
+                AnalyticsPlaybackHelper.shared.trimSilenceAmountChanged(amount: option)
                 ToastManager.shared.show(L10n.tvPlayerTrimSilenceSet(option.description))
             }
         }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -41,7 +41,9 @@ struct PlaylistDetailView: View {
             Button(L10n.playlistPlayAllSheetButtonTitle, role: .confirm) {
                 model.buttonConfirmPlayPlaylistTapped()
             }
-            Button(L10n.cancel, role: .cancel) {}
+            Button(L10n.cancel, role: .cancel) {
+                Analytics.track(.filterPlayAllDismissed)
+            }
         } message: {
             Text(L10n.playlistPlayAllSheetDescription)
         }
@@ -50,6 +52,7 @@ struct PlaylistDetailView: View {
                 .ignoresSafeArea()
         }
         .task {
+            Analytics.track(.filterShown)
             model.load()
         }
     }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -63,6 +63,8 @@ class PlaylistDetailsViewModel {
     private static let playlistEpisodeLimit = 1000
 
     func setShowArchived(_ value: Bool) {
+        guard value != showArchived else { return }
+        Analytics.track(value ? .filterShowArchivedTapped : .filterHideArchivedTapped)
         showArchived = value
         applyArchivedFilter()
         UserDefaults.standard.set(value, forKey: Self.archiveStorageKey(for: playlist))
@@ -75,6 +77,8 @@ class PlaylistDetailsViewModel {
     func playAll() {
         guard !episodes.isEmpty else { return }
 
+        Analytics.track(.filterPlayAllTapped)
+
         if playbackManager.playIfSafe(playlist: playlist, episodeIDs: episodes.map(\.uuid)) {
             isShowingNowPlaying = true
         } else {
@@ -83,6 +87,7 @@ class PlaylistDetailsViewModel {
     }
 
     func buttonConfirmPlayPlaylistTapped() {
+        Analytics.track(.filterPlayAllReplaceAndPlayTapped, properties: ["save_up_next": Settings.saveCurrentUpNextQueueIntoPlaylist])
         playbackManager.play(playlist: playlist)
         isShowingNowPlaying = true
     }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -6,6 +6,7 @@ struct PlaylistsView: View {
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
 
     @State private var model = PlaylistsViewModel()
+    @State private var didTrackShown = false
 
     enum Layout {
         static let gridSize = CGFloat(496)
@@ -24,6 +25,11 @@ struct PlaylistsView: View {
         }
         .task {
             model.load()
+        }
+        .onChange(of: model.state) { _, newState in
+            guard !didTrackShown, newState != .loading else { return }
+            didTrackShown = true
+            Analytics.track(.filterListShown, properties: ["filter_count": model.playlists.count])
         }
     }
 

--- a/Pocket Casts TV App/UI/Podcasts/FolderDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderDetailViewModel.swift
@@ -21,7 +21,24 @@ class FolderDetailViewModel {
             let podcasts = dataManager.allPodcastsInFolder(folder: folder)
             await MainActor.run {
                 self.podcasts = podcasts
+                Analytics.track(.folderShown, properties: [
+                    "number_of_podcasts": podcasts.count,
+                    "sort_order": Self.sortOrderAnalyticsValue(for: folder)
+                ])
             }
+        }
+    }
+
+    /// Mirrors iOS `Folder.librarySort().analyticsDescription`. `folder.sortType` is stored
+    /// using the old `LibrarySort.Old` raw-value scheme (1/2/5/6/7), not `LibrarySort`'s native values.
+    private static func sortOrderAnalyticsValue(for folder: Folder) -> String {
+        switch Int(folder.sortType) {
+        case 1: return "date_added"
+        case 2: return "name"
+        case 5: return "episode_release_date"
+        case 6: return "drag_and_drop"
+        case 7: return "episode_recently_played"
+        default: return "date_added"
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -45,6 +45,7 @@ struct PodcastDetailView: View {
         .onAppear { tabRouter.isShowingDetail = true }
         .onDisappear { tabRouter.isShowingDetail = false }
         .task {
+            Analytics.track(.podcastScreenShown, properties: ["uuid": model.podcastUuid])
             model.load()
         }
     }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -84,12 +84,16 @@ class PodcastDetailViewModel {
 
     func subscribe() {
         guard let podcast else { return }
+        Analytics.track(.podcastScreenSubscribeTapped)
+        Analytics.track(.podcastSubscribed, properties: ["source": "podcast_screen", "uuid": podcast.uuid])
         isFollowing = true
         serverPodcastManager.subscribe(to: podcast.uuid, completion: nil)
     }
 
     func unsubscribe() {
         guard let podcast else { return }
+        Analytics.track(.podcastScreenUnsubscribeTapped)
+        Analytics.track(.podcastUnsubscribed, properties: ["source": "podcast_screen", "uuid": podcast.uuid])
         isFollowing = false
         podcastManager.unsubscribe(podcast: podcast)
     }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -32,6 +32,11 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
         }
         .task {
             await model.load()
+            Analytics.track(.podcastsListShown, properties: [
+                "sort_order": "name",
+                "number_of_podcasts": model.items.filter { $0.podcast != nil }.count,
+                "number_of_folders": model.items.filter { $0.folder != nil }.count
+            ])
         }
     }
 
@@ -69,11 +74,17 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
                             .frame(width: Layout.gridSize, height: Layout.gridSize)
                     }
                     .buttonStyle(.card)
+                    .simultaneousGesture(TapGesture().onEnded {
+                        Analytics.track(.podcastsListPodcastTapped)
+                    })
                 } else if let folder = item.folder {
                     NavigationLink(value: folder) {
                         FolderCardView(folder: folder)
                     }
                     .buttonStyle(.card)
+                    .simultaneousGesture(TapGesture().onEnded {
+                        Analytics.track(.podcastsListFolderTapped)
+                    })
                 }
             }
         }

--- a/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
@@ -52,6 +52,9 @@ struct ProfileMenuView: View {
         } message: {
             Text(L10n.tvProfileMenuLogOutConfirmationMessage)
         }
+        .onAppear {
+            Analytics.track(.profileShown)
+        }
     }
 
     // MARK: - Signed-in
@@ -70,6 +73,7 @@ struct ProfileMenuView: View {
 
             // Group 1
             Button {
+                Analytics.track(.profileSettingsButtonTapped)
                 // Settings destination not yet implemented for TV
             } label: {
                 Label(L10n.settings, systemImage: "gearshape")

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -68,6 +68,13 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                                 .frame(width: Layout.cellSize, height: Layout.cellSize)
                         }
                         .buttonStyle(.card)
+                        .simultaneousGesture(TapGesture().onEnded {
+                            Analytics.track(.searchResultTapped, properties: [
+                                "source": "search",
+                                "uuid": podcast.uuid,
+                                "result_type": podcast.isLocal == true ? "podcast_local_result" : "podcast_remote_result"
+                            ])
+                        })
                     case .episode:
                         EmptyView()
                     }
@@ -84,6 +91,11 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
             LazyVGrid(columns: episodeItems, spacing: 24, content: {
                 ForEach(model.episodeResults, id: \.self) { episode in
                     Button() {
+                        Analytics.track(.searchResultTapped, properties: [
+                            "source": "search",
+                            "uuid": episode.uuid,
+                            "result_type": "episode"
+                        ])
                         Task {
                             let playSuccess = await model.playEpisode(episode)
                             await MainActor.run {

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -4,6 +4,7 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
 
     @Bindable var model: ViewModel
     @State private var searchText = ""
+    @State private var didTrackShown = false
 
     var body: some View {
         NavigationStack {
@@ -39,6 +40,11 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
             }
             .onChange(of: searchText) { _, newValue in
                 model.search(query: newValue)
+            }
+            .onAppear {
+                guard !didTrackShown else { return }
+                didTrackShown = true
+                Analytics.track(.searchShown, properties: ["source": "search"])
             }
         }
     }

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -109,6 +109,7 @@ class SearchViewModel: SearchableViewModel {
             guard !Task.isCancelled else { return }
             var uuids: Set<String> = []
             state = .searching
+            Analytics.track(.searchPerformed, properties: ["source": "search"])
             var combinedPodcastsResults: [CombinedSearchResultType] = []
             var suggestions: [String] = []
             do {

--- a/Pocket Casts TV App/UI/Starred/StarredEpisodesView.swift
+++ b/Pocket Casts TV App/UI/Starred/StarredEpisodesView.swift
@@ -17,6 +17,7 @@ struct StarredEpisodesView: View {
             }
         }
         .task {
+            Analytics.track(.starredShown)
             model.load()
         }
     }

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -18,6 +18,7 @@ struct UpNextView: View {
             }
         }
         .task {
+            Analytics.track(.upNextShown, properties: ["source": "tab_bar"])
             model.load()
         }
     }

--- a/Pocket Casts TV App/UI/WelcomeView.swift
+++ b/Pocket Casts TV App/UI/WelcomeView.swift
@@ -39,9 +39,15 @@ struct WelcomeView: View {
                         NavigationLink(value: Destination.signIn) {
                             Text(L10n.tvWelcomeSignIn)
                         }
+                        .simultaneousGesture(TapGesture().onEnded {
+                            Analytics.track(.setupAccountButtonTapped, properties: ["button": "sign_in"])
+                        })
                         NavigationLink(value: Destination.createAccount) {
                             Text(L10n.tvWelcomeCreateFreeAccount)
                         }
+                        .simultaneousGesture(TapGesture().onEnded {
+                            Analytics.track(.setupAccountButtonTapped, properties: ["button": "create_account"])
+                        })
                     }
                     Spacer()
                     Button(L10n.tvWelcomeBrowseWithoutAccount) {
@@ -73,6 +79,9 @@ struct WelcomeView: View {
                 podcastGrid
                 gradientView
             }
+        }
+        .task {
+            Analytics.track(.setupAccountShown)
         }
     }
 

--- a/PocketCastsTests/Tests/Analytics/AnalyticsTrackPropertiesTests.swift
+++ b/PocketCastsTests/Tests/Analytics/AnalyticsTrackPropertiesTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import podcasts
+
+/// Tests that `Analytics` normalizes event properties before handing them to adapters.
+///
+/// `AnalyticsDescribable` values must be replaced by their `analyticsDescription`,
+/// and every value must reach the adapter unboxed. The previous implementation
+/// (`(value as? AnalyticsDescribable)?.analyticsDescription ?? value`) selected the
+/// `??` overload returning `T?`, which boxed every value into an `Optional`. Adapters
+/// that serialize properties via `String(describing:)` then emitted `Optional("…")`
+/// instead of the underlying value, so these assertions deliberately check the
+/// `String(describing:)` form, which is what fails under the old implementation.
+class AnalyticsTrackPropertiesTests: XCTestCase {
+
+    private var analytics: Analytics!
+
+    override func setUp() {
+        super.setUp()
+        analytics = Analytics.shared
+        reset()
+    }
+
+    override func tearDown() {
+        reset()
+        super.tearDown()
+    }
+
+    private func reset() {
+        Analytics.unregister()
+        Settings.setAnalytics(optOut: false)
+    }
+
+    func testTrackNormalizesDescribableAndPlainProperties() {
+        let adapter = CapturingAnalyticsAdapter()
+        let didTrack = expectation(description: "adapter receives tracked event")
+        adapter.onTrack = { didTrack.fulfill() }
+        Analytics.register(adapters: [adapter])
+
+        analytics.track(.applicationOpened, properties: [
+            "describable": DescribableValue(),
+            "plainString": "hello",
+            "plainInt": 42
+        ])
+
+        wait(for: [didTrack], timeout: 1)
+
+        let properties = try? XCTUnwrap(adapter.lastTrackedProperties)
+
+        // Describable values are replaced by their description...
+        XCTAssertEqual(properties?["describable"] as? String, DescribableValue.description)
+        // ...and plain values pass through unchanged.
+        XCTAssertEqual(properties?["plainString"] as? String, "hello")
+        XCTAssertEqual(properties?["plainInt"] as? Int, 42)
+
+        // Crucially, no value should be boxed into an Optional. Under the old
+        // implementation each of these would describe as `Optional(…)`.
+        XCTAssertEqual(describing(properties?["describable"]), DescribableValue.description)
+        XCTAssertEqual(describing(properties?["plainString"]), "hello")
+        XCTAssertEqual(describing(properties?["plainInt"]), "42")
+    }
+
+    private func describing(_ value: Sendable?) -> String? {
+        value.map { String(describing: $0) }
+    }
+}
+
+// MARK: - Test Helpers
+
+private struct DescribableValue: AnalyticsDescribable {
+    static let description = "DescribableValueDescription"
+    var analyticsDescription: String { Self.description }
+}
+
+private final class CapturingAnalyticsAdapter: AnalyticsAdapter {
+    var lastTrackedProperties: [String: Sendable]?
+    var onTrack: (() -> Void)?
+
+    func track(name: String, properties: [String: Sendable]) async {
+        lastTrackedProperties = properties
+        onTrack?()
+    }
+}

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
@@ -51,12 +51,6 @@
             ReferencedContainer = "container:podcasts.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "-PCSimulateDataLoss"
-            isEnabled = "NO">
-         </CommandLineArgument>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
@@ -51,6 +51,12 @@
             ReferencedContainer = "container:podcasts.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-PCSimulateDataLoss"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/podcasts/Analytics/Adapters/AnalyticsOSLogAdapter.swift
+++ b/podcasts/Analytics/Adapters/AnalyticsOSLogAdapter.swift
@@ -1,0 +1,21 @@
+import Foundation
+import OSLog
+
+/// Tracking adapter that prints every event to the unified logging system (Console / Xcode).
+///
+/// Logs under the running app's bundle identifier, so each target (iOS, tvOS, App Clip…)
+/// surfaces its events under its respective subsystem, all in the `Analytics` category.
+/// Filter with `subsystem:<bundle id> category:Analytics`.
+struct AnalyticsOSLogAdapter: AnalyticsAdapter {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "PocketCasts", category: "Analytics")
+
+    func track(name: String, properties: [String: Sendable]) async {
+        // Event name is public (non-sensitive, useful for filtering); properties default to
+        // private so they're visible while debugging but redacted in release logs.
+        if properties.isEmpty {
+            Self.logger.debug("🔵 Tracked: \(name, privacy: .public)")
+        } else {
+            Self.logger.debug("🔵 Tracked: \(name, privacy: .public) \(String(describing: properties), privacy: .private)")
+        }
+    }
+}

--- a/podcasts/Analytics/Adapters/AnalyticsOSLogAdapter.swift
+++ b/podcasts/Analytics/Adapters/AnalyticsOSLogAdapter.swift
@@ -10,8 +10,6 @@ struct AnalyticsOSLogAdapter: AnalyticsAdapter {
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "PocketCasts", category: "Analytics")
 
     func track(name: String, properties: [String: Sendable]) async {
-        // Event name is public (non-sensitive, useful for filtering); properties default to
-        // private so they're visible while debugging but redacted in release logs.
         if properties.isEmpty {
             Self.logger.debug("🔵 Tracked: \(name, privacy: .public)")
         } else {

--- a/podcasts/Analytics/Analytics.swift
+++ b/podcasts/Analytics/Analytics.swift
@@ -38,8 +38,11 @@ class Analytics {
     }
 
     private func _track(_ eventName: String, properties: [String: Sendable]? = nil) {
-        var properties: [String: Sendable] = (properties ?? [:]).mapValues { value in
-            (value as? AnalyticsDescribable)?.analyticsDescription ?? value
+        var properties: [String: Sendable] = (properties ?? [:]).mapValues { value -> Sendable in
+            if let describable = value as? AnalyticsDescribable {
+                return describable.analyticsDescription
+            }
+            return value
         }
 #if !os(watchOS) && !APPCLIP && !os(tvOS)
         if FeatureFlag.appThemePropertiesLogging.enabled {

--- a/podcasts/AppDelegate+Analytics.swift
+++ b/podcasts/AppDelegate+Analytics.swift
@@ -16,7 +16,10 @@ extension AppDelegate {
 
         // Only setup if protected data is available, the user hasn't opted out, and we aren't already registered
         if !Settings.analyticsOptOut() {
-            adapters = [AnalyticsLoggingAdapter(), AnalyticsOSLogAdapter(), TracksAdapter(), CrashLoggingAdapter()]
+            adapters = [AnalyticsLoggingAdapter(), TracksAdapter(), CrashLoggingAdapter()]
+#if DEBUG
+            adapters.append(AnalyticsOSLogAdapter())
+#endif
         }
 
         // LiveAnalyticsStreamer buffers events for all builds, sends when server enables liveAnalyticsUrl

--- a/podcasts/AppDelegate+Analytics.swift
+++ b/podcasts/AppDelegate+Analytics.swift
@@ -16,7 +16,7 @@ extension AppDelegate {
 
         // Only setup if protected data is available, the user hasn't opted out, and we aren't already registered
         if !Settings.analyticsOptOut() {
-            adapters = [AnalyticsLoggingAdapter(), TracksAdapter(), CrashLoggingAdapter()]
+            adapters = [AnalyticsLoggingAdapter(), AnalyticsOSLogAdapter(), TracksAdapter(), CrashLoggingAdapter()]
         }
 
         // LiveAnalyticsStreamer buffers events for all builds, sends when server enables liveAnalyticsUrl


### PR DESCRIPTION
| 📘 Part of: #614 |  <!-- project issue number, if applicable -->
|:---:|

<!-- Analytics-only change; no tracking issue. -->

Adds analytics to the tvOS app for every screen **except Home** (whose design is still being decided, along with its Discover sub-screens). Every event **reuses an existing `AnalyticsEvent`** case — the same one iOS fires for the equivalent screen/action — so **no new event types are introduced**.

Two supporting changes are included:

- **`AnalyticsOSLogAdapter`** — a new adapter that prints each tracked event via `os.Logger`, under the running app's **bundle identifier** so every target (iOS, tvOS, App Clip…) surfaces its events under its respective subsystem, in the `Analytics` category. Registered in both `AppDelegate+Analytics` (iOS) and `AnalyticsSetup` (tvOS). Filter in Console with `subsystem:<bundle id> category:Analytics`.
- **Fix in `Analytics._track`** — the property transform used the optional-returning `??` overload, which boxed every value in an `Optional` (e.g. `Optional("name")`) before it reached the adapters/Tracks. Resolved explicitly so all adapters receive clean values.

You can use OSLog "category" filter to filter in only analytics events for testing:

<img width="982" height="367" alt="Screenshot 2026-06-11 at 4 15 51 PM" src="https://github.com/user-attachments/assets/cace1b55-6b64-4431-a9b5-4e9ee9d8b339" />

### tvOS events added

All events below already existed for iOS; this PR wires them up on tvOS. New `source` string values introduced (not new events): `search` (Search screen) and `qr_code` (device-pairing auth).

| Event | Description |
|---|---|
| `podcasts_list_shown` | Podcasts tab (subscribed grid) appeared |
| `podcasts_list_podcast_tapped` | A podcast was tapped in the Podcasts grid |
| `podcasts_list_folder_tapped` | A folder was tapped in the Podcasts grid |
| `podcast_screen_shown` | Podcast details page appeared |
| `podcast_screen_subscribe_tapped` | Subscribe/Follow button tapped on the podcast page |
| `podcast_subscribed` | Subscribed to a podcast (`source: podcast_screen`) |
| `podcast_screen_unsubscribe_tapped` | Unsubscribe/Unfollow button tapped on the podcast page |
| `podcast_unsubscribed` | Unsubscribed from a podcast (`source: podcast_screen`) |
| `folder_shown` | Folder details page appeared |
| `filter_list_shown` | Filters/Playlists list appeared |
| `filter_shown` | A filter/playlist details page appeared |
| `filter_play_all_tapped` | "Play All" tapped on a filter |
| `filter_play_all_replace_and_play_tapped` | Confirmed replacing Up Next and playing the filter |
| `filter_play_all_dismissed` | Dismissed the "Play All" replace–Up Next confirmation |
| `filter_show_archived_tapped` | Enabled "show archived" on a filter |
| `filter_hide_archived_tapped` | Disabled "show archived" on a filter |
| `up_next_shown` | Up Next screen appeared (`source: tab_bar`) |
| `player_shown` | Now Playing player appeared |
| `playback_effect_speed_changed` | Changed playback speed in the player |
| `playback_effect_volume_boost_toggled` | Toggled volume boost in the player |
| `playback_effect_trim_silence_amount_changed` | Changed the trim-silence amount in the player |
| `search_shown` | Search screen appeared (`source: search`) |
| `search_performed` | A search query was executed (`source: search`) |
| `search_result_tapped` | Tapped a podcast/episode search result (`source: search`) |
| `starred_shown` | Starred episodes screen appeared |
| `listening_history_shown` | Listening history screen appeared |
| `profile_shown` | Profile menu appeared |
| `profile_settings_button_tapped` | Tapped Settings in the profile menu |
| `setup_account_shown` | Signed-out welcome/landing screen appeared |
| `setup_account_button_tapped` | Tapped Sign In / Create account on the welcome screen |
| `sign_in_shown` | Sign In screen appeared |
| `create_account_shown` | Create Account screen appeared |
| `user_signed_in` | Completed sign-in (`source: password` for manual, `qr_code` for device pairing) |
| `user_account_created` | Created an account via device pairing (`source: qr_code`) |

> The player's trim-silence menu also gained a small bug fix: it now actually applies the selected amount (previously it only showed a toast), which is also what the `playback_effect_trim_silence_amount_changed` event reflects.

## To test

1. Build and run the **Pocket Casts TV App** scheme on a tvOS simulator.
2. Open **Console.app** (or watch the Xcode debug console) and filter by `subsystem:<tvOS app bundle id> category:Analytics` to see `🔵 Tracked: …` lines.
3. Walk the screens and confirm each logs the expected event **once** with clean (non-`Optional`) properties:
   - **Podcasts** tab → tap a podcast → Subscribe then Unsubscribe → back → open a folder.
   - **Filters** → open a filter → "Play All" (and Cancel the confirmation) → toggle Show/Hide archived.
   - **Up Next** tab.
   - **Now Playing** → change playback speed, toggle volume boost, change trim silence.
   - **Search** → type a query → tap a podcast result and an episode result.
   - **Profile** → Starred Episodes, Listening History, Settings.
   - Signed out: **Welcome** → Sign In (QR) and Create account flows.
4. Confirm the auto-fired playback/episode events (play/pause, add/remove Up Next, mark played, archive) still fire **exactly once** — i.e. nothing is double-counted.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
