### PR TITLE
Update GitHub PR template to use Event Horizon

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,4 +16,4 @@ Fixes PCIOS- <!-- issue number, if applicable -->
 
 - [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
 - [ ] I have considered adding unit tests for my changes.
-- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
+- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.


### PR DESCRIPTION
## Description

Updates the analytics reminder in the GitHub pull request template to point at the new [Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) instead of the old Google Sheets spreadsheet. Analytics definitions have moved to Event Horizon, so this keeps the checklist link accurate and points contributors to the right place when adding or changing analytics events.

## Testing Instructions

1. Open a new pull request (or preview the template) and verify the checklist line reads "I have updated (or requested that someone edit) the Event Horizon schema...".
2. Confirm the link resolves to the Event Horizon schema repo.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
