### PR TITLE
[PC TV] Add Discover list analytics events

### DIFF
--- a/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
@@ -1,0 +1,41 @@
+import PocketCastsServer
+
+/// Centralizes the tvOS Discover list analytics events.
+///
+/// These reuse the iOS `discover_list_*` / `discover_categories_pill_tapped` event
+/// names but add a `source` ("home" or "search") so we can tell whether the
+/// interaction happened on the Home tab or in Search, since tvOS has no dedicated
+/// Discover screen and no `AnalyticsSourceProvider` to merge a source automatically.
+enum DiscoverAnalytics {
+
+    /// Source token for Discover content shown on the Home tab.
+    static let homeSource = "home"
+
+    /// Source token for Discover content shown in Search (when no query is active).
+    static let searchSource = "search"
+
+    static func listImpression(listId: String, source: String) {
+        Analytics.track(.discoverListImpression, properties: ["list_id": listId, "source": source])
+    }
+
+    static func podcastTapped(listId: String, podcastUuid: String, source: String) {
+        Analytics.track(.discoverListPodcastTapped, properties: ["list_id": listId, "podcast_uuid": podcastUuid, "source": source])
+    }
+
+    static func episodeTapped(listId: String, podcastUuid: String?, episodeUuid: String, source: String) {
+        var properties: [String: Sendable] = ["list_id": listId, "episode_uuid": episodeUuid, "source": source]
+        if let podcastUuid {
+            properties["podcast_uuid"] = podcastUuid
+        }
+        Analytics.track(.discoverListEpisodeTapped, properties: properties)
+    }
+
+    static func categoryPillTapped(_ category: DiscoverCategory, region: String?, source: String) {
+        Analytics.track(.discoverCategoriesPillTapped, properties: [
+            "name": category.name ?? "none",
+            "region": region ?? "none",
+            "id": category.id ?? -1,
+            "source": source
+        ])
+    }
+}

--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -31,12 +31,34 @@ struct DiscoverSection {
     let subtitle: String?
     let podcasts: [DiscoverPodcast]
     let sponsoredPodcastsIDs: Set<String>
+    /// Analytics list identifier for the section, used by the `discover_list_*` events.
+    let listId: String?
 
-    init(title: String? = nil, subtitle: String? = nil, podcasts: [DiscoverPodcast] = [], sponsoredPodcastsIDs: Set<String> = []) {
+    init(title: String? = nil, subtitle: String? = nil, podcasts: [DiscoverPodcast] = [], sponsoredPodcastsIDs: Set<String> = [], listId: String? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.podcasts = podcasts
         self.sponsoredPodcastsIDs = sponsoredPodcastsIDs
+        self.listId = listId
+    }
+}
+
+struct DiscoverEpisodesSection {
+    let episodes: [DiscoverEpisode]
+    /// Analytics list identifier for the section, used by the `discover_list_*` events.
+    let listId: String?
+
+    init(episodes: [DiscoverEpisode] = [], listId: String? = nil) {
+        self.episodes = episodes
+        self.listId = listId
+    }
+}
+
+extension DiscoverItem {
+    /// Resolves the analytics `list_id` for a section, matching the iOS scheme:
+    /// the item's uuid, falling back to the collection's `list_id`, then the item's id.
+    func listId(collection: PodcastCollection?) -> String? {
+        uuid ?? collection?.listId ?? id
     }
 }
 
@@ -86,14 +108,15 @@ actor DiscoverManager {
 
     func loadDiscoverSection(sourceItem: DiscoverItem) async -> DiscoverSection {
         guard  let discoverLayout = await getLayout(), let source = sourceItem.source else {
-            return DiscoverSection(title: nil, podcasts: [])
+            return DiscoverSection(title: nil, podcasts: [], listId: sourceItem.listId(collection: nil))
         }
         let regionCode = regionCode(for: discoverLayout)
         let regionSource = source.replacingOccurrences(of: discoverLayout.regionCodeToken, with: regionCode)
 
         let podcastCollection = await discoverServerHandler.discoverPodcastCollection(source: regionSource, authenticated: sourceItem.authenticated)
+        let listId = sourceItem.listId(collection: podcastCollection)
         guard var listOfPodcasts = podcastCollection?.podcasts else {
-            return DiscoverSection(title: podcastCollection?.title, podcasts: [])
+            return DiscoverSection(title: podcastCollection?.title, podcasts: [], listId: listId)
         }
 
         let sponsoredPodcasts = await loadSponsoredPodcasts(item: sourceItem)
@@ -103,7 +126,7 @@ actor DiscoverManager {
             }
         }
 
-        return DiscoverSection(title: podcastCollection?.title, subtitle: podcastCollection?.subtitle, podcasts: listOfPodcasts, sponsoredPodcastsIDs: Set(sponsoredPodcasts.values.compactMap({$0.uuid})))
+        return DiscoverSection(title: podcastCollection?.title, subtitle: podcastCollection?.subtitle, podcasts: listOfPodcasts, sponsoredPodcastsIDs: Set(sponsoredPodcasts.values.compactMap({$0.uuid})), listId: listId)
     }
 
     func findItem(of type: DiscoverType) async -> DiscoverItem? {
@@ -177,23 +200,31 @@ actor DiscoverManager {
         return resultPodcasts
     }
 
-    func loadDiscoverEpisodesSection(type: DiscoverType) async -> [DiscoverEpisode] {
+    func currentRegion() async -> String? {
+        guard let discoverLayout = await getLayout() else {
+            return nil
+        }
+        return Settings.discoverRegion(discoverLayout: discoverLayout)
+    }
+
+    func loadDiscoverEpisodesSection(type: DiscoverType) async -> DiscoverEpisodesSection {
         guard let sourceItem = await findItem(of: type) else {
-            return []
+            return DiscoverEpisodesSection()
         }
         return await loadDiscoverEpisodesSection(item: sourceItem)
     }
 
-    func loadDiscoverEpisodesSection(item: DiscoverItem) async -> [DiscoverEpisode] {
+    func loadDiscoverEpisodesSection(item: DiscoverItem) async -> DiscoverEpisodesSection {
         guard let source = item.source else {
-            return []
+            return DiscoverEpisodesSection(listId: item.listId(collection: nil))
         }
         let podcastCollection = await discoverServerHandler.discoverPodcastCollection(source: source, authenticated: item.authenticated)
+        let listId = item.listId(collection: podcastCollection)
         guard let listOfEpisodes = podcastCollection?.episodes else {
-            return []
+            return DiscoverEpisodesSection(listId: listId)
         }
 
-        return listOfEpisodes
+        return DiscoverEpisodesSection(episodes: listOfEpisodes, listId: listId)
     }
 
     func makeVideoItem(layout: DiscoverLayout) -> DiscoverItem {

--- a/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
@@ -25,7 +25,7 @@ struct DiscoverAllView: View {
         ScrollView {
             LazyVStack(spacing: 80) {
                 ForEach(Array(model.sections.enumerated()), id: \.offset) { _, item in
-                    DiscoverRowSection(item: item)
+                    DiscoverRowSection(item: item, source: DiscoverAnalytics.searchSource)
                 }
             }
         }
@@ -43,11 +43,13 @@ struct DiscoverAllView: View {
 struct DiscoverRowSection: View {
 
     var item: DiscoverItem
+    let source: String
 
     @State var title: String
 
-    init(item: DiscoverItem) {
+    init(item: DiscoverItem, source: String) {
         self.item = item
+        self.source = source
         _title = State<String>(initialValue: item.title?.localized ?? "")
     }
 
@@ -55,13 +57,13 @@ struct DiscoverRowSection: View {
         HomeSection(title: title, focusSection: item.focusStoreID) {
             switch item.rowType {
             case .categories:
-                DiscoverCategoriesRow(popularOnly: false)
+                DiscoverCategoriesRow(popularOnly: false, source: source)
             case .featured:
-                DiscoverFeaturedPodcastsRow(item: item)
+                DiscoverFeaturedPodcastsRow(item: item, source: source)
             case .listVideoEpisode:
-                DiscoverVideoEpisodesRow(item: item)
+                DiscoverVideoEpisodesRow(item: item, source: source)
             case .singlePodcast:
-                DiscoverSinglePodcastRow(item: item) { title in
+                DiscoverSinglePodcastRow(item: item, source: source) { title in
                     if item.isSponsored == true {
                         self.title = L10n.tvSponsoredPodcastSectionTitle
                     } else {
@@ -71,7 +73,7 @@ struct DiscoverRowSection: View {
                     }
                 }
             default:
-                DiscoverPodcastRow(item: item) { title in
+                DiscoverPodcastRow(item: item, source: source) { title in
                     if let title {
                         self.title = title
                     }

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoriesModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoriesModel.swift
@@ -10,8 +10,14 @@ class DiscoverCategoriesModel {
 
     let popularOnly: Bool
 
-    init(popularOnly: Bool = false, discoverManager: DiscoverManager = DiscoverManager.shared) {
+    /// Analytics source ("home" or "search") used by `discover_categories_pill_tapped`.
+    let source: String
+
+    private(set) var region: String?
+
+    init(popularOnly: Bool = false, source: String, discoverManager: DiscoverManager = DiscoverManager.shared) {
         self.popularOnly = popularOnly
+        self.source = source
         self.discoverManager = discoverManager
     }
 
@@ -23,10 +29,16 @@ class DiscoverCategoriesModel {
 
     func load() async {
         let categories = await discoverManager.loadDiscoverCategories(popularOnly: popularOnly)
+        let region = await discoverManager.currentRegion()
 
         await MainActor.run {
             state = categories.isEmpty ? .empty : .ready
             self.categories = categories
+            self.region = region
         }
+    }
+
+    func trackPillTapped(_ category: DiscoverCategory) {
+        DiscoverAnalytics.categoryPillTapped(category, region: region, source: source)
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoriesRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoriesRow.swift
@@ -10,8 +10,8 @@ struct DiscoverCategoriesRow: View {
 
     @State private var model: DiscoverCategoriesModel
 
-    init(popularOnly: Bool) {
-        _model = State(wrappedValue: DiscoverCategoriesModel(popularOnly: popularOnly))
+    init(popularOnly: Bool, source: String) {
+        _model = State(wrappedValue: DiscoverCategoriesModel(popularOnly: popularOnly, source: source))
     }
 
     var body: some View {
@@ -42,6 +42,9 @@ struct DiscoverCategoriesRow: View {
                         .buttonStyle(.card)
                         .setFocus(section: DiscoverType.categories.rawValue)
                         .padding(.vertical, 24)
+                        .simultaneousGesture(TapGesture().onEnded {
+                            model.trackPillTapped(category)
+                        })
                     }
                 }
             })

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
@@ -9,6 +9,8 @@ struct DiscoverFeaturedPodcastCell: View {
 
     let podcast: DiscoverPodcast
     let sponsored: Bool
+    let listId: String?
+    let source: String
 
     @Environment(\.isFocused) var isFocused: Bool
 
@@ -20,9 +22,11 @@ struct DiscoverFeaturedPodcastCell: View {
         static let cardWidth = CGFloat(1604)
     }
 
-    init(podcast: DiscoverPodcast, sponsored: Bool = false) {
+    init(podcast: DiscoverPodcast, sponsored: Bool = false, listId: String? = nil, source: String = "") {
         self.podcast = podcast
         self.sponsored = sponsored
+        self.listId = listId
+        self.source = source
     }
 
     var body: some View {
@@ -76,6 +80,11 @@ struct DiscoverFeaturedPodcastCell: View {
                         NavigationLink(value: podcast) {
                             Text(L10n.tvDiscoverFeaturedGoToPodcast)
                         }
+                        .simultaneousGesture(TapGesture().onEnded {
+                            if let listId, let podcastUuid = podcast.uuid {
+                                DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, source: source)
+                            }
+                        })
                     }
                     .padding(.vertical, 24)
                 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastsRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastsRow.swift
@@ -11,13 +11,13 @@ struct DiscoverFeaturedPodcastsRow: View {
 
     private let callback: ((String?)->())?
 
-    init(type: DiscoverType, callback: ((String?) -> ())? = nil) {
-        _model = State(wrappedValue: DiscoverSectionModel(type: type))
+    init(type: DiscoverType, source: String, callback: ((String?) -> ())? = nil) {
+        _model = State(wrappedValue: DiscoverSectionModel(type: type, source: source))
         self.callback = callback
     }
 
-    init(item: DiscoverItem, callback: ((String?) -> ())? = nil) {
-        _model = State(wrappedValue: DiscoverSectionModel(item: item))
+    init(item: DiscoverItem, source: String, callback: ((String?) -> ())? = nil) {
+        _model = State(wrappedValue: DiscoverSectionModel(item: item, source: source))
         self.callback = callback
     }
 
@@ -36,6 +36,7 @@ struct DiscoverFeaturedPodcastsRow: View {
             await model.load()
             await MainActor.run {
                 callback?(model.title)
+                model.trackImpression()
             }
         }
     }
@@ -47,7 +48,7 @@ struct DiscoverFeaturedPodcastsRow: View {
         ScrollView(.horizontal) {
             LazyHStack(spacing: 48, content: {
                 ForEach(model.podcasts, id: \.uuid) { podcast in
-                    DiscoverFeaturedPodcastCell(podcast: podcast, sponsored: model.sponsored.contains(podcast.uuid ?? ""))
+                    DiscoverFeaturedPodcastCell(podcast: podcast, sponsored: model.sponsored.contains(podcast.uuid ?? ""), listId: model.listId, source: model.source)
                         .setFocus(section: model.focusStoreID)
                         .id(podcast.uuid)
                         .focused($focusedID, equals: podcast.uuid)

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -11,13 +11,13 @@ struct DiscoverPodcastRow: View {
 
     private let callback: ((String?)->())?
 
-    init(type: DiscoverType, callback: ((String?) -> ())? = nil) {
-        _model = State(wrappedValue: DiscoverSectionModel(type: type))
+    init(type: DiscoverType, source: String, callback: ((String?) -> ())? = nil) {
+        _model = State(wrappedValue: DiscoverSectionModel(type: type, source: source))
         self.callback = callback
     }
 
-    init(item: DiscoverItem, callback: ((String?) -> ())? = nil) {
-        _model = State(wrappedValue: DiscoverSectionModel(item: item))
+    init(item: DiscoverItem, source: String, callback: ((String?) -> ())? = nil) {
+        _model = State(wrappedValue: DiscoverSectionModel(item: item, source: source))
         self.callback = callback
     }
 
@@ -36,6 +36,7 @@ struct DiscoverPodcastRow: View {
             await model.load()
             await MainActor.run {
                 callback?(model.title)
+                model.trackImpression()
             }
         }
     }
@@ -52,6 +53,9 @@ struct DiscoverPodcastRow: View {
                         .buttonStyle(.card)
                         .padding(.vertical, 24)
                         .setFocus(section: model.focusStoreID)
+                        .simultaneousGesture(TapGesture().onEnded {
+                            model.trackPodcastTapped(podcast)
+                        })
                     }
                 }
             })

--- a/Pocket Casts TV App/UI/Discover/DiscoverSectionEpisodesModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSectionEpisodesModel.swift
@@ -16,15 +16,22 @@ class DiscoverSectionEpisodesModel {
 
     let item: DiscoverItem?
 
-    init(type: DiscoverType, discoverManager: DiscoverManager = DiscoverManager.shared) {
+    /// Analytics source ("home" or "search") used by the `discover_list_*` events.
+    let source: String
+
+    private(set) var listId: String?
+
+    init(type: DiscoverType, source: String, discoverManager: DiscoverManager = DiscoverManager.shared) {
         self.type = type
         self.item = nil
+        self.source = source
         self.discoverManager = discoverManager
     }
 
-    init(item: DiscoverItem, discoverManager: DiscoverManager = DiscoverManager.shared) {
+    init(item: DiscoverItem, source: String, discoverManager: DiscoverManager = DiscoverManager.shared) {
         self.type = nil
         self.item = item
+        self.source = source
         self.discoverManager = discoverManager
     }
 
@@ -35,20 +42,27 @@ class DiscoverSectionEpisodesModel {
     }
 
     func load() async {
-        let episodes: [DiscoverEpisode]
+        let section: DiscoverEpisodesSection
         if let type {
-            episodes = await discoverManager.loadDiscoverEpisodesSection(type: type)
+            section = await discoverManager.loadDiscoverEpisodesSection(type: type)
         } else if let item {
-            episodes = await discoverManager.loadDiscoverEpisodesSection(item: item)
+            section = await discoverManager.loadDiscoverEpisodesSection(item: item)
         } else {
             state = .empty
             return
         }
 
         await MainActor.run {
-            state = episodes.isEmpty ? .empty : .ready
-            self.episodes = episodes
+            state = section.episodes.isEmpty ? .empty : .ready
+            self.episodes = section.episodes
             title =  L10n.tvHomeVideoSectionTitle
+            listId = section.listId
         }
+    }
+
+    /// Fires once the section's episodes are on screen, mirroring iOS's `viewDidAppear` impression.
+    func trackImpression() {
+        guard state == .ready, let listId else { return }
+        DiscoverAnalytics.listImpression(listId: listId, source: source)
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverSectionModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSectionModel.swift
@@ -18,15 +18,22 @@ class DiscoverSectionModel {
 
     let item: DiscoverItem?
 
-    init(type: DiscoverType, discoverManager: DiscoverManager = DiscoverManager.shared) {
+    /// Analytics source ("home" or "search") used by the `discover_list_*` events.
+    let source: String
+
+    private(set) var listId: String?
+
+    init(type: DiscoverType, source: String, discoverManager: DiscoverManager = DiscoverManager.shared) {
         self.type = type
         self.item = nil
+        self.source = source
         self.discoverManager = discoverManager
     }
 
-    init(item: DiscoverItem, discoverManager: DiscoverManager = DiscoverManager.shared) {
+    init(item: DiscoverItem, source: String, discoverManager: DiscoverManager = DiscoverManager.shared) {
         self.type = nil
         self.item = item
+        self.source = source
         self.discoverManager = discoverManager
     }
 
@@ -57,7 +64,19 @@ class DiscoverSectionModel {
             title = composedTitle
             sponsored = section.sponsoredPodcastsIDs
             isSponsored = item?.isSponsored ?? false
+            listId = section.listId
         }
+    }
+
+    /// Fires once the section's podcasts are on screen, mirroring iOS's `viewDidAppear` impression.
+    func trackImpression() {
+        guard state == .ready, let listId else { return }
+        DiscoverAnalytics.listImpression(listId: listId, source: source)
+    }
+
+    func trackPodcastTapped(_ podcast: DiscoverPodcast) {
+        guard let listId, let podcastUuid = podcast.uuid else { return }
+        DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, source: source)
     }
 
     var focusStoreID: String {

--- a/Pocket Casts TV App/UI/Discover/DiscoverSinglePodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSinglePodcastRow.swift
@@ -7,8 +7,8 @@ struct DiscoverSinglePodcastRow: View {
 
     private let callback: ((String?)->())?
 
-    init(item: DiscoverItem, callback: ((String?) -> ())? = nil) {
-        _model = State(wrappedValue: DiscoverSectionModel(item: item))
+    init(item: DiscoverItem, source: String, callback: ((String?) -> ())? = nil) {
+        _model = State(wrappedValue: DiscoverSectionModel(item: item, source: source))
         self.callback = callback
     }
 
@@ -27,6 +27,7 @@ struct DiscoverSinglePodcastRow: View {
             await model.load()
             await MainActor.run {
                 callback?(model.title)
+                model.trackImpression()
             }
         }
     }
@@ -47,6 +48,9 @@ struct DiscoverSinglePodcastRow: View {
                     }
                     .setFocus(section: model.focusStoreID)
                     .buttonStyle(ChromelessButtonStyle())
+                    .simultaneousGesture(TapGesture().onEnded {
+                        model.trackPodcastTapped(podcast)
+                    })
                 }
             })
         }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -11,6 +11,9 @@ struct DiscoverVideoEpisodeCell: View {
 
     @State private var model: DiscoverVideoEpisodeModel
 
+    private let listId: String?
+    private let source: String
+
     enum FocusValues {
         case playEpisode
         case goPodcast
@@ -31,8 +34,10 @@ struct DiscoverVideoEpisodeCell: View {
         static let cardWidth = CGFloat(716)
     }
 
-    init(episode: DiscoverEpisode) {
+    init(episode: DiscoverEpisode, listId: String? = nil, source: String = "") {
         _model = State(wrappedValue: DiscoverVideoEpisodeModel(episode: episode))
+        self.listId = listId
+        self.source = source
     }
 
     var body: some View {
@@ -75,6 +80,16 @@ struct DiscoverVideoEpisodeCell: View {
         }
     }
 
+    private func trackEpisodeTapped() {
+        guard let listId, let episodeUuid = model.episode.uuid else { return }
+        DiscoverAnalytics.episodeTapped(listId: listId, podcastUuid: model.episode.podcastUuid, episodeUuid: episodeUuid, source: source)
+    }
+
+    private func trackPodcastTapped() {
+        guard let listId, let podcastUuid = model.episode.podcastUuid else { return }
+        DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, source: source)
+    }
+
     private func expand() {
         guard !isAnimating else { return }
         isAnimating = true
@@ -113,6 +128,7 @@ struct DiscoverVideoEpisodeCell: View {
     var focusedContent: some View {
         HStack(alignment: .bottom) {
             Button(L10n.tvDiscoverPlayEpisode) {
+                trackEpisodeTapped()
                 Task {
                     let successPlay = await TVDataManager.shared.playEpisode(model.episode)
                     await MainActor.run {
@@ -132,6 +148,9 @@ struct DiscoverVideoEpisodeCell: View {
                 }
                 .focused($focusedButton, equals: FocusValues.goPodcast)
                 .setFocus(section: DiscoverType.video.rawValue)
+                .simultaneousGesture(TapGesture().onEnded {
+                    trackPodcastTapped()
+                })
             }
             Spacer()
         }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodesRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodesRow.swift
@@ -15,13 +15,13 @@ struct DiscoverVideoEpisodesRow: View {
 
     private let callback: ((String?)->())?
 
-    init(type: DiscoverType, callback: ((String?) -> ())? = nil) {
-        _model = State(wrappedValue: DiscoverSectionEpisodesModel(type: type))
+    init(type: DiscoverType, source: String, callback: ((String?) -> ())? = nil) {
+        _model = State(wrappedValue: DiscoverSectionEpisodesModel(type: type, source: source))
         self.callback = callback
     }
 
-    init(item: DiscoverItem, callback: ((String?) -> ())? = nil) {
-        _model = State(wrappedValue: DiscoverSectionEpisodesModel(item: item))
+    init(item: DiscoverItem, source: String, callback: ((String?) -> ())? = nil) {
+        _model = State(wrappedValue: DiscoverSectionEpisodesModel(item: item, source: source))
         self.callback = callback
     }
 
@@ -40,6 +40,7 @@ struct DiscoverVideoEpisodesRow: View {
             await model.load()
             await MainActor.run {
                 callback?(model.title)
+                model.trackImpression()
                 resetFocus(in: focusNS)
             }
         }
@@ -49,7 +50,7 @@ struct DiscoverVideoEpisodesRow: View {
         ScrollView(.horizontal) {
             LazyHStack(spacing: Layout.spacing, content: {
                 ForEach(model.episodes, id: \.uuid) { episode in
-                    DiscoverVideoEpisodeCell(episode: episode)
+                    DiscoverVideoEpisodeCell(episode: episode, listId: model.listId, source: model.source)
                         .padding(.vertical, Layout.spacing / 2)
                         .setFocus(section: model.item?.focusStoreID ?? "")
                         .focused($focusedID, equals: episode.uuid)

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -110,7 +110,7 @@ struct HomeView: View {
 
     var youMightLikeRow: some View {
         HomeSection(title: L10n.tvHomeRecommendedForYouTitle, focusSection: DiscoverType.recommendationsUser.rawValue) {
-            DiscoverPodcastRow(type: .recommendationsUser)
+            DiscoverPodcastRow(type: .recommendationsUser, source: DiscoverAnalytics.homeSource)
         }
     }
 
@@ -118,7 +118,7 @@ struct HomeView: View {
 
     var lovedByListenersOfRow: some View {
         HomeSection(title: L10n.tvHomeRecommendUserPodcastSectionTitle(sectionPodcast ?? ""), focusSection: DiscoverType.recommendationsSocial.rawValue) {
-            DiscoverPodcastRow(type: .recommendationsSocial) { title in
+            DiscoverPodcastRow(type: .recommendationsSocial, source: DiscoverAnalytics.homeSource) { title in
                 sectionPodcast = title
             }
         }
@@ -126,26 +126,26 @@ struct HomeView: View {
 
     var trendingRow: some View {
         HomeSection(title: L10n.tvHomeTrendingSectionTitle, focusSection: DiscoverType.trending.rawValue) {
-            DiscoverPodcastRow(type: .trending)
+            DiscoverPodcastRow(type: .trending, source: DiscoverAnalytics.homeSource)
         }
     }
 
     var featuredRow: some View {
         HomeSection(title: L10n.tvHomeFeaturedSectionTitle, focusSection: DiscoverType.featured.rawValue) {
-            DiscoverFeaturedPodcastsRow(type: .featured)
+            DiscoverFeaturedPodcastsRow(type: .featured, source: DiscoverAnalytics.homeSource)
         }
     }
 
     var videoRow: some View {
         HomeSection(title: L10n.tvHomeVideoSectionTitle, focusSection: DiscoverType.video.rawValue) {
-            DiscoverVideoEpisodesRow(type: .video)
+            DiscoverVideoEpisodesRow(type: .video, source: DiscoverAnalytics.homeSource)
         }
     }
 
     @State private var curatedTitle: String?
     var curatedRow: some View {
         HomeSection(title: curatedTitle ?? L10n.loading, focusSection: DiscoverType.curatedList.rawValue) {
-            DiscoverPodcastRow(type: .curatedList) { title in
+            DiscoverPodcastRow(type: .curatedList, source: DiscoverAnalytics.homeSource) { title in
                 curatedTitle = title
             }
         }
@@ -153,7 +153,7 @@ struct HomeView: View {
 
     var categoriesRow: some View {
         HomeSection(title: L10n.tvHomeBrowseCategoriesSectionTitle, focusSection: DiscoverType.categories.rawValue) {
-            DiscoverCategoriesRow(popularOnly: true)
+            DiscoverCategoriesRow(popularOnly: true, source: DiscoverAnalytics.homeSource)
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: #614 |
|:---:|

<!-- Analytics-only change; no tracking issue. -->

Follow-up to #4511. Wires up the Discover **list** events on tvOS, as discussed with @SergioEstevao and @davidgonzalezwp. Every event **reuses an existing iOS `AnalyticsEvent`** — no new types. The only addition is a **`source`** property (`home`/`search`) so we can tell whether the interaction happened on the Home tab or in Search.

### tvOS events added

| Event | Description |
|---|---|
| `discover_list_impression` | A Discover list section appeared (`list_id`, `source`) |
| `discover_list_podcast_tapped` | Tapped a podcast in a list, incl. featured/video "Go to podcast" (`list_id`, `podcast_uuid`, `source`) |
| `discover_list_episode_tapped` | Played a video episode from a list (`list_id`, `podcast_uuid`, `episode_uuid`, `source`) |
| `discover_categories_pill_tapped` | Tapped a category cell (`name`, `region`, `id`, `source`) |

`list_id` follows the iOS scheme (`DiscoverItem.uuid ?? PodcastCollection.list_id ?? DiscoverItem.id`). Impressions fire `onAppear` to match iOS. The category **detail** grid and non-Discover Home rows are out of scope.

## To test

1. Run the **Pocket Casts TV App** scheme on a tvOS simulator and watch the Xcode console for `🔵 Tracked: …` lines.
2. **Home** → scroll the Discover rows, open a podcast, play a video episode, tap a category → confirm the four events fire with `source: home`.
3. **Search** (no query) → repeat against the Discover content → confirm the same events fire with `source: search`.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
