### PR TITLE
tvOS: Reworks the layout of the tvOS Podcast More Info modal.

### DIFF
--- a/Pocket Casts TV App/UI/Common/ScrollableTextView.swift
+++ b/Pocket Casts TV App/UI/Common/ScrollableTextView.swift
@@ -13,7 +13,7 @@ struct ScrollableTextView: View {
     /// Height of the soft fade at the top and bottom edges. The inner text view insets its
     /// text by the same amount (see `ScrollableTextRepresentable`) so the first and last
     /// lines come to rest just past the fade rather than dissolving into it.
-    private let edgeFade = CGFloat(36)
+    private let edgeFade = CGFloat(24)
 
     @FocusState private var isFocused: Bool
     @State private var scrollCoordinator = ScrollableTextCoordinator()

--- a/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
@@ -12,7 +12,7 @@ struct PodcastMoreInfoView: View {
     private enum Layout {
         static let modalWidth = CGFloat(1280)
         static let modalHeight = CGFloat(880)
-        static let metadataColumnWidth = CGFloat(420)
+        static let metadataColumnWidth = CGFloat(360)
         static let artworkSize = CGFloat(240)
         static let columnGutter = CGFloat(40)
         static let contentInsets = EdgeInsets(top: 80, leading: 80, bottom: 0, trailing: 80)
@@ -23,13 +23,31 @@ struct PodcastMoreInfoView: View {
     }
 
     var body: some View {
-        HStack(alignment: .top, spacing: Layout.columnGutter) {
-            metadataColumn
-                .frame(width: Layout.metadataColumnWidth, alignment: .leading)
-                .padding(.bottom, 40)
-            if !descriptionHTML.isEmpty {
-                aboutColumn
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        VStack {
+            HStack(alignment: .top) {
+                PodcastImage(uuid: podcast.uuid, size: .page)
+                    .frame(width: Layout.artworkSize, height: Layout.artworkSize)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                Spacer()
+                    .frame(width: Layout.metadataColumnWidth - Layout.artworkSize)
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(podcast.author ?? "")
+                        .font(.caption)
+                        .foregroundStyle(Color.pcTextSecondary)
+                    Text(podcast.title ?? "")
+                        .font(.title2)
+                        .foregroundStyle(Color.pcTextPrimary)
+                }
+                Spacer()
+            }
+            HStack(alignment: .top, spacing: 0) {
+                metadataColumn
+                    .frame(width: Layout.metadataColumnWidth, alignment: .leading)
+                    .padding(.bottom, 40)
+                if !descriptionHTML.isEmpty {
+                    aboutColumn
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                }
             }
         }
         .padding(Layout.contentInsets)
@@ -39,17 +57,6 @@ struct PodcastMoreInfoView: View {
 
     private var metadataColumn: some View {
         VStack(alignment: .leading, spacing: 40) {
-            PodcastImage(uuid: podcast.uuid, size: .page)
-                .frame(width: Layout.artworkSize, height: Layout.artworkSize)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
-            VStack(alignment: .leading, spacing: 8) {
-                Text(podcast.author ?? "")
-                    .font(.caption)
-                    .foregroundStyle(Color.pcTextSecondary)
-                Text(podcast.title ?? "")
-                    .font(.title2)
-                    .foregroundStyle(Color.pcTextPrimary)
-            }
             VStack(alignment: .leading, spacing: 24) {
                 if let network = podcast.author {
                     infoRow(label: L10n.tvPodcastDetailNetwork, value: network)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
@@ -14,7 +14,6 @@ struct PodcastMoreInfoView: View {
         static let modalHeight = CGFloat(880)
         static let metadataColumnWidth = CGFloat(360)
         static let artworkSize = CGFloat(240)
-        static let columnGutter = CGFloat(40)
         static let contentInsets = EdgeInsets(top: 80, leading: 80, bottom: 0, trailing: 80)
     }
 

--- a/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
@@ -23,27 +23,21 @@ struct PodcastMoreInfoView: View {
     }
 
     var body: some View {
-        VStack {
-            HStack(alignment: .top) {
-                PodcastImage(uuid: podcast.uuid, size: .page)
-                    .frame(width: Layout.artworkSize, height: Layout.artworkSize)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                Spacer()
-                    .frame(width: Layout.metadataColumnWidth - Layout.artworkSize)
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(podcast.author ?? "")
+        HStack(alignment: .top, spacing: 0) {
+            metadataColumn
+                .frame(width: Layout.metadataColumnWidth, alignment: .leading)
+                .padding(.bottom, 40)
+            VStack(alignment: .leading, spacing: 8) {
+                if let author = podcast.author {
+                    Text(author)
                         .font(.caption)
                         .foregroundStyle(Color.pcTextSecondary)
-                    Text(podcast.title ?? "")
+                }
+                if let title = podcast.title {
+                    Text(title)
                         .font(.title2)
                         .foregroundStyle(Color.pcTextPrimary)
                 }
-                Spacer()
-            }
-            HStack(alignment: .top, spacing: 0) {
-                metadataColumn
-                    .frame(width: Layout.metadataColumnWidth, alignment: .leading)
-                    .padding(.bottom, 40)
                 if !descriptionHTML.isEmpty {
                     aboutColumn
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -56,26 +50,27 @@ struct PodcastMoreInfoView: View {
     }
 
     private var metadataColumn: some View {
-        VStack(alignment: .leading, spacing: 40) {
-            VStack(alignment: .leading, spacing: 24) {
-                if let network = podcast.author {
-                    infoRow(label: L10n.tvPodcastDetailNetwork, value: network)
-                }
-                if let website = podcast.podcastUrl {
-                    infoRow(label: L10n.tvPodcastDetailWebsite, value: website)
-                }
-                if let frequency = podcast.displayableFrequency() {
-                    infoRow(label: L10n.tvPodcastDetailSchedule, value: frequency)
-                }
-                if let nextEpisode = podcast.displayableNextEpisodeDate() {
-                    infoRow(label: L10n.tvPodcastDetailNextEpisode, value: nextEpisode)
-                }
+        VStack(alignment: .leading, spacing: 24) {
+            PodcastImage(uuid: podcast.uuid, size: .page)
+                .frame(width: Layout.artworkSize, height: Layout.artworkSize)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            if let network = podcast.author {
+                infoRow(label: L10n.tvPodcastDetailNetwork, value: network)
+            }
+            if let website = podcast.podcastUrl {
+                infoRow(label: L10n.tvPodcastDetailWebsite, value: website)
+            }
+            if let frequency = podcast.displayableFrequency() {
+                infoRow(label: L10n.tvPodcastDetailSchedule, value: frequency)
+            }
+            if let nextEpisode = podcast.displayableNextEpisodeDate() {
+                infoRow(label: L10n.tvPodcastDetailNextEpisode, value: nextEpisode)
             }
         }
     }
 
     private var aboutColumn: some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 24) {
             Text(L10n.tvPodcastDetailAbout)
                 .font(.title3)
                 .foregroundStyle(Color.pcTextPrimary)
@@ -87,6 +82,7 @@ struct PodcastMoreInfoView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         }
+        .padding(.top, 32)
     }
 
     private func infoRow(label: String, value: String) -> some View {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
@@ -70,9 +70,6 @@ struct PodcastMoreInfoView: View {
 
     private var aboutColumn: some View {
         VStack(alignment: .leading, spacing: 24) {
-            Text(L10n.tvPodcastDetailAbout)
-                .font(.title3)
-                .foregroundStyle(Color.pcTextPrimary)
             if let descriptionText {
                 ScrollableTextView(attributedText: descriptionText)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastMoreInfoView.swift
@@ -69,7 +69,7 @@ struct PodcastMoreInfoView: View {
     }
 
     private var aboutColumn: some View {
-        VStack(alignment: .leading, spacing: 24) {
+        VStack(alignment: .leading, spacing: 0) {
             if let descriptionText {
                 ScrollableTextView(attributedText: descriptionText)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -78,7 +78,6 @@ struct PodcastMoreInfoView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         }
-        .padding(.top, 32)
     }
 
     private func infoRow(label: String, value: String) -> some View {


### PR DESCRIPTION
Fixes [PCIOS-760](https://linear.app/a8c/issue/PCIOS-760/fix-header-in-more-info-modal)
|:---:|

Reworks the layout of the tvOS **Podcast More Info** modal.

## What changed

- Moved the podcast **author** and **title** out of the left metadata column and into the top of the right-hand content column, so they sit directly above the description.
- Narrowed the metadata column (`420` → `360`) and removed the inter-column gutter, tightening the modal layout.
- Adjusted vertical spacing in the metadata column (`40` → `24`), the about column (`16` → `24`), and added top padding to the about column.
- Removed the now-unused `columnGutter` layout constant.

## To test

1. On the tvOS app, open a podcast and tap **More Info**.
2. Verify the author and title appear at the top of the right column, above the About description.
3. Verify the left column shows the artwork and the Network / Website / Schedule / Next Episode rows with the updated spacing.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
