### PR TITLE
Fix some more Xcode warnings

### DIFF
--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -476,7 +476,7 @@ extension AppDelegate {
             }
             let userCode = parameters["user_code"] as? String
 
-            NavigationManager.sharedManager.navigateTo(NavigationManager.deviceApprovePageKey, data: [NavigationManager.deviceApproveCodeKey: userCode])
+            NavigationManager.sharedManager.navigateTo(NavigationManager.deviceApprovePageKey, data: [NavigationManager.deviceApproveCodeKey: userCode as Any])
             return true
         }
     }

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -121,7 +121,7 @@ extension MiniPlayerViewController {
     }
 
     func closeUpNextAndFullPlayer(completion: (() -> Void)? = nil) {
-        if let fullScreenPlayer {
+        if fullScreenPlayer != nil {
             closeFullScreenPlayer(completion: {
                 completion?()
             })

--- a/podcasts/Referrals/Banner/ReferralsClaimBannerView.swift
+++ b/podcasts/Referrals/Banner/ReferralsClaimBannerView.swift
@@ -52,7 +52,6 @@ struct ReferralsClaimBannerView: View {
 #Preview {
     ReferralsClaimBannerView(viewModel: ReferralClaimPassModel(referralURL: nil, coordinator: ReferralsCoordinator.shared))
             .environmentObject(Theme(previewTheme: .light))
-            .previewLayout(.sizeThatFits)
             .padding(16)
             .frame(height: 105)
 }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Cleans up three low-risk Xcode build warnings (continuing the prior warning-cleanup PRs, e.g. #4205). Each is a behavior-neutral one-liner:

- **`ReferralsClaimBannerView.swift`** — removed `.previewLayout(.sizeThatFits)`, which Xcode warns is *ignored* inside a `#Preview` macro (no-op; preview-only). Not switched to `#Preview(traits:)` since that overload is iOS 17+ and below the deployment target.
- **`MiniPlayerViewController+Positioning.swift`** — replaced an unused `if let fullScreenPlayer` binding with a `fullScreenPlayer != nil` test (the bound value was never used).
- **`AppDelegate+UrlHandling.swift`** — made the existing implicit `String?` → `Any` coercion explicit with `as Any` (identical behavior, silences the warning).

Sendable/concurrency, AVAsset async-load, NavigationLink/trait/edge-inset, and XIB Dynamic Type warnings are intentionally left out of scope.

## To test

1. Build the app (`Pocket Casts Staging`, StagingDebug) and confirm it compiles with no errors.
2. Confirm the three warnings above no longer appear in the build log.
3. Smoke-test that nothing regressed: open the mini player and dismiss it (closes the full-screen player), and exercise the `/pair` TV-pairing deep link.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)