### PR TITLE
[PC TV] Add empty state for folder detail view

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
@@ -5,6 +5,10 @@ struct FolderDetailView: View {
 
     @State var model: FolderDetailViewModel
 
+    @Environment(\.dismiss) var dismiss
+
+    @Environment(MainTabViewModel.self) var tabRouter: MainTabViewModel
+
     init(folder: Folder) {
         self.model = FolderDetailViewModel(folder: folder)
     }
@@ -19,6 +23,30 @@ struct FolderDetailView: View {
     @Namespace private var podcastGridNamespace
 
     var body: some View {
+        ZStack {
+            switch model.state {
+                case .loading:
+                    ProgressView()
+                case .empty:
+                    emptyView
+                case .ready:
+                    podcastList
+            }
+        }
+        .task {
+            model.load()
+        }
+        .toolbar(.hidden, for: .tabBar)
+        .onAppear {
+            tabRouter.isShowingDetail = true
+        }
+        .onDisappear {
+            tabRouter.isShowingDetail = false
+        }
+    }
+
+    @ViewBuilder
+    var podcastList: some View {
         let firstID = model.podcasts.first?.id
         ScrollView {
             VStack(alignment: .leading, spacing: 40) {
@@ -41,8 +69,17 @@ struct FolderDetailView: View {
         .navigationDestination(for: Podcast.self) { podcast in
             PodcastDetailView(model: PodcastDetailViewModel(podcast: podcast))
         }
-        .task {
-            model.load()
+    }
+
+    var emptyView: some View {
+        ContentUnavailableView {
+            Text(L10n.folderEmptyTitle)
+        } description: {
+            Text(L10n.tvFolderEmptyMessage)
+        } actions: {
+            Button(L10n.ok) {
+                dismiss()
+            }
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/FolderDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderDetailViewModel.swift
@@ -11,6 +11,14 @@ class FolderDetailViewModel {
 
     private var cancellables = Set<AnyCancellable>()
 
+    enum State: Equatable, Hashable {
+        case loading
+        case ready
+        case empty
+    }
+
+    var state: State = .loading
+
     init(folder: Folder, dataManager: DataManager = DataManager.sharedManager) {
         self.folder = folder
         self.dataManager = dataManager
@@ -21,6 +29,7 @@ class FolderDetailViewModel {
             let podcasts = dataManager.allPodcastsInFolder(folder: folder)
             await MainActor.run {
                 self.podcasts = podcasts
+                self.state = podcasts.isEmpty ? .empty : .ready
                 Analytics.track(.folderShown, properties: [
                     "number_of_podcasts": podcasts.count,
                     "sort_order": Self.sortOrderAnalyticsValue(for: folder)

--- a/Pocket Casts TV App/UI/Podcasts/FolderDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderDetailViewModel.swift
@@ -9,8 +9,6 @@ class FolderDetailViewModel {
     var podcasts = [Podcast]()
     private var dataManager: DataManager
 
-    private var cancellables = Set<AnyCancellable>()
-
     enum State: Equatable, Hashable {
         case loading
         case ready

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6445,3 +6445,5 @@
 /* Message/Body of an alert that explains that the user should tap a button and sign in again */
 "tv_account_signed_out_alert_message" = "There was a problem and you've been logged out.\nTap the button below to log in to your Pocket Casts account again.";
 
+"tv_folder_empty_message" = "Edit you folder in the mobile app, they'll be waiting here when you're done.";
+

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6445,5 +6445,6 @@
 /* Message/Body of an alert that explains that the user should tap a button and sign in again */
 "tv_account_signed_out_alert_message" = "There was a problem and you've been logged out.\nTap the button below to log in to your Pocket Casts account again.";
 
-"tv_folder_empty_message" = "Edit you folder in the mobile app, they'll be waiting here when you're done.";
+/* Message shown on the empty folder view in the TV app, directing the user to add podcasts to the folder using the mobile app */
+"tv_folder_empty_message" = "Edit your folder in the mobile app, they'll be waiting here when you're done.";
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

<img width="320"  alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-06-25 at 15 11 43" src="https://github.com/user-attachments/assets/e132ba94-dd16-46e1-ab5d-9095defd102e" />


## Summary

Adds an empty state to the TV app's folder detail view. When a folder contains no podcasts, the view now shows a `ContentUnavailableView` directing the user to edit the folder in the mobile app, with an OK button that dismisses the view. The folder detail view model gains a `loading / ready / empty` state that drives the view, and the toolbar/tab-bar presentation is fixed while a detail is shown.

This PR also includes a small follow-up cleanup: the new `tv_folder_empty_message` string now has the required translator comment, and a typo ("Edit you folder" → "Edit your folder") was corrected.

## To test

1. On the TV app, open the Podcasts tab.
2. Open a folder that has no podcasts in it.
3. Verify the empty state appears with the message and an OK button, and that tapping OK dismisses the folder view.
4. Open a folder that has podcasts and verify the grid still displays as before.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)