### PR TITLE
Remove legacy window-based OptionsPicker presentation

### DIFF
--- a/podcasts/Common SwiftUI/BannerAdReporter.swift
+++ b/podcasts/Common SwiftUI/BannerAdReporter.swift
@@ -47,18 +47,18 @@ struct BannerAdReporter {
         }
         reportOptions.addAction(action: removeAction)
 
-        let reportPicker = OptionsPicker(title: L10n.bannerAdsReportAdTitle)
-        for action in ReportActionType.allCases {
-            reportPicker.addAction(action: OptionAction(label: action.label) {
-                handle(action: action)
-            })
-        }
-
-        let reportAction = OptionAction(label: L10n.bannerAdsReportAd, icon: "show_notes") {
-            reportPicker.show()
+        let reportAction = OptionAction(label: L10n.bannerAdsReportAd, icon: "show_notes", action: {})
+        reportAction.submenu = {
+            let reportPicker = OptionsPicker(title: L10n.bannerAdsReportAdTitle)
+            for action in ReportActionType.allCases {
+                reportPicker.addAction(action: OptionAction(label: action.label) {
+                    handle(action: action)
+                })
+            }
+            return reportPicker
         }
         reportOptions.addAction(action: reportAction)
 
-        reportOptions.show()
+        reportOptions.present()
     }
 }

--- a/podcasts/DescriptiveActionView.swift
+++ b/podcasts/DescriptiveActionView.swift
@@ -155,15 +155,10 @@ class DescriptiveActionView: UIView {
         config.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 24, bottom: 12, trailing: 24)
 
         let actionButton = UIButton(configuration: config, primaryAction: UIAction(title: action.label, handler: { [weak self] _ in
-            if self?.delegate?.isPresentedAsSheet == true {
-                // Dismiss the sheet before running the action so an action that
-                // presents another screen doesn't hit "already presenting".
-                self?.delegate?.animateOut(optionChosen: true)
-                action.action()
-            } else {
-                action.action()
-                self?.delegate?.animateOut(optionChosen: true)
-            }
+            // Dismiss the sheet before running the action so an action that
+            // presents another screen doesn't hit "already presenting".
+            self?.delegate?.animateOut(optionChosen: true)
+            action.action()
         }))
         actionButton.configurationUpdateHandler = { button in
             var config = button.configuration
@@ -190,15 +185,10 @@ class DescriptiveActionView: UIView {
         actionButton.isOn = !action.outline
         actionButton.setup()
         actionButton.buttonTapped = { [weak self] in
-            if self?.delegate?.isPresentedAsSheet == true {
-                // Dismiss the sheet before running the action so an action that
-                // presents another screen doesn't hit "already presenting".
-                self?.delegate?.animateOut(optionChosen: true)
-                action.action()
-            } else {
-                action.action()
-                self?.delegate?.animateOut(optionChosen: true)
-            }
+            // Dismiss the sheet before running the action so an action that
+            // presents another screen doesn't hit "already presenting".
+            self?.delegate?.animateOut(optionChosen: true)
+            action.action()
         }
         return actionButton
     }

--- a/podcasts/Episode/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+Actions.swift
@@ -38,7 +38,7 @@ extension EpisodeDetailViewController {
         }
         addPicker.addAction(action: addToPlaylistAction)
 
-        addPicker.show(statusBarStyle: preferredStatusBarStyle)
+        addPicker.present(from: self)
     }
 
     @IBAction func episodeStatusTapped(_ sender: Any) {
@@ -103,7 +103,7 @@ extension EpisodeDetailViewController {
             yesAction.destructive = true
             confirmation.addAction(action: yesAction)
 
-            confirmation.show(statusBarStyle: preferredStatusBarStyle)
+            confirmation.present(from: self)
         } else if episode.downloading() || episode.queued() || episode.waitingForWifi() {
             PlaybackActionHelper.stopDownload(episodeUuid: episode.uuid)
         } else {

--- a/podcasts/OptionsPicker.swift
+++ b/podcasts/OptionsPicker.swift
@@ -2,19 +2,17 @@ import UIKit
 
 class OptionsPicker {
     private var title: String?
-    private var window: UIWindow?
     private var optionsController: OptionsPickerRootController?
 
     private var noActionCallback: (() -> Void)?
 
-    init(title: String? = nil, themeOverride: Theme.ThemeType? = nil, iconTintStyle: ThemeStyle = .primaryIcon01, colors: OptionsPickerRootController.Colors? = nil, portraitOnly: Bool = true) {
+    init(title: String? = nil, themeOverride: Theme.ThemeType? = nil, iconTintStyle: ThemeStyle = .primaryIcon01, colors: OptionsPickerRootController.Colors? = nil) {
         self.title = title
-        setup(themeOverride: themeOverride, iconTintStyle: iconTintStyle, colors: colors, portraitOnly: portraitOnly)
+        setup(themeOverride: themeOverride, iconTintStyle: iconTintStyle, colors: colors)
     }
 
-    private func setup(themeOverride: Theme.ThemeType?, iconTintStyle: ThemeStyle = .primaryIcon01, colors: OptionsPickerRootController.Colors? = nil, portraitOnly: Bool) {
+    private func setup(themeOverride: Theme.ThemeType?, iconTintStyle: ThemeStyle = .primaryIcon01, colors: OptionsPickerRootController.Colors? = nil) {
         optionsController = OptionsPickerRootController()
-        optionsController?.portraitOnly = portraitOnly
         optionsController?.delegate = self
         optionsController?.setup(title: title, themeOverride: themeOverride, iconTintStyle: iconTintStyle, colors: colors)
     }
@@ -43,24 +41,6 @@ class OptionsPicker {
 
     func setNoActionCallback(_ callback: @escaping () -> Void) {
         noActionCallback = callback
-    }
-
-    func show(statusBarStyle: UIStatusBarStyle? = nil) {
-        guard let rootController = optionsController else { return }
-        //TODO: Figure this out and fix it
-        #if !APPCLIP
-        window = SceneHelper.newMainScreenWindow()
-        #endif
-        window?.rootViewController = rootController
-        window?.windowLevel = UIWindow.Level.alert
-        window?.makeKeyAndVisible()
-
-        let additionalPaddingRequired: CGFloat = window?.safeAreaInsets.bottom ?? 0
-        if let statusBarStyle {
-            rootController.overrideStatusBarStyle = statusBarStyle
-        }
-        rootController.aboutToPresentOptions(bottomPadding: additionalPaddingRequired)
-        rootController.animateIn()
     }
 
     /// Presents the options using a native, self-sizing sheet from the given
@@ -98,8 +78,6 @@ class OptionsPicker {
             noActionCallback()
         }
 
-        window?.resignKey()
-        window = nil
         optionsController?.delegate = nil
     }
 }

--- a/podcasts/OptionsPickerRootController.swift
+++ b/podcasts/OptionsPickerRootController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate, UISheetPresentationControllerDelegate {
+class OptionsPickerRootController: UIViewController, UISheetPresentationControllerDelegate {
 
     struct Colors {
         let title: UIColor
@@ -17,13 +17,9 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         }
     }
 
-    @objc var overrideStatusBarStyle = AppTheme.defaultStatusBarStyle()
-
     private var scrollView: UIScrollView!
     private var stackView: UIStackView!
-    private var stackBgView: UIView!
 
-    private let buttonCornerRadius: CGFloat = 8
     private var actionHeight: CGFloat = 72
     private let layoutHorizontalMargin = CGFloat(20)
     private var actionsAdded = 0
@@ -33,29 +29,14 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
     // this is not a weak var on purpose, nothing retains an OptionsPicker so we will until it dismisses
     var delegate: OptionsPicker?
 
-    var portraitOnly = true
-
-    private var scrollViewBottomAnchor: NSLayoutConstraint?
-    private var scrollViewTopAnchor: NSLayoutConstraint?
-    private var scrollViewHeightConstraint: NSLayoutConstraint?
-    private var scrollViewMaxHeightConstraint: NSLayoutConstraint?
-
-    private weak var dismissView: UIView?
-    private(set) var isPresentedAsSheet = false
-
     private var sheetTopPadding: CGFloat {
         stackView.arrangedSubviews.count > 1 ? 12 : 0
-    }
-
-    override var preferredStatusBarStyle: UIStatusBarStyle {
-        overrideStatusBarStyle
     }
 
     func setup(title: String?, themeOverride: Theme.ThemeType? = nil, iconTintStyle: ThemeStyle, colors: Colors? = nil) {
         let colors = colors ?? Colors(theme: themeOverride ?? Theme.sharedTheme.activeTheme)
 
         view.clipsToBounds = true
-        view.layer.cornerRadius = 6
         self.themeOverride = themeOverride
         self.iconTintStyle = iconTintStyle
 
@@ -87,46 +68,14 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
             stackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor)
         ])
 
-        // The scroll view height matches its content height when possible,
-        // but is capped at the available vertical space so it never overflows.
-        let maxHeightConstraint = scrollView.heightAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.heightAnchor, constant: -75)
-        maxHeightConstraint.priority = .required
-        scrollViewMaxHeightConstraint = maxHeightConstraint
-
-        // A lower-priority constraint makes the scroll view shrink-wrap its content
-        // so it doesn't scroll when all content fits on screen.
-        scrollViewHeightConstraint = scrollView.heightAnchor.constraint(equalTo: stackView.heightAnchor)
-        scrollViewHeightConstraint?.priority = .defaultHigh
-
-        scrollViewTopAnchor = view.bottomAnchor.constraint(equalTo: scrollView.topAnchor)
-        scrollViewBottomAnchor = view.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor)
+        // The scroll view fills the sheet; its content scrolls when the options
+        // are taller than the available space.
         NSLayoutConstraint.activate([
             scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            maxHeightConstraint,
-            scrollViewHeightConstraint!,
-            scrollViewTopAnchor!
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
-
-        let dismissView = UIView()
-        dismissView.backgroundColor = UIColor.clear
-        dismissView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(dismissView)
-        self.dismissView = dismissView
-
-        dismissView.isAccessibilityElement = true
-        dismissView.accessibilityLabel = L10n.accessibilityDismiss
-        dismissView.accessibilityTraits = [.button]
-        NSLayoutConstraint.activate([
-            dismissView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            dismissView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            dismissView.topAnchor.constraint(equalTo: view.topAnchor),
-            dismissView.bottomAnchor.constraint(equalTo: scrollView.topAnchor)
-        ])
-
-        let dismissGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(backgroundTapped))
-        dismissGestureRecognizer.delegate = self
-        dismissView.addGestureRecognizer(dismissGestureRecognizer)
 
         if let title {
             addTitle(title, titleColor: colors.title)
@@ -169,7 +118,7 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
 
     func addAttributedDescriptiveActions(title: String, message: String, icon: String, actions: [OptionAction]) {
         let actionView = DescriptiveActionView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: actionHeight), title: title, message: message, icon: icon, actions: actions, delegate: self, themeOverride: themeOverride, iconTintStyle: iconTintStyle) { [weak self] in
-            self?.backgroundTapped()
+            self?.animateOut(optionChosen: false)
         }
         stackView.addArrangedSubview(actionView)
         NSLayoutConstraint.activate([
@@ -198,42 +147,17 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         actionsAdded += 1
     }
 
-    func aboutToPresentOptions(bottomPadding: CGFloat) {
-        let bottomPaddingView = UIView()
-        bottomPaddingView.backgroundColor = .clear
-        NSLayoutConstraint.activate([
-            bottomPaddingView.heightAnchor.constraint(equalToConstant: bottomPadding),
-        ])
-        stackView.addArrangedSubview(bottomPaddingView)
-        NSLayoutConstraint.activate([
-            bottomPaddingView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
-        ])
-    }
-
     // MARK: - Native Sheet Presentation
 
-    /// Reconfigures the layout so the content fills a natively-presented sheet
-    /// instead of animating in as a bottom card over a dimmed window.
+    /// Applies the styling and per-action layout needed before the options are
+    /// shown in a natively-presented sheet.
     func configureForSheetPresentation() {
-        isPresentedAsSheet = true
-
         if LiquidGlass.isEnabled {
             view.backgroundColor = scrollView.backgroundColor?.withAlphaComponent(0.85)
             scrollView.backgroundColor = .clear
         } else {
             view.backgroundColor = scrollView.backgroundColor
         }
-        view.layer.cornerRadius = 0
-        dismissView?.isHidden = true
-
-        scrollViewTopAnchor?.isActive = false
-        scrollViewMaxHeightConstraint?.isActive = false
-        scrollViewHeightConstraint?.isActive = false
-
-        NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
 
         scrollView.contentInset = UIEdgeInsets(top: sheetTopPadding, left: 0, bottom: 0, right: 0)
 
@@ -259,61 +183,24 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
         delegate?.controllerDidAnimateOut(optionChosen: false)
     }
 
-    // MARK: - Animate in/out
-
-    func animateIn() {
-        view.backgroundColor = UIColor.black.withAlphaComponent(0)
-        view.layoutIfNeeded()
-        UIView.animate(withDuration: Constants.Animation.bottomCardAnimationTime, delay: 0, options: .curveEaseOut, animations: { [weak self] in
-            self?.scrollViewTopAnchor?.isActive = false
-            self?.scrollViewBottomAnchor?.isActive = true
-            self?.view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
-
-            self?.view?.layoutIfNeeded()
-        }, completion: nil)
-    }
+    // MARK: - Dismissal
 
     func animateOut(optionChosen: Bool) {
-        if isPresentedAsSheet {
-            // Collect this picker and any parent pickers it was stacked on
-            // (e.g. the root menu under a submenu). Dismissing the bottom-most
-            // one collapses the whole stack in a single animation, so choosing
-            // a submenu option closes both sheets.
-            var pickers = [self]
-            var presenter = presentingViewController
-            while let parentPicker = presenter as? OptionsPickerRootController {
-                pickers.append(parentPicker)
-                presenter = parentPicker.presentingViewController
-            }
-            presenter?.dismiss(animated: true) {
-                for picker in pickers {
-                    picker.delegate?.controllerDidAnimateOut(optionChosen: optionChosen)
-                }
-            }
-            return
+        // Collect this picker and any parent pickers it was stacked on
+        // (e.g. the root menu under a submenu). Dismissing the bottom-most
+        // one collapses the whole stack in a single animation, so choosing
+        // a submenu option closes both sheets.
+        var pickers = [self]
+        var presenter = presentingViewController
+        while let parentPicker = presenter as? OptionsPickerRootController {
+            pickers.append(parentPicker)
+            presenter = parentPicker.presentingViewController
         }
-
-        view?.layoutIfNeeded()
-        UIView.animate(withDuration: Constants.Animation.bottomCardAnimationTime, animations: { [weak self] in
-            self?.scrollViewBottomAnchor?.isActive = false
-            self?.scrollViewTopAnchor?.isActive = true
-
-            self?.view.backgroundColor = UIColor.clear
-
-            self?.view?.layoutIfNeeded()
-        }) { [weak self] _ in
-            self?.delegate?.controllerDidAnimateOut(optionChosen: optionChosen)
+        presenter?.dismiss(animated: true) {
+            for picker in pickers {
+                picker.delegate?.controllerDidAnimateOut(optionChosen: optionChosen)
+            }
         }
-    }
-
-    @objc private func backgroundTapped() {
-        animateOut(optionChosen: false)
-    }
-
-    // MARK: - UIGestureRecognizerDelegate
-
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        touch.view?.isDescendant(of: scrollView) == false
     }
 
     // MARK: - Drawing Helpers
@@ -367,11 +254,5 @@ class OptionsPickerRootController: UIViewController, UIGestureRecognizerDelegate
             dividerView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
             dividerView.topAnchor.constraint(equalTo: containerView.topAnchor)
         ])
-    }
-
-    // MARK: - Orientation
-
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        portraitOnly ? .portrait : .allButUpsideDown
     }
 }

--- a/podcasts/SimpleActionView.swift
+++ b/podcasts/SimpleActionView.swift
@@ -199,16 +199,13 @@ class SimpleActionView: UIView {
         } else if let submenu = action.submenu?(), let delegate {
             action.action()
             submenu.present(from: delegate)
-        } else if delegate?.isPresentedAsSheet == true {
+        } else {
             // The sheet is a real presented view controller. Start its
             // dismissal *before* running the action so that an action which
             // presents another screen doesn't hit "already presenting" — this
             // lets UIKit serialize the dismiss and the new presentation.
             delegate?.animateOut(optionChosen: true)
             action.action()
-        } else {
-            action.action()
-            delegate?.animateOut(optionChosen: true)
         }
     }
 

--- a/podcasts/VideoViewController.swift
+++ b/podcasts/VideoViewController.swift
@@ -195,7 +195,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     private func skipForwardLongPressed() {
         guard let episode = PlaybackManager.shared.currentEpisode() else { return }
 
-        let options = OptionsPicker(title: nil, themeOverride: .dark, portraitOnly: false)
+        let options = OptionsPicker(title: nil, themeOverride: .dark)
 
         let markPlayedOption = OptionAction(label: L10n.markPlayedShort, icon: nil) {
             AnalyticsEpisodeHelper.shared.currentSource = .videoPlayerSkipForwardLongPress


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Removes the legacy `OptionsPicker.show(statusBarStyle:)` entry point and all the window-based presentation machinery that only it reached. Native sheet presentation (`present()` / `present(from:)`) had already replaced it everywhere; this PR migrates the last caller and deletes the dead code.

**What was removed**
- `show(statusBarStyle:)` and its custom `UIWindow` setup (`window`, `SceneHelper.newMainScreenWindow()`, `windowLevel` / `makeKeyAndVisible`).
- `overrideStatusBarStyle` + the `preferredStatusBarStyle` override.
- `aboutToPresentOptions(bottomPadding:)`, `animateIn()`, and the bottom-card branch of `animateOut()`.
- The background-tap dismiss path: `dismissView`, `backgroundTapped`, its tap gesture, and `UIGestureRecognizerDelegate` conformance.
- The off-screen/animate constraints (`scrollViewTopAnchor` / `scrollViewBottomAnchor` / `scrollViewHeightConstraint` / `scrollViewMaxHeightConstraint`) — `setup()` now installs the final sheet layout directly.
- `portraitOnly` + `supportedInterfaceOrientations`, the now-vestigial `isPresentedAsSheet` flag (it was always true once legacy was gone), and dead `stackBgView` / `buttonCornerRadius`.

**Caller migrations**
- `BannerAdReporter` moved from `show()` to `present()`, with its chained "Report Ad" picker using the idiomatic `OptionAction.submenu` API.
- `VideoViewController` dropped the now-meaningless `portraitOnly: false` argument (sheet orientation follows the presenting controller).
- `EpisodeDetailViewController+Actions` callers were migrated to `present(from:)`.

Current sheet visuals are preserved exactly.

## To test

1. Play a video episode, long-press skip-forward, and confirm the options sheet appears and works in both portrait and landscape.
2. On an episode detail screen, tap "Add to Up Next" / Up Next options and the download/delete confirmation — confirm both present and dismiss as native sheets.
3. With banner ads enabled, open the ad report sheet: tap **Report ad**, confirm the second sheet appears, pick a reason, and verify both sheets dismiss and the confirmation toast shows.
4. Exercise a submenu-style picker (e.g. a podcast list Sort option) and confirm choosing a sub-option collapses both sheets together.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)