### PR TITLE
[PC TV] Show/hide profile & PC logo based on navigation stack depth

### DIFF
--- a/Pocket Casts TV App/UI/Common/View+NavigationDetailSync.swift
+++ b/Pocket Casts TV App/UI/Common/View+NavigationDetailSync.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 extension View {
     func syncNavigationDetail(path: NavigationPath, tabRouter: MainTabViewModel) -> some View {
-        onChange(of: path.isEmpty) { _, isEmpty in
+        onChange(of: path.isEmpty, initial: true) { _, isEmpty in
             tabRouter.isShowingDetail = !isEmpty
         }
     }

--- a/Pocket Casts TV App/UI/Common/View+NavigationDetailSync.swift
+++ b/Pocket Casts TV App/UI/Common/View+NavigationDetailSync.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+extension View {
+    func syncNavigationDetail(path: NavigationPath, tabRouter: MainTabViewModel) -> some View {
+        onChange(of: path.isEmpty) { _, isEmpty in
+            tabRouter.isShowingDetail = !isEmpty
+        }
+    }
+}

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
@@ -35,8 +35,6 @@ struct DiscoverPodcastsListView: View {
             await model.load()
         }
         .toolbar(.hidden, for: .tabBar)
-        .onAppear { tabRouter.isShowingDetail = true }
-        .onDisappear { tabRouter.isShowingDetail = false }
     }
 
     var loadingView: some View {

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -59,8 +59,10 @@ struct HomeView: View {
         }
     }
 
+    @State private var path = NavigationPath()
+
     var homeView: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             ScrollView {
                 VStack(alignment: .leading, spacing: HomeSectionLayout.sectionSpacing) {
                     if coordinator.userState.isLoggedIn {
@@ -97,6 +99,13 @@ struct HomeView: View {
             }
             .navigationDestination(for: DiscoverCategory.self) { discoverCategory in
                 DiscoverPodcastsListView(category: discoverCategory)
+            }
+            .onChange(of: path) { _, newPath in
+                if newPath.isEmpty {
+                    tabRouter.isShowingDetail = false
+                } else {
+                    tabRouter.isShowingDetail = true
+                }
             }
         }
         .fullScreenCover(isPresented: $showNowPlayingPlayer) {

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -100,13 +100,7 @@ struct HomeView: View {
             .navigationDestination(for: DiscoverCategory.self) { discoverCategory in
                 DiscoverPodcastsListView(category: discoverCategory)
             }
-            .onChange(of: path) { _, newPath in
-                if newPath.isEmpty {
-                    tabRouter.isShowingDetail = false
-                } else {
-                    tabRouter.isShowingDetail = true
-                }
-            }
+            .syncNavigationDetail(path: path, tabRouter: tabRouter)
         }
         .fullScreenCover(isPresented: $showNowPlayingPlayer) {
             NowPlayingView()

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -31,9 +31,7 @@ struct PlaylistDetailView: View {
             }
         }
         .toolbar(.hidden, for: .tabBar)
-        .defaultFocus($focusedSection, .episodes)
-        .onAppear { tabRouter.isShowingDetail = true }
-        .onDisappear { tabRouter.isShowingDetail = false }
+        .defaultFocus($focusedSection, .episodes)        
         .confirmationDialog(
             L10n.playlistPlayAllSheetTitle,
             isPresented: $model.isShowingReplaceUpNextConfirmation,

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -31,7 +31,7 @@ struct PlaylistDetailView: View {
             }
         }
         .toolbar(.hidden, for: .tabBar)
-        .defaultFocus($focusedSection, .episodes)        
+        .defaultFocus($focusedSection, .episodes)
         .confirmationDialog(
             L10n.playlistPlayAllSheetTitle,
             isPresented: $model.isShowingReplaceUpNextConfirmation,

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -47,8 +47,9 @@ struct PlaylistsView: View {
         ProgressView()
     }
 
+    @State private var path = NavigationPath()
     var playlistsView: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 40) {
                     Text(L10n.tvTabPlaylists)
@@ -56,6 +57,13 @@ struct PlaylistsView: View {
                         .foregroundStyle(Color.pcTextPrimary)
                     playlistsCollection
                 }
+            }
+        }
+        .onChange(of: path) { _, newPath in
+            if newPath.isEmpty {
+                tabRouter.isShowingDetail = false
+            } else {
+                tabRouter.isShowingDetail = true
             }
         }
     }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -59,13 +59,7 @@ struct PlaylistsView: View {
                 }
             }
         }
-        .onChange(of: path) { _, newPath in
-            if newPath.isEmpty {
-                tabRouter.isShowingDetail = false
-            } else {
-                tabRouter.isShowingDetail = true
-            }
-        }
+        .syncNavigationDetail(path: path, tabRouter: tabRouter)
     }
 
     var emptyView: some View {

--- a/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
@@ -36,7 +36,7 @@ struct FolderDetailView: View {
         .task {
             model.load()
         }
-        .toolbar(.hidden, for: .tabBar)        
+        .toolbar(.hidden, for: .tabBar)
     }
 
     @ViewBuilder

--- a/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderDetailView.swift
@@ -36,13 +36,7 @@ struct FolderDetailView: View {
         .task {
             model.load()
         }
-        .toolbar(.hidden, for: .tabBar)
-        .onAppear {
-            tabRouter.isShowingDetail = true
-        }
-        .onDisappear {
-            tabRouter.isShowingDetail = false
-        }
+        .toolbar(.hidden, for: .tabBar)        
     }
 
     @ViewBuilder

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -42,9 +42,7 @@ struct PodcastDetailView: View {
             }
         }
         .toolbar(.hidden, for: .tabBar)
-        .defaultFocus($focusedSection, .episodes)
-        .onAppear { tabRouter.isShowingDetail = true }
-        .onDisappear { tabRouter.isShowingDetail = false }
+        .defaultFocus($focusedSection, .episodes)        
         .task {
             Analytics.track(.podcastScreenShown, properties: ["uuid": model.podcastUuid])
             model.load()

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -42,7 +42,7 @@ struct PodcastDetailView: View {
             }
         }
         .toolbar(.hidden, for: .tabBar)
-        .defaultFocus($focusedSection, .episodes)        
+        .defaultFocus($focusedSection, .episodes)
         .task {
             Analytics.track(.podcastScreenShown, properties: ["uuid": model.podcastUuid])
             model.load()

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -45,8 +45,10 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
         ProgressView()
     }
 
+    @State private var path = NavigationPath()
+
     var podcastsView: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 40) {
                     Text(L10n.tvTabPodcasts)
@@ -54,6 +56,13 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
                         .foregroundStyle(Color.pcTextPrimary)
                     podcastGrid
                 }
+            }
+        }
+        .onChange(of: path) { _, newPath in
+            if newPath.isEmpty {
+                tabRouter.isShowingDetail = false
+            } else {
+                tabRouter.isShowingDetail = true
             }
         }
     }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -58,13 +58,7 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
                 }
             }
         }
-        .onChange(of: path) { _, newPath in
-            if newPath.isEmpty {
-                tabRouter.isShowingDetail = false
-            } else {
-                tabRouter.isShowingDetail = true
-            }
-        }
+        .syncNavigationDetail(path: path, tabRouter: tabRouter)
     }
 
     var emptyView: some View {

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -53,13 +53,7 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                 Analytics.track(.searchShown, properties: ["source": "search"])
             }
         }
-        .onChange(of: path) { _, newPath in
-            if newPath.isEmpty {
-                tabRouter.isShowingDetail = false
-            } else {
-                tabRouter.isShowingDetail = true
-            }
-        }
+        .syncNavigationDetail(path: path, tabRouter: tabRouter)
     }
 }
 

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -59,4 +59,5 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
 
 #Preview {
     SearchView(model: SearchViewModel())
+        .environment(MainTabViewModel())
 }

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -2,12 +2,16 @@ import SwiftUI
 
 struct SearchView<ViewModel: SearchableViewModel>: View {
 
+    @Environment(MainTabViewModel.self) var tabRouter: MainTabViewModel
+
     @Bindable var model: ViewModel
     @State private var searchText = ""
     @State private var didTrackShown = false
 
+    @State private var path = NavigationPath()
+
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $path) {
             VStack {
                 SearchResultsView(model: model)
             }
@@ -47,6 +51,13 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                 guard !didTrackShown else { return }
                 didTrackShown = true
                 Analytics.track(.searchShown, properties: ["source": "search"])
+            }
+        }
+        .onChange(of: path) { _, newPath in
+            if newPath.isEmpty {
+                tabRouter.isShowingDetail = false
+            } else {
+                tabRouter.isShowingDetail = true
             }
         }
     }


### PR DESCRIPTION
Fixes PCIOS-

## Summary

On tvOS, the profile button and Pocket Casts logo in the tab bar should be hidden when a detail screen is shown. Previously this was done with `onAppear`/`onDisappear` on each detail view, which is fragile — `onDisappear` fires for reasons other than back-navigation (sheets covering the view, app backgrounding) and the ordering during transitions is unreliable.

This PR moves the logic to the parent `NavigationStack` containers, tracking `path.isEmpty` to determine whether a detail is shown. This is more reliable because it directly reflects the navigation state.

### Changes
- Remove `onAppear`/`onDisappear` `isShowingDetail` toggling from `DiscoverPodcastsListView`, `PlaylistDetailView`, `FolderDetailView`, and `PodcastDetailView`
- Add `@State private var path: NavigationPath` to each tab's root view (`HomeView`, `PlaylistsView`, `PodcastsView`, `SearchView`) and bind it to `NavigationStack`
- Observe `path.isEmpty` changes to set `tabRouter.isShowingDetail` — fires only on the empty/non-empty boundary, not every push/pop
- Extract the repeated pattern into a `View` extension `syncNavigationDetail(path:tabRouter:)` in `Common/View+NavigationDetailSync.swift`
- Fix trailing whitespace left behind in detail views

## To test

1. Open the app on Apple TV
2. Navigate to the Podcasts tab → tap a podcast → confirm the profile button and PC logo are hidden
3. Go back → confirm they reappear
4. Repeat for Playlists tab → playlist detail, Home tab → discover category, and Search tab → podcast result
5. Confirm no visual glitches during navigation transitions

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.