### PR TITLE
[PC TV] Add login & search failure analytics events

### DIFF
--- a/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
+++ b/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
@@ -33,8 +33,13 @@ struct CreateAccountView: View {
                 await pairing.start()
             }
             .onChange(of: pairing.state) {
-                if case .finished = pairing.state {
+                switch pairing.state {
+                case .finished:
                     finish()
+                case .error(let error, _):
+                    Analytics.track(.userAccountCreationFailed, properties: ["error_code": (error as NSError).code])
+                default:
+                    break
                 }
             }
     }

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -94,13 +94,23 @@ struct SignInView: View {
             }
         }
         .onChange(of: model.state) {
-            if case .finished = model.state {
+            switch model.state {
+            case .finished:
                 finishSignIn(source: "password")
+            case .error(let error, _):
+                Analytics.track(.userSignInFailed, properties: ["source": "password", "error_code": (error as NSError).code])
+            default:
+                break
             }
         }
         .onChange(of: model.pairing.state) {
-            if case .finished = model.pairing.state {
+            switch model.pairing.state {
+            case .finished:
                 finishSignIn(source: "qr_code")
+            case .error(let error, _):
+                Analytics.track(.userSignInFailed, properties: ["source": "qr_code", "error_code": (error as NSError).code])
+            default:
+                break
             }
         }
         .onAppear {

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -171,11 +171,16 @@ class SearchViewModel: SearchableViewModel {
 
                 podcastResults = combinedPodcastsResults
                 episodeResults = episodes
-                state = (combinedPodcastsResults.isEmpty && episodes.isEmpty) ? .empty : .results
+                let isEmpty = combinedPodcastsResults.isEmpty && episodes.isEmpty
+                if isEmpty {
+                    Analytics.track(.searchEmptyResults, properties: ["source": "search", "term": query])
+                }
+                state = isEmpty ? .empty : .results
             }  catch is CancellationError {
                 return
             } catch {
                 guard !Task.isCancelled else { return }
+                Analytics.track(.searchFailed, properties: ["source": "search", "error_code": (error as NSError).code])
                 state  = .error(error)
             }
         }


### PR DESCRIPTION
Adds the missing **failure-path** analytics on tvOS so **login** and **search** success-rates become measurable — the success events already fired, but their failure/empty counterparts didn't. Events reuse existing `AnalyticsEvent` cases and mirror iOS property shapes. **No timing added** (out of scope).

| Event | Trigger | `source` | Other properties |
|---|---|---|---|
| `user_sign_in_failed` | Manual (username/password) sign-in fails | `password` | `error_code` |
| `user_sign_in_failed` | QR device-pairing sign-in fails | `qr_code` | `error_code` |
| `user_account_creation_failed` | QR create-account fails | — | `error_code` |
| `search_failed` | Search request throws | `search` | `error_code` |
| `search_empty_results` | Search returns no results | `search` | `term` |

`user_sign_in_failed` fires for both sources, symmetric with the existing `user_signed_in` (which already fires for both); QR is tvOS's primary login path, so password-only would leave the denominator blind.

## To test

Force each failure and watch the `AnalyticsLoggingAdapter` console output: wrong manual credentials → `user_sign_in_failed` (`password`); QR sign-in / create-account in airplane mode → `user_sign_in_failed` (`qr_code`) / `user_account_creation_failed`; a no-result search → `search_empty_results`; an offline search → `search_failed`.

<img width="668" height="105" alt="Screenshot 2026-06-16 at 4 05 42 PM" src="https://github.com/user-attachments/assets/65013d1b-aadd-4e99-8f96-d1010505f439" />

## Checklist

- [x] Considered user-facing release notes — analytics-only, none needed.
- [x] Considered unit tests — events fire from SwiftUI `.onChange` / async `catch`, validated via the logging adapter (as in prior tvOS analytics PRs).
- [x] Marked these events available on tvOS in the schema: Automattic/EventHorizonSchemas#88.
- [ ] Updated [the analytics spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing). ⚠️ **Still needs doing** for the 5 events above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)