### PR TITLE
[PC TV] Show player full screen from Up Next

### DIFF
--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -209,6 +209,10 @@ struct MainTabView: View {
                 tabRouter.pendingAuthFlow = nil
             }
         }
+        .fullScreenCover(isPresented: $tabRouter.showFullScreenPlayer) {
+            NowPlayingView()
+                .ignoresSafeArea()
+        }
     }
 
     var logoAccessory: some View {

--- a/Pocket Casts TV App/UI/MainTabViewModel.swift
+++ b/Pocket Casts TV App/UI/MainTabViewModel.swift
@@ -11,6 +11,7 @@ final class MainTabViewModel {
     var isShowingDetail: Bool = false
     var pendingAuthFlow: ProfileMenuView.AuthDestination?
     var profileDestination: ProfileMenuView.ProfileDestination?
+    var showFullScreenPlayer: Bool = false
 
     var scrollOffset: CGFloat = 0
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -121,7 +121,6 @@ struct EpisodeRowWithActions: View {
     var context: EpisodeActionContext = .default
     @FocusState.Binding var focus: EpisodeRowFocus?
     var customPlayDisplayAction: (() -> ())? = nil
-    
     @State private var isPlaying = false
     @State private var isShowingActions = false
     @State private var isShowingShowNotes = false
@@ -144,10 +143,9 @@ struct EpisodeRowWithActions: View {
     var body: some View {
         HStack(spacing: Layout.spacing) {
             Button {
-                if customPlayDisplayAction != nil {
-                    customPlayDisplayAction?()
-                }
-                else {
+                if let customPlayDisplayAction {
+                    customPlayDisplayAction()
+                } else {
                     isPlaying = true
                 }
                 model.play()

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -119,8 +119,9 @@ struct EpisodeRowWithActions: View {
 
     let model: EpisodeRowViewModel
     var context: EpisodeActionContext = .default
-
     @FocusState.Binding var focus: EpisodeRowFocus?
+    var customPlayDisplayAction: (() -> ())? = nil
+    
     @State private var isPlaying = false
     @State private var isShowingActions = false
     @State private var isShowingShowNotes = false
@@ -143,7 +144,12 @@ struct EpisodeRowWithActions: View {
     var body: some View {
         HStack(spacing: Layout.spacing) {
             Button {
-                isPlaying = true
+                if customPlayDisplayAction != nil {
+                    customPlayDisplayAction?()
+                }
+                else {
+                    isPlaying = true
+                }
                 model.play()
             } label: {
                 HStack(spacing: 0) {

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -40,9 +40,11 @@ struct UpNextView: View {
             LazyVStack(alignment: .leading, spacing: 24) {
                 headerRow
                 ForEach(model.episodes) { episode in
-                    EpisodeRowWithActions(model: episode, context: .upNext, focus: $rowFocus)
-                        .frame(width: 1160)
-                        .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
+                    EpisodeRowWithActions(model: episode, context: .upNext, focus: $rowFocus) {
+                        tabRouter.showFullScreenPlayer = true
+                    }
+                    .frame(width: 1160)
+                    .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
                 }
             }
             .focusScope(rowNamespace)


### PR DESCRIPTION
Fixes [POC-703](https://linear.app/a8c/issue/POC-703/pressing-an-episode-to-play-in-upnext)

## What

When tapping an episode in the Up Next list on tvOS, the full-screen player now opens at the top-level tab level rather than inside the Up Next sheet.

## Why

The player was previously presented via `EpisodeRowWithActions`'s own per-row `.fullScreenCover($isPlaying)`, which caused it to appear associated to the Row. When tapping to play the row/episode was moved out of the list making the player to dissappear. Routing the presentation through `MainTabViewModel.showFullScreenPlayer` and a `.fullScreenCover` on `MainTabView` ensures the player stays put.

## Changes

- `MainTabViewModel` — adds `showFullScreenPlayer: Bool` flag
- `MainTabView` — attaches a `.fullScreenCover` driven by `showFullScreenPlayer` to present `NowPlayingView` at the tab root
- `EpisodeRowWithActions` — adds an optional `customPlayDisplayAction` closure; when provided, it runs instead of the default `isPlaying = true` local presentation
- `UpNextView` — passes a closure that sets `tabRouter.showFullScreenPlayer = true` when an episode row's play button is tapped

## Reviewer notes

- The per-row `.fullScreenCover($isPlaying)` in `EpisodeRowWithActions` is still used by other contexts (Podcasts, Starred, History); only Up Next routes through the tab-level cover.
- `customPlayDisplayAction` uses `if let` optional binding (idiomatic Swift) rather than an explicit nil check.