### PR TITLE
[PC TV] Add slower playback speeds down to 0.5x

### DIFF
--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -133,7 +133,7 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
     }
 
     private func makePlaybackSpeedMenu() -> UIMenu {
-        let speeds = Array(stride(from: 1.0, through: 3.0, by: 0.1))
+        let speeds = Array(stride(from: SharedConstants.PlaybackEffects.minimumPlaybackSpeed, through: SharedConstants.PlaybackEffects.maximumPlaybackSpeed, by: 0.1))
         let actions = speeds.map { speed in
             UIAction(
                 title: String(format: "%.1fx", speed),


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-471

The tvOS player's playback speed menu started at 1.0x, so slower speeds were unavailable. This extends the menu down to 0.5x to match iOS. The bounds now come from the shared `SharedConstants.PlaybackEffects` min/max constants instead of being hardcoded, keeping tvOS in sync with iOS. The backing `PlaybackManager` already supported these speeds — only the tvOS menu was capping the lower bound.

<img width="1222" height="789" alt="Screenshot 2026-06-18 at 2 13 57 PM" src="https://github.com/user-attachments/assets/e15de2eb-6fbd-4665-a92c-1a1360936b3d" />

**Note**: asking David if we need this much granularity.

## To test

1. On Apple TV, start playing an episode and open the Now Playing screen.
2. Open the playback speed menu.
3. Verify speeds now range from 0.5x to 3.0x in 0.1 increments.
4. Select a speed below 1.0x (e.g. 0.5x) and confirm playback slows accordingly and the toast/checkmark reflects the selection.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.