### PR TITLE
[PC TV] Track signInShown from entry buttons instead of onAppear

### DIFF
--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -118,9 +118,6 @@ struct SignInView: View {
                 break
             }
         }
-        .onAppear {
-            Analytics.track(.signInShown)
-        }
         .background(Color.pcBackgroundBase)
     }
 

--- a/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
@@ -116,6 +116,7 @@ struct ProfileMenuView: View {
     private var signedOutMenu: some View {
         VStack(spacing: 24) {
             Button {
+                Analytics.track(.signInShown)
                 onAuthSelected(.signIn)
             } label: {
                 Label(L10n.tvProfileMenuLogIn, systemImage: "person.crop.circle")

--- a/Pocket Casts TV App/UI/WelcomeView.swift
+++ b/Pocket Casts TV App/UI/WelcomeView.swift
@@ -41,6 +41,7 @@ struct WelcomeView: View {
                         }
                         .simultaneousGesture(TapGesture().onEnded {
                             Analytics.track(.setupAccountButtonTapped, properties: ["button": "sign_in"])
+                            Analytics.track(.signInShown)
                         })
                         NavigationLink(value: Destination.createAccount) {
                             Text(L10n.tvWelcomeCreateFreeAccount)


### PR DESCRIPTION
On Apple TV the `.signInShown` analytics event was firing unreliably and often multiple times for a single visit. It was tracked from `SignInView`'s `.onAppear`, but the view is presented inside `navigationDestination` / `fullScreenCover` content builders. Those builders get re-invoked as their parent re-evaluates (the QR pairing flow constantly mutates state), so `SignInView` was repeatedly torn down and rebuilt — its `@State` reset each time, defeating an "only track once" guard, and `.onAppear` re-fired on each rebuild.

Rather than fight the view-identity churn, this moves the event to the two buttons that actually lead to the sign-in screen, so it fires exactly once per tap:

- Welcome screen → "Log In" link
- Profile menu → "Log In" item (signed-out)

The `.onAppear` tracking (and its now-unused guard) is removed.

## To test

1. Launch the TV app signed out.
2. On the Welcome screen, tap **Log In** → verify `signInShown` fires exactly once.
3. Go back, then start browsing without an account; open the profile menu and tap **Log In** → verify `signInShown` fires exactly once.
4. On the sign-in screen, switch between the QR and Manual tabs and let the QR code load → verify no additional `signInShown` events fire.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
