### PR TITLE
[PC TV] Avoid multiple discover server calls on startup

### DIFF
--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -51,13 +51,20 @@ actor DiscoverManager {
     }
 
     private var cachedLayout: DiscoverLayout?
+    private var layoutFetchTask: Task<(DiscoverLayout?, Bool), Never>?
 
     private func getLayout() async -> DiscoverLayout? {
-        if cachedLayout != nil {
+        if let cachedLayout {
             return cachedLayout
         }
 
-        let (result, _) = await discoverServerHandler.discoverPage()
+        let task = layoutFetchTask ?? Task {
+            await discoverServerHandler.discoverPage()
+        }
+        layoutFetchTask = task
+        let (result, _) = await task.value
+        layoutFetchTask = nil
+
         guard let layout = result else {
             return nil
         }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

<!-- Fixes PCIOS- -->

On the tvOS app, `DiscoverManager.getLayout()` made a fresh `discoverPage()` network request on every call when the layout wasn't yet cached. During startup several callers can hit `getLayout()` concurrently before the first response lands, so the cache is still empty and each one fires its own request — resulting in multiple redundant discover server calls.

This change coalesces concurrent fetches: the first caller starts a single `Task` and stores it in `layoutFetchTask`; any caller that arrives while it's in flight awaits the same task instead of starting its own. Once the result lands it's cached as before and the in-flight task is cleared (so failures still retry on the next call).

## To test

1. Launch the tvOS app fresh (cold start) so the Discover layout is not cached.
2. Confirm the Discover tab loads its sections correctly.
3. Using a network proxy (e.g. Charles/Proxyman) or server logs, verify only a **single** request to the discover page endpoint is made on startup, instead of multiple.
4. Confirm that on a failed discover request, a subsequent navigation/refresh retries the request.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.