### PR TITLE
[PC TV] Refactor Toast to use SwiftUI glass material

### DIFF
--- a/Pocket Casts TV App/UI/Common/Toast/ToastManager.swift
+++ b/Pocket Casts TV App/UI/Common/Toast/ToastManager.swift
@@ -5,13 +5,13 @@ class ToastManager {
     static let shared = ToastManager()
     private init() {}
 
-    private var currentToast: UIView?
+    private var currentToast: UIHostingController<ToastView>?
     private var dismissTask: Task<Void, Never>?
 
     func show(_ message: String, duration: TimeInterval = 3.0) {
         Task { @MainActor in
             dismissTask?.cancel()
-            currentToast?.removeFromSuperview()
+            currentToast?.view.removeFromSuperview()
 
             guard let hostView = ToastWindow.shared?.rootViewController?.view else { return }
 
@@ -21,7 +21,7 @@ class ToastManager {
             }
             toast.translatesAutoresizingMaskIntoConstraints = false
             hostView.addSubview(toast)
-            currentToast = toast
+            currentToast = toastVC
 
             NSLayoutConstraint.activate([
                 toast.trailingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.trailingAnchor, constant: 0),
@@ -33,7 +33,7 @@ class ToastManager {
             toast.transform = CGAffineTransform(translationX: 300, y: 0)
             UIView.animate(withDuration: 0.3) {
                 toast.alpha = 1
-                toast.transform = CGAffineTransform(translationX: 0, y: 0)
+                toast.transform = .identity
             }
 
             dismissTask = Task { [weak self] in
@@ -44,7 +44,7 @@ class ToastManager {
                     toast.transform = CGAffineTransform(translationX: 0, y: 20)
                 }) { _ in
                     toast.removeFromSuperview()
-                    if self?.currentToast === toast {
+                    if self?.currentToast?.view === toast {
                         self?.currentToast = nil
                     }
                 }

--- a/Pocket Casts TV App/UI/Common/Toast/ToastManager.swift
+++ b/Pocket Casts TV App/UI/Common/Toast/ToastManager.swift
@@ -1,10 +1,11 @@
 import UIKit
+import SwiftUI
 
 class ToastManager {
     static let shared = ToastManager()
     private init() {}
 
-    private var currentToast: ToastView?
+    private var currentToast: UIView?
     private var dismissTask: Task<Void, Never>?
 
     func show(_ message: String, duration: TimeInterval = 3.0) {
@@ -14,21 +15,25 @@ class ToastManager {
 
             guard let hostView = ToastWindow.shared?.rootViewController?.view else { return }
 
-            let toast = ToastView(message: message)
+            let toastVC = UIHostingController(rootView: ToastView(message: message))
+            guard let toast = toastVC.view else {
+                return
+            }
+            toast.translatesAutoresizingMaskIntoConstraints = false
             hostView.addSubview(toast)
             currentToast = toast
 
             NSLayoutConstraint.activate([
                 toast.trailingAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.trailingAnchor, constant: 0),
-                toast.topAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.topAnchor, constant: 62),
+                toast.topAnchor.constraint(equalTo: hostView.safeAreaLayoutGuide.topAnchor, constant: -80),
                 toast.widthAnchor.constraint(lessThanOrEqualTo: hostView.widthAnchor, multiplier: 0.6)
             ])
 
             toast.alpha = 0
-            toast.transform = CGAffineTransform(translationX: 0, y: 20)
+            toast.transform = CGAffineTransform(translationX: 300, y: 0)
             UIView.animate(withDuration: 0.3) {
                 toast.alpha = 1
-                toast.transform = .identity
+                toast.transform = CGAffineTransform(translationX: 0, y: 0)
             }
 
             dismissTask = Task { [weak self] in

--- a/Pocket Casts TV App/UI/Common/Toast/ToastView.swift
+++ b/Pocket Casts TV App/UI/Common/Toast/ToastView.swift
@@ -6,6 +6,8 @@ struct ToastView: View {
 
     var body: some View {
         Text(message)
+            .font(.caption)
+            .multilineTextAlignment(.center)
             .padding(.horizontal, 30)
             .padding(.vertical, 20)
             .glassEffect(.regular)

--- a/Pocket Casts TV App/UI/Common/Toast/ToastView.swift
+++ b/Pocket Casts TV App/UI/Common/Toast/ToastView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct ToastView: View {
+
+    let message: String
+
+    var body: some View {
+        HStack {
+            Text(message)
+                .padding(.horizontal, 30)
+                .padding(.vertical, 20)
+        }
+        .glassEffect(.regular)
+    }
+}

--- a/Pocket Casts TV App/UI/Common/Toast/ToastView.swift
+++ b/Pocket Casts TV App/UI/Common/Toast/ToastView.swift
@@ -5,11 +5,9 @@ struct ToastView: View {
     let message: String
 
     var body: some View {
-        HStack {
-            Text(message)
-                .padding(.horizontal, 30)
-                .padding(.vertical, 20)
-        }
-        .glassEffect(.regular)
+        Text(message)
+            .padding(.horizontal, 30)
+            .padding(.vertical, 20)
+            .glassEffect(.regular)
     }
 }

--- a/Pocket Casts TV App/UI/Common/Toast/ToastWindow.swift
+++ b/Pocket Casts TV App/UI/Common/Toast/ToastWindow.swift
@@ -38,35 +38,3 @@ class ToastHostViewController: UIViewController {
         view.isUserInteractionEnabled = false
     }
 }
-
-class ToastView: UIView {
-    private let messageLabel = UILabel()
-
-    init(message: String) {
-        super.init(frame: .zero)
-        setupUI(message: message)
-    }
-
-    required init?(coder: NSCoder) { fatalError() }
-
-    private func setupUI(message: String) {
-        backgroundColor = .pcBackgroundOverlay
-        layer.cornerRadius = 10
-        translatesAutoresizingMaskIntoConstraints = false
-
-        messageLabel.text = message
-        messageLabel.textColor = .pcTextPrimary
-        messageLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
-        messageLabel.numberOfLines = 0
-        messageLabel.textAlignment = .center
-        messageLabel.translatesAutoresizingMaskIntoConstraints = false
-
-        addSubview(messageLabel)
-        NSLayoutConstraint.activate([
-            messageLabel.topAnchor.constraint(equalTo: topAnchor, constant: 20),
-            messageLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -20),
-            messageLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30),
-            messageLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -30),
-        ])
-    }
-}


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Refactors the Apple TV Toast to use SwiftUI with the system Liquid Glass material, replacing the previous hand-rolled UIKit `ToastView`.

### What changed
- Replaced the UIKit `ToastView: UIView` (deleted from `ToastWindow.swift`) with a SwiftUI `ToastView` rendered via `UIHostingController`.
- The toast background is now the system `.glassEffect(.regular)` material (the TV target deploys to tvOS 26, so no availability guard is needed).
- Updated the entry animation to slide in from the trailing edge.

### Cleanups (from a follow-up simplify pass)
- `ToastManager` now retains the `UIHostingController` (via `currentToast`) instead of only its `.view`, so the SwiftUI host isn't deallocated while the toast is still animating on screen.
- Restored `.identity` for the reset transform and dropped a redundant single-child `HStack` wrapper in `ToastView`.

## To test

1. Run the Apple TV app.
2. Trigger an action that shows a toast (e.g. an episode/podcast action that surfaces feedback).
3. Confirm the toast slides in from the trailing edge with the glass material, stays for ~3s, then animates out.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
