### PR TITLE
[PC TV] Show create account when acting on empty screens without an account

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -4,6 +4,7 @@ import PocketCastsDataModel
 struct PlaylistsView: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
+    @Environment(\.requireAccount) private var requireAccount
 
     @State private var model = PlaylistsViewModel()
     @State private var didTrackShown = false
@@ -52,7 +53,7 @@ struct PlaylistsView: View {
 
     var emptyView: some View {
         EmptyDataView(title: L10n.tvPlaylistsEmptyTitle, subtitle: L10n.tvPlaylistsEmptySubtitle, actionTitle: L10n.tvPlaylistsEmptyActionTitle) {
-            tabRouter.selectedTab = .home
+            requireAccount { tabRouter.selectedTab = .home }
         }
     }
 

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -8,6 +8,7 @@ fileprivate enum Layout {
 struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
+    @Environment(\.requireAccount) private var requireAccount
 
     @State private var model: ViewModel
 
@@ -59,7 +60,7 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
 
     var emptyView: some View {
         EmptyDataView(title: L10n.tvPodcastsEmptyTitle, subtitle: L10n.tvPodcastsEmptySubtitle, actionTitle: L10n.tvPodcastsEmptyActionTitle) {
-            tabRouter.selectedTab = .home
+            requireAccount { tabRouter.selectedTab = .home }
         }
     }
 

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct UpNextView: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
+    @Environment(\.requireAccount) private var requireAccount
 
     @State private var model = UpNextViewModel()
 
@@ -60,7 +61,7 @@ struct UpNextView: View {
 
     var emptyView: some View {
         EmptyDataView(title: L10n.tvUpNextEmptyTitle, subtitle: L10n.tvUpNextEmptySubtitle, actionTitle: L10n.tvUpNextEmptyActionTitle) {
-            tabRouter.selectedTab = .home
+            requireAccount { tabRouter.selectedTab = .home }
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-731](https://linear.app/a8c/issue/PCIOS-731/for-signed-out-state-show-loginsign-flows-on-podcasts-and-playlists) <!-- issue number, if applicable -->

On the TV app, the empty-state views for **Podcasts**, **Playlists**, and **Up Next** offer an action that navigates the user to the Home tab. Previously this action ran unconditionally, even for users without an account.

This PR wraps the empty-screen action in the existing `requireAccount { … }` gate so that a logged-out user is first prompted to create an account before the navigation runs — matching the behaviour already used elsewhere in the TV app (e.g. `PodcastDetailView`, `EpisodeRow`).

## To test

1. Launch the TV app while **not** signed in to an account.
2. Open the **Podcasts** tab while it is empty and trigger the empty-state action.
3. Confirm the create-account flow is presented instead of navigating straight to Home.
4. Repeat for the **Playlists** and **Up Next** empty screens.
5. Sign in to an account and confirm the empty-state action navigates to Home as before, without prompting.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.