### PR TITLE
Show episode artwork on episode details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add a Star Episodes action to Up Next multi-select and show a star indicator on Up Next cells [#4605](https://github.com/Automattic/pocket-casts-ios/pull/4605)
 - Fix the Files navigation bar not being transparent [#4604](https://github.com/Automattic/pocket-casts-ios/pull/4604)
 - Fix Control Center timeline continuing to advance while playback is paused [#4530](https://github.com/Automattic/pocket-casts-ios/pull/4530)
+- Show episode artwork on the episode details page [#4616](https://github.com/Automattic/pocket-casts-ios/pull/4616)
 
 8.15
 -----

--- a/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
+++ b/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
@@ -111,7 +111,7 @@ private class ShowInfoCoordinatorMock: ShowInfoCoordinating {
         ""
     }
 
-    func loadEpisodeArtworkUrl(podcastUuid: String, episodeUuid: String) async throws -> String? {
+    func loadEpisodeArtworkUrl(podcastUuid: String, episodeUuid: String) async throws -> URL? {
         nil
     }
 

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
@@ -9,7 +9,7 @@ final class TranscriptManagerTests: XCTestCase {
             return ""
         }
 
-        func loadEpisodeArtworkUrl(podcastUuid: String, episodeUuid: String) async throws -> String? {
+        func loadEpisodeArtworkUrl(podcastUuid: String, episodeUuid: String) async throws -> URL? {
             return nil
         }
 

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
@@ -13,7 +13,7 @@ protocol ShowInfoCoordinating {
     func loadEpisodeArtworkUrl(
         podcastUuid: String,
         episodeUuid: String
-    ) async throws -> String?
+    ) async throws -> URL?
 
     func loadChapters(
         podcastUuid: String,

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -37,9 +37,9 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
     func loadEpisodeArtworkUrl(
         podcastUuid: String,
         episodeUuid: String
-    ) async throws -> String? {
+    ) async throws -> URL? {
         let metadata = try await loadShowInfo(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
-        return metadata?.image
+        return metadata?.image.flatMap(URL.init(string:))
     }
 
     public func loadChapters(

--- a/podcasts/Episode/EpisodeDetailViewController.swift
+++ b/podcasts/Episode/EpisodeDetailViewController.swift
@@ -153,9 +153,12 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     private var docController: UIDocumentInteractionController?
     private var starButton: UIButton?
 
-    /// The episode's own artwork URL, when the show provides one and the user has opted in to
-    /// episode artwork. When set, it's displayed instead of the podcast artwork.
+    /// The episode's own artwork URL once resolved, or `nil` if the show provides no
+    /// episode-specific artwork (in which case we fall back to the podcast artwork).
     private var episodeArtworkURL: URL?
+
+    /// Whether the episode artwork fetch has completed, regardless of its result.
+    private var didResolveEpisodeArtwork = false
 
     var rawShowNotes: String?
     var lastThemeRenderedNotesIn: Theme.ThemeType?
@@ -425,32 +428,30 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     }
 
     private func updateArtwork() {
-        // Once the episode artwork is available, the transition animation owns the artwork views,
-        // so we leave them untouched on subsequent updates.
-        guard episodeArtworkURL == nil else { return }
-
-        if let uuid = episode.parentPodcast()?.uuid {
+        // While episode artwork is enabled but not yet resolved, show a placeholder. Once resolved,
+        // show the episode's own artwork, falling back to the podcast artwork when there is none.
+        if Settings.loadEmbeddedImages, !didResolveEpisodeArtwork {
+            podcastImage.setPlaceholder(size: .page)
+        } else if let episodeArtworkURL {
+            podcastImage.setEpisodeArtwork(url: episodeArtworkURL, size: .page)
+        } else if let uuid = episode.parentPodcast()?.uuid {
             podcastImage.setPodcast(uuid: uuid, size: .page)
         }
     }
 
     /// Some shows provide custom artwork for individual episodes. When the user has opted in to
-    /// episode artwork, fetch the episode's artwork URL and display it instead of the show's artwork.
+    /// episode artwork, fetch the episode's artwork URL and display it (see `updateArtwork`).
     private func loadEpisodeArtwork() {
-        guard Settings.loadEmbeddedImages, episodeArtworkURL == nil else { return }
+        guard Settings.loadEmbeddedImages, !didResolveEpisodeArtwork else { return }
 
         let podcastUuid = episode.parentIdentifier()
         let episodeUuid = episode.uuid
-        Task {
-            guard let url = try? await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: podcastUuid, episodeUuid: episodeUuid) else {
-                return
-            }
-
-            await MainActor.run { [weak self] in
-                guard let self, self.episode.uuid == episodeUuid else { return }
-                self.episodeArtworkURL = url
-                self.podcastImage.setEpisodeArtwork(url: url, size: .page, badgeBorderColor: ThemeColor.primaryUi01(for: self.themeOverride))
-            }
+        Task { @MainActor [weak self] in
+            let url = try? await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+            guard let self, self.episode.uuid == episodeUuid else { return }
+            self.episodeArtworkURL = url
+            self.didResolveEpisodeArtwork = true
+            self.updateArtwork()
         }
     }
 

--- a/podcasts/Episode/EpisodeDetailViewController.swift
+++ b/podcasts/Episode/EpisodeDetailViewController.swift
@@ -153,6 +153,10 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     private var docController: UIDocumentInteractionController?
     private var starButton: UIButton?
 
+    /// The episode's own artwork URL, when the show provides one and the user has opted in to
+    /// episode artwork. When set, it's displayed instead of the podcast artwork.
+    private var episodeArtworkURL: URL?
+
     var rawShowNotes: String?
     var lastThemeRenderedNotesIn: Theme.ThemeType?
     var downloadingShowNotes = false
@@ -255,6 +259,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         super.viewDidAppear(animated)
 
         loadShowNotes()
+        loadEpisodeArtwork()
 
         bookmarksController.view.isHidden = false
 
@@ -407,9 +412,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
 
         episodeName.text = episode.displayableTitle()
         podcastName.text = podcast.title
-        if let uuid = episode.parentPodcast()?.uuid {
-            podcastImage.setPodcast(uuid: uuid, size: .page)
-        }
+        updateArtwork()
 
         episodeInfo.text = DateFormatHelper.sharedHelper.longLocalizedFormat(episode.publishedDate) + " · " + episode.displayableTimeLeft()
 
@@ -419,6 +422,36 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         updateProgress()
         updateMessageView()
         updateColors()
+    }
+
+    private func updateArtwork() {
+        // Once the episode artwork is available, the transition animation owns the artwork views,
+        // so we leave them untouched on subsequent updates.
+        guard episodeArtworkURL == nil else { return }
+
+        if let uuid = episode.parentPodcast()?.uuid {
+            podcastImage.setPodcast(uuid: uuid, size: .page)
+        }
+    }
+
+    /// Some shows provide custom artwork for individual episodes. When the user has opted in to
+    /// episode artwork, fetch the episode's artwork URL and display it instead of the show's artwork.
+    private func loadEpisodeArtwork() {
+        guard Settings.loadEmbeddedImages, episodeArtworkURL == nil else { return }
+
+        let podcastUuid = episode.parentIdentifier()
+        let episodeUuid = episode.uuid
+        Task {
+            guard let url = try? await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: podcastUuid, episodeUuid: episodeUuid) else {
+                return
+            }
+
+            await MainActor.run { [weak self] in
+                guard let self, self.episode.uuid == episodeUuid else { return }
+                self.episodeArtworkURL = url
+                self.podcastImage.setEpisodeArtwork(url: url, size: .page, badgeBorderColor: ThemeColor.primaryUi01(for: self.themeOverride))
+            }
+        }
     }
 
     @objc private func playbackProgressDidChange() {

--- a/podcasts/Episode/EpisodeDetailViewController.swift
+++ b/podcasts/Episode/EpisodeDetailViewController.swift
@@ -153,11 +153,7 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     private var docController: UIDocumentInteractionController?
     private var starButton: UIButton?
 
-    /// The episode's own artwork URL once resolved, or `nil` if the show provides no
-    /// episode-specific artwork (in which case we fall back to the podcast artwork).
     private var episodeArtworkURL: URL?
-
-    /// Whether the episode artwork fetch has completed, regardless of its result.
     private var didResolveEpisodeArtwork = false
 
     var rawShowNotes: String?
@@ -439,8 +435,6 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
         }
     }
 
-    /// Some shows provide custom artwork for individual episodes. When the user has opted in to
-    /// episode artwork, fetch the episode's artwork URL and display it (see `updateArtwork`).
     private func loadEpisodeArtwork() {
         guard Settings.loadEmbeddedImages, !didResolveEpisodeArtwork else { return }
 

--- a/podcasts/EpisodeArtwork.swift
+++ b/podcasts/EpisodeArtwork.swift
@@ -76,8 +76,7 @@ class EpisodeArtwork {
     /// Attempts to load episode artwork from show notes URL.
     /// - Returns: true if artwork was successfully loaded and saved, false otherwise
     private func loadArtworkFromShowNotes(podcastUuid: String, episodeUuid: String) async -> Bool {
-        guard let imageUrl = try? await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: podcastUuid, episodeUuid: episodeUuid),
-              let url = URL(string: imageUrl) else {
+        guard let url = try? await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: podcastUuid, episodeUuid: episodeUuid) else {
             return false
         }
 

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -278,8 +278,7 @@ class PlaylistDetailViewModel: ObservableObject {
             for episode in episodes {
                 group.addTask {
                     if includingEpisodeArtwork,
-                       let imageUrl = try await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: episode.episode.podcastUuid, episodeUuid: episode.episode.uuid),
-                       let url = URL(string: imageUrl) {
+                       let url = try await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: episode.episode.podcastUuid, episodeUuid: episode.episode.uuid) {
                         return PlaylistArtworkView.ImageItem(id: episode.episode.uuid, url: url)
                     }
                     let url = self.imageManager.podcastUrl(imageSize: .detail, uuid: episode.episode.podcastUuid)

--- a/podcasts/PlaylistCellViewModel.swift
+++ b/podcasts/PlaylistCellViewModel.swift
@@ -158,8 +158,7 @@ class PlaylistCellViewModel: ObservableObject {
             for episode in episodes {
                 group.addTask {
                     if includingEpisodeArtwork,
-                       let imageUrl = try await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: episode.episode.podcastUuid, episodeUuid: episode.episode.uuid),
-                       let url = URL(string: imageUrl) {
+                       let url = try await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: episode.episode.podcastUuid, episodeUuid: episode.episode.uuid) {
                         return PlaylistArtworkView.ImageItem(id: episode.episode.uuid, url: url)
                     }
                     let url = self.imageManager.podcastUrl(imageSize: .grid, uuid: episode.episode.podcastUuid)

--- a/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
+++ b/podcasts/PlaylistMetadataLoader/PlaylistMetadataLoader.swift
@@ -349,8 +349,7 @@ actor PlaylistMetadataLoader {
             for episode in episodes {
                 group.addTask {
                     if includingEpisodeArtwork,
-                       let imageUrl = try await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: episode.episode.podcastUuid, episodeUuid: episode.episode.uuid),
-                       let url = URL(string: imageUrl) {
+                       let url = try await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(podcastUuid: episode.episode.podcastUuid, episodeUuid: episode.episode.uuid) {
                         return PlaylistArtworkView.ImageItem(id: episode.episode.uuid, url: url)
                     }
                     let url = self.imageManager.podcastUrl(imageSize: .grid, uuid: episode.episode.podcastUuid)

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -7,9 +7,6 @@ class PodcastImageView: UIView {
     private var shadowView: UIView?
     var imageView: UIImageView?
 
-    /// The show artwork shrunk into the bottom-right corner once episode artwork is displayed.
-    private var episodeArtworkBadge: UIImageView?
-
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -48,91 +45,22 @@ class PodcastImageView: UIView {
         adjustForSize(size)
     }
 
+    /// Loads the episode's own artwork, fading it in over whatever placeholder is currently shown.
     func setEpisodeArtwork(url: URL, size: PodcastThumbnailSize) {
         guard let imageView else { return }
         adjustForSize(size)
 
-        let placeholder = imageView.image ?? ImageManager.sharedManager.placeHolderImage(size)
-        let processor = DefaultImageProcessor.default
-        imageView.kf.setImage(with: url, placeholder: placeholder, options: [
-            .processor(processor),
-            .transition(.fade(Constants.Animation.defaultAnimationTime)),
-            .forceTransition
+        imageView.kf.setImage(with: url, options: [
+            .processor(DefaultImageProcessor.default),
+            .transition(.fade(Constants.Animation.defaultAnimationTime))
         ])
     }
 
-    /// Transitions from the currently displayed show artwork to the episode artwork: the show
-    /// artwork shrinks into a small rounded badge in the bottom-right corner while the episode
-    /// artwork is revealed from underneath, taking the main artwork's place.
-    func setEpisodeArtwork(url: URL, size: PodcastThumbnailSize, badgeBorderColor: UIColor) {
-        guard let imageView else { return }
+    /// Shows the standard gray placeholder, e.g. while artwork is being fetched.
+    func setPlaceholder(size: PodcastThumbnailSize) {
+        imageView?.kf.cancelDownloadTask()
+        imageView?.image = ImageManager.sharedManager.placeHolderImage(size)
         adjustForSize(size)
-
-        // We can only animate the show artwork into the corner if it's already on screen, and we
-        // only want to run the transition once. Otherwise just fade the episode artwork in.
-        guard let showArtwork = imageView.image, episodeArtworkBadge == nil else {
-            setEpisodeArtwork(url: url, size: size)
-            return
-        }
-
-        // Load the episode artwork up front so it's fully ready before we reveal it from under the
-        // show artwork, avoiding a placeholder flashing during the animation.
-        KingfisherManager.shared.retrieveImage(with: url) { [weak self] result in
-            guard let self, let imageView = self.imageView, self.episodeArtworkBadge == nil,
-                  case .success(let value) = result else { return }
-            self.animateToEpisodeArtwork(value.image, showArtwork: showArtwork, in: imageView, badgeBorderColor: badgeBorderColor)
-        }
-    }
-
-    private func animateToEpisodeArtwork(_ episodeImage: UIImage, showArtwork: UIImage, in imageView: UIImageView, badgeBorderColor: UIColor) {
-        // The badge holds the show artwork and starts out exactly overlapping the main artwork, so
-        // the transition begins seamlessly.
-        let badge = UIImageView(image: showArtwork)
-        badge.frame = bounds
-        badge.contentMode = .scaleAspectFill
-        badge.clipsToBounds = true
-        badge.layer.cornerRadius = imageView.layer.cornerRadius
-        badge.layer.cornerCurve = .continuous
-        badge.layer.borderColor = badgeBorderColor.cgColor
-        addSubview(badge)
-        episodeArtworkBadge = badge
-
-        // Reveal the episode artwork in the main image view (hidden under the badge for now), and
-        // start it slightly scaled down so it appears to scale up into place. The scale is anchored
-        // to the top-left corner so the artwork grows toward the bottom-right as the badge retreats
-        // there, keeping the two motions coherent and never exposing the edges.
-        imageView.image = episodeImage
-        let revealScale: CGFloat = 0.92
-        imageView.transform = CGAffineTransform(translationX: -bounds.width * (1 - revealScale) / 2,
-                                                y: -bounds.height * (1 - revealScale) / 2)
-            .scaledBy(x: revealScale, y: revealScale)
-
-        // The badge ends as a small square in the bottom-right corner, overhanging it slightly so
-        // it reads as sitting on top of the episode artwork.
-        let scale: CGFloat = 0.32
-        let protrusion: CGFloat = 10
-        let badgeSize = CGSize(width: bounds.width * scale, height: bounds.height * scale)
-        let finalFrame = CGRect(x: bounds.width - badgeSize.width + protrusion,
-                                y: bounds.height - badgeSize.height + protrusion,
-                                width: badgeSize.width,
-                                height: badgeSize.height)
-
-        let duration: TimeInterval = 0.7
-        let borderWidth: CGFloat = 2
-        let borderAnimation = CABasicAnimation(keyPath: "borderWidth")
-        borderAnimation.fromValue = 0
-        borderAnimation.toValue = borderWidth
-        borderAnimation.duration = duration
-        borderAnimation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        badge.layer.borderWidth = borderWidth
-        badge.layer.add(borderAnimation, forKey: "borderWidth")
-
-        // A gently damped spring gives a smooth settle without a hard stop or noticeable bounce.
-        let animator = UIViewPropertyAnimator(duration: duration, dampingRatio: 0.9) {
-            badge.frame = finalFrame
-            imageView.transform = .identity
-        }
-        animator.startAnimation()
     }
 
     func setTransparentNoArtwork(size: PodcastThumbnailSize) {

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -7,6 +7,9 @@ class PodcastImageView: UIView {
     private var shadowView: UIView?
     var imageView: UIImageView?
 
+    /// The show artwork shrunk into the bottom-right corner once episode artwork is displayed.
+    private var episodeArtworkBadge: UIImageView?
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -43,6 +46,93 @@ class PodcastImageView: UIView {
 
         ImageManager.sharedManager.loadImage(episode: episode, imageView: imageView, size: size)
         adjustForSize(size)
+    }
+
+    func setEpisodeArtwork(url: URL, size: PodcastThumbnailSize) {
+        guard let imageView else { return }
+        adjustForSize(size)
+
+        let placeholder = imageView.image ?? ImageManager.sharedManager.placeHolderImage(size)
+        let processor = DefaultImageProcessor.default
+        imageView.kf.setImage(with: url, placeholder: placeholder, options: [
+            .processor(processor),
+            .transition(.fade(Constants.Animation.defaultAnimationTime)),
+            .forceTransition
+        ])
+    }
+
+    /// Transitions from the currently displayed show artwork to the episode artwork: the show
+    /// artwork shrinks into a small rounded badge in the bottom-right corner while the episode
+    /// artwork is revealed from underneath, taking the main artwork's place.
+    func setEpisodeArtwork(url: URL, size: PodcastThumbnailSize, badgeBorderColor: UIColor) {
+        guard let imageView else { return }
+        adjustForSize(size)
+
+        // We can only animate the show artwork into the corner if it's already on screen, and we
+        // only want to run the transition once. Otherwise just fade the episode artwork in.
+        guard let showArtwork = imageView.image, episodeArtworkBadge == nil else {
+            setEpisodeArtwork(url: url, size: size)
+            return
+        }
+
+        // Load the episode artwork up front so it's fully ready before we reveal it from under the
+        // show artwork, avoiding a placeholder flashing during the animation.
+        KingfisherManager.shared.retrieveImage(with: url) { [weak self] result in
+            guard let self, let imageView = self.imageView, self.episodeArtworkBadge == nil,
+                  case .success(let value) = result else { return }
+            self.animateToEpisodeArtwork(value.image, showArtwork: showArtwork, in: imageView, badgeBorderColor: badgeBorderColor)
+        }
+    }
+
+    private func animateToEpisodeArtwork(_ episodeImage: UIImage, showArtwork: UIImage, in imageView: UIImageView, badgeBorderColor: UIColor) {
+        // The badge holds the show artwork and starts out exactly overlapping the main artwork, so
+        // the transition begins seamlessly.
+        let badge = UIImageView(image: showArtwork)
+        badge.frame = bounds
+        badge.contentMode = .scaleAspectFill
+        badge.clipsToBounds = true
+        badge.layer.cornerRadius = imageView.layer.cornerRadius
+        badge.layer.cornerCurve = .continuous
+        badge.layer.borderColor = badgeBorderColor.cgColor
+        addSubview(badge)
+        episodeArtworkBadge = badge
+
+        // Reveal the episode artwork in the main image view (hidden under the badge for now), and
+        // start it slightly scaled down so it appears to scale up into place. The scale is anchored
+        // to the top-left corner so the artwork grows toward the bottom-right as the badge retreats
+        // there, keeping the two motions coherent and never exposing the edges.
+        imageView.image = episodeImage
+        let revealScale: CGFloat = 0.92
+        imageView.transform = CGAffineTransform(translationX: -bounds.width * (1 - revealScale) / 2,
+                                                y: -bounds.height * (1 - revealScale) / 2)
+            .scaledBy(x: revealScale, y: revealScale)
+
+        // The badge ends as a small square in the bottom-right corner, overhanging it slightly so
+        // it reads as sitting on top of the episode artwork.
+        let scale: CGFloat = 0.32
+        let protrusion: CGFloat = 10
+        let badgeSize = CGSize(width: bounds.width * scale, height: bounds.height * scale)
+        let finalFrame = CGRect(x: bounds.width - badgeSize.width + protrusion,
+                                y: bounds.height - badgeSize.height + protrusion,
+                                width: badgeSize.width,
+                                height: badgeSize.height)
+
+        let duration: TimeInterval = 0.7
+        let borderWidth: CGFloat = 2
+        let borderAnimation = CABasicAnimation(keyPath: "borderWidth")
+        borderAnimation.fromValue = 0
+        borderAnimation.toValue = borderWidth
+        borderAnimation.duration = duration
+        borderAnimation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        badge.layer.borderWidth = borderWidth
+        badge.layer.add(borderAnimation, forKey: "borderWidth")
+
+        // A gently damped spring gives a smooth settle without a hard stop or noticeable bounce.
+        let animator = UIViewPropertyAnimator(duration: duration, dampingRatio: 0.9) {
+            badge.frame = finalFrame
+            imageView.transform = .identity
+        }
+        animator.startAnimation()
     }
 
     func setTransparentNoArtwork(size: PodcastThumbnailSize) {

--- a/podcasts/PodcastImageView.swift
+++ b/podcasts/PodcastImageView.swift
@@ -45,7 +45,6 @@ class PodcastImageView: UIView {
         adjustForSize(size)
     }
 
-    /// Loads the episode's own artwork, fading it in over whatever placeholder is currently shown.
     func setEpisodeArtwork(url: URL, size: PodcastThumbnailSize) {
         guard let imageView else { return }
         adjustForSize(size)
@@ -56,7 +55,6 @@ class PodcastImageView: UIView {
         ])
     }
 
-    /// Shows the standard gray placeholder, e.g. while artwork is being fetched.
     func setPlaceholder(size: PodcastThumbnailSize) {
         imageView?.kf.cancelDownloadTask()
         imageView?.image = ImageManager.sharedManager.placeHolderImage(size)

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -197,11 +197,10 @@ extension SharingModal.Option {
 
     func loadEpisodeArtworkUrl() async -> URL? {
         guard Settings.loadEmbeddedImages, let episode else { return nil }
-        guard let urlString = try? await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(
+        return try? await ShowInfoCoordinator.shared.loadEpisodeArtworkUrl(
             podcastUuid: episode.podcastUuid,
             episodeUuid: episode.uuid
-        ) else { return nil }
-        return URL(string: urlString)
+        )
     }
 
     @MainActor


### PR DESCRIPTION
| 📘 Part of: #482 |
|:---:|

Fixes PCIOS-482

When the "episode artwork" setting is enabled, the episode details page showed the podcast artwork instead of the episode's own artwork, even though the player shows episode artwork. This displays the episode artwork there too (matching the web app).

## To test

1. Enable Settings → Appearance → "Use embedded artwork".
2. Open an episode that has its own artwork (e.g. podcast "La Bonne Auberge", episode "Cyberpunk - Choomba Night").
3. The details page shows a gray placeholder briefly, then the episode artwork (not the podcast artwork).
4. Open an episode without dedicated artwork → it falls back to the podcast artwork.
5. Disable the setting and reopen an episode → the podcast artwork is shown, as before.


https://github.com/user-attachments/assets/3a05aa28-1eba-47b1-940a-767cb9f46b10



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.