### PR TITLE
[PC TV] Add Search filter, archived, More Info & sign-out analytics events

### DIFF
--- a/Pocket Casts TV App/Analytics/AnalyticsSetup.swift
+++ b/Pocket Casts TV App/Analytics/AnalyticsSetup.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PocketCastsServer
 
 enum AnalyticsSetup {
     private static var didSetup = false
@@ -19,5 +20,20 @@ enum AnalyticsSetup {
         adapters.append(LiveAnalyticsStreamer())
 
         Analytics.register(adapters: adapters)
+
+        addObservers()
+    }
+
+    /// Mirrors the iOS `AppDelegate+Analytics` observer so that signing out —
+    /// whether user-initiated from the profile menu or forced by the server —
+    /// fires `userSignedOut`. The notification is posted by `SyncManager.signout`.
+    private static func addObservers() {
+        NotificationCenter.default.addObserver(forName: .serverUserWillBeSignedOut, object: nil, queue: .main) { notification in
+            guard let userInfo = notification.userInfo, let userInitiated = userInfo["user_initiated"] as? Bool else {
+                return
+            }
+
+            Analytics.track(.userSignedOut, properties: ["user_initiated": userInitiated])
+        }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -109,6 +109,7 @@ struct PodcastDetailView: View {
                     .font(.caption2)
                 }
                 Button() {
+                    Analytics.track(.podcastScreenToggleSummary, properties: ["is_expanded": true])
                     isShowingMoreInfo = true
                 } label: {
                     Text(L10n.tvPodcastDetailMoreInfoTitle)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -31,9 +31,11 @@ class PodcastDetailViewModel {
     }
 
     func setShowArchived(_ value: Bool) {
+        guard value != showArchived else { return }
         showArchived = value
         load()
         UserDefaults.standard.set(value, forKey: Self.archiveStorageKey(for: podcastUuid))
+        Analytics.track(.podcastScreenToggleArchived, properties: ["show_archived": value])
     }
 
     init(podcastUuid: String,

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -41,6 +41,9 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
             .onChange(of: searchText) { _, newValue in
                 model.search(query: newValue)
             }
+            .onChange(of: model.scope) { _, newValue in
+                Analytics.track(.searchFilterTapped, properties: ["source": "search", "filter": newValue.analyticsDescription])
+            }
             .onAppear {
                 guard !didTrackShown else { return }
                 didTrackShown = true

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -14,6 +14,16 @@ enum SearchScope: CaseIterable {
             return L10n.episodes
         }
     }
+
+    /// Matches the iOS `SearchResultsListView.DisplayMode` analytics values.
+    var analyticsDescription: String {
+        switch self {
+        case .podcasts:
+            return "podcasts"
+        case .episodes:
+            return "episodes"
+        }
+    }
 }
 
 enum SearchState {


### PR DESCRIPTION
| 📘 Part of: #614 |  <!-- project issue number, if applicable -->
|:---:|

<!-- Analytics-only change; no tracking issue. -->

Follow-up to #4506. Wires up four more analytics events on the tvOS app, including the two requested in @SergioEstevao's review of that PR (`search_filter_tapped`, `podcast_screen_toggle_archived`). As with #4506, every event **reuses an existing `AnalyticsEvent`** case — the same one iOS fires for the equivalent action — so **no new event types are introduced**.

### tvOS events added

All events below already existed for iOS; this PR wires them up on tvOS.

| Event | Description |
|---|---|
| `search_filter_tapped` | Changed the search results scope between Podcasts and Episodes (`source: search`, `filter: podcasts`/`episodes`) |
| `podcast_screen_toggle_archived` | Toggled show/hide archived episodes on the podcast page (`show_archived: true`/`false`) |
| `podcast_screen_toggle_summary` | Tapped "More Info" on the podcast page to reveal the podcast summary (`is_expanded: true`) |
| `user_signed_out` | Signed out — user-initiated from the profile menu or server-forced (`user_initiated: true`/`false`) |

A couple of mapping notes, since tvOS UI differs from iOS:

- **`podcast_screen_toggle_summary`** is reused for the tvOS **"More Info"** button. tvOS has no inline expandable summary like iOS; "More Info" is how the summary/about content is revealed, so it fires with `is_expanded: true` when opened.
- **`podcast_screen_toggle_archived`** only fires on an actual change. The tvOS archived filter is a menu with two explicit Show/Hide options (not iOS's single toggle), so re-selecting the already-active option is intentionally a no-op.
- **`user_signed_out`** is wired via a `.serverUserWillBeSignedOut` notification observer in `AnalyticsSetup`, mirroring iOS's `AppDelegate+Analytics`. This means it also fires on server-forced sign-outs (`user_initiated: false`), not just the profile-menu button.

## To test

1. Build and run the **Pocket Casts TV App** scheme on a tvOS simulator.
2. Open **Console.app** (or watch the Xcode debug console) and filter by `subsystem:<tvOS app bundle id> category:Analytics` to see `🔵 Tracked: …` lines.
3. **Search** → type a query → switch the scope control between **Podcasts** and **Episodes** → confirm `search_filter_tapped` fires with the matching `filter`.
4. **Podcast page** → open the archived filter menu → switch between **Show**/**Hide archived** → confirm `podcast_screen_toggle_archived` fires with `show_archived` reflecting the new state, and that re-selecting the already-active option does **not** fire again.
5. **Podcast page** → **More Info** → confirm `podcast_screen_toggle_summary` fires with `is_expanded: true`.
6. **Profile** → **Log out** → confirm `user_signed_out` fires with `user_initiated: true`.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
