### PR TITLE
[PC TV] Player ellipsis menu: mark as played / archive

### DIFF
--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -7,10 +7,6 @@ struct NowPlayingView: View {
     @State private var isShowingDescription = false
     @State private var isShowingMarkAsPlayedConfirmation = false
     @State private var isShowingArchiveConfirmation = false
-    // `NowPlayingView` is hosted inside a `fullScreenCover`, which doesn't
-    // inherit the requireAccount environment from its presenter — read it
-    // back here so the ellipsis-menu actions can gate themselves.
-    @Environment(\.requireAccount) private var requireAccount
     // Mark Played and Archive both stop playback, which leaves the player
     // empty. Dismiss closes the fullScreenCover variants; the Now Playing
     // *tab* is separately swapped back to Home by `MainTabRouter`'s
@@ -22,8 +18,7 @@ struct NowPlayingView: View {
             model: model,
             isShowingDescription: $isShowingDescription,
             isShowingMarkAsPlayedConfirmation: $isShowingMarkAsPlayedConfirmation,
-            isShowingArchiveConfirmation: $isShowingArchiveConfirmation,
-            requireAccount: requireAccount
+            isShowingArchiveConfirmation: $isShowingArchiveConfirmation
         )
         .requireAccountSupport()
         .sheet(isPresented: $isShowingDescription) {
@@ -67,7 +62,11 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
     @Binding var isShowingDescription: Bool
     @Binding var isShowingMarkAsPlayedConfirmation: Bool
     @Binding var isShowingArchiveConfirmation: Bool
-    let requireAccount: RequireAccountAction
+    // Read here (rather than in the parent `NowPlayingView`) so the gated
+    // implementation installed by `.requireAccountSupport()` — applied to
+    // this representable above — is the one we see. Reading it upstream
+    // would resolve to the default no-op that runs actions immediately.
+    @Environment(\.requireAccount) private var requireAccount
     @State private var isTransportBarVisible = true
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -39,8 +39,9 @@ struct NowPlayingView: View {
         // don't interrupt anything.
         .alert(L10n.playerMarkAsPlayedConfirmation, isPresented: $isShowingMarkAsPlayedConfirmation) {
             Button(L10n.markPlayedShort, role: .destructive) {
+                AnalyticsEpisodeHelper.shared.currentSource = .player
                 model.markAsPlayed()
-                ToastManager.shared.show(L10n.markPlayed)
+                ToastManager.shared.show(L10n.markPlayedShort)
                 dismiss()
             }
             Button(L10n.cancel, role: .cancel) {}
@@ -49,6 +50,7 @@ struct NowPlayingView: View {
         }
         .alert(L10n.playerArchivedConfirmation, isPresented: $isShowingArchiveConfirmation) {
             Button(L10n.archive, role: .destructive) {
+                AnalyticsEpisodeHelper.shared.currentSource = .player
                 model.archive()
                 ToastManager.shared.show(L10n.podcastArchived)
                 dismiss()
@@ -257,6 +259,7 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
                 image: UIImage(systemName: "circle")
             ) { _ in
                 requireAccount {
+                    AnalyticsEpisodeHelper.shared.currentSource = .player
                     model.markAsUnplayed()
                     ToastManager.shared.show(L10n.markUnplayedShort)
                 }
@@ -282,6 +285,7 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
                     image: UIImage(systemName: "tray.and.arrow.up")
                 ) { _ in
                     requireAccount {
+                        AnalyticsEpisodeHelper.shared.currentSource = .player
                         model.unarchive()
                         ToastManager.shared.show(L10n.unarchive)
                     }

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -302,8 +302,9 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
             children.append(archiveToggle)
         }
 
+        // No title: the ellipsis icon already conveys "more", and the
+        // action labels (Mark Played / Archive) speak for themselves.
         return UIMenu(
-            title: L10n.tvPlayerMore,
             image: UIImage(systemName: "ellipsis"),
             children: children
         )

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -5,20 +5,67 @@ import PocketCastsDataModel
 struct NowPlayingView: View {
     @State private var model = NowPlayingViewModel()
     @State private var isShowingDescription = false
+    @State private var isShowingMarkAsPlayedConfirmation = false
+    @State private var isShowingArchiveConfirmation = false
+    // `NowPlayingView` is hosted inside a `fullScreenCover`, which doesn't
+    // inherit the requireAccount environment from its presenter — read it
+    // back here so the ellipsis-menu actions can gate themselves.
+    @Environment(\.requireAccount) private var requireAccount
+    // Mark Played and Archive both stop playback, which leaves the player
+    // empty. Dismiss closes the fullScreenCover variants; the Now Playing
+    // *tab* is separately swapped back to Home by `MainTabRouter`'s
+    // existing playback observer.
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        NowPlayingPlayerRepresentable(model: model, isShowingDescription: $isShowingDescription)
-            .sheet(isPresented: $isShowingDescription) {
-                if let episode = model.episode {
-                    EpisodeShowNotesView(episode: episode, podcast: model.podcast)
-                }
+        NowPlayingPlayerRepresentable(
+            model: model,
+            isShowingDescription: $isShowingDescription,
+            isShowingMarkAsPlayedConfirmation: $isShowingMarkAsPlayedConfirmation,
+            isShowingArchiveConfirmation: $isShowingArchiveConfirmation,
+            requireAccount: requireAccount
+        )
+        .requireAccountSupport()
+        .sheet(isPresented: $isShowingDescription) {
+            if let episode = model.episode {
+                EpisodeShowNotesView(episode: episode, podcast: model.podcast)
             }
+        }
+        // Mark Played and Archive both end playback (via
+        // `EpisodeManager.markAsPlayed` / `archiveEpisode` →
+        // `PlaybackManager.removeIfPlayingOrQueued`), so mirror the iOS
+        // player and confirm before doing it. The reverse actions
+        // (Mark Unplayed / Unarchive) skip confirmation since they
+        // don't interrupt anything.
+        .alert(L10n.playerMarkAsPlayedConfirmation, isPresented: $isShowingMarkAsPlayedConfirmation) {
+            Button(L10n.markPlayedShort, role: .destructive) {
+                model.markAsPlayed()
+                ToastManager.shared.show(L10n.markPlayed)
+                dismiss()
+            }
+            Button(L10n.cancel, role: .cancel) {}
+        } message: {
+            Text(L10n.playerMarkAsPlayedConfirmationMessage)
+        }
+        .alert(L10n.playerArchivedConfirmation, isPresented: $isShowingArchiveConfirmation) {
+            Button(L10n.archive, role: .destructive) {
+                model.archive()
+                ToastManager.shared.show(L10n.podcastArchived)
+                dismiss()
+            }
+            Button(L10n.cancel, role: .cancel) {}
+        } message: {
+            Text(L10n.playerArchivedConfirmationMessage)
+        }
     }
 }
 
 private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
     @Bindable var model: NowPlayingViewModel
     @Binding var isShowingDescription: Bool
+    @Binding var isShowingMarkAsPlayedConfirmation: Bool
+    @Binding var isShowingArchiveConfirmation: Bool
+    let requireAccount: RequireAccountAction
     @State private var isTransportBarVisible = true
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
@@ -79,7 +126,8 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
         uiViewController.player?.currentItem?.externalMetadata = createMetadataItems()
         uiViewController.transportBarCustomMenuItems = [
             makePlaybackSpeedMenu(),
-            makePlaybackEffectsMenu()
+            makePlaybackEffectsMenu(),
+            makeEpisodeActionsMenu()
         ]
         ensureEpisodeDescriptionInfoAction(on: uiViewController)
         // Suppress AVKit's system loading spinner while the player is still
@@ -189,6 +237,72 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
             title: L10n.tvPlayerPlaybackEffects,
             image: UIImage(systemName: "speaker.wave.3"),
             children: [volumeBoostSection]
+        )
+    }
+
+    /// Builds the ellipsis menu sitting alongside the playback-speed and
+    /// playback-effects round buttons on the transport bar. Shows the
+    /// played/unplayed and archive/unarchive entries that match the current
+    /// episode's state, so the action label always reflects what the tap
+    /// will do.
+    private func makeEpisodeActionsMenu() -> UIMenu {
+        // Mark Played and Archive both stop playback as a side effect of
+        // `EpisodeManager.markAsPlayed` / `archiveEpisode`, so the
+        // destructive sides defer to the parent SwiftUI view's `.alert`
+        // for a confirmation step before running. The reverses are direct.
+        let playToggle: UIAction
+        if model.isPlayed {
+            playToggle = UIAction(
+                title: L10n.markUnplayedShort,
+                image: UIImage(systemName: "circle")
+            ) { _ in
+                requireAccount {
+                    model.markAsUnplayed()
+                    ToastManager.shared.show(L10n.markUnplayedShort)
+                }
+            }
+        } else {
+            playToggle = UIAction(
+                title: L10n.markPlayedShort,
+                image: UIImage(systemName: "checkmark.circle")
+            ) { _ in
+                requireAccount {
+                    isShowingMarkAsPlayedConfirmation = true
+                }
+            }
+        }
+
+        var children: [UIAction] = [playToggle]
+
+        if model.canArchive {
+            let archiveToggle: UIAction
+            if model.isArchived {
+                archiveToggle = UIAction(
+                    title: L10n.unarchive,
+                    image: UIImage(systemName: "tray.and.arrow.up")
+                ) { _ in
+                    requireAccount {
+                        model.unarchive()
+                        ToastManager.shared.show(L10n.unarchive)
+                    }
+                }
+            } else {
+                archiveToggle = UIAction(
+                    title: L10n.archive,
+                    image: UIImage(systemName: "archivebox")
+                ) { _ in
+                    requireAccount {
+                        isShowingArchiveConfirmation = true
+                    }
+                }
+            }
+            children.append(archiveToggle)
+        }
+
+        return UIMenu(
+            title: L10n.tvPlayerMore,
+            image: UIImage(systemName: "ellipsis"),
+            children: children
         )
     }
 

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -187,6 +187,38 @@ class NowPlayingViewModel: Identifiable {
         }
     }
 
+    var isPlayed: Bool {
+        episode?.played() ?? false
+    }
+
+    var canArchive: Bool {
+        episode is Episode
+    }
+
+    var isArchived: Bool {
+        (episode as? Episode)?.archived ?? false
+    }
+
+    func markAsPlayed() {
+        guard let episode else { return }
+        EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
+    }
+
+    func markAsUnplayed() {
+        guard let episode else { return }
+        EpisodeManager.markAsUnplayed(episode: episode, fireNotification: true)
+    }
+
+    func archive() {
+        guard let episode = episode as? Episode else { return }
+        EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
+    }
+
+    func unarchive() {
+        guard let episode = episode as? Episode else { return }
+        EpisodeManager.unarchiveEpisode(episode: episode, fireNotification: true)
+    }
+
     fileprivate func observeUpNextChanges() {
         NotificationCenter.default.publisher(for: Constants.Notifications.playbackTrackChanged)
             .receive(on: DispatchQueue.main)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6187,9 +6187,6 @@
 /* tv player playback effects menu title */
 "tv_player_playback_effects" = "Playback effects";
 
-/* tv player ellipsis menu title; sits above episode actions like Mark Played and Archive */
-"tv_player_more" = "More";
-
 /* tv player volume boost toggle title */
 "tv_player_volume_boost" = "Volume boost";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6187,6 +6187,9 @@
 /* tv player playback effects menu title */
 "tv_player_playback_effects" = "Playback effects";
 
+/* tv player ellipsis menu title; sits above episode actions like Mark Played and Archive */
+"tv_player_more" = "More";
+
 /* tv player volume boost toggle title */
 "tv_player_volume_boost" = "Volume boost";
 


### PR DESCRIPTION
Fixes PCIOS-757

## Summary

Adds a third **More** round button to the fullscreen player's transport bar (after Playback Speed and Playback Effects) holding two state-aware episode actions: **Mark Played / Mark Unplayed** and **Archive / Unarchive**.

- Mark Played and Archive confirm via alert first (matching the iOS player), because the underlying `EpisodeManager` calls stop playback as a side effect. Their reverses run directly.
- After a destructive action's alert is confirmed, the view dismisses itself so any `fullScreenCover` presentation closes. The Now Playing *tab* is already swapped back to Home by `MainTabRouter`'s existing playback observer, so no extra routing is needed.
- All four actions are wrapped in `requireAccount { … }`, read from `@Environment(\.requireAccount)` inside `NowPlayingPlayerRepresentable` (where `.requireAccountSupport()` is applied), so logged-out users hit the create-account modal before anything runs.
- The ellipsis popover shows only the action entries with no title header.

## To test

1. Play any episode and open the fullscreen player. Verify a new **ellipsis** round button appears to the right of Playback Effects.
2. Focus it — the popover shows the entries matching the current episode's state (e.g. "Mark Played" + "Archive" for an unplayed, non-archived episode), with no title header.
3. Tap **Mark Played** → confirmation alert appears → confirm → playback stops, toast "Mark as Played" shows, the player closes (fullScreenCover dismisses, the Now Playing tab swaps back to Home).
4. Repeat for **Archive** → same behaviour with the archive confirmation alert.
5. Tap **Mark Unplayed** / **Unarchive** (when the inverse state is true) → action runs immediately, toast confirms, player stays open.
6. While **logged out**, tap any of the four actions → create-account modal appears instead of running the action.
7. User-uploaded files: confirm the archive entry is hidden (no `canArchive`).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- <a href="https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing"> ] I have updated (or requested that someone edit) [the spreadsheet</a> to reflect any new or changed analytics.