### PR TITLE
TV: Fix header offset on Search and Discover screens

### DIFF
--- a/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
@@ -4,7 +4,7 @@ import PocketCastsServer
 struct DiscoverAllView: View {
 
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
-    
+
     @State private var model = DiscoverAllViewModel()
 
     var body: some View {

--- a/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
@@ -3,6 +3,8 @@ import PocketCastsServer
 
 struct DiscoverAllView: View {
 
+    @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
+    
     @State private var model = DiscoverAllViewModel()
 
     var body: some View {
@@ -28,6 +30,11 @@ struct DiscoverAllView: View {
                     DiscoverRowSection(item: item, source: DiscoverAnalytics.searchSource)
                 }
             }
+        }
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            geometry.contentInsets.top + geometry.contentOffset.y
+        } action: { _, after in
+            tabRouter.scrollOffset = after
         }
         .navigationDestination(for: DiscoverPodcast.self) { podcast in
             if let uuid = podcast.uuid {

--- a/Pocket Casts TV App/UI/MainTabRouter.swift
+++ b/Pocket Casts TV App/UI/MainTabRouter.swift
@@ -12,6 +12,8 @@ final class MainTabRouter {
     var pendingAuthFlow: ProfileMenuView.AuthDestination?
     var profileDestination: ProfileMenuView.ProfileDestination?
 
+    var scrollOffset: CGFloat = 0
+
     var currentPlayingEpisode: BaseEpisode?
 
     init() {

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -39,28 +39,28 @@ struct MainTabContentView: View {
             switch tab {
             case .home:
                 HomeView()
-                    .onScrollGeometryChange(for: Double.self) { geometry in
+                    .onScrollGeometryChange(for: CGFloat.self) { geometry in
                         geometry.contentInsets.top + geometry.contentOffset.y
                     } action: { _, after in
                         tabRouter.scrollOffset = after
                     }
             case .podcasts:
                 PodcastsView()
-                    .onScrollGeometryChange(for: Double.self) { geometry in
+                    .onScrollGeometryChange(for: CGFloat.self) { geometry in
                         geometry.contentInsets.top + geometry.contentOffset.y
                     } action: { _, after in
                         tabRouter.scrollOffset = after
                     }
             case .playlists:
                 PlaylistsView()
-                    .onScrollGeometryChange(for: Double.self) { geometry in
+                    .onScrollGeometryChange(for: CGFloat.self) { geometry in
                         geometry.contentInsets.top + geometry.contentOffset.y
                     } action: { _, after in
                         tabRouter.scrollOffset = after
                     }
             case .upNext:
                 UpNextView()
-                    .onScrollGeometryChange(for: Double.self) { geometry in
+                    .onScrollGeometryChange(for: CGFloat.self) { geometry in
                         geometry.contentInsets.top + geometry.contentOffset.y
                     } action: { _, after in
                         tabRouter.scrollOffset = after

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -66,7 +66,7 @@ struct MainTabContentView: View {
                         tabRouter.scrollOffset = after
                     }
             case .search:
-                SearchView(model: SearchViewModel())
+                SearchViewContainer()
             case .nowPlaying:
                 NowPlayingTab()
             }

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-enum MainTab: Int, CaseIterable, Identifiable {
+enum MainTab: Int, CaseIterable, Identifiable, Equatable {
     case home = 0
     case podcasts
     case playlists
@@ -32,47 +32,44 @@ enum MainTab: Int, CaseIterable, Identifiable {
 struct MainTabContentView: View {
     let tab: MainTab
 
-    @Binding var scrollOffset: Double
+    @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
 
     var body: some View {
-        switch tab {
-        case .home:
-            HomeView()
-                .onScrollGeometryChange(for: Double.self) { geometry in
-                    geometry.contentInsets.top + geometry.contentOffset.y
-                } action: { _, after in
-                    self.scrollOffset = after
-                }
-        case .podcasts:
-            PodcastsView()
-                .onScrollGeometryChange(for: Double.self) { geometry in
-                    geometry.contentInsets.top + geometry.contentOffset.y
-                } action: { _, after in
-                    self.scrollOffset = after
-                }
-        case .playlists:
-            PlaylistsView()
-                .onScrollGeometryChange(for: Double.self) { geometry in
-                    geometry.contentInsets.top + geometry.contentOffset.y
-                } action: { _, after in
-                    self.scrollOffset = after
-                }
-        case .upNext:
-            UpNextView()
-                .onScrollGeometryChange(for: Double.self) { geometry in
-                    geometry.contentInsets.top + geometry.contentOffset.y
-                } action: { _, after in
-                    self.scrollOffset = after
-                }
-        case .search:
-            SearchView(model: SearchViewModel())
-                .onScrollGeometryChange(for: Double.self) { geometry in
-                    geometry.contentInsets.top + geometry.contentOffset.y
-                } action: { _, after in
-                    self.scrollOffset = after
-                }
-        case .nowPlaying:
-            NowPlayingTab()
+        ZStack {
+            switch tab {
+            case .home:
+                HomeView()
+                    .onScrollGeometryChange(for: Double.self) { geometry in
+                        geometry.contentInsets.top + geometry.contentOffset.y
+                    } action: { _, after in
+                        tabRouter.scrollOffset = after
+                    }
+            case .podcasts:
+                PodcastsView()
+                    .onScrollGeometryChange(for: Double.self) { geometry in
+                        geometry.contentInsets.top + geometry.contentOffset.y
+                    } action: { _, after in
+                        tabRouter.scrollOffset = after
+                    }
+            case .playlists:
+                PlaylistsView()
+                    .onScrollGeometryChange(for: Double.self) { geometry in
+                        geometry.contentInsets.top + geometry.contentOffset.y
+                    } action: { _, after in
+                        tabRouter.scrollOffset = after
+                    }
+            case .upNext:
+                UpNextView()
+                    .onScrollGeometryChange(for: Double.self) { geometry in
+                        geometry.contentInsets.top + geometry.contentOffset.y
+                    } action: { _, after in
+                        tabRouter.scrollOffset = after
+                    }
+            case .search:
+                SearchView(model: SearchViewModel())                    
+            case .nowPlaying:
+                NowPlayingTab()
+            }
         }
     }
 }
@@ -96,7 +93,6 @@ struct MainTabView: View {
     @State private var tabRouter = MainTabRouter()
     @FocusState private var focusedArea: FocusArea?
     @FocusState private var profileFocused: Bool
-    @State private var scrollOffset: Double = 0
     @Environment(AppCoordinator.self) var coordinator
 
     enum FocusArea: Hashable {
@@ -111,7 +107,7 @@ struct MainTabView: View {
                 ForEach(MainTab.allCases) { tab in
                     if tabRouter.shouldShowTab(tab) {
                         Tab(value: tab) {
-                            MainTabContentView(tab: tab, scrollOffset: $scrollOffset)
+                            MainTabContentView(tab: tab)
                                 .environment(tabRouter)
                                 .focused($focusedArea, equals: .content)
                         } label: {
@@ -151,7 +147,7 @@ struct MainTabView: View {
                 }
                 .padding(.vertical, 48)
                 .padding(.horizontal, 84)
-                .offset(x: 0, y: -scrollOffset)
+                .offset(x: 0, y: -tabRouter.scrollOffset)
                 Spacer()
             }
         }

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -66,7 +66,7 @@ struct MainTabContentView: View {
                         tabRouter.scrollOffset = after
                     }
             case .search:
-                SearchView(model: SearchViewModel())                    
+                SearchView(model: SearchViewModel())
             case .nowPlaying:
                 NowPlayingTab()
             }

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -8,6 +8,8 @@ fileprivate enum Layout {
 
 struct SearchResultsView<ViewModel: SearchableViewModel>: View {
 
+    @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
+    
     @Bindable var model: ViewModel
 
     @State private var showNowPlayingPlayer = false
@@ -84,6 +86,11 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                 PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: podcast.uuid))
             }
         }
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            geometry.contentInsets.top + geometry.contentOffset.y
+        } action: { _, after in
+            tabRouter.scrollOffset = after
+        }
     }
 
     var episodeResults: some View {
@@ -112,6 +119,11 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                     .buttonStyle(.card)
                 }
             })
+        }
+        .onScrollGeometryChange(for: CGFloat.self) { geometry in
+            geometry.contentInsets.top + geometry.contentOffset.y
+        } action: { _, after in
+            tabRouter.scrollOffset = after
         }
     }
 }

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -9,7 +9,7 @@ fileprivate enum Layout {
 struct SearchResultsView<ViewModel: SearchableViewModel>: View {
 
     @Environment(MainTabRouter.self) var tabRouter: MainTabRouter
-    
+
     @Bindable var model: ViewModel
 
     @State private var showNowPlayingPlayer = false

--- a/Pocket Casts TV App/UI/Search/SearchViewContainer.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewContainer.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+struct SearchViewContainer: View {
+
+    @State private var model = SearchViewModel()
+
+    var body: some View {
+        SearchView(model: model)
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -6737,6 +6737,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		30E86BEDCAC549C19A296B6A /* Colors */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/scripts/themes/theme.csv",
+				"$(SRCROOT)/scripts/themes/generate_themes.rb",
+			);
+			name = Colors;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/podcasts/ThemeColor.swift",
+				"$(SRCROOT)/podcasts/ThemeStyle.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "make generate_colors\n";
+		};
 		3C5194112B716756006632DE /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -6817,28 +6839,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "make generate_code\n";
-		};
-		30E86BEDCAC549C19A296B6A /* Colors */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/scripts/themes/theme.csv",
-				"$(SRCROOT)/scripts/themes/generate_themes.rb",
-			);
-			name = Colors;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(SRCROOT)/podcasts/ThemeColor.swift",
-				"$(SRCROOT)/podcasts/ThemeStyle.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "make generate_colors\n";
 		};
 		C716FF45296F2BE3006B787D /* Modify Plist */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

On the Apple TV app, the collapsing header offset was driven by a `@Binding var scrollOffset` that only the main tab content views updated. As a result, scrolling inside the **Search** results and **Discover (See All)** screens did not move the header, leaving content visually misaligned/overlapping.

This PR moves `scrollOffset` onto `MainTabRouter` (the shared `@Observable` environment object) so any screen can report its scroll position:

- `MainTabRouter` now owns `scrollOffset` instead of a local `@State`/`@Binding` in `MainTabView`.
- `MainTabContentView` reads the router from the environment and wraps its content in a `ZStack`.
- `SearchResultsView` (podcast and episode result lists) and `DiscoverAllView` now report their scroll offset through the router via `onScrollGeometryChange`.
- `MainTab` now conforms to `Equatable`.

## To test

1. Launch the Apple TV app.
2. Go to the **Search** tab and search for something with enough results to scroll.
3. Scroll the podcast and episode result lists and confirm the header collapses/offsets correctly without overlapping the content.
4. Go to **Discover** and open a **See All** list.
5. Scroll the list and confirm the header offset tracks the scroll position correctly.
6. Sanity-check the existing tabs (Home, Podcasts, Playlists, Up Next) still scroll/offset as before.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
