### PR TITLE
[PC TV] Add home_shown and sign_in_type_tapped analytics events

### DIFF
--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -98,6 +98,9 @@ struct SignInView: View {
                 model.state = .start
             }
         }
+        .onChange(of: loginType) {
+            Analytics.track(.signInTypeTapped, properties: ["type": loginType == .qr ? "qr" : "password"])
+        }
         .onChange(of: model.state) {
             switch model.state {
             case .finished:

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -38,6 +38,7 @@ struct HomeView: View {
         }
         .animation(.easeInOut, value: model.state)
         .task {
+            Analytics.track(.homeShown)
             model.load()
         }
     }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -57,6 +57,7 @@ enum AnalyticsEvent: String {
 
     case signInShown
     case signInDismissed
+    case signInTypeTapped // tvOS: switching between QR code and password sign-in
 
     // MARK: - Select Account Type
 
@@ -416,6 +417,7 @@ enum AnalyticsEvent: String {
 
     // MARK: - Discover
 
+    case homeShown // tvOS Home tab
     case discoverShown
     case discoverCategoryShown
     case discoverCategoriesPillTapped


### PR DESCRIPTION
Fixes PCIOS-793.

Wires up two new tvOS-only analytics events:

- **`home_shown`** — fired when the Home tab appears (`HomeView` `.task`).
- **`sign_in_type_tapped`** — fired when the user switches the sign-in picker between QR code and password (`SignInView` `.onChange(of: loginType)`), with a `type` property of `qr` or `password`.

Schema changes are in Automattic/EventHorizonSchemas#93.

## To test

1. Run the **Pocket Casts TV App** target on the tvOS simulator.
2. Watch the console for `AnalyticsLoggingAdapter` output.
3. From the logged-out state, open Sign In and toggle the picker between **QR Code** and **Password** → each switch logs `sign_in_type_tapped` with `type` = `qr` / `password`.
4. Sign in and land on the Home tab → `home_shown` is logged when Home appears.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.