### PR TITLE
[PC TV] Add Firebase Remote Config

### DIFF
--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 import PocketCastsServer
 import PocketCastsDataModel
+import PocketCastsUtils
 import Firebase
+import FirebaseRemoteConfig
 
 @Observable
 class AppCoordinator {
@@ -122,6 +124,29 @@ class AppCoordinator {
 
     private func setupFirebase() {
         FirebaseApp.configure()
+
+        FirebaseManager.refreshRemoteConfig { [weak self] _ in
+            self?.updateRemoteFeatureFlags()
+        }
+    }
+
+    /// Applies remotely overridden feature flags to the `FeatureFlagOverrideStore`, so the rest of
+    /// the app reads them through `FeatureFlag.enabled`. Mirrors `AppDelegate`/`AppClipAppDelegate`,
+    /// each of which owns its own copy; skipped in debug builds where local overrides take precedence.
+    private func updateRemoteFeatureFlags(forceReload: Bool = false) {
+        guard BuildEnvironment.current != .debug || forceReload else { return }
+
+        FeatureFlag.allCases.forEach { flag in
+            guard let remoteKey = flag.remoteKey else { return }
+            let remoteValue = RemoteConfig.remoteConfig().configValue(forKey: remoteKey)
+            guard remoteValue.source == .remote else { return }
+            do {
+                FileLog.shared.console("Override \(flag): \(remoteValue.boolValue)")
+                try FeatureFlagOverrideStore().override(flag, withValue: remoteValue.boolValue)
+            } catch {
+                FileLog.shared.addMessage("Failed to set remote feature flag \(flag): \(error)")
+            }
+        }
     }
 
     private func setupDiscover() {

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1233,6 +1233,7 @@
 		F5F5097E2CEBFDE6007D6E39 /* skip.json in Resources */ = {isa = PBXBuildFile; fileRef = BD85E3A31E6670DF001B17C1 /* skip.json */; };
 		F5F884632CC9EAA6002BED2C /* Humane-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = F5F884622CC9EAA6002BED2C /* Humane-Bold.otf */; };
 		F5FDDD842E58E8B000FB1C33 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
+		FFFEB10A2F9BDA9A00E68E0C /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
 		F5FDDD852E58E94500FB1C33 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		F5FF61202BD076BA00190711 /* Sharing.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5FF611F2BD076BA00190711 /* Sharing.xcassets */; };
 		FCCC80732DD56B380080EB2C /* HowToUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCC80722DD56B380080EB2C /* HowToUploadView.swift */; };
@@ -7799,6 +7800,7 @@
 				FF6033FC2FAB4C8300EB3AD5 /* AutoplayHelper.swift in Sources */,
 				FF49FEAD2F9BBCA900E68E0C /* LocalizationHelpers.swift in Sources */,
 				FF492A7A2F9BDA9A00E68E0C /* Constants.swift in Sources */,
+				FFFEB10A2F9BDA9A00E68E0C /* FirebaseManager.swift in Sources */,
 				FF8FFE6E2FAA8F240086A867 /* TranscriptFormat.swift in Sources */,
 				FF65058B2FAA963100C3662E /* Notifications.swift in Sources */,
 				FF32F3EB2FAB972700226E58 /* AuthenticationHelper.swift in Sources */,


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-737

The tvOS app configured Firebase but never fetched Remote Config or applied remote feature flags. This wires that up after `FirebaseApp.configure()`, reusing the shared `FirebaseManager.refreshRemoteConfig` (the file is now a member of the tvOS target, like the App Clip). As on iOS, remote overrides are skipped in debug builds.

## To test

1. Build and run the **Pocket Casts TV App** (staging) on Apple TV or the tvOS simulator.
2. Confirm it launches and reaches welcome/browsing normally — Remote Config is fetched at startup and must not block or crash.
3. Optional full check: change a remote-controlled flag (one with a `remoteKey`) in the Firebase console, run a TestFlight/release build, relaunch, and confirm the flag reflects the remote value.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.