### PR TITLE
Exclude .claude harness directory from SwiftLint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,8 @@ swiftlint_version: 0.63.2
 # Project configuration
 #
 excluded:
+  # Claude Code harness directory, including transient git worktrees
+  - .claude
   - BuildTools/.build
   - DerivedData
   - fastlane


### PR DESCRIPTION
SwiftLint lints the entire repo root, so it picks up file copies inside Claude Code git worktrees (`.claude/worktrees/`). The existing `fastlane` exclusion uses relative-path matching and doesn't cover the nested `fastlane` copy inside those worktrees, producing spurious warnings.

This adds `.claude` to the `excluded` list so transient worktrees and other harness files never pollute lint output. No source code is affected — the actual codebase already lints clean.

## To test

1. Ensure a Claude Code worktree exists under `.claude/worktrees/` (or any `.swift` file that would violate a rule).
2. Run `make lint`.
3. Confirm there are no warnings and no files under `.claude/` are scanned.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.