### PR TITLE
Fix crash scrolling the podcast page after it's popped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 8.15
 -----
+- Fix a rare crash when leaving a podcast page while it's still scrolling [#4623](https://github.com/Automattic/pocket-casts-ios/pull/4623)
 - Fix "Download All" on a season not warning before using cellular data [#4523](https://github.com/Automattic/pocket-casts-ios/pull/4523)
 - Fix Share swipe action not dismissing on episode cells [#4522](https://github.com/Automattic/pocket-casts-ios/pull/4522)
 - Fix the Filters search header popping back when few episodes match [#4527](https://github.com/Automattic/pocket-casts-ios/pull/4527)

--- a/podcasts/Common Components/View Controllers/PCViewController.swift
+++ b/podcasts/Common Components/View Controllers/PCViewController.swift
@@ -238,7 +238,9 @@ class PCViewController: SimpleNotificationsViewController {
         }
 
         guard let navigationBar = navigationController?.navigationBar else {
-            assertionFailure("navigationBar is missing")
+            // `navigationController` is nil once this view controller has been popped off the stack.
+            // A scroll view can still fire `scrollViewDidScroll` mid-deceleration after the pop, which
+            // funnels here — there's simply no bar left to style, so this is expected, not an error.
             return
         }
         let appearance = UINavigationBarAppearance()


### PR DESCRIPTION
Fixes a crash on the podcast page reported via Sentry.

**Note:** I'm not sure why `assertionFailure` is seemingly firing in production, but it's a separate issue.

A scroll view can keep firing `scrollViewDidScroll` during momentum deceleration *after* its view controller is popped off the navigation stack. By that point `navigationController` is `nil`, so `setTransparentNavBarScrolled` has no bar to style. The `guard` already handled this gracefully with an early `return`, but the `assertionFailure("navigationBar is missing")` on that path crashed Debug/TestFlight builds for what is actually a normal lifecycle race.

This removes the bogus assertion (keeping the graceful `return`) and documents why `nil` is expected here.

## To test

This is hard to reproduce reliably (it's a deceleration-vs-pop race), but to exercise the path:

1. Open a podcast page.
2. Scroll down so the nav bar blurs (past the header).
3. Flick to start a fast scroll, then immediately tap the back button mid-deceleration to pop the screen.
4. Verify there's no crash (on `main`/Debug this could hit the assertion).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.