### PR TITLE
Align generated chapters to the played audio timeline via fingerprint timing

### DIFF
--- a/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
+++ b/PocketCastsTests/Tests/Playback/Chapters/ChapterManagerTests.swift
@@ -85,6 +85,50 @@ class ChapterManagerTests: XCTestCase {
         XCTAssertEqual(nextVisiblePlayableChapter, chapterInfo(startTime: 201, duration: 300, shouldPlay: true))
     }
 
+    /// Generated chapters are timed against the reference (clean) audio; when a
+    /// fingerprint mapping is available their start times should be re-mapped onto
+    /// the played file's timeline (here a flat +30s dynamic-ad shift).
+    func testGeneratedChaptersAreRemappedToPlaybackTimeline() async {
+        let parserMock = PodcastChapterParserMock() // no file chapters -> falls through to generated
+        let showInfoCoordinatorMock = GeneratedChaptersShowInfoCoordinatorMock(generatedChapters: [
+            GeneratedChapter(title: "One", timestamp: "00:00", startTime: 0),
+            GeneratedChapter(title: "Two", timestamp: "01:40", startTime: 100),
+            GeneratedChapter(title: "Three", timestamp: "03:20", startTime: 200)
+        ])
+        let mapper = ChapterReferenceTimeMappingMock(offset: 30, hasMapping: true)
+        ChapterReferenceTimeMappingProvider.current = mapper
+        defer { ChapterReferenceTimeMappingProvider.current = nil }
+
+        let chapterManager = ChapterManager(chapterParser: parserMock, showInfoCoordinator: showInfoCoordinatorMock)
+        await chapterManager.parseChapters(episode: EpisodeMock(), duration: 300)
+
+        XCTAssertEqual(chapterManager.chapterAt(index: 0)?.startTime.seconds ?? -1, 30, accuracy: 0.01)
+        XCTAssertEqual(chapterManager.chapterAt(index: 1)?.startTime.seconds ?? -1, 130, accuracy: 0.01)
+        XCTAssertEqual(chapterManager.chapterAt(index: 2)?.startTime.seconds ?? -1, 230, accuracy: 0.01)
+        // Durations are recomputed from the adjusted start times; the last runs to the episode end.
+        XCTAssertEqual(chapterManager.chapterAt(index: 0)?.duration ?? -1, 100, accuracy: 0.01)
+        XCTAssertEqual(chapterManager.chapterAt(index: 2)?.duration ?? -1, 70, accuracy: 0.01)
+    }
+
+    /// Without a usable mapping the generated chapters keep their reference times.
+    func testGeneratedChaptersKeepReferenceTimeWhenMappingUnavailable() async {
+        let parserMock = PodcastChapterParserMock()
+        let showInfoCoordinatorMock = GeneratedChaptersShowInfoCoordinatorMock(generatedChapters: [
+            GeneratedChapter(title: "One", timestamp: "00:00", startTime: 0),
+            GeneratedChapter(title: "Two", timestamp: "01:40", startTime: 100)
+        ])
+        // Mapping present but not yet active -> must be treated as unavailable.
+        let mapper = ChapterReferenceTimeMappingMock(offset: 30, hasMapping: false)
+        ChapterReferenceTimeMappingProvider.current = mapper
+        defer { ChapterReferenceTimeMappingProvider.current = nil }
+
+        let chapterManager = ChapterManager(chapterParser: parserMock, showInfoCoordinator: showInfoCoordinatorMock)
+        await chapterManager.parseChapters(episode: EpisodeMock(), duration: 300)
+
+        XCTAssertEqual(chapterManager.chapterAt(index: 0)?.startTime.seconds ?? -1, 0, accuracy: 0.01)
+        XCTAssertEqual(chapterManager.chapterAt(index: 1)?.startTime.seconds ?? -1, 100, accuracy: 0.01)
+    }
+
     func chapterInfo(startTime: TimeInterval, duration: TimeInterval, shouldPlay: Bool) -> ChapterInfo {
         let chapterInfo = ChapterInfo()
         chapterInfo.shouldPlay = shouldPlay
@@ -128,5 +172,43 @@ private class EpisodeMock: Episode {
     override var downloadUrl: String? {
         get { "https://pocketcasts.com/" }
         set {}
+    }
+}
+
+private class GeneratedChaptersShowInfoCoordinatorMock: ShowInfoCoordinating {
+    let generatedChapters: [GeneratedChapter]
+
+    init(generatedChapters: [GeneratedChapter]) {
+        self.generatedChapters = generatedChapters
+    }
+
+    func loadShowNotes(podcastUuid: String, episodeUuid: String) async throws -> String {
+        ""
+    }
+
+    func loadEpisodeArtworkUrl(podcastUuid: String, episodeUuid: String) async throws -> URL? {
+        nil
+    }
+
+    func loadChapters(podcastUuid: String, episodeUuid: String) async throws -> ([PocketCastsDataModel.Episode.Metadata.EpisodeChapter]?, [podcasts.PodcastIndexChapter]?, [GeneratedChapter]?) {
+        (nil, nil, generatedChapters)
+    }
+
+    func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
+        return (transcripts: [], hasGeneratedTranscripts: true, isDisplayingGeneratedTranscript: true)
+    }
+}
+
+private class ChapterReferenceTimeMappingMock: ChapterReferenceTimeMapping {
+    let offset: TimeInterval
+    var hasChapterReferenceMapping: Bool
+
+    init(offset: TimeInterval, hasMapping: Bool) {
+        self.offset = offset
+        self.hasChapterReferenceMapping = hasMapping
+    }
+
+    func playbackTime(forReferenceTime referenceTime: TimeInterval) -> TimeInterval? {
+        referenceTime + offset
     }
 }

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1397,6 +1397,10 @@
 		FF9BCB342EA659C900A25F12 /* playback_2025_listened.json in Resources */ = {isa = PBXBuildFile; fileRef = FF9BCB322EA659B400A25F12 /* playback_2025_listened.json */; };
 		FF9CBAF22EC9293000989151 /* playback2025_listening_time_numbers.json in Resources */ = {isa = PBXBuildFile; fileRef = FF9CBAF12EC9293000989151 /* playback2025_listening_time_numbers.json */; };
 		FF9ED3552C86010F00B6E630 /* TipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF9ED3542C86010F00B6E630 /* TipView.swift */; };
+		FFB537852FFBCFB50068E0E1 /* ChaptersFingerprintSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB537842FFBCFA10068E0E1 /* ChaptersFingerprintSync.swift */; };
+		FFB537862FFBCFB50068E0E1 /* ChaptersFingerprintSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB537842FFBCFA10068E0E1 /* ChaptersFingerprintSync.swift */; };
+		FFB537872FFBCFB50068E0E1 /* ChaptersFingerprintSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB537842FFBCFA10068E0E1 /* ChaptersFingerprintSync.swift */; };
+		FFB537882FFBCFB50068E0E1 /* ChaptersFingerprintSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB537842FFBCFA10068E0E1 /* ChaptersFingerprintSync.swift */; };
 		FFB74B0F2E993A8C00F16857 /* end_of_year_2025_intro.json in Resources */ = {isa = PBXBuildFile; fileRef = FFB74B0D2E993A8C00F16857 /* end_of_year_2025_intro.json */; };
 		FFE067392F86ADD000437ACC /* TranscriptFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF54BCA82C5A2F3900A342E5 /* TranscriptFormat.swift */; };
 		FFE4107F2FBB5FED00716EAA /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
@@ -2732,6 +2736,7 @@
 		FF9BCB322EA659B400A25F12 /* playback_2025_listened.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = playback_2025_listened.json; sourceTree = "<group>"; };
 		FF9CBAF12EC9293000989151 /* playback2025_listening_time_numbers.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = playback2025_listening_time_numbers.json; sourceTree = "<group>"; };
 		FF9ED3542C86010F00B6E630 /* TipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TipView.swift; sourceTree = "<group>"; };
+		FFB537842FFBCFA10068E0E1 /* ChaptersFingerprintSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChaptersFingerprintSync.swift; sourceTree = "<group>"; };
 		FFB74B0D2E993A8C00F16857 /* end_of_year_2025_intro.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = end_of_year_2025_intro.json; sourceTree = "<group>"; };
 		FFEE599B2EB378B300D4B145 /* Humane-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Humane-SemiBold.otf"; sourceTree = "<group>"; };
 		FFEE59C22EB37F4300D4B145 /* playback2025_listening_time.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = playback2025_listening_time.json; sourceTree = "<group>"; };
@@ -4116,6 +4121,7 @@
 		BD3E3CD5170426AC0066AE3D /* Chapters */ = {
 			isa = PBXGroup;
 			children = (
+				FFB537842FFBCFA10068E0E1 /* ChaptersFingerprintSync.swift */,
 				BD35E9171D45AC3E00CAE2A7 /* ChapterInfo.swift */,
 				BD44E36C20937D9C008BD7F0 /* PodcastChapterParser.swift */,
 				8BBE19EF2BEA9865009E944B /* PodcastIndexChapterDataRetriever.swift */,
@@ -7183,6 +7189,7 @@
 				8B087FC929DC976F0027EAE5 /* PodcastImage.swift in Sources */,
 				BD95ED6A1BAFA532004335B0 /* CountryChooserViewController.swift in Sources */,
 				8B5BD0B82C50235400C687CB /* Episode+Transcript.swift in Sources */,
+				FFB537882FFBCFB50068E0E1 /* ChaptersFingerprintSync.swift in Sources */,
 				C713D4F52A04C90500A78468 /* ProfileImage.swift in Sources */,
 				466DE3F6278794D50046F722 /* EpisodeListTableViewCell.swift in Sources */,
 				9AD809AF2EA12D940050649B /* PlaylistDetailFetchOperation.swift in Sources */,
@@ -7530,6 +7537,7 @@
 				BDE48A1B2410D06C00ECA6CA /* PlaybackItem.swift in Sources */,
 				8B1F88072C6404D00038E0D2 /* ArrayExtension.swift in Sources */,
 				BDE48A182410D05A00ECA6CA /* PlaybackQueue.swift in Sources */,
+				FFB537872FFBCFB50068E0E1 /* ChaptersFingerprintSync.swift in Sources */,
 				BDE48A3D2410D83100ECA6CA /* SJCommonUtils.m in Sources */,
 				BDE48A292410D27300ECA6CA /* BaseEpisode+Formatting.swift in Sources */,
 				FF54BCAA2C5A2F4D00A342E5 /* TranscriptFormat.swift in Sources */,
@@ -7660,6 +7668,7 @@
 				F5F509232CEBEE87007D6E39 /* BaseEpisode+Formatting.swift in Sources */,
 				F5F5094E2CEBF451007D6E39 /* DescriptiveActionView.swift in Sources */,
 				F5F509712CEBF8C1007D6E39 /* SJMediaMetadataHelper.m in Sources */,
+				FFB537862FFBCFB50068E0E1 /* ChaptersFingerprintSync.swift in Sources */,
 				F5D5F7C82CEBE865001F492D /* PlayerTabsView.swift in Sources */,
 				F5F509042CEBEA73007D6E39 /* AppTheme.swift in Sources */,
 				F5F509522CEBF4AC007D6E39 /* Settings.swift in Sources */,
@@ -7780,6 +7789,7 @@
 				FF8FFE442FAA49BE0086A867 /* PodcastManager+Cleanup.swift in Sources */,
 				FFE477202FBE0D8100716EAA /* ServerPodcastManager+Subscription.swift in Sources */,
 				FF6033FD2FAB4C9700EB3AD5 /* EpisodesDataManager.swift in Sources */,
+				FFB537852FFBCFB50068E0E1 /* ChaptersFingerprintSync.swift in Sources */,
 				FF8FFE612FAA63750086A867 /* Enumerations.swift in Sources */,
 				FF8FFE652FAA8E5B0086A867 /* PodcastChapterParser.swift in Sources */,
 				FF8FFE6B2FAA8EA00086A867 /* Chapters.swift in Sources */,

--- a/podcasts/ChapterInfo.swift
+++ b/podcasts/ChapterInfo.swift
@@ -9,6 +9,12 @@ class ChapterInfo: Equatable {
     var title = ""
     var url: String?
     var startTime = CMTime(seconds: 0, preferredTimescale: 0)
+
+    /// For generated chapters only: the original start time in the reference
+    /// (generated-transcript) timeline, before it's mapped onto the played
+    /// audio file's timeline via fingerprint timing. `nil` for every other
+    /// chapter source, which are already expressed in the played file's timeline.
+    var referenceStartTime: CMTime?
     #if !os(watchOS)
         var image: UIImage?
     #endif

--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -3,6 +3,26 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import CoreMedia
 
+/// Maps a time in the generated-content (reference) timeline onto the played
+/// audio file's timeline. In the main app this is implemented by
+/// `FingerprintTimingManager`; targets that don't include fingerprinting (App
+/// Clip, watchOS, tvOS) simply leave the provider unset, so the adjustment is a
+/// no-op there and generated chapters keep their reference times.
+protocol ChapterReferenceTimeMapping: AnyObject {
+    /// Whether a usable mapping is currently available.
+    var hasChapterReferenceMapping: Bool { get }
+
+    /// The played-file time for a time in the reference timeline, or `nil` if it
+    /// can't be mapped.
+    func playbackTime(forReferenceTime referenceTime: TimeInterval) -> TimeInterval?
+}
+
+/// Registered by the app once fingerprint timing is available. Stays `nil` in
+/// targets without fingerprinting.
+enum ChapterReferenceTimeMappingProvider {
+    static var current: ChapterReferenceTimeMapping?
+}
+
 enum ChapterOrigin {
     case podcastIndex
     case nativeMedia
@@ -38,6 +58,12 @@ class ChapterManager {
 
     private var lastEpisodeUuid = ""
 
+    /// Duration of the episode the current chapters belong to. Used to recompute
+    /// generated-chapter durations after their start times are re-mapped.
+    private var episodeDuration: TimeInterval = 0
+
+    private var mappingObserver: NSObjectProtocol?
+
     var numberOfChaptersSkipped = 0
 
     var currentChapters = Chapters()
@@ -53,6 +79,22 @@ class ChapterManager {
         showInfoCoordinator: ShowInfoCoordinating = ShowInfoCoordinator.shared) {
         self.chapterParser = chapterParser
         self.showInfoCoordinator = showInfoCoordinator
+
+        // The fingerprint mapping is built asynchronously and keeps growing during
+        // playback, so re-align generated chapters whenever it advances.
+        mappingObserver = NotificationCenter.default.addObserver(
+            forName: Constants.Notifications.fingerprintTimingMappingUpdated,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.applyGeneratedChapterTiming()
+        }
+    }
+
+    deinit {
+        if let mappingObserver {
+            NotificationCenter.default.removeObserver(mappingObserver)
+        }
     }
 
     func visibleChapterCount() -> Int {
@@ -138,6 +180,7 @@ class ChapterManager {
     func parseChapters(episode: BaseEpisode, duration: TimeInterval) async {
         // store the last episode uuid we were asked to check chapters for, we use that below in case this method is called multiple times to not return old results
         lastEpisodeUuid = episode.uuid
+        episodeDuration = duration
 
         try? await parseLocalAndRemoteChapters(for: episode, duration: duration)
     }
@@ -231,8 +274,53 @@ class ChapterManager {
             .compactMap { Int($0) }
             .forEach { self.chapters[safe: $0]?.shouldPlay = false }
 
+        // Apply any mapping that already exists; if none is ready yet the chapters
+        // keep their reference times and get re-aligned once the mapping advances.
+        // Skip the notification here since we post `podcastChaptersDidUpdate` below.
+        applyGeneratedChapterTiming(notifyIfChanged: false)
+
         updateCurrentChapter(time: PlaybackManager.shared.currentTime())
 
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastChaptersDidUpdate)
+    }
+
+    /// Re-map generated chapter start times from the reference (transcript)
+    /// timeline onto the played audio file's timeline using fingerprint timing,
+    /// so chapter markers line up with what's actually playing when dynamic ads
+    /// have shifted the real positions. No-op for other chapter sources, when no
+    /// mapping is available, or in targets without fingerprinting.
+    private func applyGeneratedChapterTiming(notifyIfChanged: Bool = true) {
+        guard chaptersOrigin == .generated else { return }
+        guard let mapper = ChapterReferenceTimeMappingProvider.current, mapper.hasChapterReferenceMapping else { return }
+
+        // `chapters` is kept sorted by reference start time by the parser, and the
+        // mapping is monotonic, so this order also holds in the played timeline.
+        var didChange = false
+        for chapter in chapters {
+            guard let referenceTime = chapter.referenceStartTime?.seconds else { continue }
+            let mappedTime = mapper.playbackTime(forReferenceTime: referenceTime) ?? referenceTime
+            if abs(mappedTime - chapter.startTime.seconds) > 0.001 {
+                chapter.startTime = CMTime(seconds: mappedTime, preferredTimescale: 1000000)
+                didChange = true
+            }
+        }
+
+        guard didChange else { return }
+
+        // Durations are gaps between consecutive start times, so recompute them
+        // from the adjusted values (the last chapter runs to the episode end).
+        for (index, chapter) in chapters.enumerated() {
+            if let nextChapter = chapters[safe: index + 1] {
+                chapter.duration = max(0, nextChapter.startTime.seconds - chapter.startTime.seconds)
+            } else {
+                chapter.duration = max(0, episodeDuration - chapter.startTime.seconds)
+            }
+        }
+
+        updateCurrentChapter(time: PlaybackManager.shared.currentTime())
+
+        if notifyIfChanged {
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastChaptersDidUpdate)
+        }
     }
 }

--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -3,26 +3,6 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import CoreMedia
 
-/// Maps a time in the generated-content (reference) timeline onto the played
-/// audio file's timeline. In the main app this is implemented by
-/// `FingerprintTimingManager`; targets that don't include fingerprinting (App
-/// Clip, watchOS, tvOS) simply leave the provider unset, so the adjustment is a
-/// no-op there and generated chapters keep their reference times.
-protocol ChapterReferenceTimeMapping: AnyObject {
-    /// Whether a usable mapping is currently available.
-    var hasChapterReferenceMapping: Bool { get }
-
-    /// The played-file time for a time in the reference timeline, or `nil` if it
-    /// can't be mapped.
-    func playbackTime(forReferenceTime referenceTime: TimeInterval) -> TimeInterval?
-}
-
-/// Registered by the app once fingerprint timing is available. Stays `nil` in
-/// targets without fingerprinting.
-enum ChapterReferenceTimeMappingProvider {
-    static var current: ChapterReferenceTimeMapping?
-}
-
 enum ChapterOrigin {
     case podcastIndex
     case nativeMedia

--- a/podcasts/ChaptersFingerprintSync.swift
+++ b/podcasts/ChaptersFingerprintSync.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Maps a time in the generated-content (reference) timeline onto the played
+/// audio file's timeline. In the main app this is implemented by
+/// `FingerprintTimingManager`; targets that don't include fingerprinting (App
+/// Clip, watchOS, tvOS) simply leave the provider unset, so the adjustment is a
+/// no-op there and generated chapters keep their reference times.
+protocol ChapterReferenceTimeMapping: AnyObject {
+    /// Whether a usable mapping is currently available.
+    var hasChapterReferenceMapping: Bool { get }
+
+    /// The played-file time for a time in the reference timeline, or `nil` if it
+    /// can't be mapped.
+    func playbackTime(forReferenceTime referenceTime: TimeInterval) -> TimeInterval?
+}
+
+/// Registered by the app once fingerprint timing is available. Stays `nil` in
+/// targets without fingerprinting.
+enum ChapterReferenceTimeMappingProvider {
+    static var current: ChapterReferenceTimeMapping?
+}
+
+#if !os(watchOS) && !APPCLIP && !os(tvOS)
+// MARK: - ChapterReferenceTimeMapping
+extension FingerprintTimingManager: ChapterReferenceTimeMapping {
+    /// A mapping is usable once we've reached `.active` (enough coverage to trust
+    /// the reference↔playback interpolation). `playbackTime(forReferenceTime:)`
+    /// is already declared above and satisfies the protocol requirement.
+    var hasChapterReferenceMapping: Bool {
+        if case .active = state {
+            return true
+        }
+        return false
+    }
+}
+#endif

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -18,6 +18,7 @@ struct Constants {
         static let playbackProgress = NSNotification.Name(rawValue: "SJPlaybackProg")
         static let playbackTrackChanged = NSNotification.Name(rawValue: "SJTrackChanged")
         static let podcastChaptersDidUpdate = NSNotification.Name(rawValue: "SJChaptersChanged")
+        static let fingerprintTimingMappingUpdated = NSNotification.Name(rawValue: "SJFingerprintTimingMappingUpdated")
         static let podcastChapterChanged = NSNotification.Name(rawValue: "SJChapterChanged")
         static let podcastColorsDownloaded = NSNotification.Name(rawValue: "SJPodcastColorsReady")
         static let playbackEnded = NSNotification.Name(rawValue: "SJPlaybackEnd")

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -371,8 +371,18 @@ final class FingerprintTimingManager: NSObject {
 
     /// Tell interested consumers (e.g. `ChapterManager`, to re-align generated
     /// chapters) that the reference↔playback mapping has advanced.
+    ///
+    /// Posted with a non-blocking `async` hop rather than `postOnMainThread`'s
+    /// `main.sync`: this is called from within `queue`, and the consumers it
+    /// wakes (`playbackTime(forReferenceTime:)`, `matchedReferenceTime(...)`,
+    /// etc.) re-enter `queue` via `queue.sync` from the main thread. A blocking
+    /// `main.sync` here would cross those two synchronous hops and deadlock /
+    /// trip the `dispatchPrecondition(.notOnQueue(queue))` guard. Nothing needs
+    /// the post to complete synchronously.
     private func postMappingUpdated() {
-        NotificationCenter.postOnMainThread(notification: Constants.Notifications.fingerprintTimingMappingUpdated)
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: Constants.Notifications.fingerprintTimingMappingUpdated, object: nil)
+        }
     }
 
     // MARK: - Track Preparation

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -100,7 +100,7 @@ final class FingerprintTimingManager: NSObject {
 
     override init() {
         super.init()
-        ChapterReferenceTimeMappingProvider.current = self
+        
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleEpisodeDownloaded(_:)),
@@ -1328,20 +1328,6 @@ final class FingerprintTimingManager: NSObject {
         }
         let preferred = FeatureFlag.streamAndCachePlayingEpisode.enabled ? tempPath : streamingPath
         return .streaming(URL(fileURLWithPath: preferred))
-    }
-}
-
-// MARK: - ChapterReferenceTimeMapping
-
-extension FingerprintTimingManager: ChapterReferenceTimeMapping {
-    /// A mapping is usable once we've reached `.active` (enough coverage to trust
-    /// the reference↔playback interpolation). `playbackTime(forReferenceTime:)`
-    /// is already declared above and satisfies the protocol requirement.
-    var hasChapterReferenceMapping: Bool {
-        if case .active = state {
-            return true
-        }
-        return false
     }
 }
 

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -100,6 +100,7 @@ final class FingerprintTimingManager: NSObject {
 
     override init() {
         super.init()
+        ChapterReferenceTimeMappingProvider.current = self
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleEpisodeDownloaded(_:)),
@@ -368,6 +369,12 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
+    /// Tell interested consumers (e.g. `ChapterManager`, to re-align generated
+    /// chapters) that the reference↔playback mapping has advanced.
+    private func postMappingUpdated() {
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.fingerprintTimingMappingUpdated)
+    }
+
     // MARK: - Track Preparation
 
     private func prepareForEpisode(_ episode: BaseEpisode?) {
@@ -553,6 +560,7 @@ final class FingerprintTimingManager: NSObject {
                 FileLog.shared.addMessage(
                     "FingerprintTimingManager: skipping stream — full mapping loaded from cache for \(uuid)"
                 )
+                postMappingUpdated()
                 return
             }
 
@@ -1026,6 +1034,10 @@ final class FingerprintTimingManager: NSObject {
             }
         }
 
+        if inserted > 0 {
+            postMappingUpdated()
+        }
+
         #if DEBUG
         // `inserted` is the mapping count committed during this call, not a
         // ratio to windows processed — the drift filter holds candidates in a
@@ -1306,6 +1318,20 @@ final class FingerprintTimingManager: NSObject {
         }
         let preferred = FeatureFlag.streamAndCachePlayingEpisode.enabled ? tempPath : streamingPath
         return .streaming(URL(fileURLWithPath: preferred))
+    }
+}
+
+// MARK: - ChapterReferenceTimeMapping
+
+extension FingerprintTimingManager: ChapterReferenceTimeMapping {
+    /// A mapping is usable once we've reached `.active` (enough coverage to trust
+    /// the reference↔playback interpolation). `playbackTime(forReferenceTime:)`
+    /// is already declared above and satisfies the protocol requirement.
+    var hasChapterReferenceMapping: Bool {
+        if case .active = state {
+            return true
+        }
+        return false
     }
 }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -17,7 +17,13 @@ class PlaybackManager: ServerPlaybackDelegate {
     private static let notSeeking: TimeInterval = -1
     private var seekingTo: TimeInterval = PlaybackManager.notSeeking
 
-    private let chapterManager = ChapterManager()
+    private lazy var chapterManager: ChapterManager = {
+        let chapterManager = ChapterManager()
+#if !os(watchOS) && !APPCLIP && !os(tvOS)
+        ChapterReferenceTimeMappingProvider.current = FingerprintTimingManager.shared
+#endif
+        return chapterManager
+    }()
 
     var sleepTimeRemaining = -1 as TimeInterval
 

--- a/podcasts/PodcastChapterParser.swift
+++ b/podcasts/PodcastChapterParser.swift
@@ -81,6 +81,11 @@ class PodcastChapterParser {
             chapterInfo.title = chapter.title
             chapterInfo.index = index
             chapterInfo.startTime = CMTime(seconds: chapter.startTime, preferredTimescale: 1000000)
+            // Generated chapters are timed against the reference (clean) audio the
+            // transcript was generated from. Keep the reference time so the played
+            // file's timeline can be recovered via fingerprint timing (dynamic ads
+            // shift the real positions). See `ChapterManager.applyGeneratedChapterTiming`.
+            chapterInfo.referenceStartTime = chapterInfo.startTime
             if let nextChapterStartTime = sortedChapters[safe: index + 1]?.startTime {
                 chapterInfo.duration = nextChapterStartTime - chapter.startTime
             } else {


### PR DESCRIPTION
Fixes [POC-654](https://linear.app/a8c/issue/POC-654/use-fingerprint-to-adjust-timings)
|:---:|

## Summary

Generated chapters are timed against the **reference** (clean) audio the transcript was generated from. When the played file contains dynamic ads, the real audio positions shift, so the generated chapter markers drift out of sync with what's actually playing.

This PR re-maps each generated chapter's start time from the reference timeline onto the **played file's timeline** using `FingerprintTimingManager` (the same mapping already used for synced-transcript seeking), and recomputes chapter durations from the adjusted start times.

Because the fingerprint mapping is built asynchronously and grows around the current playback position during playback, chapters are re-aligned both at parse time and again whenever the mapping advances — via a new `fingerprintTimingMappingUpdated` notification. Chapters ahead of the covered region keep their reference times until coverage reaches them, then self-correct.

### Notes for reviewers

- `ChapterManager` compiles into targets that do **not** include the `Fingerprint` sources (Watch, App Clip, TV). To avoid breaking those builds, the dependency is decoupled behind the `ChapterReferenceTimeMapping` protocol + a `ChapterReferenceTimeMappingProvider` registry. The provider stays unset in those targets, so the adjustment is a no-op there and generated chapters simply keep their reference times.
- `FingerprintTimingManager` conforms to the protocol (`hasChapterReferenceMapping` is true once `.active`, and the existing `playbackTime(forReferenceTime:)` satisfies the mapping requirement) and registers itself as the provider in the main app.
- The adjustment is gated on `chaptersOrigin == .generated` **and** an active mapping. The active-mapping requirement implicitly covers "has generated transcripts", since the fingerprint reference only exists for generated-transcript episodes.
- No new analytics events were added.

## To test

1. Play an episode that has generated transcripts and generated chapters, where the played file contains dynamic ads.
2. Open the transcript so synced-transcript preparation kicks in (this builds the fingerprint mapping).
3. As playback progresses and the mapping reaches `.active`, confirm the chapter markers/boundaries line up with the real audio content rather than being offset by the inserted ads.
4. Regression: on an episode with embedded/native or Podcast Index chapters, confirm nothing changes.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. <!-- No analytics changes -->
