### PR TITLE
Add soft progressive-blur edge to podcast grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix the Filters search header popping back when few episodes match [#4527](https://github.com/Automattic/pocket-casts-ios/pull/4527)
 - Drop iOS 16 and watchOS 9 [#4521](https://github.com/Automattic/pocket-casts-ios/issues/4521)
 - Fix incorrect section heading when opening an episode on the Apple Watch [#4528](https://github.com/Automattic/pocket-casts-ios/pull/4528)
+- Add a soft blur edge to the bottom of the podcast grid under Liquid Glass [#4567](https://github.com/Automattic/pocket-casts-ios/pull/4567)
 
 8.14
 -----

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -64,9 +64,16 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private var glassButtonStack: UIStackView?
     private var accessoryEnvironmentConstraints: [NSLayoutConstraint] = []
 
+    /// A thin themed layer behind the glass content. The tab accessory's glass samples
+    /// the grid scrolling behind it, so over bright artwork the controls lose contrast;
+    /// tinting toward the page background keeps them readable.
+    private var glassTintView: UIView?
+
     private enum GlassMetrics {
         /// How much the Liquid Glass skip glyphs are scaled down from the asset.
         static let skipIconScale: CGFloat = 0.9
+        /// Alpha of the thin `primaryUi02` layer tinting the glass.
+        static let tintAlpha: CGFloat = 0.2
     }
 
     /// Wraps `content` in a vibrancy effect so it blends with the tab accessory's glass.
@@ -197,9 +204,22 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         buttonStack.alignment = .center
         glassButtonStack = buttonStack
 
+        let glassTint = UIView()
+        glassTint.translatesAutoresizingMaskIntoConstraints = false
+        glassTint.isUserInteractionEnabled = false
+        glassTintView = glassTint
+
+        view.addSubview(glassTint)
         view.addSubview(podcastArtwork)
         view.addSubview(textStack)
         view.addSubview(buttonStack)
+
+        NSLayoutConstraint.activate([
+            glassTint.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            glassTint.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            glassTint.topAnchor.constraint(equalTo: view.topAnchor),
+            glassTint.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
 
         timeLeftHost.didMove(toParent: self)
 
@@ -622,6 +642,8 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         let actionColor = currentPodcastTintColor()
         let iconColor = ThemeColor.podcastIcon03(podcastColor: actionColor)
         let bgColor = ThemeColor.primaryUi02()
+
+        glassTintView?.backgroundColor = bgColor.withAlphaComponent(GlassMetrics.tintAlpha)
 
         // System color so the vibrancy wrapper can modulate it.
         episodeTitleLabel?.textColor = .label

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -48,7 +48,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     /// Height of the soft bottom blur edge shown over the grid under Liquid Glass.
     /// The gradient fade means only the lower portion reads strongly, so this can be
     /// generous without looking like a solid bar.
-    private static let bottomBlurHeight: CGFloat = 220
+    private static let bottomBlurHeight: CGFloat = 180
 
     private lazy var bottomBlurView = ProgressiveBlurView()
 

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -331,12 +331,14 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         bottomBlurView.isHidden = Settings.libraryType() == .list
     }
 
-    /// Picks the blur material per theme. The same material reads heavier in dark mode,
-    /// so use a thinner one there to keep the soft edge subtle.
+    /// Tunes the blur per theme. The same material reads heavier in dark mode, so use a
+    /// thinner one there to keep the blur subtle, and instead layer in extra opacity
+    /// (fading toward the grid's own background) to dim the bright artwork enough.
     private func updateBottomBlurEffect() {
         guard LiquidGlass.isEnabled else { return }
-        let style: UIBlurEffect.Style = Theme.sharedTheme.activeTheme.isDark ? .systemThinMaterial : .systemMaterial
-        bottomBlurView.setBlurEffect(UIBlurEffect(style: style))
+        let isDark = Theme.sharedTheme.activeTheme.isDark
+        bottomBlurView.setBlurEffect(UIBlurEffect(style: isDark ? .systemThinMaterial : .systemMaterial))
+        bottomBlurView.setTintColor(isDark ? ThemeColor.primaryUi02().withAlphaComponent(0.4) : nil)
     }
 
     @objc func refreshGridItems() {

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -45,6 +45,13 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
 
     private var lastWillLayoutWidth: CGFloat = 0
 
+    /// Height of the soft bottom blur edge shown over the grid under Liquid Glass.
+    /// The gradient fade means only the lower portion reads strongly, so this can be
+    /// generous without looking like a solid bar.
+    private static let bottomBlurHeight: CGFloat = 220
+
+    private lazy var bottomBlurView = ProgressiveBlurView()
+
     private var homeGridDataHelper = HomeGridDataHelper()
 
     private lazy var refreshQueue: OperationQueue = {
@@ -81,6 +88,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
 
         adjustSettingsForGridType()
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: podcastsCollectionView)
+        setupBottomBlur()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -292,6 +300,43 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         if let themeableCollectionView = podcastsCollectionView as? ThemeableCollectionView {
             themeableCollectionView.style = .primaryUi02
         }
+        updateBottomBlur()
+    }
+
+    /// Adds a soft progressive-blur edge to the bottom of the grid under Liquid Glass.
+    ///
+    /// The system scroll edge effect samples the scrolling content, so over a grid of
+    /// colorful artwork it washes out and barely registers — which is what hurts the
+    /// readability of the floating tab bar / mini player. A dedicated blur overlay,
+    /// pinned to the bottom of the screen behind the bar, gives a consistently visible
+    /// soft edge. List view keeps the system default.
+    private func setupBottomBlur() {
+        guard LiquidGlass.isEnabled else { return }
+
+        bottomBlurView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(bottomBlurView)
+        NSLayoutConstraint.activate([
+            bottomBlurView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bottomBlurView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomBlurView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            bottomBlurView.heightAnchor.constraint(equalToConstant: Self.bottomBlurHeight)
+        ])
+        updateBottomBlurEffect()
+        updateBottomBlur()
+    }
+
+    /// Shows the bottom blur only for the grid layouts, where readability suffers.
+    private func updateBottomBlur() {
+        guard LiquidGlass.isEnabled else { return }
+        bottomBlurView.isHidden = Settings.libraryType() == .list
+    }
+
+    /// Picks the blur material per theme. The same material reads heavier in dark mode,
+    /// so use a thinner one there to keep the soft edge subtle.
+    private func updateBottomBlurEffect() {
+        guard LiquidGlass.isEnabled else { return }
+        let style: UIBlurEffect.Style = Theme.sharedTheme.activeTheme.isDark ? .systemThinMaterial : .systemMaterial
+        bottomBlurView.setBlurEffect(UIBlurEffect(style: style))
     }
 
     @objc func refreshGridItems() {
@@ -474,6 +519,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     override func handleThemeChanged() {
         super.handleThemeChanged()
         podcastsCollectionView.reloadData()
+        updateBottomBlurEffect()
     }
 
     private func setupBannerAd(promotion: BlazePromotion, shouldAnimate: Bool) {

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -332,13 +332,14 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     }
 
     /// Tunes the blur per theme. The same material reads heavier in dark mode, so use a
-    /// thinner one there to keep the blur subtle, and instead layer in extra opacity
-    /// (fading toward the grid's own background) to dim the bright artwork enough.
+    /// thinner one there to keep the blur subtle. In both modes layer in extra opacity
+    /// (fading toward the grid's own background) to dim the bright artwork enough — light
+    /// mode needs the heavier tint since the material washes out more there.
     private func updateBottomBlurEffect() {
         guard LiquidGlass.isEnabled else { return }
         let isDark = Theme.sharedTheme.activeTheme.isDark
         bottomBlurView.setBlurEffect(UIBlurEffect(style: isDark ? .systemThinMaterial : .systemMaterial))
-        bottomBlurView.setTintColor(isDark ? ThemeColor.primaryUi02().withAlphaComponent(0.4) : nil)
+        bottomBlurView.setTintColor(ThemeColor.primaryUi02().withAlphaComponent(isDark ? 0.4 : 0.6))
     }
 
     @objc func refreshGridItems() {

--- a/podcasts/Utilities/ProgressiveBlurView.swift
+++ b/podcasts/Utilities/ProgressiveBlurView.swift
@@ -1,0 +1,53 @@
+import UIKit
+
+/// A blur overlay whose strength ramps from fully transparent at the top to fully
+/// blurred at the bottom, producing a soft progressive-blur edge.
+///
+/// The system scroll edge effect samples the scrolling content, so over busy,
+/// multicolor content (such as a grid of podcast artwork) it washes out and barely
+/// registers. This view lays a controllable, consistently visible material blur over
+/// the bottom of that content so it fades out cleanly behind floating bottom bars.
+final class ProgressiveBlurView: UIView {
+    private let blurView: UIVisualEffectView
+    private let gradientMask = CAGradientLayer()
+
+    init(effect: UIVisualEffect = UIBlurEffect(style: .systemMaterial)) {
+        blurView = UIVisualEffectView(effect: effect)
+        super.init(frame: .zero)
+
+        // The overlay is purely decorative; it must never intercept touches meant
+        // for the content scrolling underneath it.
+        isUserInteractionEnabled = false
+        blurView.isUserInteractionEnabled = false
+        addSubview(blurView)
+
+        // Alpha mask: transparent at the top, opaque at the bottom. Masking the
+        // effect view fades the blur in towards the bottom edge.
+        gradientMask.colors = [UIColor.clear.cgColor, UIColor.white.cgColor]
+        gradientMask.startPoint = CGPoint(x: 0.5, y: 0)
+        gradientMask.endPoint = CGPoint(x: 0.5, y: 1)
+        blurView.layer.mask = gradientMask
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Swaps the underlying blur material, e.g. to use a lighter material in dark mode
+    /// where the same style reads heavier.
+    func setBlurEffect(_ effect: UIVisualEffect?) {
+        blurView.effect = effect
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        // The mask is a CALayer, so disable implicit animations to keep it pinned to
+        // the blur view during bounds changes (rotation, safe-area updates).
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        blurView.frame = bounds
+        gradientMask.frame = bounds
+        CATransaction.commit()
+    }
+}

--- a/podcasts/Utilities/ProgressiveBlurView.swift
+++ b/podcasts/Utilities/ProgressiveBlurView.swift
@@ -7,8 +7,11 @@ import UIKit
 /// multicolor content (such as a grid of podcast artwork) it washes out and barely
 /// registers. This view lays a controllable, consistently visible material blur over
 /// the bottom of that content so it fades out cleanly behind floating bottom bars.
+/// An optional tint can be layered on top to push the edge more opaque than the blur
+/// material alone manages.
 final class ProgressiveBlurView: UIView {
     private let blurView: UIVisualEffectView
+    private let tintView = UIView()
     private let gradientMask = CAGradientLayer()
 
     init(effect: UIVisualEffect = UIBlurEffect(style: .systemMaterial)) {
@@ -19,14 +22,16 @@ final class ProgressiveBlurView: UIView {
         // for the content scrolling underneath it.
         isUserInteractionEnabled = false
         blurView.isUserInteractionEnabled = false
+        tintView.isUserInteractionEnabled = false
         addSubview(blurView)
+        addSubview(tintView)
 
-        // Alpha mask: transparent at the top, opaque at the bottom. Masking the
-        // effect view fades the blur in towards the bottom edge.
+        // Alpha mask: transparent at the top, opaque at the bottom. Masking the whole
+        // view fades both the blur and the tint in towards the bottom edge together.
         gradientMask.colors = [UIColor.clear.cgColor, UIColor.white.cgColor]
         gradientMask.startPoint = CGPoint(x: 0.5, y: 0)
         gradientMask.endPoint = CGPoint(x: 0.5, y: 1)
-        blurView.layer.mask = gradientMask
+        layer.mask = gradientMask
     }
 
     required init?(coder: NSCoder) {
@@ -39,14 +44,21 @@ final class ProgressiveBlurView: UIView {
         blurView.effect = effect
     }
 
+    /// Lays an optional tint over the blur (faded by the same gradient) to make the
+    /// edge more opaque than the blur material alone. Pass `nil` for no tint.
+    func setTintColor(_ color: UIColor?) {
+        tintView.backgroundColor = color ?? .clear
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
 
         // The mask is a CALayer, so disable implicit animations to keep it pinned to
-        // the blur view during bounds changes (rotation, safe-area updates).
+        // the view during bounds changes (rotation, safe-area updates).
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         blurView.frame = bounds
+        tintView.frame = bounds
         gradientMask.frame = bounds
         CATransaction.commit()
     }


### PR DESCRIPTION
Under Liquid Glass, the system bottom scroll edge effect samples the scrolling content, so over a grid of colorful podcast artwork it washes out and barely registers — leaving the floating tab bar / mini player hard to read against the artwork. The system removes the blur when the app needs it the most.


https://github.com/user-attachments/assets/04802f16-0bfb-4692-8f7a-4eb464074b54


This adds a dedicated material-blur overlay (`ProgressiveBlurView`) pinned to the bottom of the grid that fades in via a gradient mask, giving a consistently visible soft edge regardless of the content behind it. It's shown for the grid layouts only; list view keeps the system default. The overlay is non-interactive, so it never intercepts touches on the cells underneath.

https://github.com/user-attachments/assets/5ff9acf0-9867-4b7f-ab21-4c3b8161fa4f

This change also adds a thin layer of color under the mini player itself because, as it's further from the bottom, it benefits less from the progressive blur.


## To test

1. Open the **Podcasts** tab with several subscriptions, in **Large grid** or **Small grid** layout.
2. Scroll the grid and confirm the artwork fades out softly behind the tab bar / mini player (instead of clashing with it), in both light and dark themes.
3. Switch to **List** layout and confirm the custom blur is not shown.

## Screenshots

**Before / After**

<img width="1087" height="1108" alt="Screenshot 2026-06-18 at 7 11 54 PM" src="https://github.com/user-attachments/assets/29e25197-2c3e-4283-af24-ffaeb99f4439" />


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.