### PR TITLE
Fix optionals in live analytics

### DIFF
--- a/podcasts/Analytics/Analytics.swift
+++ b/podcasts/Analytics/Analytics.swift
@@ -38,8 +38,11 @@ class Analytics {
     }
 
     private func _track(_ eventName: String, properties: [String: Sendable]? = nil) {
-        var properties: [String: Sendable] = (properties ?? [:]).mapValues { value in
-            (value as? AnalyticsDescribable)?.analyticsDescription ?? value
+        var properties: [String: Sendable] = (properties ?? [:]).mapValues { value -> Sendable in
+            if let describable = value as? AnalyticsDescribable {
+                return describable.analyticsDescription
+            }
+            return value
         }
 #if !os(watchOS) && !APPCLIP && !os(tvOS)
         if FeatureFlag.appThemePropertiesLogging.enabled {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

The property transform in `Analytics._track` used the optional-returning `??` overload, which boxed every value in an `Optional` (e.g. `Optional("name")`) before it reached the adapters/Tracks. This resolves it explicitly with an `if let` and an explicit `Sendable` closure return type so all adapters receive clean (non-`Optional`) values.

This is a focused backport to `release/8.14` of the `_track` fix originally landed on `trunk` in #4506.

```swift
var properties: [String: Sendable] = (properties ?? [:]).mapValues { value -> Sendable in
    if let describable = value as? AnalyticsDescribable {
        return describable.analyticsDescription
    }
    return value
}
```

## To test

1. Build and run the app and register an adapter (e.g. the OS log adapter) that prints tracked event properties.
2. Trigger any analytics event that carries properties (e.g. a screen-shown or tap event).
3. Confirm property values are logged as clean values (e.g. `name`) rather than boxed optionals (e.g. `Optional("name")`).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)