### PR TITLE
[PC TV] Improve Made for TV play button and card focus

### DIFF
--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -82,6 +82,14 @@ struct DiscoverVideoEpisodeCell: View {
         .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .content)
         .scaleEffect(isFocused ? 1.1 : 1.0)
         .animation(.easeInOut, value: isFocused)
+        .onChange(of: focusedButton) { oldValue, newValue in
+            // When focus first enters the card it can land on either collapsed
+            // button; force it onto Play so a single click starts playback.
+            // Moving within the card (left to "Go to podcast") is preserved.
+            if oldValue == nil, let newValue, newValue != .playEpisode {
+                focusedButton = .playEpisode
+            }
+        }
         .task {
             await model.load()
         }
@@ -106,6 +114,20 @@ struct DiscoverVideoEpisodeCell: View {
 
     var focusedContent: some View {
         HStack(alignment: .bottom, spacing: 16) {
+            if let podcast = model.podcast {
+                NavigationLink(value: podcast) {
+                    Text(L10n.tvDiscoverFeaturedGoToPodcast)
+                        .foregroundColor(isFocused ? nil : .clear)
+                        .animation(.default, value: isFocused)
+                }
+                .collapsedWhenUnfocused(isFocused)
+                .animation(.none, value: isFocused)
+                .focused($focusedButton, equals: FocusValues.goPodcast)
+                .setFocus(section: DiscoverType.video.rawValue)
+                .simultaneousGesture(TapGesture().onEnded {
+                    trackPodcastTapped()
+                })
+            }
             Button() {
                 trackEpisodeTapped()
                 Task {
@@ -129,20 +151,6 @@ struct DiscoverVideoEpisodeCell: View {
             .setFocus(section: DiscoverType.video.rawValue)
             .contextMenu {
                 DiscoveryEpisodeMenuButtons(podcastUuid: model.episode.podcastUuid ?? "", episodeUuid: model.episode.uuid ?? "", showNotesEpisode: $showNotesEpisode)
-            }
-            if let podcast = model.podcast {
-                NavigationLink(value: podcast) {
-                    Text(L10n.tvDiscoverFeaturedGoToPodcast)
-                        .foregroundColor(isFocused ? nil : .clear)
-                        .animation(.default, value: isFocused)
-                }
-                .collapsedWhenUnfocused(isFocused)
-                .animation(.none, value: isFocused)
-                .focused($focusedButton, equals: FocusValues.goPodcast)
-                .setFocus(section: DiscoverType.video.rawValue)
-                .simultaneousGesture(TapGesture().onEnded {
-                    trackPodcastTapped()
-                })
             }
             Spacer()
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Fixes an issue with it taking two clicks to move to the next card by changing the order of the buttons in "Made for TV" rows.

## To test

1. Launch the Pocket Casts TV app and sign in.
2. On the Home screen, focus the **Made for TV** row.
3. Move focus left/right across the episode cards — each card should land on the circular play button by default.
4. Press select on a focused card — playback should start immediately, with no extra navigation.
5. Press left on a focused card to reach **Go to podcast** and confirm it still navigates to the podcast detail screen.
6. Confirm the play button renders as a perfect circle and sits close to the **Go to podcast** button.

https://github.com/user-attachments/assets/1365d26d-62df-4ebb-8823-470e485cc9d5


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
