### PR TITLE
[PC TV] Fix focus clipping in episode row with actions

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -172,9 +172,6 @@ struct EpisodeRowWithActions: View {
         .contextMenu {
             EpisodeActionButtons(model: model, context: context, isShowingShowNotes: $isShowingShowNotes)
         }
-        .if(isFocused) { content in
-            content.clipShape(RoundedRectangle(cornerRadius: 12))
-        }
         .animation(.easeInOut(duration: 0.2), value: shouldShowMoreButton)
         .onChange(of: isShowingActions) { _, showing in
             guard !showing else { return }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

On tvOS, `EpisodeRowWithActions` applied an extra `clipShape(RoundedRectangle(cornerRadius: 12))` to the whole row (play button **and** the ellipsis "More" button) whenever the row was focused. That outer clip cut off the focus highlight/scale on the row's contents. The inner play button already clips itself, so the focus-time clip was both redundant and visually wrong. This removes it.

It also made context menus appear more reliable on long-press – the `if` was messing with it.

## To test

1. Build and run the tvOS app (`Pocket Casts TV App`).
2. Open a podcast and scroll down to the episode list.
3. Move focus across the episode rows.
4. Verify the focused row (and its ellipsis "More" button) renders its focus highlight fully, without being clipped at the rounded corners.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
