### PR TITLE
[PC TV] Add download app modal to playlists empty state

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/DownloadAppModal.swift
+++ b/Pocket Casts TV App/UI/Playlists/DownloadAppModal.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct DownloadAppModal: View {
+    @Environment(\.dismiss) private var dismiss
+
+    private let downloadURL = "https://www.pocketcasts.com/downloads"
+
+    var body: some View {
+        VStack(spacing: 48) {
+            VStack(spacing: 16) {
+                Text(L10n.tvPlaylistsDownloadTitle)
+                    .font(.title2)
+                    .foregroundStyle(Color.pcTextPrimary)
+                Text(L10n.tvPlaylistsDownloadSubtitle)
+                    .font(.body)
+                    .foregroundStyle(Color.pcTextSecondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: 800)
+            }
+            QRCodeView(url: downloadURL)
+            Text(verbatim: "pocketcasts.com/downloads")
+                .font(.caption)
+                .foregroundStyle(Color.pcTextSecondary)
+            Button(L10n.done) {
+                dismiss()
+            }
+        }
+        .padding(80)
+    }
+}
+
+#Preview {
+    DownloadAppModal()
+}

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -8,6 +8,7 @@ struct PlaylistsView: View {
 
     @State private var model: PlaylistsViewModel
     @State private var didTrackShown = false
+    @State private var showDownloadModal = false
 
     enum Layout {
         static let gridSize = CGFloat(496)
@@ -29,6 +30,9 @@ struct PlaylistsView: View {
             }
         }
         .animation(.easeInOut, value: model.state)
+        .sheet(isPresented: $showDownloadModal) {
+            DownloadAppModal()
+        }
         .task {
             model.load()
         }
@@ -63,7 +67,7 @@ struct PlaylistsView: View {
             Text(L10n.tvPlaylistsEmptySubtitle)
         } actions: {
             Button(L10n.tvPlaylistsEmptyActionTitle) {
-                requireAccount { tabRouter.selectedTab = .home }
+                showDownloadModal = true
             }
         }
     }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6196,6 +6196,12 @@
 /* tv playlists empty button action title */
 "tv_playlists_empty_action_title" = "Create a playlist";
 
+/* tv playlists download modal title */
+"tv_playlists_download_title" = "Create playlists on your phone";
+
+/* tv playlists download modal subtitle */
+"tv_playlists_download_subtitle" = "They'll be waiting here when you're done. Scan to get the app";
+
 /* tv keep listening title */
 "tv_home_keep_listening_title" = "Picking up where you left off";
 


### PR DESCRIPTION
Fixes PCIOS-750

When the Playlists tab is empty, tapping "Create a playlist" now opens a modal sheet with a QR code that links to `pocketcasts.com/downloads`. This guides Apple TV users to download the mobile app, where playlists are created and managed.

## To test

1. On tvOS, open the app and navigate to the Playlists tab
2. If you have existing playlists, temporarily remove them or use an account with none
3. Confirm the empty state shows "Your playlists live here" with a "Create a playlist" button
4. Press the button — a modal sheet should appear with:
   - Title: "Create playlists on your phone"
   - Subtitle: "They'll be waiting here when you're done. Scan to get the app"
   - A QR code linking to pocketcasts.com/downloads
   - A "Done" button that dismisses the modal
5. Scan the QR code to confirm it points to the correct URL

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

<img width="1920" height="1080" alt="Simulator Screenshot - Apple TV 4K (3rd generation) (at 1080p) - 2026-06-25 at 00 32 33" src="https://github.com/user-attachments/assets/950882a8-7c12-4354-a07f-279c4445def7" />

