### PR TITLE
Remove FeatureFlag.liquidGlass

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -310,9 +310,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// This does not control automatic crash reporting.
     case watchSentryLogs
 
-    /// Enable the Liquid Glass UI redesign
-    case liquidGlass
-
     /// Show explicit content badges on podcasts
     case showExplicitBadges
 
@@ -532,8 +529,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .watchSentryLogs:
             false
-        case .liquidGlass:
-            true
         case .showExplicitBadges:
             true
         case .shareProfile:

--- a/podcasts/LiquidGlass.swift
+++ b/podcasts/LiquidGlass.swift
@@ -1,10 +1,8 @@
 import Foundation
 import UIKit
-import PocketCastsUtils
 
 enum LiquidGlass {
     static var isEnabled: Bool {
-        guard FeatureFlag.liquidGlass.enabled else { return false }
         if #available(iOS 26.0, *) { return true }
         return false
     }

--- a/podcasts/Main/MainTabBarController+Animations.swift
+++ b/podcasts/Main/MainTabBarController+Animations.swift
@@ -118,7 +118,7 @@ extension MainTabBarController {
     static let upNextGenieViewTag = 776_611
 
     @objc func animateEpisodeAddedToUpNext(_ notification: Notification) {
-        guard FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) else { return }
+        guard #available(iOS 26.0, *) else { return }
         guard let episodeUuid = notification.object as? String,
               let episode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else {
             // Nothing to animate — just keep the count current.

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -1202,7 +1202,7 @@ private extension MainTabBarController {
     }
 
     func loadProfileTabAvatar(forceRefresh: Bool) {
-        guard FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) else { return }
+        guard #available(iOS 26.0, *) else { return }
 
         guard let email = ServerSettings.syncingEmail(), !email.isEmpty,
               let url = URL(string: "https://www.gravatar.com/avatar/\(email.sha256)?d=404&s=256") else {
@@ -1234,7 +1234,7 @@ private extension MainTabBarController {
 
 extension MainTabBarController {
     @objc func refreshUpNextTabBadge() {
-        guard FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) else { return }
+        guard #available(iOS 26.0, *) else { return }
 
         // Clamping lives in `composeUpNextTabImage`; track the true count here.
         let count = PlaybackManager.shared.queue.upNextCount()

--- a/podcasts/MiniPlayerViewController+TransitionDelegate.swift
+++ b/podcasts/MiniPlayerViewController+TransitionDelegate.swift
@@ -1,5 +1,4 @@
 import Foundation
-import PocketCastsUtils
 
 extension MiniPlayerViewController: UIViewControllerTransitioningDelegate {
     func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
@@ -7,7 +6,7 @@ extension MiniPlayerViewController: UIViewControllerTransitioningDelegate {
             return nil
         }
 
-        if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
+        if #available(iOS 26.0, *) {
             return PlayerZoomAnimator(
                 isPresenting: false,
                 fullPlayer: fullPlayer,
@@ -27,7 +26,7 @@ extension MiniPlayerViewController: UIViewControllerTransitioningDelegate {
         let presentVelocity = pendingPresentVelocity
         pendingPresentVelocity = 0
 
-        if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
+        if #available(iOS 26.0, *) {
             // Blank the player view before UIKit can position and render it
             // at its final frame — otherwise the first render shows the
             // fully-opaque player flashing in behind the panel.

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -100,7 +100,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         view.isHidden = false
 
-        if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
+        if #available(iOS 26.0, *) {
             setupLiquidGlassLayout()
         } else {
             setupCorners()
@@ -583,7 +583,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     private func updateColors() {
         view.backgroundColor = .clear
 
-        if FeatureFlag.liquidGlass.enabled, #available(iOS 26.0, *) {
+        if #available(iOS 26.0, *) {
             updateColorsLiquidGlass()
         } else {
             updateColorsLegacy()

--- a/podcasts/New Creation/New Preview/Rules/SmartPlaylistRule.swift
+++ b/podcasts/New Creation/New Preview/Rules/SmartPlaylistRule.swift
@@ -1,5 +1,4 @@
 import Foundation
-import PocketCastsUtils
 
 enum SmartPlaylistRule: Int, CaseIterable, Identifiable {
     case podcast, duration, episode, releaseDate, downloadStatus, mediaType, starred
@@ -26,7 +25,6 @@ enum SmartPlaylistRule: Int, CaseIterable, Identifiable {
     }
 
     var isMenuCompatible: Bool {
-        guard FeatureFlag.liquidGlass.enabled else { return false }
         switch self {
         case .releaseDate, .downloadStatus, .mediaType, .starred:
             return true

--- a/podcasts/PlayerContainerViewController+Gestures.swift
+++ b/podcasts/PlayerContainerViewController+Gestures.swift
@@ -18,7 +18,7 @@ extension PlayerContainerViewController: UIGestureRecognizerDelegate {
             // Round the player's corners for the drag so it reads as a card
             // lifting off the screen. They're squared again if the drag springs
             // back, or carried into the dismiss transition if it closes.
-            if FeatureFlag.liquidGlass.enabled, #available(iOS 26, *) {
+            if #available(iOS 26, *) {
                 roundCornersForPlayerTransition()
             }
         case .changed:
@@ -53,7 +53,7 @@ extension PlayerContainerViewController: UIGestureRecognizerDelegate {
                 }, completion: { _ in
                     // Settled back full-screen: square the corners so the player
                     // covers the whole screen with no edge gaps.
-                    if FeatureFlag.liquidGlass.enabled, #available(iOS 26, *) {
+                    if #available(iOS 26, *) {
                         self.resetCornersAfterPlayerTransition()
                     }
                 })


### PR DESCRIPTION
Removes the `liquidGlass` feature flag (already defaulted to `true`), graduating it to always-on. Liquid Glass behavior is now governed purely by `#available(iOS 26.0, *)`. No behavior change on iOS 26+; pre-iOS 26 keeps the legacy paths.

## To test

1. On iOS 26, confirm the Liquid Glass UI renders as before (mini/full player, tab bar avatar & Up Next badge, smart playlist rule menus).
2. On pre-iOS 26, confirm the legacy UI is unaffected.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
