### PR TITLE
[PC TV] Episode details entry points and modal polish

### DIFF
--- a/Pocket Casts TV App/Data/ShowNotesLoader.swift
+++ b/Pocket Casts TV App/Data/ShowNotesLoader.swift
@@ -1,0 +1,31 @@
+import Foundation
+import PocketCastsDataModel
+import PocketCastsServer
+
+/// Loads an episode's HTML show notes for the TV app.
+///
+/// Mirrors the relevant slice of the iOS `ShowInfoCoordinator`, but only pulls
+/// the show-notes-shaped data. Uses `ShowInfoDataRetriever` (shared via
+/// `PocketCastsServer`) so cache + network behavior matches iOS, then decodes
+/// the per-episode JSON into `Episode.Metadata` and extracts `showNotes`.
+actor ShowNotesLoader {
+    static let shared = ShowNotesLoader()
+
+    private let dataRetriever: ShowInfoDataRetriever
+
+    init(dataRetriever: ShowInfoDataRetriever = ShowInfoDataRetriever()) {
+        self.dataRetriever = dataRetriever
+    }
+
+    func loadShowNotes(podcastUuid: String, episodeUuid: String) async -> String {
+        guard let json = try? await dataRetriever.loadEpisodeDataFromCache(for: podcastUuid, episodeUuid: episodeUuid),
+              let data = json.data(using: .utf8) else {
+            return CacheServerHandler.noShowNotesMessage
+        }
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let metadata = try? decoder.decode(Episode.Metadata.self, from: data)
+        return metadata?.showNotes ?? CacheServerHandler.noShowNotesMessage
+    }
+}

--- a/Pocket Casts TV App/UI/Common/ShowNotesWebView.swift
+++ b/Pocket Casts TV App/UI/Common/ShowNotesWebView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+import UIKit
+
+/// Renders raw HTML show notes in a scroll-and-focus pattern that works on
+/// tvOS.
+///
+/// tvOS lacks `WKWebView`, so HTML is parsed into an `NSAttributedString` and
+/// rendered by a `UITextView` (the only readily-available rich-text renderer)
+/// with its own scroll view. SwiftUI then owns focus and remote-input handling:
+/// `.focusable(true)` + `@FocusState` claims focus when the sheet opens, and
+/// `.onMoveCommand` translates remote swipes / simulator arrow keys into
+/// programmatic scrolls on the `UITextView` via a small coordinator.
+struct ShowNotesWebView: View {
+    let html: String
+
+    @FocusState private var isFocused: Bool
+    @State private var scrollCoordinator = ShowNotesScrollCoordinator()
+
+    var body: some View {
+        ShowNotesAttributedTextView(html: html, coordinator: scrollCoordinator)
+            .focusable(true)
+            .focused($isFocused)
+            .onAppear { isFocused = true }
+            .onMoveCommand { direction in
+                switch direction {
+                case .up:    scrollCoordinator.scroll(by: -150)
+                case .down:  scrollCoordinator.scroll(by: 150)
+                default:     break
+                }
+            }
+    }
+}
+
+/// Holds a weak reference to the inner `UITextView` so SwiftUI move-commands
+/// can drive its scroll offset.
+final class ShowNotesScrollCoordinator {
+    weak var textView: UITextView?
+
+    func scroll(by dy: CGFloat) {
+        guard let textView else { return }
+        let maxY = max(0, textView.contentSize.height - textView.bounds.height)
+        let newY = max(0, min(maxY, textView.contentOffset.y + dy))
+        textView.setContentOffset(CGPoint(x: textView.contentOffset.x, y: newY), animated: true)
+    }
+}
+
+private struct ShowNotesAttributedTextView: UIViewRepresentable {
+    let html: String
+    let coordinator: ShowNotesScrollCoordinator
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.isScrollEnabled = true
+        textView.isSelectable = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.attributedText = makeAttributedString()
+        coordinator.textView = textView
+        return textView
+    }
+
+    func updateUIView(_ textView: UITextView, context: Context) {
+        textView.attributedText = makeAttributedString()
+        coordinator.textView = textView
+    }
+
+    private func makeAttributedString() -> NSAttributedString {
+        let wrapped = """
+        <html><head><style>
+        body { color: #FBFBFC; font-family: -apple-system; font-size: 28px; line-height: 1.4; }
+        a { color: #F43769; text-decoration: underline; }
+        h1, h2, h3, h4, h5, h6 { color: #FBFBFC; font-weight: 600; }
+        img { display: none; }
+        </style></head><body>\(html)</body></html>
+        """
+        guard let data = wrapped.data(using: .utf8) else {
+            return NSAttributedString(string: html)
+        }
+        let attributed = try? NSAttributedString(
+            data: data,
+            options: [
+                .documentType: NSAttributedString.DocumentType.html,
+                .characterEncoding: String.Encoding.utf8.rawValue
+            ],
+            documentAttributes: nil
+        )
+        return attributed ?? NSAttributedString(string: html)
+    }
+}

--- a/Pocket Casts TV App/UI/Common/ShowNotesWebView.swift
+++ b/Pocket Casts TV App/UI/Common/ShowNotesWebView.swift
@@ -56,12 +56,16 @@ private struct ShowNotesAttributedTextView: UIViewRepresentable {
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
         textView.attributedText = makeAttributedString()
+        textView.tag = html.hashValue
         coordinator.textView = textView
         return textView
     }
 
     func updateUIView(_ textView: UITextView, context: Context) {
-        textView.attributedText = makeAttributedString()
+        if textView.tag != html.hashValue {
+            textView.attributedText = makeAttributedString()
+            textView.tag = html.hashValue
+        }
         coordinator.textView = textView
     }
 

--- a/Pocket Casts TV App/UI/Player/EpisodeShowNotesView.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodeShowNotesView.swift
@@ -18,7 +18,7 @@ struct EpisodeShowNotesView: View {
         VStack(alignment: .leading, spacing: 32) {
             header
             Text(L10n.tvEpisodeShowNotesTitle)
-                .font(.title3)
+                .font(.headline)
                 .foregroundStyle(Color.pcTextPrimary)
             content
         }
@@ -31,9 +31,9 @@ struct EpisodeShowNotesView: View {
 
     @ViewBuilder
     private var header: some View {
-        HStack(alignment: .top, spacing: 40) {
+        HStack(alignment: .top, spacing: 32) {
             artwork
-                .frame(width: 200, height: 200)
+                .frame(width: 160, height: 160)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
             VStack(alignment: .leading, spacing: 8) {
                 if let podcastTitle = podcast?.title {

--- a/Pocket Casts TV App/UI/Player/EpisodeShowNotesView.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodeShowNotesView.swift
@@ -23,7 +23,7 @@ struct EpisodeShowNotesView: View {
             content
         }
         .padding(80)
-        .frame(width: 862, alignment: .topLeading)
+        .frame(width: 862, height: 960, alignment: .topLeading)
         .task {
             await loadShowNotes()
         }
@@ -42,7 +42,7 @@ struct EpisodeShowNotesView: View {
                         .foregroundStyle(Color.pcTextSecondary)
                 }
                 Text(episode.displayableTitle())
-                    .font(.headline)
+                    .font(.body)
                     .foregroundStyle(Color.pcTextPrimary)
                     .fixedSize(horizontal: false, vertical: true)
                 Text(metadataLine)
@@ -67,12 +67,12 @@ struct EpisodeShowNotesView: View {
     private var content: some View {
         if let showNotes {
             // `UITextView` with `isScrollEnabled = true` reports no intrinsic
-            // height, so without an explicit frame the modal collapses to just
-            // the header. The fixed height gives the text view a real frame to
-            // render and scroll within.
+            // height, so it relies on the parent's fixed frame to know what
+            // area it can render and scroll within. `maxHeight: .infinity`
+            // makes it absorb whatever space the header leaves inside the
+            // modal's fixed outer height.
             ShowNotesWebView(html: showNotes)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .frame(height: 720)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
         } else {
             HStack(spacing: 16) {
                 ProgressView()

--- a/Pocket Casts TV App/UI/Player/EpisodeShowNotesView.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodeShowNotesView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+import PocketCastsDataModel
+import PocketCastsServer
+import PocketCastsUtils
+
+/// Modal that renders an episode's HTML show notes alongside a header summary
+/// (artwork, episode title, podcast name, publish date).
+///
+/// Presentation is via `.sheet`, matching `PodcastMoreInfoView`'s pattern.
+struct EpisodeShowNotesView: View {
+    let episode: BaseEpisode
+    let podcast: Podcast?
+
+    @State private var showNotes: String?
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 32) {
+            header
+            Text(L10n.tvEpisodeShowNotesTitle)
+                .font(.title3)
+                .foregroundStyle(Color.pcTextPrimary)
+            content
+        }
+        .padding(80)
+        .frame(width: 862, alignment: .topLeading)
+        .task {
+            await loadShowNotes()
+        }
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        HStack(alignment: .top, spacing: 40) {
+            artwork
+                .frame(width: 200, height: 200)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            VStack(alignment: .leading, spacing: 8) {
+                if let podcastTitle = podcast?.title {
+                    Text(podcastTitle)
+                        .font(.caption)
+                        .foregroundStyle(Color.pcTextSecondary)
+                }
+                Text(episode.displayableTitle())
+                    .font(.headline)
+                    .foregroundStyle(Color.pcTextPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(metadataLine)
+                    .font(.caption)
+                    .foregroundStyle(Color.pcTextSecondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var artwork: some View {
+        if let podcastUuid = (episode as? Episode)?.podcastUuid {
+            PodcastImage(uuid: podcastUuid, size: .page)
+        } else {
+            Image(ImageResource.pcLogo)
+                .resizable()
+                .scaledToFit()
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let showNotes {
+            // `UITextView` with `isScrollEnabled = true` reports no intrinsic
+            // height, so without an explicit frame the modal collapses to just
+            // the header. The fixed height gives the text view a real frame to
+            // render and scroll within.
+            ShowNotesWebView(html: showNotes)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(height: 720)
+        } else {
+            HStack(spacing: 16) {
+                ProgressView()
+                Text(L10n.tvEpisodeShowNotesLoading)
+                    .font(.body)
+                    .foregroundStyle(Color.pcTextSecondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var metadataLine: String {
+        let date = DateFormatHelper.sharedHelper.tinyLocalizedFormat(episode.publishedDate).localizedUppercase
+        let duration = episode.displayableDuration
+        return [date, duration].filter { !$0.isEmpty }.joined(separator: " · ")
+    }
+
+    private func loadShowNotes() async {
+        guard let podcastUuid = (episode as? Episode)?.podcastUuid else {
+            showNotes = CacheServerHandler.noShowNotesMessage
+            return
+        }
+        showNotes = await ShowNotesLoader.shared.loadShowNotes(
+            podcastUuid: podcastUuid,
+            episodeUuid: episode.uuid
+        )
+    }
+}

--- a/Pocket Casts TV App/UI/Player/EpisodeShowNotesView.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodeShowNotesView.swift
@@ -23,7 +23,7 @@ struct EpisodeShowNotesView: View {
             content
         }
         .padding(80)
-        .frame(width: 862, height: 960, alignment: .topLeading)
+        .frame(width: 1200, height: 920, alignment: .topLeading)
         .task {
             await loadShowNotes()
         }

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -94,7 +94,7 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
 
     private static let episodeDescriptionActionIdentifier = UIAction.Identifier("com.pocketcasts.tv.episodeDescription")
 
-    /// Appends an "Episode description" action to the player's default Info tab
+    /// Appends an "Episode details" action to the player's default Info tab
     /// alongside the system-provided "Play from Beginning" entry. Identifier-
     /// keyed so repeated `updateUIViewController` calls don't stack duplicates.
     /// The handler flips a SwiftUI `@Binding` rather than calling
@@ -113,7 +113,7 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
         ) { _ in
             isShowingDescription = true
         }
-        // Prepend so "Episode description" appears above the system's default
+        // Prepend so "Episode details" appears above the system's default
         // "Play from Beginning" entry in the Info tab.
         playerViewController.infoViewActions = [action] + current
     }

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -2,8 +2,23 @@ import SwiftUI
 import AVKit
 import PocketCastsDataModel
 
-struct NowPlayingView: UIViewControllerRepresentable {
+struct NowPlayingView: View {
     @State private var model = NowPlayingViewModel()
+    @State private var isShowingDescription = false
+
+    var body: some View {
+        NowPlayingPlayerRepresentable(model: model, isShowingDescription: $isShowingDescription)
+            .sheet(isPresented: $isShowingDescription) {
+                if let episode = model.episode {
+                    EpisodeShowNotesView(episode: episode, podcast: model.podcast)
+                }
+            }
+    }
+}
+
+private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
+    @Bindable var model: NowPlayingViewModel
+    @Binding var isShowingDescription: Bool
     @State private var isTransportBarVisible = true
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
@@ -66,6 +81,7 @@ struct NowPlayingView: UIViewControllerRepresentable {
             makePlaybackSpeedMenu(),
             makePlaybackEffectsMenu()
         ]
+        ensureEpisodeDescriptionInfoAction(on: uiViewController)
         // Suppress AVKit's system loading spinner while the player is still
         // preparing. Hiding playback controls also hides the spinner that
         // lives in the same transport overlay; our branded loading UI in
@@ -74,6 +90,32 @@ struct NowPlayingView: UIViewControllerRepresentable {
         if uiViewController.showsPlaybackControls != shouldShowControls {
             uiViewController.showsPlaybackControls = shouldShowControls
         }
+    }
+
+    private static let episodeDescriptionActionIdentifier = UIAction.Identifier("com.pocketcasts.tv.episodeDescription")
+
+    /// Appends an "Episode description" action to the player's default Info tab
+    /// alongside the system-provided "Play from Beginning" entry. Identifier-
+    /// keyed so repeated `updateUIViewController` calls don't stack duplicates.
+    /// The handler flips a SwiftUI `@Binding` rather than calling
+    /// `AVPlayerViewController.present(...)` directly — UIKit modal presentation
+    /// from inside an Info-tab action is unreliable on tvOS, so the parent
+    /// SwiftUI view owns the sheet instead.
+    private func ensureEpisodeDescriptionInfoAction(on playerViewController: AVPlayerViewController) {
+        let identifier = Self.episodeDescriptionActionIdentifier
+        let current = playerViewController.infoViewActions ?? []
+        guard !current.contains(where: { $0.identifier == identifier }) else { return }
+
+        let action = UIAction(
+            title: L10n.tvEpisodeShowNotesTitle,
+            image: UIImage(systemName: "info.circle"),
+            identifier: identifier
+        ) { _ in
+            isShowingDescription = true
+        }
+        // Prepend so "Episode description" appears above the system's default
+        // "Play from Beginning" entry in the Info tab.
+        playerViewController.infoViewActions = [action] + current
     }
 
     private func createMetadataItems() -> [AVMetadataItem] {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -110,6 +110,7 @@ struct EpisodeRowWithActions: View {
     @FocusState private var focusedElement: FocusElement?
     @State private var isPlaying = false
     @State private var isShowingActions = false
+    @State private var isShowingShowNotes = false
     @State private var restoreFocus = false
 
     private enum FocusElement: Hashable {
@@ -131,6 +132,9 @@ struct EpisodeRowWithActions: View {
 
     @ViewBuilder
     private var actionButtons: some View {
+        if model.podcastUuid != nil {
+            Button(L10n.tvEpisodeShowNotesAction) { isShowingShowNotes = true }
+        }
         switch context {
         case .default:
             Button(L10n.playNextInUpNext) { requireAccount { model.playNext() } }
@@ -196,6 +200,9 @@ struct EpisodeRowWithActions: View {
         .fullScreenCover(isPresented: $isPlaying) {
             NowPlayingView()
                 .ignoresSafeArea()
+        }
+        .sheet(isPresented: $isShowingShowNotes) {
+            EpisodeShowNotesView(episode: model.episode, podcast: model.podcast)
         }
         .confirmationDialog(model.displayTitle, isPresented: $isShowingActions) {
             actionButtons

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6118,6 +6118,15 @@
 /* tv podcast more info next episode label */
 "tv_podcast_detail_next_episode" = "Next episode";
 
+/* tv episode row action that opens the episode description modal. The leading ⓘ glyph stands in for an SF Symbol since tvOS .confirmationDialog strips Labels' images. */
+"tv_episode_show_notes_action" = "ⓘ  Episode description";
+
+/* tv title shown above the rendered HTML episode description inside the modal */
+"tv_episode_show_notes_title" = "Episode description";
+
+/* tv fallback message shown inside the modal while the episode description is being fetched */
+"tv_episode_show_notes_loading" = "Loading episode description…";
+
 /* tv podcast detail recommended episode section title */
 "tv_podcast_detail_start_here" = "The episode to try first";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6118,11 +6118,11 @@
 /* tv podcast more info next episode label */
 "tv_podcast_detail_next_episode" = "Next episode";
 
-/* tv episode row action that opens the episode description modal. The leading ⓘ glyph stands in for an SF Symbol since tvOS .confirmationDialog strips Labels' images. */
-"tv_episode_show_notes_action" = "ⓘ  Episode description";
+/* tv episode row action that opens the episode details modal. The leading ⓘ glyph stands in for an SF Symbol since tvOS .confirmationDialog strips Labels' images. */
+"tv_episode_show_notes_action" = "ⓘ  Episode details";
 
-/* tv title shown above the rendered HTML episode description inside the modal */
-"tv_episode_show_notes_title" = "Episode description";
+/* tv title shown above the rendered HTML episode description inside the episode details modal */
+"tv_episode_show_notes_title" = "Episode details";
 
 /* tv fallback message shown inside the modal while the episode description is being fetched */
 "tv_episode_show_notes_loading" = "Loading episode description…";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6124,8 +6124,8 @@
 /* tv title shown above the rendered HTML episode description inside the episode details modal */
 "tv_episode_show_notes_title" = "Episode details";
 
-/* tv fallback message shown inside the modal while the episode description is being fetched */
-"tv_episode_show_notes_loading" = "Loading episode description…";
+/* tv fallback message shown inside the episode details modal while the show notes are being fetched */
+"tv_episode_show_notes_loading" = "Loading episode details…";
 
 /* tv podcast detail recommended episode section title */
 "tv_podcast_detail_start_here" = "The episode to try first";


### PR DESCRIPTION
Fixes PCIOS-682

Adds an entry point on tvOS for viewing an episode's show notes ("Episode details") from two places, and a modal that renders the HTML body alongside a header summary (artwork, podcast/episode title, publish date, duration).

- Episode row "…" menu in podcast/playlist contexts gets a new **Episode details** action (`ⓘ Episode details`).
- Fullscreen player's Info tab gets a matching **Episode details** action (prepended above the system's "Play from Beginning" entry).
- Both routes present `EpisodeShowNotesView` as a sheet, which fetches and renders show notes HTML via a tvOS-friendly `UITextView`-backed view (no `WKWebView` on tvOS).
- Modal is sized to a stable `862×960` so the layout doesn't clip on long episode titles — the inner show notes area absorbs whatever vertical space the header leaves.
- Copy is consolidated as **Episode details** across all three surfaces (menu, player action, modal title).

## To test

1. Run the **Pocket Casts TV** target on an Apple TV (or simulator).
2. Open a podcast and select any episode row → press the **"…"** button → tap **ⓘ Episode details**. Confirm the modal opens with the episode header at top, an "Episode details" section title, and the show notes body. Use the remote's up/down swipes to scroll the body.
3. Start playing an episode. In the fullscreen player, open the **Info** tab on the transport bar → select **Episode details**. Confirm the same modal opens.
4. Try the flow with both **short** episode titles (1–2 lines) and **long** ones (4+ lines). Verify the header isn't clipped in either case and the body is still visible.
5. While the notes are loading, confirm the modal shows **"Loading episode details…"** with a spinner.
6. For an episode without notes / not yet refreshed, confirm a fallback message renders.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to \`CHANGELOG.md\` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.


https://github.com/user-attachments/assets/077ac3db-2798-473a-a6c4-f257072532d0

