### PR TITLE
[PC TV] Route empty-state actions to Search and fix Up Next empty trigger

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -60,7 +60,7 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
 
     var emptyView: some View {
         EmptyDataView(title: L10n.tvPodcastsEmptyTitle, subtitle: L10n.tvPodcastsEmptySubtitle, actionTitle: L10n.tvPodcastsEmptyActionTitle) {
-            requireAccount { tabRouter.selectedTab = .home }
+            tabRouter.selectedTab = .search
         }
     }
 

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -16,7 +16,17 @@ struct UpNextView: View {
             case .loading:
                 loadingView
             case .ready:
-                upNextView
+                // The model's "empty" state means the entire queue is empty
+                // (including the currently playing episode at index 0). When
+                // the user clears every queued episode but something is still
+                // playing, only that currently playing item remains and the
+                // visible list — `queuedEpisodes` — is empty even though the
+                // model is `.ready`. Show the empty state in that case too.
+                if queuedEpisodes.isEmpty {
+                    emptyView
+                } else {
+                    upNextView
+                }
             case .empty:
                 emptyView
             }
@@ -81,7 +91,7 @@ struct UpNextView: View {
 
     var emptyView: some View {
         EmptyDataView(title: L10n.tvUpNextEmptyTitle, subtitle: L10n.tvUpNextEmptySubtitle, actionTitle: L10n.tvUpNextEmptyActionTitle) {
-            requireAccount { tabRouter.selectedTab = .home }
+            tabRouter.selectedTab = .search
         }
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-751

## Summary

- **Podcasts** and **Up Next** empty-state CTAs now route to the **Search/Discover** tab instead of Home, and no longer go through \`requireAccount\` — logged-out users are sent straight to browse instead of being bounced into auth.
- **Up Next** flips to the empty state as soon as the visible queue is empty. Previously the currently-playing episode at index 0 kept the model in \`.ready\`, so manually clearing every queued episode left the page showing just the header with nothing below.

Existing button copy (\"Discover podcasts\", \"Add episodes\") already fits the new destination, so no string changes.

## To test

1. While **logged in**, subscribe to no podcasts and open the **Podcasts** tab. Tap **Discover podcasts** → lands on the Search/Discover tab.
2. While **logged out**, open the **Podcasts** tab → same empty state. Tap **Discover podcasts** → lands on Search/Discover **without** an auth prompt.
3. Repeat 1 and 2 for the **Up Next** tab with an empty queue: tap **Add episodes** → Search/Discover, no auth prompt when logged out.
4. With **something currently playing** and one or more episodes queued in Up Next, open Up Next. Use the per-row \"Remove from Up Next\" action to remove episodes one by one. The instant the last queued episode is removed, the page should switch to the **empty state** (header should not linger on its own).
5. With **nothing playing** and a few queued episodes, do the same — empty state appears after the last one is removed (covers the original case where the full queue empties).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to \`CHANGELOG.md\` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.