### PR TITLE
Disable deep link to pair until we can process it correctly

### DIFF
--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -7,8 +7,6 @@ import PocketCastsUtils
 
 extension AppDelegate {
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        handleContinue(userActivity)
-
         // This is temporary workaround to avoid the app handling the /pair urls as a share url until we implement the proper pair URL handling on 8.15
         // This will make the user to be redirected to the web page
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
@@ -18,6 +16,8 @@ extension AppDelegate {
                 return false
             }
         }
+
+        handleContinue(userActivity)
 
         return true
     }

--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -7,8 +7,8 @@ import PocketCastsUtils
 
 extension AppDelegate {
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        // This is temporary workaround to avoid the app handling the /pair urls as a share url until we implement the proper pair URL handling on 8.15
-        // This will make the user to be redirected to the web page
+        /// Temporary workaround: avoid the app handling the /pair urls as a share url until we implement proper pair URL handling.
+        /// Returning false causes the system to fall back to opening the universal link in the browser.
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
             if let incomingURL = userActivity.webpageURL,
                let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true),

--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -14,12 +14,11 @@ extension AppDelegate {
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
             if let incomingURL = userActivity.webpageURL,
                let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true),
-               let path = components.path
-                path.startsWith(string: "/pair") {
+               let path = components.path, path.startsWith(string: "/pair") {
                 return false
             }
         }
-        
+
         return true
     }
 

--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -43,6 +43,12 @@ extension AppDelegate {
                 return
             }
 
+            // This is temporary workaround to avoid the app handling the /pair urls as a share url until we implement the proper pair URL handling on 8.15
+            // This will make the user to be redirected to the web page
+            if path.startsWith(string: "/pair") {
+                return
+            }
+
             if path.startsWith(string: "/redeem") {
                 handleReferralsDeepLink(url: incomingURL)
                 return

--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -9,6 +9,17 @@ extension AppDelegate {
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         handleContinue(userActivity)
 
+        // This is temporary workaround to avoid the app handling the /pair urls as a share url until we implement the proper pair URL handling on 8.15
+        // This will make the user to be redirected to the web page
+        if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
+            if let incomingURL = userActivity.webpageURL,
+               let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true),
+               let path = components.path
+                path.startsWith(string: "/pair") {
+                return false
+            }
+        }
+        
         return true
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-726](https://linear.app/a8c/issue/PCIOS-726/disable-pair-deep-links-on-older-version-of-the-app)
 <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR disables handling of deep links for the url `pocketcasts.com/pair` in this version until we have proper pair url handling on a future version.
This is to avoid an scenario where users of this version of the app try to open the link and end up in random podcast page because of the way the share deeplink code handles this.

## To test

1. Start the app
2. Open a link `pocketcasts.com\pair` using a QR code or by pasting and clicking on on the Messages app
3. Check that the app is not opened but Safari is opened to the proper `pair` URL

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
