### PR TITLE
[PC-TV] Disable non mvp options

### DIFF
--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -141,7 +141,7 @@ struct NowPlayingView: UIViewControllerRepresentable {
         return UIMenu(
             title: L10n.tvPlayerPlaybackEffects,
             image: UIImage(systemName: "speaker.wave.3"),
-            children: [volumeBoostSection, trimSection]
+            children: [volumeBoostSection]
         )
     }
 

--- a/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
@@ -70,7 +70,7 @@ struct ProfileMenuView: View {
             } label: {
                 Text(L10n.tvProfileMenuStarredEpisodes)
                     .frame(minWidth: 400)
-            }            
+            }
             Button {
                 onProfileSelected(.history)
             } label: {

--- a/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
@@ -70,13 +70,7 @@ struct ProfileMenuView: View {
             } label: {
                 Text(L10n.tvProfileMenuStarredEpisodes)
                     .frame(minWidth: 400)
-            }
-            Button {
-                // Files destination not yet implemented for TV
-            } label: {
-                Text(L10n.files)
-                    .frame(minWidth: 400)
-            }
+            }            
             Button {
                 onProfileSelected(.history)
             } label: {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
This PR just disables two options are currently not part of the MVP:
 - User Files 
 - Trim Silence

I didn't remove all the code associated just hide it because we will want to add this in a future version.

## To test

1. Start the app
2. Check if Files in Profile options is no longer shown
3. Play an episode
4. Check that trim silence options is no longer shown
## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
