### PR TITLE
Update Automattic-Tracks-iOS to 4.3.0

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9432273f1581b26f58e9b33ef1f1ef4c2a45f288df5ddc2d6346db54e774597d",
+  "originHash" : "db741593a59d57d398e6bc2a2e7a6494331bf6b834530d25257eeca52aaa9856",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -42,7 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "revision" : "5b648ab79fc1857d4a8fecc78b73505c2be6fbdd"
+        "revision" : "5b648ab79fc1857d4a8fecc78b73505c2be6fbdd",
+        "version" : "4.3.0"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -42,7 +42,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Automattic-Tracks-iOS",
       "state" : {
-        "revision" : "8e889c30cd8234d5809966f25fd61abbb10d345e"
+        "revision" : "5b648ab79fc1857d4a8fecc78b73505c2be6fbdd"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/ra1028/DifferenceKit", from: "1.2.0"),
         .package(url: "https://github.com/krisk/fuse-swift", from: "1.4.0"),
         .package(url: "https://github.com/shiftyjelly/SwipeCellKit", from: "2.7.6"),
-        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS", revision: "8e889c30cd8234d5809966f25fd61abbb10d345e"),
+        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS", revision: "5b648ab79fc1857d4a8fecc78b73505c2be6fbdd"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.23.0"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", from: "7.1.0"),
         .package(url: "https://github.com/Automattic/Agrume", from: "5.6.12"),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/ra1028/DifferenceKit", from: "1.2.0"),
         .package(url: "https://github.com/krisk/fuse-swift", from: "1.4.0"),
         .package(url: "https://github.com/shiftyjelly/SwipeCellKit", from: "2.7.6"),
-        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS", revision: "5b648ab79fc1857d4a8fecc78b73505c2be6fbdd"),
+        .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS", exact: "4.3.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.23.0"),
         .package(url: "https://github.com/google/GoogleSignIn-iOS", from: "7.1.0"),
         .package(url: "https://github.com/Automattic/Agrume", from: "5.6.12"),


### PR DESCRIPTION
Bumps `Automattic-Tracks-iOS` from an untagged trunk revision (`8e889c3`) to the [`4.3.0`](https://github.com/Automattic/Automattic-Tracks-iOS/releases/tag/4.3.0) release tag.

<details>
<summary>AI-generated details</summary>

Bumps `Automattic-Tracks-iOS` from an untagged trunk revision (`8e889c3`) to the [`4.3.0`](https://github.com/Automattic/Automattic-Tracks-iOS/releases/tag/4.3.0) release tag, pinning the consumer to a shipped version rather than a moving commit.

What 4.3.0 adds over the previously pinned revision:

- Track Lockdown Mode status as a device property
- Store the Tracks Core Data DB in Caches on tvOS

No API changes — the bump is additive.
</details>

## To test

Green CI.

## Checklist

- [x] I have considered if this change warrants user-facing release notes — N.A.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

