### PR TITLE
[PC TV] Fix sign-in URL generation

### DIFF
--- a/Pocket Casts TV App/UI/Auth/PairingSession.swift
+++ b/Pocket Casts TV App/UI/Auth/PairingSession.swift
@@ -82,8 +82,4 @@ class PairingSession {
         }
         return host + url.path()
     }
-
-    var pairURLString: String {
-        return pairURLComplete ?? ServerConstants.Urls.tvPair
-    }
 }

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -14,8 +14,11 @@ struct SignInView: View {
         static let qrSize = CGFloat(240)
     }
 
-    var enterCodePrompt: AttributedString {
-        let baseString = L10n.tvSignInEnterCodeInUrl(model.pairing.pairURLPretty, model.pairing.pairURLString)
+    var enterCodePrompt: AttributedString? {
+        guard let pairingURLComplete = model.pairing.pairURLComplete else {
+            return nil
+        }
+        let baseString = L10n.tvSignInEnterCodeInUrl(model.pairing.pairURLPretty, pairingURLComplete)
         var attributedString = (try? AttributedString(markdown: baseString)) ?? AttributedString(baseString)
 
         var linkStyle = AttributeContainer()
@@ -70,15 +73,18 @@ struct SignInView: View {
                             Text(L10n.tvSignInSubtitle)
                                 .font(.headline)
                                 .foregroundStyle(Color.pcTextSecondary)
-                            QRCodeView(url: model.pairing.pairURLString)
-                            separator
-                            Text(enterCodePrompt)
-                                .font(.headline)
-                                .foregroundStyle(Color.pcTextSecondary)
-                            qrCodeDigits
+                            if let urlComplete = model.pairing.pairURLComplete, let codePrompt = enterCodePrompt {
+                                QRCodeView(url: urlComplete)
+                                separator
+                                Text(codePrompt)
+                                    .font(.headline)
+                                    .foregroundStyle(Color.pcTextSecondary)
+                                qrCodeDigits
+                            }
                         }
                     }
                 }
+                .animation(.easeInOut, value: loginType)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
             .padding(.top, 80)

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -14,11 +14,8 @@ struct SignInView: View {
         static let qrSize = CGFloat(240)
     }
 
-    var enterCodePrompt: AttributedString? {
-        guard let pairingURLComplete = model.pairing.pairURLComplete else {
-            return nil
-        }
-        let baseString = L10n.tvSignInEnterCodeInUrl(model.pairing.pairURLPretty, pairingURLComplete)
+    func enterCodePrompt(url: String) -> AttributedString {
+        let baseString = L10n.tvSignInEnterCodeInUrl(model.pairing.pairURLPretty, url)
         var attributedString = (try? AttributedString(markdown: baseString)) ?? AttributedString(baseString)
 
         var linkStyle = AttributeContainer()
@@ -73,10 +70,10 @@ struct SignInView: View {
                             Text(L10n.tvSignInSubtitle)
                                 .font(.headline)
                                 .foregroundStyle(Color.pcTextSecondary)
-                            if let urlComplete = model.pairing.pairURLComplete, let codePrompt = enterCodePrompt {
+                            if let urlComplete = model.pairing.pairURLComplete {
                                 QRCodeView(url: urlComplete)
                                 separator
-                                Text(codePrompt)
+                                Text(enterCodePrompt(url: urlComplete))
                                     .font(.headline)
                                     .foregroundStyle(Color.pcTextSecondary)
                                 qrCodeDigits

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -77,6 +77,8 @@ struct SignInView: View {
                                     .font(.headline)
                                     .foregroundStyle(Color.pcTextSecondary)
                                 qrCodeDigits
+                            } else {
+                                ProgressView()
                             }
                         }
                     }


### PR DESCRIPTION
Fixes the Pocket Casts TV sign-in QR/URL generation so the on-screen prompt and QR code only appear once the final pairing URL has been resolved.

Previously `SignInView` fell back to a placeholder URL (`ServerConstants.Urls.tvPair`) via `pairURLString` while the real pairing URL was still being fetched, which could show the user a code/URL that wasn't yet valid. This PR removes that fallback and gates rendering on `pairURLComplete`:

- Removed the `pairURLString` fallback helper from `PairingSession`.
- `SignInView` now only renders the QR code, separator, prompt, and digits once `pairURLComplete` is available.
- Added an `easeInOut` animation when switching login modes so the content area transitions smoothly.
- Simplified `enterCodePrompt` into a function taking the resolved URL, removing a redundant double-unwrap at the call site.

## To test

1. Launch the Pocket Casts TV app.
2. Go to the sign-in screen with the QR option selected.
3. Confirm the QR code, URL prompt, and pairing digits only appear once the final pairing URL is ready (no flash of a placeholder URL/code).
4. Switch between QR and manual login modes and confirm the transition animates smoothly without the logo/title/picker shifting.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
