### PR TITLE
[PC TV] Remove trailing periods from titles

### DIFF
--- a/Pocket Casts TV App/UI/Auth/SigningInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SigningInView.swift
@@ -58,7 +58,7 @@ struct SigningInView<ViewModel: SigningInViewModelProtocol>: View {
             VStack(spacing: 96) {
                 Spacer()
                 VStack(spacing: 16) {
-                    Text(L10n.tvSigningInTitle)
+                    Text(L10n.tvSigningInTitleNew)
                         .font(.title)
                         .foregroundStyle(Color.pcTextPrimary)
                     Text(L10n.tvSigningInSubtitle)

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
@@ -56,7 +56,7 @@ struct DiscoverPodcastsListView: View {
 
     var emptyView: some View {
         ContentUnavailableView {
-            Text(L10n.tvPodcastsEmptyTitle)
+            Text(L10n.tvPodcastsEmptyTitleNew)
         } description: {
             Text(L10n.tvPodcastsEmptySubtitle)
         } actions: {

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -49,7 +49,7 @@ struct HomeView: View {
 
     var emptyView: some View {
         ContentUnavailableView {
-            Text(L10n.tvPodcastsEmptyTitle)
+            Text(L10n.tvPodcastsEmptyTitleNew)
         } description: {
             Text(L10n.tvPodcastsEmptySubtitle)
         } actions: {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -60,7 +60,7 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
 
     var emptyView: some View {
         ContentUnavailableView {
-            Text(L10n.tvPodcastsEmptyTitle)
+            Text(L10n.tvPodcastsEmptyTitleNew)
         } description: {
             Text(L10n.tvPodcastsEmptySubtitle)
         } actions: {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6104,7 +6104,7 @@
 "tv_create_account_modal_step_log_in" = "The TV will log you in";
 
 /* tv signing in title */
-"tv_signing_in_title" = "Good to see you.";
+"tv_signing_in_title_new" = "Good to see you";
 
 /* tv signing in subtitle */
 "tv_signing_in_subtitle" = "Loading your podcasts now.";
@@ -6113,7 +6113,7 @@
 "tv_resync_fetching_episodes" = "Fetching latest episodes";
 
 /* tv podcasts empty title */
-"tv_podcasts_empty_title" = "Time to fill this up.";
+"tv_podcasts_empty_title_new" = "Time to fill this up";
 
 /* tv podcasts empty subtitle */
 "tv_podcasts_empty_subtitle" = "Followed podcasts show up here, ready to play.";
@@ -6398,7 +6398,7 @@
 "tv_sponsored_podcast_section_title" = "Pocket Casts recommends";
 
 /* tv Discover failed to load title*/
-"tv_discover_failed_to_load_title" = "Discover failed to load.";
+"tv_discover_failed_to_load_title" = "Discover failed to load";
 
 /* tv Discover failed to load subtitle*/
 "tv_discover_failed_to_load_subtitle" = "Make sure you are connected to the internet and try again.";
@@ -6440,7 +6440,7 @@
 "device_approve_generic_error_alert_title" = "Device approval failed";
 
 /* Title of an alert that informs the user that they have been signed out of their account */
-"tv_account_signed_out_alert_title" = "You've been logged out.";
+"tv_account_signed_out_alert_title" = "You've been logged out";
 
 /* Message/Body of an alert that explains that the user should tap a button and sign in again */
 "tv_account_signed_out_alert_message" = "There was a problem and you've been logged out.\nTap the button below to log in to your Pocket Casts account again.";


### PR DESCRIPTION
Removes the trailing `.` from four tvOS titles (podcasts empty state, signing-in, "Discover failed to load", signed-out alert) — by convention only details/subtitles get periods. The two already-translated keys are re-keyed with `_new` to force fresh translations; the rest are edited in place.

## To test

1. Run the **Pocket Casts TV App** (staging) on the tvOS simulator.
2. With no followed podcasts, open **Home** → empty-state title reads **"Time to fill this up"** (no period).
3. Sign in → title reads **"Good to see you"**; force a Discover load failure → **"Discover failed to load"**; trigger the signed-out state → **"You've been logged out"** — all with no trailing period.
4. Confirm each subtitle/detail line still ends with a period.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
