### PR TITLE
[PC TV] Fix Now Playing loading state

### DIFF
--- a/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
+++ b/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
@@ -49,21 +49,14 @@ struct MediaOverlayView: View {
         .ignoresSafeArea()
     }
 
-    /// Branded loading state shown while AVKit's system spinner is suppressed.
-    /// Sits centered over the artwork so the screen never looks empty during
-    /// initial load or mid-stream buffering.
     private var loadingOverlay: some View {
         VStack(spacing: 24) {
             ProgressView()
                 .progressViewStyle(.circular)
                 .tint(.white)
-                .scaleEffect(2.0)
-            Text(L10n.loading)
-                .font(.title3)
-                .foregroundStyle(.white.opacity(0.85))
+                .scaleEffect(1.3)
         }
         .padding(48)
-        .background(.black.opacity(0.4), in: RoundedRectangle(cornerRadius: 24))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
+++ b/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
@@ -50,13 +50,10 @@ struct MediaOverlayView: View {
     }
 
     private var loadingOverlay: some View {
-        VStack(spacing: 24) {
-            ProgressView()
-                .progressViewStyle(.circular)
-                .tint(.white)
-                .scaleEffect(1.3)
-        }
-        .padding(48)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        ProgressView()
+            .progressViewStyle(.circular)
+            .tint(.white)
+            .scaleEffect(1.3)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -16,7 +16,7 @@ struct NowPlayingView: View {
             isShowingMarkAsPlayedConfirmation: $isShowingMarkAsPlayedConfirmation,
             isShowingArchiveConfirmation: $isShowingArchiveConfirmation
         )
-        .onAppear() {
+        .onAppear {
             model.load()
         }
         .requireAccountSupport()

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -7,10 +7,6 @@ struct NowPlayingView: View {
     @State private var isShowingDescription = false
     @State private var isShowingMarkAsPlayedConfirmation = false
     @State private var isShowingArchiveConfirmation = false
-    // Mark Played and Archive both stop playback, which leaves the player
-    // empty. Dismiss closes the fullScreenCover variants; the Now Playing
-    // *tab* is separately swapped back to Home by `MainTabRouter`'s
-    // existing playback observer.
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -20,6 +16,9 @@ struct NowPlayingView: View {
             isShowingMarkAsPlayedConfirmation: $isShowingMarkAsPlayedConfirmation,
             isShowingArchiveConfirmation: $isShowingArchiveConfirmation
         )
+        .onAppear() {
+            model.load()
+        }
         .requireAccountSupport()
         .sheet(isPresented: $isShowingDescription) {
             if let episode = model.episode {
@@ -74,7 +73,6 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
         controller.allowedSubtitleOptionLanguages = []
         controller.delegate = context.coordinator
         controller.appliesPreferredDisplayCriteriaAutomatically = false
-        model.load()
         addOverlay(to: controller)
         return controller
     }

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -68,7 +68,7 @@ struct UpNextView: View {
         let episodeText = count == 1
             ? L10n.podcastEpisodeCountSingular
             : L10n.podcastEpisodeCountPluralFormat(count.localized())
-        let totalSeconds =  model.episodes.reduce(0.0) { sum, episode in
+        let totalSeconds = model.episodes.reduce(0.0) { sum, episode in
             sum + max(0, episode.duration - episode.playedUpTo)
         }
         let timeText = L10n.podcastTimeLeft(

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -39,10 +39,10 @@ struct UpNextView: View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 24) {
                 headerRow
-                ForEach(queuedEpisodes) { episode in
+                ForEach(model.episodes) { episode in
                     EpisodeRowWithActions(model: episode, context: .upNext, focus: $rowFocus)
                         .frame(width: 1160)
-                        .prefersDefaultFocus(episode.id == queuedEpisodes.first?.id, in: rowNamespace)
+                        .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
                 }
             }
             .focusScope(rowNamespace)
@@ -54,7 +54,7 @@ struct UpNextView: View {
             Text(L10n.tvTabUpNext)
                 .font(.title2)
                 .foregroundStyle(Color.pcTextPrimary)
-            if !queuedEpisodes.isEmpty {
+            if !model.episodes.isEmpty {
                 Text(summaryText)
                     .font(.caption)
                     .foregroundStyle(Color.pcTextSecondary)
@@ -63,18 +63,12 @@ struct UpNextView: View {
         .frame(width: 1160, alignment: .leading)
     }
 
-    /// The Up Next queue minus the currently playing episode at index 0, which
-    /// the player surfaces elsewhere.
-    private var queuedEpisodes: [EpisodeRowViewModel] {
-        Array(model.episodes.dropFirst())
-    }
-
     private var summaryText: String {
-        let count = queuedEpisodes.count
+        let count = model.episodes.count
         let episodeText = count == 1
             ? L10n.podcastEpisodeCountSingular
             : L10n.podcastEpisodeCountPluralFormat(count.localized())
-        let totalSeconds = queuedEpisodes.reduce(0.0) { sum, episode in
+        let totalSeconds =  model.episodes.reduce(0.0) { sum, episode in
             sum + max(0, episode.duration - episode.playedUpTo)
         }
         let timeText = L10n.podcastTimeLeft(

--- a/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
@@ -41,14 +41,14 @@ class UpNextViewModel {
             let episodes = self.loadEpisodeViewModels(using: dataManager)
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                state = episodes.isEmpty ? .empty : .ready
+                state = episodes.isEmpty || episodes.count == 1 ? .empty : .ready
                 self.episodes = episodes
             }
         }
     }
 
     private func loadEpisodeViewModels(using dataManager: DataManager) -> [EpisodeRowViewModel] {
-        dataManager.allUpNextEpisodes().map { episode in
+        dataManager.allUpNextEpisodes().dropFirst().map { episode in
             let podcast = (episode as? Episode).flatMap { $0.parentPodcast(dataManager: dataManager) }
             return EpisodeRowViewModel(episode: episode, podcast: podcast)
         }

--- a/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
@@ -41,7 +41,7 @@ class UpNextViewModel {
             let episodes = self.loadEpisodeViewModels(using: dataManager)
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                state = episodes.isEmpty || episodes.count == 1 ? .empty : .ready
+                state = episodes.isEmpty ? .empty : .ready
                 self.episodes = episodes
             }
         }


### PR DESCRIPTION
Fixes [PCIOS-776](https://linear.app/a8c/issue/PCIOS-776/loading-state-before-playing-looks-rough)
Fixes the Now Playing loading state on the Pocket Casts TV app and tidies up the Up Next empty-state handling.

### What changed
- **Now Playing loading fix:** move `model.load()` to the SwiftUI view's `.onAppear` (instead of inside `makeUIViewController`), so the player model loads reliably when the screen appears rather than only on view-controller creation.
- **Loading overlay:** simplified the branded loading state in `MediaOverlayView` to a smaller, background-less circular spinner.
- **Up Next:** the currently-playing episode (index 0 of the Up Next queue) is now dropped at the data layer (`UpNextViewModel.loadEpisodeViewModels`) rather than in the view, and the queue shows the empty state when it contains only the currently-playing episode.
- General cleanup/lint of the touched TV files.


https://github.com/user-attachments/assets/01c98631-7ae4-46e5-9cb3-43ca8bd1db9a



## To test

1. On the TV app, start playing an episode and open Now Playing — confirm the branded spinner shows briefly while loading and the player loads correctly.
2. Navigate away and back to Now Playing — confirm the model reloads and playback state is correct.
3. Open the Up Next tab with only the currently-playing episode queued — confirm it shows the empty state.
4. Add episodes to Up Next — confirm they appear and the summary (count + time left) is correct.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.
