### PR TITLE
Hide mini player during multi-selection

### DIFF
--- a/podcasts/Extensions/UIViewController+TabBar.swift
+++ b/podcasts/Extensions/UIViewController+TabBar.swift
@@ -5,12 +5,15 @@ extension UIViewController {
     /// On earlier OS versions, or when the view controller isn't inside a
     /// tab bar controller, this is a no-op.
     func setEnclosingTabBarHidden(_ hidden: Bool, animated: Bool) {
-        // Workaround: `setTabBarHidden(_:animated:)` is buggy on iOS 27, so we
-        // disable tab bar hiding there for now. There's a follow-up ticket to
-        // re-enable this once Apple fixes the underlying issues.
-        guard #unavailable(iOS 27) else { return }
-
         guard #available(iOS 26, *), let tabBarController else { return }
+
         tabBarController.setTabBarHidden(hidden, animated: animated)
+
+        let miniPlayer = appDelegate()?.miniPlayer()
+        if hidden {
+            miniPlayer?.hideMiniPlayer(animated)
+        } else {
+            miniPlayer?.showMiniPlayer()
+        }
     }
 }

--- a/podcasts/Extensions/UIViewController+TabBar.swift
+++ b/podcasts/Extensions/UIViewController+TabBar.swift
@@ -5,6 +5,11 @@ extension UIViewController {
     /// On earlier OS versions, or when the view controller isn't inside a
     /// tab bar controller, this is a no-op.
     func setEnclosingTabBarHidden(_ hidden: Bool, animated: Bool) {
+        // Workaround: `setTabBarHidden(_:animated:)` is buggy on iOS 27, so we
+        // disable tab bar hiding there for now. There's a follow-up ticket to
+        // re-enable this once Apple fixes the underlying issues.
+        guard #unavailable(iOS 27) else { return }
+
         guard #available(iOS 26, *), let tabBarController else { return }
         tabBarController.setTabBarHidden(hidden, animated: animated)
     }

--- a/podcasts/Extensions/UIViewController+TabBar.swift
+++ b/podcasts/Extensions/UIViewController+TabBar.swift
@@ -11,7 +11,7 @@ extension UIViewController {
 
         let miniPlayer = appDelegate()?.miniPlayer()
         if hidden {
-            miniPlayer?.hideMiniPlayer(animated)
+            miniPlayer?.hideMiniPlayer(animated, isTransient: true)
         } else {
             miniPlayer?.showMiniPlayer()
         }

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -2,11 +2,15 @@ import Foundation
 import PocketCastsUtils
 
 extension MiniPlayerViewController {
-    func hideMiniPlayer(_ animated: Bool) {
+    /// - parameter isTransient: If enabled, hiding temporarily with an intention to
+    /// quickly show it again later.
+    func hideMiniPlayer(_ animated: Bool, isTransient: Bool = false) {
         if LiquidGlass.isEnabled, #available(iOS 26, *) {
             guard let tabBarController = parent as? UITabBarController, tabBarController.bottomAccessory != nil else { return }
             tabBarController.setBottomAccessory(nil, animated: animated)
-            tabBarController.tabBarMinimizeBehavior = .never
+            if !isTransient {
+                tabBarController.tabBarMinimizeBehavior = .never
+            }
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.miniPlayerDidDisappear)
             return
         }
@@ -35,8 +39,8 @@ extension MiniPlayerViewController {
         if LiquidGlass.isEnabled, #available(iOS 26.0, *) {
             guard let tabBarController = parent as? UITabBarController, tabBarController.bottomAccessory == nil else { return }
             let accessory = UITabAccessory(contentView: view)
-            tabBarController.setBottomAccessory(accessory, animated: true)
             tabBarController.tabBarMinimizeBehavior = Settings.tabBarMinimizingEnabled ? .onScrollDown : .never
+            tabBarController.setBottomAccessory(accessory, animated: true)
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.miniPlayerDidAppear)
             return
         }


### PR DESCRIPTION
## To test

- Verify that the mini player now gets briefly hidden during multiple selection

<img width="340" alt="Screenshot 2026-07-01 at 10 53 46 AM" src="https://github.com/user-attachments/assets/9cf3f44b-809c-4e8a-add9-410f3fd80067" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.