### PR TITLE
Fix UserEpisode equality casting to the wrong type

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
@@ -160,7 +160,7 @@ public class UserEpisode: NSObject, BaseEpisode {
     }
 
     override public func isEqual(_ object: Any?) -> Bool {
-        guard let otherEpisode = object as? Episode else { return false }
+        guard let otherEpisode = object as? UserEpisode else { return false }
 
         return otherEpisode.uuid == uuid
     }

--- a/Modules/Tests/PocketCastsDataModelTests/EpisodeEqualityTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/EpisodeEqualityTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+
+@testable import PocketCastsDataModel
+
+/// Equality/hashing tests for `Episode` and `UserEpisode`.
+///
+/// Both types are `NSObject` subclasses conforming to `BaseEpisode`, so their
+/// `isEqual(_:)` overrides back Swift's `==`, `Set`, `contains(_:)`, and
+/// `firstIndex(of:)`. A regression here (e.g. casting to the wrong sibling
+/// type) silently breaks collection operations rather than failing to compile.
+class EpisodeEqualityTests: XCTestCase {
+    private func makeUserEpisode(uuid: String, id: Int64 = 0) -> UserEpisode {
+        let episode = UserEpisode()
+        episode.uuid = uuid
+        episode.id = id
+        return episode
+    }
+
+    private func makeEpisode(uuid: String, id: Int64 = 0) -> Episode {
+        let episode = Episode()
+        episode.uuid = uuid
+        episode.id = id
+        return episode
+    }
+
+    // MARK: - UserEpisode
+
+    func testUserEpisodesWithSameUuidAreEqual() {
+        let a = makeUserEpisode(uuid: "file-123", id: 1)
+        let b = makeUserEpisode(uuid: "file-123", id: 1)
+
+        XCTAssertEqual(a, b)
+    }
+
+    func testUserEpisodeIsEqualToItself() {
+        let a = makeUserEpisode(uuid: "file-123", id: 1)
+
+        XCTAssertEqual(a, a)
+    }
+
+    func testUserEpisodesWithDifferentUuidsAreNotEqual() {
+        let a = makeUserEpisode(uuid: "file-123", id: 1)
+        let b = makeUserEpisode(uuid: "file-456", id: 2)
+
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testUserEpisodeContainsFindsEqualInstance() {
+        let a = makeUserEpisode(uuid: "file-123", id: 1)
+        let b = makeUserEpisode(uuid: "file-123", id: 1)
+
+        XCTAssertTrue([a].contains(b))
+        XCTAssertEqual([a].firstIndex(of: b), 0)
+    }
+
+    func testUserEpisodeSetDeduplicatesEqualInstances() {
+        let a = makeUserEpisode(uuid: "file-123", id: 1)
+        let b = makeUserEpisode(uuid: "file-123", id: 1)
+
+        let set: Set<UserEpisode> = [a, b]
+
+        XCTAssertEqual(set.count, 1)
+    }
+
+    func testUserEpisodeIsNotEqualToNonEpisodeObjects() {
+        let a = makeUserEpisode(uuid: "file-123", id: 1)
+
+        XCTAssertFalse(a.isEqual("file-123"))
+        XCTAssertFalse(a.isEqual(nil))
+    }
+
+    // MARK: - Cross type isolation
+
+    func testUserEpisodeIsNotEqualToEpisodeWithSameUuid() {
+        let userEpisode = makeUserEpisode(uuid: "shared-uuid", id: 1)
+        let episode = makeEpisode(uuid: "shared-uuid", id: 1)
+
+        XCTAssertNotEqual(userEpisode, episode)
+        XCTAssertNotEqual(episode, userEpisode)
+    }
+
+    // MARK: - Episode
+
+    func testEpisodesWithSameUuidAreEqual() {
+        let a = makeEpisode(uuid: "ep-123", id: 1)
+        let b = makeEpisode(uuid: "ep-123", id: 1)
+
+        XCTAssertEqual(a, b)
+        XCTAssertTrue([a].contains(b))
+    }
+
+    func testEpisodesWithDifferentUuidsAreNotEqual() {
+        let a = makeEpisode(uuid: "ep-123", id: 1)
+        let b = makeEpisode(uuid: "ep-456", id: 2)
+
+        XCTAssertNotEqual(a, b)
+    }
+}


### PR DESCRIPTION
`UserEpisode.isEqual(_:)` cast the object to `Episode`, but `UserEpisode` and `Episode` are siblings (neither subclasses the other), so the cast always failed and two equal `UserEpisode`s never compared equal. Fixed by casting to `UserEpisode`, mirroring `Episode.isEqual`.

**No user-facing impact:** latent since the initial commit — every episode comparison in the app goes through `uuid` strings, so no current code path hit the broken `isEqual`. This removes a landmine for future code and adds regression tests.

## To test

Covered by unit tests; no manual QA needed.

1. Run `make test_staging ONLY_TESTING=PocketCastsDataModelTests/EpisodeEqualityTests`.
2. Confirm all cases pass.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. (No user-facing impact — no CHANGELOG entry.)
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.