### PR TITLE
[PC TV] Apple-TV-style depth on focused cards

### DIFF
--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoryCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoryCell.swift
@@ -71,7 +71,8 @@ struct DiscoverCategoryCell: View {
         .padding(.horizontal, 36)
         .frame(height: Layout.cardHeight)
         .background(style(for: colorIndex))
-        .clipped()
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .focusedCardDepth(isFocused: isFocused, cornerRadius: 16)
         .task {
             await model.load()
         }

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
@@ -113,7 +113,7 @@ struct DiscoverFeaturedPodcastCell: View {
         }
         .background(Color.pcBackgroundSunken)
         .clipShape(RoundedRectangle(cornerRadius: 12))
-        .clipped()
+        .focusedCardDepth(isFocused: focusedButton != nil, cornerRadius: 12)
         .scaleEffect(focusedButton != nil ? 1 : 0.95)
         .animation(.default, value: focusedButton)
         .focusSection()

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -49,7 +49,10 @@ struct DiscoverPodcastRow: View {
                 ForEach(model.podcasts, id: \.uuid) { podcast in
                     if let uuid = podcast.uuid {
                         NavigationLink(value: podcast) {
-                            FocusedPodcastCover(uuid: uuid, size: Layout.gridSize)
+                            PodcastImage(uuid: uuid, size: .page)
+                                .frame(width: Layout.gridSize, height: Layout.gridSize)
+                                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                                .focusedCardDepth(cornerRadius: 12, style: .surface)
                         }
                         .buttonStyle(.card)
                         .padding(.vertical, 24)
@@ -62,22 +65,5 @@ struct DiscoverPodcastRow: View {
             })
         }
         .scrollClipDisabled()
-    }
-}
-
-/// Bare podcast cover that picks up the focused-card surface depth treatment.
-/// Has to live as its own `View` so `@Environment(\.isFocused)` resolves to the
-/// `.card` button's focus state rather than the row's.
-private struct FocusedPodcastCover: View {
-    let uuid: String
-    let size: CGFloat
-
-    @Environment(\.isFocused) private var isFocused
-
-    var body: some View {
-        PodcastImage(uuid: uuid, size: .page)
-            .frame(width: size, height: size)
-            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-            .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .surface)
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -49,8 +49,7 @@ struct DiscoverPodcastRow: View {
                 ForEach(model.podcasts, id: \.uuid) { podcast in
                     if let uuid = podcast.uuid {
                         NavigationLink(value: podcast) {
-                            PodcastImage(uuid: uuid, size: .page)
-                                .frame(width: Layout.gridSize, height: Layout.gridSize)
+                            FocusedPodcastCover(uuid: uuid, size: Layout.gridSize)
                         }
                         .buttonStyle(.card)
                         .padding(.vertical, 24)
@@ -63,5 +62,22 @@ struct DiscoverPodcastRow: View {
             })
         }
         .scrollClipDisabled()
+    }
+}
+
+/// Bare podcast cover that picks up the focused-card surface depth treatment.
+/// Has to live as its own `View` so `@Environment(\.isFocused)` resolves to the
+/// `.card` button's focus state rather than the row's.
+private struct FocusedPodcastCover: View {
+    let uuid: String
+    let size: CGFloat
+
+    @Environment(\.isFocused) private var isFocused
+
+    var body: some View {
+        PodcastImage(uuid: uuid, size: .page)
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .surface)
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -78,6 +78,7 @@ struct DiscoverVideoEpisodeCell: View {
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .clipped()
+        .focusedCardDepth(isFocused: isFocused, cornerRadius: 12)
         .focusSection()
         .focusScope(ns)
         .scaleEffect(isFocused ? 1.1 : 1.0)

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -78,7 +78,7 @@ struct DiscoverVideoEpisodeCell: View {
         }
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .clipped()
-        .focusedCardDepth(isFocused: isFocused, cornerRadius: 12)
+        .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .content)
         .focusSection()
         .focusScope(ns)
         .scaleEffect(isFocused ? 1.1 : 1.0)

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -67,6 +67,7 @@ private struct NowPlayingRowLabel: View {
         .padding(32)
         .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
         .clipShape(RoundedRectangle(cornerRadius: 12))
+        .focusedCardDepth(isFocused: isFocused, cornerRadius: 12)
     }
 }
 

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -67,7 +67,7 @@ private struct NowPlayingRowLabel: View {
         .padding(32)
         .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
         .clipShape(RoundedRectangle(cornerRadius: 12))
-        .focusedCardDepth(isFocused: isFocused, cornerRadius: 12)
+        .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .content)
     }
 }
 

--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -63,7 +63,7 @@ struct PlaylistCell: View {
         .background(isFocused ? Color.pcBackgroundActive : model.playlistColor)
         .animation(.spring(response: 0.3, dampingFraction: 0.6), value: isFocused)
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-        .focusedCardDepth(isFocused: isFocused, cornerRadius: 16)
+        .focusedCardDepth(isFocused: isFocused, cornerRadius: 16, style: .content)
         .task {
             model.load()
         }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -62,7 +62,8 @@ struct PlaylistCell: View {
         .frame(height: Layout.cardHeight)
         .background(isFocused ? Color.pcBackgroundActive : model.playlistColor)
         .animation(.spring(response: 0.3, dampingFraction: 0.6), value: isFocused)
-        .clipped()
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .focusedCardDepth(isFocused: isFocused, cornerRadius: 16)
         .task {
             model.load()
         }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -16,12 +16,23 @@ struct EpisodeRow: View {
 
     let model: EpisodeRowViewModel
     var isActive: Bool?
+    /// Whether the row should paint its own background, clip, and focused-card
+    /// depth. `EpisodeRowWithActions` wraps the row in a wider container that
+    /// provides those itself; everywhere else (standalone rows in Up Next, the
+    /// podcast detail list, the player button) renders the surface inline.
+    fileprivate var providesCardSurface: Bool = true
 
     @Environment(\.isFocused) private var isFocused: Bool
 
     init(model: EpisodeRowViewModel, isActive: Bool? = nil) {
         self.model = model
         self.isActive = isActive
+    }
+
+    fileprivate init(model: EpisodeRowViewModel, isActive: Bool?, providesCardSurface: Bool) {
+        self.model = model
+        self.isActive = isActive
+        self.providesCardSurface = providesCardSurface
     }
 
     enum Layout {
@@ -65,9 +76,12 @@ struct EpisodeRow: View {
             Spacer()
         }
         .padding(32)
-        .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .content)
+        .if(providesCardSurface) { content in
+            content
+                .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .content)
+        }
         .opacity(archivedOpacity)
         .animation(.easeInOut(duration: 0.15), value: archivedOpacity)
     }
@@ -134,12 +148,16 @@ struct EpisodeRowWithActions: View {
                 model.play()
             } label: {
                 HStack(spacing: 0) {
-                    EpisodeRow(model: model, isActive: isEpisodeFocused)
+                    // Lets the outer container paint a single continuous card
+                    // surface across both the row and the more-button gutter,
+                    // so the depth treatment renders on the full width.
+                    EpisodeRow(model: model, isActive: isEpisodeFocused, providesCardSurface: false)
                     Spacer()
                         .frame(width: !shouldShowMoreButton ? Layout.spacing + MoreButtonStyle.Layout.size : 0)
                 }
                 .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
+                .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .content)
             }
             .buttonStyle(EpisodeRowButtonStyle())
             .focused($focusedElement, equals: .episode)

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -67,7 +67,7 @@ struct EpisodeRow: View {
         .padding(32)
         .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
         .clipShape(RoundedRectangle(cornerRadius: 12))
-        .focusedCardDepth(isFocused: isFocused, cornerRadius: 12)
+        .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .content)
         .opacity(archivedOpacity)
         .animation(.easeInOut(duration: 0.15), value: archivedOpacity)
     }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -16,23 +16,12 @@ struct EpisodeRow: View {
 
     let model: EpisodeRowViewModel
     var isActive: Bool?
-    /// Whether the row should paint its own background, clip, and focused-card
-    /// depth. `EpisodeRowWithActions` wraps the row in a wider container that
-    /// provides those itself; everywhere else (standalone rows in Up Next, the
-    /// podcast detail list, the player button) renders the surface inline.
-    fileprivate var providesCardSurface: Bool = true
 
     @Environment(\.isFocused) private var isFocused: Bool
 
     init(model: EpisodeRowViewModel, isActive: Bool? = nil) {
         self.model = model
         self.isActive = isActive
-    }
-
-    fileprivate init(model: EpisodeRowViewModel, isActive: Bool?, providesCardSurface: Bool) {
-        self.model = model
-        self.isActive = isActive
-        self.providesCardSurface = providesCardSurface
     }
 
     enum Layout {
@@ -76,12 +65,9 @@ struct EpisodeRow: View {
             Spacer()
         }
         .padding(32)
-        .if(providesCardSurface) { content in
-            content
-                .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-                .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .content)
-        }
+        .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .content)
         .opacity(archivedOpacity)
         .animation(.easeInOut(duration: 0.15), value: archivedOpacity)
     }
@@ -148,16 +134,12 @@ struct EpisodeRowWithActions: View {
                 model.play()
             } label: {
                 HStack(spacing: 0) {
-                    // Lets the outer container paint a single continuous card
-                    // surface across both the row and the more-button gutter,
-                    // so the depth treatment renders on the full width.
-                    EpisodeRow(model: model, isActive: isEpisodeFocused, providesCardSurface: false)
+                    EpisodeRow(model: model, isActive: isEpisodeFocused)
                     Spacer()
                         .frame(width: !shouldShowMoreButton ? Layout.spacing + MoreButtonStyle.Layout.size : 0)
                 }
                 .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
                 .clipShape(RoundedRectangle(cornerRadius: 12))
-                .focusedCardDepth(isFocused: isFocused, cornerRadius: 12, style: .content)
             }
             .buttonStyle(EpisodeRowButtonStyle())
             .focused($focusedElement, equals: .episode)

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -67,6 +67,7 @@ struct EpisodeRow: View {
         .padding(32)
         .background(isFocused ? Color.pcBackgroundActive : Color.pcBackgroundSunken)
         .clipShape(RoundedRectangle(cornerRadius: 12))
+        .focusedCardDepth(isFocused: isFocused, cornerRadius: 12)
         .opacity(archivedOpacity)
         .animation(.easeInOut(duration: 0.15), value: archivedOpacity)
     }

--- a/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
@@ -31,6 +31,7 @@ struct FolderCardView: View {
         .frame(width: cardSize, height: cardSize)
         .background(Color(uiColor: AppTheme.folderColor(colorInt: model.folder.color)))
         .clipShape(RoundedRectangle(cornerRadius: 12))
+        .focusedCardDepth(cornerRadius: 12, style: .surface)
         .task {
             model.load()
         }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -80,6 +80,8 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
                     NavigationLink(value: podcast) {
                         PodcastImage(uuid: podcast.uuid, size: .page)
                             .frame(width: Layout.gridSize, height: Layout.gridSize)
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .focusedCardDepth(cornerRadius: 12, style: .surface)
                     }
                     .buttonStyle(.card)
                     .simultaneousGesture(TapGesture().onEnded {

--- a/Pocket Casts TV App/UI/RootView.swift
+++ b/Pocket Casts TV App/UI/RootView.swift
@@ -30,7 +30,15 @@ struct RootView: View {
             await coordinator.load()
         }
         .ignoresSafeArea()
-        .background(Color.pcBackgroundSurface)
+        .background(
+            // Subtle "lit from above" gradient instead of a flat fill: makes the
+            // page feel less plastic and lets focused-card shadows read against it.
+            LinearGradient(
+                colors: [Color.pcBackgroundTop, Color.pcBackgroundBottom],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
     }
 }
 

--- a/Pocket Casts TV App/UI/Style/Color+Style.swift
+++ b/Pocket Casts TV App/UI/Style/Color+Style.swift
@@ -36,6 +36,13 @@ extension Color {
 
     static let pcBackgroundSurface = Color(uiColor: .appearance(light: "#F0F1F2", dark: "#1F2123"))
 
+    // Top/bottom stops of the page gradient applied in `RootView`. The top is a touch
+    // lighter than `pcBackgroundSurface` (to mimic light hitting the screen from above)
+    // and the bottom a touch darker, so focused-card shadows have something to read against.
+    static let pcBackgroundTop = Color(uiColor: .appearance(light: "#FFFFFF", dark: "#2B2E32"))
+
+    static let pcBackgroundBottom = Color(uiColor: .appearance(light: "#E6E7E9", dark: "#171819"))
+
     static let pcBackgroundBase = Color(uiColor: .appearance(light: "#F7F7F8", dark: "#292B2E"))
 
     static let pcBackgroundOverlay = Color(uiColor: .pcBackgroundOverlay)

--- a/Pocket Casts TV App/UI/Style/Color+Style.swift
+++ b/Pocket Casts TV App/UI/Style/Color+Style.swift
@@ -47,9 +47,10 @@ extension Color {
 
     static let pcBackgroundOverlay = Color(uiColor: .pcBackgroundOverlay)
 
-    // Focus highlight (`bg-active`). The focused surface inverts against the page: near-white in dark
-    // mode, near-black in light mode. Paired with `pcShadowFocus` to lift it off the page.
-    static let pcBackgroundActive = Color(uiColor: .appearance(light: "#161718", dark: "#FBFBFC"))
+    // Focus highlight (`bg-active`). The focused surface inverts against the page but stays a
+    // step back from pure black/white — a silvery card in dark mode, a charcoal card in light —
+    // so the sheen and shadow on focused cards do the lifting instead of raw brightness.
+    static let pcBackgroundActive = Color(uiColor: .appearance(light: "#2A2D31", dark: "#D4D6DB"))
 
     // `bg-active-20` token: the active color at 20% opacity. Alpha is applied inside each branch so
     // the color still re-resolves between light and dark (calling `withAlphaComponent` on a dynamic

--- a/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
+++ b/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
@@ -29,6 +29,26 @@ extension View {
     ) -> some View {
         modifier(FocusedCardDepth(isFocused: isFocused, cornerRadius: cornerRadius, style: style))
     }
+
+    /// Variant that picks up `\.isFocused` from the surrounding environment. Use
+    /// directly inside a `Button` / `NavigationLink` label so call sites that
+    /// don't already track focus don't need a wrapper struct just to read it.
+    func focusedCardDepth(
+        cornerRadius: CGFloat = 12,
+        style: FocusedCardStyle = .surface
+    ) -> some View {
+        modifier(EnvironmentFocusedCardDepth(cornerRadius: cornerRadius, style: style))
+    }
+}
+
+private struct EnvironmentFocusedCardDepth: ViewModifier {
+    @Environment(\.isFocused) private var isFocused
+    let cornerRadius: CGFloat
+    let style: FocusedCardStyle
+
+    func body(content: Content) -> some View {
+        content.focusedCardDepth(isFocused: isFocused, cornerRadius: cornerRadius, style: style)
+    }
 }
 
 private struct FocusedCardDepth: ViewModifier {

--- a/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
+++ b/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+extension View {
+    /// Apple-TV-style depth for focused cards: a soft drop shadow that lifts the card
+    /// off the page, plus a subtle diagonal sheen that mimics light hitting the surface.
+    ///
+    /// Apply after the card's `.clipShape(...)` / `.clipped()` so the shadow draws outside
+    /// the clipped surface. The sheen overlay is inset to match the clip.
+    func focusedCardDepth(isFocused: Bool, cornerRadius: CGFloat = 12) -> some View {
+        modifier(FocusedCardDepth(isFocused: isFocused, cornerRadius: cornerRadius))
+    }
+}
+
+private struct FocusedCardDepth: ViewModifier {
+    let isFocused: Bool
+    let cornerRadius: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            stops: [
+                                .init(color: .white.opacity(0.22), location: 0.0),
+                                .init(color: .white.opacity(0.04), location: 0.45),
+                                .init(color: .black.opacity(0.10), location: 1.0)
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .blendMode(.plusLighter)
+                    .opacity(isFocused ? 1 : 0)
+                    .allowsHitTesting(false)
+            }
+            .shadow(
+                color: .black.opacity(isFocused ? 0.45 : 0),
+                radius: isFocused ? 32 : 0,
+                x: 0,
+                y: isFocused ? 20 : 0
+            )
+            .animation(.easeInOut(duration: 0.2), value: isFocused)
+    }
+}

--- a/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
+++ b/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
@@ -18,27 +18,31 @@ private struct FocusedCardDepth: ViewModifier {
     func body(content: Content) -> some View {
         content
             .overlay {
+                // `.overlay` blend mode brightens the white stops and darkens the black ones
+                // against whatever sits beneath, so both ends of the gradient contribute.
+                // `.plusLighter` would silently swallow the dark side.
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                     .fill(
                         LinearGradient(
                             stops: [
-                                .init(color: .white.opacity(0.22), location: 0.0),
-                                .init(color: .white.opacity(0.04), location: 0.45),
-                                .init(color: .black.opacity(0.10), location: 1.0)
+                                .init(color: .white.opacity(0.45), location: 0.0),
+                                .init(color: .white.opacity(0.12), location: 0.35),
+                                .init(color: .clear, location: 0.55),
+                                .init(color: .black.opacity(0.28), location: 1.0)
                             ],
                             startPoint: .topLeading,
                             endPoint: .bottomTrailing
                         )
                     )
-                    .blendMode(.plusLighter)
+                    .blendMode(.overlay)
                     .opacity(isFocused ? 1 : 0)
                     .allowsHitTesting(false)
             }
             .shadow(
-                color: .black.opacity(isFocused ? 0.45 : 0),
-                radius: isFocused ? 32 : 0,
+                color: .black.opacity(isFocused ? 0.6 : 0),
+                radius: isFocused ? 44 : 0,
                 x: 0,
-                y: isFocused ? 20 : 0
+                y: isFocused ? 26 : 0
             )
             .animation(.easeInOut(duration: 0.2), value: isFocused)
     }

--- a/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
+++ b/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
@@ -25,10 +25,11 @@ private struct FocusedCardDepth: ViewModifier {
                     .fill(
                         LinearGradient(
                             stops: [
-                                .init(color: .white.opacity(0.45), location: 0.0),
-                                .init(color: .white.opacity(0.12), location: 0.35),
-                                .init(color: .clear, location: 0.55),
-                                .init(color: .black.opacity(0.28), location: 1.0)
+                                .init(color: .white.opacity(0.85), location: 0.0),
+                                .init(color: .white.opacity(0.45), location: 0.18),
+                                .init(color: .white.opacity(0.15), location: 0.40),
+                                .init(color: .clear, location: 0.58),
+                                .init(color: .black.opacity(0.45), location: 1.0)
                             ],
                             startPoint: .topLeading,
                             endPoint: .bottomTrailing

--- a/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
+++ b/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
@@ -64,10 +64,10 @@ private struct FocusedCardDepth: ViewModifier {
                     .allowsHitTesting(false)
             }
             .shadow(
-                color: .black.opacity(isFocused ? 0.6 : 0),
-                radius: isFocused ? 44 : 0,
+                color: .black.opacity(isFocused ? 0.85 : 0),
+                radius: isFocused ? 60 : 0,
                 x: 0,
-                y: isFocused ? 26 : 0
+                y: isFocused ? 36 : 0
             )
             .animation(.easeInOut(duration: 0.2), value: isFocused)
     }
@@ -86,9 +86,9 @@ private struct FocusedCardDepth: ViewModifier {
                     .fill(
                         LinearGradient(
                             stops: [
-                                .init(color: .white.opacity(0.55), location: 0.0),
-                                .init(color: .white.opacity(0.25), location: 0.20),
-                                .init(color: .white.opacity(0.08), location: 0.40),
+                                .init(color: .white.opacity(0.28), location: 0.0),
+                                .init(color: .white.opacity(0.12), location: 0.20),
+                                .init(color: .white.opacity(0.04), location: 0.40),
                                 .init(color: .clear, location: 0.60)
                             ],
                             startPoint: .topLeading,
@@ -102,8 +102,8 @@ private struct FocusedCardDepth: ViewModifier {
                         LinearGradient(
                             stops: [
                                 .init(color: .clear, location: 0.40),
-                                .init(color: .black.opacity(0.30), location: 0.85),
-                                .init(color: .black.opacity(0.55), location: 1.0)
+                                .init(color: .black.opacity(0.16), location: 0.85),
+                                .init(color: .black.opacity(0.30), location: 1.0)
                             ],
                             startPoint: .topLeading,
                             endPoint: .bottomTrailing

--- a/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
+++ b/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
@@ -56,24 +56,41 @@ private struct FocusedCardDepth: ViewModifier {
     private var highlight: some View {
         switch style {
         case .surface:
-            // `.overlay` blend brightens the white stops and darkens the black ones
-            // against whatever sits beneath, so both ends of the gradient contribute.
-            // `.plusLighter` would silently swallow the dark side.
-            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                .fill(
-                    LinearGradient(
-                        stops: [
-                            .init(color: .white.opacity(0.85), location: 0.0),
-                            .init(color: .white.opacity(0.45), location: 0.18),
-                            .init(color: .white.opacity(0.15), location: 0.40),
-                            .init(color: .clear, location: 0.58),
-                            .init(color: .black.opacity(0.45), location: 1.0)
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
+            // Two stacked passes: a `.plusLighter` glint that's purely additive
+            // (always brightens, never darkens, so it pops on any underlying
+            // colour) and an `.overlay` falloff that adds bottom-trailing depth.
+            // `.overlay` on its own caps highlight intensity against busy
+            // artwork; splitting them out gives a stronger specular feel.
+            ZStack {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            stops: [
+                                .init(color: .white.opacity(0.55), location: 0.0),
+                                .init(color: .white.opacity(0.25), location: 0.20),
+                                .init(color: .white.opacity(0.08), location: 0.40),
+                                .init(color: .clear, location: 0.60)
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
                     )
-                )
-                .blendMode(.overlay)
+                    .blendMode(.plusLighter)
+
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            stops: [
+                                .init(color: .clear, location: 0.40),
+                                .init(color: .black.opacity(0.30), location: 0.85),
+                                .init(color: .black.opacity(0.55), location: 1.0)
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .blendMode(.overlay)
+            }
 
         case .content:
             // Thin inner stroke that catches light along the top edge and lays a

--- a/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
+++ b/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
@@ -1,41 +1,45 @@
 import SwiftUI
 
+/// How the focused-card highlight renders. Both styles share the same drop shadow;
+/// they differ in what they paint on top of the card.
+enum FocusedCardStyle {
+    /// Full diagonal specular sheen across the whole face. Use on cards that are
+    /// mostly artwork or a flat colour (`DiscoverCategoryCell`, `PlaylistCell`,
+    /// `DiscoverFeaturedPodcastCell`) where the sheen has nothing to muddy.
+    case surface
+
+    /// Thin inner edge highlight only — a lit top edge and a subtle rim line at the
+    /// bottom, with the body of the card left untouched. Use on cards that pair a
+    /// cover with text (`EpisodeRow`, `NowPlayingRow`, `DiscoverVideoEpisodeCell`)
+    /// so the highlight doesn't wash artwork or text. Closer to how tvOS handles
+    /// focus on content-heavy cards.
+    case content
+}
+
 extension View {
-    /// Apple-TV-style depth for focused cards: a soft drop shadow that lifts the card
-    /// off the page, plus a subtle diagonal sheen that mimics light hitting the surface.
+    /// Apple-TV-style depth for focused cards: a soft drop shadow plus a focus
+    /// highlight whose shape depends on `style` — see ``FocusedCardStyle``.
     ///
-    /// Apply after the card's `.clipShape(...)` / `.clipped()` so the shadow draws outside
-    /// the clipped surface. The sheen overlay is inset to match the clip.
-    func focusedCardDepth(isFocused: Bool, cornerRadius: CGFloat = 12) -> some View {
-        modifier(FocusedCardDepth(isFocused: isFocused, cornerRadius: cornerRadius))
+    /// Apply after the card's `.clipShape(...)` so the shadow draws outside the
+    /// clipped surface and the highlight is inset to match.
+    func focusedCardDepth(
+        isFocused: Bool,
+        cornerRadius: CGFloat = 12,
+        style: FocusedCardStyle = .surface
+    ) -> some View {
+        modifier(FocusedCardDepth(isFocused: isFocused, cornerRadius: cornerRadius, style: style))
     }
 }
 
 private struct FocusedCardDepth: ViewModifier {
     let isFocused: Bool
     let cornerRadius: CGFloat
+    let style: FocusedCardStyle
 
     func body(content: Content) -> some View {
         content
             .overlay {
-                // `.overlay` blend mode brightens the white stops and darkens the black ones
-                // against whatever sits beneath, so both ends of the gradient contribute.
-                // `.plusLighter` would silently swallow the dark side.
-                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .fill(
-                        LinearGradient(
-                            stops: [
-                                .init(color: .white.opacity(0.85), location: 0.0),
-                                .init(color: .white.opacity(0.45), location: 0.18),
-                                .init(color: .white.opacity(0.15), location: 0.40),
-                                .init(color: .clear, location: 0.58),
-                                .init(color: .black.opacity(0.45), location: 1.0)
-                            ],
-                            startPoint: .topLeading,
-                            endPoint: .bottomTrailing
-                        )
-                    )
-                    .blendMode(.overlay)
+                highlight
                     .opacity(isFocused ? 1 : 0)
                     .allowsHitTesting(false)
             }
@@ -46,5 +50,50 @@ private struct FocusedCardDepth: ViewModifier {
                 y: isFocused ? 26 : 0
             )
             .animation(.easeInOut(duration: 0.2), value: isFocused)
+    }
+
+    @ViewBuilder
+    private var highlight: some View {
+        switch style {
+        case .surface:
+            // `.overlay` blend brightens the white stops and darkens the black ones
+            // against whatever sits beneath, so both ends of the gradient contribute.
+            // `.plusLighter` would silently swallow the dark side.
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        stops: [
+                            .init(color: .white.opacity(0.85), location: 0.0),
+                            .init(color: .white.opacity(0.45), location: 0.18),
+                            .init(color: .white.opacity(0.15), location: 0.40),
+                            .init(color: .clear, location: 0.58),
+                            .init(color: .black.opacity(0.45), location: 1.0)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .blendMode(.overlay)
+
+        case .content:
+            // Thin inner stroke that catches light along the top edge and lays a
+            // subtle rim shadow along the bottom — leaves the body of the card
+            // alone so artwork and text don't get muddied.
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                .strokeBorder(
+                    LinearGradient(
+                        stops: [
+                            .init(color: .white.opacity(0.55), location: 0.0),
+                            .init(color: .white.opacity(0.10), location: 0.25),
+                            .init(color: .clear, location: 0.55),
+                            .init(color: .black.opacity(0.22), location: 1.0)
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    ),
+                    lineWidth: 1.5
+                )
+                .blendMode(.overlay)
+        }
     }
 }

--- a/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
+++ b/Pocket Casts TV App/UI/Style/FocusedCardDepth.swift
@@ -56,12 +56,21 @@ private struct FocusedCardDepth: ViewModifier {
     let cornerRadius: CGFloat
     let style: FocusedCardStyle
 
+    // Reduce-transparency users get the lift (shadow) but skip the blend-mode
+    // sheen — translucent overlays are exactly what the setting opts out of.
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    // Reduce-motion users get the focused/unfocused states applied without the
+    // easing curve, so focus changes feel snappy rather than animated.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     func body(content: Content) -> some View {
         content
             .overlay {
-                highlight
-                    .opacity(isFocused ? 1 : 0)
-                    .allowsHitTesting(false)
+                if !reduceTransparency {
+                    highlight
+                        .opacity(isFocused ? 1 : 0)
+                        .allowsHitTesting(false)
+                }
             }
             .shadow(
                 color: .black.opacity(isFocused ? 0.85 : 0),
@@ -69,7 +78,7 @@ private struct FocusedCardDepth: ViewModifier {
                 x: 0,
                 y: isFocused ? 36 : 0
             )
-            .animation(.easeInOut(duration: 0.2), value: isFocused)
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: isFocused)
     }
 
     @ViewBuilder
@@ -133,4 +142,25 @@ private struct FocusedCardDepth: ViewModifier {
                 .blendMode(.overlay)
         }
     }
+}
+
+#Preview("Focused card styles") {
+    HStack(spacing: 64) {
+        VStack(spacing: 16) {
+            Text(".surface").font(.caption)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(LinearGradient(colors: [.indigo, .purple], startPoint: .top, endPoint: .bottom))
+                .frame(width: 220, height: 300)
+                .focusedCardDepth(isFocused: true, cornerRadius: 16, style: .surface)
+        }
+        VStack(spacing: 16) {
+            Text(".content").font(.caption)
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(white: 0.85))
+                .frame(width: 220, height: 300)
+                .focusedCardDepth(isFocused: true, cornerRadius: 16, style: .content)
+        }
+    }
+    .padding(80)
+    .background(Color.pcBackgroundSurface)
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1233,7 +1233,6 @@
 		F5F5097E2CEBFDE6007D6E39 /* skip.json in Resources */ = {isa = PBXBuildFile; fileRef = BD85E3A31E6670DF001B17C1 /* skip.json */; };
 		F5F884632CC9EAA6002BED2C /* Humane-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = F5F884622CC9EAA6002BED2C /* Humane-Bold.otf */; };
 		F5FDDD842E58E8B000FB1C33 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
-		FFFEB10A2F9BDA9A00E68E0C /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
 		F5FDDD852E58E94500FB1C33 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
 		F5FF61202BD076BA00190711 /* Sharing.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5FF611F2BD076BA00190711 /* Sharing.xcassets */; };
 		FCCC80732DD56B380080EB2C /* HowToUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCC80722DD56B380080EB2C /* HowToUploadView.swift */; };
@@ -1404,6 +1403,7 @@
 		FFF024CF2B62B13A00457373 /* Pocket Casts Configuration.storekit in Resources */ = {isa = PBXBuildFile; fileRef = C7547F77286F571900DC1C9E /* Pocket Casts Configuration.storekit */; };
 		FFF23E8A2CC91E370046D3AD /* ServerPodcastManager+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF23E892CC91E2A0046D3AD /* ServerPodcastManager+Subscription.swift */; };
 		FFFCD23F2C7768F900A345ED /* Referrals.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FFFCD23E2C7768F900A345ED /* Referrals.xcassets */; };
+		FFFEB10A2F9BDA9A00E68E0C /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */


### PR DESCRIPTION
## Summary

Adds depth to focused cards across the tvOS app: each focused surface gets a soft drop shadow and a focus highlight tuned to its content (full diagonal sheen for artwork cards, edge-stroke highlight for text-heavy ones). A subtle top-to-bottom page gradient replaces the flat background so the shadows have something to read against, and `pcBackgroundActive` is stepped back from pure white/black so the focused surface reads as a silvery/charcoal material instead of raw brightness.

### What changed

- **New `focusedCardDepth(...)` modifier** ([`FocusedCardDepth.swift`](Pocket%20Casts%20TV%20App/UI/Style/FocusedCardDepth.swift)) with two styles — `.surface` (full diagonal specular sheen for artwork) and `.content` (1.5pt inner-stroke highlight for cover-plus-text cards). Both share the same drop shadow. Accessibility-aware: respects `accessibilityReduceTransparency` (drops the sheen, keeps the shadow) and `accessibilityReduceMotion` (drops the easing).
- **Applied** to discover category / featured / video / podcast-row cells, the Your Podcasts grid (covers + folders), `PlaylistCell`, `EpisodeRow`, `NowPlayingRow`.
- **`RootView` background**: flat `pcBackgroundSurface` → top→bottom `LinearGradient` via new `pcBackgroundTop` / `pcBackgroundBottom` tokens.
- **`pcBackgroundActive` retuned**: dark `#FBFBFC` → `#D4D6DB`, light `#161718` → `#2A2D31`. Global focus-highlight token — touches every focused surface in the TV app.
- **Rounded corners** added to `DiscoverCategoryCell` and `PlaylistCell` (16pt) where they were previously `.clipped()` rectangles, so the depth overlay matches a real card shape.

## To test

1. Home → focus through Now Playing, Up Next, Made for TV, You might like, playlists, category cards. Each should pick up shadow + highlight on focus.
2. Podcasts tab → covers and folders both lift on focus.
3. Discover → featured carousel and category grid both lift.
4. Toggle light/dark appearance; toggle Reduce Motion / Reduce Transparency in Settings.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. _(Visual refinement only; no behavioural change.)_
- [x] I have considered adding unit tests for my changes. _(UI-only modifier; verified by `#Preview` in `FocusedCardDepth.swift`.)_
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. _(No analytics changes.)_