### PR TITLE
Fix scrolled transparent nav bar ignoring the in-app theme on iOS 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.16
 -----
+- Fix the smart playlist and podcast page header showing the system light/dark appearance instead of the in-app theme when scrolling on iOS 18 [#4662](https://github.com/Automattic/pocket-casts-ios/pull/4662)
 - Fix episode lists jumping when a background download finishes [#4648](https://github.com/Automattic/pocket-casts-ios/pull/4648)
 - Fix a rare crash during playback when an audio buffer fails to allocate [#4645](https://github.com/Automattic/pocket-casts-ios/pull/4645)
 - Add a "Remove from Up Next" multi-select action outside the Up Next screen [#4606](https://github.com/Automattic/pocket-casts-ios/pull/4606)

--- a/podcasts/Common Components/View Controllers/PCViewController.swift
+++ b/podcasts/Common Components/View Controllers/PCViewController.swift
@@ -247,6 +247,7 @@ class PCViewController: SimpleNotificationsViewController {
         appearance.configureWithTransparentBackground()
         if scrolled {
             appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = navBgColor ?? ThemeColor.secondaryUi01()
         }
         navigationBar.standardAppearance = appearance
         navigationBar.scrollEdgeAppearance = appearance


### PR DESCRIPTION
Fixes PCIOS-799.

On iOS 18, scrolling in smart playlists (and the podcast page) turned the nav bar the system light/dark color instead of the in-app theme — e.g. a light band under a dark theme when the system was set to Light. iOS 26 was unaffected.

`PCViewController.setTransparentNavBarScrolled(_:)` built its scrolled bar with `configureWithOpaqueBackground()` but never set a color, so iOS derived one from the trait collection — which follows the system appearance pre-Liquid Glass. Fixed by pinning it to the theme color, mirroring `setupNavBar`. Centralized, so it covers both the playlist and podcast pages.

<img width="456" height="972" alt="Screenshot 2026-07-01 at 1 41 37 PM" src="https://github.com/user-attachments/assets/4625247a-8aae-4157-9e12-55db59cb9cbc" />


## To test

1. On iOS 18.x, set **Settings > Display & Brightness** to **Light**.
2. In Pocket Casts, pick a dark theme under **Profile > Settings > Appearance**.
3. Open a smart playlist with enough episodes to scroll and scroll down.
4. Verify the header stays dark (matching the theme) instead of turning light. Repeat on a podcast page.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
