### PR TITLE
Increase spacing for controls in collapsed mode

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -250,7 +250,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     override func updateViewConstraints() {
         if #available(iOS 26.0, *), let glassButtonStack, let glassProgressView {
             let isInline = forcedInlineLayout ?? (view.traitCollection.tabAccessoryEnvironment == .inline)
-            let buttonWidth: CGFloat = isInline ? 40 : 44
+            let buttonWidth: CGFloat = 44
             skipBackBtnWidthConstraint.constant = buttonWidth
             playPauseBtnWidthConstraint.constant = buttonWidth
             skipFwdBtnWidthConstraint.constant = buttonWidth


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Increase the width in the collapsed mode so it's true 44pt.

<img width="981" height="609" alt="Screenshot 2026-06-19 at 11 33 34 AM" src="https://github.com/user-attachments/assets/0d842592-1169-48ca-be52-2258255466d2" />

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
