### PR TITLE
[PC TV] Report tvOS platform in LiveAnalyticsStreamer

### DIFF
--- a/podcasts/Analytics/Adapters/LiveAnalyticsStreamer.swift
+++ b/podcasts/Analytics/Adapters/LiveAnalyticsStreamer.swift
@@ -49,6 +49,14 @@ actor LiveAnalyticsStreamer: AnalyticsAdapter {
 
     private let encoder = JSONEncoder()
 
+    private static let platform: String = {
+#if os(tvOS)
+        "tvOS"
+#else
+        "iOS"
+#endif
+    }()
+
     private let dateFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -65,7 +73,7 @@ actor LiveAnalyticsStreamer: AnalyticsAdapter {
             properties: properties.reduce(into: [String: String]()) { result, entry in
                 result[entry.key] = String(describing: entry.value)
             },
-            platform: "iOS"
+            platform: Self.platform
         )
         bufferEvent(event)
     }


### PR DESCRIPTION
Fixes PCIOS-727.

The Live analytics adapter is already registered on the tvOS target, but `LiveAnalyticsStreamer` hardcodes `platform: "iOS"` — so every event sent from tvOS is mislabeled as iOS.

This resolves the platform string at compile time via `#if os(tvOS)`, mirroring the existing `pcios`/`pctvos` split in `TracksAdapter`. iOS behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)