### PR TITLE
Fix explicit badge on podcast header

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -764,6 +764,7 @@ class PodcastDataManager {
         values.append(podcast.usedCustomEffectsBefore)
         values.append(podcast.isPrivate)
         values.append(DBUtils.nullIfNil(value: podcast.fundingURL))
+        values.append(podcast.isExplicit)
 
         if includeIdForWhere {
             values.append(podcast.id)

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -74,7 +74,8 @@ class PodcastDataManager {
         "folderUuid",
         "usedCustomEffectsBefore",
         "isPrivate",
-        "fundingURL"
+        "fundingURL",
+        "isExplicit"
     ]
 
     func setup(dbQueue: PCDBQueue) {

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Podcast+fromDatabase.swift
@@ -57,6 +57,7 @@ extension Podcast {
         podcast.usedCustomEffectsBefore = rs.bool(forColumn: "usedCustomEffectsBefore")
         podcast.isPrivate = rs.bool(forColumn: "isPrivate")
         podcast.fundingURL = rs.string(forColumn: "fundingURL")
+        podcast.isExplicit = rs.bool(forColumn: "isExplicit")
 
         return podcast
     }

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -532,7 +532,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .liquidGlass:
             true
         case .showExplicitBadges:
-            false
+            true
         case .shareProfile:
             BuildEnvironment.current == .debug
         }

--- a/podcasts/Common Components/ExplicitBadge.swift
+++ b/podcasts/Common Components/ExplicitBadge.swift
@@ -13,7 +13,13 @@ enum ExplicitBadgeHelper {
     private static var imageCache: [Theme.ThemeType: UIImage] = [:]
     private static var cacheSize = CGFloat(badgeFontSize)
 
-    static func badgeImage(for theme: Theme.ThemeType? = nil, fontSize: CGFloat = badgeFontSize) -> UIImage {
+    static func badgeImage(for theme: Theme.ThemeType? = nil) -> UIImage {
+        let metric = UIFontMetrics(forTextStyle: .largeTitle)
+        let fontSize = metric.scaledValue(for: badgeFontSize)
+        return badgeImage(for: theme, fontSize: fontSize)
+    }
+
+    private static func badgeImage(for theme: Theme.ThemeType? = nil, fontSize: CGFloat = badgeFontSize) -> UIImage {
         if cacheSize != fontSize {
             cacheSize = fontSize
             imageCache.removeAll()

--- a/podcasts/Common Components/ExplicitBadge.swift
+++ b/podcasts/Common Components/ExplicitBadge.swift
@@ -2,22 +2,34 @@ import SwiftUI
 import PocketCastsUtils
 
 enum ExplicitBadgeHelper {
-    static let badgeSize: CGFloat = 11
+
+    static let badgeFontSize: CGFloat = 8
+    static var badgeSize: CGFloat {
+        let metric = UIFontMetrics(forTextStyle: .largeTitle)
+        let fontSize = metric.scaledValue(for: badgeFontSize)
+        return fontSize * 1.5
+    }
 
     private static var imageCache: [Theme.ThemeType: UIImage] = [:]
+    private static var cacheSize = CGFloat(badgeFontSize)
 
-    static func badgeImage(for theme: Theme.ThemeType? = nil) -> UIImage {
+    static func badgeImage(for theme: Theme.ThemeType? = nil, fontSize: CGFloat = badgeFontSize) -> UIImage {
+        if cacheSize != fontSize {
+            cacheSize = fontSize
+            imageCache.removeAll()
+        }
         let resolvedTheme = theme ?? Theme.sharedTheme.activeTheme
         if let cached = imageCache[resolvedTheme] {
             return cached
         }
-        let image = renderBadgeImage(for: resolvedTheme)
+        let image = renderBadgeImage(for: resolvedTheme, fontSize: fontSize)
         imageCache[resolvedTheme] = image
         return image
     }
 
-    private static func renderBadgeImage(for theme: Theme.ThemeType) -> UIImage {
+    private static func renderBadgeImage(for theme: Theme.ThemeType, fontSize: CGFloat = badgeFontSize) -> UIImage {
         let bgColor = ThemeColor.primaryIcon03(for: theme)
+        let badgeSize = fontSize * 1.5
         let renderer = UIGraphicsImageRenderer(size: CGSize(width: badgeSize, height: badgeSize))
         return renderer.image { _ in
             let rect = CGRect(origin: .zero, size: CGSize(width: badgeSize, height: badgeSize))
@@ -26,7 +38,7 @@ enum ExplicitBadgeHelper {
 
             let text = "E" as NSString
             let attrs: [NSAttributedString.Key: Any] = [
-                .font: UIFont.systemFont(ofSize: 7, weight: .heavy),
+                .font: UIFont.systemFont(ofSize: fontSize, weight: .heavy),
                 .foregroundColor: UIColor.white,
             ]
             let textSize = text.size(withAttributes: attrs)
@@ -41,8 +53,10 @@ enum ExplicitBadgeHelper {
     }
 
     static func inlineTitle(_ title: String, isExplicit: Bool, theme: Theme.ThemeType? = nil) -> Text {
+        let metric = UIFontMetrics(forTextStyle: .largeTitle)
+        let fontSize = metric.scaledValue(for: badgeFontSize)
         if FeatureFlag.showExplicitBadges.enabled, isExplicit {
-            return Text(title) + Text(" ") + Text(Image(uiImage: badgeImage(for: theme))).baselineOffset(-1).accessibilityLabel(L10n.podcastExplicitContent)
+            return Text(title) + Text(" ") + Text(Image(uiImage: badgeImage(for: theme, fontSize: fontSize))).baselineOffset(-1).accessibilityLabel(L10n.podcastExplicitContent)
         }
         return Text(title)
     }
@@ -52,8 +66,12 @@ enum ExplicitBadgeHelper {
             return NSAttributedString(string: title, attributes: [.font: font])
         }
         let result = NSMutableAttributedString(string: title + " ", attributes: [.font: font])
-        let image = badgeImage(for: theme)
 
+        let metric = UIFontMetrics(forTextStyle: .largeTitle)
+        let fontSize = metric.scaledValue(for: badgeFontSize)
+        let badgeSize = fontSize * 1.5
+
+        let image = badgeImage(for: theme, fontSize: fontSize)
         let attachment = NSTextAttachment()
         attachment.image = image
         let yOffset = (font.capHeight - badgeSize) / 2

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
@@ -83,7 +83,7 @@ struct PodcastHeaderView: View {
     func makeText() -> Text {
         var output = Text(viewModel.displayCategoryAndAuthor)
         if FeatureFlag.showExplicitBadges.enabled, viewModel.podcast.isExplicit {
-            output = output + ExplicitBadgeHelper.inlineTitle(" ·", isExplicit: true)
+            output = output + ExplicitBadgeHelper.inlineTitle(" ·", isExplicit: true, theme: theme.activeTheme)
         }
         return output
     }

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 import SwiftUI
+import PocketCastsUtils
 
 struct PodcastBlurHeaderView: View {
 
@@ -79,9 +80,16 @@ struct PodcastHeaderView: View {
         .padding(.horizontal, 16)
     }
 
+    func makeText() -> Text {
+        var output = Text(viewModel.displayCategoryAndAuthor)
+        if FeatureFlag.showExplicitBadges.enabled, viewModel.podcast.isExplicit {
+            output = output + ExplicitBadgeHelper.inlineTitle(" ·", isExplicit: true)
+        }
+        return output
+    }
     private var podcastCategory: some View {
         VStack {
-            Text(viewModel.displayCategoryAndAuthor)
+                makeText()
                 .font(.footnote)
                 .multilineTextAlignment(.center)
                 .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
Fixes [POC-664](https://linear.app/a8c/issue/POC-664/add-the-explicit-badge-to-the-podcast-page) <!-- issue number, if applicable -->

This PR fixes the explicit badge so it correctly appears on the podcast page and scales properly with Dynamic Type.

- Persist and read the `isExplicit` flag from the database (`PodcastDataManager` column list + `Podcast+fromDatabase`), so the explicit state is available when a podcast is loaded.
- Add the explicit "E" badge to the podcast header, appended after the category/author line when `FeatureFlag.showExplicitBadges` is enabled and the podcast is explicit.
- Make the badge scale with Dynamic Type by deriving its size from a `UIFontMetrics`-scaled font size, and invalidate the rendered-image cache when the requested font size changes.

| 1 | 2 | 3 | 4 |
| - | - | - | - |
| <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-16 at 12 21 37" src="https://github.com/user-attachments/assets/06ec601c-3d54-4b86-9242-570e3453ae03" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-16 at 12 21 27" src="https://github.com/user-attachments/assets/4570e072-ace5-42a4-a998-d387c027f669" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-16 at 12 21 20" src="https://github.com/user-attachments/assets/9c7e6ceb-a29c-4e27-a0fb-ff81b8f2959f" /> | <img width="750" height="1334" alt="Simulator Screenshot - iPhone SE (2nd generation) - 2026-06-16 at 12 21 10" src="https://github.com/user-attachments/assets/81d81059-cefc-414f-b7e0-3229501802ec" /> |

## To test

1. Enable the `showExplicitBadges` feature flag.
2. Open a podcast marked as explicit and confirm the "E" badge appears next to the category/author in the header.
3. Open a non-explicit podcast and confirm no badge is shown.
4. Change the system text size (Settings → Accessibility → Display & Text Size, or Control Center) and confirm the badge scales with the text.
5. Confirm the badge still renders correctly across light/dark themes.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
