### PR TITLE
[PC TV] Consolidate "Log in" copy

### DIFF
--- a/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
+++ b/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
@@ -23,7 +23,7 @@ struct CreateAccountView: View {
     private let steps = [
         L10n.tvCreateAccountModalStepScan,
         L10n.tvCreateAccountModalStepCreate,
-        L10n.tvCreateAccountModalStepSignIn
+        L10n.tvCreateAccountModalStepLogIn
     ]
 
     var body: some View {
@@ -163,7 +163,7 @@ struct CreateAccountView: View {
 
     private func pairingError(message: String) -> some View {
         ContentUnavailableView {
-            Label(L10n.tvSignInQrCodeErrorTitle, systemImage: "wifi.exclamationmark")
+            Label(L10n.tvLogInQrCodeErrorTitle, systemImage: "wifi.exclamationmark")
         } description: {
             Text(message)
         } actions: {

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -127,7 +127,7 @@ struct SignInView: View {
 
     func qrCodeError(message: String) -> some View {
         ContentUnavailableView {
-            Label(L10n.tvSignInQrCodeErrorTitle, systemImage: "wifi.exclamationmark")
+            Label(L10n.tvLogInQrCodeErrorTitle, systemImage: "wifi.exclamationmark")
         } description: {
             Text(message)
         } actions: {
@@ -205,7 +205,7 @@ struct SignInView: View {
             } label: {
                 switch model.state {
                 case .start, .error:
-                    Text(L10n.signIn)
+                    Text(L10n.accountLogin)
                         .frame(minWidth: 300)
                 case .waiting:
                     ProgressView()

--- a/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
@@ -50,7 +50,7 @@ struct ProfileMenuView: View {
             }
             Button(L10n.cancel, role: .cancel) {}
         } message: {
-            Text(L10n.tvProfileMenuLogOutConfirmationMessage)
+            Text(L10n.tvProfileMenuLogOutConfirmationMessageVersion2)
         }
         .onAppear {
             Analytics.track(.profileShown)

--- a/Pocket Casts TV App/UI/WelcomeView.swift
+++ b/Pocket Casts TV App/UI/WelcomeView.swift
@@ -37,7 +37,7 @@ struct WelcomeView: View {
                         .padding(.bottom, 16)
                     HStack(spacing: 16) {
                         NavigationLink(value: Destination.signIn) {
-                            Text(L10n.tvWelcomeSignIn)
+                            Text(L10n.tvWelcomeLogIn)
                         }
                         .simultaneousGesture(TapGesture().onEnded {
                             Analytics.track(.setupAccountButtonTapped, properties: ["button": "sign_in"])

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6022,8 +6022,8 @@
 /* tv welcome subtitle */
 "tv_welcome_subtitle" = "Your podcasts. On the big screen. Obviously.";
 
-/* tv welcome sign in */
-"tv_welcome_sign_in" = "Sign in";
+/* tv welcome log in */
+"tv_welcome_log_in" = "Log in";
 
 /* tv welcome create free account */
 "tv_welcome_create_free_account" = "Create free account";
@@ -6046,8 +6046,8 @@
 /* tv sign enter code go url.  %1$@ is the visible url and %2$@ the full url to enter the code*/
 "tv_sign_in_enter_code_go_url" = "going to [%1$@](%2$@)";
 
-/* tv sign in error title shown when the app fails to fetch the QR sign in code */
-"tv_sign_in_qr_code_error_title" = "Couldn't get your sign in code";
+/* tv log in error title shown when the app fails to fetch the QR log in code */
+"tv_log_in_qr_code_error_title" = "Couldn't get your log in code";
 
 /* tv create account title */
 "tv_create_account_title" = "Create your free account";
@@ -6073,8 +6073,8 @@
 /* tv create account modal step - create your account */
 "tv_create_account_modal_step_create" = "Create your account";
 
-/* tv create account modal step - the TV signs you in automatically */
-"tv_create_account_modal_step_sign_in" = "The TV will sign you in";
+/* tv create account modal step - the TV logs you in automatically */
+"tv_create_account_modal_step_log_in" = "The TV will log you in";
 
 /* tv signing in title */
 "tv_signing_in_title" = "Good to see you.";
@@ -6257,7 +6257,7 @@
 "tv_profile_menu_log_out_confirmation_title" = "Log out?";
 
 /* tv Profile menu — message warning that logging out erases all locally stored data from this Apple TV */
-"tv_profile_menu_log_out_confirmation_message" = "This removes all downloaded podcasts and data from this Apple TV. You can sign in again to restore them.";
+"tv_profile_menu_log_out_confirmation_message_version_2" = "This removes all downloaded podcasts and data from this Apple TV. You can log in again to restore them.";
 
 /* tv Profile menu — log in action (signed-out state) */
 "tv_profile_menu_log_in" = "Log in";


### PR DESCRIPTION
Fixes PCIOS-742.

Consolidates the inconsistent mix of "Sign in" and "Log in" across the tvOS app to "Log in".

Strings whose copy changed got new localization keys (`sign_in` → `log_in`, or a `_version_2` bump) so every locale gets re-translated. The manual-login submit button now reuses the existing `account_login` ("Log in") string instead of the shared iOS `sign_in` ("Sign In") string, so iOS is unaffected.

## To test

1. Launch the tvOS app while signed out — the Welcome screen button now reads **Log in** (was "Sign in").
2. Open Log in → **User/Pass**: the submit button reads **Log in**. Force a QR fetch failure to see "Couldn't get your **log in** code".
3. In the create-account flow, the third step modal reads "The TV will **log you in**".
4. Profile → **Log out**: the confirmation message reads "…You can **log in** again to restore them."

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.