### PR TITLE
Migrate deprecated onChange(of:perform:) to iOS 17 two-parameter API

### DIFF
--- a/Pocket Casts Watch App/UI/Main Page/SourceInterfaceNavigationView.swift
+++ b/Pocket Casts Watch App/UI/Main Page/SourceInterfaceNavigationView.swift
@@ -137,7 +137,7 @@ struct SourceInterfaceNavigationView: View {
                 refreshAccountSection
             }.onAppear {
                 model.willActivate()
-            }.onChange(of: activeSource) { newValue in
+            }.onChange(of: activeSource) { _, newValue in
                 guard let newValue, let newSource = Source(rawValue: newValue) else {
                     return
                 }

--- a/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingContainerView.swift
+++ b/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingContainerView.swift
@@ -28,7 +28,7 @@ struct NowPlayingContainerView: View {
         }
         .navigationTitle(L10n.nowPlayingShortTitle.prefixSourceUnicode)
         .restorable(.nowPlaying)
-        .onChange(of: optionSelected) { _ in
+        .onChange(of: optionSelected) {
             withAnimation {
                 selection = 2
             }

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleView.swift
@@ -32,7 +32,7 @@ struct BookmarkEditTitleView: View {
         .frame(maxWidth: .infinity)
         .padding()
         .background(theme.background)
-        .onChange(of: viewModel.didAppear) { _ in
+        .onChange(of: viewModel.didAppear) {
             focusedField = .title
         }
     }
@@ -126,12 +126,12 @@ struct BookmarkEditTitleView: View {
                 .frame(height: textFieldSize.height)
 
                 // Enforce the max length of the title
-                .onChange(of: bookmarkTitle, perform: { newValue in
+                .onChange(of: bookmarkTitle) { _, newValue in
                     let max = Constants.Values.bookmarkMaxTitleLength
                     guard newValue.count > max else { return }
 
                     bookmarkTitle = String(newValue.prefix(max))
-                })
+                }
 
                 // Trigger the save action
                 .onSubmit {

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -223,8 +223,8 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
             if useExternalActionBar {
                 content()
                     .onAppear { notifyExternalActionBar() }
-                    .onChange(of: viewModel.numberOfSelectedItems) { _ in notifyExternalActionBar() }
-                    .onChange(of: viewModel.isMultiSelecting) { _ in notifyExternalActionBar() }
+                    .onChange(of: viewModel.numberOfSelectedItems) { notifyExternalActionBar() }
+                    .onChange(of: viewModel.isMultiSelecting) { notifyExternalActionBar() }
                     .onDisappear {
                         externalActionBarHandler?(ExternalActionBarState(visible: false, title: nil, showEdit: false, showShare: false, isMultiSelecting: false))
                     }

--- a/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Plans View/CancelSubscriptionPlanRow.swift
@@ -31,8 +31,8 @@ struct CancelSubscriptionPlanRow: View {
                                 .onAppear {
                                     badgeHeight = proxy.size.height
                                 }
-                                .onChange(of: proxy.size.height) {
-                                    badgeHeight = $0
+                                .onChange(of: proxy.size.height) { _, newValue in
+                                    badgeHeight = newValue
                                 }
                         }
                     )

--- a/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyView.swift
@@ -44,7 +44,7 @@ struct CancelSubscriptionSurveyView: View {
                     }
                     .id("content")
                 }
-                .onChange(of: isFocused) { focused in
+                .onChange(of: isFocused) { _, focused in
                     withAnimation {
                         scrollProxy.scrollTo(focused ? "bottom" : "content", anchor: focused ? .bottom : .top)
                     }

--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -128,14 +128,14 @@ struct CategoriesPillsView: View {
                 .presentationDetents([.medium, .large])
                     .presentationDragIndicator(.hidden)
         }
-        .onChange(of: showingCategories) { isShowing in
+        .onChange(of: showingCategories) { _, isShowing in
             if isShowing {
                 Analytics.track(.discoverCategoriesPickerShown, properties: ["region": region ?? "none"])
             } else {
                 Analytics.track(.discoverCategoriesPickerClosed, properties: ["region": region ?? "none"])
             }
         }
-        .onChange(of: selectedCategory) { _ in
+        .onChange(of: selectedCategory) {
             showingCategories = false
         }
     }

--- a/podcasts/Common SwiftUI/Toast/ToastView.swift
+++ b/podcasts/Common SwiftUI/Toast/ToastView.swift
@@ -57,14 +57,14 @@ struct ToastView<Style: ToastTheme>: View {
             .font(size: 14, style: .subheadline, weight: .medium)
         }
         // Wait for the initial content size to be calculated before appearing so we can animate in
-        .onChange(of: contentSize, perform: { _ in
+        .onChange(of: contentSize) {
             guard !isVisible else { return }
 
             isVisible = true
             viewModel.didAppear()
-        })
+        }
         // Inform the view model that we're dismissing
-        .onChange(of: dismissDirection) { newValue in
+        .onChange(of: dismissDirection) { _, newValue in
             guard newValue != .none else { return }
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
@@ -72,7 +72,7 @@ struct ToastView<Style: ToastTheme>: View {
             }
         }
         // Handle when the view model tells us to auto dismiss
-        .onChange(of: viewModel.didAutoDismiss) { newValue in
+        .onChange(of: viewModel.didAutoDismiss) { _, newValue in
             guard newValue, dismissDirection == .none else { return }
 
             autoDismiss()

--- a/podcasts/DeveloperMenu.swift
+++ b/podcasts/DeveloperMenu.swift
@@ -400,7 +400,7 @@ struct DeveloperMenu: View {
                 Toggle(isOn: $enableDebugPlaylistLimit) {
                     Text("Enable Debug Playlists limit")
                 }
-                .onChange(of: enableDebugPlaylistLimit) { newValue in
+                .onChange(of: enableDebugPlaylistLimit) { _, newValue in
                     Settings.debugPlaylistsLimit = newValue ? 6 : Constants.Limits.maxFilterItems
                 }
                 Button("Show Playlists Onboarding") {

--- a/podcasts/End of Year/Stories/2025/IntroStory2025.swift
+++ b/podcasts/End of Year/Stories/2025/IntroStory2025.swift
@@ -46,7 +46,7 @@ struct IntroStory2025: StoryView {
                 )
                 .opacity(animationFinished ? 0 : opacity)
         }
-        .onChange(of: animationProgress) { position in
+        .onChange(of: animationProgress) { _, position in
             if afterLoading {
                 self.opacity = 1
                 self.scale = 10

--- a/podcasts/End of Year/Stories/2025/NumberListened2025.swift
+++ b/podcasts/End of Year/Stories/2025/NumberListened2025.swift
@@ -122,7 +122,7 @@ struct NumberListened2025: ShareableStory {
                 stepCounter.start()
             }
         }
-        .onChange(of: stepCounter.counter) { _ in
+        .onChange(of: stepCounter.counter) {
             startCoverAnimation()
         }
     }

--- a/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
+++ b/podcasts/End of Year/Stories/2025/PaidStoryWallView2025.swift
@@ -102,7 +102,7 @@ struct PaidStoryWallView2025: StoryView {
                 .ignoresSafeArea()
                 .allowsHitTesting(false)
         }
-        .onChange(of: subscriptionModel.subscriptionTier) { newValue in
+        .onChange(of: subscriptionModel.subscriptionTier) { _, newValue in
             if newValue != subscriptionTier, newValue != .none {
                 pauseState.play()
                 storyModel.next()

--- a/podcasts/End of Year/Views/StoriesView.swift
+++ b/podcasts/End of Year/Views/StoriesView.swift
@@ -96,7 +96,7 @@ struct StoriesView: View {
                 notNowAction: model.start
             )
         )
-        .onChange(of: pauseState.isPaused) { isPaused in
+        .onChange(of: pauseState.isPaused) { _, isPaused in
             if isPaused {
                 model.pause()
             } else {

--- a/podcasts/Folders/Create & Edit/Views/EditFolderView.swift
+++ b/podcasts/Folders/Create & Edit/Views/EditFolderView.swift
@@ -22,7 +22,7 @@ struct EditFolderView: View {
                         .padding(.bottom, -8)
                         .padding(.top, 30)
                     TextField("", text: $model.name)
-                        .onChange(of: model.name, perform: model.validateFolderName)
+                        .onChange(of: model.name) { _, newValue in model.validateFolderName(newValue) }
                         .themedTextField()
                 }
                 .padding(.bottom, 10)

--- a/podcasts/Folders/Create & Edit/Views/NameFolderView.swift
+++ b/podcasts/Folders/Create & Edit/Views/NameFolderView.swift
@@ -21,7 +21,7 @@ struct NameFolderView: View {
             Text(L10n.name.localizedUppercase)
                 .textStyle(SecondaryText())
                 .font(.subheadline)
-                .onChange(of: model.name, perform: model.validateFolderName)
+                .onChange(of: model.name) { _, newValue in model.validateFolderName(newValue) }
             TextField(L10n.folderName, text: $model.name)
                 .focusMe(state: $focusOnTextField)
                 .themedTextField()
@@ -64,7 +64,7 @@ struct FocusModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content.focused($focused, equals: true)
-            .onChange(of: state, perform: changeFocus)
+            .onChange(of: state) { _, newValue in changeFocus(newValue) }
     }
 
     private func changeFocus(_ value: Bool) {

--- a/podcasts/Folders/Create & Edit/Views/SuggestedFoldersView.swift
+++ b/podcasts/Folders/Create & Edit/Views/SuggestedFoldersView.swift
@@ -138,7 +138,7 @@ struct SuggestedFoldersView: View {
         .onAppear {
             track(.suggestedFoldersPageShown)
         }
-        .onChange(of: createFolderActive) { newFolder in
+        .onChange(of: createFolderActive) { _, newFolder in
             if newFolder {
                 track(.suggestedFoldersCreateCustomFolderTapped)
             }

--- a/podcasts/New Search/Views/Results/LocalSearchView.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchView.swift
@@ -57,7 +57,7 @@ struct LocalSearchView: View {
                     view
                 }
             })
-            .onChange(of: navigationPath) { newValue in
+            .onChange(of: navigationPath) { _, newValue in
                 UIApplication.shared.endEditing(true) // Dismiss the keyboard and end editing any time we navigate between sections.
                 handleNavigationPathChange(newValue, previousPath: previousNavigationPath)
                 previousNavigationPath = newValue

--- a/podcasts/New Search/Views/Results/NewSearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/NewSearchResultsView.swift
@@ -112,7 +112,7 @@ struct NewSearchResultsView: View {
         }
         .padding(.bottom, 8)
         .background(theme.secondaryUi01)
-        .onChange(of: displayMode) { newValue in
+        .onChange(of: displayMode) { _, newValue in
             searchAnalyticsHelper.trackFilterTapped(newValue.analyticsDescription)
         }
     }

--- a/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalView.swift
+++ b/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalView.swift
@@ -48,7 +48,7 @@ struct InformationalModalView: View {
                 }
         }
         .background(theme.primaryUi01.ignoresSafeArea())
-        .onChange(of: currentIndex ?? 0) { newValue in
+        .onChange(of: currentIndex ?? 0) { _, newValue in
             viewModel.pageDidChange(newValue)
         }
     }

--- a/podcasts/Onboarding/Patron/PatronAppIconUnlock.swift
+++ b/podcasts/Onboarding/Patron/PatronAppIconUnlock.swift
@@ -72,7 +72,7 @@ struct PatronAppIconUnlock: View {
         }
         .background(pinWheelBackground)
         .background(Color(hex: "F3F0FE"))
-        .onChange(of: isUnlocked) { newValue in
+        .onChange(of: isUnlocked) { _, newValue in
             guard newValue, !reduceMotion else { return }
 
             haptics.spring()

--- a/podcasts/Onboarding/Plus/UpgradeLandingView.swift
+++ b/podcasts/Onboarding/Plus/UpgradeLandingView.swift
@@ -99,10 +99,10 @@ struct UpgradeLandingView: View {
                                 contentIsScrollable = true
                             }
                         }
-                        .onChange(of: currentPage) { value in
+                        .onChange(of: currentPage) { _, value in
                             viewModel.changedSubscriptionTier(value)
                         }
-                        .onChange(of: currentSubscriptionPeriod) { value in
+                        .onChange(of: currentSubscriptionPeriod) { _, value in
                             viewModel.changedSubscriptionPeriod(value)
                         }
                     }

--- a/podcasts/PressableLottieButtonStyle.swift
+++ b/podcasts/PressableLottieButtonStyle.swift
@@ -34,7 +34,7 @@ struct PressableLottieButtonStyle: ButtonStyle {
 
                 configuration.label
             }
-            .onChange(of: configuration.isPressed) { isPressed in
+            .onChange(of: configuration.isPressed) { _, isPressed in
                 if isPressed && !lastPressed {
                     haptic()
                     if replayOnPress {

--- a/podcasts/Sharing/Clip/MediaTrimBar.swift
+++ b/podcasts/Sharing/Clip/MediaTrimBar.swift
@@ -36,7 +36,7 @@ struct MediaTrimBar: View {
                                          bottomTrailingRadius: 0,
                                          topTrailingRadius: 0))
                 }
-                .onChange(of: isPlaying) { isPlaying in
+                .onChange(of: isPlaying) { _, isPlaying in
                     if isPlaying {
                         playbackManager.play(episode: episode, clipTime: _clipTime)
                     } else {
@@ -49,7 +49,7 @@ struct MediaTrimBar: View {
                     playbackManager.stop()
                 }
             MediaTrimView(duration: episode.duration, startTime: $clipTime.start, endTime: $clipTime.end, playTime: $clipTime.playback)
-                .onChange(of: clipTime.playback) { newValue in
+                .onChange(of: clipTime.playback) { _, newValue in
                     if let currentTime = playbackManager.currentTime, abs(currentTime - newValue) > 0.1 {
                         playbackManager.seek(to: CMTime(seconds: newValue, preferredTimescale: 600))
                     }

--- a/podcasts/Sharing/Clip/MediaTrimView.swift
+++ b/podcasts/Sharing/Clip/MediaTrimView.swift
@@ -36,10 +36,10 @@ struct MediaTrimView: View {
                 AudioWaveformView(width: geometry.size.width * scale)
                     .border(Colors.trimBorderColor, width: Constants.trimLineWidth)
                 PlayheadView(position: scaledPosition($playPosition), validRange: scaledPosition($startPosition).wrappedValue...scaledPosition($endPosition).wrappedValue)
-                    .onChange(of: playTime) { playTime in
+                    .onChange(of: playTime) { _, playTime in
                         playPosition = durationRelative(value: playTime, for: geometry.size.width).clamped(to: startPosition...endPosition)
                     }
-                    .onChange(of: playPosition) { playPosition in
+                    .onChange(of: playPosition) { _, playPosition in
                         playTime = (playPosition * duration) / geometry.size.width
                     }
                     .frame(width: Constants.playLineWidth)

--- a/podcasts/Sharing/Clip/PlayheadView.swift
+++ b/podcasts/Sharing/Clip/PlayheadView.swift
@@ -28,7 +28,7 @@ struct PlayheadView: View {
                             position = realPosition
                         }
                 )
-                .onChange(of: position) { position in
+                .onChange(of: position) { _, position in
                     // Only update playhead when not dragging
                     if lastTranslation == nil {
                         realPosition = position

--- a/podcasts/Styles.swift
+++ b/podcasts/Styles.swift
@@ -412,7 +412,7 @@ extension View {
         self
             .scaleEffect(isPressed ? scaleEffectNumber : 1.0, anchor: .center)
             .animation(.interpolatingSpring(stiffness: 350, damping: 10, initialVelocity: 10), value: isPressed)
-            .onChange(of: isPressed) { pressed in
+            .onChange(of: isPressed) { _, pressed in
                 guard enableHaptic, pressed else { return }
 
                 UIImpactFeedbackGenerator(style: .rigid).impactOccurred()

--- a/podcasts/Syncing/SyncSigninView.swift
+++ b/podcasts/Syncing/SyncSigninView.swift
@@ -86,7 +86,7 @@ struct SyncSigninView: View {
                 .submitLabel(.next)
                 .focused($focusedField, equals: .email)
                 .onSubmit { focusedField = .password }
-                .onChange(of: model.email) { _ in model.textFieldChanged() }
+                .onChange(of: model.email) { model.textFieldChanged() }
         }
         .padding(9)
         .themedTextField(hasErrored: model.errorMessage != nil)
@@ -118,7 +118,7 @@ struct SyncSigninView: View {
                 .accessibilityLabel(model.showPassword ? L10n.signInHidePasswordLabel : L10n.signInShowPasswordLabel)
                 .tint(theme.primaryIcon03)
             }
-            .onChange(of: model.password) { _ in model.textFieldChanged() }
+            .onChange(of: model.password) { model.textFieldChanged() }
         }
         .padding(9)
         .themedTextField(hasErrored: model.errorMessage != nil)

--- a/podcasts/Utilities/SwiftUI/ContentSizeGeometryReader.swift
+++ b/podcasts/Utilities/SwiftUI/ContentSizeGeometryReader.swift
@@ -27,7 +27,7 @@ struct ContentSizeGeometryReader<Content: View>: View {
         }
         .frame(maxWidth: contentSize != .zero ? contentSize.width : nil)
         .frame(maxHeight: contentSize != .zero ? contentSize.height : nil)
-        .onChange(of: contentSize) { newValue in
+        .onChange(of: contentSize) { _, newValue in
             contentSizeUpdated?(newValue)
         }
     }

--- a/podcasts/Utilities/SwiftUI/HorizontalCarousel.swift
+++ b/podcasts/Utilities/SwiftUI/HorizontalCarousel.swift
@@ -155,7 +155,7 @@ struct HorizontalCarousel<Content: View, T: Identifiable>: View {
                     })
                 , including: scrollEnabled ? .all : .subviews)
             // Update the internal visible index if the selection index changes
-            .onChange(of: index) { newValue in
+            .onChange(of: index) { _, newValue in
                 visibleIndex = newValue
             }
         }
@@ -263,14 +263,14 @@ struct CarouselEqualHeightsView<Content: View>: View {
         ContentSizeReader(contentSize: $contentSize) {
             content()
         }
-        .onChange(of: contentSize, perform: { newValue in
+        .onChange(of: contentSize) { _, newValue in
             // Don't send changes for small increments
             guard Int(newValue.height) != Int(calculatedHeight) else {
                 return
             }
 
             calculatedHeight = newValue.height
-        })
+        }
         .preference(key: CarouselEqualHeightsKey.self, value: [calculatedHeight])
     }
 }

--- a/podcasts/Utilities/SwiftUI/NonBlockingLongPressView.swift
+++ b/podcasts/Utilities/SwiftUI/NonBlockingLongPressView.swift
@@ -21,7 +21,7 @@ struct NonBlockingLongPressView<Content: View>: View {
         // ScrollView drag will stop working
         .simultaneousGesture(longPressGesture)
         .highPriorityGesture(tapGesture)
-        .onChange(of: pressed) { newValue in
+        .onChange(of: pressed) { _, newValue in
             onPressed?(newValue)
         }
     }

--- a/podcasts/Utilities/SwiftUI/SearchField.swift
+++ b/podcasts/Utilities/SwiftUI/SearchField.swift
@@ -101,13 +101,13 @@ struct SearchField: View {
         .opacity(isEnabled ? 1 : 0.8)
 
         // Animate the shows cancel button in or out
-        .onChange(of: isFocused) { newValue in
+        .onChange(of: isFocused) { _, newValue in
             withAnimation {
                 isCancelVisible = newValue
             }
         }
         // If the disabled state changes, then remove focus from the field
-        .onChange(of: isEnabled) { newValue in
+        .onChange(of: isEnabled) { _, newValue in
             guard newValue else { return }
 
             isFocused = false

--- a/podcasts/Utilities/SwiftUI/SelectCircleButtonStyle.swift
+++ b/podcasts/Utilities/SwiftUI/SelectCircleButtonStyle.swift
@@ -28,7 +28,7 @@ struct SelectCircleButtonStyle: ButtonStyle {
                 .animation(.linear(duration: 0.1), value: selected)
             )
             .contentShape(Circle())
-            .onChange(of: configuration.isPressed) { pressed in
+            .onChange(of: configuration.isPressed) { _, pressed in
                 if pressed {
                     selected.toggle()
                 }

--- a/podcasts/Utilities/SwiftUI/View+Buttonize.swift
+++ b/podcasts/Utilities/SwiftUI/View+Buttonize.swift
@@ -55,8 +55,8 @@ struct OnPressedActionButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .contentShape(Rectangle())
-            .onChange(of: configuration.isPressed, perform: { newValue in
+            .onChange(of: configuration.isPressed) { _, newValue in
                 onPressed(newValue)
-            })
+            }
     }
 }


### PR DESCRIPTION
Replaces all deprecated `onChange(of:perform:)` / single-parameter `onChange(of:) { value in }` call sites with the iOS 17+ `onChange(of:initial:_:)` overload, clearing the build warnings.

No behavior change: the new overload defaults `initial: false` (matching the old API, which never fired on initial), and each closure preserves exactly how it used its value:
- `{ newValue in … }` → `{ _, newValue in … }`
- `{ _ in … }` → `{ … }`
- `perform: someFunc` → `{ _, newValue in someFunc(newValue) }`

The `EndOfYear` SwiftPM module (`PlayPauseAnimatableModifier.swift`) is intentionally left as-is: that package targets iOS 16 / watchOS 9, where the new overload isn't available, and the deprecation warning isn't emitted below iOS 17.

## To test

This is a compile-only refactor with no behavior change. Smoke test the touched flows:
1. Build the app — no `onChange(of:perform:)` deprecation warnings remain.
2. Create/edit a Folder — name validation still works as you type.
3. Add/edit a Bookmark — title length limit still enforced.
4. Open Search — filter pills and local-search navigation behave as before.
5. Open the Clip sharing screen — playhead/trim scrubbing and play/pause still work.
6. Trigger a Toast and the End of Year stories — animations/auto-dismiss behave as before.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.