### PR TITLE
Improve DiscoverVideoEpisodeCell focus handling

### DIFF
--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -24,7 +24,9 @@ struct DiscoverVideoEpisodeCell: View {
     @State private var lastFocusedButton: FocusValues? = nil
     @FocusState private var isContainerFocused: Bool
 
-    @State private var isFocused = false
+    private var isFocused: Bool {
+        focusedButton != nil
+    }
     @State private var isAnimating = false
 
     @State var showNowPlayingPlayer: Bool = false
@@ -45,12 +47,10 @@ struct DiscoverVideoEpisodeCell: View {
 
     var body: some View {
         ZStack(alignment: .bottomLeading) {
-            placeholderFocusView
             VStack {
                 Spacer()
-                if isFocused {
+                ZStack {
                     focusedContent
-                } else {
                     nonFocusedContent
                 }
             }
@@ -81,15 +81,7 @@ struct DiscoverVideoEpisodeCell: View {
         .focusSection()
         .focusScope(ns)
         .scaleEffect(isFocused ? 1.1 : 1.0)
-        .animation(.easeInOut, value: isFocused)
-        .onChange(of: focusedButton) { _, focused in
-            if let focused {
-                lastFocusedButton = focused
-            }
-            if focused == nil, isFocused, !isAnimating {
-                collapse()
-            }
-        }
+        .animation(.snappy, value: isFocused)
         .task {
             await model.load()
         }
@@ -112,41 +104,6 @@ struct DiscoverVideoEpisodeCell: View {
         DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, source: source)
     }
 
-    private func expand() {
-        guard !isAnimating else { return }
-        isAnimating = true
-        withAnimation(.easeInOut(duration: 0.2)) {
-            isFocused = true
-        } completion: {
-            isAnimating = false
-            focusedButton = lastFocusedButton ?? .playEpisode
-        }
-    }
-
-    private func collapse() {
-        guard !isAnimating else { return }
-        isAnimating = true
-        withAnimation(.easeInOut(duration: 0.2)) {
-            isFocused = false
-        } completion: {
-            isAnimating = false
-        }
-    }
-
-    var placeholderFocusView: some View {
-        Rectangle()
-        .foregroundStyle(.clear)
-        .focusable(!isFocused)
-        .focused($isContainerFocused)
-        .setFocus(section: DiscoverType.video.rawValue)
-        .buttonStyle(ChromelessButtonStyle())
-        .onChange(of: isContainerFocused) { _, focused in
-            if focused, !isAnimating {
-                expand()
-            }
-        }
-    }
-
     var focusedContent: some View {
         HStack(alignment: .bottom, spacing: 16) {
             Button(L10n.tvDiscoverPlayEpisode) {
@@ -162,6 +119,7 @@ struct DiscoverVideoEpisodeCell: View {
                     }
                 }
             }
+            .frame(width: isFocused ? nil : 1, height: isFocused ? nil : 1)
             .focused($focusedButton, equals: FocusValues.playEpisode)
             .setFocus(section: DiscoverType.video.rawValue)
             .contextMenu {
@@ -171,6 +129,7 @@ struct DiscoverVideoEpisodeCell: View {
                 NavigationLink(value: podcast) {
                     Text(L10n.tvDiscoverFeaturedGoToPodcast)
                 }
+                .frame(width: isFocused ? nil : 1, height: isFocused ? nil : 1)
                 .focused($focusedButton, equals: FocusValues.goPodcast)
                 .setFocus(section: DiscoverType.video.rawValue)
                 .simultaneousGesture(TapGesture().onEnded {
@@ -210,7 +169,7 @@ struct DiscoverVideoEpisodeCell: View {
                 Spacer()
             }
         }
-        .transition(.opacity.combined(with: .scale(scale: 0.95)))
+        .opacity(isFocused ? 0 : 1)
     }
 
     var backgroundThumbnail: some View {

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -101,7 +101,7 @@ struct DiscoverVideoEpisodeCell: View {
 
     var focusedContent: some View {
         HStack(alignment: .bottom, spacing: 16) {
-            Button(L10n.tvDiscoverPlayEpisode) {
+            Button() {
                 trackEpisodeTapped()
                 Task {
                     let successPlay = await TVDataManager.shared.playEpisode(model.episode)
@@ -113,6 +113,9 @@ struct DiscoverVideoEpisodeCell: View {
                         }
                     }
                 }
+            } label: {
+                Text(L10n.tvDiscoverPlayEpisode)
+                    .foregroundColor(isFocused ? nil : .clear)
             }
             .collapsedWhenUnfocused(isFocused)
             .focused($focusedButton, equals: FocusValues.playEpisode)
@@ -123,6 +126,7 @@ struct DiscoverVideoEpisodeCell: View {
             if let podcast = model.podcast {
                 NavigationLink(value: podcast) {
                     Text(L10n.tvDiscoverFeaturedGoToPodcast)
+                        .foregroundColor(isFocused ? nil : .clear)
                 }
                 .collapsedWhenUnfocused(isFocused)
                 .focused($focusedButton, equals: FocusValues.goPodcast)

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -21,13 +21,10 @@ struct DiscoverVideoEpisodeCell: View {
     }
 
     @FocusState private var focusedButton: FocusValues?
-    @State private var lastFocusedButton: FocusValues? = nil
-    @FocusState private var isContainerFocused: Bool
 
     private var isFocused: Bool {
         focusedButton != nil
     }
-    @State private var isAnimating = false
 
     @State var showNowPlayingPlayer: Bool = false
 
@@ -46,13 +43,11 @@ struct DiscoverVideoEpisodeCell: View {
     }
 
     var body: some View {
-        ZStack(alignment: .bottomLeading) {
-            VStack {
-                Spacer()
-                ZStack {
-                    focusedContent
-                    nonFocusedContent
-                }
+        VStack {
+            Spacer()
+            ZStack {
+                focusedContent
+                nonFocusedContent
             }
         }
         .padding(32)
@@ -119,7 +114,7 @@ struct DiscoverVideoEpisodeCell: View {
                     }
                 }
             }
-            .frame(width: isFocused ? nil : 1, height: isFocused ? nil : 1)
+            .collapsedWhenUnfocused(isFocused)
             .focused($focusedButton, equals: FocusValues.playEpisode)
             .setFocus(section: DiscoverType.video.rawValue)
             .contextMenu {
@@ -129,7 +124,7 @@ struct DiscoverVideoEpisodeCell: View {
                 NavigationLink(value: podcast) {
                     Text(L10n.tvDiscoverFeaturedGoToPodcast)
                 }
-                .frame(width: isFocused ? nil : 1, height: isFocused ? nil : 1)
+                .collapsedWhenUnfocused(isFocused)
                 .focused($focusedButton, equals: FocusValues.goPodcast)
                 .setFocus(section: DiscoverType.video.rawValue)
                 .simultaneousGesture(TapGesture().onEnded {
@@ -146,28 +141,26 @@ struct DiscoverVideoEpisodeCell: View {
     }
 
     var nonFocusedContent: some View {
-        Group {
-            HStack(alignment: .bottom, spacing: 48) {
-                if let podcastUuid = model.episode.podcastUuid {
-                    PodcastImage(uuid: podcastUuid, size: .list)
-                        .frame(width: Layout.imageSize, height: Layout.imageSize)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                }
-                VStack(alignment: .leading, spacing: 8) {
-                    if let title = model.episode.podcastTitle {
-                        Text(title)
-                            .font(.caption)
-                            .foregroundColor(.pcTextOnColorSecondary)
-                    }
-                    if let description = model.episode.title {
-                        Text(description)
-                            .lineLimit(1)
-                            .font(.caption)
-                            .foregroundColor(.pcTextOnColorPrimary)
-                    }
-                }
-                Spacer()
+        HStack(alignment: .bottom, spacing: 48) {
+            if let podcastUuid = model.episode.podcastUuid {
+                PodcastImage(uuid: podcastUuid, size: .list)
+                    .frame(width: Layout.imageSize, height: Layout.imageSize)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
             }
+            VStack(alignment: .leading, spacing: 8) {
+                if let title = model.episode.podcastTitle {
+                    Text(title)
+                        .font(.caption)
+                        .foregroundColor(.pcTextOnColorSecondary)
+                }
+                if let description = model.episode.title {
+                    Text(description)
+                        .lineLimit(1)
+                        .font(.caption)
+                        .foregroundColor(.pcTextOnColorPrimary)
+                }
+            }
+            Spacer()
         }
         .opacity(isFocused ? 0 : 1)
     }
@@ -192,6 +185,14 @@ struct DiscoverVideoEpisodeCell: View {
                 endPoint: UnitPoint(x: 0.59, y: 0.81)
             )
         }
+    }
+}
+
+private extension View {
+    /// Shrinks the view to a 1x1 frame when not focused so it stays in the tvOS
+    /// focus chain (reachable by the focus engine) while remaining visually hidden.
+    func collapsedWhenUnfocused(_ isFocused: Bool) -> some View {
+        frame(width: isFocused ? nil : 1, height: isFocused ? nil : 1)
     }
 }
 


### PR DESCRIPTION
Fix [PCIOS-781](https://linear.app/a8c/issue/PCIOS-781/fix-navigation-artifacts-in-made-for-tv-row)
|:---:|

Change how the focus on discover video episode cell is handled so focus conflicts are avoided when moving around quickly on the row

What changed:
- Removed dead state left over from the old `expand()`/`collapse()`/`placeholderFocusView` machinery: `lastFocusedButton`, `isContainerFocused`, and `isAnimating` (each was declaration-only, never read or written).
- Dropped a redundant top-level `ZStack` that wrapped a single `VStack`, and a redundant `Group` wrapper around the single `HStack` in `nonFocusedContent`.
- Extracted the repeated `.frame(width: isFocused ? nil : 1, height: isFocused ? nil : 1)` trick into a documented `collapsedWhenUnfocused(_:)` view helper that explains why the 1×1 frame exists (keeping buttons in the tvOS focus chain while visually hidden).

Why: reduces noise and clarifies the intent of the focus trick so the cell is easier to maintain.

## To test

1. On the TV app, open Discover and navigate to a video episode row.
2. Move focus onto / off a video cell — it should expand/collapse and the Play / Go to Podcast buttons should focus exactly as before.
3. Confirm playback preview and navigation still work.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
