### PR TITLE
Make mini player play/pause button larger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix the Filters search header popping back when few episodes match [#4527](https://github.com/Automattic/pocket-casts-ios/pull/4527)
 - Drop iOS 16 and watchOS 9 [#4521](https://github.com/Automattic/pocket-casts-ios/issues/4521)
 - Fix incorrect section heading when opening an episode on the Apple Watch [#4528](https://github.com/Automattic/pocket-casts-ios/pull/4528)
+- Make the mini player play/pause button larger [#4566](https://github.com/Automattic/pocket-casts-ios/pull/4566)
 
 8.14
 -----

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -146,7 +146,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         podcastArtwork.layer.cornerRadius = 6
         podcastArtwork.layer.masksToBounds = true
 
-        playPauseBtn.visualSize = 28
+        playPauseBtn.visualSize = 32
 
         // The skip glyphs read a touch heavy next to the smaller glass
         // play/pause button, so scale the (template) assets down slightly.
@@ -237,7 +237,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
             NSLayoutConstraint.deactivate(accessoryEnvironmentConstraints)
             accessoryEnvironmentConstraints = [
-                glassProgressView.widthAnchor.constraint(equalToConstant: isInline ? 34 : 44),
+                glassProgressView.widthAnchor.constraint(equalToConstant: isInline ? 34 : 52),
                 glassButtonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: isInline ? -4 : -8),
             ]
             NSLayoutConstraint.activate(accessoryEnvironmentConstraints)


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Bumps the mini player's primary control so it reads larger and is easier to tap. The play/pause button's visual size goes from 28pt to 32pt, and the glass progress view widens from 44pt to 52pt in the expanded (non-inline) layout. The inline layout is unchanged.

<img width="541" height="249" alt="Screenshot 2026-06-18 at 6 19 38 PM" src="https://github.com/user-attachments/assets/4f90379e-4b89-43c4-87fd-dc1331873e03" />


## To test

1. Start playing an episode so the mini player appears.
2. Confirm the play/pause button is noticeably larger and well-aligned with the skip controls.
3. Confirm the surrounding glass progress view comfortably fits the larger button without clipping.
4. Trigger the inline mini player variant and confirm it is unchanged.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.