### PR TITLE
Up Next Duration tooltip

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -367,6 +367,9 @@ enum AnalyticsEvent: String {
     case episodeRecentlyPlayedSortOptionTooltipShown
     case episodeRecentlyPlayedSortOptionTooltipDismissed
 
+    case upNextSortTooltipShown
+    case upNextSortTooltipClosed
+
     case episodeAddedToList
     case episodeRemovedFromList
 

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -61,6 +61,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 Settings.shouldShowPodcastFeeReloadTip = false
                 Settings.shouldShowPodcastViewChangesTip = false
                 Settings.shouldShowRecentlyPlayedSortingTip = false
+                Settings.shouldShowUpNextSortDurationTip = false
                 Settings.shouldShowPlaylistsOnboarding = false
             case .sameVersion:
                 break

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -181,6 +181,8 @@ struct Constants {
 
         static let shouldShowRecentlyPlayedSortingTip = "ShouldShowRecentlyPlayedSortingTip"
 
+        static let shouldShowUpNextSortDurationTip = "ShouldShowUpNextSortDurationTip"
+
         static let newFilterTip = "NewFilterTip"
         static let newFilterTipCreationView = "NewFilterTipCreationView"
         static let playlistDragAndDropTip = "PlaylistDragAndDropTip"

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -422,6 +422,13 @@ struct DeveloperMenu: View {
                 Text("Playlist Rebranding")
             }
             Section {
+                Button("Reset Up Next Sort Tooltip") {
+                    Settings.shouldShowUpNextSortDurationTip = true
+                }
+            } header: {
+                Text("Up Next")
+            }
+            Section {
                 Text(Bundle.main.identifier)
             } header: {
                 Text("Bundle ID")

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1502,6 +1502,18 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Up Next Sort by Duration Tip
+
+    // Defaults to true so upgrading users are told about the new duration sort once; AppDelegate suppresses it for fresh installs.
+    static var shouldShowUpNextSortDurationTip: Bool {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.shouldShowUpNextSortDurationTip) as? Bool ?? true
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.shouldShowUpNextSortDurationTip)
+        }
+    }
+
     // MARK: - Playlists
 
     static var shouldShowNewFilterTip: Bool {

--- a/podcasts/TipView.swift
+++ b/podcasts/TipView.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import UIKit
 
 struct TipView: View {
     let title: String
@@ -72,6 +73,85 @@ struct TipViewStatic: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - Popover presentation
+
+/// Where a tip popover points.
+enum TipAnchor {
+    /// A source item (a `UIView` or `UIBarButtonItem`); the popover points at it. Preferred.
+    case item(UIPopoverPresentationControllerSourceItem)
+    /// A source view with an explicit rect within it, for cases that need to anchor to a sub-rect.
+    case view(UIView, rect: CGRect = .null)
+}
+
+extension UIViewController {
+    /// Presents a `TipViewStatic` as a themed, non-adaptive popover anchored to `anchor`, installing its own retained delegate so callers don't conform to `UIPopoverPresentationControllerDelegate`.
+    @discardableResult
+    func presentTip(
+        title: String,
+        message: String?,
+        anchor: TipAnchor,
+        arrow: UIPopoverArrowDirection = .up,
+        idealSize: CGSize = CGSize(width: 300, height: 120),
+        showClose: Bool = false,
+        passthroughViews: [UIView]? = nil,
+        onTap: (() -> Void)? = nil,
+        onDismiss: (() -> Void)? = nil,
+        onShow: (() -> Void)? = nil
+    ) -> UIViewController? {
+        let tipView = TipViewStatic(title: title, message: message, showClose: showClose, onTap: onTap)
+            .frame(maxWidth: idealSize.width, minHeight: idealSize.height)
+            .setupDefaultEnvironment()
+        let hostingController = UIHostingController(rootView: tipView)
+        hostingController.view.backgroundColor = .clear
+        hostingController.view.clipsToBounds = false
+        hostingController.modalPresentationStyle = .popover
+        hostingController.sizingOptions = [.preferredContentSize]
+
+        guard let popover = hostingController.popoverPresentationController else { return nil }
+
+        // The popover holds its delegate weakly, so tie its lifetime to the hosting controller, otherwise it deallocates immediately and the popover becomes a sheet on compact widths.
+        let delegate = TipPopoverDelegate(onDismiss: onDismiss)
+        objc_setAssociatedObject(hostingController, &tipPopoverDelegateKey, delegate, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+
+        popover.delegate = delegate
+        popover.permittedArrowDirections = arrow
+        popover.backgroundColor = ThemeColor.primaryUi01()
+        if let passthroughViews {
+            popover.passthroughViews = passthroughViews
+        }
+        switch anchor {
+        case .item(let item):
+            popover.sourceItem = item
+        case .view(let sourceView, let rect):
+            popover.sourceView = sourceView
+            popover.sourceRect = rect
+        }
+
+        present(hostingController, animated: true, completion: onShow)
+        return hostingController
+    }
+}
+
+private var tipPopoverDelegateKey: UInt8 = 0
+
+/// Keeps a tip popover non-adaptive and forwards outside-tap dismissals. Retained via an associated object on the hosting controller (see `presentTip`).
+private final class TipPopoverDelegate: NSObject, UIPopoverPresentationControllerDelegate {
+    private let onDismiss: (() -> Void)?
+
+    init(onDismiss: (() -> Void)?) {
+        self.onDismiss = onDismiss
+    }
+
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        // Keep the default popover behaviour instead of adapting to a sheet on compact widths.
+        .none
+    }
+
+    func popoverPresentationControllerDidDismissPopover(_ popoverPresentationController: UIPopoverPresentationController) {
+        onDismiss?()
     }
 }
 

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -1,7 +1,6 @@
 import PocketCastsDataModel
 import PocketCastsUtils
 import PocketCastsServer
-import SwiftUI
 import UIKit
 
 class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
@@ -413,7 +412,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     var userEpisodeDetailVC: UserEpisodeDetailViewController?
 
-    /// The "Sort by duration" tooltip popover, while it's on screen. See UpNextViewController+Tip.
+    /// The "Sort by duration" tooltip popover, while it's on screen. See `UIViewController.presentTip` in TipView.swift.
     var upNextSortDurationTip: UIViewController?
 
     func showEpisodeDetailViewController(for episode: BaseEpisode?) {

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -1,6 +1,7 @@
 import PocketCastsDataModel
 import PocketCastsUtils
 import PocketCastsServer
+import SwiftUI
 import UIKit
 
 class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
@@ -241,6 +242,8 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         track(.upNextShown, properties: ["source": source])
 
         AnalyticsHelper.upNextOpened()
+
+        showUpNextSortDurationTipIfNeeded()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -371,6 +374,8 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     @objc private func sortButtonTapped() {
+        // If the tooltip is still up, opening the picker counts as discovering the feature: dismiss and mark it seen.
+        dismissUpNextSortDurationTip()
         let optionsPicker = makeSortOptionsPicker()
         optionsPicker.present(from: self)
     }
@@ -407,6 +412,9 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     var userEpisodeDetailVC: UserEpisodeDetailViewController?
+
+    /// The "Sort by duration" tooltip popover, while it's on screen. See UpNextViewController+Tip.
+    var upNextSortDurationTip: UIViewController?
 
     func showEpisodeDetailViewController(for episode: BaseEpisode?) {
         if let episode = episode as? Episode, let parentPodcast = episode.parentPodcast() {
@@ -677,5 +685,47 @@ extension UpNextViewController {
         super.traitCollectionDidChange(previousTraitCollection)
         guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
         updateSize()
+    }
+}
+
+// MARK: - Sort by Duration tooltip
+
+/// Shows a one-time "Sort by duration" tooltip on the Up Next tab, only for upgrading users since AppDelegate suppresses the flag on fresh installs.
+extension UpNextViewController {
+    func showUpNextSortDurationTipIfNeeded() {
+        guard
+            Settings.shouldShowUpNextSortDurationTip,
+            FeatureFlag.upNextSort.enabled,
+            source == .tabBar,
+            upNextSortDurationTip == nil,
+            // Only when the sort button is actually on screen (it's hidden while the queue is empty).
+            !sortButton.isHidden,
+            PlaybackManager.shared.queue.upNextCount() > 0
+        else {
+            return
+        }
+        upNextSortDurationTip = presentTip(
+            title: L10n.upNextSortDurationTooltipTitle,
+            message: L10n.upNextSortDurationTooltipBody,
+            anchor: .item(sortButton),
+            onTap: { [weak self] in
+                self?.dismissUpNextSortDurationTip()
+            },
+            onDismiss: { [weak self] in
+                self?.dismissUpNextSortDurationTip()
+            },
+            onShow: { [weak self] in
+                self?.track(.upNextSortTooltipShown)
+            }
+        )
+    }
+
+    func dismissUpNextSortDurationTip() {
+        guard upNextSortDurationTip != nil else { return }
+        Settings.shouldShowUpNextSortDurationTip = false
+        track(.upNextSortTooltipClosed)
+        upNextSortDurationTip?.dismiss(animated: true) { [weak self] in
+            self?.upNextSortDurationTip = nil
+        }
     }
 }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -5066,6 +5066,12 @@
 /* Up Next sort option that orders episodes by time remaining, longest first */
 "up_next_sort_longest_to_shortest" = "Longest to shortest";
 
+/* Title of the tooltip shown on the Up Next tab that alerts users to the new sort by duration option */
+"up_next_sort_duration_tooltip_title" = "Sort by duration";
+
+/* Description of the tooltip shown on the Up Next tab that alerts users to the new sort by duration option */
+"up_next_sort_duration_tooltip_body" = "Shortest to longest, or the reverse — fit the episode to the time you’ve actually got.";
+
 /* Title for manage downloads file space usage banner and modal */
 "manage_downloads_title" = "Need to free up space?";
 


### PR DESCRIPTION
Adds a one time "Sort by duration" tooltip anchored to the sort button in the Up Next tab, to surface the new duration sorting capability.

Fixes https://linear.app/a8c/issue/POC-673/ios-whats-new-tooltip

## To test

1. Settings -> Beta Features -> check `upNextSort` is enabled.
2. Settings -> Developer -> tap **Reset Up Next Sort Tooltip**.
3. Open the **Up Next** tab with at least one episode queued.
4. Verify the "Sort by duration" tooltip appears anchored to the sort button.
5. Tap the page and confirm the tooltip closes.
6. Confirm the tooltip does not reappear on subsequent visits to the page.
7. Settings -> Developer -> tap **Reset Up Next Sort Tooltip**.
8. Disable the beta feature`upNextSort` and confirm the tooltip doesn't appear.

## Screenshots 

| Light | Dark |
| --- | --- |
| <img width="1260" height="2736" alt="Simulator Screenshot - iPhone Air - 2026-06-29 at 15 59 41" src="https://github.com/user-attachments/assets/12f8ad1f-b4d2-45cd-bdde-f9738ac6ffcf" /> | <img width="1260" height="2736" alt="Simulator Screenshot - iPhone Air - 2026-06-29 at 16 00 02" src="https://github.com/user-attachments/assets/58a27146-9012-40d7-bb11-df0774734f68" /> | 

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.




