### PR TITLE
Redirect /pair deep links to Safari

### DIFF
--- a/podcasts/AppDelegate+SiriShortcuts.swift
+++ b/podcasts/AppDelegate+SiriShortcuts.swift
@@ -46,6 +46,7 @@ extension AppDelegate {
             // This is temporary workaround to avoid the app handling the /pair urls as a share url until we implement the proper pair URL handling on 8.15
             // This will make the user to be redirected to the web page
             if path.startsWith(string: "/pair") {
+                UIApplication.shared.open(incomingURL, options: [:])
                 return
             }
 


### PR DESCRIPTION
Fixes PCIOS- <!-- issue number, if applicable -->

When the app receives a `/pair` deep link (used for pairing with Pocket Casts on tvOS/Apple TV), it currently bails out early as a temporary workaround until proper `/pair` URL handling lands in 8.15. Previously this just dropped the URL, leaving the user stuck in the app with nothing happening. This change opens the incoming URL in Safari so the user is redirected to the web page and can complete pairing there.

## To test

1. Trigger a `/pair` universal link (e.g. tap a pairing link that opens Pocket Casts).
2. Confirm the app no longer silently handles the link.
3. Confirm Safari opens to the pairing web page for the incoming URL.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the spreadsheet](https://docs.google.com/spreadsheets/d/107jqrutZhU0fVZJ19SBqxxVKbV2NWSdQC9MFYdLiAxc/edit?usp=sharing) to reflect any new or changed analytics.
