### PR TITLE
TV: Improve podcast load failure view

### DIFF
--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -3,6 +3,7 @@ import PocketCastsDataModel
 
 struct PodcastDetailView: View {
 
+    @Environment(\.dismiss) var dismiss
     @Environment(MainTabViewModel.self) var tabRouter: MainTabViewModel
     @Environment(\.requireAccount) private var requireAccount
     @State var model: PodcastDetailViewModel
@@ -56,8 +57,14 @@ struct PodcastDetailView: View {
     }
 
     var failedView: some View {
-        VStack {
+        ContentUnavailableView {
+            Text(L10n.podcastErrorTitle)
+        } description: {
             Text(L10n.podcastErrorMessage)
+        } actions: {
+            Button(L10n.ok) {
+                dismiss()
+            }
         }
     }
 

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -58,9 +58,9 @@ struct PodcastDetailView: View {
 
     var failedView: some View {
         ContentUnavailableView {
-            Text(L10n.podcastErrorTitle)
+            Text(L10n.tvPodcastErrorTitle)
         } description: {
-            Text(L10n.podcastErrorMessage)
+            Text(L10n.tvPodcastErrorMessage)
         } actions: {
             Button(L10n.ok) {
                 dismiss()

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6448,3 +6448,9 @@
 /* Message shown on the empty folder view in the TV app, directing the user to add podcasts to the folder using the mobile app */
 "tv_folder_empty_message" = "Edit your folder in the mobile app, they'll be waiting here when you're done.";
 
+/* Title to shown when failed to load a podcast information*/
+"tv_podcast_error_title" = "Couldn't load podcast details";
+
+/* Message to shown when failed to load a podcast information*/
+"tv_podcast_error_message" = "Check your internet connection and try again";
+


### PR DESCRIPTION
Fixes PCIOS-

When a podcast fails to load on the TV app, the detail screen only showed a bare error message with no clear title or way to leave the screen. This PR replaces that with a `ContentUnavailableView` that presents a title, a description message, and an **OK** button that dismisses the detail view so the user can navigate back.

## To test

1. Open the TV app and navigate to a podcast detail screen.
2. Force the podcast load to fail (e.g. disconnect networking or use a podcast that can't be loaded).
3. Confirm the failure view now shows a title, an explanatory message, and an **OK** button.
4. Tap **OK** and confirm the detail screen is dismissed.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.