### PR TITLE
Fix hasCustomImage decoding in UserEpisode.populateFromMap

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Public/Model/UserEpisode+Encoding.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/UserEpisode+Encoding.swift
@@ -49,7 +49,7 @@ public extension UserEpisode {
         uploadStatus = decodeInt32FromString(value: episodeMap["uploadStatus"])
         imageUrl = episodeMap["imageUrl"]
         imageColor = decodeInt32FromString(value: episodeMap["imageColor"])
-        hasCustomImage = decodeBoolFromString(value: "hasCustomImage")
+        hasCustomImage = decodeBoolFromString(value: episodeMap["hasCustomImage"])
         id = decodeInt64FromString(value: episodeMap["episodeId"])
         sizeInBytes = decodeInt64FromString(value: episodeMap["sizeInBytes"])
     }

--- a/Modules/Tests/PocketCastsDataModelTests/UserEpisodeEncodingTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/UserEpisodeEncodingTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+
+@testable import PocketCastsDataModel
+
+class UserEpisodeEncodingTests: XCTestCase {
+    /// `hasCustomImage` must survive the encode/decode round-trip used to sync
+    /// user episodes to the Watch. Regression test for a bug where
+    /// `populateFromMap` decoded the literal key string `"hasCustomImage"`
+    /// instead of `episodeMap["hasCustomImage"]`, so the flag was always `false`
+    /// and custom-image user files showed placeholder artwork on the Watch.
+    func testHasCustomImageSurvivesRoundTrip() {
+        let episode = UserEpisode()
+        episode.uuid = "test-uuid"
+        episode.hasCustomImage = true
+
+        let map = episode.encodeToMap()
+
+        // Sanity check: the value is encoded correctly.
+        XCTAssertEqual(map["hasCustomImage"], "true")
+
+        let decoded = UserEpisode()
+        decoded.populateFromMap(map)
+
+        XCTAssertTrue(decoded.hasCustomImage, "hasCustomImage should be preserved through encode/decode")
+    }
+}


### PR DESCRIPTION
`UserEpisode.populateFromMap(_:)` decoded `hasCustomImage` from the literal string `"hasCustomImage"` instead of `episodeMap["hasCustomImage"]`. `Bool("hasCustomImage")` is always `nil`, so the flag always decoded to `false`.

This map is only used to sync user episodes (uploaded Files) from the phone to the Apple Watch. **No user-facing symptom:** the Watch's artwork path (`UserEpisode.urlForImage`) keys off `imageColor`/`imageUrl` — both of which round-trip correctly — not `hasCustomImage`, and the decoded flag isn't read anywhere else on the Watch. Fixing anyway since it's a clear correctness bug and could bite a future consumer of the decoded object.

Added a unit test covering the encode/decode round-trip.

## To test

1. `make test_staging ONLY_TESTING=PocketCastsDataModelTests/UserEpisodeEncodingTests`
2. Test passes. Reverting the one-line fix in `UserEpisode+Encoding.swift` makes it fail.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. (Not needed — no user-facing behavior change.)
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. (No analytics changes.)
