### PR TITLE
[PC TV] Fix snackbar confirmation copy

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -92,7 +92,7 @@ class EpisodeRowViewModel: Identifiable {
 
     func markAsPlayed() {
         EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
-        ToastManager.shared.show(L10n.markPlayed)
+        ToastManager.shared.show(L10n.tvEpisodeMarkedAsPlayed)
     }
 
     var canArchive: Bool {
@@ -110,17 +110,18 @@ class EpisodeRowViewModel: Identifiable {
     func archive() {
         guard let episode = episode as? Episode else { return }
         EpisodeManager.archiveEpisode(episode: episode, fireNotification: true)
-        ToastManager.shared.show(L10n.podcastArchived)
+        ToastManager.shared.show(L10n.tvEpisodeArchived)
     }
 
     func unarchive() {
         guard let episode = episode as? Episode else { return }
         EpisodeManager.unarchiveEpisode(episode: episode, fireNotification: true)
+        ToastManager.shared.show(L10n.tvEpisodeUnarchived)
     }
 
     func removeFromUpNext() {
         playbackManager.removeIfPlayingOrQueued(episode: episode, fireNotification: true, userInitiated: true)
-        ToastManager.shared.show(L10n.removeFromUpNext)
+        ToastManager.shared.show(L10n.tvEpisodeRemovedFromUpNext)
     }
 
     private func setupObservers() {
@@ -165,7 +166,7 @@ enum EpisodeUpNextActions {
         } else {
             playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: true, userInitiated: true)
         }
-        ToastManager.shared.show(L10n.playNextInUpNext)
+        ToastManager.shared.show(L10n.tvEpisodeWillPlayNext)
     }
 
     static func playLast(_ episode: BaseEpisode, playbackManager: PlaybackManager = .shared) {
@@ -175,7 +176,7 @@ enum EpisodeUpNextActions {
         } else {
             playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: false, userInitiated: true)
         }
-        ToastManager.shared.show(L10n.playLastInUpNext)
+        ToastManager.shared.show(L10n.tvEpisodeWillPlayLast)
     }
 }
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6217,6 +6217,24 @@
 /* tv player toast shown when trim silence setting changes. %1$@ is the selected option name */
 "tv_player_trim_silence_set" = "Trim silence: %1$@";
 
+/* tv toast confirming an episode was marked as played */
+"tv_episode_marked_as_played" = "Marked as played";
+
+/* tv toast confirming an episode was archived */
+"tv_episode_archived" = "Archived";
+
+/* tv toast confirming an episode was unarchived */
+"tv_episode_unarchived" = "Unarchived";
+
+/* tv toast confirming an episode was removed from the Up Next queue */
+"tv_episode_removed_from_up_next" = "Removed from Up Next";
+
+/* tv toast confirming an episode was queued to play next in Up Next */
+"tv_episode_will_play_next" = "Will play next";
+
+/* tv toast confirming an episode was queued to play last in Up Next */
+"tv_episode_will_play_last" = "Will play last";
+
 /* tv up next empty title */
 "tv_up_next_empty_title" = "Nothing queued up";
 


### PR DESCRIPTION
Fixes PCIOS-741

The tvOS episode-action toasts were reusing the iOS button-label strings (imperatives like "Mark as Played", "Remove From Up Next"), so the confirmations read as commands rather than results. This adds dedicated tvOS confirmation strings (matching the existing `tv_player_*` toast style) and wires up a missing confirmation for unarchive.

| Action | Before | After |
|---|---|---|
| Mark as played | "Mark as Played" | "Marked as played" |
| Archive | "Archived" | "Archived" |
| Unarchive | _(no toast)_ | "Unarchived" |
| Remove from Up Next | "Remove From Up Next" | "Removed from Up Next" |
| Play next | "Play next in Up Next" | "Will play next" |
| Play last | "Play last in Up Next" | "Will play last" |

The shared iOS strings are left untouched (they're correct as button labels). Follow/unfollow and play keep no toast — the Follow button flips to "Following" and Play opens the full-screen player, so both already have clear in-place feedback.

## To test

1. On the tvOS app, open a podcast and focus an episode, then open the "…" actions menu.
2. Trigger each action and confirm the toast in the top-right reads as a result:
   - Mark as played → "Marked as played"
   - Archive → "Archived"; then unarchive the same episode → "Unarchived"
   - Play Next → "Will play next"; Play Last → "Will play last"
3. In the Up Next tab, remove an episode → "Removed from Up Next".

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.