### PR TITLE
[PC TV] Simplify search view modifiers

### DIFF
--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -28,9 +28,6 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                 .searchScopes($model.scope, scopes: {
                     ForEach(SearchScope.allCases, id: \.self) { scope in
                         Text(scope.localizedName)
-                            .font(.caption2)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
                             .tag(scope)
                     }
                 })

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -12,8 +12,8 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                 SearchResultsView(model: model)
             }
             .searchable(text: $searchText, prompt: L10n.tvSearchPrompt)
-            .if(model.isInSearchMode) { content in
-                content.searchSuggestions {
+            .searchSuggestions {
+                if model.isInSearchMode {
                     if searchText.isEmpty {
                         ForEach(model.searchHistory, id: \.self) { search in
                             Text(search).searchCompletion(search)
@@ -25,12 +25,14 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                         }
                     }
                 }
-                .searchScopes($model.scope, scopes: {
+            }
+            .searchScopes($model.scope) {
+                if model.isInSearchMode {
                     ForEach(SearchScope.allCases, id: \.self) { scope in
                         Text(scope.localizedName)
                             .tag(scope)
                     }
-                })
+                }
             }
             .onSubmit {
                 model.saveHistory(searchText)


### PR DESCRIPTION
Simplifies the tvOS search view by removing the `.if(model.isInSearchMode)` conditional modifier. The `.searchSuggestions` and `.searchScopes` modifiers are now always applied, with the search-mode check moved inside their content closures. This keeps the view's identity stable across search-mode changes while preserving the exact same behavior (no suggestions or scope bar when browsing Discover). Also removes the no-op scope styling modifiers.

## To test

1. Open the Search tab and confirm Discover shows with no scope bar or suggestions.
2. Type a query: the scope bar (Podcasts/Episodes) and suggestions appear.
3. Switch scopes, clear the query, and confirm the browse view returns to its original state.