### PR TITLE
Space out controls in mini player more

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -224,15 +224,14 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     override func updateViewConstraints() {
         if #available(iOS 26.0, *), let glassButtonStack, let glassProgressView {
             let isInline = forcedInlineLayout ?? (view.traitCollection.tabAccessoryEnvironment == .inline)
-            let buttonWidth: CGFloat = 44
-            skipBackBtnWidthConstraint.constant = buttonWidth
-            playPauseBtnWidthConstraint.constant = buttonWidth
-            skipFwdBtnWidthConstraint.constant = buttonWidth
+            skipBackBtnWidthConstraint.constant = 47
+            playPauseBtnWidthConstraint.constant = 47
+            skipFwdBtnWidthConstraint.constant = 47
 
             NSLayoutConstraint.deactivate(accessoryEnvironmentConstraints)
             accessoryEnvironmentConstraints = [
                 glassProgressView.widthAnchor.constraint(equalToConstant: isInline ? 34 : 52),
-                glassButtonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: isInline ? -4 : -8),
+                glassButtonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -4),
             ]
             NSLayoutConstraint.activate(accessoryEnvironmentConstraints)
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Make the play button a notch wider and easier to tap.

**Before**

<img width="456" height="237" alt="Screenshot 2026-06-26 at 7 49 06 PM" src="https://github.com/user-attachments/assets/ceb8d097-ad90-487c-92a2-3bc959e8465d" />

**After**

<img width="456" height="213" alt="Screenshot 2026-06-26 at 9 12 12 PM" src="https://github.com/user-attachments/assets/06e465d0-220c-4bee-92ce-617510a21844" />

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
