### PR TITLE
Remove /pair URL interception workaround

### DIFF
--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -7,15 +7,6 @@ import PocketCastsUtils
 
 extension AppDelegate {
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        /// Temporary workaround: avoid the app handling the /pair urls as a share url until we implement proper pair URL handling.
-        /// Returning false causes the system to fall back to opening the universal link in the browser.
-        if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
-            if let incomingURL = userActivity.webpageURL,
-               let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true),
-               let path = components.path, path.startsWith(string: "/pair") {
-                return false
-            }
-        }
 
         handleContinue(userActivity)
 
@@ -40,12 +31,6 @@ extension AppDelegate {
 
             //If path is just the base share URL let's return
             if path.isEmpty || path == "/", URL(string: ServerConstants.Urls.share())?.host == incomingURL.host {
-                return
-            }
-
-            // This is temporary workaround to avoid the app handling the /pair urls as a share url until we implement the proper pair URL handling on 8.15
-            // This will make the user to be redirected to the web page
-            if path.startsWith(string: "/pair") {
                 return
             }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Removes the temporary workaround that prevented the app from handling `/pair` universal links and deep links. Previously, the app intentionally bailed out (returning `false` for browsing web activity and early-returning in the deep link handler) on any URL whose path started with `/pair`, which forced those links to fall back to opening in the browser. This was a stopgap until proper pair URL handling was in place. With the interception removed, `/pair` URLs now flow through the normal handling path.

## To test

1. Build and run the staging app.
2. Open a `/pair` universal link (e.g. tapping one in another app or from a message).
3. Verify the app opens and routes the URL through the standard deep link handling rather than being kicked out to the browser.
4. Confirm other deep links (e.g. `/redeem`, share URLs) continue to work as before.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
