### PR TITLE
[PC TV] Derive playlist pill colour from front cover artwork

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -7,9 +7,6 @@ import PocketCastsDataModel
 class PlaylistDetailsViewModel {
 
     @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
-    /// Bumped when a podcast colour download lands so `playlistColor` re-runs
-    /// against the freshly-updated row instead of the stale defaults.
-    private var colorRefreshTrigger: Int = 0
 
     enum State: Equatable, Hashable {
         case loading
@@ -24,6 +21,8 @@ class PlaylistDetailsViewModel {
     let playlist: EpisodeFilter
     var episodes: [Episode] = []
     var showArchived: Bool = false
+    /// Cached so SwiftUI doesn't redo the podcast lookup + colour reshaping on every `body` evaluation.
+    var playlistColor: Color
 
     private var allEpisodes: [Episode] = []
     private let dataManager: DataManager
@@ -40,6 +39,7 @@ class PlaylistDetailsViewModel {
         self.dataManager = dataManager
         self.playbackManager = playbackManager
         self.showArchived = UserDefaults.standard.bool(forKey: Self.archiveStorageKey(for: playlist))
+        self.playlistColor = Self.fallbackPillColor(for: playlist.uuid)
         observePodcastColorDownloads()
     }
 
@@ -57,7 +57,7 @@ class PlaylistDetailsViewModel {
                     let uuid = notification.object as? String,
                     self.episodes.first?.podcastUuid == uuid
                 else { return }
-                self.colorRefreshTrigger &+= 1
+                self.refreshPlaylistColor()
             }
             .store(in: &cancellables)
     }
@@ -77,6 +77,7 @@ class PlaylistDetailsViewModel {
             await MainActor.run {
                 allEpisodes = playlistEpisodes
                 applyArchivedFilter()
+                refreshPlaylistColor()
                 state = .ready
             }
         }
@@ -90,6 +91,7 @@ class PlaylistDetailsViewModel {
         Analytics.track(value ? .filterShowArchivedTapped : .filterHideArchivedTapped)
         showArchived = value
         applyArchivedFilter()
+        refreshPlaylistColor()
         UserDefaults.standard.set(value, forKey: Self.archiveStorageKey(for: playlist))
     }
 
@@ -132,21 +134,16 @@ class PlaylistDetailsViewModel {
         return L10n.tvPlaylistDetailEpisodeCount(episodes.count)
     }
 
-    /// Pill background colour. Pulled from the podcast whose artwork sits on
-    /// the front of the cover stack so the pill visually echoes that image.
-    /// Falls back to a deterministic palette while episodes haven't loaded,
-    /// for an empty playlist with no cover to sample, or when the server
-    /// hasn't provided usable colour metadata for the front cover podcast.
-    var playlistColor: Color {
-        // Touch the trigger so `@Observable` re-runs this getter when a
-        // delayed colour download lands.
-        _ = colorRefreshTrigger
+    /// Re-derive the pill colour from the front-cover podcast's tint, falling back to a
+    /// deterministic palette when no usable tint is available.
+    private func refreshPlaylistColor() {
         if let uuid = episodes.first?.podcastUuid,
            let podcast = dataManager.findPodcast(uuid: uuid, includeUnsubscribed: true),
            let color = Self.pillColor(from: ColorManager.lightThemeTintForPodcast(podcast)) {
-            return color
+            playlistColor = color
+        } else {
+            playlistColor = Self.fallbackPillColor(for: playlist.uuid)
         }
-        return Self.fallbackPillColor(for: playlist.uuid)
     }
 
     /// Reshape a podcast tint into something legible as a card background:

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -171,20 +171,21 @@ class PlaylistDetailsViewModel {
 
     /// Deterministic per-seed palette so playlists whose front cover has no
     /// usable colour metadata still render distinct from each other.
+    private static let fallbackPalette: [Color] = [
+        Color(red: 0.15, green: 0.25, blue: 0.5),
+        Color(red: 0.5, green: 0.17, blue: 0.15),
+        Color(red: 0.21, green: 0.22, blue: 0.14),
+        Color(red: 0.5, green: 0.35, blue: 0.12),
+        Color(red: 0.15, green: 0.4, blue: 0.3),
+        Color(red: 0.3, green: 0.2, blue: 0.45)
+    ]
+
     private static func fallbackPillColor(for seed: String) -> Color {
-        let palette: [Color] = [
-            Color(red: 0.15, green: 0.25, blue: 0.5),
-            Color(red: 0.5, green: 0.17, blue: 0.15),
-            Color(red: 0.21, green: 0.22, blue: 0.14),
-            Color(red: 0.5, green: 0.35, blue: 0.12),
-            Color(red: 0.15, green: 0.4, blue: 0.3),
-            Color(red: 0.3, green: 0.2, blue: 0.45)
-        ]
         // `String.hashValue` is per-run randomised in Swift; sum the unicode
         // scalars instead so a given playlist gets the same pill colour each
         // launch.
-        let index = seed.unicodeScalars.reduce(0) { $0 + Int($1.value) } % palette.count
-        return palette[index]
+        let index = seed.unicodeScalars.reduce(0) { $0 + Int($1.value) } % fallbackPalette.count
+        return fallbackPalette[index]
     }
 
     var coverPodcastsUuids: [String] {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -6,7 +6,6 @@ import PocketCastsDataModel
 @Observable
 class PlaylistDetailsViewModel {
 
-    private var cancellable: AnyCancellable?
     @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
     /// Bumped when a podcast colour download lands so `playlistColor` re-runs
     /// against the freshly-updated row instead of the stale defaults.
@@ -56,7 +55,7 @@ class PlaylistDetailsViewModel {
                 guard
                     let self,
                     let uuid = notification.object as? String,
-                    self.coverPodcastsUuids.contains(uuid)
+                    self.episodes.first?.podcastUuid == uuid
                 else { return }
                 self.colorRefreshTrigger &+= 1
             }
@@ -142,7 +141,7 @@ class PlaylistDetailsViewModel {
         // Touch the trigger so `@Observable` re-runs this getter when a
         // delayed colour download lands.
         _ = colorRefreshTrigger
-        if let uuid = coverPodcastsUuids.first,
+        if let uuid = episodes.first?.podcastUuid,
            let podcast = dataManager.findPodcast(uuid: uuid, includeUnsubscribed: true),
            let color = Self.pillColor(from: ColorManager.lightThemeTintForPodcast(podcast)) {
             return color

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -21,7 +21,6 @@ class PlaylistDetailsViewModel {
     let playlist: EpisodeFilter
     var episodes: [Episode] = []
     var showArchived: Bool = false
-    /// Cached so SwiftUI doesn't redo the podcast lookup + colour reshaping on every `body` evaluation.
     var playlistColor: Color
 
     private var allEpisodes: [Episode] = []
@@ -43,10 +42,8 @@ class PlaylistDetailsViewModel {
         observePodcastColorDownloads()
     }
 
-    /// Newly-subscribed podcasts arrive with `colorVersion = 1`, so the
-    /// initial `ColorManager` lookup returns defaults and schedules a
-    /// background colour download. Listen for the resulting notification so
-    /// the pill can refresh its background once the metadata lands.
+    /// Newly-subscribed podcasts return defaults until colour metadata downloads — refresh
+    /// the pill when that happens.
     private func observePodcastColorDownloads() {
         NotificationCenter.default
             .publisher(for: Constants.Notifications.podcastColorsDownloaded)
@@ -64,9 +61,8 @@ class PlaylistDetailsViewModel {
 
     func load() {
         Task {
-            // `DataManager.playlistEpisodes(for:)` always filters archived out, so go through the
-            // query builder directly with `shouldShowArchived: true` to keep archived episodes in
-            // `allEpisodes` and let the local toggle decide what to display.
+            // `DataManager.playlistEpisodes(for:)` always filters archived out, so query directly
+            // with `shouldShowArchived: true` and let the local toggle decide what to display.
             let query = PlaylistQueryBuilder.query(
                 clause: .episode,
                 for: playlist,
@@ -134,8 +130,6 @@ class PlaylistDetailsViewModel {
         return L10n.tvPlaylistDetailEpisodeCount(episodes.count)
     }
 
-    /// Re-derive the pill colour from the front-cover podcast's tint, falling back to a
-    /// deterministic palette when no usable tint is available.
     private func refreshPlaylistColor() {
         if let uuid = episodes.first?.podcastUuid,
            let podcast = dataManager.findPodcast(uuid: uuid, includeUnsubscribed: true),
@@ -146,11 +140,8 @@ class PlaylistDetailsViewModel {
         }
     }
 
-    /// Reshape a podcast tint into something legible as a card background:
-    /// keep the hue, clamp the saturation/brightness into a calm-but-vivid
-    /// range. Returns `nil` for tints with no usable chroma (greys, near
-    /// black) — `getHue` reports `H = 0` on a grey, so a naïve saturation
-    /// floor would convert every metadata-less podcast into brown.
+    /// Returns `nil` for tints with no usable chroma — `getHue` reports `H = 0` for greys,
+    /// so a naïve saturation floor would turn every metadata-less podcast brown.
     private static func pillColor(from tint: UIColor) -> Color? {
         var h: CGFloat = 0
         var s: CGFloat = 0
@@ -166,8 +157,6 @@ class PlaylistDetailsViewModel {
         ))
     }
 
-    /// Deterministic per-seed palette so playlists whose front cover has no
-    /// usable colour metadata still render distinct from each other.
     private static let fallbackPalette: [Color] = [
         Color(red: 0.15, green: 0.25, blue: 0.5),
         Color(red: 0.5, green: 0.17, blue: 0.15),
@@ -178,9 +167,7 @@ class PlaylistDetailsViewModel {
     ]
 
     private static func fallbackPillColor(for seed: String) -> Color {
-        // `String.hashValue` is per-run randomised in Swift; sum the unicode
-        // scalars instead so a given playlist gets the same pill colour each
-        // launch.
+        // `String.hashValue` is per-run randomised; sum unicode scalars for a stable seed.
         let index = seed.unicodeScalars.reduce(0) { $0 + Int($1.value) } % fallbackPalette.count
         return fallbackPalette[index]
     }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -7,6 +7,10 @@ import PocketCastsDataModel
 class PlaylistDetailsViewModel {
 
     private var cancellable: AnyCancellable?
+    @ObservationIgnored private var cancellables: Set<AnyCancellable> = []
+    /// Bumped when a podcast colour download lands so `playlistColor` re-runs
+    /// against the freshly-updated row instead of the stale defaults.
+    private var colorRefreshTrigger: Int = 0
 
     enum State: Equatable, Hashable {
         case loading
@@ -37,6 +41,26 @@ class PlaylistDetailsViewModel {
         self.dataManager = dataManager
         self.playbackManager = playbackManager
         self.showArchived = UserDefaults.standard.bool(forKey: Self.archiveStorageKey(for: playlist))
+        observePodcastColorDownloads()
+    }
+
+    /// Newly-subscribed podcasts arrive with `colorVersion = 1`, so the
+    /// initial `ColorManager` lookup returns defaults and schedules a
+    /// background colour download. Listen for the resulting notification so
+    /// the pill can refresh its background once the metadata lands.
+    private func observePodcastColorDownloads() {
+        NotificationCenter.default
+            .publisher(for: Constants.Notifications.podcastColorsDownloaded)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                guard
+                    let self,
+                    let uuid = notification.object as? String,
+                    self.coverPodcastsUuids.contains(uuid)
+                else { return }
+                self.colorRefreshTrigger &+= 1
+            }
+            .store(in: &cancellables)
     }
 
     func load() {
@@ -109,8 +133,59 @@ class PlaylistDetailsViewModel {
         return L10n.tvPlaylistDetailEpisodeCount(episodes.count)
     }
 
+    /// Pill background colour. Pulled from the podcast whose artwork sits on
+    /// the front of the cover stack so the pill visually echoes that image.
+    /// Falls back to a deterministic palette while episodes haven't loaded,
+    /// for an empty playlist with no cover to sample, or when the server
+    /// hasn't provided usable colour metadata for the front cover podcast.
     var playlistColor: Color {
-        return MockData.playlistsSpec[Int(playlist.sortPosition) % MockData.playlistsSpec.count].2
+        // Touch the trigger so `@Observable` re-runs this getter when a
+        // delayed colour download lands.
+        _ = colorRefreshTrigger
+        if let uuid = coverPodcastsUuids.first,
+           let podcast = dataManager.findPodcast(uuid: uuid, includeUnsubscribed: true),
+           let color = Self.pillColor(from: ColorManager.lightThemeTintForPodcast(podcast)) {
+            return color
+        }
+        return Self.fallbackPillColor(for: playlist.uuid)
+    }
+
+    /// Reshape a podcast tint into something legible as a card background:
+    /// keep the hue, clamp the saturation/brightness into a calm-but-vivid
+    /// range. Returns `nil` for tints with no usable chroma (greys, near
+    /// black) — `getHue` reports `H = 0` on a grey, so a naïve saturation
+    /// floor would convert every metadata-less podcast into brown.
+    private static func pillColor(from tint: UIColor) -> Color? {
+        var h: CGFloat = 0
+        var s: CGFloat = 0
+        var b: CGFloat = 0
+        var a: CGFloat = 0
+        tint.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+        guard s > 0.15, b > 0.1 else { return nil }
+        return Color(UIColor(
+            hue: h,
+            saturation: min(max(s, 0.5), 0.85),
+            brightness: min(max(b, 0.3), 0.45),
+            alpha: a
+        ))
+    }
+
+    /// Deterministic per-seed palette so playlists whose front cover has no
+    /// usable colour metadata still render distinct from each other.
+    private static func fallbackPillColor(for seed: String) -> Color {
+        let palette: [Color] = [
+            Color(red: 0.15, green: 0.25, blue: 0.5),
+            Color(red: 0.5, green: 0.17, blue: 0.15),
+            Color(red: 0.21, green: 0.22, blue: 0.14),
+            Color(red: 0.5, green: 0.35, blue: 0.12),
+            Color(red: 0.15, green: 0.4, blue: 0.3),
+            Color(red: 0.3, green: 0.2, blue: 0.45)
+        ]
+        // `String.hashValue` is per-run randomised in Swift; sum the unicode
+        // scalars instead so a given playlist gets the same pill colour each
+        // launch.
+        let index = seed.unicodeScalars.reduce(0) { $0 + Int($1.value) } % palette.count
+        return palette[index]
     }
 
     var coverPodcastsUuids: [String] {


### PR DESCRIPTION
Fixes PCIOS-758

## Summary

Replaces the hard-coded 4-colour spec palette behind each playlist pill with a colour derived from the podcast whose artwork sits on the front of the cover stack.

- Reads the cover podcast's \`primaryColor\` via \`ColorManager.lightThemeTintForPodcast\` and clamps saturation/brightness so vivid tints still read as a calm card background.
- For greys / near-black tints (covers \`getHue\` reporting \`H = 0\` on a true grey — what made every metadata-less pill read as brown before), falls back to a 6-colour palette seeded by the playlist UUID's scalar sum. Stable across launches and more diverse than the previous 4-by-sort-position scheme.
- Observes \`Constants.Notifications.podcastColorsDownloaded\` so a pill refreshes once \`ColorManager\` has finished fetching colour metadata in the background (freshly-subscribed shows arrive with \`colorVersion = 1\`, forcing the default until the download lands).

## To test

1. **Returning user, podcasts with cached colour metadata.** Open the Playlists tab. Each pill should render immediately with a colour that visibly echoes the front-most cover artwork (e.g. blue cover → blue-ish pill).
2. **Fresh install / freshly-subscribed podcasts.** Log out and back in. Open the Playlists tab — pills first render in the deterministic fallback palette, then within a moment (after \`ColorManager\` finishes the colour download) flip to artwork-derived colours.
3. **Playlists with no episodes / no cover.** Should render in the fallback palette and stay stable across launches.
4. **Diversity.** Multiple playlists with metadata-less cover podcasts should land on visibly different colours (not the same brown).
5. **No regressions on focus.** Focusing a pill still applies the \`pcBackgroundActive\` highlight (unchanged); leaving focus returns to the derived/fallback colour.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to \`CHANGELOG.md\` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.

<img width="1559" height="978" alt="Screenshot 2026-06-18 at 8 14 06 PM" src="https://github.com/user-attachments/assets/0fe76dd0-4d9f-4e5f-a21f-10a342eac4b5" />

