### PR TITLE
Re-state unchecked Sendable conformance on Operation subclasses

### DIFF
--- a/Modules/Sources/EndOfYear/StoryShareableProvider.swift
+++ b/Modules/Sources/EndOfYear/StoryShareableProvider.swift
@@ -8,7 +8,7 @@ import PocketCastsUtils
 /// and when the user taps "Share" we use this provider to
 /// avoid blocking the main thread and the share sheet
 /// having a delay when appearing.
-public class StoryShareableProvider: UIActivityItemProvider {
+public class StoryShareableProvider: UIActivityItemProvider, @unchecked Sendable {
     public static var shared = StoryShareableProvider()
 
     public var generatedItem: Any?

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsUtils
 
-class ApiBaseTask: Operation {
+class ApiBaseTask: Operation, @unchecked Sendable {
     private let syncTimeout = 60 as TimeInterval
     private let isoDateFormatter = ISO8601DateFormatter()
     let apiVersion = "2"

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/CancelSubscriptionTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/CancelSubscriptionTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class CancelSubscriptionTask: ApiBaseTask {
+class CancelSubscriptionTask: ApiBaseTask, @unchecked Sendable {
     private let bundleUuid: String
 
     var completion: ((Bool) -> Void)?

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangeEmailTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangeEmailTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class ChangeEmailTask: ApiBaseTask {
+class ChangeEmailTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool) -> Void)?
 
     private var newEmail: String

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangePasswordTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangePasswordTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class ChangePasswordTask: ApiBaseTask {
+class ChangePasswordTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool) -> Void)?
 
     private var oldPassword: String

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/DeleteAccountTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/DeleteAccountTask.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsUtils
 import SwiftProtobuf
 
-class DeleteAccountTask: ApiBaseTask {
+class DeleteAccountTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool, String?) -> Void)?
 
     override func apiTokenAcquired(token: String) {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ExchangeSonosTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ExchangeSonosTask.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Swaps the current Authorization token with one for use with Sonos connections
-class ExchangeSonosTask: ApiBaseTask {
+class ExchangeSonosTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((String?) -> Void)?
 
     override func apiTokenAcquired(token: String) {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/MetadataTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/MetadataTask.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsUtils
 
-class MetadataTask: Operation {
+class MetadataTask: Operation, @unchecked Sendable {
     static let minBytesInFile = 150 * 1024 as Int64
 
     var episodeUuid = ""

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/PositionSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/PositionSyncTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class PositionSyncTask: ApiBaseTask {
+class PositionSyncTask: ApiBaseTask, @unchecked Sendable {
     private let upTo: TimeInterval
     private let duration: TimeInterval
     private let episode: Episode

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/PurchaseReceiptTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/PurchaseReceiptTask.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 import SwiftProtobuf
 import UIKit
 
-class PurchaseReceiptTask: ApiBaseTask {
+class PurchaseReceiptTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool) -> Void)?
     override func apiTokenAcquired(token: String) {
         let url = ServerConstants.Urls.api() + "subscription/purchase/ios"

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RecommendEpisodesTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RecommendEpisodesTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class RecommendEpisodesTask: ApiBaseTask {
+class RecommendEpisodesTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Episode?) -> Void)?
 
     override func apiTokenAcquired(token: String) {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RedeemPromoCodeTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RedeemPromoCodeTask.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 import SwiftProtobuf
 import UIKit
 
-class RedeemPromoCodeTask: ApiBaseTask {
+class RedeemPromoCodeTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Int, String?, APIError?) -> Void)?
     private var promoCode: String
 

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveBookmarksTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveBookmarksTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class RetrieveBookmarksTask: ApiBaseTask {
+class RetrieveBookmarksTask: ApiBaseTask, @unchecked Sendable {
     typealias BookmarkRetrievedHandler = ([Api_BookmarkResponse]?) -> Void
 
     let onBookmarksRetrieved: BookmarkRetrievedHandler

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class RetrieveCustomFilesTask: ApiBaseTask {
+class RetrieveCustomFilesTask: ApiBaseTask, @unchecked Sendable {
     override func apiTokenAcquired(token: String) {
         let url = ServerConstants.Urls.api() + "files"
 

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveEpisodesTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveEpisodesTask.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsUtils
 import SwiftProtobuf
 
-class RetrieveEpisodesTask: ApiBaseTask {
+class RetrieveEpisodesTask: ApiBaseTask, @unchecked Sendable {
     var completion: (([EpisodeSyncInfo]?) -> Void)?
 
     private var podcastUuid: String

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUploadStatus.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUploadStatus.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class RetrieveFileUploadStatusTask: ApiBaseTask {
+class RetrieveFileUploadStatusTask: ApiBaseTask, @unchecked Sendable {
     private let episode: UserEpisode
 
     init(episode: UserEpisode) {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUsageTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUsageTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class RetrieveFileUsageTask: ApiBaseTask {
+class RetrieveFileUsageTask: ApiBaseTask, @unchecked Sendable {
     override func apiTokenAcquired(token: String) {
         let url = ServerConstants.Urls.api() + "files/usage/"
 

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveLastSyncDateTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveLastSyncDateTask.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsUtils
 import SwiftProtobuf
 
-class RetrieveLastSyncDateTask: ApiBaseTask {
+class RetrieveLastSyncDateTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((String?) -> Void)?
 
     override func apiTokenAcquired(token: String) {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePlaylistsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePlaylistsTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class RetrievePlaylistsTask: ApiBaseTask {
+class RetrievePlaylistsTask: ApiBaseTask, @unchecked Sendable {
     var completion: (([(EpisodeFilter, [Episode])]?) -> Void)?
 
     override func apiTokenAcquired(token: String) {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePodcastsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePodcastsTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class RetrievePodcastsTask: ApiBaseTask {
+class RetrievePodcastsTask: ApiBaseTask, @unchecked Sendable {
     var completion: (([PodcastSyncInfo]?, [FolderSyncInfo]?, Bool) -> Void)?
 
     override func apiTokenAcquired(token: String) {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStarredTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStarredTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class RetrieveStarredTask: ApiBaseTask {
+class RetrieveStarredTask: ApiBaseTask, @unchecked Sendable {
     var completion: (([Episode]?) -> Void)?
 
     private var convertedEpisodes = [Episode]()

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStatsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStatsTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class RetrieveStatsTask: ApiBaseTask {
+class RetrieveStatsTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((RemoteStats?) -> Void)?
 
     var getFullStatsData = false

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/StarredSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/StarredSyncTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class StarredSyncTask: ApiBaseTask {
+class StarredSyncTask: ApiBaseTask, @unchecked Sendable {
     private let episode: Episode
 
     init(episode: Episode) {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class SubscriptionStatusTask: ApiBaseTask {
+class SubscriptionStatusTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool) -> Void)?
 
     override func apiTokenAcquired(token: String) {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/SupportFeedbackTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/SupportFeedbackTask.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsUtils
 import SwiftProtobuf
 
-class SupportFeedbackTask: ApiBaseTask {
+class SupportFeedbackTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool) -> Void)?
 
     private let message: String

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFileDeleteTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFileDeleteTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class UploadFileDeleteTask: ApiBaseTask {
+class UploadFileDeleteTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool) -> Void)?
     private let episode: UserEpisode
 

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFilePlayRequestTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFilePlayRequestTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class UploadFilePlayRequestTask: ApiBaseTask {
+class UploadFilePlayRequestTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((URL?) -> Void)?
     private let episode: UserEpisode
 

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFileRequestTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFileRequestTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class UploadFileRequestTask: ApiBaseTask {
+class UploadFileRequestTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((URL?) -> Void)?
     private let episode: UserEpisode
 

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFilesUpdateTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFilesUpdateTask.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 import SwiftProtobuf
 import UIKit
 
-class UploadFilesUpdateTask: ApiBaseTask {
+class UploadFilesUpdateTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Int) -> Void)?
 
     private var episodes = [UserEpisode]()

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadImageDeleteTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadImageDeleteTask.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 import SwiftProtobuf
 import UIKit
 
-class UploadImageDeleteTask: ApiBaseTask {
+class UploadImageDeleteTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool) -> Void)?
     private let episode: UserEpisode
 

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadImageRequestTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadImageRequestTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class UploadImageRequestTask: ApiBaseTask {
+class UploadImageRequestTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((URL?) -> Void)?
     private let episode: UserEpisode
 

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UserPodcastRatingTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UserPodcastRatingTask.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 import SwiftProtobuf
 import PocketCastsDataModel
 
-class UserPodcastRatingAddTask: ApiBaseTask {
+class UserPodcastRatingAddTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool) -> Void)?
 
     private let uuid: String
@@ -45,7 +45,7 @@ class UserPodcastRatingAddTask: ApiBaseTask {
     }
 }
 
-class UserPodcastRatingGetTask: ApiBaseTask {
+class UserPodcastRatingGetTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool, UserPodcastRating?) -> Void)?
 
     private let uuid: String

--- a/Modules/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Refresh/PodcastSearchOperation.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class PodcastSearchOperation: Operation {
+class PodcastSearchOperation: Operation, @unchecked Sendable {
     private let completion: (PodcastSearchResponse?) -> Void
     private let searchQuery: MainServerHandler.PodcastSearchQuery
 

--- a/Modules/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Refresh/RefreshOperation.swift
@@ -2,7 +2,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import UIKit
 
-class RefreshOperation: Operation {
+class RefreshOperation: Operation, @unchecked Sendable {
     private var refreshResult: RefreshResult
 
     private var completionHandler: ((RefreshFetchResult) -> Void)?

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncHistoryTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncHistoryTask.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftProtobuf
 
-class SyncHistoryTask: ApiBaseTask {
+class SyncHistoryTask: ApiBaseTask, @unchecked Sendable {
     enum HistoryAction: Int {
         case add = 1, delete = 2, clearAll = 3
     }

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -119,7 +119,7 @@ extension AppSettings {
     }
 }
 
-class SyncSettingsTask: ApiBaseTask {
+class SyncSettingsTask: ApiBaseTask, @unchecked Sendable {
 
     private let appSettings: SettingsStore<AppSettings>
 

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -3,7 +3,7 @@ import SwiftProtobuf
 import PocketCastsDataModel
 import PocketCastsUtils
 
-class SyncTask: ApiBaseTask {
+class SyncTask: ApiBaseTask, @unchecked Sendable {
     private static let processDataLock = NSObject()
 
     lazy var importQueue: OperationQueue = {

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -28,7 +28,7 @@ public class SyncYearListeningProgress: ObservableObject {
     }
 }
 
-class SyncYearListeningHistoryTask: ApiBaseTask {
+class SyncYearListeningHistoryTask: ApiBaseTask, @unchecked Sendable {
     private var token: String?
 
     private let yearToSync: Int32

--- a/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -29,7 +29,7 @@ public enum UpNextSyncError: LocalizedError {
     }
 }
 
-class UpNextSyncTask: ApiBaseTask {
+class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
     private static let processDataLock = NSObject()
 
     override func main() {

--- a/podcasts/End of Year/StoryShareableText.swift
+++ b/podcasts/End of Year/StoryShareableText.swift
@@ -3,7 +3,7 @@ import PocketCastsServer
 import PocketCastsDataModel
 import EndOfYear
 
-class StoryShareableText: UIActivityItemProvider, ShareableMetadataDataSource {
+class StoryShareableText: UIActivityItemProvider, ShareableMetadataDataSource, @unchecked Sendable {
     private var text: String
 
     private let pocketCastsUrl = ServerConstants.Urls.share()

--- a/podcasts/New Detail/Operation/PlaylistDetailFetchOperation.swift
+++ b/podcasts/New Detail/Operation/PlaylistDetailFetchOperation.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 
-class PlaylistDetailFetchOperation: Operation {
+class PlaylistDetailFetchOperation: Operation, @unchecked Sendable {
     typealias CompletionHandler = ([ListEpisode], Int) -> Void
 
     private let episodesDataManager: EpisodesDataManager

--- a/podcasts/OpmlImporter.swift
+++ b/podcasts/OpmlImporter.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
 
-class OpmlImporter: Operation, XMLParserDelegate {
+class OpmlImporter: Operation, XMLParserDelegate, @unchecked Sendable {
     private var podcastsToAdd = [String]()
     private var pollUuids = [String]()
     private var failedCount = 0

--- a/podcasts/SharingItemProvider.swift
+++ b/podcasts/SharingItemProvider.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class SharingItemProvider: UIActivityItemProvider, @unchecked Sendable {
-    private var sharingString: String
+    private let sharingString: String
 
     init(sharingString: String) {
         self.sharingString = sharingString

--- a/podcasts/SharingItemProvider.swift
+++ b/podcasts/SharingItemProvider.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class SharingItemProvider: UIActivityItemProvider {
+class SharingItemProvider: UIActivityItemProvider, @unchecked Sendable {
     private var sharingString: String
 
     init(sharingString: String) {


### PR DESCRIPTION
Re-instates `@unchecked Sendable` conformance on our `Operation` subclasses (the API tasks, refresh, and playlist-fetch operations) plus a couple of `UIActivityItemProvider` subclasses. These were dropped while cleaning up Xcode warnings, but `Operation` still requires the conformance to build without concurrency warnings, so we need to put it back for now.

Longer term we should redesign these tasks and remove the `Operation` usage entirely rather than keep papering over it with `@unchecked Sendable`.

## To test

1. Build the app — there should be no Sendable/concurrency warnings on the affected types.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
