### PR TITLE
[PC TV] Fix white link color in light mode

### DIFF
--- a/Pocket Casts TV App/UI/Common/ScrollableTextView.swift
+++ b/Pocket Casts TV App/UI/Common/ScrollableTextView.swift
@@ -51,6 +51,10 @@ private struct ScrollableTextRepresentable: UIViewRepresentable {
         textView.backgroundColor = .clear
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
+        textView.linkTextAttributes = [
+            .foregroundColor: UIColor.pcTextPrimary,
+            .underlineStyle: NSUnderlineStyle.single.rawValue
+        ]
         textView.attributedText = themed(attributedText)
         textView.tag = attributedText.hash
         coordinator.textView = textView


### PR DESCRIPTION
Fixes  PCIOS-766.

Links in podcast descriptions and episode show notes rendered white in light mode on tvOS, making them invisible against the background.

`ScrollableTextView`'s `UITextView` never set `linkTextAttributes`, so for any `.link` range UIKit applied its default link styling (a white tint on tvOS), overriding the `pcTextPrimary` foreground color set on the attributed string. The fix sets `linkTextAttributes` explicitly to `pcTextPrimary` + single underline. Since `pcTextPrimary` is a dynamic color, links now read correctly in both light and dark mode.

## To test

1. Set the system appearance to **Light** on Apple TV.
2. Open a podcast and tap **More Info** to view a description that contains a link.
3. Verify links appear in the primary text color (dark) with an underline, not white/invisible.
4. Open an episode's **Show Notes** containing a link and verify the same.
5. Switch to **Dark** appearance and confirm links remain legible (light) with an underline.

<img width="1920" height="1132" alt="Screenshot 2026-06-18 at 12 43 24 PM" src="https://github.com/user-attachments/assets/50345949-bf20-4dd1-809a-a64a612d6ef1" />


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.