### PR TITLE
TV: Create account & show approval result in device pairing flow

### DIFF
--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/DeviceApproveTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/DeviceApproveTask.swift
@@ -27,10 +27,15 @@ class DeviceApproveTask: ApiBaseTask, @unchecked Sendable {
 
             let data = try request.serializedData()
 
-            let (response, httpStatus) = postToServer(url: urlString, token: token, data: data)
+            let (responseData, httpStatus) = postToServer(url: urlString, token: token, data: data)
 
-            guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
-                completion?(.failure(APIError.UNKNOWN))
+            guard let responseData, httpStatus == ServerConstants.HttpConstants.ok else {
+                if let errorResponse = ApiServerHandler.extractErrorResponse(data: responseData, response: nil, error: nil) {
+                    FileLog.shared.addMessage("Unable to approve device, status code: \(httpStatus), server error: \(errorResponse.rawValue)")
+                    completion?(.failure(errorResponse))
+                    return
+                }
+                completion?(httpStatus == ServerConstants.HttpConstants.serverError ? .failure(APIError.NO_CONNECTION) : .failure(APIError.UNKNOWN))
                 return
             }
             let changeResponse = try Api_DeviceApproveResponse(serializedBytes: responseData)
@@ -39,7 +44,7 @@ class DeviceApproveTask: ApiBaseTask, @unchecked Sendable {
             FileLog.shared.addMessage("API device approved response \(changeResponse)")
         } catch {
             FileLog.shared.addMessage("Failed to approve device \(error.localizedDescription)")
-            completion?(.failure(APIError.UNKNOWN))
+            completion?((error as NSError).isConnectivityError ? .failure(APIError.NO_CONNECTION) : .failure(error))
         }
     }
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -1033,6 +1033,6 @@ enum AnalyticsEvent: String {
     case deviceApproveConnectTapped
     case deviceApproveDismissed
     case deviceSetupAccountTapped
-    case deviceApproveSuccessfull
+    case deviceApproveSuccessful
     case deviceApproveFailed
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -1033,4 +1033,6 @@ enum AnalyticsEvent: String {
     case deviceApproveConnectTapped
     case deviceApproveDismissed
     case deviceSetupAccountTapped
+    case deviceApproveSuccessfull
+    case deviceApproveFailed
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -1032,4 +1032,5 @@ enum AnalyticsEvent: String {
     case deviceApproveShown
     case deviceApproveConnectTapped
     case deviceApproveDismissed
+    case deviceSetupAccountTapped
 }

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -448,6 +448,7 @@ enum PlusUpgradeViewSource: String {
     case whatsNew
     case sonosLink = "sonos_link"
     case deepLink
+    case deviceApproval = "device_approval"
 
     /// Converts the enum into a Firebase promotionId, this matches the values set on Android
     func promotionId() -> String {

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -393,7 +393,7 @@ struct DeveloperMenu: View {
                     showDeviceApproval = true
                 }
                 .sheet(isPresented: $showDeviceApproval) {
-                    DeviceApproveView(userCode: "")
+                    DeviceApproveView(userCode: "", model: DeviceApproveViewModel(presentingViewController: SceneHelper.rootViewController(includeTopMost: true) ?? UIViewController()))
                 }
             } header: {
                 Text("TV")

--- a/podcasts/DeviceApprove/DeviceApproveView.swift
+++ b/podcasts/DeviceApprove/DeviceApproveView.swift
@@ -10,6 +10,20 @@ class DeviceApproveViewModel: ObservableObject {
     var email: String {
         return ServerSettings.syncingEmail() ?? ""
     }
+
+    func presentAccountFlow() {
+        let controller = OnboardingFlow.shared.begin(flow: .none, source: .onboarding, accountCreated: { created in
+            print("Account created:\(created)")
+        })
+        let baseVC = presentingViewController.presentedViewController ?? presentingViewController
+        baseVC.present(controller, animated: true)
+    }
+
+    let presentingViewController: UIViewController
+
+    init(presentingViewController: UIViewController) {
+        self.presentingViewController = presentingViewController
+    }
 }
 
 struct DeviceApproveView: View {
@@ -20,12 +34,13 @@ struct DeviceApproveView: View {
 
     @State private var userCode: String
 
-    @StateObject private var model = DeviceApproveViewModel()
+    @StateObject private var model: DeviceApproveViewModel
 
     @State private var showFailureAlert: Bool = false
 
-    init(userCode: String?) {
+    init(userCode: String?, model: DeviceApproveViewModel) {
         _userCode = State(initialValue: userCode ?? "")
+        _model = StateObject(wrappedValue: model)
     }
 
     var body: some View {
@@ -36,6 +51,7 @@ struct DeviceApproveView: View {
             title
             description
             accountCard
+            accountFlowLink
             if model.isUserLoggedIn {
                 codeField
             }
@@ -115,6 +131,19 @@ struct DeviceApproveView: View {
         )
     }
 
+    @ViewBuilder
+    private var accountFlowLink: some View {
+        if !model.isUserLoggedIn {
+            Button {
+                model.presentAccountFlow()
+            } label: {
+                Text(L10n.setupAccount)
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundStyle(theme.primaryInteractive01)
+            }
+        }
+    }
+
     private var codeField: some View {
         TextField(L10n.deviceApproveCodePlaceholder, text: $userCode)
             .multilineTextAlignment(.center)
@@ -182,6 +211,6 @@ private struct CircleLogo: View {
 }
 
 #Preview {
-    DeviceApproveView(userCode: "12345")
+    DeviceApproveView(userCode: "12345", model: DeviceApproveViewModel(presentingViewController: UIViewController()))
         .environmentObject(Theme(previewTheme: .light))
 }

--- a/podcasts/DeviceApprove/DeviceApproveView.swift
+++ b/podcasts/DeviceApprove/DeviceApproveView.swift
@@ -3,7 +3,20 @@ import PocketCastsServer
 import PocketCastsUtils
 import UIKit
 
+@MainActor
 class DeviceApproveViewModel: ObservableObject {
+
+    @Published
+    var showSuccessAlert: Bool = false
+
+    @Published
+    var showFailureAlert: Bool = false
+
+    @Published
+    var errorMessage: String = ""
+
+    @Published
+    var errorTitle: String = ""
 
     var isUserLoggedIn: Bool {
         return SyncManager.isUserLoggedIn()
@@ -23,6 +36,38 @@ class DeviceApproveViewModel: ObservableObject {
 
     let presentingViewController: UIViewController
 
+    func actionButtonTapped(userCode: String) {
+        guard isUserLoggedIn else {
+            Analytics.track(.deviceSetupAccountTapped)
+            presentAccountFlow()
+            return
+        }
+        Task {
+            Analytics.track(.deviceApproveConnectTapped)
+            do {
+                let result = try await AuthenticationHelper.deviceApprove(userCode: userCode, approve: true)
+                if result.success == true {
+                    Analytics.track(.deviceApproveSuccessful)
+                    showSuccessAlert = true
+                } else {
+                    Analytics.track(.deviceApproveFailed)
+                    errorTitle = L10n.deviceApproveExpiredAlertTitle
+                    errorMessage = L10n.deviceApproveExpiredAlertMessage
+                    showFailureAlert = true
+                }
+            } catch let error as APIError {
+                showFailureAlert = true
+                if error == APIError.INVALID_GRANT {
+                    errorTitle = L10n.deviceApproveExpiredAlertTitle
+                    errorMessage = L10n.deviceApproveExpiredAlertMessage
+                } else {
+                    errorTitle = L10n.deviceApproveGenericErrorAlertTitle
+                    errorMessage = L10n.pleaseTryAgainLater
+                }
+            }
+        }
+    }
+
     init(presentingViewController: UIViewController) {
         self.presentingViewController = presentingViewController
     }
@@ -37,10 +82,6 @@ struct DeviceApproveView: View {
     @State private var userCode: String
 
     @StateObject private var model: DeviceApproveViewModel
-
-    @State private var showFailureAlert: Bool = false
-
-    @State private var showSuccessAlert: Bool = false
 
     init(userCode: String?, model: DeviceApproveViewModel) {
         _userCode = State(initialValue: userCode ?? "")
@@ -68,14 +109,14 @@ struct DeviceApproveView: View {
         .onAppear() {
             Analytics.track(.deviceApproveShown)
         }
-        .alert(L10n.deviceApproveExpiredAlertTitle, isPresented: $showFailureAlert) {
+        .alert(model.errorTitle, isPresented: $model.showFailureAlert) {
             Button(L10n.ok, role: .cancel) {
                 dismiss()
             }
         } message: {
-            Text(L10n.deviceApproveExpiredAlertMessage)
+            Text(model.errorMessage)
         }
-        .alert(L10n.deviceApproveSuccessAlertTitle, isPresented: $showSuccessAlert) {
+        .alert(L10n.deviceApproveSuccessAlertTitle, isPresented: $model.showSuccessAlert) {
             Button(L10n.ok, role: .cancel) {
                 dismiss()
             }
@@ -157,22 +198,7 @@ struct DeviceApproveView: View {
 
     private var actionButton: some View {
         Button {
-            if model.isUserLoggedIn {
-                Task {
-                    Analytics.track(.deviceApproveConnectTapped)
-                    let result = try? await AuthenticationHelper.deviceApprove(userCode: userCode, approve: true)
-                    if result?.success == true {
-                        Analytics.track(.deviceApproveSuccessful)
-                        showSuccessAlert = true
-                    } else {
-                        Analytics.track(.deviceApproveFailed)
-                        showFailureAlert = true
-                    }
-                }
-            } else {
-                Analytics.track(.deviceSetupAccountTapped)
-                model.presentAccountFlow()
-            }
+            model.actionButtonTapped(userCode: userCode)
         } label: {
             Text(model.isUserLoggedIn ? L10n.deviceApproveConnectButton : L10n.setupAccount)
                 .textStyle(RoundedButton())

--- a/podcasts/DeviceApprove/DeviceApproveView.swift
+++ b/podcasts/DeviceApprove/DeviceApproveView.swift
@@ -159,16 +159,11 @@ struct DeviceApproveView: View {
             if model.isUserLoggedIn {
                 Task {
                     Analytics.track(.deviceApproveConnectTapped)
-                    do {
-                        let result = try await AuthenticationHelper.deviceApprove(userCode: userCode, approve: true)
-                        if result.success {
-                            Analytics.track(.deviceApproveSuccessfull)
-                            showSuccessAlert = true
-                        } else {
-                            Analytics.track(.deviceApproveFailed)
-                            showFailureAlert = true
-                        }
-                    } catch {
+                    let result = try? await AuthenticationHelper.deviceApprove(userCode: userCode, approve: true)
+                    if result?.success == true {
+                        Analytics.track(.deviceApproveSuccessfull)
+                        showSuccessAlert = true
+                    } else {
                         Analytics.track(.deviceApproveFailed)
                         showFailureAlert = true
                     }

--- a/podcasts/DeviceApprove/DeviceApproveView.swift
+++ b/podcasts/DeviceApprove/DeviceApproveView.swift
@@ -50,13 +50,15 @@ struct DeviceApproveView: View {
             logos
             title
             description
-            accountCard
-            accountFlowLink
             if model.isUserLoggedIn {
+                accountCard
                 codeField
             }
             Spacer()
             actionButton
+        }
+        .overlay(alignment: .topTrailing) {
+            closeButton
         }
         .padding()
         .onAppear() {
@@ -91,15 +93,15 @@ struct DeviceApproveView: View {
     }
 
     private var description: some View {
-        Text(L10n.deviceApproveDescription)
+        Text(model.isUserLoggedIn ? L10n.deviceApproveDescription : L10n.deviceApproveLoginRequired)
             .font(size: 15, style: .caption, weight: .regular)
             .multilineTextAlignment(.center)
             .foregroundStyle(theme.primaryText02)
     }
 
+    @ViewBuilder
     private var accountCard: some View {
         HStack(alignment: .center, spacing: 16) {
-            if model.isUserLoggedIn {
                 ProfileImage(email: model.email)
                     .frame(width: 48, height: 48)
                     .clipShape(Circle())
@@ -113,12 +115,6 @@ struct DeviceApproveView: View {
                         .multilineTextAlignment(.center)
                         .foregroundStyle(theme.primaryText01)
                 }
-            } else {
-                Text(L10n.deviceApproveLoginRequired)
-                    .font(size: 15, style: .caption, weight: .regular)
-                    .multilineTextAlignment(.leading)
-                    .foregroundStyle(theme.primaryText02)
-            }
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -129,19 +125,6 @@ struct DeviceApproveView: View {
                 .inset(by: 0.5)
                 .stroke(theme.primaryUi05, lineWidth: 1)
         )
-    }
-
-    @ViewBuilder
-    private var accountFlowLink: some View {
-        if !model.isUserLoggedIn {
-            Button {
-                model.presentAccountFlow()
-            } label: {
-                Text(L10n.setupAccount)
-                    .font(.system(size: 15, weight: .regular))
-                    .foregroundStyle(theme.primaryInteractive01)
-            }
-        }
     }
 
     private var codeField: some View {
@@ -174,13 +157,30 @@ struct DeviceApproveView: View {
                     }
                 }
             } else {
-                dismiss()
-                Analytics.track(.deviceApproveDismissed)
+                Analytics.track(.deviceSetupAccountTapped)
+                model.presentAccountFlow()
             }
         } label: {
-            Text(model.isUserLoggedIn ? L10n.deviceApproveConnectButton : L10n.close)
+            Text(model.isUserLoggedIn ? L10n.deviceApproveConnectButton : L10n.setupAccount)
                 .textStyle(RoundedButton())
         }
+    }
+
+    private var closeButton: some View {
+        Button() {
+            Analytics.track(.deviceApproveDismissed)
+            dismiss()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(theme.primaryUi01)
+                .frame(width: 32, height: 32)
+                .background(theme.primaryInteractive01)
+                .clipShape(Circle())
+        }
+        .accessibilityLabel(L10n.close)
+        .padding(.top, 16)
+        .padding(.trailing, 16)
     }
 }
 

--- a/podcasts/DeviceApprove/DeviceApproveView.swift
+++ b/podcasts/DeviceApprove/DeviceApproveView.swift
@@ -61,7 +61,7 @@ struct DeviceApproveView: View {
             Spacer()
             actionButton
         }
-        .overlay(alignment: .topTrailing) {
+        .overlay(alignment: .topLeading) {
             closeButton
         }
         .padding()
@@ -193,7 +193,7 @@ struct DeviceApproveView: View {
         }
         .accessibilityLabel(L10n.close)
         .padding(.top, 16)
-        .padding(.trailing, 16)
+        .padding(.leading, 16)
     }
 }
 

--- a/podcasts/DeviceApprove/DeviceApproveView.swift
+++ b/podcasts/DeviceApprove/DeviceApproveView.swift
@@ -225,7 +225,6 @@ struct DeviceApproveView: View {
                     content
                         .foregroundStyle(theme.primaryText01)
                 }
-
         }
         .glassStyle()
         .accessibilityLabel(L10n.close)

--- a/podcasts/DeviceApprove/DeviceApproveView.swift
+++ b/podcasts/DeviceApprove/DeviceApproveView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PocketCastsServer
+import PocketCastsUtils
 
 class DeviceApproveViewModel: ObservableObject {
 
@@ -12,8 +13,8 @@ class DeviceApproveViewModel: ObservableObject {
     }
 
     func presentAccountFlow() {
-        let controller = OnboardingFlow.shared.begin(flow: .none, source: .onboarding, accountCreated: { created in
-            print("Account created:\(created)")
+        let controller = OnboardingFlow.shared.begin(flow: .deviceApproval, source: .deviceApproval, accountCreated: { created in
+            FileLog.shared.addMessage("Account created:\(created)")
         })
         let baseVC = presentingViewController.presentedViewController ?? presentingViewController
         baseVC.present(controller, animated: true)
@@ -37,6 +38,8 @@ struct DeviceApproveView: View {
     @StateObject private var model: DeviceApproveViewModel
 
     @State private var showFailureAlert: Bool = false
+
+    @State private var showSuccessAlert: Bool = false
 
     init(userCode: String?, model: DeviceApproveViewModel) {
         _userCode = State(initialValue: userCode ?? "")
@@ -70,6 +73,13 @@ struct DeviceApproveView: View {
             }
         } message: {
             Text(L10n.deviceApproveExpiredAlertMessage)
+        }
+        .alert(L10n.deviceApproveSuccessAlertTitle, isPresented: $showSuccessAlert) {
+            Button(L10n.ok, role: .cancel) {
+                dismiss()
+            }
+        } message: {
+            Text(L10n.deviceApproveSuccessAlertMessage)
         }
     }
 
@@ -149,10 +159,17 @@ struct DeviceApproveView: View {
             if model.isUserLoggedIn {
                 Task {
                     Analytics.track(.deviceApproveConnectTapped)
-                    let result = try await AuthenticationHelper.deviceApprove(userCode: userCode, approve: true)
-                    if result.success {
-                        dismiss()
-                    } else {
+                    do {
+                        let result = try await AuthenticationHelper.deviceApprove(userCode: userCode, approve: true)
+                        if result.success {
+                            Analytics.track(.deviceApproveSuccessfull)
+                            showSuccessAlert = true
+                        } else {
+                            Analytics.track(.deviceApproveFailed)
+                            showFailureAlert = true
+                        }
+                    } catch {
+                        Analytics.track(.deviceApproveFailed)
                         showFailureAlert = true
                     }
                 }

--- a/podcasts/DeviceApprove/DeviceApproveView.swift
+++ b/podcasts/DeviceApprove/DeviceApproveView.swift
@@ -161,7 +161,7 @@ struct DeviceApproveView: View {
                     Analytics.track(.deviceApproveConnectTapped)
                     let result = try? await AuthenticationHelper.deviceApprove(userCode: userCode, approve: true)
                     if result?.success == true {
-                        Analytics.track(.deviceApproveSuccessfull)
+                        Analytics.track(.deviceApproveSuccessful)
                         showSuccessAlert = true
                     } else {
                         Analytics.track(.deviceApproveFailed)

--- a/podcasts/DeviceApprove/DeviceApproveView.swift
+++ b/podcasts/DeviceApprove/DeviceApproveView.swift
@@ -93,8 +93,10 @@ struct DeviceApproveView: View {
             Spacer()
                 .frame(height: 100)
             logos
-            title
-            description
+            VStack(spacing: 8) {
+                title
+                description
+            }
             if model.isUserLoggedIn {
                 accountCard
                 codeField
@@ -210,17 +212,54 @@ struct DeviceApproveView: View {
             Analytics.track(.deviceApproveDismissed)
             dismiss()
         } label: {
-            Image(systemName: "xmark")
+            Image("close")
                 .font(.system(size: 14, weight: .bold))
-                .foregroundStyle(theme.primaryUi01)
-                .frame(width: 32, height: 32)
-                .background(theme.primaryInteractive01)
-                .clipShape(Circle())
+                .frame(width: 44, height: 44)
+                .if(!isiOS26) { content in
+                    content
+                        .foregroundStyle(theme.primaryUi01)
+                        .background(theme.primaryInteractive01)
+                        .clipShape(Circle())
+                }
+                .if(isiOS26) { content in
+                    content
+                        .foregroundStyle(theme.primaryText01)
+                }
+
         }
+        .glassStyle()
         .accessibilityLabel(L10n.close)
         .padding(.top, 16)
         .padding(.leading, 16)
     }
+
+    var isiOS26: Bool {
+        if #available(iOS 26.0, *) {
+            return true
+        } else {
+            return false
+        }
+    }
+}
+
+struct GlassButtonModifier: ViewModifier {
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .buttonStyle(.plain)
+                .glassEffect(.regular.interactive(), in: .circle)
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    func glassStyle()
+    -> some View {
+        modifier(GlassButtonModifier())
+  }
 }
 
 private struct CircleLogo: View {
@@ -251,5 +290,5 @@ private struct CircleLogo: View {
 
 #Preview {
     DeviceApproveView(userCode: "12345", model: DeviceApproveViewModel(presentingViewController: UIViewController()))
-        .environmentObject(Theme(previewTheme: .light))
+        .environmentObject(Theme(previewTheme: .dark))
 }

--- a/podcasts/DeviceApprove/DeviceApproveView.swift
+++ b/podcasts/DeviceApprove/DeviceApproveView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsServer
 import PocketCastsUtils
+import UIKit
 
 class DeviceApproveViewModel: ObservableObject {
 

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -596,7 +596,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
     func showApproveDevice(code: String?) {
         guard let controller = view.window?.rootViewController else { return }
-        let vc = ThemedHostingController(rootView: DeviceApproveView(userCode: code))
+        let vc = ThemedHostingController(rootView: DeviceApproveView(userCode: code, model: DeviceApproveViewModel(presentingViewController: controller)))
         controller.present(vc, animated: true)
     }
 

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -172,6 +172,9 @@ struct OnboardingFlow: AnalyticsSourceProvider {
 
         case encourageAccountCreation = "encourage_account_creation"
 
+        /// When approving a tv device login
+        case deviceApproval = "device_approval"
+
         var analyticsDescription: String { rawValue }
 
         /// If after a successful sign in or sign up the onboarding flow

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6377,4 +6377,5 @@
 /* Message of the alert shown when the Apple TV has been successfully connected to the user's account. */
 "device_approve_success_alert_message" = "Your Apple TV is now connected to your account.";
 
-
+/* Title of the alert shown when approval failed. */
+"device_approve_generic_error_alert_title" = "Device approval failed";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6371,4 +6371,10 @@
 /* Message of the alert shown when the pairing code has expired, telling the user to generate a new code on their TV. */
 "device_approve_expired_alert_message" = "Please go back to your TV to generate a new one.";
 
+/* Title of the alert shown when the Apple TV has been successfully connected to the user's account. */
+"device_approve_success_alert_title" = "Apple TV connected";
+
+/* Message of the alert shown when the Apple TV has been successfully connected to the user's account. */
+"device_approve_success_alert_message" = "Your Apple TV is now connected to your account.";
+
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-729](https://linear.app/a8c/issue/PCIOS-729/allow-create-account-on-pairing) <!-- issue number, if applicable -->

https://github.com/user-attachments/assets/973b8ec7-c37e-46c7-94fb-72b5b9eea22e


This PR builds out the "Connect to Apple TV" device-approval flow so it works for both signed-in and signed-out users:

- **Account creation for signed-out users**: the action button now launches the onboarding flow using a dedicated `.deviceApproval` flow/source (added to `OnboardingFlow.Flow` and `PlusUpgradeViewSource`) instead of the placeholder `.none`/`.onboarding`, and logs via `FileLog` rather than `print`.
- **Success & failure feedback**: after tapping Connect, the user now sees a success alert ("Apple TV connected") or a failure alert, including when the request throws. New analytics events `deviceApproveSuccessfull` and `deviceApproveFailed` are tracked.
- **Localization**: the success alert title/message are now localized (`device_approve_success_alert_title` / `device_approve_success_alert_message`) — previously a hardcoded string.
- **Wiring**: `DeviceApproveView` now takes a `DeviceApproveViewModel`, so the entry points in `MainTabBarController` and the developer menu pass a presenting view controller.

## To test

1. Build and run the staging app while **signed out**.
2. Open the Developer Menu → **TV** section → tap the device approval entry (or trigger the approval deep link).
3. Confirm the screen shows the "login required" copy and the button reads **Set up Account**; tap it and confirm the onboarding/account-creation flow appears.
4. Sign in to an account, then re-open the device approval screen.
5. Confirm it shows your account card and a code field; enter a valid 6-character code and tap **Connect**.
6. Confirm a success alert ("Apple TV connected") appears; tapping OK dismisses the screen.
7. Enter an invalid/expired code and tap **Connect**; confirm the failure alert appears.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
