### PR TITLE
Fix Playlists tab background in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Make the mini player controls larger [#4566](https://github.com/Automattic/pocket-casts-ios/pull/4566)
 - Add a soft blur edge to the bottom of the podcast grid under Liquid Glass [#4567](https://github.com/Automattic/pocket-casts-ios/pull/4567)
 - Add Up Next queue sorting [#4550](https://github.com/Automattic/pocket-casts-ios/pull/4550)
+- Fix the Playlists tab background in dark mode [#4593](https://github.com/Automattic/pocket-casts-ios/pull/4593)
 
 8.14
 -----

--- a/podcasts/NewPlaylistCell.swift
+++ b/podcasts/NewPlaylistCell.swift
@@ -38,7 +38,7 @@ class NewPlaylistCell: ThemeableCell {
 
         accessoryType = .disclosureIndicator
 
-        self.style = .primaryUi01
+        self.style = .primaryUi02
         iconStyle = .primaryIcon02
 
         updateColor()

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -16,7 +16,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
     @IBOutlet var filtersTable: ThemeableTable! {
         didSet {
             registerCells()
-            filtersTable.themeStyle = .primaryUi01
+            filtersTable.themeStyle = .primaryUi02
             filtersTable.dragDelegate = self
             filtersTable.dropDelegate = self
             filtersTable.separatorStyle = .none


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes the Playlists tab background color in dark mode. The `NewPlaylistCell` and the filters table were using `.primaryUi01`, which didn't match the intended background; switched both to `.primaryUi02`.

Originally reported by @rviljoen. It's pretty noticeable on dark mode when you switch tabs. "Playlists" is the only outlier.

## To test

1. Set the app to a dark theme (Settings → Appearance).
2. Open the Playlists tab.
3. Verify the table background and the "New Playlist" cell use the correct `primaryUi02` background and no longer look mismatched.
4. Switch to a light theme and confirm it still looks correct.

Before / After

<img width="360" alt="Screenshot 2026-06-22 at 9 32 56 PM" src="https://github.com/user-attachments/assets/96ec7914-152d-4a3d-987e-1e0bd2af9377" />
<img width="300"alt="Screenshot 2026-06-22 at 9 39 38 PM" src="https://github.com/user-attachments/assets/4d09c410-d61a-45c2-aae5-67a3e063f474" />


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
