### PR TITLE
TV: Handle server-initiated sign-out (token expiry)

### DIFF
--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -171,7 +171,7 @@ class AppCoordinator {
             userInitiated == false
         else {
             return
-        }        
+        }
         state = .serverSignedOut
     }
 }

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -52,6 +52,8 @@ class AppCoordinator {
         }
 
         setupDiscover()
+
+        setupSignOutObservation()
     }
 
     func signIn() {
@@ -153,5 +155,23 @@ class AppCoordinator {
         Task {
             let _ = await DiscoverServerHandler.shared.discoverPage()
         }
+    }
+
+    private func setupSignOutObservation() {
+        NotificationCenter.default.addObserver(forName: .serverUserWillBeSignedOut, object: nil, queue: .main) { [weak self] notification in
+            self?.handleSignOutNotification(notification)
+        }
+    }
+
+    private func handleSignOutNotification(_ notification: Notification) {
+        guard
+            let userInfo = notification.userInfo,
+            let userInitiated = userInfo["user_initiated"] as? Bool,
+            userInitiated == false
+        else {
+            return
+        }
+
+        //TODO: Handle signout notification that was cause by token expiration
     }
 }

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -14,6 +14,7 @@ class AppCoordinator {
         case signedIn
         case userSync
         case dataLossResync
+        case userSignedOut
     }
 
     var state: State = .loading
@@ -173,5 +174,6 @@ class AppCoordinator {
         }
 
         //TODO: Handle signout notification that was cause by token expiration
+        state = .userSignedOut
     }
 }

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -14,7 +14,7 @@ class AppCoordinator {
         case signedIn
         case userSync
         case dataLossResync
-        case userSignedOut
+        case serverSignedOut
     }
 
     var state: State = .loading
@@ -171,9 +171,7 @@ class AppCoordinator {
             userInitiated == false
         else {
             return
-        }
-
-        //TODO: Handle signout notification that was cause by token expiration
-        state = .userSignedOut
+        }        
+        state = .serverSignedOut
     }
 }

--- a/Pocket Casts TV App/UI/Auth/UserSignedOutView.swift
+++ b/Pocket Casts TV App/UI/Auth/UserSignedOutView.swift
@@ -15,7 +15,7 @@ struct UserSignedOutView: View {
                 .padding(.bottom, 16)
             HStack {
                 Button(L10n.tvWelcomeLogIn) {
-                    coordinator.state = .welcome
+                    coordinator.logout()
                 }
             }
         }

--- a/Pocket Casts TV App/UI/Auth/UserSignedOutView.swift
+++ b/Pocket Casts TV App/UI/Auth/UserSignedOutView.swift
@@ -6,12 +6,13 @@ struct UserSignedOutView: View {
 
     var body: some View {
         VStack(spacing: 24) {
-            Text(L10n.accountSignedOutAlertTitle)
+            Text(L10n.tvAccountSignedOutAlertTitle)
                 .font(.title)
                 .foregroundColor(Color.pcTextPrimary)
-            Text(L10n.accountSignedOutAlertMessage)
+            Text(L10n.tvAccountSignedOutAlertMessage)
                 .font(.headline)
                 .foregroundColor(Color.pcTextSecondary)
+                .multilineTextAlignment(.center)
                 .padding(.bottom, 16)
             HStack {
                 Button(L10n.tvWelcomeLogIn) {

--- a/Pocket Casts TV App/UI/Auth/UserSignedOutView.swift
+++ b/Pocket Casts TV App/UI/Auth/UserSignedOutView.swift
@@ -14,10 +14,8 @@ struct UserSignedOutView: View {
                 .foregroundColor(Color.pcTextSecondary)
                 .multilineTextAlignment(.center)
                 .padding(.bottom, 16)
-            HStack {
-                Button(L10n.tvWelcomeLogIn) {
-                    coordinator.logout()
-                }
+            Button(L10n.tvWelcomeLogIn) {
+                coordinator.logout()
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Pocket Casts TV App/UI/Auth/UserSignedOutView.swift
+++ b/Pocket Casts TV App/UI/Auth/UserSignedOutView.swift
@@ -21,6 +21,9 @@ struct UserSignedOutView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.pcBackgroundSurface)
         .ignoresSafeArea()
+        .onAppear {
+            Analytics.track(.signedOutAlertShown)
+        }
     }
 }
 

--- a/Pocket Casts TV App/UI/Auth/UserSignedOutView.swift
+++ b/Pocket Casts TV App/UI/Auth/UserSignedOutView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import PocketCastsServer
+
+struct UserSignedOutView: View {
+    @Environment(AppCoordinator.self) private var coordinator
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text(L10n.accountSignedOutAlertTitle)
+                .font(.title)
+                .foregroundColor(Color.pcTextPrimary)
+            Text(L10n.accountSignedOutAlertMessage)
+                .font(.headline)
+                .foregroundColor(Color.pcTextSecondary)
+                .padding(.bottom, 16)
+            HStack {
+                Button(L10n.tvWelcomeLogIn) {
+                    coordinator.state = .welcome
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.pcBackgroundSurface)
+        .ignoresSafeArea()
+    }
+}
+
+#Preview {
+    UserSignedOutView()
+        .environment(AppCoordinator())
+}

--- a/Pocket Casts TV App/UI/RootView.swift
+++ b/Pocket Casts TV App/UI/RootView.swift
@@ -21,6 +21,8 @@ struct RootView: View {
                 SigningInView()
             case .dataLossResync:
                 DataLossResyncView()
+            case .userSignedOut:
+                UserSignedOutView()
             }
         }
         .animation(.easeInOut, value: coordinator.state)

--- a/Pocket Casts TV App/UI/RootView.swift
+++ b/Pocket Casts TV App/UI/RootView.swift
@@ -21,7 +21,7 @@ struct RootView: View {
                 SigningInView()
             case .dataLossResync:
                 DataLossResyncView()
-            case .userSignedOut:
+            case .serverSignedOut:
                 UserSignedOutView()
             }
         }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6410,5 +6410,5 @@
 "tv_account_signed_out_alert_title" = "You've been logged out.";
 
 /* Message/Body of an alert that explains that the user should tap a button and sign in again */
-"tv_account_signed_out_alert_message" = "There was a problem and you've been logged out\nTap the button below to log in into your Pocket Casts account again.";
+"tv_account_signed_out_alert_message" = "There was a problem and you've been logged out.\nTap the button below to log in to your Pocket Casts account again.";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6373,7 +6373,6 @@
 /* tv app Now Playing tab */
 "tv_tab_now_playing" = "Now Playing";
 
-
 /* Title on the screen prompting the user to approve pairing their account with an Apple TV. */
 "device_approve_title" = "Connect to Apple TV";
 
@@ -6406,3 +6405,10 @@
 
 /* Title of the alert shown when approval failed. */
 "device_approve_generic_error_alert_title" = "Device approval failed";
+
+/* Title of an alert that informs the user that they have been signed out of their account */
+"tv_account_signed_out_alert_title" = "You've been logged out.";
+
+/* Message/Body of an alert that explains that the user should tap a button and sign in again */
+"tv_account_signed_out_alert_message" = "There was a problem and you've been logged out\nTap the button below to log in into your Pocket Casts account again.";
+


### PR DESCRIPTION
Fixes [PCIOS-685](https://linear.app/a8c/issue/POC-685/handle-scenario-where-token-is-invalidated-server-side-and-we-unable)

Handles the case where the tvOS app's session is invalidated server-side (e.g. token expiry / non-user-initiated sign-out). Previously the app had no dedicated handling for this — the user could be left in a broken signed-in state after the server forced a sign-out.

<img width="649" height="393" alt="Screenshot 2026-06-22 at 10 47 41" src="https://github.com/user-attachments/assets/bdab731c-af67-47ee-9b7b-ad413ac5b568" />


## What changed

- `AppCoordinator` now observes `.serverUserWillBeSignedOut` and, when the sign-out was **not** user-initiated (`user_initiated == false`), transitions to a new `.serverSignedOut` state.
- New `UserSignedOutView` informs the user they've been logged out and offers a button to log in again (calls `coordinator.logout()`).
- `RootView` renders `UserSignedOutView` for the `.serverSignedOut` state.
- Added localized strings `tv_account_signed_out_alert_title` / `tv_account_signed_out_alert_message`.

## To test

1. Sign in on the tvOS app.
2. Trigger a non-user-initiated sign-out (e.g. simulate `SyncManager.signout()` with a server-initiated/token-expiry path, or invalidate the token server-side).
3. Confirm the "You've been logged out" screen appears with a working **Log in** button that returns you to the welcome/sign-in flow.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] [I have updated](https://github.com/Automattic/EventHorizonSchemas/pull/92) (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.