### PR TITLE
[tvOS] Clean up keychain and DB on new install

### DIFF
--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -191,5 +191,6 @@ class AppCoordinator {
 
         update()
         UserDefaults.standard.set(true, forKey: updateKey)
+        UserDefaults.standard.synchronize()
     }
 }

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -178,14 +178,12 @@ class AppCoordinator {
     }
 
     private func checkDefaults() {
-        let defaults = UserDefaults.standard
         performUpdateIfRequired(updateKey: "v1_run") {
             FileLog.shared.addMessage("AppCoordinator v1Run")
             // ensure that all previous log in information is wiped and database cleanup
             SyncManager.clearTokensFromKeyChain()
             DataManager.sharedManager.deleteAllData()
         }
-        defaults.synchronize()
     }
 
     private func performUpdateIfRequired(updateKey: String, update: () -> Void) {

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -25,6 +25,8 @@ class AppCoordinator {
         // Ensure database and tables are setup before we go forward
         let _ = DataManager.sharedManager
 
+        checkDefaults()
+
         ServerConfig.shared.syncDelegate = ServerSyncManager.shared
         ServerConfig.shared.playbackDelegate = PlaybackManager.shared
 
@@ -173,5 +175,23 @@ class AppCoordinator {
             return
         }
         state = .serverSignedOut
+    }
+
+    private func checkDefaults() {
+        let defaults = UserDefaults.standard
+        performUpdateIfRequired(updateKey: "v1_run") {
+            FileLog.shared.addMessage("AppCoordinator v1Run")
+            // ensure that all previous log in information is wiped and database cleanup
+            SyncManager.clearTokensFromKeyChain()
+            DataManager.sharedManager.deleteAllData()
+        }
+        defaults.synchronize()
+    }
+
+    private func performUpdateIfRequired(updateKey: String, update: () -> Void) {
+        if UserDefaults.standard.bool(forKey: updateKey) { return } // already performed this update
+
+        update()
+        UserDefaults.standard.set(true, forKey: updateKey)
     }
 }


### PR DESCRIPTION
Fixes PCIOS-

On tvOS, a fresh app install can inherit stale keychain credentials from a previous install (the keychain survives app deletion on Apple TV). This wipes any leftover login tokens and local database data on the first run of a new install, so the app starts from a genuinely clean state instead of acting half-signed-in.

This mirrors the existing iOS `v5Run` new-install behavior (`AppDelegate+Defaults.swift`), using the same `performUpdateIfRequired` one-time-migration pattern keyed off `UserDefaults`.

## To test

1. Install a build, sign in, then delete the app (leaving keychain entries behind).
2. Reinstall and launch the app.
3. Verify it starts at the welcome/signed-out screen with no leftover data, and that `FileLog` shows the `AppCoordinator v1Run` message.
4. Relaunch again and confirm the cleanup does **not** run a second time.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)