### PR TITLE
[PC TV] Fix archived filter label color on focus

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -205,7 +205,6 @@ struct PlaylistDetailView: View {
 
     private struct ArchivedFilterLabel: View {
         let showArchived: Bool
-        @Environment(\.isFocused) private var isFocused: Bool
 
         var body: some View {
             HStack(spacing: 8) {
@@ -213,7 +212,7 @@ struct PlaylistDetailView: View {
                 Image(systemName: "chevron.down")
             }
             .font(.caption2)
-            .foregroundStyle(isFocused ? Color.pcTextPrimaryActive : Color.pcTextPrimary)
+            .foregroundStyle(Color.pcTextPrimary)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -161,7 +161,6 @@ struct PodcastDetailView: View {
 
     private struct ArchivedFilterLabel: View {
         let showArchived: Bool
-        @Environment(\.isFocused) private var isFocused: Bool
 
         var body: some View {
             HStack(spacing: 8) {
@@ -169,7 +168,7 @@ struct PodcastDetailView: View {
                 Image(systemName: "chevron.down")
             }
             .font(.caption2)
-            .foregroundStyle(isFocused ? Color.pcTextPrimaryActive : Color.pcTextPrimary)
+            .foregroundStyle(Color.pcTextPrimary)
         }
     }
 


### PR DESCRIPTION
Fixes PCIOS-747.

Removes the `@Environment(\.isFocused)`-driven color swap on the archived filter label in the tvOS podcast and playlist detail views. The label now always uses `Color.pcTextPrimary` instead of switching to the active color on focus. It switches automatically thanks to the appearance.

<img width="1920" height="1132" alt="Screenshot 2026-06-17 at 5 34 57 PM" src="https://github.com/user-attachments/assets/bf00de36-5be9-470a-b3ba-8b62a1dc3fe5" />


## To test

1. On the tvOS app, open a podcast or playlist detail view.
2. Focus the archived filter label.
3. Verify the label keeps a consistent text color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)