### PR TITLE
Tab bar minor adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix the Filters search header popping back when few episodes match [#4527](https://github.com/Automattic/pocket-casts-ios/pull/4527)
 - Drop iOS 16 and watchOS 9 [#4521](https://github.com/Automattic/pocket-casts-ios/issues/4521)
 - Fix incorrect section heading when opening an episode on the Apple Watch [#4528](https://github.com/Automattic/pocket-casts-ios/pull/4528)
-- Make the mini player play/pause button larger [#4566](https://github.com/Automattic/pocket-casts-ios/pull/4566)
+- Make the mini player controls larger [#4566](https://github.com/Automattic/pocket-casts-ios/pull/4566)
 - Add a soft blur edge to the bottom of the podcast grid under Liquid Glass [#4567](https://github.com/Automattic/pocket-casts-ios/pull/4567)
 
 8.14

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -64,11 +64,6 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private var glassButtonStack: UIStackView?
     private var accessoryEnvironmentConstraints: [NSLayoutConstraint] = []
 
-    private enum GlassMetrics {
-        /// How much the Liquid Glass skip glyphs are scaled down from the asset.
-        static let skipIconScale: CGFloat = 0.9
-    }
-
     /// Wraps `content` in a vibrancy effect so it blends with the tab accessory's glass.
     private static func makeVibrancyWrapper(style: UIVibrancyEffectStyle, content: UIView) -> UIVisualEffectView {
         let vibrancy = UIVibrancyEffect(blurEffect: UIBlurEffect(style: .systemChromeMaterial), style: style)
@@ -152,8 +147,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         // play/pause button, so scale the (template) assets down slightly.
         for button in [skipBackBtn, skipFwdBtn] {
             guard let button, let image = button.image(for: .normal) else { continue }
-            let target = CGSize(width: image.size.width * GlassMetrics.skipIconScale,
-                                height: image.size.height * GlassMetrics.skipIconScale)
+            let target = CGSize(width: image.size.width, height: image.size.height)
             button.setImage(image.resizeProportionally(to: target).withRenderingMode(.alwaysTemplate), for: .normal)
         }
 

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -64,16 +64,9 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private var glassButtonStack: UIStackView?
     private var accessoryEnvironmentConstraints: [NSLayoutConstraint] = []
 
-    /// A thin themed layer behind the glass content. The tab accessory's glass samples
-    /// the grid scrolling behind it, so over bright artwork the controls lose contrast;
-    /// tinting toward the page background keeps them readable.
-    private var glassTintView: UIView?
-
     private enum GlassMetrics {
         /// How much the Liquid Glass skip glyphs are scaled down from the asset.
         static let skipIconScale: CGFloat = 0.9
-        /// Alpha of the thin `primaryUi02` layer tinting the glass.
-        static let tintAlpha: CGFloat = 0.33
     }
 
     /// Wraps `content` in a vibrancy effect so it blends with the tab accessory's glass.
@@ -204,22 +197,9 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         buttonStack.alignment = .center
         glassButtonStack = buttonStack
 
-        let glassTint = UIView()
-        glassTint.translatesAutoresizingMaskIntoConstraints = false
-        glassTint.isUserInteractionEnabled = false
-        glassTintView = glassTint
-
-        view.addSubview(glassTint)
         view.addSubview(podcastArtwork)
         view.addSubview(textStack)
         view.addSubview(buttonStack)
-
-        NSLayoutConstraint.activate([
-            glassTint.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            glassTint.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            glassTint.topAnchor.constraint(equalTo: view.topAnchor),
-            glassTint.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-        ])
 
         timeLeftHost.didMove(toParent: self)
 
@@ -642,8 +622,6 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         let actionColor = currentPodcastTintColor()
         let iconColor = ThemeColor.podcastIcon03(podcastColor: actionColor)
         let bgColor = ThemeColor.primaryUi02()
-
-        glassTintView?.backgroundColor = bgColor.withAlphaComponent(GlassMetrics.tintAlpha)
 
         // System color so the vibrancy wrapper can modulate it.
         episodeTitleLabel?.textColor = .label

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -343,7 +343,11 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
 
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
-        bottomFadeHeightConstraint?.constant = bottomFadeHeight
+        guard let bottomFadeHeightConstraint else { return }
+        bottomFadeHeightConstraint.constant = bottomFadeHeight
+        UIView.animate(withDuration: 0.3) {
+            self.view.layoutIfNeeded()
+        }
     }
 
     /// Fades the grid into its own background color toward the bottom edge, so the

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -45,12 +45,15 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
 
     private var lastWillLayoutWidth: CGFloat = 0
 
-    /// Height of the soft bottom fade edge shown over the grid under Liquid Glass.
+    /// Base height of the soft bottom fade edge shown over the grid under Liquid Glass,
+    /// measured from the bottom safe area upward. The bottom safe area inset is added on
+    /// top of this so the fade always clears the home indicator / floating bar.
     /// The gradient fade means only the lower portion reads strongly, so this can be
     /// generous without looking like a solid bar.
-    private static let bottomFadeHeight: CGFloat = 180
+    private static let bottomFadeHeight: CGFloat = 16
 
     private lazy var bottomFadeView = ProgressiveFadeView()
+    private var bottomFadeHeightConstraint: NSLayoutConstraint?
 
     private var homeGridDataHelper = HomeGridDataHelper()
 
@@ -320,14 +323,27 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
 
         bottomFadeView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(bottomFadeView)
+        let heightConstraint = bottomFadeView.heightAnchor.constraint(equalToConstant: bottomFadeHeight)
+        bottomFadeHeightConstraint = heightConstraint
         NSLayoutConstraint.activate([
             bottomFadeView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomFadeView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             bottomFadeView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            bottomFadeView.heightAnchor.constraint(equalToConstant: Self.bottomFadeHeight)
+            heightConstraint
         ])
         podcastsCollectionView.bottomEdgeEffect.isHidden = true
         updateBottomFadeColor()
+    }
+
+    /// The fade is pinned to the very bottom of the view, so it must cover the bottom
+    /// safe area (home indicator / floating bar) plus the base fade height above it.
+    private var bottomFadeHeight: CGFloat {
+        Self.bottomFadeHeight + view.safeAreaInsets.bottom
+    }
+
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+        bottomFadeHeightConstraint?.constant = bottomFadeHeight
     }
 
     /// Fades the grid into its own background color toward the bottom edge, so the

--- a/podcasts/Utilities/ProgressiveFadeView.swift
+++ b/podcasts/Utilities/ProgressiveFadeView.swift
@@ -27,7 +27,7 @@ final class ProgressiveFadeView: UIView {
 
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
         gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
-        gradientLayer.locations = [0, 0.8, 1]
+        gradientLayer.locations = [0, 0.25, 0.8, 1]
         setColor(color)
     }
 
@@ -39,8 +39,6 @@ final class ProgressiveFadeView: UIView {
     /// holds solid across the lower portion. Pass `nil` for no fade.
     func setColor(_ color: UIColor?) {
         let color = color ?? .clear
-        // Fade from the *same* color at zero alpha (not `.clear`, which is transparent
-        // black) so the ramp doesn't dip through a grey band in the middle.
-        gradientLayer.colors = [color.withAlphaComponent(0).cgColor, color.cgColor, color.cgColor]
+        gradientLayer.colors = [color.withAlphaComponent(0).cgColor, color.withAlphaComponent(0.66).cgColor, color.cgColor, color.cgColor]
     }
 }


### PR DESCRIPTION
Minor Liquid Glass polish for the tab bar / mini player area:

- Removed the extra `glassTintView` from the mini player – it wasn't really helping much in light mode and produced poor results in dark mode
- Softened the bottom grid fade with an extra gradient stop so it ramps more gradually.
- Made the grid's bottom fade height adjust dynamically to the bottom safe area inset so it always clears the floating bar / home indicator
- Make back/forward controls a notch larger too

## To test

1. Enable Liquid Glass and run on iOS 26.
2. Play an episode and confirm the mini player renders cleanly over the tab bar (no extra tint band).
3. Scroll the podcast grid and confirm the bottom edge fades smoothly behind the tab bar.
4. Rotate the device / change the bottom safe area and confirm the fade still covers the bar correctly.
5. 
<img width="796" height="376" alt="Screenshot 2026-06-22 at 2 03 56 PM" src="https://github.com/user-attachments/assets/3f46cdd7-b369-4a5c-9dea-e91060776d4d" />
<img width="684" height="304" alt="Screenshot 2026-06-22 at 2 04 21 PM" src="https://github.com/user-attachments/assets/19ac278f-fd8b-4342-a8b3-dcd4b4d66ff4" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
