### PR TITLE
TV: Refactor HomeSection into shared RowSection

### DIFF
--- a/Pocket Casts TV App/UI/Common/RowSection.swift
+++ b/Pocket Casts TV App/UI/Common/RowSection.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Single source of truth for the spacing between Home + Discover sections
+/// and between a section's title and its content row.
+enum HomeSectionLayout {
+    static let titleSpacing: CGFloat = 16
+    static let sectionSpacing: CGFloat = 64
+}
+
+struct HomeSection<Content: View>: View {
+    private let title: String
+    private let focusSection: AnyHashable
+    private let content: Content
+
+    @Environment(FocusStore.self) var focusStore
+
+    init(title: String, focusSection: AnyHashable, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+        self.focusSection = focusSection
+    }
+
+    private var isFocusedSection: Bool {
+        focusStore.focusedID == focusSection
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: HomeSectionLayout.titleSpacing) {
+            titleView
+            content
+        }
+        .focusSection()
+    }
+
+    // Always reserve space for the larger (focused) title so the layout
+    // doesn't jump when the title resizes on focus changes. A hidden copy at
+    // the largest font sizes the slot; the visible title is overlaid and
+    // bottom-aligned so its distance to the content below stays constant.
+    private var titleView: some View {
+        Text(title)
+            .font(.title3)
+            .hidden()
+            .overlay(alignment: .bottomLeading) {
+                Text(title)
+                    .font(isFocusedSection ? .title3 : .headline)
+                    .foregroundStyle(Color.pcTextPrimary)
+            }
+    }
+}

--- a/Pocket Casts TV App/UI/Common/RowSection.swift
+++ b/Pocket Casts TV App/UI/Common/RowSection.swift
@@ -2,12 +2,12 @@ import SwiftUI
 
 /// Single source of truth for the spacing between Home + Discover sections
 /// and between a section's title and its content row.
-enum HomeSectionLayout {
+enum RowSectionLayout {
     static let titleSpacing: CGFloat = 16
     static let sectionSpacing: CGFloat = 64
 }
 
-struct HomeSection<Content: View>: View {
+struct RowSection<Content: View>: View {
     private let title: String
     private let focusSection: AnyHashable
     private let content: Content
@@ -25,7 +25,7 @@ struct HomeSection<Content: View>: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: HomeSectionLayout.titleSpacing) {
+        VStack(alignment: .leading, spacing: RowSectionLayout.titleSpacing) {
             titleView
             content
         }

--- a/Pocket Casts TV App/UI/Common/RowSection.swift
+++ b/Pocket Casts TV App/UI/Common/RowSection.swift
@@ -37,13 +37,16 @@ struct RowSection<Content: View>: View {
     // the largest font sizes the slot; the visible title is overlaid and
     // bottom-aligned so its distance to the content below stays constant.
     private var titleView: some View {
-        Text(title)
-            .font(.title3)
-            .hidden()
-            .overlay(alignment: .bottomLeading) {
-                Text(title)
-                    .font(isFocusedSection ? .title3 : .headline)
-                    .foregroundStyle(Color.pcTextPrimary)
-            }
+        HStack {
+            Text(title)
+                .font(.title3)
+                .hidden()
+                .overlay(alignment: .bottomLeading) {
+                    Text(title)
+                        .font(isFocusedSection ? .title3 : .headline)
+                        .foregroundStyle(Color.pcTextPrimary)
+                }
+            Spacer()
+        }
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
@@ -31,7 +31,7 @@ struct DiscoverAllView: View {
 
     var discoverList: some View {
         ScrollView {
-            LazyVStack(spacing: HomeSectionLayout.sectionSpacing) {
+            LazyVStack(spacing: RowSectionLayout.sectionSpacing) {
                 ForEach(Array(model.sections.enumerated()), id: \.offset) { _, item in
                     DiscoverRowSection(item: item, source: DiscoverAnalytics.searchSource)
                 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoriesRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoriesRow.swift
@@ -22,7 +22,7 @@ struct DiscoverCategoriesRow: View {
             case .empty:
                 EmptyView()
             case .ready:
-                HomeSection(title: L10n.tvHomeBrowseCategoriesSectionTitle, focusSection: DiscoverType.categories.rawValue) {
+                RowSection(title: L10n.tvHomeBrowseCategoriesSectionTitle, focusSection: DiscoverType.categories.rawValue) {
                     list
                 }
             }

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastsRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastsRow.swift
@@ -29,7 +29,7 @@ struct DiscoverFeaturedPodcastsRow: View {
             case .empty:
                 EmptyView()
             case .ready:
-                HomeSection(title: model.title, focusSection: model.focusStoreID) {
+                RowSection(title: model.title, focusSection: model.focusStoreID) {
                     podcastList
                 }
             }

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -29,7 +29,7 @@ struct DiscoverPodcastRow: View {
             case .empty:
                 EmptyView()
             case .ready:
-                HomeSection(title: model.title, focusSection: model.focusStoreID) {
+                RowSection(title: model.title, focusSection: model.focusStoreID) {
                     podcastList
                 }
             }

--- a/Pocket Casts TV App/UI/Discover/DiscoverSinglePodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSinglePodcastRow.swift
@@ -20,7 +20,7 @@ struct DiscoverSinglePodcastRow: View {
             case .empty:
                 EmptyView()
             case .ready:
-                HomeSection(title: (model.item?.isSponsored ?? false) ? L10n.tvSponsoredPodcastSectionTitle : model.title, focusSection: model.focusStoreID) {
+                RowSection(title: (model.item?.isSponsored ?? false) ? L10n.tvSponsoredPodcastSectionTitle : model.title, focusSection: model.focusStoreID) {
                     podcastList
                 }
             }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodesRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodesRow.swift
@@ -33,7 +33,7 @@ struct DiscoverVideoEpisodesRow: View {
             case .empty:
                 EmptyView()
             case .ready:
-                HomeSection(title: model.title, focusSection: model.focusStoreID) {
+                RowSection(title: model.title, focusSection: model.focusStoreID) {
                     mainContent
                 }
             }

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -195,54 +195,6 @@ struct HomeView: View {
     }
 }
 
-/// Single source of truth for the spacing between Home + Discover sections
-/// and between a section's title and its content row.
-enum HomeSectionLayout {
-    static let titleSpacing: CGFloat = 16
-    static let sectionSpacing: CGFloat = 64
-}
-
-struct HomeSection<Content: View>: View {
-    private let title: String
-    private let focusSection: AnyHashable
-    private let content: Content
-
-    @Environment(FocusStore.self) var focusStore
-
-    init(title: String, focusSection: AnyHashable, @ViewBuilder content: () -> Content) {
-        self.title = title
-        self.content = content()
-        self.focusSection = focusSection
-    }
-
-    private var isFocusedSection: Bool {
-        focusStore.focusedID == focusSection
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: HomeSectionLayout.titleSpacing) {
-            titleView
-            content
-        }
-        .focusSection()
-    }
-
-    // Always reserve space for the larger (focused) title so the layout
-    // doesn't jump when the title resizes on focus changes. A hidden copy at
-    // the largest font sizes the slot; the visible title is overlaid and
-    // bottom-aligned so its distance to the content below stays constant.
-    private var titleView: some View {
-        Text(title)
-            .font(.title3)
-            .hidden()
-            .overlay(alignment: .bottomLeading) {
-                Text(title)
-                    .font(isFocusedSection ? .title3 : .headline)
-                    .foregroundStyle(Color.pcTextPrimary)
-            }
-    }
-}
-
 #Preview {
     HomeView(model: HomeViewModel())
         .environment(AppCoordinator())

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -62,7 +62,7 @@ struct HomeView: View {
     var homeView: some View {
         NavigationStack {
             ScrollView {
-                VStack(alignment: .leading, spacing: HomeSectionLayout.sectionSpacing) {
+                VStack(alignment: .leading, spacing: RowSectionLayout.sectionSpacing) {
                     if coordinator.userState.isLoggedIn {
                         nowPlayingRow
                         upNextRow
@@ -108,7 +108,7 @@ struct HomeView: View {
     @ViewBuilder
     var nowPlayingRow: some View {
         if model.shouldShowNowPlayingRow, let currentPlaying = model.currentPlaying {
-            HomeSection(title: L10n.tvHomeKeepListeningTitle, focusSection: Section.homeNowPlaying.rawValue) {
+            RowSection(title: L10n.tvHomeKeepListeningTitle, focusSection: Section.homeNowPlaying.rawValue) {
                 NowPlayingRow(model: currentPlaying) {
                     showNowPlayingPlayer = true
                 }
@@ -151,7 +151,7 @@ struct HomeView: View {
     @ViewBuilder
     var upNextRow: some View {
         if model.upNext.count > 1 {
-            HomeSection(title: L10n.tvTabUpNext, focusSection: Section.homeUpNext.rawValue) {
+            RowSection(title: L10n.tvTabUpNext, focusSection: Section.homeUpNext.rawValue) {
                 ScrollView(.horizontal) {
                     LazyHStack(spacing: 24) {
                         ForEach(model.upNext) { episode in
@@ -180,7 +180,7 @@ struct HomeView: View {
     }
 
     var newReleasesRow: some View {
-        HomeSection(title: L10n.tvHomeNewReleases, focusSection: Section.homeNewReleases.rawValue) {
+        RowSection(title: L10n.tvHomeNewReleases, focusSection: Section.homeNewReleases.rawValue) {
             ScrollView(.horizontal) {
                 LazyHStack(spacing: 24) {
                     ForEach(model.newReleases) { episode in


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

This PR refactors the Apple TV `HomeSection` into a shared, more generically-named `RowSection`, since the component is used by both the Home and Discover screens.

Changes:
- Moved `HomeSection` (and its `HomeSectionLayout` constants) out of `HomeView.swift` into a dedicated `RowSection.swift` under `UI/Common/`, renaming them to `RowSection` / `RowSectionLayout` to better reflect their shared use.
- Updated all Home and Discover call sites to use the new `RowSection` / `RowSectionLayout` names.
- Wrapped the section title in an `HStack` with a trailing `Spacer()` so the title always stays leading-aligned regardless of the content row's width.

No behavior change is intended — this is a rename/move plus a layout fix to keep titles left-aligned.

## To test

1. Build and run the Pocket Casts TV App.
2. Open the Home screen and confirm the "Keep Listening", "Up Next" and "New Releases" sections render with their titles correctly positioned and spaced.
3. Move focus between sections and confirm the title resizes on focus without the layout jumping.
4. Open the Discover screen and confirm all rows (categories, featured, single podcast, video episodes, etc.) render with titles left-aligned and consistent spacing.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
