### PR TITLE
Fix build on Xcode 27 beta 2

### DIFF
--- a/podcasts/Utilities/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/Utilities/SwiftUI/HorizontalCarousel.swift
@@ -30,9 +30,9 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
 
     init(currentIndex: Binding<Int>? = .constant(0), items: [T], @ViewBuilder content: @escaping (T) -> Content) {
         self._index = currentIndex ?? .constant(0)
-        self.visibleIndex = currentIndex?.wrappedValue ?? 0
         self.items = items
         self.content = content
+        self.visibleIndex = currentIndex?.wrappedValue ?? 0
     }
 
     /// Sets the number of items to display per page


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Reorders property initialization in `HorizontalCarousel.init`. `visibleIndex` is a `@State` property, so assigning it via `self.visibleIndex = …` goes through the wrapped-value setter, which references `self` and therefore requires all stored properties to be initialized first. The assignment previously ran before `items` and `content` were set; it's now moved to the end of `init`.

## To test

1. Open any screen that uses `HorizontalCarousel` (e.g. the onboarding/upsell carousels).
2. Confirm it builds and the carousel renders, swipes between pages, and reports the correct current index.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.