### PR TITLE
tvOS: Query new releases from subscribed podcasts on Home

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -255,6 +255,23 @@ class EpisodeDataManager {
         loadMultiple(query: "SELECT * from \(DataManager.episodeTableName) WHERE podcast_id = ? AND wasDeleted = 0 ORDER BY publishedDate DESC, addedDate DESC LIMIT ?", values: [podcast.id, limit], dbQueue: dbQueue)
     }
 
+    func findNewReleaseEpisodes(limit: Int, dbQueue: PCDBQueue) -> [Episode] {
+        let twoWeeksInSeconds: TimeInterval = 14 * 24 * 60 * 60
+        let twoWeeksAgo = Date(timeIntervalSinceNow: -twoWeeksInSeconds).timeIntervalSince1970
+        let query = """
+        SELECT episode.* FROM \(DataManager.episodeTableName) episode
+        JOIN \(DataManager.podcastTableName) podcast ON episode.podcast_id = podcast.id
+        WHERE podcast.subscribed = 1
+        AND episode.playingStatus = \(PlayingStatus.notPlayed.rawValue)
+        AND episode.wasDeleted = 0
+        AND episode.archived = 0
+        AND episode.publishedDate > ?
+        ORDER BY episode.publishedDate DESC, episode.addedDate DESC
+        LIMIT ?
+        """
+        return loadMultiple(query: query, values: [twoWeeksAgo, limit], dbQueue: dbQueue)
+    }
+
     func allUpNextEpisodes(dbQueue: PCDBQueue) -> [Episode] {
         let upNextTableName = DataManager.playlistEpisodeTableName
         let episodeTableName = DataManager.episodeTableName

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -539,6 +539,11 @@ public class DataManager {
         episodeManager.findLatestEpisodes(podcast: podcast, limit: limit, dbQueue: dbQueue)
     }
 
+    /// Unplayed episodes from subscribed podcasts, most recently published first.
+    public func findNewReleaseEpisodes(limit: Int) -> [Episode] {
+        episodeManager.findNewReleaseEpisodes(limit: limit, dbQueue: dbQueue)
+    }
+
     public func unsyncedEpisodes(limit: Int) -> [Episode] {
         episodeManager.unsyncedEpisodes(limit: limit, dbQueue: dbQueue)
     }

--- a/Pocket Casts TV App/UI/Home/HomeViewModel.swift
+++ b/Pocket Casts TV App/UI/Home/HomeViewModel.swift
@@ -35,13 +35,8 @@ class HomeViewModel {
         Task {
             let podcasts = fetchPodcasts()
             let upNextEpisodes = dataManager.allUpNextEpisodes()
-            var newEpisodes = [EpisodeRowViewModel]()
-            for podcast in podcasts.prefix(8) {
-                guard let latest: Episode = dataManager.findLatestEpisode(podcast: podcast) else {
-                    continue
-                }
-                let result = EpisodeRowViewModel(episode: latest, podcast: podcast)
-                newEpisodes.append(result)
+            let newEpisodes = dataManager.findNewReleaseEpisodes(limit: 12).map { episode in
+                makeRowViewModel(for: episode)
             }
 
             await MainActor.run { [weak self, newEpisodes] in


### PR DESCRIPTION
Fixes PCIOS-

The tvOS Home screen's "New Releases" row previously surfaced only the single latest episode from each of the first 8 subscribed podcasts. That approach missed newer episodes from podcasts beyond the first 8, and could show already-listened or stale episodes.

This replaces that logic with a dedicated `DataManager.findNewReleaseEpisodes(limit:)` query that returns, across **all** subscribed podcasts:

- episodes **not listened to** (`playingStatus = notPlayed` — excludes in-progress and completed)
- published within the **last two weeks** (matching the app's built-in New Releases smart filter window of `24 * 14` hours)
- excluding deleted and archived episodes
- sorted by **release date**, newest first
- capped at **12** episodes

The `HomeViewModel` now calls this query directly instead of looping over podcasts and fetching each one's latest episode.

## To test

1. On tvOS, subscribe to several podcasts (more than 8, with recent episodes).
2. Open the Home screen.
3. Confirm the "New Releases" row shows up to 12 unplayed episodes from across your subscriptions, most recent first.
4. Start playing one of the episodes (making it in-progress), then reload Home — confirm it no longer appears in New Releases.
5. Confirm episodes older than two weeks do not appear.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.