### PR TITLE
TV: Enable Sentry crash logging

### DIFF
--- a/Pocket Casts TV App/Analytics/AnalyticsSetup.swift
+++ b/Pocket Casts TV App/Analytics/AnalyticsSetup.swift
@@ -11,7 +11,7 @@ enum AnalyticsSetup {
         var adapters: [AnalyticsAdapter] = []
 
         if !Settings.analyticsOptOut() {
-            adapters = [AnalyticsLoggingAdapter(), TracksAdapter()]
+            adapters = [AnalyticsLoggingAdapter(), TracksAdapter(), CrashLoggingAdapter()]
 #if DEBUG
             adapters.append(AnalyticsOSLogAdapter())
 #endif

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -2969,8 +2969,6 @@
 		FF8FF6A72FAA47450086A867 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				"Adapters/Crash Logging/CrashLoggingAdapter.swift",
-				"Adapters/Crash Logging/CrashLoggingDataProvider.swift",
 				AnalyticsAppThemeProvider.swift,
 				WidgetAnalytics.swift,
 			);
@@ -6737,6 +6735,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		30E86BEDCAC549C19A296B6A /* Colors */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/scripts/themes/theme.csv",
+				"$(SRCROOT)/scripts/themes/generate_themes.rb",
+			);
+			name = Colors;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/podcasts/ThemeColor.swift",
+				"$(SRCROOT)/podcasts/ThemeStyle.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "make generate_colors\n";
+		};
 		3C5194112B716756006632DE /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -6817,28 +6837,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "make generate_code\n";
-		};
-		30E86BEDCAC549C19A296B6A /* Colors */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/scripts/themes/theme.csv",
-				"$(SRCROOT)/scripts/themes/generate_themes.rb",
-			);
-			name = Colors;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(SRCROOT)/podcasts/ThemeColor.swift",
-				"$(SRCROOT)/podcasts/ThemeStyle.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "make generate_colors\n";
 		};
 		C716FF45296F2BE3006B787D /* Modify Plist */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-738](https://linear.app/a8c/issue/PCIOS-738/add-sentry-integration) <!-- issue number, if applicable -->

This PR enables Sentry crash logging for the **Pocket Casts TV App**.

- Adds `CrashLoggingAdapter()` to the analytics adapters used by the TV app, so crashes are reported to Sentry (alongside the existing `AnalyticsLoggingAdapter` and `TracksAdapter`).
- Updates `podcasts.xcodeproj` to include `CrashLoggingAdapter.swift` and `CrashLoggingDataProvider.swift` in the TV app target (removed from the file-system synchronized membership exceptions).

## To test

1. Build and run the **Pocket Casts TV App** scheme on a tvOS Simulator or device.
2. Confirm the app launches and analytics are set up without errors (verify the crash logging adapter is registered when analytics opt-out is off).
3. Trigger/simulate a crash and confirm it is reported to Sentry.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
