### PR TITLE
[PC TV] Auto-play video previews on Discover video cells

### DIFF
--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -34,10 +34,11 @@ struct DiscoverVideoEpisodeCell: View {
         static let cardHeight = CGFloat(402)
         static let cardWidth = CGFloat(716)
         static let fadeDuration: TimeInterval = 0.5
+        static let playDelay: TimeInterval = 2
     }
 
     init(episode: DiscoverEpisode, listId: String? = nil, source: String = "") {
-        _model = State(wrappedValue: DiscoverVideoEpisodeModel(episode: episode, fadeDuration: Layout.fadeDuration))
+        _model = State(wrappedValue: DiscoverVideoEpisodeModel(episode: episode, fadeDuration: Layout.fadeDuration, playDelay: Layout.playDelay))
         self.listId = listId
         self.source = source
     }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -56,7 +56,19 @@ struct DiscoverVideoEpisodeCell: View {
         .padding(32)
         .frame(width: Layout.cardWidth, height: Layout.cardHeight)
         .background {
-            backgroundThumbnail
+            if isFocused, let player = model.player {
+                VideoPlayer(player: player)
+                    .focusable(false)
+            } else {
+                backgroundThumbnail
+            }
+        }
+        .onChange(of: isFocused) { _, newValue in
+            if newValue {
+                model.play()
+            } else {
+                model.pause()
+            }
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .clipped()

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -59,8 +59,12 @@ struct DiscoverVideoEpisodeCell: View {
             if isFocused, let player = model.player, model.isPlaying {
                 VideoPlayer(player: player)
                     .focusable(false)
+                    .transition(.opacity)
+                    .animation(.smooth(duration: 1), value: model.isPlaying)
             } else {
                 backgroundThumbnail
+                    .transition(.opacity)
+                    .animation(.smooth(duration: 1), value: model.isPlaying)
             }
         }
         .onChange(of: isFocused) { _, newValue in

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -33,10 +33,11 @@ struct DiscoverVideoEpisodeCell: View {
         static let imageSize = CGFloat(72)
         static let cardHeight = CGFloat(402)
         static let cardWidth = CGFloat(716)
+        static let fadeDuration: TimeInterval = 0.5
     }
 
     init(episode: DiscoverEpisode, listId: String? = nil, source: String = "") {
-        _model = State(wrappedValue: DiscoverVideoEpisodeModel(episode: episode))
+        _model = State(wrappedValue: DiscoverVideoEpisodeModel(episode: episode, fadeDuration: Layout.fadeDuration))
         self.listId = listId
         self.source = source
     }
@@ -56,16 +57,16 @@ struct DiscoverVideoEpisodeCell: View {
         .padding(32)
         .frame(width: Layout.cardWidth, height: Layout.cardHeight)
         .background {
-            if isFocused, let player = model.player, model.isPlaying {
-                VideoPlayer(player: player)
-                    .focusable(false)
-                    .transition(.opacity)
-                    .animation(.smooth(duration: 1), value: model.isPlaying)
-            } else {
-                backgroundThumbnail
-                    .transition(.opacity)
-                    .animation(.smooth(duration: 1), value: model.isPlaying)
+            Group {
+                if isFocused, let player = model.player, model.isPlaying {
+                    VideoPlayer(player: player)
+                        .focusable(false)
+                } else {
+                    backgroundThumbnail
+                }
             }
+            .transition(.opacity)
+            .animation(.smooth(duration: Layout.fadeDuration), value: model.isPlaying)
         }
         .onChange(of: isFocused) { _, newValue in
             if newValue {

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -142,7 +142,7 @@ struct DiscoverVideoEpisodeCell: View {
     }
 
     var focusedContent: some View {
-        HStack(alignment: .bottom) {
+        HStack(alignment: .bottom, spacing: 16) {
             Button(L10n.tvDiscoverPlayEpisode) {
                 trackEpisodeTapped()
                 Task {

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -56,7 +56,7 @@ struct DiscoverVideoEpisodeCell: View {
         .padding(32)
         .frame(width: Layout.cardWidth, height: Layout.cardHeight)
         .background {
-            if isFocused, let player = model.player {
+            if isFocused, let player = model.player, model.isPlaying {
                 VideoPlayer(player: player)
                     .focusable(false)
             } else {

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -8,9 +8,13 @@ class DiscoverVideoEpisodeModel {
 
     private let discoverManager: DiscoverManager
 
+    private let playbackManager: PlaybackManager
+
     let episode: DiscoverEpisode
 
     let maxPreviewTime: Double
+
+    let fadeDuration: TimeInterval
 
     var thumbnail: UIImage?
 
@@ -20,10 +24,14 @@ class DiscoverVideoEpisodeModel {
 
     private var timeObserver: Any?
 
-    init(episode: DiscoverEpisode, maxPreviewTime: Double = 30, discoverManager: DiscoverManager = DiscoverManager.shared) {
+    init(episode: DiscoverEpisode, maxPreviewTime: Double = 30, fadeDuration: TimeInterval = 0.5,
+         discoverManager: DiscoverManager = DiscoverManager.shared,
+         playbackManager: PlaybackManager = .shared) {
         self.episode = episode
         self.maxPreviewTime = maxPreviewTime
+        self.fadeDuration = fadeDuration
         self.discoverManager = discoverManager
+        self.playbackManager = playbackManager
     }
 
     deinit {
@@ -108,7 +116,7 @@ class DiscoverVideoEpisodeModel {
     }
 
     func pause() {
-        fadePause()
+        fadePause(duration: self.fadeDuration)
         DispatchQueue.main.async { [weak self] in
             self?.isPlaying = false
         }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -110,6 +110,7 @@ class DiscoverVideoEpisodeModel {
     func play() {
         player?.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
         player?.play()
+        player?.volume = playbackManager.playing() ? 0 : 1
         DispatchQueue.main.async { [weak self] in
             self?.isPlaying = true
         }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -10,13 +10,24 @@ class DiscoverVideoEpisodeModel {
 
     let episode: DiscoverEpisode
 
+    let loopTime: Double
+
     var thumbnail: UIImage?
 
     var player: AVPlayer?
 
-    init(episode: DiscoverEpisode, discoverManager: DiscoverManager = DiscoverManager.shared) {
+    private var timeObserver: Any?
+
+    init(episode: DiscoverEpisode, loopTime: Double = 30, discoverManager: DiscoverManager = DiscoverManager.shared) {
         self.episode = episode
+        self.loopTime = loopTime
         self.discoverManager = discoverManager
+    }
+
+    deinit {
+        if let observer = timeObserver {
+            player?.removeTimeObserver(observer)
+        }
     }
 
     func load() async {
@@ -68,6 +79,20 @@ class DiscoverVideoEpisodeModel {
             return
         }
         player = AVPlayer(url: videoUrl)
+
+        let interval = CMTime(seconds: 0.01, preferredTimescale: 600)
+
+        timeObserver = player?.addPeriodicTimeObserver(
+            forInterval: interval,
+            queue: .main
+        ) { [weak player, weak self] time in
+            guard let self else {
+                return
+            }
+            if time.seconds >= self.loopTime {
+                player?.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
+            }
+        }
     }
 
     func play() {
@@ -76,8 +101,8 @@ class DiscoverVideoEpisodeModel {
 
     func pause() {
         player?.pause()
+        player?.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
     }
-
 }
 
 extension DiscoverEpisode {

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -24,6 +24,8 @@ class DiscoverVideoEpisodeModel {
 
     private var timeObserver: Any?
 
+    private var fadeTimer: Timer?
+
     init(episode: DiscoverEpisode, maxPreviewTime: Double = 30, fadeDuration: TimeInterval = 0.5,
          discoverManager: DiscoverManager = DiscoverManager.shared,
          playbackManager: PlaybackManager = .shared) {
@@ -38,6 +40,7 @@ class DiscoverVideoEpisodeModel {
         if let observer = timeObserver {
             player?.removeTimeObserver(observer)
         }
+        fadeTimer?.invalidate()
     }
 
     func load() async {
@@ -80,10 +83,6 @@ class DiscoverVideoEpisodeModel {
         episode.discoverPodcast
     }
 
-    var shouldAutoPlay: Bool {
-        return PlaybackManager.shared.playing()
-    }
-
     private var isFadePausing = false
 
     private func setupPlayer() {
@@ -108,6 +107,11 @@ class DiscoverVideoEpisodeModel {
     }
 
     func play() {
+        // Cancel any in-flight fade so it can't pause this fresh playback.
+        fadeTimer?.invalidate()
+        fadeTimer = nil
+        isFadePausing = false
+
         player?.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
         player?.play()
         player?.volume = playbackManager.playing() ? 0 : 1
@@ -117,32 +121,35 @@ class DiscoverVideoEpisodeModel {
     }
 
     func pause() {
-        fadePause(duration: self.fadeDuration)
+        fadePause(duration: fadeDuration)
         DispatchQueue.main.async { [weak self] in
             self?.isPlaying = false
         }
     }
 
-    func fadePause(duration: TimeInterval = 1) {
-        isFadePausing = true
+    func fadePause(duration: TimeInterval) {
         guard let player else {
             isFadePausing = false
             return
         }
+        isFadePausing = true
+
         let steps = 20
         let stepDuration = duration / Double(steps)
         let volumeStep = player.volume / Float(steps)
 
         var currentStep = 0
-        Timer.scheduledTimer(withTimeInterval: stepDuration, repeats: true) { [weak self] timer in
+        fadeTimer?.invalidate()
+        fadeTimer = Timer.scheduledTimer(withTimeInterval: stepDuration, repeats: true) { [weak self] timer in
             currentStep += 1
             player.volume -= volumeStep
 
             if currentStep >= steps {
                 timer.invalidate()
+                self?.fadeTimer = nil
                 player.pause()
                 self?.isFadePausing = false
-                player.volume = 1.0  // restore for next play
+                player.volume = 1.0
             }
         }
     }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -111,9 +111,14 @@ class DiscoverVideoEpisodeModel {
         fadeTimer?.invalidate()
         fadeTimer = nil
 
-        player?.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
-        player?.play()
-        player?.volume = playbackManager.playing() ? 0 : 1
+        guard let player else {
+            isPlaying = false
+            return
+        }
+
+        player.volume = playbackManager.playing() ? 0 : 1
+        player.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
+        player.play()
         isPlaying = true
     }
 

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -91,7 +91,7 @@ class DiscoverVideoEpisodeModel {
         }
         player = AVPlayer(url: videoUrl)
 
-        let interval = CMTime(seconds: 0.01, preferredTimescale: 600)
+        let interval = CMTime(seconds: 0.5, preferredTimescale: 600)
 
         timeObserver = player?.addPeriodicTimeObserver(
             forInterval: interval,

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -107,7 +107,7 @@ class DiscoverVideoEpisodeModel {
             guard let self else {
                 return
             }
-            if time.seconds >= self.maxPreviewTime, !isFadePausing {
+            if time.seconds >= self.maxPreviewTime, self.isPlaying, !isFadePausing {
                 self.pause()
             }
         }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -16,6 +16,8 @@ class DiscoverVideoEpisodeModel {
 
     let fadeDuration: TimeInterval
 
+    let playDelay: TimeInterval
+
     var thumbnail: UIImage?
 
     var player: AVPlayer?
@@ -26,12 +28,16 @@ class DiscoverVideoEpisodeModel {
 
     private var fadeTimer: Timer?
 
+    private var playDelayTimer: Timer?
+
     init(episode: DiscoverEpisode, maxPreviewTime: Double = 30, fadeDuration: TimeInterval = 0.5,
+         playDelay: TimeInterval = 2,
          discoverManager: DiscoverManager = DiscoverManager.shared,
          playbackManager: PlaybackManager = .shared) {
         self.episode = episode
         self.maxPreviewTime = maxPreviewTime
         self.fadeDuration = fadeDuration
+        self.playDelay = playDelay
         self.discoverManager = discoverManager
         self.playbackManager = playbackManager
     }
@@ -41,6 +47,7 @@ class DiscoverVideoEpisodeModel {
             player?.removeTimeObserver(observer)
         }
         fadeTimer?.invalidate()
+        playDelayTimer?.invalidate()
     }
 
     func load() async {
@@ -107,6 +114,15 @@ class DiscoverVideoEpisodeModel {
     }
 
     func play() {
+        // Wait a moment before starting so scrolling past a card doesn't trigger playback.
+        playDelayTimer?.invalidate()
+        playDelayTimer = Timer.scheduledTimer(withTimeInterval: playDelay, repeats: false) { [weak self] _ in
+            self?.playDelayTimer = nil
+            self?.startPlayback()
+        }
+    }
+
+    private func startPlayback() {
         // Cancel any in-flight fade so it can't pause this fresh playback.
         fadeTimer?.invalidate()
         fadeTimer = nil
@@ -123,6 +139,10 @@ class DiscoverVideoEpisodeModel {
     }
 
     func pause() {
+        // Cancel a pending delayed play so an unfocused card never starts.
+        playDelayTimer?.invalidate()
+        playDelayTimer = nil
+
         fadePause(duration: fadeDuration)
         isPlaying = false
     }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -83,7 +83,7 @@ class DiscoverVideoEpisodeModel {
         episode.discoverPodcast
     }
 
-    private var isFadePausing = false
+    private var isFadePausing: Bool { fadeTimer != nil }
 
     private func setupPlayer() {
         guard let urlString = episode.url, let videoUrl = URL(string: urlString) else {
@@ -110,29 +110,28 @@ class DiscoverVideoEpisodeModel {
         // Cancel any in-flight fade so it can't pause this fresh playback.
         fadeTimer?.invalidate()
         fadeTimer = nil
-        isFadePausing = false
 
         player?.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
         player?.play()
         player?.volume = playbackManager.playing() ? 0 : 1
-        DispatchQueue.main.async { [weak self] in
-            self?.isPlaying = true
-        }
+        isPlaying = true
     }
 
     func pause() {
         fadePause(duration: fadeDuration)
-        DispatchQueue.main.async { [weak self] in
-            self?.isPlaying = false
-        }
+        isPlaying = false
     }
 
     func fadePause(duration: TimeInterval) {
         guard let player else {
-            isFadePausing = false
             return
         }
-        isFadePausing = true
+
+        // Nothing to fade when already muted (something else is playing) — just stop.
+        guard player.volume > 0 else {
+            player.pause()
+            return
+        }
 
         let steps = 20
         let stepDuration = duration / Double(steps)
@@ -148,7 +147,6 @@ class DiscoverVideoEpisodeModel {
                 timer.invalidate()
                 self?.fadeTimer = nil
                 player.pause()
-                self?.isFadePausing = false
                 player.volume = 1.0
             }
         }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -141,7 +141,7 @@ class DiscoverVideoEpisodeModel {
         fadeTimer?.invalidate()
         fadeTimer = Timer.scheduledTimer(withTimeInterval: stepDuration, repeats: true) { [weak self] timer in
             currentStep += 1
-            player.volume -= volumeStep
+            player.volume = max(0, player.volume - volumeStep)
 
             if currentStep >= steps {
                 timer.invalidate()

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -10,17 +10,19 @@ class DiscoverVideoEpisodeModel {
 
     let episode: DiscoverEpisode
 
-    let loopTime: Double
+    let maxPreviewTime: Double
 
     var thumbnail: UIImage?
 
     var player: AVPlayer?
 
+    var isPlaying: Bool = false
+
     private var timeObserver: Any?
 
-    init(episode: DiscoverEpisode, loopTime: Double = 30, discoverManager: DiscoverManager = DiscoverManager.shared) {
+    init(episode: DiscoverEpisode, maxPreviewTime: Double = 30, discoverManager: DiscoverManager = DiscoverManager.shared) {
         self.episode = episode
-        self.loopTime = loopTime
+        self.maxPreviewTime = maxPreviewTime
         self.discoverManager = discoverManager
     }
 
@@ -74,6 +76,8 @@ class DiscoverVideoEpisodeModel {
         return PlaybackManager.shared.playing()
     }
 
+    private var isFadePausing = false
+
     private func setupPlayer() {
         guard let urlString = episode.url, let videoUrl = URL(string: urlString) else {
             return
@@ -85,23 +89,53 @@ class DiscoverVideoEpisodeModel {
         timeObserver = player?.addPeriodicTimeObserver(
             forInterval: interval,
             queue: .main
-        ) { [weak player, weak self] time in
+        ) { [weak self] time in
             guard let self else {
                 return
             }
-            if time.seconds >= self.loopTime {
-                player?.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
+            if time.seconds >= self.maxPreviewTime, !isFadePausing {
+                self.pause()
             }
         }
     }
 
     func play() {
+        player?.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
         player?.play()
+        DispatchQueue.main.async { [weak self] in
+            self?.isPlaying = true
+        }
     }
 
     func pause() {
-        player?.pause()
-        player?.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
+        fadePause()
+        DispatchQueue.main.async { [weak self] in
+            self?.isPlaying = false
+        }
+    }
+
+    func fadePause(duration: TimeInterval = 1) {
+        isFadePausing = true
+        guard let player else {
+            isFadePausing = false
+            return
+        }
+        let steps = 20
+        let stepDuration = duration / Double(steps)
+        let volumeStep = player.volume / Float(steps)
+
+        var currentStep = 0
+        Timer.scheduledTimer(withTimeInterval: stepDuration, repeats: true) { [weak self] timer in
+            currentStep += 1
+            player.volume -= volumeStep
+
+            if currentStep >= steps {
+                timer.invalidate()
+                player.pause()
+                self?.isFadePausing = false
+                player.volume = 1.0  // restore for next play
+            }
+        }
     }
 }
 

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -12,29 +12,35 @@ class DiscoverVideoEpisodeModel {
 
     var thumbnail: UIImage?
 
+    var player: AVPlayer?
+
     init(episode: DiscoverEpisode, discoverManager: DiscoverManager = DiscoverManager.shared) {
         self.episode = episode
         self.discoverManager = discoverManager
     }
 
     func load() async {
-        if let urlString = episode.url, let videoUrl = URL(string: urlString) {
-            do {
-                var videoFrame: UIImage?
-                let cachedVideoFrame = await ImageManager.sharedManager.retrieveDiscoverVideoThumbnail(imageUrl: urlString)
-                if cachedVideoFrame != nil {
-                    videoFrame = cachedVideoFrame
-                } else {
-                    let image = try await thumbnail(url: videoUrl, at: CMTime(seconds: 1, preferredTimescale: 600))
-                    let _ = await ImageManager.sharedManager.storeDiscoverVideoThumbnail(for: urlString, image: image)
-                    videoFrame = image
-                }
-                await MainActor.run { [videoFrame] in
-                    thumbnail = videoFrame
-                }
-            } catch {
-                FileLog.shared.addMessage("[DiscoverVideoEpisodeModel] Failed to generate discover video thumbnail for episode \(episode.uuid ?? "unknown"): \(error.localizedDescription)")
+        guard let urlString = episode.url, let videoUrl = URL(string: urlString) else {
+            return
+        }
+
+        setupPlayer()
+
+        do {
+            var videoFrame: UIImage?
+            let cachedVideoFrame = await ImageManager.sharedManager.retrieveDiscoverVideoThumbnail(imageUrl: urlString)
+            if cachedVideoFrame != nil {
+                videoFrame = cachedVideoFrame
+            } else {
+                let image = try await thumbnail(url: videoUrl, at: CMTime(seconds: 1, preferredTimescale: 600))
+                let _ = await ImageManager.sharedManager.storeDiscoverVideoThumbnail(for: urlString, image: image)
+                videoFrame = image
             }
+            await MainActor.run { [videoFrame] in
+                thumbnail = videoFrame
+            }
+        } catch {
+            FileLog.shared.addMessage("[DiscoverVideoEpisodeModel] Failed to generate discover video thumbnail for episode \(episode.uuid ?? "unknown"): \(error.localizedDescription)")
         }
     }
 
@@ -52,6 +58,26 @@ class DiscoverVideoEpisodeModel {
     var podcast: DiscoverPodcast? {
         episode.discoverPodcast
     }
+
+    var shouldAutoPlay: Bool {
+        return PlaybackManager.shared.playing()
+    }
+
+    private func setupPlayer() {
+        guard let urlString = episode.url, let videoUrl = URL(string: urlString) else {
+            return
+        }
+        player = AVPlayer(url: videoUrl)
+    }
+
+    func play() {
+        player?.play()
+    }
+
+    func pause() {
+        player?.pause()
+    }
+
 }
 
 extension DiscoverEpisode {


### PR DESCRIPTION
Fixes [PCIOS-745](https://linear.app/a8c/issue/PCIOS-745/fix-button-spacing-and-enable-video-autoplay-in-made-for-tv-row)
|:---:|

Adds an auto-playing, muted video preview to the Discover video episode cells on Pocket Casts TV. When a video episode card gains focus it begins playing a short preview that cross-fades in from the thumbnail; when focus is lost (or the preview reaches its time limit) the audio fades out and the card cross-fades back to the thumbnail.

### What changed
- **`DiscoverVideoEpisodeCell`** — the card background now swaps between the thumbnail and a `VideoPlayer` based on focus/playback state, wrapped in a `Group` with an opacity `.transition`/`.animation` so the swap cross-fades smoothly. Focus changes drive `model.play()` / `model.pause()`.
- **`DiscoverVideoEpisodeModel`** — owns the preview `AVPlayer`: sets it up on load, enforces a `maxPreviewTime` cap via a periodic time observer, and fades the audio out on pause via a step timer. Preview audio is muted when something else is already playing so it doesn't talk over the user's current playback.

### Why
The Discover video row previously showed only static thumbnails; previewing the video on focus makes the row feel alive and helps users decide what to play, matching the richer Discover experience.

### Reviewer notes
- The cross-fade is keyed on `model.isPlaying` (not raw focus) so the video only appears once playback has actually started, avoiding a flash of an empty player.
- The fade timer is invalidated on re-focus and in `deinit` so a quick unfocus→refocus can't let a stale fade pause a freshly-started preview.
- `VideoPlayer` (AVKit) tears its controller down immediately on removal, so the video→thumbnail direction may still snap on some hardware even with the transition in place — worth a look on-device.

## To test
1. Open the TV app and go to the Discover tab.
2. Scroll to a video episodes row.
3. Move focus onto a video card — the preview should fade in and start playing (muted if you already have audio playing).
4. Move focus away — audio should fade out and the card should cross-fade back to the thumbnail.
5. Leave a card focused past the preview time limit — it should fade out/pause automatically.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.