### PR TITLE
Fix incorrect section heading on Watch episode details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 8.15
 -----
 - Tag Ask AI widget tickets for dedicated inbox routing [#4227](https://github.com/Automattic/pocket-casts-ios/pull/4227)
+- Fix incorrect section heading when opening an episode on the Apple Watch [#4528](https://github.com/Automattic/pocket-casts-ios/pull/4528)
 
 8.14
 -----

--- a/Pocket Casts Watch App/UI/Episode Lists/Download List/DownloadListView.swift
+++ b/Pocket Casts Watch App/UI/Episode Lists/Download List/DownloadListView.swift
@@ -5,7 +5,7 @@ struct DownloadListView: View {
     var body: some View {
         ItemListContainer(isEmpty: viewModel.episodes.isEmpty, loading: viewModel.isLoading) {
             List {
-                EpisodeListView(title: L10n.podcastsPlural.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: .downloads)
+                EpisodeListView(title: L10n.downloads.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: .downloads)
             }
         }
         .navigationTitle(L10n.downloads.prefixSourceUnicode)

--- a/Pocket Casts Watch App/UI/Episode Lists/Files List/FilesListView.swift
+++ b/Pocket Casts Watch App/UI/Episode Lists/Files List/FilesListView.swift
@@ -5,13 +5,13 @@ struct FilesListView: View {
     var body: some View {
         ItemListContainer(isEmpty: $viewModel.episodes.isEmpty, loading: viewModel.isLoading) {
             List {
-                EpisodeListView(title: L10n.settingsFiles.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: .files)
+                EpisodeListView(title: L10n.files.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: .files)
                 .withOrderPickerToolbar(selectedOption: viewModel.sortOrder, title: L10n.filesSort, supportsToolbar: viewModel.supportsSort) { option in
                         viewModel.sortOrder = option
                     }
             }
         }
-        .navigationTitle(L10n.settingsFiles.prefixSourceUnicode)
+        .navigationTitle(L10n.files.prefixSourceUnicode)
         .restorable(.files)
         .onAppear {
             viewModel.loadUserEpisodes()

--- a/Pocket Casts Watch App/UI/Episode Lists/Filter EpisodeList/FilterEpisodeListView.swift
+++ b/Pocket Casts Watch App/UI/Episode Lists/Filter EpisodeList/FilterEpisodeListView.swift
@@ -29,7 +29,7 @@ struct FilterEpisodeListView: View {
     var body: some View {
         headerWithContent {
             ItemListContainer(isEmpty: $viewModel.episodes.isEmpty, loading: viewModel.isLoading) {
-                EpisodeListView(title: L10n.settingsFiles.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: .filter(uuid: viewModel.filter.uuid))
+                EpisodeListView(title: L10n.playlists.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: .filter(uuid: viewModel.filter.uuid))
             }
         }
         .navigationTitle(L10n.playlists.prefixSourceUnicode)

--- a/Pocket Casts Watch App/UI/Episode Lists/Up Next/UpNextView.swift
+++ b/Pocket Casts Watch App/UI/Episode Lists/Up Next/UpNextView.swift
@@ -12,7 +12,7 @@ struct UpNextView: View {
         ItemListContainer(isEmpty: viewModel.isEmpty, noItemsTitle: L10n.watchUpNextNoItemsTitle, noItemsSubtitle: L10n.watchUpNextNoItemsSubtitle) {
             List {
                 NowPlayingRow(isPlaying: $viewModel.isPlaying, podcastName: $viewModel.upNextTitle)
-                EpisodeListView(title: L10n.settingsFiles.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: nil)
+                EpisodeListView(title: L10n.upNext.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: nil)
                     .padding(.vertical, 10)
             }
             .listStyle(.plain)


### PR DESCRIPTION
Fixes PCIOS-362

On the Apple Watch app, the heading at the top of an episode's detail screen comes from the `title` each list passes into `EpisodeListView`, which forwards it to `EpisodeView`'s `navigationTitle`. Several lists passed the wrong literal, so episodes opened from a **Playlist**, **Up Next**, or **Downloads** showed an unrelated heading (`Files Settings` or `Podcasts`) instead of the section they came from.

This uses the matching category label for each section, mirroring the existing Podcasts behaviour where the heading acts as a "which section am I in" breadcrumb (e.g. Podcasts > [podcast] > [episode] stays "Podcasts" throughout):

- `FilterEpisodeListView` (Playlists): `L10n.settingsFiles` → `L10n.playlists`
- `UpNextView` (Up Next): `L10n.settingsFiles` → `L10n.upNext`
- `DownloadListView` (Downloads): `L10n.podcastsPlural` → `L10n.downloads`
- `FilesListView` (Files): `L10n.settingsFiles` → `L10n.files`, including the list screen's own title, which had reused the Settings string

No new strings — all four `L10n` keys already exist and are used elsewhere.

## To test

- On the Watch app, open **Playlists** → a playlist → tap an episode
- [x] Verify the heading reads **Playlists** (was "Files Settings")
- Open **Up Next** → tap an episode
- [x] Verify the heading reads **Up Next** (was "Files Settings")
- Open **Downloads** → tap an episode
- [x] Verify the heading reads **Downloads** (was "Podcasts")
- Open **Files** → tap an episode
- [x] Verify both the Files list title and the episode heading read **Files** (was "Files Settings")
- Open **Podcasts** → a podcast → tap an episode
- [x] Confirm the heading still reads **Podcasts** (regression check)

<img width="416" height="496" alt="image" src="https://github.com/user-attachments/assets/bf496de6-bb81-49c7-89c4-073652839212" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes. <!-- String-only UI label change; no logic to unit test. -->
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics. <!-- n/a — no analytics changes. -->
