### PR TITLE
[PC TV] Show now playing row on logged out home

### DIFF
--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -74,6 +74,7 @@ struct HomeView: View {
                             tabRouter.selectedTab = .search
                         }
                     } else {
+                        nowPlayingRow
                         featuredRow
                         videoRow
                         BannerRow(type: .createAccount, focusSection: Section.homeBanner.rawValue) {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

This adds the now playing row to the logged-out home screen on the Pocket Casts TV app. Previously the `nowPlayingRow` was only shown when the user was signed in; this change displays it on the logged-out home view as well, so playback in progress remains accessible without an account.

## To test

1. On the Pocket Casts TV app, make sure you are logged out.
2. Start playing an episode so there is active "now playing" content.
3. Navigate to the Home tab.
4. Verify the now playing row appears at the top of the home screen (above the featured row).
5. Confirm the row is focusable and resumes the current playback as expected.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
