### PR TITLE
[PC-TV] Add a display version on the profile screen

### DIFF
--- a/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
@@ -29,12 +29,16 @@ struct ProfileMenuView: View {
     }
 
     var body: some View {
-        Group {
+        VStack {
             if coordinator.userState.isLoggedIn {
                 signedInMenu
             } else {
                 signedOutMenu
             }
+            Text(Settings.displayableVersion())
+                .font(.caption)
+                .foregroundStyle(Color.pcTextSecondary)
+                .padding(.top, 5)
         }
         .padding(80)
         .frame(width: 862, alignment: .center)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->
Just displays the version number on profile so it's easier to support issues

## To test

- Start the app
- Open Profile icon
- Check if the version number shown on the bottom

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
