### PR TITLE
Add HLS feature flag

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -322,6 +322,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable Generated Chapters
     case generatedChapters
 
+    /// Enable HLS streaming playback
+    case hls
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -543,6 +546,8 @@ public enum FeatureFlag: String, CaseIterable {
         case .upNextSort:
             true
         case .generatedChapters:
+            BuildEnvironment.current == .debug
+        case .hls:
             BuildEnvironment.current == .debug
         }
     }


### PR DESCRIPTION
Fixes PCIOS-808

Adds a new `hls` feature flag to `FeatureFlag.swift` to gate upcoming HLS streaming playback work. The flag defaults to enabled only in debug builds (matching recent flags like `generatedChapters`) and exposes a `hls` remote key so it can be toggled via Firebase Remote Config. No behavior is gated behind it yet.

## To test

1. Build and run the app in a debug configuration.
2. Open Settings and navigate to the feature flag override screen (Developer/debug menu).
3. Confirm an `hls` flag appears in the list and can be toggled on/off.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
