### PR TITLE
[PC TV] Route empty state actions in Up Next and Podcasts to Discover

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -8,7 +8,6 @@ fileprivate enum Layout {
 struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabViewModel.self) var tabRouter: MainTabViewModel
-    @Environment(\.requireAccount) private var requireAccount
 
     @State private var model: ViewModel
 
@@ -66,7 +65,7 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
             Text(L10n.tvPodcastsEmptySubtitle)
         } actions: {
             Button(L10n.tvPodcastsEmptyActionTitle) {
-                requireAccount { tabRouter.selectedTab = .home }
+                tabRouter.selectedTab = .home
             }
         }
     }

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -4,7 +4,6 @@ import PocketCastsUtils
 struct UpNextView: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabViewModel.self) var tabRouter: MainTabViewModel
-    @Environment(\.requireAccount) private var requireAccount
 
     @State private var model: UpNextViewModel
 
@@ -90,7 +89,7 @@ struct UpNextView: View {
             Text(L10n.tvUpNextEmptySubtitle)
         } actions: {
             Button(L10n.tvUpNextEmptyActionTitle) {
-                requireAccount { tabRouter.selectedTab = .home }
+                tabRouter.selectedTab = .home
             }
         }
     }


### PR DESCRIPTION
Fixes PCIOS-751.

Routes the empty-state action buttons in the **Up Next** and **Podcasts** tabs to Discover (Home) instead of triggering account creation. The `requireAccount` gate is dropped so the action navigates unconditionally, matching the existing Discover category empty state.

## To test
1. Sign out on Apple TV.
2. **Podcasts** tab → tap "Discover podcasts" → lands on Home/Discover, no Create Account prompt.
3. **Up Next** tab → tap "Add episodes" → same.