### PR TITLE
Fix tvOS focus loss when an episode row is removed from a list

### DIFF
--- a/Pocket Casts TV App/UI/History/ListeningHistoryView.swift
+++ b/Pocket Casts TV App/UI/History/ListeningHistoryView.swift
@@ -4,6 +4,7 @@ struct ListeningHistoryView: View {
 
     @State private var model = ListeningHistoryViewModel()
     @Namespace private var rowNamespace
+    @FocusState private var rowFocus: EpisodeRowFocus?
 
     var body: some View {
         ZStack {
@@ -26,7 +27,7 @@ struct ListeningHistoryView: View {
         List {
             Section {
                 ForEach(model.episodes) { episode in
-                    EpisodeRowWithActions(model: episode)
+                    EpisodeRowWithActions(model: episode, focus: $rowFocus)
                         .frame(width: 1160)
                         .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
                 }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -6,6 +6,7 @@ struct PlaylistDetailView: View {
     @Environment(MainTabViewModel.self) var tabRouter: MainTabViewModel
     let model: PlaylistDetailsViewModel
     @FocusState private var focusedSection: FocusSection?
+    @FocusState private var rowFocus: EpisodeRowFocus?
 
     enum FocusSection: Hashable {
         case episodes
@@ -159,7 +160,7 @@ struct PlaylistDetailView: View {
         List {
             Section {
                 ForEach(model.episodes, id: \.uuid) { episode in
-                    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: episode, podcast: nil))
+                    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: episode, podcast: nil), focus: $rowFocus)
                         .prefersDefaultFocus(episode.uuid == model.episodes.first?.uuid, in: episodeListNamespace)
                         .listRowInsets(Layout.rowInsets)
                 }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -96,32 +96,45 @@ struct MoreButtonStyle: ButtonStyle {
     }
 }
 
+/// Identifies which element of which episode row holds focus. Lifted out of the
+/// row (where it used to be per-row private `@FocusState` plus a per-row
+/// `defaultFocus`) into a single state the enclosing list owns and keys by
+/// episode UUID. This lets tvOS recover focus to a neighbouring row when the
+/// focused row is removed (archive, remove-from-Up-Next, …) instead of dropping
+/// focus entirely and recursing over the orphaned cell container.
+enum EpisodeRowFocus: Hashable {
+    case episode(String)
+    case more(String)
+
+    var episodeID: String {
+        switch self {
+        case .episode(let id), .more(let id):
+            return id
+        }
+    }
+}
+
 struct EpisodeRowWithActions: View {
 
     let model: EpisodeRowViewModel
     var context: EpisodeActionContext = .default
 
-    @FocusState private var focusedElement: FocusElement?
+    @FocusState.Binding var focus: EpisodeRowFocus?
     @State private var isPlaying = false
     @State private var isShowingActions = false
     @State private var isShowingShowNotes = false
     @State private var restoreFocus = false
-
-    private enum FocusElement: Hashable {
-        case episode
-        case more
-    }
 
     private enum Layout {
         static let spacing = CGFloat(32)
     }
 
     private var shouldShowMoreButton: Bool {
-        focusedElement != nil || restoreFocus
+        focus?.episodeID == model.id || restoreFocus
     }
 
     private var isEpisodeFocused: Bool {
-        focusedElement == .episode
+        focus == .episode(model.id)
     }
 
     @Environment(\.isFocused) private var isFocused: Bool
@@ -141,7 +154,7 @@ struct EpisodeRowWithActions: View {
                 .clipShape(RoundedRectangle(cornerRadius: 12))
             }
             .buttonStyle(EpisodeRowButtonStyle())
-            .focused($focusedElement, equals: .episode)
+            .focused($focus, equals: .episode(model.id))
 
             if shouldShowMoreButton {
                 Button {
@@ -151,7 +164,7 @@ struct EpisodeRowWithActions: View {
                     Image(systemName: "ellipsis")
                 }
                 .buttonStyle(MoreButtonStyle())
-                .focused($focusedElement, equals: .more)
+                .focused($focus, equals: .more(model.id))
                 .transition(.opacity.combined(with: .scale(scale: 0.8)).animation(.easeOut(duration: 0.2).delay(0.15)))
             }
         }
@@ -161,7 +174,6 @@ struct EpisodeRowWithActions: View {
         .if(isFocused) { content in
             content.clipShape(RoundedRectangle(cornerRadius: 12))
         }
-        .defaultFocus($focusedElement, .episode)
         .animation(.easeInOut(duration: 0.2), value: shouldShowMoreButton)
         .onChange(of: isShowingActions) { _, showing in
             guard !showing else { return }
@@ -171,10 +183,14 @@ struct EpisodeRowWithActions: View {
             // the ellipsis ourselves, otherwise our assignment is overwritten.
             Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(100))
+                // If the action removed this row the list has already moved focus
+                // to a neighbour — only restore the ellipsis when focus was simply
+                // dropped or is still on us, never fight the hand-off.
+                guard focus == nil || focus?.episodeID == model.id else { return }
                 var transaction = Transaction()
                 transaction.disablesAnimations = true
                 withTransaction(transaction) {
-                    focusedElement = .more
+                    focus = .more(model.id)
                     restoreFocus = false
                 }
             }
@@ -309,7 +325,8 @@ extension View {
 }
 
 #Preview {
-    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: MockData.makeStubEpisodes().first!, podcast: MockData.makeStubPodcasts().first!))
+    @Previewable @FocusState var focus: EpisodeRowFocus?
+    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: MockData.makeStubEpisodes().first!, podcast: MockData.makeStubPodcasts().first!), focus: $focus)
     .environment(AppCoordinator())
     .environment(MainTabViewModel())
 }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -8,6 +8,7 @@ struct PodcastDetailView: View {
     @State var model: PodcastDetailViewModel
 
     @FocusState private var focusedSection: FocusSection?
+    @FocusState private var rowFocus: EpisodeRowFocus?
     @State private var isShowingMoreInfo = false
 
     init(podcast: Podcast) {
@@ -130,7 +131,7 @@ struct PodcastDetailView: View {
     }
 
     private func episodeRow(for episode: EpisodeRowViewModel) -> some View {
-        EpisodeRowWithActions(model: episode)
+        EpisodeRowWithActions(model: episode, focus: $rowFocus)
     }
 
     private var archivedFilterMenu: some View {

--- a/Pocket Casts TV App/UI/Starred/StarredEpisodesView.swift
+++ b/Pocket Casts TV App/UI/Starred/StarredEpisodesView.swift
@@ -4,6 +4,7 @@ struct StarredEpisodesView: View {
 
     @State private var model = StarredEpisodesViewModel()
     @Namespace private var rowNamespace
+    @FocusState private var rowFocus: EpisodeRowFocus?
 
     var body: some View {
         ZStack {
@@ -26,7 +27,7 @@ struct StarredEpisodesView: View {
         List {
             Section {
                 ForEach(model.episodes) { episode in
-                    EpisodeRowWithActions(model: episode)
+                    EpisodeRowWithActions(model: episode, focus: $rowFocus)
                         .frame(width: 1160)
                         .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
                 }

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -9,6 +9,7 @@ struct UpNextView: View {
     @State private var model: UpNextViewModel
 
     @Namespace private var rowNamespace
+    @FocusState private var rowFocus: EpisodeRowFocus?
 
     init(model: UpNextViewModel) {
         _model = State(wrappedValue: model)
@@ -40,7 +41,7 @@ struct UpNextView: View {
             LazyVStack(alignment: .leading, spacing: 24) {
                 headerRow
                 ForEach(queuedEpisodes) { episode in
-                    EpisodeRowWithActions(model: episode, context: .upNext)
+                    EpisodeRowWithActions(model: episode, context: .upNext, focus: $rowFocus)
                         .frame(width: 1160)
                         .prefersDefaultFocus(episode.id == queuedEpisodes.first?.id, in: rowNamespace)
                 }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

## Summary

On tvOS, performing a row-removing action (e.g. **Archive** with *Hide archived* on, or **Remove from Up Next**) on the focused episode caused focus to disappear, with the console spamming:

> Ignoring attempt to add focus items in already-visited container. This can potentially cause infinite recursion. Container: … SwiftUI.ListTableViewCell …

### Root cause

Each `EpisodeRowWithActions` owned its focus in a **private** `@FocusState` and declared its own per-row `.defaultFocus(…, .episode)` *inside* the list's `.focusScope`. When an action tore the focused row out of the `List`:

- the focus state lived on the destroyed row, so nothing could redirect focus, and
- every surviving row re-asserting `defaultFocus` within the same `focusScope` made the focus engine re-enter the orphaned `ListTableViewCell` — the "already-visited container" recursion — and focus was dropped entirely.

### Fix

Lift focus out of the row into a single **list-owned** `@FocusState` keyed by episode UUID (`EpisodeRowFocus`), and drop the per-row `defaultFocus`. With one shared focus state and no competing per-row defaults, tvOS recovers focus to a neighbouring row when the focused row is removed instead of recursing and dropping it. Applied across all shared episode lists: Podcast detail, Playlist detail, Starred, Listening history, Up Next.

No behavior change on `HomeView` / Search, which use the plain `EpisodeRow`.

## To test

1. On an Apple TV (or tvOS simulator), open a podcast with episodes and make sure the archived filter is set to **Hide archived**.
2. Focus an episode mid-list and open the **…** menu → **Archive**.
3. Confirm focus moves to a neighbouring episode (not lost), and the Xcode console shows no "already-visited container / infinite recursion" warnings.
4. Repeat on **Up Next**: focus a queued episode → **…** → **Remove from Up Next**, and confirm focus stays in the list.
5. Sanity-check focus navigation still works on Playlist detail, Starred, and Listening history.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.