### PR TITLE
Remove HiddenScrollContentBackground modifier

### DIFF
--- a/podcasts/Folder History/FolderHistoryEntryView.swift
+++ b/podcasts/Folder History/FolderHistoryEntryView.swift
@@ -51,7 +51,7 @@ struct FolderHistoryEntryView: View {
                 .listRowSeparatorTint(theme.primaryUi05)
             }
         }
-        .modifier(HiddenScrollContentBackground())
+        .scrollContentBackground(.hidden)
         .background(theme.primaryUi04)
         .onAppear { model.loadFoldersHistory(for: entryDate) }
         .navigationTitle("\(entryDate.formatted())")

--- a/podcasts/Folder History/FolderHistoryView.swift
+++ b/podcasts/Folder History/FolderHistoryView.swift
@@ -29,7 +29,7 @@ struct FolderHistoryView: View {
                 }
             }
         }
-        .modifier(HiddenScrollContentBackground())
+        .scrollContentBackground(.hidden)
         .background(theme.primaryUi04)
         .sheet(item: $selectedEntry) { entry in
             FolderHistoryEntryView(entryDate: entry.date)

--- a/podcasts/Up Next History/UpNextEntryView.swift
+++ b/podcasts/Up Next History/UpNextEntryView.swift
@@ -88,7 +88,7 @@ struct UpNextEntryView: View {
             .listRowBackground(theme.primaryUi02)
             .listRowSeparatorTint(theme.primaryUi05)
         }
-        .modifier(HiddenScrollContentBackground())
+        .scrollContentBackground(.hidden)
         .onAppear { model.loadEpisodes(for: entryDate) }
     }
 

--- a/podcasts/Up Next History/UpNextHistoryView.swift
+++ b/podcasts/Up Next History/UpNextHistoryView.swift
@@ -29,7 +29,7 @@ struct UpNextHistoryView: View {
                 }
             }
         }
-        .modifier(HiddenScrollContentBackground())
+        .scrollContentBackground(.hidden)
         .background(theme.primaryUi04)
         .sheet(item: $selectedEntry) { entry in
             UpNextEntryView(entryDate: entry.date)
@@ -47,13 +47,6 @@ struct UpNextHistoryView: View {
             }
         })
         .applyDefaultThemeOptions()
-    }
-}
-
-struct HiddenScrollContentBackground: ViewModifier {
-    public func body(content: Content) -> some View {
-        content
-            .scrollContentBackground(.hidden)
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

<!-- No associated issue -->

Replaces the trivial `HiddenScrollContentBackground` `ViewModifier` with direct `.scrollContentBackground(.hidden)` calls. The modifier added no behavior beyond a single SwiftUI call, so inlining it removes an unnecessary indirection. Updated all four call sites (Folder History and Up Next History views) and deleted the now-unused struct.

## To test

1. Open **Profile → Settings → Up Next History** and confirm the list still renders with the themed background (no default system list background showing through).
2. Tap an entry to open the Up Next History entry detail and confirm the same.
3. Repeat for **Folder History** and its entry detail view.
4. Verify in both light and dark themes.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)