### PR TITLE
Add Up Next queue sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix incorrect section heading when opening an episode on the Apple Watch [#4528](https://github.com/Automattic/pocket-casts-ios/pull/4528)
 - Make the mini player play/pause button larger [#4566](https://github.com/Automattic/pocket-casts-ios/pull/4566)
 - Add a soft blur edge to the bottom of the podcast grid under Liquid Glass [#4567](https://github.com/Automattic/pocket-casts-ios/pull/4567)
+- Add Up Next queue sorting [#4550](https://github.com/Automattic/pocket-casts-ios/pull/4550)
 
 8.14
 -----

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -319,6 +319,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the Share Profile feature
     case shareProfile
 
+    /// Enable the Up Next sort button
+    case upNextSort
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -534,6 +537,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .showExplicitBadges:
             true
         case .shareProfile:
+            BuildEnvironment.current == .debug
+        case .upNextSort:
             BuildEnvironment.current == .debug
         }
     }

--- a/PocketCastsTests/PlaybackQueueTests.swift
+++ b/PocketCastsTests/PlaybackQueueTests.swift
@@ -34,6 +34,59 @@ final class PlaybackQueueTests: XCTestCase {
                        "Should not include stale episode UUID in replacement list")
     }
 
+    func testReorderUpNextPersistsNewOrderAndKeepsMissingEntriesAtBottom() {
+        let playbackQueue = PlaybackQueue()
+        let mockDataManager = MockDataManager()
+        DataManager.sharedManager = mockDataManager
+
+        // Position 0 is the now playing episode, which stays pinned and isn't reordered.
+        mockDataManager.upNextEpisodes = [
+            playlistEpisode(uuid: "now-playing", position: 0),
+            playlistEpisode(uuid: "a", position: 1),
+            playlistEpisode(uuid: "b", position: 2),
+            playlistEpisode(uuid: "missing", position: 3) // no matching episode in sortedEpisodes
+        ]
+
+        // Desired new order for the known episodes.
+        playbackQueue.reorderUpNext(sortedEpisodes: [episode("b"), episode("a")])
+
+        let savedUuids = mockDataManager.savedPlaylistEpisodes.map { $0.episodeUuid }
+        let savedPositions = mockDataManager.savedPlaylistEpisodes.map { $0.episodePosition }
+
+        // The known episodes follow the sorted order, the missing entry sinks to the bottom...
+        XCTAssertEqual(savedUuids, ["b", "a", "missing"])
+        // ...and positions start at 1 since position 0 is reserved for the now playing episode.
+        XCTAssertEqual(savedPositions, [1, 2, 3])
+    }
+
+    func testReorderUpNextDoesNothingWithFewerThanTwoSortedEpisodes() {
+        let playbackQueue = PlaybackQueue()
+        let mockDataManager = MockDataManager()
+        DataManager.sharedManager = mockDataManager
+
+        mockDataManager.upNextEpisodes = [
+            playlistEpisode(uuid: "now-playing", position: 0),
+            playlistEpisode(uuid: "a", position: 1)
+        ]
+
+        playbackQueue.reorderUpNext(sortedEpisodes: [episode("a")])
+
+        XCTAssertTrue(mockDataManager.savedPlaylistEpisodes.isEmpty, "Reordering one episode should be a no-op")
+    }
+
+    private func playlistEpisode(uuid: String, position: Int32) -> PlaylistEpisode {
+        let playlistEpisode = PlaylistEpisode()
+        playlistEpisode.episodeUuid = uuid
+        playlistEpisode.episodePosition = position
+        return playlistEpisode
+    }
+
+    private func episode(_ uuid: String) -> Episode {
+        let episode = Episode()
+        episode.uuid = uuid
+        return episode
+    }
+
     func testRecentUserInteractionReturnsFalseWhenNoPreviousInteraction() {
         let playbackQueue = PlaybackQueue()
 
@@ -71,12 +124,17 @@ final class PlaybackQueueTests: XCTestCase {
 
 fileprivate class MockDataManager: DataManager {
     var savedReplaceEpisodes: [String] = []
+    var savedPlaylistEpisodes: [PlaylistEpisode] = []
     var upNextEpisodes: [PlaylistEpisode] = []
     var deleteCalled = false
     var cacheManuallyDelayed = false
 
     override func allUpNextPlaylistEpisodes() -> [PlaylistEpisode] {
         return upNextEpisodes
+    }
+
+    override func save(playlistEpisodes: [PlaylistEpisode]) {
+        savedPlaylistEpisodes = playlistEpisodes
     }
 
     override func deleteAllUpNextEpisodes() {

--- a/PocketCastsTests/UpNextSortOptionTests.swift
+++ b/PocketCastsTests/UpNextSortOptionTests.swift
@@ -41,6 +41,31 @@ final class UpNextSortOptionTests: XCTestCase {
         XCTAssertEqual(sorted, ["old", "mid", "new"])
     }
 
+    func testEqualPublishedDatesBreakTieByAddedDate() {
+        let episodes = [
+            episode("addedLater", published: date(1), added: date(2)),
+            episode("addedEarlier", published: date(1), added: date(1))
+        ]
+
+        XCTAssertEqual(UpNextSortOption.newestToOldest.sort(episodes).map { $0.uuid },
+                       ["addedEarlier", "addedLater"])
+        XCTAssertEqual(UpNextSortOption.oldestToNewest.sort(episodes).map { $0.uuid },
+                       ["addedEarlier", "addedLater"])
+    }
+
+    func testEpisodesWithoutPublishedDateGoToTheBottom() {
+        let episodes = [
+            episode("noDate", published: nil, added: date(1)),
+            episode("new", published: date(3)),
+            episode("old", published: date(1))
+        ]
+
+        XCTAssertEqual(UpNextSortOption.newestToOldest.sort(episodes).map { $0.uuid },
+                       ["new", "old", "noDate"])
+        XCTAssertEqual(UpNextSortOption.oldestToNewest.sort(episodes).map { $0.uuid },
+                       ["old", "new", "noDate"])
+    }
+
     func testShortestToLongestSortsByDurationAscending() {
         let episodes = [
             episode("long", duration: 3_000),

--- a/PocketCastsTests/UpNextSortOptionTests.swift
+++ b/PocketCastsTests/UpNextSortOptionTests.swift
@@ -4,11 +4,12 @@ import XCTest
 
 final class UpNextSortOptionTests: XCTestCase {
 
-    private func episode(_ uuid: String, published: Date? = nil, duration: Double = 0, added: Date? = nil) -> Episode {
+    private func episode(_ uuid: String, published: Date? = nil, duration: Double = 0, playedUpTo: Double = 0, added: Date? = nil) -> Episode {
         let episode = Episode()
         episode.uuid = uuid
         episode.publishedDate = published
         episode.duration = duration
+        episode.playedUpTo = playedUpTo
         episode.addedDate = added
         return episode
     }
@@ -66,11 +67,11 @@ final class UpNextSortOptionTests: XCTestCase {
                        ["old", "new", "noDate"])
     }
 
-    func testShortestToLongestSortsByDurationAscending() {
+    func testShortestToLongestSortsByTimeRemainingAscending() {
         let episodes = [
-            episode("long", duration: 3_000),
             episode("short", duration: 600),
-            episode("medium", duration: 1_800)
+            episode("medium", duration: 1_800),
+            episode("long", duration: 3_000)
         ]
 
         let sorted = UpNextSortOption.shortestToLongest.sort(episodes).map { $0.uuid }
@@ -78,16 +79,31 @@ final class UpNextSortOptionTests: XCTestCase {
         XCTAssertEqual(sorted, ["short", "medium", "long"])
     }
 
-    func testLongestToShortestSortsByDurationDescending() {
+    func testLongestToShortestSortsByTimeRemainingDescending() {
         let episodes = [
-            episode("long", duration: 3_000),
             episode("short", duration: 600),
-            episode("medium", duration: 1_800)
+            episode("medium", duration: 1_800),
+            episode("long", duration: 3_000)
         ]
 
         let sorted = UpNextSortOption.longestToShortest.sort(episodes).map { $0.uuid }
 
         XCTAssertEqual(sorted, ["long", "medium", "short"])
+    }
+
+    func testTimeRemainingAccountsForAlreadyPlayedTime() {
+        // A long episode that's almost finished has less time remaining than a
+        // short, unplayed one, so it should sort first when shortest-to-longest.
+        let episodes = [
+            episode("longAlmostDone", duration: 3_000, playedUpTo: 2_900), // 100 remaining
+            episode("shortUnplayed", duration: 600, playedUpTo: 0),        // 600 remaining
+            episode("midHalfPlayed", duration: 1_800, playedUpTo: 900)     // 900 remaining
+        ]
+
+        XCTAssertEqual(UpNextSortOption.shortestToLongest.sort(episodes).map { $0.uuid },
+                       ["longAlmostDone", "shortUnplayed", "midHalfPlayed"])
+        XCTAssertEqual(UpNextSortOption.longestToShortest.sort(episodes).map { $0.uuid },
+                       ["midHalfPlayed", "shortUnplayed", "longAlmostDone"])
     }
 
     func testEpisodesWithoutDurationAlwaysGoToTheBottom() {
@@ -103,10 +119,10 @@ final class UpNextSortOptionTests: XCTestCase {
                        ["long", "short", "noDuration"])
     }
 
-    func testEqualDurationsBreakTieByAddedDate() {
+    func testEqualTimeRemainingBreakTieByAddedDate() {
         let episodes = [
-            episode("addedLater", duration: 1_000, added: date(2)),
-            episode("addedEarlier", duration: 1_000, added: date(1))
+            episode("addedLater", duration: 2_000, playedUpTo: 1_000, added: date(2)),  // 1_000 remaining
+            episode("addedEarlier", duration: 1_000, playedUpTo: 0, added: date(1))     // 1_000 remaining
         ]
 
         let sorted = UpNextSortOption.shortestToLongest.sort(episodes).map { $0.uuid }

--- a/PocketCastsTests/UpNextSortOptionTests.swift
+++ b/PocketCastsTests/UpNextSortOptionTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import podcasts
+@testable import PocketCastsDataModel
+
+final class UpNextSortOptionTests: XCTestCase {
+
+    private func episode(_ uuid: String, published: Date? = nil, duration: Double = 0, added: Date? = nil) -> Episode {
+        let episode = Episode()
+        episode.uuid = uuid
+        episode.publishedDate = published
+        episode.duration = duration
+        episode.addedDate = added
+        return episode
+    }
+
+    private func date(_ daysFromNow: Double) -> Date {
+        Date(timeIntervalSince1970: 1_000_000 + daysFromNow * 86_400)
+    }
+
+    func testNewestToOldestSortsByPublishedDateDescending() {
+        let episodes = [
+            episode("old", published: date(1)),
+            episode("new", published: date(3)),
+            episode("mid", published: date(2))
+        ]
+
+        let sorted = UpNextSortOption.newestToOldest.sort(episodes).map { $0.uuid }
+
+        XCTAssertEqual(sorted, ["new", "mid", "old"])
+    }
+
+    func testOldestToNewestSortsByPublishedDateAscending() {
+        let episodes = [
+            episode("old", published: date(1)),
+            episode("new", published: date(3)),
+            episode("mid", published: date(2))
+        ]
+
+        let sorted = UpNextSortOption.oldestToNewest.sort(episodes).map { $0.uuid }
+
+        XCTAssertEqual(sorted, ["old", "mid", "new"])
+    }
+
+    func testShortestToLongestSortsByDurationAscending() {
+        let episodes = [
+            episode("long", duration: 3_000),
+            episode("short", duration: 600),
+            episode("medium", duration: 1_800)
+        ]
+
+        let sorted = UpNextSortOption.shortestToLongest.sort(episodes).map { $0.uuid }
+
+        XCTAssertEqual(sorted, ["short", "medium", "long"])
+    }
+
+    func testLongestToShortestSortsByDurationDescending() {
+        let episodes = [
+            episode("long", duration: 3_000),
+            episode("short", duration: 600),
+            episode("medium", duration: 1_800)
+        ]
+
+        let sorted = UpNextSortOption.longestToShortest.sort(episodes).map { $0.uuid }
+
+        XCTAssertEqual(sorted, ["long", "medium", "short"])
+    }
+
+    func testEpisodesWithoutDurationAlwaysGoToTheBottom() {
+        let episodes = [
+            episode("noDuration", duration: 0, added: date(1)),
+            episode("long", duration: 3_000),
+            episode("short", duration: 600)
+        ]
+
+        XCTAssertEqual(UpNextSortOption.shortestToLongest.sort(episodes).map { $0.uuid },
+                       ["short", "long", "noDuration"])
+        XCTAssertEqual(UpNextSortOption.longestToShortest.sort(episodes).map { $0.uuid },
+                       ["long", "short", "noDuration"])
+    }
+
+    func testEqualDurationsBreakTieByAddedDate() {
+        let episodes = [
+            episode("addedLater", duration: 1_000, added: date(2)),
+            episode("addedEarlier", duration: 1_000, added: date(1))
+        ]
+
+        let sorted = UpNextSortOption.shortestToLongest.sort(episodes).map { $0.uuid }
+
+        XCTAssertEqual(sorted, ["addedEarlier", "addedLater"])
+    }
+}

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -465,6 +465,7 @@ enum AnalyticsEvent: String {
     case upNextQueueReordered
     case upNextDismissed
     case upNextShuffleEnabled
+    case upNextSort
     case upNextDiscoverButtonTapped
 
     // MARK: - Privacy

--- a/podcasts/Common Components/Buttons/HitTargetButton.swift
+++ b/podcasts/Common Components/Buttons/HitTargetButton.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+/// A button whose tappable area is expanded to a minimum size, centered on its
+/// bounds, without affecting its visible layout. Useful for small icon buttons
+/// that need to meet Apple's recommended 44x44pt minimum tap target.
+final class HitTargetButton: UIButton {
+    var minimumHitTarget = CGSize(width: 44, height: 44)
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        let dx = min(0, (bounds.width - minimumHitTarget.width) / 2)
+        let dy = min(0, (bounds.height - minimumHitTarget.height) / 2)
+        return bounds.insetBy(dx: dx, dy: dy).contains(point)
+    }
+}

--- a/podcasts/Common Components/SettingsTableHeader.swift
+++ b/podcasts/Common Components/SettingsTableHeader.swift
@@ -125,15 +125,3 @@ class SettingsTableHeader: ThemeableView {
         lockImage?.updateSizeConstraints(to: iconSize)
     }
 }
-
-/// A button whose tappable area is expanded to a minimum size, centered on its
-/// bounds, without affecting its visible layout.
-private final class HitTargetButton: UIButton {
-    var minimumHitTarget = CGSize(width: 44, height: 44)
-
-    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        let dx = min(0, (bounds.width - minimumHitTarget.width) / 2)
-        let dy = min(0, (bounds.height - minimumHitTarget.height) / 2)
-        return bounds.insetBy(dx: dx, dy: dy).contains(point)
-    }
-}

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -184,6 +184,34 @@ class PlaybackQueue: NSObject {
         refreshAppFiring(notificationName: Constants.Notifications.upNextQueueChanged)
     }
 
+    /// Reorders the Up Next queue to match `sortedEpisodes` (the queued episodes excluding now playing, which stays pinned at the top).
+    func reorderUpNext(sortedEpisodes: [BaseEpisode]) {
+        guard sortedEpisodes.count > 1 else { return }
+
+        // Up Next playlist entries, excluding the now playing episode at index 0.
+        var remaining = Array(DataManager.sharedManager.allUpNextPlaylistEpisodes().dropFirst())
+        var ordered = [PlaylistEpisode]()
+
+        // Match the sorted episodes back to their playlist entries...
+        for episode in sortedEpisodes {
+            if let index = remaining.firstIndex(where: { $0.episodeUuid == episode.uuid }) {
+                ordered.append(remaining.remove(at: index))
+            }
+        }
+        // ...and keep any entries without metadata (e.g. not-yet-synced episodes) at the bottom.
+        ordered.append(contentsOf: remaining)
+
+        for (index, playlistEpisode) in ordered.enumerated() {
+            // position 0 is the now playing episode, so the queue starts at 1
+            playlistEpisode.episodePosition = Int32(index + 1)
+        }
+        DataManager.sharedManager.save(playlistEpisodes: ordered)
+
+        saveReplaceIfRequired()
+
+        refreshAppFiring(notificationName: Constants.Notifications.upNextQueueChanged)
+    }
+
     func insert(episode: BaseEpisode, position: Int) {
         let existingEpisode = contains(episode: episode)
 

--- a/podcasts/UpNextViewController+Table.swift
+++ b/podcasts/UpNextViewController+Table.swift
@@ -37,6 +37,9 @@ extension UpNextViewController: UITableViewDelegate, UITableViewDataSource {
             shuffleButton.isHidden = true
             clearQueueButton.isEnabled = PlaybackManager.shared.queue.upNextCount() > 0
         }
+        if FeatureFlag.upNextSort.enabled {
+            sortButton.isHidden = PlaybackManager.shared.queue.upNextCount() == 0
+        }
         return headerView
     }
 

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -593,7 +593,7 @@ enum UpNextSortOption: CaseIterable, AnalyticsDescribable {
         }
     }
 
-    /// Returns the episodes reordered for this option. Both publish-date and duration sorts break ties by added date so the order is deterministic; for duration sorts, zero/unknown durations also sink to the bottom.
+    /// Returns the episodes reordered for this option. Both publish-date and time-remaining sorts break ties by added date so the order is deterministic; for time-remaining sorts, episodes with unknown duration also sink to the bottom.
     func sort(_ episodes: [BaseEpisode]) -> [BaseEpisode] {
         switch self {
         case .newestToOldest:
@@ -601,9 +601,9 @@ enum UpNextSortOption: CaseIterable, AnalyticsDescribable {
         case .oldestToNewest:
             return sortedByPublishedDate(episodes, ascending: true)
         case .shortestToLongest:
-            return sortedByDuration(episodes, ascending: true)
+            return sortedByTimeRemaining(episodes, ascending: true)
         case .longestToShortest:
-            return sortedByDuration(episodes, ascending: false)
+            return sortedByTimeRemaining(episodes, ascending: false)
         }
     }
 
@@ -623,7 +623,7 @@ enum UpNextSortOption: CaseIterable, AnalyticsDescribable {
         }
     }
 
-    private func sortedByDuration(_ episodes: [BaseEpisode], ascending: Bool) -> [BaseEpisode] {
+    private func sortedByTimeRemaining(_ episodes: [BaseEpisode], ascending: Bool) -> [BaseEpisode] {
         episodes.sorted { lhs, rhs in
             let lhsHasDuration = lhs.duration > 0
             let rhsHasDuration = rhs.duration > 0
@@ -633,12 +633,16 @@ enum UpNextSortOption: CaseIterable, AnalyticsDescribable {
                 return lhsHasDuration
             }
 
-            // Same duration (including both unknown): keep the order they were added.
-            if lhs.duration == rhs.duration {
+            // Compare by the episodes time remaining.
+            let lhsRemaining = lhs.duration - lhs.playedUpTo
+            let rhsRemaining = rhs.duration - rhs.playedUpTo
+
+            // Same time remaining (including both unknown): keep the order they were added.
+            if lhsRemaining == rhsRemaining {
                 return (lhs.addedDate ?? .distantPast) < (rhs.addedDate ?? .distantPast)
             }
 
-            return ascending ? lhs.duration < rhs.duration : lhs.duration > rhs.duration
+            return ascending ? lhsRemaining < rhsRemaining : lhsRemaining > rhsRemaining
         }
     }
 }

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -53,9 +53,10 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     var changedViaSwipeToRemove = false
 
     let remainingLabel = ThemeableLabel()
-    let shuffleButton = UIButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
-    let sortButton = UIButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
-    let clearQueueButton = UIButton(frame: CGRect(x: 0, y: 0, width: 93, height: 16))
+    // Use HitTargetButton so these small header controls meet Apple's recommended 44x44pt minimum tap target without changing their visible size.
+    let shuffleButton = HitTargetButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
+    let sortButton = HitTargetButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
+    let clearQueueButton = HitTargetButton(frame: CGRect(x: 0, y: 0, width: 93, height: 16))
     var selectedPlayListEpisodes = [PlaylistEpisode]() {
         didSet {
             multiSelectActionBar.setSelectedCount(count: selectedPlayListEpisodes.count)

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -592,17 +592,33 @@ enum UpNextSortOption: CaseIterable, AnalyticsDescribable {
         }
     }
 
-    /// Returns the episodes reordered for this option; for duration sorts, zero/unknown durations sink to the bottom and ties break by added date.
+    /// Returns the episodes reordered for this option. Both publish-date and duration sorts break ties by added date so the order is deterministic; for duration sorts, zero/unknown durations also sink to the bottom.
     func sort(_ episodes: [BaseEpisode]) -> [BaseEpisode] {
         switch self {
         case .newestToOldest:
-            return episodes.sorted { ($0.publishedDate ?? .distantPast) > ($1.publishedDate ?? .distantPast) }
+            return sortedByPublishedDate(episodes, ascending: false)
         case .oldestToNewest:
-            return episodes.sorted { ($0.publishedDate ?? .distantFuture) < ($1.publishedDate ?? .distantFuture) }
+            return sortedByPublishedDate(episodes, ascending: true)
         case .shortestToLongest:
             return sortedByDuration(episodes, ascending: true)
         case .longestToShortest:
             return sortedByDuration(episodes, ascending: false)
+        }
+    }
+
+    private func sortedByPublishedDate(_ episodes: [BaseEpisode], ascending: Bool) -> [BaseEpisode] {
+        // Missing dates sort last: to the future when ascending, to the past when descending.
+        let fallback: Date = ascending ? .distantFuture : .distantPast
+        return episodes.sorted { lhs, rhs in
+            let lhsDate = lhs.publishedDate ?? fallback
+            let rhsDate = rhs.publishedDate ?? fallback
+
+            // Same published date (including both missing): keep the order they were added.
+            if lhsDate == rhsDate {
+                return (lhs.addedDate ?? .distantPast) < (rhs.addedDate ?? .distantPast)
+            }
+
+            return ascending ? lhsDate < rhsDate : lhsDate > rhsDate
         }
     }
 

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -54,6 +54,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     let remainingLabel = ThemeableLabel()
     let shuffleButton = UIButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
+    let sortButton = UIButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
     let clearQueueButton = UIButton(frame: CGRect(x: 0, y: 0, width: 93, height: 16))
     var selectedPlayListEpisodes = [PlaylistEpisode]() {
         didSet {
@@ -84,11 +85,27 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             remainingLabel.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -8)
         ])
 
+        if FeatureFlag.upNextSort.enabled {
+            headerView.addSubview(sortButton)
+            sortButton.translatesAutoresizingMaskIntoConstraints = false
+            sortButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+            NSLayoutConstraint.activate([
+                sortButton.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -20),
+                sortButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
+                sortButton.widthAnchor.constraint(equalToConstant: 24),
+                sortButton.heightAnchor.constraint(equalToConstant: 24)
+            ])
+        }
+
+        // When the sort button is shown, the shuffle/clear buttons sit to its left.
+        let trailingButtonAnchor = FeatureFlag.upNextSort.enabled ? sortButton.leadingAnchor : headerView.trailingAnchor
+        let trailingButtonConstant: CGFloat = FeatureFlag.upNextSort.enabled ? -16 : -20
+
         headerView.addSubview(shuffleButton)
         shuffleButton.translatesAutoresizingMaskIntoConstraints = false
         shuffleButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         NSLayoutConstraint.activate([
-            shuffleButton.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -20),
+            shuffleButton.trailingAnchor.constraint(equalTo: trailingButtonAnchor, constant: trailingButtonConstant),
             shuffleButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
             shuffleButton.leadingAnchor.constraint(greaterThanOrEqualTo: remainingLabel.trailingAnchor, constant: 10),
             shuffleButton.widthAnchor.constraint(equalToConstant: 24),
@@ -99,7 +116,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         clearQueueButton.translatesAutoresizingMaskIntoConstraints = false
         clearQueueButton.setContentCompressionResistancePriority(.required, for: .horizontal)
         NSLayoutConstraint.activate([
-            clearQueueButton.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -20),
+            clearQueueButton.trailingAnchor.constraint(equalTo: trailingButtonAnchor, constant: trailingButtonConstant),
             clearQueueButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
             clearQueueButton.leadingAnchor.constraint(greaterThanOrEqualTo: remainingLabel.trailingAnchor, constant: 10)
         ])
@@ -110,6 +127,9 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         } else {
             shuffleButton.isHidden = true
             clearQueueButton.isEnabled = PlaybackManager.shared.queue.upNextCount() > 0
+        }
+        if FeatureFlag.upNextSort.enabled {
+            sortButton.isHidden = PlaybackManager.shared.queue.upNextCount() == 0
         }
         updateSize()
         return headerView
@@ -330,6 +350,42 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             clearQueueButton.titleLabel?.adjustsFontForContentSizeCategory = true
             clearQueueButton.addTarget(self, action: #selector(clearQueueTapped), for: .touchUpInside)
         }
+        setupSortButtonIfNecessary()
+    }
+
+    private func setupSortButtonIfNecessary() {
+        guard FeatureFlag.upNextSort.enabled, sortButton.allTargets.isEmpty else { return }
+        NotificationCenter.default.addObserver(self, selector: #selector(updateSortButtonImage), name: Constants.Notifications.themeChanged, object: nil)
+        updateSortButtonImage()
+        sortButton.addTarget(self, action: #selector(sortButtonTapped), for: .touchUpInside)
+    }
+
+    @objc private func updateSortButtonImage() {
+        let image = UIImage(named: "podcast-sort")?
+            .withTintColor(AppTheme.colorForStyle(.primaryIcon02, themeOverride: themeOverride), renderingMode: .alwaysOriginal)
+        sortButton.setImage(image, for: .normal)
+        sortButton.imageView?.adjustsImageSizeForAccessibilityContentSizeCategory = true
+        sortButton.imageView?.contentMode = .scaleAspectFit
+        sortButton.accessibilityLabel = L10n.upNextSortTitle
+    }
+
+    @objc private func sortButtonTapped() {
+        let optionsPicker = makeSortOptionsPicker()
+        optionsPicker.present(from: self)
+    }
+
+    private func makeSortOptionsPicker() -> OptionsPicker {
+        let optionsPicker = OptionsPicker(title: L10n.upNextSortTitle.localizedUppercase, themeOverride: themeOverride)
+        for option in UpNextSortOption.allCases {
+            let action = OptionAction(label: option.description) { [weak self] in
+                let queue = PlaybackManager.shared.queue
+                queue.reorderUpNext(sortedEpisodes: option.sort(queue.allEpisodes(includeNowPlaying: false)))
+                self?.reloadTable()
+                self?.track(.upNextSort, properties: ["sort_type": option.analyticsDescription])
+            }
+            optionsPicker.addAction(action: action)
+        }
+        return optionsPicker
     }
 
     @objc private func updateShuffleButtonState() {
@@ -502,6 +558,74 @@ enum UpNextViewSource: String, AnalyticsDescribable {
     var analyticsDescription: String { rawValue }
 }
 
+/// Sort orders offered by the Up Next sort button; a one-off reorder, so there's no persisted "current" option.
+enum UpNextSortOption: CaseIterable, AnalyticsDescribable {
+    case newestToOldest
+    case oldestToNewest
+    case shortestToLongest
+    case longestToShortest
+
+    /// User facing label shown in the options picker.
+    var description: String {
+        switch self {
+        case .newestToOldest:
+            return L10n.upNextSortNewestToOldest
+        case .oldestToNewest:
+            return L10n.upNextSortOldestToNewest
+        case .shortestToLongest:
+            return L10n.upNextSortShortestToLongest
+        case .longestToShortest:
+            return L10n.upNextSortLongestToShortest
+        }
+    }
+
+    var analyticsDescription: String {
+        switch self {
+        case .newestToOldest:
+            return "newest_to_oldest"
+        case .oldestToNewest:
+            return "oldest_to_newest"
+        case .shortestToLongest:
+            return "shortest_to_longest"
+        case .longestToShortest:
+            return "longest_to_shortest"
+        }
+    }
+
+    /// Returns the episodes reordered for this option; for duration sorts, zero/unknown durations sink to the bottom and ties break by added date.
+    func sort(_ episodes: [BaseEpisode]) -> [BaseEpisode] {
+        switch self {
+        case .newestToOldest:
+            return episodes.sorted { ($0.publishedDate ?? .distantPast) > ($1.publishedDate ?? .distantPast) }
+        case .oldestToNewest:
+            return episodes.sorted { ($0.publishedDate ?? .distantFuture) < ($1.publishedDate ?? .distantFuture) }
+        case .shortestToLongest:
+            return sortedByDuration(episodes, ascending: true)
+        case .longestToShortest:
+            return sortedByDuration(episodes, ascending: false)
+        }
+    }
+
+    private func sortedByDuration(_ episodes: [BaseEpisode], ascending: Bool) -> [BaseEpisode] {
+        episodes.sorted { lhs, rhs in
+            let lhsHasDuration = lhs.duration > 0
+            let rhsHasDuration = rhs.duration > 0
+
+            // Episodes with no known duration always sink to the bottom.
+            if lhsHasDuration != rhsHasDuration {
+                return lhsHasDuration
+            }
+
+            // Same duration (including both unknown): keep the order they were added.
+            if lhs.duration == rhs.duration {
+                return (lhs.addedDate ?? .distantPast) < (rhs.addedDate ?? .distantPast)
+            }
+
+            return ascending ? lhs.duration < rhs.duration : lhs.duration > rhs.duration
+        }
+    }
+}
+
 extension UpNextViewController: AnalyticsSourceProvider {
     var analyticsSource: AnalyticsSource {
         .upNext
@@ -515,6 +639,9 @@ extension UpNextViewController {
         let metric = UIFontMetrics(forTextStyle: .largeTitle)
         let buttonSize = max(24, metric.scaledValue(for: 24))
         shuffleButton.updateSizeConstraints(to: buttonSize)
+        if FeatureFlag.upNextSort.enabled {
+            sortButton.updateSizeConstraints(to: buttonSize)
+        }
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5039,6 +5039,21 @@
 /* Toast message displayed when the user enables the Up Next Shuffle option */
 "up_next_shuffle_toast_message" = "Shuffle is on. Episodes will play in random order.";
 
+/* Title shown at the top of the Up Next sort options picker */
+"up_next_sort_title" = "Sort Up Next";
+
+/* Up Next sort option that orders episodes by release date, newest first */
+"up_next_sort_newest_to_oldest" = "Newest to oldest";
+
+/* Up Next sort option that orders episodes by release date, oldest first */
+"up_next_sort_oldest_to_newest" = "Oldest to newest";
+
+/* Up Next sort option that orders episodes by duration, shortest first */
+"up_next_sort_shortest_to_longest" = "Shortest to longest";
+
+/* Up Next sort option that orders episodes by duration, longest first */
+"up_next_sort_longest_to_shortest" = "Longest to shortest";
+
 /* Title for manage downloads file space usage banner and modal */
 "manage_downloads_title" = "Need to free up space?";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5048,10 +5048,10 @@
 /* Up Next sort option that orders episodes by release date, oldest first */
 "up_next_sort_oldest_to_newest" = "Oldest to newest";
 
-/* Up Next sort option that orders episodes by duration, shortest first */
+/* Up Next sort option that orders episodes by time remaining, shortest first */
 "up_next_sort_shortest_to_longest" = "Shortest to longest";
 
-/* Up Next sort option that orders episodes by duration, longest first */
+/* Up Next sort option that orders episodes by time remaining, longest first */
 "up_next_sort_longest_to_shortest" = "Longest to shortest";
 
 /* Title for manage downloads file space usage banner and modal */


### PR DESCRIPTION
This change introduces Up Next sorting. The plan to only to add sort by duration but iOS was missing sort by publish date so this include this.

Fixes https://linear.app/a8c/issue/POC-671/ios-add-up-next-duration-sort

## Test Steps

1. Go to the Up Next tab
2. Clear your Up Next
3. ✅ Verify the sort button is hidden
4. Add episodes from various dates to your Up Next
5. Tap the sort button
6. ✅ Verify all the sort options work as they should
7. ✅ Verify the analytic event `up_next_sort` is fire with the [right properties](https://glowing-adventure-r62o7m1.pages.github.io/#/product/pocket-casts?q=up_next_sorted&event=up_next_sort).
8. Disable the feature flag `upNextSort` and confirm sort no longer appears (this will take an app restart).

## Screenshots

<img width="400" src="https://github.com/user-attachments/assets/d1ce7fec-ff61-48b8-b92f-2ea71c318774" />

<img width="400" src="https://github.com/user-attachments/assets/ea41d0e2-8d39-40f4-ab3a-e35482f4bed0" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
