### PR TITLE
[PC TV] Make screen transitions smoother

### DIFF
--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -5,7 +5,7 @@ import Firebase
 
 @Observable
 class AppCoordinator {
-    enum State {
+    enum State: Equatable {
         case loading
         case welcome
         case browsing

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -32,6 +32,7 @@ struct HomeView: View {
                 emptyView
             }
         }
+        .animation(.easeInOut, value: model.state)
         .task {
             model.load()
         }

--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -120,6 +120,7 @@ struct MainTabView: View {
                     }
                 }
             }
+            .animation(.easeInOut, value: tabRouter.selectedTab)
             .focused($focusedArea, equals: .tabBar)
         }.overlay(alignment: .top) {
             accessoryView

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -24,6 +24,7 @@ struct PlaylistsView: View {
                 emptyView
             }
         }
+        .animation(.easeInOut, value: model.state)
         .task {
             model.load()
         }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -31,6 +31,7 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
                 emptyView
             }
         }
+        .animation(.easeInOut, value: model.state)
         .task {
             await model.load()
             Analytics.track(.podcastsListShown, properties: [

--- a/Pocket Casts TV App/UI/RootView.swift
+++ b/Pocket Casts TV App/UI/RootView.swift
@@ -23,6 +23,7 @@ struct RootView: View {
                 DataLossResyncView()
             }
         }
+        .animation(.easeInOut, value: coordinator.state)
         .environment(coordinator)
         .environment(focusStore)
         .task {

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -54,6 +54,7 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
             }
         }
         .animation(.easeInOut, value: model.state)
+        .animation(.easeInOut, value: model.scope)
         .fullScreenCover(isPresented: $showNowPlayingPlayer) {
             NowPlayingView()
                 .ignoresSafeArea()

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -53,6 +53,7 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                 DiscoverAllView()
             }
         }
+        .animation(.easeInOut, value: model.state)
         .fullScreenCover(isPresented: $showNowPlayingPlayer) {
             NowPlayingView()
                 .ignoresSafeArea()

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -26,12 +26,26 @@ enum SearchScope: CaseIterable {
     }
 }
 
-enum SearchState {
+enum SearchState: Equatable {
     case query
     case searching
     case results
     case error(Error)
     case empty
+
+    static func == (lhs: SearchState, rhs: SearchState) -> Bool {
+        switch (lhs, rhs) {
+        case (.query, .query),
+             (.searching, .searching),
+             (.results, .results),
+             (.empty, .empty):
+            return true
+        case let (.error(lhsError), .error(rhsError)):
+            return (lhsError as NSError) == (rhsError as NSError)
+        default:
+            return false
+        }
+    }
 }
 
 protocol SearchableViewModel: AnyObject, Observation.Observable {

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
 
-enum SearchScope: CaseIterable {
+enum SearchScope: CaseIterable, Equatable {
     case podcasts
     case episodes
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-752](https://linear.app/a8c/issue/PCIOS-752/make-first-load-smoother) <!-- issue number, if applicable -->

This PR makes the tvOS app's screen transitions smoother by adding `.easeInOut` animations driven by view-model state changes. Previously, switching between the loading, results, empty, and error states (and between tabs) happened abruptly with no transition.

Changes:
- Added `.animation(.easeInOut, value:)` modifiers keyed on the relevant state to `HomeView`, `PlaylistsView`, `PodcastsView`, `SearchResultsView`, `RootView`, and to `MainTabView` (keyed on the selected tab).
- Made `SearchState` conform to `Equatable` (with a custom `==` that compares wrapped errors via `NSError`) so it can be used as an `animation(value:)` trigger.

## To test

1. Launch the Pocket Casts TV App.
2. Navigate between the Home, Podcasts, Playlists, and Search tabs and confirm the tab content cross-fades smoothly rather than snapping.
3. Open Search and run a query: confirm the transitions between the query, searching, results, empty, and error states animate smoothly.
4. Observe app launch / root state changes and confirm they animate rather than pop in abruptly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
