### PR TITLE
Show chapter artwork in the system Now Playing info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add context menus and Edit-mode reordering to the Folder screen [#4590](https://github.com/Automattic/pocket-casts-ios/pull/4590)
 - Add Up Next queue sorting [#4550](https://github.com/Automattic/pocket-casts-ios/pull/4550)
 - Fix the Playlists tab background in dark mode [#4593](https://github.com/Automattic/pocket-casts-ios/pull/4593)
+- Show chapter artwork on the lock screen, Control Center, and CarPlay [#4596](https://github.com/Automattic/pocket-casts-ios/pull/4596)
 
 8.14
 -----

--- a/podcasts/NowPlayingHelper.swift
+++ b/podcasts/NowPlayingHelper.swift
@@ -27,6 +27,14 @@ class NowPlayingHelper {
         let playingInfo = nowPlayingInfo(for: episode, currentChapters: currentChapters)
         var nowPlayingInfoWithProgress = NowPlayingHelper.addUpToInformationToNowPlaying(playingInfo, duration: duration, upTo: upTo, playbackRate: playbackRate)
 
+        // Prefer the current chapter's artwork when it's available, matching the in-app player (NowPlayingPlayerItemViewController).
+        if let chapterArtwork = currentChapters.artwork {
+            let artwork = MPMediaItemArtwork(boundsSize: chapterArtwork.size, requestHandler: { _ in chapterArtwork })
+            nowPlayingInfoWithProgress[MPMediaItemPropertyArtwork] = artwork
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfoWithProgress
+            return
+        }
+
         let size = ImageManager.sizeFor(imageSize: .page)
         ImageManager.sharedManager.imageForEpisode(episode, size: .page) { image in
             let imageToUse = image ?? UIImage(named: "noartwork-page")!

--- a/podcasts/NowPlayingHelper.swift
+++ b/podcasts/NowPlayingHelper.swift
@@ -27,7 +27,6 @@ class NowPlayingHelper {
         let playingInfo = nowPlayingInfo(for: episode, currentChapters: currentChapters)
         var nowPlayingInfoWithProgress = NowPlayingHelper.addUpToInformationToNowPlaying(playingInfo, duration: duration, upTo: upTo, playbackRate: playbackRate)
 
-        // Prefer the current chapter's artwork when it's available, matching the in-app player (NowPlayingPlayerItemViewController).
         if let chapterArtwork = currentChapters.artwork {
             let artwork = MPMediaItemArtwork(boundsSize: chapterArtwork.size, requestHandler: { _ in chapterArtwork })
             nowPlayingInfoWithProgress[MPMediaItemPropertyArtwork] = artwork

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -97,6 +97,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(refreshRemoteCommands), name: Constants.Notifications.remoteCommandSettingsChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateNowPlayingInfo), name: Constants.Notifications.userEpisodeUpdated, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateAllNowPlayingData), name: .episodeEmbeddedArtworkLoaded, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateAllNowPlayingData), name: Constants.Notifications.podcastChaptersDidUpdate, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(handleCurrentlyPlayingEpisodeUpdated), name: Constants.Notifications.currentlyPlayingEpisodeUpdated, object: nil)
 
         // run these on a background queue because some of them might call our singleton instance back, causing a crash because PlaybackManager.shared is called from the init method
@@ -405,7 +406,8 @@ class PlaybackManager: ServerPlaybackDelegate {
                 trackChapterSkipped()
             } else {
                 fireChapterChangeNotification()
-                updateNowPlayingInfo()
+                // Rebuild the full now playing info so the chapter's artwork is refreshed, not just the progress.
+                updateAllNowPlayingData()
             }
         }
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -406,7 +406,6 @@ class PlaybackManager: ServerPlaybackDelegate {
                 trackChapterSkipped()
             } else {
                 fireChapterChangeNotification()
-                // Rebuild the full now playing info so the chapter's artwork is refreshed, not just the progress.
                 updateAllNowPlayingData()
             }
         }


### PR DESCRIPTION
Request from a user.

The system "Now Playing" info (lock screen, Control Center, CarPlay) now shows the current chapter's artwork when available, falling back to episode artwork. This matches the in-app player (`NowPlayingPlayerItemViewController`), which already swaps to chapter art and matches how other apps work.

`setAllNowPlayingInfo` prefers `Chapters.artwork` when present, and `PlaybackManager` now triggers a full now-playing rebuild on chapter load and chapter change so the artwork stays in sync regardless of the "publish chapter titles" setting.

## To test

1. Play an episode that has embedded chapter artwork (different image per chapter).
2. Lock the device (or open Control Center / connect to CarPlay).
3. Verify the lock screen artwork shows the current chapter's image, not the episode image.
4. Let playback cross into the next chapter and verify the artwork updates to the new chapter's image.
5. Play an episode with chapters that have **no** artwork and confirm the episode artwork is still shown.
6. Toggle off "Publish chapter titles" in settings and confirm chapter artwork still updates on the lock screen.


<img width="360" alt="Screenshot 2026-06-23 at 1 42 51 PM" src="https://github.com/user-attachments/assets/fb0e8f53-e66b-4b3d-a0e6-3f50ef381352" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
