### PR TITLE
[PC TV] Smooth out transitions between main screens

### DIFF
--- a/Pocket Casts TV App/PocketCastsTVApp.swift
+++ b/Pocket Casts TV App/PocketCastsTVApp.swift
@@ -17,6 +17,9 @@ struct PocketCastsTVApp: App {
     var body: some Scene {
         WindowGroup {
             RootView()
+            .task {
+                appLifecycleAnalytics.didBecomeActive()
+            }
         }
         .onChange(of: scenePhase) { _, newPhase in
             appLifecycleAnalytics.handle(scenePhase: newPhase)

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -70,7 +70,7 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
             }
             Color.pcBackgroundSunken
                 .opacity(blackOverlayOpaque ? 1 : 0)
-                .animation(reduceMotion ? nil : .easeInOut(duration: Pacing.fadeDuration), value: blackOverlayOpaque)
+                .animation(reduceMotion ? nil : .smooth, value: blackOverlayOpaque)
                 .allowsHitTesting(false)
                 .ignoresSafeArea()
         }

--- a/Pocket Casts TV App/UI/RootView.swift
+++ b/Pocket Casts TV App/UI/RootView.swift
@@ -12,20 +12,27 @@ struct RootView: View {
                     Spacer()
                     ProgressView()
                     Spacer()
-                }.frame(maxWidth: .infinity)
+                }
+                .frame(maxWidth: .infinity)
+                .transition(.opacity)
             case .welcome:
                 WelcomeView()
+                    .transition(.opacity)
             case .browsing, .signedIn:
                 MainTabView()
+                    .transition(.opacity)
             case .userSync:
                 SigningInView()
+                    .transition(.opacity)
             case .dataLossResync:
                 DataLossResyncView()
+                    .transition(.opacity)
             case .serverSignedOut:
                 UserSignedOutView()
+                    .transition(.opacity)
             }
         }
-        .animation(.easeInOut, value: coordinator.state)
+        .animation(.smooth, value: coordinator.state)
         .environment(coordinator)
         .environment(focusStore)
         .task {


### PR DESCRIPTION
Fixes [PCIOS-794](https://linear.app/a8c/issue/PCIOS-794/smooth-transition-from-welcome-screen-to-logged-out-home)
|:---:|

## Summary

Improves the transitions between the main screens of the Pocket Casts TV app so switching between the loading, welcome, main tab, sign-in, data-loss-resync, and signed-out states feels smoother and no longer briefly flashes the previous screen.

Changes:
- `RootView`: each state case now uses an explicit `.transition(.opacity)` and the root `animation` driving `coordinator.state` changes was switched from `.easeInOut` to `.smooth`.
- `SigningInView`: the black overlay fade now uses `.smooth` instead of `.easeInOut(duration:)`, avoiding the bounce that could reveal the previous screen.

## To test

1. Launch the Pocket Casts TV app.
2. Move through the main flows: launch (loading) → welcome → sign in → main tabs, and sign out.
3. Confirm the transitions between screens fade smoothly with no bounce and without briefly showing the previous screen.
4. With Reduce Motion enabled, confirm transitions still behave correctly.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
