### PR TITLE
Fix force-unwrapping a failable audio buffer during playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.16
 -----
+- Fix a rare crash during playback when an audio buffer fails to allocate [#4645](https://github.com/Automattic/pocket-casts-ios/pull/4645)
 - Add a "Remove from Up Next" multi-select action outside the Up Next screen [#4606](https://github.com/Automattic/pocket-casts-ios/pull/4606)
 - Add a Star Episodes action to Up Next multi-select and show a star indicator on Up Next cells [#4605](https://github.com/Automattic/pocket-casts-ios/pull/4605)
 - Fix the Files navigation bar not being transparent [#4604](https://github.com/Automattic/pocket-casts-ios/pull/4604)

--- a/podcasts/AudioReadTask.swift
+++ b/podcasts/AudioReadTask.swift
@@ -194,9 +194,16 @@ class AudioReadTask {
             return nil
         }
 
-        let audioPCMBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: bufferLength)
+        guard let audioPCMBuffer = AVAudioPCMBuffer(pcmFormat: outputFormat, frameCapacity: bufferLength) else {
+            bufferManager.readErrorOccurred.value = true
+            cancelled.value = true
+            objc_sync_exit(lock)
+            FileLog.shared.addMessage("[AudioReadTask] Failed to allocate AVAudioPCMBuffer (format: \(outputFormat), capacity: \(bufferLength))")
+
+            return nil
+        }
         do {
-            try audioFile.read(into: audioPCMBuffer!)
+            try audioFile.read(into: audioPCMBuffer)
         } catch {
             objc_sync_exit(lock)
             FileLog.shared.addMessage("[AudioReadTask] read failed: \(error.localizedDescription)")
@@ -204,7 +211,7 @@ class AudioReadTask {
         }
 
         // check that we actually read something
-        if audioPCMBuffer?.frameLength == 0 {
+        if audioPCMBuffer.frameLength == 0 {
             objc_sync_exit(lock)
             handleReachedEndOfFile()
 
@@ -228,10 +235,10 @@ class AudioReadTask {
         hasProcessedFirstBuffer = true
 
         // Process through VoiceBoostN if enabled
-        if let vbnState = voiceBoostNState, let buffer = audioPCMBuffer,
-           let channelData = buffer.floatChannelData {
-            let frameCount = Int32(buffer.frameLength)
-            let bufferChannelCount = Int32(buffer.format.channelCount)
+        if let vbnState = voiceBoostNState,
+           let channelData = audioPCMBuffer.floatChannelData {
+            let frameCount = Int32(audioPCMBuffer.frameLength)
+            let bufferChannelCount = Int32(audioPCMBuffer.format.channelCount)
 
             var channelPointers: [UnsafeMutablePointer<Float>?] = []
             for i in 0..<Int(bufferChannelCount) {
@@ -245,7 +252,7 @@ class AudioReadTask {
 
         currentFramePosition = audioFile.framePosition
         fadeInNextFrame = false
-        if channelCount == 0 { channelCount = (audioPCMBuffer?.audioBufferList.pointee.mNumberBuffers)! }
+        if channelCount == 0 { channelCount = audioPCMBuffer.audioBufferList.pointee.mNumberBuffers }
 
         if channelCount == 0 {
             bufferManager.readErrorOccurred.value = true
@@ -260,25 +267,19 @@ class AudioReadTask {
         // In order to prevent this issue, we convert a mono buffer to stereo buffer
         // For more info, see: https://github.com/Automattic/pocket-casts-ios/issues/62
         var audioBuffer: BufferedAudio
-        if let audioPCMBuffer,
-           audioPCMBuffer.audioBufferList.pointee.mNumberBuffers == 1,
+        if audioPCMBuffer.audioBufferList.pointee.mNumberBuffers == 1,
            let twoChannelsFormat = AVAudioFormat(standardFormatWithSampleRate: audioFile.processingFormat.sampleRate, channels: 2),
            let twoChannnelBuffer = AVAudioPCMBuffer(pcmFormat: twoChannelsFormat, frameCapacity: audioPCMBuffer.frameCapacity) {
             let converter = AVAudioConverter(from: audioFile.processingFormat, to: twoChannelsFormat)
             try? converter?.convert(to: twoChannnelBuffer, from: audioPCMBuffer)
             audioBuffer = BufferedAudio(audioBuffer: twoChannnelBuffer, framePosition: currentFramePosition, shouldFadeOut: false, shouldFadeIn: fadeInNextFrame)
         } else {
-            audioBuffer = BufferedAudio(audioBuffer: audioPCMBuffer!, framePosition: currentFramePosition, shouldFadeOut: false, shouldFadeIn: fadeInNextFrame)
+            audioBuffer = BufferedAudio(audioBuffer: audioPCMBuffer, framePosition: currentFramePosition, shouldFadeOut: false, shouldFadeIn: fadeInNextFrame)
         }
 
         var buffers = [BufferedAudio]()
         if trimSilence != .off {
-            guard let bufferListPointer = UnsafeMutableAudioBufferListPointer(audioPCMBuffer?.mutableAudioBufferList) else {
-                buffers.append(audioBuffer)
-                objc_sync_exit(lock)
-
-                return buffers
-            }
+            let bufferListPointer = UnsafeMutableAudioBufferListPointer(audioPCMBuffer.mutableAudioBufferList)
 
             let currPosition = currentFramePosition / Int64(audioFile.fileFormat.sampleRate)
             let totalDuration = cachedFrameCount / Int64(audioFile.fileFormat.sampleRate)
@@ -319,7 +320,7 @@ class AudioReadTask {
                     // pop all the ones we don't need after that
                     while buffersSavedDuringGap.canPop(), buffersSavedDuringGap.count() > (amountOfSilentFramesToReInsert - 1) {
                         _ = buffersSavedDuringGap.pop()
-                        let secondsSaved = Double((audioPCMBuffer?.frameLength)!) / audioFile.fileFormat.sampleRate
+                        let secondsSaved = Double(audioPCMBuffer.frameLength) / audioFile.fileFormat.sampleRate
                         StatsManager.shared.addTimeSavedDynamicSpeed(secondsSaved)
                     }
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

The audio read thread created an `AVAudioPCMBuffer` with its failable initializer and then force-unwrapped it (and optional-chained it) throughout `readFromFile()`. If allocation returned `nil` (memory pressure / invalid format), the force-unwrap trapped — crashing the read thread and bypassing the existing `NSException` + `do/catch` recovery.

This guards the allocation and routes a `nil` result to the existing `readErrorOccurred` error path (matching the nearby `channelCount == 0` recovery), so a failed allocation surfaces a read error instead of crashing. With the buffer now non-optional, all downstream `!`/`?` uses are removed.

## To test

This fixes a rare allocation failure that's hard to reproduce directly, so verify there's no regression in normal playback:

1. Play an episode and confirm audio plays normally.
2. Enable Trim Silence and confirm playback still works.
3. Enable a voice effect (VoiceBoost) and confirm playback still works.
4. Seek within an episode and confirm playback resumes correctly.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.