### PR TITLE
tvOS: Add "Go to Podcast" from episodes

### DIFF
--- a/Pocket Casts TV App/UI/Common/StackPath.swift
+++ b/Pocket Casts TV App/UI/Common/StackPath.swift
@@ -1,0 +1,6 @@
+import SwiftUI
+
+@Observable
+class StackPath {
+    var navigationPath = NavigationPath()
+}

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -59,10 +59,10 @@ struct HomeView: View {
         }
     }
 
-    @State private var path = NavigationPath()
+    @State private var path = StackPath()
 
     var homeView: some View {
-        NavigationStack(path: $path) {
+        NavigationStack(path: $path.navigationPath) {
             ScrollView {
                 VStack(alignment: .leading, spacing: RowSectionLayout.sectionSpacing) {
                     if coordinator.userState.isLoggedIn {
@@ -100,8 +100,12 @@ struct HomeView: View {
             .navigationDestination(for: DiscoverCategory.self) { discoverCategory in
                 DiscoverPodcastsListView(category: discoverCategory)
             }
-            .syncNavigationDetail(path: path, tabRouter: tabRouter)
+            .navigationDestination(for: Podcast.self) { podcast in
+                PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: podcast.uuid))
+            }
+            .syncNavigationDetail(path: path.navigationPath, tabRouter: tabRouter)
         }
+        .environment(path)
         .fullScreenCover(isPresented: $showNowPlayingPlayer) {
             NowPlayingView()
                 .ignoresSafeArea()

--- a/Pocket Casts TV App/UI/Player/EpisodePlayerButton.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodePlayerButton.swift
@@ -12,7 +12,7 @@ struct EpisodePlayerButton: View {
             EpisodeRow(model: model, isActive: false)
         }
         .buttonStyle(EpisodeRowButtonStyle())
-        .episodeContextMenu(model: model)
+        .episodeContextMenu(model: model, context: .other(true))
         .fullScreenCover(isPresented: $isPlaying) {
             NowPlayingView()
                 .ignoresSafeArea()

--- a/Pocket Casts TV App/UI/Player/EpisodePlayerButton.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodePlayerButton.swift
@@ -12,7 +12,7 @@ struct EpisodePlayerButton: View {
             EpisodeRow(model: model, isActive: false)
         }
         .buttonStyle(EpisodeRowButtonStyle())
-        .episodeContextMenu(model: model, context: .other(true))
+        .episodeContextMenu(model: model, context: .other(showGoToPodcast: true))
         .fullScreenCover(isPresented: $isPlaying) {
             NowPlayingView()
                 .ignoresSafeArea()

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -7,6 +7,7 @@ struct NowPlayingView: View {
     @State private var isShowingDescription = false
     @State private var isShowingMarkAsPlayedConfirmation = false
     @State private var isShowingArchiveConfirmation = false
+    @State private var isShowingPodcast = false
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -14,7 +15,8 @@ struct NowPlayingView: View {
             model: model,
             isShowingDescription: $isShowingDescription,
             isShowingMarkAsPlayedConfirmation: $isShowingMarkAsPlayedConfirmation,
-            isShowingArchiveConfirmation: $isShowingArchiveConfirmation
+            isShowingArchiveConfirmation: $isShowingArchiveConfirmation,
+            isShowingPodcast: $isShowingPodcast
         )
         .onAppear {
             model.load()
@@ -53,6 +55,12 @@ struct NowPlayingView: View {
         } message: {
             Text(L10n.playerArchivedConfirmationMessage)
         }
+        .fullScreenCover(isPresented: $isShowingPodcast) {
+            if let uuid = model.podcastUuid {
+                PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid))
+                    .background(Color.pcBackgroundSurface)
+            }
+        }
     }
 }
 
@@ -61,6 +69,7 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
     @Binding var isShowingDescription: Bool
     @Binding var isShowingMarkAsPlayedConfirmation: Bool
     @Binding var isShowingArchiveConfirmation: Bool
+    @Binding var isShowingPodcast: Bool
     // Read here (rather than in the parent `NowPlayingView`) so the gated
     // implementation installed by `.requireAccountSupport()` — applied to
     // this representable above — is the one we see. Reading it upstream
@@ -298,6 +307,16 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
                 }
             }
             children.append(archiveToggle)
+        }
+
+        if model.podcastUuid != nil {
+            let goToPodcast = UIAction(
+                title: L10n.goToPodcast,
+                image: UIImage(systemName: "archivebox")
+            ) { _ in
+                isShowingPodcast = true
+            }
+            children.append(goToPodcast)
         }
 
         // No title: the ellipsis icon already conveys "more", and the

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -312,7 +312,7 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
         if model.podcastUuid != nil {
             let goToPodcast = UIAction(
                 title: L10n.goToPodcast,
-                image: UIImage(systemName: "archivebox")
+                image: UIImage(systemName: "mic.fill")
             ) { _ in
                 isShowingPodcast = true
             }

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -206,11 +206,7 @@ class NowPlayingViewModel: Identifiable {
     }
 
     var podcastUuid: String? {
-        if let episode = episode as? Episode {
-            return episode.podcastUuid
-        } else {
-            return nil
-        }
+        return podcast?.uuid ?? (episode as? Episode)?.podcastUuid
     }
 
     var isPlayed: Bool {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -158,7 +158,7 @@ struct PlaylistDetailView: View {
         List {
             Section {
                 ForEach(model.episodes, id: \.uuid) { episode in
-                    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: episode, podcast: nil), focus: $rowFocus)
+                    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: episode, podcast: nil), context: .other(true), focus: $rowFocus)
                         .prefersDefaultFocus(episode.uuid == model.episodes.first?.uuid, in: episodeListNamespace)
                         .listRowInsets(Layout.rowInsets)
                 }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -158,7 +158,7 @@ struct PlaylistDetailView: View {
         List {
             Section {
                 ForEach(model.episodes, id: \.uuid) { episode in
-                    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: episode, podcast: nil), context: .other(true), focus: $rowFocus)
+                    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: episode, podcast: nil), context: .other(showGoToPodcast: true), focus: $rowFocus)
                         .prefersDefaultFocus(episode.uuid == model.episodes.first?.uuid, in: episodeListNamespace)
                         .listRowInsets(Layout.rowInsets)
                 }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import PocketCastsDataModel
+import PocketCastsServer
 
 struct PlaylistsView: View {
     @Environment(AppCoordinator.self) var coordinator
@@ -42,9 +43,9 @@ struct PlaylistsView: View {
         ProgressView()
     }
 
-    @State private var path = NavigationPath()
+    @State private var path = StackPath()
     var playlistsView: some View {
-        NavigationStack(path: $path) {
+        NavigationStack(path: $path.navigationPath) {
             ScrollView {
                 VStack(alignment: .leading, spacing: 40) {
                     Text(L10n.tvTabPlaylists)
@@ -53,8 +54,14 @@ struct PlaylistsView: View {
                     playlistsCollection
                 }
             }
+            .navigationDestination(for: DiscoverPodcast.self) { podcast in
+                if let uuid = podcast.uuid {
+                    PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid))
+                }
+            }
         }
-        .syncNavigationDetail(path: path, tabRouter: tabRouter)
+        .syncNavigationDetail(path: path.navigationPath, tabRouter: tabRouter)
+        .environment(path)
     }
 
     var emptyView: some View {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -311,8 +311,11 @@ struct DiscoveryEpisodeMenuButtons: View {
 
     @Environment(\.requireAccount) private var requireAccount
 
+    @Environment(StackPath.self) private var stackPath: StackPath?
+
     var body: some View {
         Button(L10n.tvEpisodeShowNotesAction) { load { showNotesEpisode = $0 } }
+        Button(L10n.goToPodcast) { goToPodcast() }
         Button(L10n.playNextInUpNext) { requireAccount { load { EpisodeUpNextActions.playNext($0.episode) } } }
         Button(L10n.playLastInUpNext) { requireAccount { load { EpisodeUpNextActions.playLast($0.episode) } } }
     }
@@ -325,6 +328,12 @@ struct DiscoveryEpisodeMenuButtons: View {
             }
             action(DiscoveryLoadedEpisode(episode: result.episode, podcast: result.podcast))
         }
+    }
+
+    private func goToPodcast() {
+        var podcast = DiscoverPodcast()
+        podcast.uuid = podcastUuid
+        stackPath?.navigationPath.append(podcast)
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -119,7 +119,7 @@ enum EpisodeRowFocus: Hashable {
 struct EpisodeRowWithActions: View {
 
     let model: EpisodeRowViewModel
-    var context: EpisodeActionContext = .other(false)
+    var context: EpisodeActionContext = .other(showGoToPodcast: false)
     @FocusState.Binding var focus: EpisodeRowFocus?
     var customPlayDisplayAction: (() -> ())? = nil
     @State private var isPlaying = false
@@ -212,14 +212,14 @@ struct EpisodeRowWithActions: View {
 }
 
 enum EpisodeActionContext {
-    case other(Bool)
+    case other(showGoToPodcast: Bool)
     case upNext
 }
 
 struct EpisodeActionButtons: View {
 
     let model: EpisodeRowViewModel
-    var context: EpisodeActionContext = .other(false)
+    var context: EpisodeActionContext = .other(showGoToPodcast: false)
     @Binding var isShowingShowNotes: Bool
 
     @Environment(\.requireAccount) private var requireAccount
@@ -234,16 +234,7 @@ struct EpisodeActionButtons: View {
             switch context {
             case .other(let showGoToPodcast):
                 if showGoToPodcast {
-                    Button(L10n.goToPodcast) {
-                        if let podcast = model.podcast {
-                            stackPath?.navigationPath.append(podcast)
-                        } else if let episode = model.episode as? Episode {
-                            let podcastUuid = episode.podcastUuid
-                            var podcast = DiscoverPodcast()
-                            podcast.uuid = podcastUuid
-                            stackPath?.navigationPath.append(podcast)
-                        }
-                    }
+                    Button(L10n.goToPodcast) { goToPodcast() }
                 }
                 Button(L10n.playNextInUpNext) { requireAccount { model.playNext() } }
                 Button(L10n.playLastInUpNext) { requireAccount { model.playLast() } }
@@ -252,10 +243,8 @@ struct EpisodeActionButtons: View {
                     Button(model.isArchived ? L10n.unarchive : L10n.archive) { requireAccount { model.isArchived ? model.unarchive() : model.archive() } }
                 }
             case .upNext:
-                if let podcast = model.podcast {
-                    Button(L10n.goToPodcast) {
-                        stackPath?.navigationPath.append(podcast)
-                    }
+                if model.podcast != nil {
+                    Button(L10n.goToPodcast) { goToPodcast() }
                 }
                 Button(L10n.playNext) { requireAccount { model.playNext() } }
                 Button(L10n.playLast) { requireAccount { model.playLast() } }
@@ -263,6 +252,19 @@ struct EpisodeActionButtons: View {
             }
         }.onAppear {
             Analytics.track(.episodeActionsShown)
+        }
+    }
+
+    /// Pushes the episode's podcast onto the navigation stack, preferring the
+    /// loaded `Podcast` and falling back to a `DiscoverPodcast` built from the
+    /// episode's podcast UUID when only the episode is known.
+    private func goToPodcast() {
+        if let podcast = model.podcast {
+            stackPath?.navigationPath.append(podcast)
+        } else if let episode = model.episode as? Episode {
+            var podcast = DiscoverPodcast()
+            podcast.uuid = episode.podcastUuid
+            stackPath?.navigationPath.append(podcast)
         }
     }
 }
@@ -286,7 +288,7 @@ private struct EpisodeContextMenuModifier: ViewModifier {
 }
 
 extension View {
-    func episodeContextMenu(model: EpisodeRowViewModel, context: EpisodeActionContext = .other(false)) -> some View {
+    func episodeContextMenu(model: EpisodeRowViewModel, context: EpisodeActionContext = .other(showGoToPodcast: false)) -> some View {
         modifier(EpisodeContextMenuModifier(model: model, context: context))
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -208,7 +208,6 @@ struct EpisodeRowWithActions: View {
         .confirmationDialog(model.displayTitle, isPresented: $isShowingActions) {
             EpisodeActionButtons(model: model, context: context, isShowingShowNotes: $isShowingShowNotes)
         }
-        
     }
 }
 

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsUtils
 import PocketCastsDataModel
+import PocketCastsServer
 
 struct EpisodeRowButtonStyle: ButtonStyle {
     @Environment(\.isFocused) var isFocused: Bool
@@ -118,7 +119,7 @@ enum EpisodeRowFocus: Hashable {
 struct EpisodeRowWithActions: View {
 
     let model: EpisodeRowViewModel
-    var context: EpisodeActionContext = .default
+    var context: EpisodeActionContext = .other(false)
     @FocusState.Binding var focus: EpisodeRowFocus?
     var customPlayDisplayAction: (() -> ())? = nil
     @State private var isPlaying = false
@@ -207,21 +208,24 @@ struct EpisodeRowWithActions: View {
         .confirmationDialog(model.displayTitle, isPresented: $isShowingActions) {
             EpisodeActionButtons(model: model, context: context, isShowingShowNotes: $isShowingShowNotes)
         }
+        
     }
 }
 
 enum EpisodeActionContext {
-    case `default`
+    case other(Bool)
     case upNext
 }
 
 struct EpisodeActionButtons: View {
 
     let model: EpisodeRowViewModel
-    var context: EpisodeActionContext = .default
+    var context: EpisodeActionContext = .other(false)
     @Binding var isShowingShowNotes: Bool
 
     @Environment(\.requireAccount) private var requireAccount
+
+    @Environment(StackPath.self) private var stackPath: StackPath?
 
     var body: some View {
         Group {
@@ -229,7 +233,19 @@ struct EpisodeActionButtons: View {
                 Button(L10n.tvEpisodeShowNotesAction) { isShowingShowNotes = true }
             }
             switch context {
-            case .default:
+            case .other(let showGoToPodcast):
+                if showGoToPodcast {
+                    Button(L10n.goToPodcast) {
+                        if let podcast = model.podcast {
+                            stackPath?.navigationPath.append(podcast)
+                        } else if let episode = model.episode as? Episode {
+                            let podcastUuid = episode.podcastUuid
+                            var podcast = DiscoverPodcast()
+                            podcast.uuid = podcastUuid
+                            stackPath?.navigationPath.append(podcast)
+                        }
+                    }
+                }
                 Button(L10n.playNextInUpNext) { requireAccount { model.playNext() } }
                 Button(L10n.playLastInUpNext) { requireAccount { model.playLast() } }
                 Button(L10n.markPlayed) { requireAccount { model.markAsPlayed() } }
@@ -237,6 +253,11 @@ struct EpisodeActionButtons: View {
                     Button(model.isArchived ? L10n.unarchive : L10n.archive) { requireAccount { model.isArchived ? model.unarchive() : model.archive() } }
                 }
             case .upNext:
+                if let podcast = model.podcast {
+                    Button(L10n.goToPodcast) {
+                        stackPath?.navigationPath.append(podcast)
+                    }
+                }
                 Button(L10n.playNext) { requireAccount { model.playNext() } }
                 Button(L10n.playLast) { requireAccount { model.playLast() } }
                 Button(L10n.removeFromUpNext) { model.removeFromUpNext() }
@@ -266,7 +287,7 @@ private struct EpisodeContextMenuModifier: ViewModifier {
 }
 
 extension View {
-    func episodeContextMenu(model: EpisodeRowViewModel, context: EpisodeActionContext = .default) -> some View {
+    func episodeContextMenu(model: EpisodeRowViewModel, context: EpisodeActionContext = .other(false)) -> some View {
         modifier(EpisodeContextMenuModifier(model: model, context: context))
     }
 }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -83,13 +83,6 @@ class EpisodeRowViewModel: Identifiable {
         PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
     }
 
-    func openPodcast() {
-        guard let podcast else {
-            return
-        }
-        print("Open Podcast: \(podcast)")
-    }
-
     func playNext() {
         EpisodeUpNextActions.playNext(episode, playbackManager: playbackManager)
     }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -83,6 +83,13 @@ class EpisodeRowViewModel: Identifiable {
         PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
     }
 
+    func openPodcast() {
+        guard let podcast else {
+            return
+        }
+        print("Open Podcast: \(podcast)")
+    }
+
     func playNext() {
         EpisodeUpNextActions.playNext(episode, playbackManager: playbackManager)
     }

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -53,6 +53,11 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                 DiscoverAllView(model: mainTabModel.discoverAllViewModel)
             }
         }
+        .navigationDestination(for: DiscoverPodcast.self) { podcast in
+            if let uuid = podcast.uuid {
+                PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid))
+            }
+        }
         .animation(.easeInOut, value: model.state)
         .animation(.easeInOut, value: model.scope)
         .fullScreenCover(isPresented: $showNowPlayingPlayer) {

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -8,10 +8,10 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
     @State private var searchText = ""
     @State private var didTrackShown = false
 
-    @State private var path = NavigationPath()
+    @State private var path = StackPath()
 
     var body: some View {
-        NavigationStack(path: $path) {
+        NavigationStack(path: $path.navigationPath) {
             VStack {
                 SearchResultsView(model: model)
             }
@@ -59,7 +59,8 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                 Analytics.track(.searchShown, properties: ["source": "search"])
             }
         }
-        .syncNavigationDetail(path: path, tabRouter: tabRouter)
+        .syncNavigationDetail(path: path.navigationPath, tabRouter: tabRouter)
+        .environment(path)
     }
 }
 

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import PocketCastsUtils
+import PocketCastsDataModel
 
 struct UpNextView: View {
     @Environment(AppCoordinator.self) var coordinator
     @Environment(MainTabViewModel.self) var tabRouter: MainTabViewModel
 
     @State private var model: UpNextViewModel
+    @State private var path = StackPath()
 
     @Namespace private var rowNamespace
     @FocusState private var rowFocus: EpisodeRowFocus?
@@ -36,19 +38,25 @@ struct UpNextView: View {
     }
 
     var upNextView: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 24) {
-                headerRow
-                ForEach(model.episodes) { episode in
-                    EpisodeRowWithActions(model: episode, context: .upNext, focus: $rowFocus) {
-                        tabRouter.showFullScreenPlayer = true
+        NavigationStack(path: $path.navigationPath) {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 24) {
+                    headerRow
+                    ForEach(model.episodes) { episode in
+                        EpisodeRowWithActions(model: episode, context: .upNext, focus: $rowFocus) {
+                            tabRouter.showFullScreenPlayer = true
+                        }
+                        .frame(width: 1160)
+                        .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
                     }
-                    .frame(width: 1160)
-                    .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
                 }
+                .focusScope(rowNamespace)
             }
-            .focusScope(rowNamespace)
-        }
+            .navigationDestination(for: Podcast.self) { podcast in
+                PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: podcast.uuid))
+            }
+            .syncNavigationDetail(path: path.navigationPath, tabRouter: tabRouter)
+        }.environment(path)
     }
 
     private var headerRow: some View {


### PR DESCRIPTION
Fixes [PCIOS-777](https://linear.app/a8c/issue/PCIOS-777/add-a-way-to-open-a-podcast-from-an-episode)

Adds a "Go to Podcast" action to episodes across the tvOS app, letting users navigate from an episode to its parent podcast's detail page.

## What changed

- **Episode context menus** (`EpisodeRow`): added a "Go to Podcast" button to the episode action menu. It pushes the episode's podcast onto the navigation stack, preferring the loaded `Podcast` and falling back to a `DiscoverPodcast` built from the episode's podcast UUID when only the episode is known.
- **Up Next**: wrapped the list in its own `NavigationStack` so the new action can navigate, and added a "Go to Podcast" action for queued episodes.
- **Now Playing**: added a "Go to Podcast" entry to the player's more-actions menu, presenting the podcast detail via a full-screen cover (the player is itself a full-screen overlay with no nav stack to push onto).
- **Home / Playlists**: registered the navigation destinations needed to resolve the podcast pushed from an episode row.
- **`StackPath`**: a small `@Observable` wrapper around `NavigationPath`, injected via the environment so the deeply-nested episode action buttons can append to the enclosing stack.

## To test

1. tvOS: open the Home, Playlists, or Up Next screen.
2. Focus an episode row and open its action menu (ellipsis).
3. Choose **Go to Podcast** — it should navigate to that podcast's detail page.
4. Start playback, open Now Playing, open the more-actions menu, and choose **Go to Podcast** — the podcast detail should be presented.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
