### PR TITLE
Fix crash and wrong-podcast selection in category promotion rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.16
 -----
+- Fix a crash and wrong-podcast taps when opening a Discover category list that shows a sponsored podcast [#4652](https://github.com/Automattic/pocket-casts-ios/pull/4652)
 - Add a "Remove from Up Next" multi-select action outside the Up Next screen [#4606](https://github.com/Automattic/pocket-casts-ios/pull/4606)
 - Add a Star Episodes action to Up Next multi-select and show a star indicator on Up Next cells [#4605](https://github.com/Automattic/pocket-casts-ios/pull/4605)
 - Fix the Files navigation bar not being transparent [#4604](https://github.com/Automattic/pocket-casts-ios/pull/4604)

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -73,7 +73,6 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
                 cell.populateFrom(promotion, isSubscribed: isSubscribed)
                 return cell
             } else {
-                // The promotion occupies row 0, so data rows are shifted down by one.
                 podcastIndexRow -= 1
             }
         }
@@ -91,7 +90,6 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
         guard let delegate else { return }
 
         if let cell = tableView.cellForRow(at: indexPath) as? DiscoverPodcastTableCell {
-            // The promotion occupies row 0, so data rows are shifted down by one.
             let podcastIndexRow = showPromotion() ? indexPath.row - 1 : indexPath.row
             let podcast = podcasts[podcastIndexRow]
 

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -73,7 +73,8 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
                 cell.populateFrom(promotion, isSubscribed: isSubscribed)
                 return cell
             } else {
-                podcastIndexRow += 1
+                // The promotion occupies row 0, so data rows are shifted down by one.
+                podcastIndexRow -= 1
             }
         }
 
@@ -90,7 +91,9 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
         guard let delegate else { return }
 
         if let cell = tableView.cellForRow(at: indexPath) as? DiscoverPodcastTableCell {
-            let podcast = podcasts[indexPath.row]
+            // The promotion occupies row 0, so data rows are shifted down by one.
+            let podcastIndexRow = showPromotion() ? indexPath.row - 1 : indexPath.row
+            let podcast = podcasts[podcastIndexRow]
 
             let categoryName = category?.name ?? "unknown"
             let listUuid = "category-\(categoryName.lowercased())-\(region ?? "unknown")"


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

A sponsored **promotion** in a category list sits at row 0, shifting the podcast rows down by one. The row index wasn't adjusted for this, so the last row read out of bounds (**crash**) and taps **opened the wrong podcast**. Fixed the index math in `cellForRowAt` and `didSelectRowAt`.

Promotions are rare and only shown to non-subscribers, so the attached DEBUG-only patch injects a fake one (and bypasses the subscriber check) to make this testable.

## To test

1. On this branch, apply the patch and run a **Debug** build:
   ```bash
   git apply mock-promotion-test.patch
   ```
2. **Discover → open any Category.**
3. Confirm a **"Mock Promotion"** row appears at the top, with the real podcasts right below it.
4. **Scroll to the last row** and **tap a few rows** — no crash, and each opens the podcast you tapped.

<details>
<summary>📎 mock-promotion-test.patch</summary>

```diff
diff --git a/podcasts/CategoryPodcastsViewController.swift b/podcasts/CategoryPodcastsViewController.swift
index 37b01c6bc..866b8b5f4 100644
--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -6,6 +6,14 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     private static let cellId = "DiscoverCell"
     private static let sponsoredCellId = "CategorySponsoredCell"
     private static let promotionRow = 0
+
+    #if DEBUG
+    /// Set to `true` to inject a fake promotion into categories that don't have one,
+    /// so the sponsored row (and its index offset) can be exercised manually. This
+    /// also bypasses the subscription gate in `showPromotion()`, so the row shows
+    /// regardless of the tester's plan.
+    private static let injectMockPromotion = true
+    #endif
     @IBOutlet var podcastsTable: UITableView! {
         didSet {
             // This will remove extra separators from tableview
@@ -83,6 +91,8 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
         cell.subscribeSource = .discoverCategory
         cell.populateFrom(podcast, number: -1)
 
+        print(tableView.numberOfRows(inSection: 0), podcastIndexRow, podcasts.count)
+
         return cell
     }
 
@@ -141,6 +151,11 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
                 strongSelf.loadingIndicator.stopAnimating()
                 strongSelf.podcasts = Array(podcasts.dropFirst(strongSelf.skipCount))
                 strongSelf.promotion = categoryDetails?.promotion
+                #if DEBUG
+                if CategoryPodcastsViewController.injectMockPromotion, strongSelf.promotion == nil {
+                    strongSelf.promotion = strongSelf.mockPromotion()
+                }
+                #endif
                 strongSelf.podcastsTable.reloadData()
 
                 if let item = strongSelf.item {
@@ -174,9 +189,34 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
     }
 
     private func showPromotion() -> Bool {
-        guard promotion != nil, !SubscriptionHelper.hasRenewingSubscription() else { return false }
+        guard promotion != nil else { return false }
+        #if DEBUG
+        // When injecting a mock promotion, ignore the subscription gate so the
+        // sponsored row shows regardless of the tester's plan.
+        if CategoryPodcastsViewController.injectMockPromotion {
+            return true
+        }
+        #endif
+        guard !SubscriptionHelper.hasRenewingSubscription() else { return false }
         return true
     }
+
+    #if DEBUG
+    /// Builds a fake promotion pointing at the first podcast in the list, so the
+    /// sponsored row can be tested even when the server doesn't return a promotion.
+    private func mockPromotion() -> DiscoverCategoryPromotion? {
+        let podcastUuid = podcasts.first?.uuid ?? "mock-podcast-uuid"
+        let json = """
+        {
+            "promotion_uuid": "mock-promotion-uuid",
+            "podcast_uuid": "\(podcastUuid)",
+            "title": "Mock Promotion",
+            "description": "Injected for testing the sponsored promotion row."
+        }
+        """
+        return try? JSONDecoder().decode(DiscoverCategoryPromotion.self, from: Data(json.utf8))
+    }
+    #endif
 }
 
 extension CategoryPodcastsViewController: DiscoverSummaryProtocol {
```
</details>

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
