### PR TITLE
Add episode sorting to the tvOS podcast screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Show episode artwork on the episode details page [#4616](https://github.com/Automattic/pocket-casts-ios/pull/4616)
 - Add support for generated chapters on episodes [#4630](https://github.com/Automattic/pocket-casts-ios/pull/4630)
 - Fix Autoplay stopping instead of continuing through manual playlists that contain episodes from podcasts you don't follow [#4624](https://github.com/Automattic/pocket-casts-ios/pull/4624)
+- Add episode sorting to the podcast screen on tvOS [#4650](https://github.com/Automattic/pocket-casts-ios/pull/4650)
 
 8.15
 -----

--- a/Pocket Casts TV App/UI/Common/MoreMenuLabel.swift
+++ b/Pocket Casts TV App/UI/Common/MoreMenuLabel.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// Standard "More" (overflow) affordance for section headers on tvOS: an
+/// ellipsis that opens a `Menu` of secondary options such as sorting. Pair it
+/// with `.buttonStyle(MoreButtonStyle())` so it renders as the same perfect
+/// circle used by the per-row ellipsis in `EpisodeRowWithActions`.
+struct MoreMenuLabel: View {
+    var body: some View {
+        Image(systemName: "ellipsis")
+            .accessibilityLabel(L10n.tvMoreMenu)
+    }
+}
+
+#Preview {
+    Menu {
+        Button("Newest to oldest") {}
+        Button("Oldest to newest") {}
+    } label: {
+        MoreMenuLabel()
+    }
+    .buttonStyle(MoreButtonStyle())
+}

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -139,6 +139,28 @@ struct PodcastDetailView: View {
         EpisodeRowWithActions(model: episode, focus: $rowFocus)
     }
 
+    /// Standard "More" menu for the episode list, holding the episode sort options.
+    private var moreMenu: some View {
+        Menu {
+            Section(L10n.sortBy) {
+                ForEach(PodcastEpisodeSortOrder.allCases, id: \.self) { order in
+                    Button {
+                        model.setSortOrder(order)
+                    } label: {
+                        if model.sortOrder == order {
+                            Label(order.description, systemImage: "checkmark")
+                        } else {
+                            Text(order.description)
+                        }
+                    }
+                }
+            }
+        } label: {
+            MoreMenuLabel()
+        }
+        .buttonStyle(MoreButtonStyle())
+    }
+
     private var archivedFilterMenu: some View {
         Menu {
             Button {
@@ -229,6 +251,7 @@ struct PodcastDetailView: View {
                         .foregroundStyle(Color.pcTextPrimary)
                     Spacer()
                     archivedFilterMenu
+                    moreMenu
                 }
                 .padding(.top, 40)
                 .padding(.bottom, 32)

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import Combine
 
 @Observable
@@ -25,6 +26,7 @@ class PodcastDetailViewModel {
     var recommendedEpisode: EpisodeRowViewModel?
     var isFollowing: Bool = false
     var showArchived: Bool = false
+    var sortOrder: PodcastEpisodeSortOrder = .newestToOldest
 
     private static func archiveStorageKey(for podcastUuid: String) -> String {
         "showArchived_podcast_\(podcastUuid)"
@@ -36,6 +38,22 @@ class PodcastDetailViewModel {
         load()
         UserDefaults.standard.set(value, forKey: Self.archiveStorageKey(for: podcastUuid))
         Analytics.track(.podcastScreenToggleArchived, properties: ["show_archived": value])
+    }
+
+    /// Persists the sort order onto the (synced) podcast like iOS does, then
+    /// reloads — `fetchEpisodes` falls back to `podcast.podcastSortOrder`, so the
+    /// list comes back in the new order.
+    func setSortOrder(_ order: PodcastEpisodeSortOrder) {
+        guard order != sortOrder, let podcast else { return }
+        if FeatureFlag.newSettingsStorage.enabled {
+            podcast.settings.episodesSortOrder = order
+            podcast.syncStatus = SyncStatus.notSynced.rawValue
+        }
+        podcast.episodeSortOrder = order.old.rawValue
+        DataManager.sharedManager.save(podcast: podcast)
+        sortOrder = order
+        load()
+        Analytics.track(.podcastsScreenSortOrderChanged, properties: ["sort_by": order])
     }
 
     init(podcastUuid: String,
@@ -79,6 +97,7 @@ class PodcastDetailViewModel {
                 self.isFollowing = podcast.subscribed != 0
                 self.episodes = allEpisodes
                 self.recommendedEpisode = nil
+                self.sortOrder = podcast.podcastSortOrder ?? .newestToOldest
                 self.state = .ready
             }
         }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6172,6 +6172,9 @@
 /* tv podcast detail option to show archived episodes in the list */
 "tv_podcast_detail_show_archived" = "Show archived";
 
+/* tv accessibility label for the More options (overflow) menu shown in section headers for sorting and filtering */
+"tv_more_menu" = "More";
+
 /* tv podcast detail empty state title shown when a podcast has no episodes */
 "tv_podcast_detail_no_episodes_title" = "No Episodes";
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-773

Adds episode sorting to the podcast screen on tvOS, matching iOS. A circular "More" (⋯) menu now sits next to the existing archived filter in the episode list header, offering the standard sort orders (Newest/Oldest, Title A–Z/Z–A, Shortest/Longest, Serial). The choice is persisted on the synced podcast settings, so it stays consistent with iOS and the rest of the app.

**Note**: I decided to not add it to "Up Next" in the scope of this PR because there was no clear way to add it (it is in a tab-based view)

## To test

1. On an Apple TV (or tvOS simulator), open a podcast with several episodes.
2. Focus the "All episodes" header and open the circular **More** (⋯) menu next to the archived filter.
3. Pick a sort order under **Sort By** — confirm the episode list reorders immediately and a checkmark marks the active order.
4. Leave and reopen the podcast — confirm the sort order is remembered.
5. Open the same podcast on iOS — confirm the sort order matches.

<img width="960" height="592" alt="Screenshot 2026-06-30 at 4 34 37 PM" src="https://github.com/user-attachments/assets/4edb9b71-9291-4cc4-a2a9-eaa24a1e425f" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.