### PR TITLE
[PC TV] Add soft scrollable edge to podcast descriptions

### DIFF
--- a/Pocket Casts TV App/UI/Common/RichTextPreviewSamples.swift
+++ b/Pocket Casts TV App/UI/Common/RichTextPreviewSamples.swift
@@ -31,5 +31,60 @@ enum RichTextPreviewSamples {
     <p>Because the details matter — and sometimes the <em>asterisks * and
     underscores _</em> in a title shouldn't turn into formatting.</p>
     """
+
+    /// A long description for exercising scrolling, the soft edge fade, and bottom clipping
+    /// in `ScrollableTextView` / `PodcastMoreInfoView`.
+    static let longDescriptionHTML = """
+    <p>A weekly show about <strong>technology</strong>, <em>design</em>, and the
+    occasional rabbit hole. Find every episode and more at
+    <a href="https://pocketcasts.com">pocketcasts.com</a>.</p>
+
+    <p>We started this podcast in a tiny home studio with a single microphone and a
+    stubborn belief that the <strong>craft</strong> behind everyday software is worth
+    talking about at length. Years later we're still here, still asking the same
+    questions, and still occasionally getting the answers completely wrong on the air.</p>
+
+    <p>Each week we dig into topics like:</p>
+    <ul>
+        <li>Engineering deep-dives
+            <ul>
+                <li>Architecture &amp; trade-offs</li>
+                <li>Testing strategies</li>
+                <li>Performance and profiling</li>
+                <li>Debugging war stories</li>
+            </ul>
+        </li>
+        <li>Long-form interviews with builders, designers, and the occasional skeptic</li>
+        <li>Listener questions, answered honestly</li>
+        <li>Tooling, workflow, and the small habits that compound over a career</li>
+    </ul>
+
+    <p>A typical episode runs in three parts:</p>
+    <ol>
+        <li>Intro &amp; news from the week</li>
+        <li>The main topic, explored in depth</li>
+        <li>Picks &amp; wrap-up, where we recommend things we love</li>
+    </ol>
+
+    <h3>Why listen?</h3>
+    <p>Because the details matter — and sometimes the <em>asterisks * and
+    underscores _</em> in a title shouldn't turn into formatting. We care about the
+    seams: the place where a clean abstraction meets a messy reality, where a design
+    system bends under a real product requirement, where the spec and the shipping
+    code quietly disagree.</p>
+
+    <p>We're also unapologetic about going long. If a subject deserves ninety minutes,
+    it gets ninety minutes. If a guest wants to follow a tangent to its natural end,
+    we follow it. The goal was never to be efficient — it was to be <em>thorough</em>,
+    and to leave you with something you can actually use on Monday morning.</p>
+
+    <h3>Who is this for?</h3>
+    <p>Engineers, designers, product folks, and anyone curious about how the things
+    they use every day actually get made. You don't need a computer science degree to
+    follow along — just a willingness to sit with a hard problem for a while.</p>
+
+    <p>Thanks for listening. Tell a friend, leave a review, and send us your questions
+    — the best episodes always start with one.</p>
+    """
 }
 #endif

--- a/Pocket Casts TV App/UI/Common/ScrollableTextView.swift
+++ b/Pocket Casts TV App/UI/Common/ScrollableTextView.swift
@@ -10,11 +10,16 @@ struct ScrollableTextView: View {
     let attributedText: NSAttributedString
     var scrollStep: CGFloat = 150
 
+    /// Height of the soft fade at the top and bottom edges. The inner text view insets its
+    /// text by the same amount (see `ScrollableTextRepresentable`) so the first and last
+    /// lines come to rest just past the fade rather than dissolving into it.
+    private let edgeFade = CGFloat(36)
+
     @FocusState private var isFocused: Bool
     @State private var scrollCoordinator = ScrollableTextCoordinator()
 
     var body: some View {
-        ScrollableTextRepresentable(attributedText: attributedText, coordinator: scrollCoordinator)
+        ScrollableTextRepresentable(attributedText: attributedText, coordinator: scrollCoordinator, verticalInset: edgeFade)
             .focusable(true)
             .focused($isFocused)
             .onAppear { isFocused = true }
@@ -23,6 +28,15 @@ struct ScrollableTextView: View {
                 case .up:    scrollCoordinator.scroll(by: -scrollStep)
                 case .down:  scrollCoordinator.scroll(by: scrollStep)
                 default:     break
+                }
+            }
+            .mask {
+                VStack(spacing: 0) {
+                    LinearGradient(colors: [.clear, .black], startPoint: .top, endPoint: .bottom)
+                        .frame(height: edgeFade)
+                    Color.black
+                    LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
+                        .frame(height: edgeFade)
                 }
             }
     }
@@ -44,12 +58,16 @@ private struct ScrollableTextRepresentable: UIViewRepresentable {
     let attributedText: NSAttributedString
     let coordinator: ScrollableTextCoordinator
 
+    /// Top/bottom padding inside the scrollable content, matched to the view's edge fade so
+    /// the first and last lines rest just past the gradient instead of being clipped by it.
+    let verticalInset: CGFloat
+
     func makeUIView(context: Context) -> UITextView {
         let textView = UITextView()
         textView.isScrollEnabled = true
         textView.isSelectable = false
         textView.backgroundColor = .clear
-        textView.textContainerInset = .zero
+        textView.textContainerInset = UIEdgeInsets(top: verticalInset, left: 0, bottom: verticalInset, right: 0)
         textView.textContainer.lineFragmentPadding = 0
         textView.attributedText = themed(attributedText)
         textView.tag = attributedText.hash

--- a/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
@@ -12,9 +12,10 @@ struct PodcastMoreInfoView: View {
     private enum Layout {
         static let modalWidth = CGFloat(1280)
         static let modalHeight = CGFloat(880)
-        static let metadataColumnWidth = CGFloat(360)
+        static let metadataColumnWidth = CGFloat(420)
         static let artworkSize = CGFloat(240)
-        static let columnGutter = CGFloat(64)
+        static let columnGutter = CGFloat(40)
+        static let contentInsets = EdgeInsets(top: 80, leading: 80, bottom: 0, trailing: 80)
     }
 
     private var descriptionHTML: String {
@@ -25,12 +26,13 @@ struct PodcastMoreInfoView: View {
         HStack(alignment: .top, spacing: Layout.columnGutter) {
             metadataColumn
                 .frame(width: Layout.metadataColumnWidth, alignment: .leading)
+                .padding(.bottom, 40)
             if !descriptionHTML.isEmpty {
                 aboutColumn
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         }
-        .padding(80)
+        .padding(Layout.contentInsets)
         .frame(width: Layout.modalWidth, height: Layout.modalHeight, alignment: .topLeading)
         .task { buildDescription() }
     }
@@ -99,11 +101,20 @@ struct PodcastMoreInfoView: View {
 }
 
 #if DEBUG
+// Presents `PodcastMoreInfoView` over a backdrop the way `PodcastDetailView` does in the
+// app (via `.sheet`), so the preview reflects the real modal presentation.
 #Preview {
-    PodcastMoreInfoView(podcast: {
+    @Previewable @State var isPresented = true
+    let podcast: Podcast = {
         let podcast = MockData.makeStubPodcasts().first!
-        podcast.podcastHTMLDescription = RichTextPreviewSamples.descriptionHTML
+        podcast.podcastHTMLDescription = RichTextPreviewSamples.longDescriptionHTML
         return podcast
-    }())
+    }()
+
+    Color.pcBackgroundBase
+        .ignoresSafeArea()
+        .sheet(isPresented: $isPresented) {
+            PodcastMoreInfoView(podcast: podcast)
+        }
 }
 #endif


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-754.

Polishes the tvOS **More Info** modal where the rich-text description is shown in a remote-scrollable `UITextView`:

- Top/bottom **soft edge fade** (`LinearGradient` mask) for a "scroll for more" affordance.
- Matching text-container inset so the first/last lines aren't clipped by the fade.
- Asymmetric content insets + rebalanced columns to remove the dead space below About.

Also switched the preview to present via `.sheet` and added a longer rich-text sample.

## To test

1. On an Apple TV, open a podcast with a long description and tap **More Info**.
2. Confirm the About text fades softly at the top and bottom edges.
3. Scroll with the remote and confirm smooth scrolling, no bottom clipping, and no empty gap below the text.
4. Repeat from a playlist detail screen's **More Info**.


https://github.com/user-attachments/assets/7dd3c08a-8155-4dc4-b189-dea218c4a979


https://github.com/user-attachments/assets/20491ce2-39b8-450b-a380-3e94264e1180



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
