### PR TITLE
TV: Add missing analytics events

### DIFF
--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -75,7 +75,7 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
                 .ignoresSafeArea()
         }
         .task {
-            Analytics.track(.signInSync)
+            Analytics.track(.signInSyncShown)
             await runSyncAnimation()
         }
     }

--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -75,6 +75,7 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
                 .ignoresSafeArea()
         }
         .task {
+            Analytics.track(.signInSync)
             await runSyncAnimation()
         }
     }

--- a/Pocket Casts TV App/UI/Player/EpisodeShowNotesView.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodeShowNotesView.swift
@@ -23,6 +23,7 @@ struct EpisodeShowNotesView: View {
         .padding([.horizontal, .top], 80)
         .frame(width: 1200, height: 920, alignment: .topLeading)
         .task {
+            Analytics.track(.episodeDetailShown)
             await loadShowNotes()
         }
     }

--- a/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
@@ -22,7 +22,7 @@ struct NowPlayingTab: View {
                     DispatchQueue.main.async {
                         PlaybackManager.shared.play(completion: {
                             DispatchQueue.main.async {
-                                PlaybackManager.shared.pause()
+                                PlaybackManager.shared.pause(userInitiated: false)
                             }
                         }, userInitiated: false)
                     }

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -68,6 +68,7 @@ class NowPlayingViewModel: Identifiable {
         timeControlStatusObservation = player.observe(\.timeControlStatus, options: [.new, .initial]) { [weak self] _, _ in
             Task { @MainActor [weak self] in
                 self?.updateLoadingState()
+                self?.updatePlayState()
             }
         }
 
@@ -88,6 +89,31 @@ class NowPlayingViewModel: Identifiable {
             Task { @MainActor [weak self] in
                 self?.updateLoadingState()
             }
+        }
+    }
+
+    private var previousTimeStatus: AVPlayer.TimeControlStatus?
+
+    private func updatePlayState() {
+        guard let player else {
+            return
+        }
+        let currentTimeStatus = player.timeControlStatus
+        guard previousTimeStatus != currentTimeStatus else {
+            return
+        }
+        previousTimeStatus = currentTimeStatus
+        switch currentTimeStatus {
+        case .playing:
+            AnalyticsPlaybackHelper.shared.currentSource = .player
+            AnalyticsPlaybackHelper.shared.play()
+        case .paused:
+            AnalyticsPlaybackHelper.shared.currentSource = .player
+            AnalyticsPlaybackHelper.shared.pause()
+        case .waitingToPlayAtSpecifiedRate:
+            break
+        @unknown default:
+            break
         }
     }
 

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -53,7 +53,7 @@ struct PlaylistDetailView: View {
                 .ignoresSafeArea()
         }
         .task {
-            Analytics.track(.filterShown)
+            Analytics.track(.filterShown, properties: ["filter_type": model.isManual ? "manual" : "smart"])
             model.load()
         }
     }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -33,7 +33,7 @@ struct PlaylistsView: View {
             DownloadAppModal()
         }
         .task {
-            model.load()
+            await model.load()
             Analytics.track(.filterListShown, properties: ["filter_count": model.playlists.count])
         }
     }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -33,13 +33,11 @@ struct PlaylistsView: View {
         .sheet(isPresented: $showDownloadModal) {
             DownloadAppModal()
         }
+        .onAppear {
+            Analytics.track(.filterListShown, properties: ["filter_count": model.playlists.count])
+        }
         .task {
             model.load()
-        }
-        .onChange(of: model.state) { _, newState in
-            guard !didTrackShown, newState != .loading else { return }
-            didTrackShown = true
-            Analytics.track(.filterListShown, properties: ["filter_count": model.playlists.count])
         }
     }
 

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -7,7 +7,6 @@ struct PlaylistsView: View {
     @Environment(\.requireAccount) private var requireAccount
 
     @State private var model: PlaylistsViewModel
-    @State private var didTrackShown = false
     @State private var showDownloadModal = false
 
     enum Layout {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -32,11 +32,9 @@ struct PlaylistsView: View {
         .sheet(isPresented: $showDownloadModal) {
             DownloadAppModal()
         }
-        .onAppear {
-            Analytics.track(.filterListShown, properties: ["filter_count": model.playlists.count])
-        }
         .task {
             model.load()
+            Analytics.track(.filterListShown, properties: ["filter_count": model.playlists.count])
         }
     }
 

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
@@ -24,14 +24,11 @@ class PlaylistsViewModel {
     }
     var playlists: [EpisodeFilter] = []
 
-    func load() {
-        Task { [weak self] in
-            guard let self else { return }
-            let playlists = dataManager.allPlaylists(includeDeleted: false)
-            await MainActor.run {
-                self.playlists = playlists
-                self.state = playlists.isEmpty ? .empty : .ready
-            }
+    func load() async {
+        let playlists = dataManager.allPlaylists(includeDeleted: false)
+        await MainActor.run {
+            self.playlists = playlists
+            self.state = playlists.isEmpty ? .empty : .ready
         }
     }
 
@@ -42,7 +39,9 @@ class PlaylistsViewModel {
         )
         .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
         .sink { [weak self] _ in
-            self?.load()
+            Task {
+                await self?.load()
+            }
         }
         .store(in: &cancellables)
     }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -238,7 +238,7 @@ struct EpisodeActionButtons: View {
                 Button(L10n.removeFromUpNext) { model.removeFromUpNext() }
             }
         }.onAppear {
-            Analytics.track(.multiSelectViewOverflowMenuShown)
+            Analytics.track(.episodeActionsShown)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -220,21 +220,25 @@ struct EpisodeActionButtons: View {
     @Environment(\.requireAccount) private var requireAccount
 
     var body: some View {
-        if model.podcastUuid != nil {
-            Button(L10n.tvEpisodeShowNotesAction) { isShowingShowNotes = true }
-        }
-        switch context {
-        case .default:
-            Button(L10n.playNextInUpNext) { requireAccount { model.playNext() } }
-            Button(L10n.playLastInUpNext) { requireAccount { model.playLast() } }
-            Button(L10n.markPlayed) { requireAccount { model.markAsPlayed() } }
-            if model.canArchive {
-                Button(model.isArchived ? L10n.unarchive : L10n.archive) { requireAccount { model.isArchived ? model.unarchive() : model.archive() } }
+        Group {
+            if model.podcastUuid != nil {
+                Button(L10n.tvEpisodeShowNotesAction) { isShowingShowNotes = true }
             }
-        case .upNext:
-            Button(L10n.playNext) { requireAccount { model.playNext() } }
-            Button(L10n.playLast) { requireAccount { model.playLast() } }
-            Button(L10n.removeFromUpNext) { model.removeFromUpNext() }
+            switch context {
+            case .default:
+                Button(L10n.playNextInUpNext) { requireAccount { model.playNext() } }
+                Button(L10n.playLastInUpNext) { requireAccount { model.playLast() } }
+                Button(L10n.markPlayed) { requireAccount { model.markAsPlayed() } }
+                if model.canArchive {
+                    Button(model.isArchived ? L10n.unarchive : L10n.archive) { requireAccount { model.isArchived ? model.unarchive() : model.archive() } }
+                }
+            case .upNext:
+                Button(L10n.playNext) { requireAccount { model.playNext() } }
+                Button(L10n.playLast) { requireAccount { model.playLast() } }
+                Button(L10n.removeFromUpNext) { model.removeFromUpNext() }
+            }
+        }.onAppear {
+            Analytics.track(.multiSelectViewOverflowMenuShown)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -163,6 +163,7 @@ enum EpisodeUpNextActions {
     static func playNext(_ episode: BaseEpisode, playbackManager: PlaybackManager = .shared) {
         if playbackManager.inUpNext(episode: episode) {
             playbackManager.queue.move(episode: episode, to: 0)
+            Analytics.track(.upNextQueueReordered, properties: ["direction": "up", "is_next": true])
         } else {
             playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: true, userInitiated: true)
         }
@@ -173,6 +174,7 @@ enum EpisodeUpNextActions {
         if playbackManager.inUpNext(episode: episode) {
             let queueCount = playbackManager.queue.upNextCount()
             playbackManager.queue.move(episode: episode, to: max(queueCount - 1, 0))
+            Analytics.track(.upNextQueueReordered, properties: ["direction": "down", "is_next": queueCount == 1])
         } else {
             playbackManager.addToUpNext(episode: episode, ignoringQueueLimit: true, toTop: false, userInitiated: true)
         }

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -16,7 +16,7 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                 if model.isInSearchMode {
                     ForEach(model.autoCompleteSuggestions, id: \.self) { suggestion in
                         Button {
-                            Analytics.track(.searchPredictiveTermTapped, properties: ["term": suggestion])
+                            Analytics.track(.searchPredictiveTermTapped, properties: ["term": suggestion, "source": "search"])
                         } label: {
                             Text(suggestion)
                                 .searchCompletion(suggestion)
@@ -25,7 +25,7 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                 } else {
                     ForEach(model.searchHistory, id: \.self) { search in
                         Button {
-                            Analytics.track(.searchHistoryItemTapped, properties: ["type": "search_term"])
+                            Analytics.track(.searchHistoryItemTapped, properties: ["type": "search_term", "source": "search"])
                         } label: {
                             Text(search).searchCompletion(search)
                         }

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -16,12 +16,20 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                 if model.isInSearchMode {
                     if searchText.isEmpty {
                         ForEach(model.searchHistory, id: \.self) { search in
-                            Text(search).searchCompletion(search)
+                            Button {
+                                Analytics.track(.searchHistoryItemTapped, properties: ["type" : "search_term"])
+                            } label: {
+                                Text(search).searchCompletion(search)
+                            }
                         }
                     } else {
                         ForEach(model.autoCompleteSuggestions, id: \.self) { suggestion in
-                            Text(suggestion)
-                                .searchCompletion(suggestion)
+                            Button {
+                                Analytics.track(.searchPredictiveTermTapped, properties: ["term": suggestion])
+                            } label: {
+                                Text(suggestion)
+                                    .searchCompletion(suggestion)
+                            }
                         }
                     }
                 }

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -14,22 +14,20 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
             .searchable(text: $searchText, prompt: L10n.tvSearchPrompt)
             .searchSuggestions {
                 if model.isInSearchMode {
-                    if searchText.isEmpty {
-                        ForEach(model.searchHistory, id: \.self) { search in
-                            Button {
-                                Analytics.track(.searchHistoryItemTapped, properties: ["type" : "search_term"])
-                            } label: {
-                                Text(search).searchCompletion(search)
-                            }
+                    ForEach(model.autoCompleteSuggestions, id: \.self) { suggestion in
+                        Button {
+                            Analytics.track(.searchPredictiveTermTapped, properties: ["term": suggestion])
+                        } label: {
+                            Text(suggestion)
+                                .searchCompletion(suggestion)
                         }
-                    } else {
-                        ForEach(model.autoCompleteSuggestions, id: \.self) { suggestion in
-                            Button {
-                                Analytics.track(.searchPredictiveTermTapped, properties: ["term": suggestion])
-                            } label: {
-                                Text(suggestion)
-                                    .searchCompletion(suggestion)
-                            }
+                    }
+                } else {
+                    ForEach(model.searchHistory, id: \.self) { search in
+                        Button {
+                            Analytics.track(.searchHistoryItemTapped, properties: ["type": "search_term"])
+                        } label: {
+                            Text(search).searchCompletion(search)
                         }
                     }
                 }

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -167,7 +167,7 @@ class SearchViewModel: SearchableViewModel {
                 autoCompleteSuggestions = suggestions
 
                 guard !Task.isCancelled else { return }
-
+                saveHistory(query)
                 let fullResults = try await fullSearchTask.search(term: query)
                 var episodes: [EpisodeSearchResult] = []
                 for searchResult in fullResults {

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -562,6 +562,7 @@ enum AnalyticsEvent: String {
     case episodeDetailPodcastNameTapped
     case episodeDetailDismissed
     case episodeDetailTabChanged
+    case episodeActionsShown
 
     // MARK: - Multi Select View
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -58,7 +58,7 @@ enum AnalyticsEvent: String {
     case signInShown
     case signInDismissed
     case signInTypeTapped // tvOS: switching between QR code and password sign-in
-    case signInSync // tvOS: sync of user data
+    case signInSyncShown // tvOS: sync of user data
 
     // MARK: - Select Account Type
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -58,6 +58,7 @@ enum AnalyticsEvent: String {
     case signInShown
     case signInDismissed
     case signInTypeTapped // tvOS: switching between QR code and password sign-in
+    case signInSync // tvOS: sync of user data
 
     // MARK: - Select Account Type
 


### PR DESCRIPTION
Adds missing analytics events to the Pocket Casts TV app and refines existing ones so the TV experience is instrumented consistently with the other platforms. Adds one new shared event, `episodeActionsShown`.

### What changed
- **Episode details** – track `episodeDetailShown` when the show notes screen appears (`EpisodeShowNotesView`).
- **Episode actions** – track the new `episodeActionsShown` event when the episode action menu is shown (`EpisodeRow` / `EpisodeActionButtons`). Added the `episodeActionsShown` case to `AnalyticsEvent`.
- **Up Next reordering** – track `upNextQueueReordered` with `direction` and `is_next` properties when an already-queued episode is moved via play next/last (`EpisodeRowViewModel`).
- **Filters** – add a `filter_type` (`manual`/`smart`) property to `filterShown` (`PlaylistDetailView`). Make `PlaylistsViewModel.load()` async and `await` it before tracking `filterListShown`, so `filter_count` reflects the loaded playlists rather than firing too early (`PlaylistsView` / `PlaylistsViewModel`).
- **Search** – track `searchPredictiveTermTapped` and `searchHistoryItemTapped`, both with a `source: "search"` property; save the search term to history when a full search runs (`SearchViewModel`). Also fixes the search-history display/save behavior.
- Removed the now-unused `didTrackShown` state flag in `PlaylistsView` after tracking moved into the load `.task`.

### To test
1. Open the TV app and navigate to an episode's show notes – confirm `episodeDetailShown` fires.
2. Open an episode's action menu – confirm `episodeActionsShown` fires.
3. Use play next / play last on an episode already in Up Next – confirm `upNextQueueReordered` fires with the expected `direction`/`is_next`.
4. Open the Filters tab – confirm `filterListShown` fires with a non-zero `filter_count`; open a filter and confirm `filterShown` includes `filter_type`.
5. Search for a term, tap a predictive suggestion and a history item – confirm `searchPredictiveTermTapped` / `searchHistoryItemTapped` fire with `source: "search"` and the term is saved to history.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have [updated](https://github.com/Automattic/EventHorizonSchemas/pull/95) (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
