### PR TITLE
PCIOS-732: iOS CarPlay: Apple Maps voice guidance repeatedly pauses playback (even when guidance volume is zero)

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -319,6 +319,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the Share Profile feature
     case shareProfile
 
+    /// Rewind ~1s on auto-resume after an audio interruption (e.g. CarPlay nav prompts)
+    case rewindOnResumeAfterInterruption
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -535,6 +538,8 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .shareProfile:
             BuildEnvironment.current == .debug
+        case .rewindOnResumeAfterInterruption:
+            true
         }
     }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2104,7 +2104,14 @@ class PlaybackManager: ServerPlaybackDelegate {
             let interruptionOption = userInfo[AVAudioSessionInterruptionOptionKey] as! NSNumber
             FileLog.shared.addMessage("PlaybackManager handleAudioInterrupt ended, should attempt to restart audio: \(interruptionOption) reason: \(interruptionReason?.description ?? "unknown")")
             if interruptionOption.uintValue == AVAudioSession.InterruptionOptions.shouldResume.rawValue, wasPlayingBeforeInterruption {
-                play(userInitiated: false)
+                if FeatureFlag.rewindOnResumeAfterInterruption.enabled {
+                    let rewindInterval: TimeInterval = 1.0
+                    let resumeTime = max(0, currentTime() - rewindInterval)
+                    FileLog.shared.addMessage("PlaybackManager rewinding \(rewindInterval)s before resuming after interruption (from \(currentTime()) to \(resumeTime))")
+                    seekTo(time: resumeTime, startPlaybackAfterSeek: true)
+                } else {
+                    play(userInitiated: false)
+                }
                 wasPlayingBeforeInterruption = false
             }
         } else if interruptionType.uintValue == AVAudioSession.InterruptionType.began.rawValue {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-732/ios-carplay-apple-maps-voice-guidance-repeatedly-pauses-playback-even

## Summary
When CarPlay navigation apps (Apple Maps, Waze) fire audio interruptions for turn-by-turn prompts, Pocket Casts resumes playback from the exact pause point — losing ~1-2 seconds of audio each time. This happens even when the nav app's guidance volume is zero, since iOS fires the interruption when the nav app activates its audio session, regardless of volume.

This PR adds a ~1s rewind ("smart resume") before auto-resuming after an audio interruption, matching the behavior of Apple Podcasts and Overcast.

## Changes
- Added `FeatureFlag.rewindOnResumeAfterInterruption` (defaults to `true`) so the behavior can be remotely toggled
- Modified `PlaybackManager.handleAudioInterruption` to seek back 1 second before resuming when an interruption ends with `.shouldResume`, using `seekTo(time:startPlaybackAfterSeek:)` instead of a plain `play()`

## Verification
- **Lint**: PASS
- **Tests**: FAIL — pre-existing build failure in CarPlay files due to iOS 26 SDK changes, unrelated to this PR
- **Diff review**: PASS — only two files changed, scoped to the fix
- **Secret scan**: PASS

## Confidence
**MEDIUM** — The code change is straightforward and follows existing patterns, but full verification requires on-device CarPlay testing which cannot be done in CI. The fix is flag-gated so it can be remotely disabled if any issues arise.

## Known Issues
- Tests fail to build due to pre-existing CarPlay API incompatibility with iOS 26 SDK. Unrelated to this PR.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/PCIOS-732/ios-carplay-apple-maps-voice-guidance-repeatedly-pauses-playback-even)