### PR TITLE
[PC TV] Up Next info subtitle and ellipsis focus restore fix

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -165,7 +165,12 @@ struct EpisodeRowWithActions: View {
         .animation(.easeInOut(duration: 0.2), value: shouldShowMoreButton)
         .onChange(of: isShowingActions) { _, showing in
             guard !showing else { return }
-            DispatchQueue.main.async {
+            // tvOS runs its own focus restoration as the dialog animates out,
+            // and it lands focus on whatever surrounds the row (often the tab
+            // bar). Wait for that pass to settle before pulling focus back to
+            // the ellipsis ourselves, otherwise our assignment is overwritten.
+            Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(100))
                 var transaction = Transaction()
                 transaction.disablesAnimations = true
                 withTransaction(transaction) {

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -7,7 +7,6 @@ struct UpNextView: View {
     @Environment(\.requireAccount) private var requireAccount
 
     @State private var model = UpNextViewModel()
-    @State private var showNowPlayingPlayer: Bool = false
 
     @Namespace private var rowNamespace
 
@@ -43,10 +42,6 @@ struct UpNextView: View {
                 }
             }
             .focusScope(rowNamespace)
-            .fullScreenCover(isPresented: $showNowPlayingPlayer) {
-                NowPlayingView()
-                    .ignoresSafeArea()
-            }
         }
     }
 
@@ -74,7 +69,7 @@ struct UpNextView: View {
         let count = queuedEpisodes.count
         let episodeText = count == 1
             ? L10n.podcastEpisodeCountSingular
-            : L10n.podcastEpisodeCountPluralFormat("\(count)")
+            : L10n.podcastEpisodeCountPluralFormat(count.localized())
         let totalSeconds = queuedEpisodes.reduce(0.0) { sum, episode in
             sum + max(0, episode.duration - episode.playedUpTo)
         }

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PocketCastsUtils
 
 struct UpNextView: View {
     @Environment(AppCoordinator.self) var coordinator
@@ -6,6 +7,9 @@ struct UpNextView: View {
     @Environment(\.requireAccount) private var requireAccount
 
     @State private var model = UpNextViewModel()
+    @State private var showNowPlayingPlayer: Bool = false
+
+    @Namespace private var rowNamespace
 
     var body: some View {
         ZStack {
@@ -28,27 +32,17 @@ struct UpNextView: View {
         ProgressView()
     }
 
-    @State private var showNowPlayingPlayer: Bool = false
-
     var upNextView: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 24) {
-                if let currentPlaying = model.episodes.first {
-                    NowPlayingRow(model: currentPlaying) {
-                        showNowPlayingPlayer = true
-                    }
-                    .frame(width: 1242, alignment: .leading)
-                }
-                Text(L10n.tvTabUpNext)
-                    .font(.title2)
-                    .foregroundStyle(Color.pcTextPrimary)
-                ForEach(model.episodes.dropFirst()) { episode in
+                headerRow
+                ForEach(queuedEpisodes) { episode in
                     EpisodeRowWithActions(model: episode, context: .upNext)
                         .frame(width: 1160)
-                        .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
+                        .prefersDefaultFocus(episode.id == queuedEpisodes.first?.id, in: rowNamespace)
                 }
-                .focusScope(rowNamespace)
             }
+            .focusScope(rowNamespace)
             .fullScreenCover(isPresented: $showNowPlayingPlayer) {
                 NowPlayingView()
                     .ignoresSafeArea()
@@ -56,13 +50,45 @@ struct UpNextView: View {
         }
     }
 
+    private var headerRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L10n.tvTabUpNext)
+                .font(.title2)
+                .foregroundStyle(Color.pcTextPrimary)
+            if !queuedEpisodes.isEmpty {
+                Text(summaryText)
+                    .font(.caption)
+                    .foregroundStyle(Color.pcTextSecondary)
+            }
+        }
+        .frame(width: 1160, alignment: .leading)
+    }
+
+    /// The Up Next queue minus the currently playing episode at index 0, which
+    /// the player surfaces elsewhere.
+    private var queuedEpisodes: [EpisodeRowViewModel] {
+        Array(model.episodes.dropFirst())
+    }
+
+    private var summaryText: String {
+        let count = queuedEpisodes.count
+        let episodeText = count == 1
+            ? L10n.podcastEpisodeCountSingular
+            : L10n.podcastEpisodeCountPluralFormat("\(count)")
+        let totalSeconds = queuedEpisodes.reduce(0.0) { sum, episode in
+            sum + max(0, episode.duration - episode.playedUpTo)
+        }
+        let timeText = L10n.podcastTimeLeft(
+            TimeFormatter.shared.multipleUnitFormattedShortTime(time: totalSeconds)
+        )
+        return "\(episodeText) - \(timeText)"
+    }
+
     var emptyView: some View {
         EmptyDataView(title: L10n.tvUpNextEmptyTitle, subtitle: L10n.tvUpNextEmptySubtitle, actionTitle: L10n.tvUpNextEmptyActionTitle) {
             requireAccount { tabRouter.selectedTab = .home }
         }
     }
-
-    @Namespace private var rowNamespace
 }
 
 #Preview {


### PR DESCRIPTION
## Summary

Fixes PCIOS-755
Fixes PCIOS-748

Tightens the Up Next page and addresses a focus regression in the per-episode actions dialog.

- Removes the standalone \"currently playing\" pill at the top of the Up Next page.
- Adds a single subtitle under the \"Up Next\" title showing the queued episode count and total remaining listening time, e.g. **\"3 episodes - 3h 41m left\"**. Reuses existing localized strings (\`podcastEpisodeCountSingular\` / \`podcastEpisodeCountPluralFormat\`, \`podcastTimeLeft\`) and \`TimeFormatter.shared.multipleUnitFormattedShortTime\`.
- Fixes \`EpisodeRowWithActions\` focus restoration after the confirmation dialog dismisses. The old \`DispatchQueue.main.async\` ran before tvOS' own focus restoration finished, so its restoration overwrote ours and focus would drop to the tab bar. A short delayed \`Task\` waits for that pass to settle before pulling focus back to the ellipsis button.

## To test

1. Open the **Up Next** tab on tvOS with several queued episodes.
2. Verify the \"currently playing\" pill is gone; the page leads with the **Up Next** title plus the subtitle (e.g. \"3 episodes - 3h 41m left\").
3. With **1 queued episode**, the subtitle reads \"1 episode - … left\" (singular).
4. Move focus onto a row, press Up to land on the **ellipsis (…) button**, press Select to open the actions dialog.
5. Press the Menu/Esc button to dismiss the dialog. Confirm focus returns to the **ellipsis button** on that same row (not to the tab bar at the top).
6. Repeat step 5 by dismissing via picking an action (e.g. Play Next) — focus should still return to the row's ellipsis.
7. Sanity check the same row's ellipsis dismissal restoration on other surfaces that use \`EpisodeRowWithActions\` (Podcast detail, Playlist detail, History, Starred).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to \`CHANGELOG.md\` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.


https://github.com/user-attachments/assets/7f425141-6914-4582-80d3-ab933c81f990

