### PR TITLE
Minor updates to Now Playing

### DIFF
--- a/podcasts/Bookmarks/Episode/EpisodeDetailTabView.swift
+++ b/podcasts/Bookmarks/Episode/EpisodeDetailTabView.swift
@@ -95,8 +95,19 @@ private extension View {
             .padding(.vertical, 8)
             .padding(.horizontal, isSmallScreen ? 6 : 12)
             .foregroundColor(highlighted ? theme.primaryUi01 : theme.primaryText02)
-            .background(highlighted ? theme.primaryText01 : nil)
+            .background(tabBackground(theme: theme, highlighted: highlighted))
             .animation(.linear(duration: 0.1), value: highlighted)
-            .cornerRadius(8)
+    }
+
+    @ViewBuilder
+    func tabBackground(theme: Theme, highlighted: Bool) -> some View {
+        if highlighted {
+            if LiquidGlass.isEnabled {
+                // Render the selected tab as a proper pill to match the player controls.
+                Capsule().fill(theme.primaryText01)
+            } else {
+                RoundedRectangle(cornerRadius: 8).fill(theme.primaryText01)
+            }
+        }
     }
 }

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -243,6 +243,11 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        if LiquidGlass.isEnabled {
+            // Slightly rounder artwork to match the pill-shaped controls.
+            episodeImage.layer.cornerRadius = 16
+        }
+
         #if !APPCLIP
         let upNextPan = UIPanGestureRecognizer(target: self, action: #selector(panGestureRecognizerHandler(_:)))
         upNextPan.delegate = self
@@ -319,6 +324,11 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+
+        if LiquidGlass.isEnabled {
+            // Render the shelf as a proper pill instead of the default rounded rectangle.
+            shelfBg.layer.cornerRadius = shelfBg.bounds.height / 2
+        }
 
         // there's some expensive operations in resizeControls,
         // so only do them if the bounds has actually changed

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -313,15 +313,23 @@ private class PlayerTabButton: UIButton {
             var config = UIBackgroundConfiguration.clear()
             config.backgroundColor = .clear
             if LiquidGlass.isEnabled {
-                config.cornerRadius = 8
+                config.cornerRadius = bounds.height / 2
             }
             return config
         }()
 
         // Background isn't animatable, so we'll default to using the layer
         layer.backgroundColor = background.cgColor
-        layer.cornerRadius = 8
+        // Render the selected tab as a proper pill under Liquid Glass.
+        layer.cornerRadius = LiquidGlass.isEnabled ? bounds.height / 2 : 8
 
         self.configuration = config
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if LiquidGlass.isEnabled {
+            layer.cornerRadius = bounds.height / 2
+        }
     }
 }

--- a/podcasts/Podcasts/Podcast Page/PodcastDetailsTabView.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastDetailsTabView.swift
@@ -86,8 +86,19 @@ private extension View {
             .padding(.vertical, 8)
             .padding(.horizontal, 12)
             .foregroundColor(highlighted ? theme.primaryUi01 : theme.primaryText02)
-            .background(highlighted ? theme.primaryText01 : nil)
-            .cornerRadius(8)
+            .background(tabBackground(theme: theme, highlighted: highlighted))
+    }
+
+    @ViewBuilder
+    func tabBackground(theme: Theme, highlighted: Bool) -> some View {
+        if highlighted {
+            if LiquidGlass.isEnabled {
+                // Render the selected tab as a proper pill to match the player controls.
+                Capsule().fill(theme.primaryText01)
+            } else {
+                RoundedRectangle(cornerRadius: 8).fill(theme.primaryText01)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Under `LiquidGlass.isEnabled`, render the player shelf and the selected tab as proper pills (capsule corner radius) and round the episode artwork a little more to match the overall look of the app.

@david-gonzalez-a8c, wdyt? Should we make this change or refresh it later with a more comprehensive change?

## To test

1. Enable the `liquidGlass` feature flag on iOS 26+.
2. Open the full-screen player.
3. Confirm the bottom action bar (shelf) is a pill, the selected top tab is a pill, and the artwork corners are rounder.
4. Disable the flag and confirm the player looks unchanged.

Before / After

<img width="340"  alt="Screenshot 2026-06-23 at 4 38 46 PM" src="https://github.com/user-attachments/assets/e95d5590-1bfb-48fc-ba47-184fabe715c0" />

<img width="340"  alt="Screenshot 2026-06-23 at 4 37 54 PM" src="https://github.com/user-attachments/assets/5fafdf12-9c7d-4d5a-afcc-d9145e8517cc" />



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.