### PR TITLE
Keep mini player title font fixed under Dynamic Type on Liquid Glass

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -158,7 +158,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         }
 
         let title = MiniPlayerScrollingTitleView()
-        title.font = .font(ofSize: 13, weight: .medium, scalingWith: .subheadline)
+        title.font = .systemFont(ofSize: 13, weight: .medium)
         episodeTitleLabel = title
         let titleVibrancy = Self.makeVibrancyWrapper(style: .label, content: title)
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

The Liquid Glass mini player title used the `scalingWith:` font helper, so it grew/shrank with Dynamic Type. The glass mini player has a fixed height, so the title should stay constant. Switched it to a fixed-size `.systemFont(ofSize: 13, weight: .medium)`.

## To test

1. Enable the Liquid Glass feature flag and run on iOS 26.
2. Start playing an episode so the mini player appears.
3. In **Settings → Accessibility → Display & Text Size → Larger Text**, drag the slider to large/accessibility sizes.
4. Confirm the mini player title stays the same size regardless of the setting.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
