### PR TITLE
Add explicit badge to Featured cell

### DIFF
--- a/podcasts/DiscoverFeaturedView.swift
+++ b/podcasts/DiscoverFeaturedView.swift
@@ -97,8 +97,13 @@ class DiscoverFeaturedView: ThemeableView {
         listType.text = isSponsored ? L10n.discoverSponsored : listName.uppercased()
         listType.setLetterSpacing(1.57)
 
+        let isExplicit = discoverPodcast.isExplicit ?? false
         if let title = discoverPodcast.title?.localized {
-            podcastTitle.text = title
+            if isExplicit {
+                podcastTitle.attributedText = ExplicitBadgeHelper.attributedTitle(title, font: podcastTitle.font)
+            } else {
+                podcastTitle.text = title
+            }
         }
 
         if let author = discoverPodcast.author {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes [PCIOS-761](https://linear.app/a8c/issue/PCIOS-761/the-featured-podcasts-dont-include-a-explicit-badge)

Adds the explicit content badge to podcast titles in the Discover "Featured" cell, matching the badge already shown elsewhere in Discover. When a featured podcast is marked explicit, the title now renders an attributed string with the explicit badge via `ExplicitBadgeHelper`; non-explicit titles render as plain text as before.

<img width="320" alt="Simulator Screenshot - iPhone 16 Pro - 2026-06-18 at 10 17 30" src="https://github.com/user-attachments/assets/42cc5808-369f-4a55-bbc2-da68ea6776d6" />


## To test

1. Open the **Discover** tab.
2. Locate the **Featured** section at the top.
3. Confirm a featured podcast that is marked explicit shows the explicit badge next to its title.
4. Confirm a non-explicit featured podcast shows its title without a badge.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
