### PR TITLE
[PC TV] Tighten Home/Discover section spacing and stabilize title hig…

### DIFF
--- a/Pocket Casts TV App/UI/Common/FocusStore.swift
+++ b/Pocket Casts TV App/UI/Common/FocusStore.swift
@@ -2,21 +2,42 @@ import SwiftUI
 
 @Observable
 class FocusStore {
-    var focusedID: AnyHashable?
+    private(set) var focusedID: AnyHashable?
+    private var holder: UUID?
+
+    /// Marks `section` as focused on behalf of a specific item. The `holder`
+    /// uniquely identifies the claimant so a later `relinquish` can tell
+    /// whether the claim is still its own or has been replaced by a sibling.
+    func claim(section: AnyHashable, holder: UUID) {
+        self.holder = holder
+        focusedID = section
+    }
+
+    /// Clears the focused section, but only if `holder` matches the current
+    /// claimant. Lets a sibling in the same section take over without the
+    /// outgoing item wiping the new claim during a focus handoff.
+    func relinquish(holder: UUID) {
+        guard self.holder == holder else { return }
+        self.holder = nil
+        focusedID = nil
+    }
 }
 
 struct FocusObserving: ViewModifier {
     @Environment(FocusStore.self) var focusStore
     @FocusState private var isFocused: Bool
+    @State private var identity = UUID()
     let section: AnyHashable
 
     func body(content: Content) -> some View {
         content
             .focused($isFocused)
             .onChange(of: isFocused) { _, newValue in
-                if newValue {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        focusStore.focusedID = section
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    if newValue {
+                        focusStore.claim(section: section, holder: identity)
+                    } else {
+                        focusStore.relinquish(holder: identity)
                     }
                 }
             }

--- a/Pocket Casts TV App/UI/Common/FocusStore.swift
+++ b/Pocket Casts TV App/UI/Common/FocusStore.swift
@@ -41,6 +41,13 @@ struct FocusObserving: ViewModifier {
                     }
                 }
             }
+            // If this view is torn down (list recycling, tab swap) the
+            // `isFocused` change to `false` may never fire, leaving the
+            // section title stuck in the highlighted state. `relinquish`
+            // checks the holder, so this won't wipe a sibling's claim.
+            .onDisappear {
+                focusStore.relinquish(holder: identity)
+            }
     }
 }
 

--- a/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
@@ -23,7 +23,7 @@ struct DiscoverAllView: View {
 
     var discoverList: some View {
         ScrollView {
-            LazyVStack(spacing: 80) {
+            LazyVStack(spacing: HomeSectionLayout.sectionSpacing) {
                 ForEach(Array(model.sections.enumerated()), id: \.offset) { _, item in
                     DiscoverRowSection(item: item, source: DiscoverAnalytics.searchSource)
                 }

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -12,7 +12,6 @@ struct HomeView: View {
 
     enum Layout {
         static let gridSize = CGFloat(250)
-        static let sectionSpacing = CGFloat(80)
     }
 
     enum Section: String {
@@ -51,7 +50,7 @@ struct HomeView: View {
     var homeView: some View {
         NavigationStack {
             ScrollView {
-                VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
+                VStack(alignment: .leading, spacing: HomeSectionLayout.sectionSpacing) {
                     if coordinator.userState.isLoggedIn {
                         nowPlayingRow
                         upNextRow
@@ -199,6 +198,13 @@ struct HomeView: View {
     }
 }
 
+/// Single source of truth for the spacing between Home + Discover sections
+/// and between a section's title and its content row.
+enum HomeSectionLayout {
+    static let titleSpacing: CGFloat = 16
+    static let sectionSpacing: CGFloat = 64
+}
+
 struct HomeSection<Content: View>: View {
     private let title: String
     private let focusSection: AnyHashable
@@ -217,7 +223,7 @@ struct HomeSection<Content: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 32) {
+        VStack(alignment: .leading, spacing: HomeSectionLayout.titleSpacing) {
             titleView
             content
         }
@@ -230,11 +236,11 @@ struct HomeSection<Content: View>: View {
     // bottom-aligned so its distance to the content below stays constant.
     private var titleView: some View {
         Text(title)
-            .font(.title2)
+            .font(.title3)
             .hidden()
             .overlay(alignment: .bottomLeading) {
                 Text(title)
-                    .font(isFocusedSection ? .title2 : .headline)
+                    .font(isFocusedSection ? .title3 : .headline)
                     .foregroundStyle(Color.pcTextPrimary)
             }
     }


### PR DESCRIPTION
## Summary

1. Centralized spacing in a new HomeSectionLayout namespace used by both HomeView and DiscoverAllView:
   • Title → content gap: 32 → 16
   • Section → section gap: 80 → 64
2. Focused-section title font: .title2 → .title3 (less dramatic emphasis swap).
3. FocusStore now tracks the specific item holding the claim, so titles only stay highlighted while one of their own rows actually has focus.

Fixes PCIOS-743
Fixex PCIOS-744

## To test

• [ ] Tighter spacing — Open Home (logged in) and Discover. Each section's title sits closer to its row, and rows sit closer to each other vs. trunk.
• [ ] Subtler emphasis — Move focus onto a row in Home/Discover. The section title gets slightly larger (.title3, not .title2) and animates in/out.
• [ ] No stale highlight on tab switch — From a focused row in Home/Discover, navigate to the Search tab. None of Search's section titles ("Featured", "Browse By Category", etc.) should appear in the highlighted (larger) size until you actually focus an item inside that section.
• [ ] Sibling handoff — Inside a single section, move focus from one card to another in the same row. The section title should stay highlighted across the handoff without flickering.
• [ ] Cross-section move — Move focus between two adjacent sections; the previous title drops back to .headline while the new one rises to .title3, animated.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.


https://github.com/user-attachments/assets/d204d3fa-98e0-4c43-974c-3cb60fb7595e
