### PR TITLE
[PC TV] Hide Discover sections when they have no content

### DIFF
--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -44,11 +44,15 @@ struct DiscoverSection {
 }
 
 struct DiscoverEpisodesSection {
+    let title: String?
+    let subtitle: String?
     let episodes: [DiscoverEpisode]
     /// Analytics list identifier for the section, used by the `discover_list_*` events.
     let listId: String?
 
-    init(episodes: [DiscoverEpisode] = [], listId: String? = nil) {
+    init(title: String? = nil, subtitle: String? = nil, episodes: [DiscoverEpisode] = [], listId: String? = nil) {
+        self.title = title
+        self.subtitle = subtitle
         self.episodes = episodes
         self.listId = listId
     }
@@ -255,13 +259,13 @@ actor DiscoverManager {
             return DiscoverEpisodesSection(listId: listId)
         }
 
-        return DiscoverEpisodesSection(episodes: listOfEpisodes, listId: listId)
+        return DiscoverEpisodesSection(title: podcastCollection?.title, subtitle: podcastCollection?.subtitle, episodes: listOfEpisodes, listId: listId)
     }
 
     func makeVideoItem(layout: DiscoverLayout) -> DiscoverItem {
         let videoItem = DiscoverItem(id: "video",
                                      uuid: "video",
-                                     title: L10n.tvHomeVideoSectionTitle,
+                                     title: "made for tv",
                                      type: "episode_video_list",
                                      summaryStyle: "collection",
                                      summaryItemCount: nil,

--- a/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
@@ -54,7 +54,7 @@ struct DiscoverRowSection: View {
     }
 
     var body: some View {
-        HomeSection(title: title, focusSection: item.focusStoreID) {
+        ZStack {
             switch item.rowType {
             case .categories:
                 DiscoverCategoriesRow(popularOnly: false, source: source)
@@ -63,21 +63,9 @@ struct DiscoverRowSection: View {
             case .listVideoEpisode:
                 DiscoverVideoEpisodesRow(item: item, source: source)
             case .singlePodcast:
-                DiscoverSinglePodcastRow(item: item, source: source) { title in
-                    if item.isSponsored == true {
-                        self.title = L10n.tvSponsoredPodcastSectionTitle
-                    } else {
-                        if let title {
-                            self.title = title
-                        }
-                    }
-                }
+                DiscoverSinglePodcastRow(item: item, source: source)
             default:
-                DiscoverPodcastRow(item: item, source: source) { title in
-                    if let title {
-                        self.title = title
-                    }
-                }
+                DiscoverPodcastRow(item: item, source: source)
             }
         }
     }

--- a/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
@@ -52,12 +52,9 @@ struct DiscoverRowSection: View {
     var item: DiscoverItem
     let source: String
 
-    @State var title: String
-
     init(item: DiscoverItem, source: String) {
         self.item = item
         self.source = source
-        _title = State<String>(initialValue: item.title?.localized ?? "")
     }
 
     var body: some View {

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoriesRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoriesRow.swift
@@ -22,7 +22,9 @@ struct DiscoverCategoriesRow: View {
             case .empty:
                 EmptyView()
             case .ready:
-                list
+                HomeSection(title: L10n.tvHomeBrowseCategoriesSectionTitle, focusSection: DiscoverType.categories.rawValue) {
+                    list
+                }
             }
         }
         .task {

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastsRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastsRow.swift
@@ -29,7 +29,9 @@ struct DiscoverFeaturedPodcastsRow: View {
             case .empty:
                 EmptyView()
             case .ready:
-                podcastList
+                HomeSection(title: model.title ?? "", focusSection: model.focusStoreID) {
+                    podcastList
+                }
             }
         }
         .task {

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastsRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastsRow.swift
@@ -29,7 +29,7 @@ struct DiscoverFeaturedPodcastsRow: View {
             case .empty:
                 EmptyView()
             case .ready:
-                HomeSection(title: model.title ?? "", focusSection: model.focusStoreID) {
+                HomeSection(title: model.title, focusSection: model.focusStoreID) {
                     podcastList
                 }
             }

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -22,14 +22,16 @@ struct DiscoverPodcastRow: View {
     }
 
     var body: some View {
-        Group {
+        ZStack {
             switch model.state {
             case .loading:
                 ProgressView()
             case .empty:
                 EmptyView()
             case .ready:
-                podcastList
+                HomeSection(title: model.title, focusSection: model.focusStoreID) {
+                    podcastList
+                }
             }
         }
         .task {
@@ -50,8 +52,7 @@ struct DiscoverPodcastRow: View {
                             PodcastImage(uuid: uuid, size: .page)
                                 .frame(width: Layout.gridSize, height: Layout.gridSize)
                         }
-                        .buttonStyle(.card)
-                        .padding(.vertical, 24)
+                        .buttonStyle(.card)                        
                         .setFocus(section: model.focusStoreID)
                         .simultaneousGesture(TapGesture().onEnded {
                             model.trackPodcastTapped(podcast)

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -53,6 +53,7 @@ struct DiscoverPodcastRow: View {
                                 .frame(width: Layout.gridSize, height: Layout.gridSize)
                         }
                         .buttonStyle(.card)
+                        .padding(.vertical, 24)
                         .setFocus(section: model.focusStoreID)
                         .simultaneousGesture(TapGesture().onEnded {
                             model.trackPodcastTapped(podcast)

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -52,7 +52,7 @@ struct DiscoverPodcastRow: View {
                             PodcastImage(uuid: uuid, size: .page)
                                 .frame(width: Layout.gridSize, height: Layout.gridSize)
                         }
-                        .buttonStyle(.card)                        
+                        .buttonStyle(.card)
                         .setFocus(section: model.focusStoreID)
                         .simultaneousGesture(TapGesture().onEnded {
                             model.trackPodcastTapped(podcast)

--- a/Pocket Casts TV App/UI/Discover/DiscoverSectionEpisodesModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSectionEpisodesModel.swift
@@ -55,7 +55,11 @@ class DiscoverSectionEpisodesModel {
         await MainActor.run {
             state = section.episodes.isEmpty ? .empty : .ready
             self.episodes = section.episodes
-            title =  L10n.tvHomeVideoSectionTitle
+            var composedTitle = section.title?.localized ?? ""
+            if let subtitle = section.subtitle?.localized, !subtitle.isEmpty {
+                composedTitle = subtitle + ": " + composedTitle
+            }
+            title = composedTitle              
             listId = section.listId
         }
     }

--- a/Pocket Casts TV App/UI/Discover/DiscoverSectionEpisodesModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSectionEpisodesModel.swift
@@ -10,7 +10,7 @@ class DiscoverSectionEpisodesModel {
 
     var sponsored = Set<String>()
 
-    var title: String?
+    var title: String = ""
 
     let type: DiscoverType?
 
@@ -64,5 +64,9 @@ class DiscoverSectionEpisodesModel {
     func trackImpression() {
         guard state == .ready, let listId else { return }
         DiscoverAnalytics.listImpression(listId: listId, source: source)
+    }
+
+    var focusStoreID: String {
+        self.item?.focusStoreID ?? self.type?.rawValue ?? ""
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverSectionEpisodesModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSectionEpisodesModel.swift
@@ -59,7 +59,7 @@ class DiscoverSectionEpisodesModel {
             if let subtitle = section.subtitle?.localized, !subtitle.isEmpty {
                 composedTitle = subtitle + ": " + composedTitle
             }
-            title = composedTitle              
+            title = composedTitle
             listId = section.listId
         }
     }

--- a/Pocket Casts TV App/UI/Discover/DiscoverSectionModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSectionModel.swift
@@ -12,7 +12,7 @@ class DiscoverSectionModel {
 
     var isSponsored: Bool = false
 
-    var title: String?
+    var title: String = ""
 
     let type: DiscoverType?
 

--- a/Pocket Casts TV App/UI/Discover/DiscoverSinglePodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSinglePodcastRow.swift
@@ -20,7 +20,7 @@ struct DiscoverSinglePodcastRow: View {
             case .empty:
                 EmptyView()
             case .ready:
-                HomeSection(title: (model.item?.isSponsored ?? false) ? L10n.tvSponsoredPodcastSectionTitle : model.title ?? "", focusSection: model.focusStoreID) {
+                HomeSection(title: (model.item?.isSponsored ?? false) ? L10n.tvSponsoredPodcastSectionTitle : model.title, focusSection: model.focusStoreID) {
                     podcastList
                 }
             }

--- a/Pocket Casts TV App/UI/Discover/DiscoverSinglePodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSinglePodcastRow.swift
@@ -20,7 +20,9 @@ struct DiscoverSinglePodcastRow: View {
             case .empty:
                 EmptyView()
             case .ready:
-                podcastList
+                HomeSection(title: (model.item?.isSponsored ?? false) ? L10n.tvSponsoredPodcastSectionTitle : model.title ?? "", focusSection: model.focusStoreID) {
+                    podcastList
+                }
             }
         }
         .task {

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodesRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodesRow.swift
@@ -33,7 +33,9 @@ struct DiscoverVideoEpisodesRow: View {
             case .empty:
                 EmptyView()
             case .ready:
-                mainContent
+                HomeSection(title: model.title, focusSection: model.focusStoreID) {
+                    mainContent
+                }
             }
         }
         .task {

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -109,52 +109,33 @@ struct HomeView: View {
     }
 
     var youMightLikeRow: some View {
-        HomeSection(title: L10n.tvHomeRecommendedForYouTitle, focusSection: DiscoverType.recommendationsUser.rawValue) {
-            DiscoverPodcastRow(type: .recommendationsUser, source: DiscoverAnalytics.homeSource)
-        }
+        DiscoverPodcastRow(type: .recommendationsUser, source: DiscoverAnalytics.homeSource)
     }
 
     @State private var sectionPodcast: String?
 
     var lovedByListenersOfRow: some View {
-        HomeSection(title: L10n.tvHomeRecommendUserPodcastSectionTitle(sectionPodcast ?? ""), focusSection: DiscoverType.recommendationsSocial.rawValue) {
-            DiscoverPodcastRow(type: .recommendationsSocial, source: DiscoverAnalytics.homeSource) { title in
-                sectionPodcast = title
-            }
-        }
+        DiscoverPodcastRow(type: .recommendationsSocial, source: DiscoverAnalytics.homeSource)
     }
 
     var trendingRow: some View {
-        HomeSection(title: L10n.tvHomeTrendingSectionTitle, focusSection: DiscoverType.trending.rawValue) {
-            DiscoverPodcastRow(type: .trending, source: DiscoverAnalytics.homeSource)
-        }
+        DiscoverPodcastRow(type: .trending, source: DiscoverAnalytics.homeSource)
     }
 
     var featuredRow: some View {
-        HomeSection(title: L10n.tvHomeFeaturedSectionTitle, focusSection: DiscoverType.featured.rawValue) {
-            DiscoverFeaturedPodcastsRow(type: .featured, source: DiscoverAnalytics.homeSource)
-        }
+        DiscoverFeaturedPodcastsRow(type: .featured, source: DiscoverAnalytics.homeSource)
     }
 
     var videoRow: some View {
-        HomeSection(title: L10n.tvHomeVideoSectionTitle, focusSection: DiscoverType.video.rawValue) {
-            DiscoverVideoEpisodesRow(type: .video, source: DiscoverAnalytics.homeSource)
-        }
+        DiscoverVideoEpisodesRow(type: .video, source: DiscoverAnalytics.homeSource)
     }
 
-    @State private var curatedTitle: String?
     var curatedRow: some View {
-        HomeSection(title: curatedTitle ?? L10n.loading, focusSection: DiscoverType.curatedList.rawValue) {
-            DiscoverPodcastRow(type: .curatedList, source: DiscoverAnalytics.homeSource) { title in
-                curatedTitle = title
-            }
-        }
+        DiscoverPodcastRow(type: .curatedList, source: DiscoverAnalytics.homeSource)
     }
 
     var categoriesRow: some View {
-        HomeSection(title: L10n.tvHomeBrowseCategoriesSectionTitle, focusSection: DiscoverType.categories.rawValue) {
-            DiscoverCategoriesRow(popularOnly: true, source: DiscoverAnalytics.homeSource)
-        }
+        DiscoverCategoriesRow(popularOnly: true, source: DiscoverAnalytics.homeSource)
     }
 
     @ViewBuilder

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -111,8 +111,6 @@ struct HomeView: View {
         DiscoverPodcastRow(type: .recommendationsUser, source: DiscoverAnalytics.homeSource)
     }
 
-    @State private var sectionPodcast: String?
-
     var lovedByListenersOfRow: some View {
         DiscoverPodcastRow(type: .recommendationsSocial, source: DiscoverAnalytics.homeSource)
     }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -9950,6 +9950,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Pocket Casts TV App/Pocket-Casts-TV-App-Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Pocket Casts";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
@@ -10002,6 +10003,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Pocket Casts TV App/Pocket-Casts-TV-App-Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Pocket Casts";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
@@ -10054,6 +10056,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Pocket Casts TV App/Pocket-Casts-TV-App-Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Pocket Casts";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;
@@ -10106,6 +10109,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Pocket Casts TV App/Pocket-Casts-TV-App-Info.plist";
+				INFOPLIST_KEY_CFBundleDisplayName = "Pocket Casts";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UIUserInterfaceStyle = Automatic;

--- a/podcasts/LocalizationHelpers.swift
+++ b/podcasts/LocalizationHelpers.swift
@@ -32,6 +32,8 @@ public extension String {
             return L10n.discoverPopular
         case "trending":
             return L10n.discoverTrending
+        case "made for tv":
+            return L10n.tvHomeVideoSectionTitle
 
         // Categories
         case "arts":


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-735](https://linear.app/a8c/issue/PCIOS-735/fix-display-of-empty-discover-sections) <!-- issue number, if applicable -->

On the Pocket Casts TV app, Discover/Home sections previously had their titles managed by the parent container (`HomeView` / `DiscoverRowSection`), which wrapped every row in a `HomeSection`. This meant a section's title (and its surrounding chrome) was rendered even when the section had no content to show — for example when a list failed to load or returned nothing.

This PR moves the `HomeSection` wrapper (and the title) down into each individual Discover row view (`DiscoverPodcastRow`, `DiscoverFeaturedPodcastsRow`, `DiscoverSinglePodcastRow`, `DiscoverVideoEpisodesRow`, `DiscoverCategoriesRow`). Each row now only renders its `HomeSection` (with title) in the `.ready` state, and renders an `EmptyView` when empty. As a result, sections that have no content no longer display an empty/orphaned title.

Supporting changes:
- `title` on `DiscoverSectionModel` / `DiscoverSectionEpisodesModel` is now a non-optional `String` (defaulting to `""`).
- Added a `focusStoreID` helper to `DiscoverSectionEpisodesModel`.
- Removed the now-unused title-binding closures and `@State` title tracking from `HomeView` and `DiscoverAllView`.

## To test

1. Build and run the **Pocket Casts TV App** on the tvOS simulator.
2. Navigate to the **Home** tab and the **Discover** tab.
3. Confirm all populated sections (Trending, Featured, Video, Categories, recommendations, curated lists, single/sponsored podcasts) show their correct titles and content.
4. Verify that sections which return no data no longer render an empty title/header.
5. Confirm focus navigation between sections still works correctly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
