### PR TITLE
[PC TV] Add context menus for episodes

### DIFF
--- a/Pocket Casts TV App/Data/TVDataManager.swift
+++ b/Pocket Casts TV App/Data/TVDataManager.swift
@@ -70,10 +70,18 @@ class TVDataManager {
         return await playEpisode(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
     }
 
-    func playEpisode(podcastUuid: String, episodeUuid: String) async -> Bool {
-        _ = await loadPodcast(podcastUuid: podcastUuid)
+    func loadEpisode(podcastUuid: String, episodeUuid: String) async -> (episode: Episode, podcast: Podcast?)? {
+        let podcast = await loadPodcast(podcastUuid: podcastUuid)
 
         guard let episode = dataManager.findEpisode(uuid: episodeUuid) else {
+            return nil
+        }
+
+        return (episode, podcast)
+    }
+
+    func playEpisode(podcastUuid: String, episodeUuid: String) async -> Bool {
+        guard let (episode, _) = await loadEpisode(podcastUuid: podcastUuid, episodeUuid: episodeUuid) else {
             return false
         }
 

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -10,7 +10,7 @@ struct DiscoverVideoEpisodeCell: View {
     @Environment(FocusStore.self) var focusStore
 
     @State private var model: DiscoverVideoEpisodeModel
-    @State private var actionsModel: DiscoveryEpisodeActionsModel
+    @State private var showNotesEpisode: DiscoveryLoadedEpisode?
 
     private let listId: String?
     private let source: String
@@ -37,7 +37,6 @@ struct DiscoverVideoEpisodeCell: View {
 
     init(episode: DiscoverEpisode, listId: String? = nil, source: String = "") {
         _model = State(wrappedValue: DiscoverVideoEpisodeModel(episode: episode))
-        _actionsModel = State(wrappedValue: DiscoveryEpisodeActionsModel(podcastUuid: episode.podcastUuid ?? "", episodeUuid: episode.uuid ?? ""))
         self.listId = listId
         self.source = source
     }
@@ -80,7 +79,7 @@ struct DiscoverVideoEpisodeCell: View {
             NowPlayingView()
                 .ignoresSafeArea()
         }
-        .sheet(item: $actionsModel.showNotesEpisode) { episode in
+        .sheet(item: $showNotesEpisode) { episode in
             EpisodeShowNotesView(episode: episode.episode, podcast: episode.podcast)
         }
     }
@@ -148,7 +147,7 @@ struct DiscoverVideoEpisodeCell: View {
             .focused($focusedButton, equals: FocusValues.playEpisode)
             .setFocus(section: DiscoverType.video.rawValue)
             .contextMenu {
-                DiscoveryEpisodeMenuButtons(model: actionsModel)
+                DiscoveryEpisodeMenuButtons(podcastUuid: model.episode.podcastUuid ?? "", episodeUuid: model.episode.uuid ?? "", showNotesEpisode: $showNotesEpisode)
             }
             if let podcast = model.podcast {
                 NavigationLink(value: podcast) {

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -10,6 +10,7 @@ struct DiscoverVideoEpisodeCell: View {
     @Environment(FocusStore.self) var focusStore
 
     @State private var model: DiscoverVideoEpisodeModel
+    @State private var actionsModel: DiscoveryEpisodeActionsModel
 
     private let listId: String?
     private let source: String
@@ -36,6 +37,7 @@ struct DiscoverVideoEpisodeCell: View {
 
     init(episode: DiscoverEpisode, listId: String? = nil, source: String = "") {
         _model = State(wrappedValue: DiscoverVideoEpisodeModel(episode: episode))
+        _actionsModel = State(wrappedValue: DiscoveryEpisodeActionsModel(podcastUuid: episode.podcastUuid ?? "", episodeUuid: episode.uuid ?? ""))
         self.listId = listId
         self.source = source
     }
@@ -77,6 +79,9 @@ struct DiscoverVideoEpisodeCell: View {
         .fullScreenCover(isPresented: $showNowPlayingPlayer) {
             NowPlayingView()
                 .ignoresSafeArea()
+        }
+        .sheet(item: $actionsModel.showNotesEpisode) { episode in
+            EpisodeShowNotesView(episode: episode.episode, podcast: episode.podcast)
         }
     }
 
@@ -142,6 +147,9 @@ struct DiscoverVideoEpisodeCell: View {
             }
             .focused($focusedButton, equals: FocusValues.playEpisode)
             .setFocus(section: DiscoverType.video.rawValue)
+            .contextMenu {
+                DiscoveryEpisodeMenuButtons(model: actionsModel)
+            }
             if let podcast = model.podcast {
                 NavigationLink(value: podcast) {
                     Text(L10n.tvDiscoverFeaturedGoToPodcast)

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -182,6 +182,7 @@ struct HomeView: View {
             EpisodeRow(model: model, isActive: false)
         }
         .buttonStyle(EpisodeRowButtonStyle())
+        .episodeContextMenu(model: model, context: .upNext)
     }
 
     var newReleasesRow: some View {

--- a/Pocket Casts TV App/UI/Player/EpisodePlayerButton.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodePlayerButton.swift
@@ -12,6 +12,7 @@ struct EpisodePlayerButton: View {
             EpisodeRow(model: model, isActive: false)
         }
         .buttonStyle(EpisodeRowButtonStyle())
+        .episodeContextMenu(model: model)
         .fullScreenCover(isPresented: $isPlaying) {
             NowPlayingView()
                 .ignoresSafeArea()

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -16,6 +16,7 @@ struct NowPlayingRow: View {
             NowPlayingRowLabel(model: model)
         }
         .buttonStyle(EpisodeRowButtonStyle())
+        .episodeContextMenu(model: model)
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -142,9 +142,6 @@ struct EpisodeRowWithActions: View {
             }
             .buttonStyle(EpisodeRowButtonStyle())
             .focused($focusedElement, equals: .episode)
-            .contextMenu {
-                EpisodeActionButtons(model: model, context: context, isShowingShowNotes: $isShowingShowNotes)
-            }
 
             if shouldShowMoreButton {
                 Button {
@@ -157,6 +154,9 @@ struct EpisodeRowWithActions: View {
                 .focused($focusedElement, equals: .more)
                 .transition(.opacity.combined(with: .scale(scale: 0.8)).animation(.easeOut(duration: 0.2).delay(0.15)))
             }
+        }
+        .contextMenu {
+            EpisodeActionButtons(model: model, context: context, isShowingShowNotes: $isShowingShowNotes)
         }
         .if(isFocused) { content in
             content.clipShape(RoundedRectangle(cornerRadius: 12))
@@ -244,75 +244,54 @@ extension View {
     }
 }
 
-@MainActor
-@Observable
-final class DiscoveryEpisodeActionsModel {
-
-    private let podcastUuid: String
-    private let episodeUuid: String
-    private let dataManager: TVDataManager
-
-    var showNotesEpisode: EpisodeRowViewModel?
-
-    private var loaded: EpisodeRowViewModel?
-
-    init(podcastUuid: String, episodeUuid: String, dataManager: TVDataManager = .shared) {
-        self.podcastUuid = podcastUuid
-        self.episodeUuid = episodeUuid
-        self.dataManager = dataManager
-    }
-
-    private func loadModel() async -> EpisodeRowViewModel? {
-        if let loaded { return loaded }
-        guard let result = await dataManager.loadEpisode(podcastUuid: podcastUuid, episodeUuid: episodeUuid) else {
-            ToastManager.shared.show(L10n.playbackFailed)
-            return nil
-        }
-        let model = EpisodeRowViewModel(episode: result.episode, podcast: result.podcast)
-        loaded = model
-        return model
-    }
-
-    func playNext() {
-        Task { await loadModel()?.playNext() }
-    }
-
-    func playLast() {
-        Task { await loadModel()?.playLast() }
-    }
-
-    func showNotes() {
-        Task { showNotesEpisode = await loadModel() }
-    }
+/// An episode loaded from its UUIDs, ready to act on or present show notes for.
+struct DiscoveryLoadedEpisode: Identifiable {
+    let episode: Episode
+    let podcast: Podcast?
+    var id: String { episode.uuid }
 }
 
+/// Context menu for episodes known only by their UUIDs (Discover, Search). The
+/// `Episode` is loaded lazily the first time an action runs; show notes are
+/// surfaced through `showNotesEpisode` so the presenting view owns the sheet.
 struct DiscoveryEpisodeMenuButtons: View {
 
-    let model: DiscoveryEpisodeActionsModel
+    let podcastUuid: String
+    let episodeUuid: String
+    @Binding var showNotesEpisode: DiscoveryLoadedEpisode?
 
     @Environment(\.requireAccount) private var requireAccount
 
     var body: some View {
-        Button(L10n.tvEpisodeShowNotesAction) { model.showNotes() }
-        Button(L10n.playNextInUpNext) { requireAccount { model.playNext() } }
-        Button(L10n.playLastInUpNext) { requireAccount { model.playLast() } }
+        Button(L10n.tvEpisodeShowNotesAction) { load { showNotesEpisode = $0 } }
+        Button(L10n.playNextInUpNext) { requireAccount { load { EpisodeUpNextActions.playNext($0.episode) } } }
+        Button(L10n.playLastInUpNext) { requireAccount { load { EpisodeUpNextActions.playLast($0.episode) } } }
+    }
+
+    private func load(_ action: @escaping (DiscoveryLoadedEpisode) -> Void) {
+        Task {
+            guard let result = await TVDataManager.shared.loadEpisode(podcastUuid: podcastUuid, episodeUuid: episodeUuid) else {
+                ToastManager.shared.show(L10n.playbackFailed)
+                return
+            }
+            action(DiscoveryLoadedEpisode(episode: result.episode, podcast: result.podcast))
+        }
     }
 }
 
 private struct DiscoveryEpisodeContextMenuModifier: ViewModifier {
 
-    @State private var model: DiscoveryEpisodeActionsModel
+    let podcastUuid: String
+    let episodeUuid: String
 
-    init(podcastUuid: String, episodeUuid: String) {
-        _model = State(initialValue: DiscoveryEpisodeActionsModel(podcastUuid: podcastUuid, episodeUuid: episodeUuid))
-    }
+    @State private var showNotesEpisode: DiscoveryLoadedEpisode?
 
     func body(content: Content) -> some View {
         content
             .contextMenu {
-                DiscoveryEpisodeMenuButtons(model: model)
+                DiscoveryEpisodeMenuButtons(podcastUuid: podcastUuid, episodeUuid: episodeUuid, showNotesEpisode: $showNotesEpisode)
             }
-            .sheet(item: $model.showNotesEpisode) { episode in
+            .sheet(item: $showNotesEpisode) { episode in
                 EpisodeShowNotesView(episode: episode.episode, podcast: episode.podcast)
             }
     }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -98,15 +98,9 @@ struct MoreButtonStyle: ButtonStyle {
 
 struct EpisodeRowWithActions: View {
 
-    enum Context {
-        case `default`
-        case upNext
-    }
-
     let model: EpisodeRowViewModel
-    var context: Context = .default
+    var context: EpisodeActionContext = .default
 
-    @Environment(\.requireAccount) private var requireAccount
     @FocusState private var focusedElement: FocusElement?
     @State private var isPlaying = false
     @State private var isShowingActions = false
@@ -130,26 +124,6 @@ struct EpisodeRowWithActions: View {
         focusedElement == .episode
     }
 
-    @ViewBuilder
-    private var actionButtons: some View {
-        if model.podcastUuid != nil {
-            Button(L10n.tvEpisodeShowNotesAction) { isShowingShowNotes = true }
-        }
-        switch context {
-        case .default:
-            Button(L10n.playNextInUpNext) { requireAccount { model.playNext() } }
-            Button(L10n.playLastInUpNext) { requireAccount { model.playLast() } }
-            Button(L10n.markPlayed) { requireAccount { model.markAsPlayed() } }
-            if model.canArchive {
-                Button(model.isArchived ? L10n.unarchive : L10n.archive) { requireAccount { model.isArchived ? model.unarchive() : model.archive() } }
-            }
-        case .upNext:
-            Button(L10n.playNext) { requireAccount { model.playNext() } }
-            Button(L10n.playLast) { requireAccount { model.playLast() } }
-            Button(L10n.removeFromUpNext) { model.removeFromUpNext() }
-        }
-    }
-
     @Environment(\.isFocused) private var isFocused: Bool
 
     var body: some View {
@@ -168,6 +142,9 @@ struct EpisodeRowWithActions: View {
             }
             .buttonStyle(EpisodeRowButtonStyle())
             .focused($focusedElement, equals: .episode)
+            .contextMenu {
+                EpisodeActionButtons(model: model, context: context, isShowingShowNotes: $isShowingShowNotes)
+            }
 
             if shouldShowMoreButton {
                 Button {
@@ -205,8 +182,145 @@ struct EpisodeRowWithActions: View {
             EpisodeShowNotesView(episode: model.episode, podcast: model.podcast)
         }
         .confirmationDialog(model.displayTitle, isPresented: $isShowingActions) {
-            actionButtons
+            EpisodeActionButtons(model: model, context: context, isShowingShowNotes: $isShowingShowNotes)
         }
+    }
+}
+
+enum EpisodeActionContext {
+    case `default`
+    case upNext
+}
+
+struct EpisodeActionButtons: View {
+
+    let model: EpisodeRowViewModel
+    var context: EpisodeActionContext = .default
+    @Binding var isShowingShowNotes: Bool
+
+    @Environment(\.requireAccount) private var requireAccount
+
+    var body: some View {
+        if model.podcastUuid != nil {
+            Button(L10n.tvEpisodeShowNotesAction) { isShowingShowNotes = true }
+        }
+        switch context {
+        case .default:
+            Button(L10n.playNextInUpNext) { requireAccount { model.playNext() } }
+            Button(L10n.playLastInUpNext) { requireAccount { model.playLast() } }
+            Button(L10n.markPlayed) { requireAccount { model.markAsPlayed() } }
+            if model.canArchive {
+                Button(model.isArchived ? L10n.unarchive : L10n.archive) { requireAccount { model.isArchived ? model.unarchive() : model.archive() } }
+            }
+        case .upNext:
+            Button(L10n.playNext) { requireAccount { model.playNext() } }
+            Button(L10n.playLast) { requireAccount { model.playLast() } }
+            Button(L10n.removeFromUpNext) { model.removeFromUpNext() }
+        }
+    }
+}
+
+private struct EpisodeContextMenuModifier: ViewModifier {
+
+    let model: EpisodeRowViewModel
+    var context: EpisodeActionContext
+
+    @State private var isShowingShowNotes = false
+
+    func body(content: Content) -> some View {
+        content
+            .contextMenu {
+                EpisodeActionButtons(model: model, context: context, isShowingShowNotes: $isShowingShowNotes)
+            }
+            .sheet(isPresented: $isShowingShowNotes) {
+                EpisodeShowNotesView(episode: model.episode, podcast: model.podcast)
+            }
+    }
+}
+
+extension View {
+    func episodeContextMenu(model: EpisodeRowViewModel, context: EpisodeActionContext = .default) -> some View {
+        modifier(EpisodeContextMenuModifier(model: model, context: context))
+    }
+}
+
+@MainActor
+@Observable
+final class DiscoveryEpisodeActionsModel {
+
+    private let podcastUuid: String
+    private let episodeUuid: String
+    private let dataManager: TVDataManager
+
+    var showNotesEpisode: EpisodeRowViewModel?
+
+    private var loaded: EpisodeRowViewModel?
+
+    init(podcastUuid: String, episodeUuid: String, dataManager: TVDataManager = .shared) {
+        self.podcastUuid = podcastUuid
+        self.episodeUuid = episodeUuid
+        self.dataManager = dataManager
+    }
+
+    private func loadModel() async -> EpisodeRowViewModel? {
+        if let loaded { return loaded }
+        guard let result = await dataManager.loadEpisode(podcastUuid: podcastUuid, episodeUuid: episodeUuid) else {
+            ToastManager.shared.show(L10n.playbackFailed)
+            return nil
+        }
+        let model = EpisodeRowViewModel(episode: result.episode, podcast: result.podcast)
+        loaded = model
+        return model
+    }
+
+    func playNext() {
+        Task { await loadModel()?.playNext() }
+    }
+
+    func playLast() {
+        Task { await loadModel()?.playLast() }
+    }
+
+    func showNotes() {
+        Task { showNotesEpisode = await loadModel() }
+    }
+}
+
+struct DiscoveryEpisodeMenuButtons: View {
+
+    let model: DiscoveryEpisodeActionsModel
+
+    @Environment(\.requireAccount) private var requireAccount
+
+    var body: some View {
+        Button(L10n.tvEpisodeShowNotesAction) { model.showNotes() }
+        Button(L10n.playNextInUpNext) { requireAccount { model.playNext() } }
+        Button(L10n.playLastInUpNext) { requireAccount { model.playLast() } }
+    }
+}
+
+private struct DiscoveryEpisodeContextMenuModifier: ViewModifier {
+
+    @State private var model: DiscoveryEpisodeActionsModel
+
+    init(podcastUuid: String, episodeUuid: String) {
+        _model = State(initialValue: DiscoveryEpisodeActionsModel(podcastUuid: podcastUuid, episodeUuid: episodeUuid))
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .contextMenu {
+                DiscoveryEpisodeMenuButtons(model: model)
+            }
+            .sheet(item: $model.showNotesEpisode) { episode in
+                EpisodeShowNotesView(episode: episode.episode, podcast: episode.podcast)
+            }
+    }
+}
+
+extension View {
+    func discoveryEpisodeContextMenu(podcastUuid: String, episodeUuid: String) -> some View {
+        modifier(DiscoveryEpisodeContextMenuModifier(podcastUuid: podcastUuid, episodeUuid: episodeUuid))
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -83,22 +83,11 @@ class EpisodeRowViewModel: Identifiable {
     }
 
     func playNext() {
-        if playbackManager.inUpNext(episode: episode) {
-            playbackManager.queue.move(episode: episode, to: 0)
-        } else {
-            playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: true, userInitiated: true)
-        }
-        ToastManager.shared.show(L10n.playNextInUpNext)
+        EpisodeUpNextActions.playNext(episode, playbackManager: playbackManager)
     }
 
     func playLast() {
-        if playbackManager.inUpNext(episode: episode) {
-            let queueCount = playbackManager.queue.upNextCount()
-            playbackManager.queue.move(episode: episode, to: max(queueCount - 1, 0))
-        } else {
-            playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: false, userInitiated: true)
-        }
-        ToastManager.shared.show(L10n.playLastInUpNext)
+        EpisodeUpNextActions.playLast(episode, playbackManager: playbackManager)
     }
 
     func markAsPlayed() {
@@ -164,6 +153,29 @@ class EpisodeRowViewModel: Identifiable {
         episode.playedUpTo = currentEpisode.playedUpTo
         episode.duration = currentEpisode.duration
         progress = currentEpisode.playedUpTo / currentEpisode.duration
+    }
+}
+
+/// Up Next queue actions shared by the episode view model and the lazily-loaded
+/// discovery/search context menus, so the move-vs-add queue logic lives in one place.
+enum EpisodeUpNextActions {
+    static func playNext(_ episode: BaseEpisode, playbackManager: PlaybackManager = .shared) {
+        if playbackManager.inUpNext(episode: episode) {
+            playbackManager.queue.move(episode: episode, to: 0)
+        } else {
+            playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: true, userInitiated: true)
+        }
+        ToastManager.shared.show(L10n.playNextInUpNext)
+    }
+
+    static func playLast(_ episode: BaseEpisode, playbackManager: PlaybackManager = .shared) {
+        if playbackManager.inUpNext(episode: episode) {
+            let queueCount = playbackManager.queue.upNextCount()
+            playbackManager.queue.move(episode: episode, to: max(queueCount - 1, 0))
+        } else {
+            playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: false, userInitiated: true)
+        }
+        ToastManager.shared.show(L10n.playLastInUpNext)
     }
 }
 

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -110,6 +110,7 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                         SearchEpisodeRow(model: episode)
                     }
                     .buttonStyle(.card)
+                    .discoveryEpisodeContextMenu(podcastUuid: episode.podcastUuid, episodeUuid: episode.uuid)
                 }
             })
         }


### PR DESCRIPTION
I assume we want these.

Surfaces episode actions as native long-press context menus on every tvOS episode row — Home (Keep Listening, New Releases, Up Next), Podcast Detail, Playlist, Up Next, Starred, History, Search, and Discover. The action list is centralized in one `EpisodeActionButtons` shared with the existing "more" button. Search/Discover rows load the full episode lazily, only when an action runs.

## To test

1. On any episode row (e.g. Home → New Releases, Podcast Detail, Search results), focus an episode and press-and-hold the remote select button.
2. Confirm the context menu appears with Show Notes / Play Next / Play Last (+ Mark as Played / Archive for library episodes).
3. Verify each action works and the show-notes sheet opens.

https://github.com/user-attachments/assets/081bb1b1-3926-47da-b49c-457014c47100


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)