### PR TITLE
Enable Up Next sort feature flag

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -539,7 +539,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .shareProfile:
             BuildEnvironment.current == .debug
         case .upNextSort:
-            BuildEnvironment.current == .debug
+            true
         }
     }
 


### PR DESCRIPTION
Enables the `upNextSort` feature flag by default so Up Next queue sorting ships in 8.15. The feature itself was added in #4550 behind the flag (previously on only in debug builds); this flips the default to `true` for all build environments.

## To test

1. Open the app and add several episodes to the Up Next queue.
2. Open the Up Next screen.
3. Confirm a **Sort** button appears in the header.
4. Tap it and switch between sort options (Newest to Oldest, Oldest to Newest, Shortest to Longest, Longest to Shortest).
5. Verify the queue reorders accordingly for each option.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
