### PR TITLE
Use .tv auth scope on tvOS via AuthenticationScope.default

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+DeviceAuth.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+DeviceAuth.swift
@@ -59,7 +59,7 @@ public extension ApiServerHandler {
         }
     }
 
-    func deviceGetToken(deviceCode: String, scope: AuthenticationScope = .tv) async throws -> AuthenticationResponse {
+    func deviceGetToken(deviceCode: String, scope: AuthenticationScope = .default) async throws -> AuthenticationResponse {
         guard let request = deviceTokenRequest(deviceCode: deviceCode, scope: scope)
         else {
             FileLog.shared.addMessage("Unable to create protobuffer request to obtain token via Third party device grant")
@@ -70,7 +70,7 @@ public extension ApiServerHandler {
     }
 
     private func deviceTokenRequest(deviceCode: String,
-                                    scope: AuthenticationScope = .tv) -> URLRequest? {
+                                    scope: AuthenticationScope = .default) -> URLRequest? {
         let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/token")
 
         var data = Api_UserTokenRequest()

--- a/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
+++ b/Modules/Sources/PocketCastsServer/Public/API/ApiServerHandler+SocialAuth.swift
@@ -35,10 +35,21 @@ public enum AuthenticationScope: String {
     case mobile
     case tv
     case sonos
+
+    /// The scope to use by default depending on the build target.
+    /// tvOS targets authenticate using the `.tv` scope, while every other
+    /// target (iOS, watchOS, etc.) uses the `.mobile` scope.
+    public static var `default`: AuthenticationScope {
+        #if os(tvOS)
+        return .tv
+        #else
+        return .mobile
+        #endif
+    }
 }
 
 public extension ApiServerHandler {
-    func validateLogin(identityToken: String?, scope: AuthenticationScope = .mobile) async throws -> AuthenticationResponse {
+    func validateLogin(identityToken: String?, scope: AuthenticationScope = .default) async throws -> AuthenticationResponse {
         guard let identityToken,
               let request = tokenRequest(identityToken: identityToken, scope: scope)
         else {
@@ -71,7 +82,7 @@ public extension ApiServerHandler {
         return try await obtainToken(request: request, usingRefreshToken: true)
     }
 
-    private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds, scope: AuthenticationScope = .mobile) -> URLRequest? {
+    private func tokenRequest(identityToken: String?, cachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy, timeoutInterval: TimeInterval = 15.seconds, scope: AuthenticationScope = .default) -> URLRequest? {
         guard let identityToken else {
             return nil
         }

--- a/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -112,7 +112,13 @@ public enum ServerConstants {
     }
 
     public enum Values {
-        static let apiScope = "mobile"
+        static var apiScope: String {
+            #if os(tvOS)
+            return "tv"
+            #else
+            return "mobile"
+            #endif
+        }
         static let deviceTypeiOS: Int32 = 1
         static let syncingEmailKey = "SJSyncingEmail"
         static let syncingPasswordKey = "SJSyncingPwd"

--- a/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInViewModel.swift
@@ -34,7 +34,7 @@ class SignInViewModel {
     func manualSignIn(username: String, password: String) async {
         state = .waiting
         do {
-            let response = try await AuthenticationHelper.validateLogin(username: username, password: password, scope: .mobile)
+            let response = try await AuthenticationHelper.validateLogin(username: username, password: password)
             if response.token != nil {
                 state = .finished
             }

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -9,7 +9,7 @@ import AuthenticationServices
 class AuthenticationHelper {
 
     @discardableResult
-    static func refreshLogin(scope: AuthenticationScope = .mobile) async throws -> String? {
+    static func refreshLogin(scope: AuthenticationScope = .default) async throws -> String? {
         if let username = ServerSettings.syncingEmail(), let password = ServerSettings.syncingPassword(), !password.isEmpty {
             return try await validateLogin(username: username, password: password, scope: scope).token
         }
@@ -22,7 +22,7 @@ class AuthenticationHelper {
 
     // MARK: Password
 
-    static func validateLogin(username: String, password: String, scope: AuthenticationScope) async throws -> AuthenticationResponse {
+    static func validateLogin(username: String, password: String, scope: AuthenticationScope = .default) async throws -> AuthenticationResponse {
         let response = try await ApiServerHandler.shared.validateLogin(username: username, password: password, scope: scope.rawValue)
         handleSuccessfulSignIn(response)
 
@@ -39,7 +39,7 @@ class AuthenticationHelper {
 
     // MARK: Apple SSO
 
-    static func validateLogin(identityToken: String, scope: AuthenticationScope = .mobile)  async throws -> AuthenticationResponse {
+    static func validateLogin(identityToken: String, scope: AuthenticationScope = .default)  async throws -> AuthenticationResponse {
         let response = try await ApiServerHandler.shared.validateLogin(identityToken: identityToken, scope: scope)
         handleSuccessfulSignIn(response)
 
@@ -90,14 +90,14 @@ class AuthenticationHelper {
     // MARK: Code Login - For tv login using a QR Code
 
     @discardableResult
-    static func deviceAuthorizeCode(scope: AuthenticationScope = .tv) async throws -> DeviceAuthorizationResponse {
+    static func deviceAuthorizeCode(scope: AuthenticationScope = .default) async throws -> DeviceAuthorizationResponse {
         let response = try await ApiServerHandler.shared.deviceAuthorizeRequest(scope: scope.rawValue)
         return response
     }
 
     @discardableResult
-    static func deviceGetToken(deviceCode: String, scope: AuthenticationScope = .tv) async throws -> AuthenticationResponse {
-        let response = try await ApiServerHandler.shared.deviceGetToken(deviceCode: deviceCode)
+    static func deviceGetToken(deviceCode: String, scope: AuthenticationScope = .default) async throws -> AuthenticationResponse {
+        let response = try await ApiServerHandler.shared.deviceGetToken(deviceCode: deviceCode, scope: scope)
         handleSuccessfulSignIn(response)
 
         return response


### PR DESCRIPTION
Authentication calls now resolve their scope based on the build target: **tvOS targets use `.tv`** while **iOS (and other targets) continue to use `.mobile`**.

This is implemented via a new `AuthenticationScope.default` static property, which is used as the default value for every auth function that has a `scope` parameter:

```swift
public static var `default`: AuthenticationScope {
    #if os(tvOS)
    return .tv
    #else
    return .mobile
    #endif
}
```

### What changed
- Added `AuthenticationScope.default` in `ApiServerHandler+SocialAuth.swift`.
- Switched the default value of the `scope` parameter to `.default` across:
  - `validateLogin(identityToken:scope:)` / `tokenRequest(...)` (SocialAuth)
  - `deviceGetToken(...)` / `deviceTokenRequest(...)` (DeviceAuth)
  - `refreshLogin`, both `validateLogin` overloads, `deviceAuthorizeCode`, `deviceGetToken` (`AuthenticationHelper`)
- **Bug fix:** the tvOS sign-in screen (`SignInViewModel`) was hardcoding `scope: .mobile`; it now uses the default and resolves to `.tv` on tvOS.
- **Bug fix:** `AuthenticationHelper.deviceGetToken` was silently dropping its `scope` argument; it now forwards it to the server handler.

### Why
The tvOS app was authenticating with the `.mobile` scope. Centralizing the default in one build-target-aware property guarantees each platform sends the correct scope without each caller having to remember to specify it.

## To test

1. Build and run the **Pocket Casts TV App** target.
2. Sign in via username/password on the tvOS sign-in screen.
3. Confirm the auth request uses the `tv` scope (rather than `mobile`).
4. On the iOS app, sign in normally and confirm it still uses the `mobile` scope.
5. Test the QR code authentication too
6. Navigate inside the app if see if sections that need authentication are showing correctly, Up Next, Your Podcasts, etc..

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)