### PR TITLE
Disable activateAudioSessionInBackground on tvOS

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -487,9 +487,13 @@ public enum FeatureFlag: String, CaseIterable {
         case .ignorePlayWithOtherAudio:
             true
         case .activateAudioSessionInBackground:
+#if os(tvOS)
+            false
+#else
             true
+#endif
         case .useCellularNetworkApis:
-			true
+            true
         case .optimizeManualPlaylistQueries:
             true
         case .useBackgroundQueueForStreamingCallback:


### PR DESCRIPTION
Fixes PCIOS-778

Defaults the `activateAudioSessionInBackground` feature flag to `false` on tvOS. On tvOS the audio session is now activated synchronously on the main thread (the original behavior) instead of being dispatched to a background queue. iOS, iPadOS, and watchOS are unaffected.

## To test

1. Build and run the tvOS target.
2. Play an episode and confirm playback starts normally.
3. Pause/resume and skip between episodes — audio session activation should behave as before with no regressions.
4. Confirm iOS/iPadOS behavior is unchanged (flag still defaults to `true` there).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
