### PR TITLE
TV: Add sponsored podcasts to category details

### DIFF
--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -197,23 +197,21 @@ actor DiscoverManager {
 
         let regionCode = regionCode(for: discoverLayout)
         let regionSource = source.replacingOccurrences(of: discoverLayout.regionCodeToken, with: regionCode)
-        var details = await discoverServerHandler.discoverCategoryDetails(source: regionSource, authenticated: false)
-
-        var sponsoredUuids = Set<String>()
-        if let layout = discoverLayout.layout {
-            for item in layout {
-                if item.categoryID == category.id,
-                   item.isSponsored == true,
-                   let source = item.source,
-                   let podcasts = await discoverServerHandler.discoverPodcastCollection(source: source, authenticated: item.authenticated == true)?.podcasts {
-                    details?.podcasts?.append(contentsOf: podcasts)
-                    sponsoredUuids = sponsoredUuids.union(Set(podcasts.compactMap({$0.uuid})))
-                }
-            }
-        }
-        guard let details else {
+        guard var details = await discoverServerHandler.discoverCategoryDetails(source: regionSource, authenticated: false) else {
             return nil
         }
+
+        var sponsoredUuids = Set<String>()
+        for item in discoverLayout.layout ?? [] {
+            if item.categoryID == category.id,
+               item.isSponsored == true,
+               let source = item.source,
+               let podcasts = await discoverServerHandler.discoverPodcastCollection(source: source, authenticated: item.authenticated == true)?.podcasts {
+                details.podcasts?.append(contentsOf: podcasts)
+                sponsoredUuids = sponsoredUuids.union(Set(podcasts.compactMap({$0.uuid})))
+            }
+        }
+
         return DiscoverCategorySection(categoryDetails: details, sponsoredPodcastsIDs: sponsoredUuids)
     }
 

--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -54,6 +54,16 @@ struct DiscoverEpisodesSection {
     }
 }
 
+struct DiscoverCategorySection {
+    let categoryDetails: DiscoverCategoryDetails
+    let sponsoredPodcastsIDs: Set<String>
+
+    init(categoryDetails: DiscoverCategoryDetails, sponsoredPodcastsIDs: Set<String> = []) {
+        self.categoryDetails = categoryDetails
+        self.sponsoredPodcastsIDs = sponsoredPodcastsIDs
+    }
+}
+
 extension DiscoverItem {
     /// Resolves the analytics `list_id` for a section, matching the iOS scheme:
     /// the item's uuid, falling back to the collection's `list_id`, then the item's id.
@@ -178,7 +188,7 @@ actor DiscoverManager {
         return serverRegion
     }
 
-    func loadDiscoverCategoryDetails(for category: DiscoverCategory) async -> DiscoverCategoryDetails? {
+    func loadDiscoverCategoryDetails(for category: DiscoverCategory) async -> DiscoverCategorySection? {
         guard let discoverLayout = await getLayout(),
               let source = category.source
         else {
@@ -187,8 +197,24 @@ actor DiscoverManager {
 
         let regionCode = regionCode(for: discoverLayout)
         let regionSource = source.replacingOccurrences(of: discoverLayout.regionCodeToken, with: regionCode)
-        let details = await discoverServerHandler.discoverCategoryDetails(source: regionSource, authenticated: false)
-        return details
+        var details = await discoverServerHandler.discoverCategoryDetails(source: regionSource, authenticated: false)
+
+        var sponsoredUuids = Set<String>()
+        if let layout = discoverLayout.layout {
+            for item in layout {
+                if item.categoryID == category.id,
+                   item.isSponsored == true,
+                   let source = item.source,
+                   let podcasts = await discoverServerHandler.discoverPodcastCollection(source: source, authenticated: item.authenticated == true)?.podcasts {
+                    details?.podcasts?.append(contentsOf: podcasts)
+                    sponsoredUuids = sponsoredUuids.union(Set(podcasts.compactMap({$0.uuid})))
+                }
+            }
+        }
+        guard let details else {
+            return nil
+        }
+        return DiscoverCategorySection(categoryDetails: details, sponsoredPodcastsIDs: sponsoredUuids)
     }
 
     func loadSponsoredPodcasts(item: DiscoverItem) async -> [Int: DiscoverPodcast] {

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoryModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoryModel.swift
@@ -8,13 +8,20 @@ class DiscoverCategoryModel {
 
     let category: DiscoverCategory
 
-    var categorySection: DiscoverCategorySection?
+    private var categorySection: DiscoverCategorySection?
 
     var coverPodcastsUuids: [String] = []
 
-    init(category: DiscoverCategory, discoverManager: DiscoverManager = DiscoverManager.shared) {
+    var podcasts: [DiscoverPodcast] = []
+
+    var sponsoredPodcastsUuids: Set<String> = []
+
+    let sponsoredPosition: Int
+
+    init(category: DiscoverCategory, discoverManager: DiscoverManager = DiscoverManager.shared, sponsoredPosition: Int = 5) {
         self.category = category
         self.discoverManager = discoverManager
+        self.sponsoredPosition = sponsoredPosition
     }
 
     enum State: Equatable, Hashable {
@@ -29,6 +36,13 @@ class DiscoverCategoryModel {
         await MainActor.run {
             state = categorySection != nil ? .ready : .empty
             self.categorySection = categorySection
+            self.podcasts = categorySection?.categoryDetails.podcasts ?? []
+            self.sponsoredPodcastsUuids = categorySection?.sponsoredPodcastsIDs ?? []
+            let indices = self.podcasts.indices(where: { podcast in
+                self.sponsoredPodcastsUuids.contains(podcast.uuid ?? "")
+            })
+            let position = podcasts.count > sponsoredPosition ? sponsoredPosition : 0
+            self.podcasts.moveSubranges(indices, to: position)
             if let podcasts = categorySection?.categoryDetails.podcasts {
                 self.coverPodcastsUuids = podcasts.compactMap { $0.uuid }
             }
@@ -46,18 +60,10 @@ class DiscoverCategoryModel {
         return category.name?.localized ?? ""
     }
 
-    var podcasts: [DiscoverPodcast] {
-        return categorySection?.categoryDetails.podcasts ?? []
-    }
-
-    var sposoredPodcastsUuids: Set<String> {
-        return categorySection?.sponsoredPodcastsIDs ?? []
-    }
-
     func isSponsored(podcast: DiscoverPodcast) -> Bool {
-        guard let section = categorySection, let uuid = podcast.uuid else {
+        guard let uuid = podcast.uuid else {
             return false
         }
-        return section.sponsoredPodcastsIDs.contains(uuid)
+        return sponsoredPodcastsUuids.contains(uuid)
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoryModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoryModel.swift
@@ -8,7 +8,7 @@ class DiscoverCategoryModel {
 
     let category: DiscoverCategory
 
-    var categoryDetails: DiscoverCategoryDetails?
+    var categorySection: DiscoverCategorySection?
 
     var coverPodcastsUuids: [String] = []
 
@@ -24,12 +24,12 @@ class DiscoverCategoryModel {
     }
 
     func load() async {
-        let detail = await discoverManager.loadDiscoverCategoryDetails(for: category)
+        let categorySection = await discoverManager.loadDiscoverCategoryDetails(for: category)
 
         await MainActor.run {
-            state = detail != nil ? .ready : .empty
-            self.categoryDetails = detail
-            if let podcasts = categoryDetails?.podcasts {
+            state = categorySection != nil ? .ready : .empty
+            self.categorySection = categorySection
+            if let podcasts = categorySection?.categoryDetails.podcasts {
                 self.coverPodcastsUuids = podcasts.compactMap { $0.uuid }
             }
         }
@@ -47,6 +47,17 @@ class DiscoverCategoryModel {
     }
 
     var podcasts: [DiscoverPodcast] {
-        return categoryDetails?.podcasts ?? []
+        return categorySection?.categoryDetails.podcasts ?? []
+    }
+
+    var sposoredPodcastsUuids: Set<String> {
+        return categorySection?.sponsoredPodcastsIDs ?? []
+    }
+
+    func isSponsored(podcast: DiscoverPodcast) -> Bool {
+        guard let section = categorySection, let uuid = podcast.uuid else {
+            return false
+        }
+        return section.sponsoredPodcastsIDs.contains(uuid)
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastCell.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct DiscoverPodcastCell: View {
+
+    fileprivate enum Layout {
+        static let gridSize = CGFloat(250)
+    }
+
+    let podcastUuid: String
+    let isSponsored: Bool
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 10) {
+            PodcastImage(uuid: podcastUuid, size: .page)
+                .padding(.horizontal, isSponsored ? 36 : 0)
+                .padding(.top, isSponsored ? 18 : 0)
+            if isSponsored {
+                Text(L10n.discoverSponsored)
+                    .font(.caption2)
+                    .foregroundColor(.pcTextSecondary)
+                    .padding(.bottom, 14)
+            }
+        }
+        .frame(width: Layout.gridSize, height: Layout.gridSize)
+    }
+}

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastCell.swift
@@ -15,7 +15,7 @@ struct DiscoverPodcastCell: View {
                 .padding(.horizontal, isSponsored ? 36 : 0)
                 .padding(.top, isSponsored ? 18 : 0)
             if isSponsored {
-                Text(L10n.discoverSponsored)
+                Text(L10n.discoverSponsored.sentenceCased)
                     .font(.caption2)
                     .foregroundColor(.pcTextSecondary)
                     .padding(.bottom, 14)

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
@@ -62,10 +62,20 @@ struct DiscoverPodcastsListView: View {
 
     var podcastGrid: some View {
         LazyVGrid(columns: gridColumns, spacing: 48) {
-            ForEach(model.categoryDetails?.podcasts ?? [], id: \.uuid) { podcast in
+            ForEach(model.podcasts, id: \.uuid) { podcast in
                 NavigationLink(value: podcast) {
-                    PodcastImage(uuid: podcast.uuid ?? "", size: .page)
-                        .frame(width: Layout.gridSize, height: Layout.gridSize)
+                    VStack(alignment: .center, spacing: 10) {
+                        PodcastImage(uuid: podcast.uuid ?? "", size: .page)
+                            .padding(.horizontal, model.isSponsored(podcast: podcast) ? 36 : 0)
+                            .padding(.top, model.isSponsored(podcast: podcast) ? 18 : 0)
+                        if model.isSponsored(podcast: podcast) {
+                            Text(L10n.discoverSponsored)
+                                .font(.caption2)
+                                .foregroundColor(.pcTextSecondary)
+                                .padding(.bottom, 14)
+                        }
+                    }
+                    .frame(width: Layout.gridSize, height: Layout.gridSize)
                 }
                 .buttonStyle(.card)
             }

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
@@ -46,7 +46,7 @@ struct DiscoverPodcastsListView: View {
     var podcastsView: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 40) {
-                Text(model.name)
+                Text(L10n.mostPopularWithName(model.name))
                     .font(.title2)
                     .foregroundStyle(Color.pcTextPrimary)
                 podcastGrid

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
@@ -64,18 +64,7 @@ struct DiscoverPodcastsListView: View {
         LazyVGrid(columns: gridColumns, spacing: 48) {
             ForEach(model.podcasts, id: \.uuid) { podcast in
                 NavigationLink(value: podcast) {
-                    VStack(alignment: .center, spacing: 10) {
-                        PodcastImage(uuid: podcast.uuid ?? "", size: .page)
-                            .padding(.horizontal, model.isSponsored(podcast: podcast) ? 36 : 0)
-                            .padding(.top, model.isSponsored(podcast: podcast) ? 18 : 0)
-                        if model.isSponsored(podcast: podcast) {
-                            Text(L10n.discoverSponsored)
-                                .font(.caption2)
-                                .foregroundColor(.pcTextSecondary)
-                                .padding(.bottom, 14)
-                        }
-                    }
-                    .frame(width: Layout.gridSize, height: Layout.gridSize)
+                    DiscoverPodcastCell(podcastUuid: podcast.uuid ?? "", isSponsored: model.isSponsored(podcast: podcast))
                 }
                 .buttonStyle(.card)
             }


### PR DESCRIPTION
Fixes: [PCIOS-740](https://linear.app/a8c/issue/PCIOS-740/show-sponsored-podcast-on-categories)
|:---:|

Adds support for **sponsored podcasts** to the category details screen in the TV app, and updates the category screen title.

### What changed
- **Sponsored podcasts in categories**: `DiscoverManager.loadDiscoverCategoryDetails(for:)` now scans the discover layout for items matching the category that are flagged `isSponsored`, fetches their podcast collections, and merges them into the category's podcast list. It returns a new `DiscoverCategorySection` carrying both the category details and the set of sponsored podcast UUIDs.
- **Fixed sponsored position**: `DiscoverCategoryModel` moves the sponsored podcasts to a fixed position (default `5`, or the front if the list is shorter) and exposes `isSponsored(podcast:)`.
- **Dedicated cell**: extracted the grid item into a new `DiscoverPodcastCell` view, which renders a "Sponsored" label for sponsored entries.
- **Title update**: the category list header now uses `L10n.mostPopularWithName(...)` ("Most Popular In …") instead of the bare category name.

### Why
Brings the TV Discover experience in line with the other platforms by surfacing sponsored podcasts within category listings.

## To test

1. Launch the TV app and open Discover.
2. Open a category that has a sponsored podcast configured in the discover layout.
3. Verify the sponsored podcast appears at the fixed position in the grid with a "Sponsored" label.
4. Verify the screen header reads "Most Popular In <Category>".

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
