### PR TITLE
tvOS: Offer to save Up Next when using Play All

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 - Fix Autoplay stopping instead of continuing through manual playlists that contain episodes from podcasts you don't follow [#4624](https://github.com/Automattic/pocket-casts-ios/pull/4624)
 - Fix separator alignment and list background color on the Discover category list [#4653](https://github.com/Automattic/pocket-casts-ios/pull/4653)
 - Add episode sorting to the podcast screen on tvOS [#4650](https://github.com/Automattic/pocket-casts-ios/pull/4650)
-- Offer to save your current Up Next as a playlist when using Play All on tvOS [#4670](https://github.com/Automattic/pocket-casts-ios/pull/4670)
 
 8.15
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix Autoplay stopping instead of continuing through manual playlists that contain episodes from podcasts you don't follow [#4624](https://github.com/Automattic/pocket-casts-ios/pull/4624)
 - Fix separator alignment and list background color on the Discover category list [#4653](https://github.com/Automattic/pocket-casts-ios/pull/4653)
 - Add episode sorting to the podcast screen on tvOS [#4650](https://github.com/Automattic/pocket-casts-ios/pull/4650)
+- Offer to save your current Up Next as a playlist when using Play All on tvOS [#4670](https://github.com/Automattic/pocket-casts-ios/pull/4670)
 
 8.15
 -----

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager+ManualPlaylist.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager+ManualPlaylist.swift
@@ -30,21 +30,11 @@ public extension DataManager {
     }
 
     private static func manualPlaylist(named name: String, sortPosition: Int) -> EpisodeFilter {
-        let playlist = EpisodeFilter()
-        playlist.uuid = UUID().uuidString
+        let playlist = EpisodeFilter.makeDefault()
         playlist.playlistName = name
         playlist.manual = true
-        playlist.syncStatus = SyncStatus.notSynced.rawValue
-        playlist.isNew = false
         playlist.sortType = PlaylistSort.dragAndDrop.rawValue
         playlist.sortPosition = Int32(sortPosition)
-        playlist.filterAllPodcasts = true
-        playlist.filterUnplayed = true
-        playlist.filterPartiallyPlayed = true
-        playlist.filterFinished = true
-        playlist.filterDownloaded = true
-        playlist.filterNotDownloaded = true
-        playlist.filterAudioVideoType = AudioVideoFilter.all.rawValue
         return playlist
     }
 }

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager+ManualPlaylist.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager+ManualPlaylist.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public extension DataManager {
+    /// Splits `episodes` into batches of `batchSize` and saves each batch as a new manual playlist.
+    /// Playlists are named `baseName`, with a ` (2)`, ` (3)`… suffix when more than one is created.
+    /// Returns the number of playlists created.
+    @discardableResult
+    func createManualPlaylists(from episodes: [Episode], batchSize: Int, baseName: String) -> Int {
+        guard !episodes.isEmpty, batchSize > 0 else { return 0 }
+
+        var batches: [[Episode]] = []
+        var startIndex = 0
+        while startIndex < episodes.count {
+            let endIndex = min(startIndex + batchSize, episodes.count)
+            batches.append(Array(episodes[startIndex..<endIndex]))
+            startIndex += batchSize
+        }
+
+        let firstSortPosition = max(0, firstSortPositionForPlaylist())
+        bumpSortPositionForAllPlaylists(adding: batches.count)
+
+        for (index, batch) in batches.enumerated() {
+            let name = index > 0 ? "\(baseName) (\(index + 1))" : baseName
+            let playlist = Self.manualPlaylist(named: name, sortPosition: firstSortPosition + index)
+            save(playlist: playlist)
+            _ = add(episodes: batch, to: playlist)
+        }
+
+        return batches.count
+    }
+
+    private static func manualPlaylist(named name: String, sortPosition: Int) -> EpisodeFilter {
+        let playlist = EpisodeFilter()
+        playlist.uuid = UUID().uuidString
+        playlist.playlistName = name
+        playlist.manual = true
+        playlist.syncStatus = SyncStatus.notSynced.rawValue
+        playlist.isNew = false
+        playlist.sortType = PlaylistSort.dragAndDrop.rawValue
+        playlist.sortPosition = Int32(sortPosition)
+        playlist.filterAllPodcasts = true
+        playlist.filterUnplayed = true
+        playlist.filterPartiallyPlayed = true
+        playlist.filterFinished = true
+        playlist.filterDownloaded = true
+        playlist.filterNotDownloaded = true
+        playlist.filterAudioVideoType = AudioVideoFilter.all.rawValue
+        return playlist
+    }
+}

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -49,6 +49,22 @@ public class EpisodeFilter: NSObject {
 
     override public init() {}
 
+    /// A new filter pre-populated with the default "match everything" rules used when creating a playlist.
+    /// Callers set the name, sort position, and any distinguishing fields (e.g. `manual`, `sortType`).
+    public static func makeDefault() -> EpisodeFilter {
+        let filter = EpisodeFilter()
+        filter.uuid = UUID().uuidString
+        filter.syncStatus = SyncStatus.notSynced.rawValue
+        filter.filterAllPodcasts = true
+        filter.filterUnplayed = true
+        filter.filterPartiallyPlayed = true
+        filter.filterFinished = true
+        filter.filterDownloaded = true
+        filter.filterNotDownloaded = true
+        filter.filterAudioVideoType = AudioVideoFilter.all.rawValue
+        return filter
+    }
+
     public func setTitle(_ title: String?, defaultTitle: String) {
         guard let title, !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             playlistName = defaultTitle

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -33,18 +33,21 @@ struct PlaylistDetailView: View {
         .toolbar(.hidden, for: .tabBar)
         .defaultFocus($focusedSection, .episodes)
         .confirmationDialog(
-            L10n.playlistPlayAllSheetTitle,
+            L10n.tvPlaylistPlayAllClearUpNextTitle,
             isPresented: $model.isShowingReplaceUpNextConfirmation,
             titleVisibility: .visible
         ) {
-            Button(L10n.playlistPlayAllSheetButtonTitle, role: .confirm) {
-                model.buttonConfirmPlayPlaylistTapped()
+            Button(L10n.tvPlaylistPlayAllSaveAndPlay, role: .confirm) {
+                model.saveUpNextAndPlay()
+            }
+            Button(L10n.tvPlaylistPlayAllPlayWithoutSaving) {
+                model.playWithoutSaving()
             }
             Button(L10n.cancel, role: .cancel) {
-                Analytics.track(.filterPlayAllDismissed)
+                model.replaceUpNextConfirmationDismissed()
             }
         } message: {
-            Text(L10n.playlistPlayAllSheetDescription)
+            Text(L10n.tvPlaylistPlayAllClearUpNextMessage)
         }
         .fullScreenCover(isPresented: $model.isShowingNowPlaying) {
             NowPlayingView()

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -37,11 +37,11 @@ struct PlaylistDetailView: View {
             isPresented: $model.isShowingReplaceUpNextConfirmation,
             titleVisibility: .visible
         ) {
-            Button(L10n.tvPlaylistPlayAllSaveAndPlay, role: .confirm) {
-                model.saveUpNextAndPlay()
-            }
-            Button(L10n.tvPlaylistPlayAllPlayWithoutSaving) {
+            Button(L10n.tvPlaylistPlayAllPlayWithoutSaving, role: .confirm) {
                 model.playWithoutSaving()
+            }
+            Button(L10n.tvPlaylistPlayAllSaveAndPlay) {
+                model.saveUpNextAndPlay()
             }
             Button(L10n.cancel, role: .cancel) {
                 model.replaceUpNextConfirmationDismissed()

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -111,14 +111,16 @@ class PlaylistDetailsViewModel {
         Analytics.track(.filterPlayAllReplaceAndPlayTapped, properties: analyticsProperties(["save_up_next": true]))
         Task { [weak self] in
             guard let self else { return }
-            let batches = await self.batchedUpNextEpisodes()
+            let episodes = self.currentUpNextEpisodes()
             await MainActor.run {
                 self.playbackManager.play(playlist: self.playlist)
                 self.isShowingNowPlaying = true
             }
-            if await self.createPlaylists(from: batches) {
+            let baseName = "\(L10n.upNext) - \(Date().monthDayString())"
+            let created = self.dataManager.createManualPlaylists(from: episodes, batchSize: Constants.Limits.maxFilterItems, baseName: baseName)
+            if created > 0 {
                 await MainActor.run {
-                    ToastManager.shared.show(batches.count > 1 ? L10n.playlistPlayAllUpNextSavedPlural : L10n.playlistPlayAllUpNextSaved)
+                    ToastManager.shared.show(created > 1 ? L10n.playlistPlayAllUpNextSavedPlural : L10n.playlistPlayAllUpNextSaved)
                 }
             }
         }
@@ -140,49 +142,9 @@ class PlaylistDetailsViewModel {
         return properties
     }
 
-    private func batchedUpNextEpisodes(batchSize: Int = Constants.Limits.maxFilterItems) async -> [[Episode]] {
+    private func currentUpNextEpisodes() -> [Episode] {
         let uuids = dataManager.allUpNextEpisodeUuids().compactMap(\.uuid)
-        let allEpisodes = dataManager.allUpNextEpisodes(from: uuids)
-
-        guard !allEpisodes.isEmpty else { return [] }
-        guard allEpisodes.count > batchSize else { return [allEpisodes] }
-
-        var result: [[Episode]] = []
-        var startIndex = 0
-        while startIndex < allEpisodes.count {
-            let endIndex = min(startIndex + batchSize, allEpisodes.count)
-            result.append(Array(allEpisodes[startIndex..<endIndex]))
-            startIndex += batchSize
-        }
-        return result
-    }
-
-    private func createPlaylists(from batches: [[Episode]]) async -> Bool {
-        guard !batches.isEmpty else { return false }
-        let firstSortPosition = max(0, dataManager.firstSortPositionForPlaylist())
-        dataManager.bumpSortPositionForAllPlaylists(adding: batches.count)
-        for (index, batch) in batches.enumerated() {
-            let playlist = newManualPlaylist(index: index + 1, sortPosition: firstSortPosition + index)
-            dataManager.save(playlist: playlist)
-            _ = dataManager.add(episodes: batch, to: playlist)
-        }
-        return true
-    }
-
-    private func newManualPlaylist(index: Int, sortPosition: Int) -> EpisodeFilter {
-        var playlistName = "\(L10n.upNext) - \(Date().monthDayString())"
-        if index > 1 {
-            playlistName += " (\(index))"
-        }
-        let playlist = EpisodeFilter()
-        playlist.uuid = UUID().uuidString
-        playlist.setTitle(playlistName, defaultTitle: L10n.playlistsDefaultNewPlaylist.localizedCapitalized)
-        playlist.manual = true
-        playlist.syncStatus = SyncStatus.notSynced.rawValue
-        playlist.isNew = false
-        playlist.sortType = PlaylistSort.dragAndDrop.rawValue
-        playlist.sortPosition = Int32(sortPosition)
-        return playlist
+        return dataManager.allUpNextEpisodes(from: uuids)
     }
 
     var playlistName: String {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -107,9 +107,6 @@ class PlaylistDetailsViewModel {
         }
     }
 
-    /// Saves the current Up Next queue as a manual playlist (splitting into several playlists if it
-    /// exceeds the per-playlist limit) and then plays the selected playlist. The queue is captured
-    /// before playback starts, since playing replaces the current Up Next.
     func saveUpNextAndPlay() {
         Analytics.track(.filterPlayAllReplaceAndPlayTapped, properties: analyticsProperties(["save_up_next": true]))
         Task { [weak self] in

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -109,19 +109,19 @@ class PlaylistDetailsViewModel {
 
     func saveUpNextAndPlay() {
         Analytics.track(.filterPlayAllReplaceAndPlayTapped, properties: analyticsProperties(["save_up_next": true]))
-        Task { [weak self] in
-            guard let self else { return }
-            let episodes = self.currentUpNextEpisodes()
-            await MainActor.run {
-                self.playbackManager.play(playlist: self.playlist)
-                self.isShowingNowPlaying = true
-            }
-            let baseName = "\(L10n.upNext) - \(Date().monthDayString())"
-            let created = self.dataManager.createManualPlaylists(from: episodes, batchSize: Constants.Limits.maxFilterItems, baseName: baseName)
+        Task { await _saveUpNextAndPlay() }
+    }
+
+    @concurrent private func _saveUpNextAndPlay() async {
+        let episodes = currentUpNextEpisodes()
+        let baseName = "\(L10n.upNext) - \(Date().monthDayString())"
+        let created = dataManager.createManualPlaylists(from: episodes, batchSize: Constants.Limits.maxFilterItems, baseName: baseName)
+        await MainActor.run {
+            self.playbackManager.play(playlist: self.playlist)
+            self.isShowingNowPlaying = true
+
             if created > 0 {
-                await MainActor.run {
-                    ToastManager.shared.show(created > 1 ? L10n.playlistPlayAllUpNextSavedPlural : L10n.playlistPlayAllUpNextSaved)
-                }
+                ToastManager.shared.show(created > 1 ? L10n.playlistPlayAllUpNextSavedPlural : L10n.playlistPlayAllUpNextSaved)
             }
         }
     }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -121,6 +121,7 @@ class PlaylistDetailsViewModel {
             self.isShowingNowPlaying = true
 
             if created > 0 {
+                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playlistChanged)
                 ToastManager.shared.show(created > 1 ? L10n.playlistPlayAllUpNextSavedPlural : L10n.playlistPlayAllUpNextSaved)
             }
         }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -98,7 +98,7 @@ class PlaylistDetailsViewModel {
     func playAll() {
         guard !episodes.isEmpty else { return }
 
-        Analytics.track(.filterPlayAllTapped)
+        Analytics.track(.filterPlayAllTapped, properties: analyticsProperties())
 
         if playbackManager.playIfSafe(playlist: playlist, episodeIDs: episodes.map(\.uuid)) {
             isShowingNowPlaying = true
@@ -107,10 +107,85 @@ class PlaylistDetailsViewModel {
         }
     }
 
-    func buttonConfirmPlayPlaylistTapped() {
-        Analytics.track(.filterPlayAllReplaceAndPlayTapped, properties: ["save_up_next": Settings.saveCurrentUpNextQueueIntoPlaylist])
+    /// Saves the current Up Next queue as a manual playlist (splitting into several playlists if it
+    /// exceeds the per-playlist limit) and then plays the selected playlist. The queue is captured
+    /// before playback starts, since playing replaces the current Up Next.
+    func saveUpNextAndPlay() {
+        Analytics.track(.filterPlayAllReplaceAndPlayTapped, properties: analyticsProperties(["save_up_next": true]))
+        Task { [weak self] in
+            guard let self else { return }
+            let batches = await self.batchedUpNextEpisodes()
+            await MainActor.run {
+                self.playbackManager.play(playlist: self.playlist)
+                self.isShowingNowPlaying = true
+            }
+            if await self.createPlaylists(from: batches) {
+                await MainActor.run {
+                    ToastManager.shared.show(batches.count > 1 ? L10n.playlistPlayAllUpNextSavedPlural : L10n.playlistPlayAllUpNextSaved)
+                }
+            }
+        }
+    }
+
+    func playWithoutSaving() {
+        Analytics.track(.filterPlayAllReplaceAndPlayTapped, properties: analyticsProperties(["save_up_next": false]))
         playbackManager.play(playlist: playlist)
         isShowingNowPlaying = true
+    }
+
+    func replaceUpNextConfirmationDismissed() {
+        Analytics.track(.filterPlayAllDismissed, properties: analyticsProperties())
+    }
+
+    private func analyticsProperties(_ additional: [String: Sendable] = [:]) -> [String: Sendable] {
+        var properties: [String: Sendable] = ["filter_type": isManual ? "manual" : "smart"]
+        additional.forEach { properties[$0.key] = $0.value }
+        return properties
+    }
+
+    private func batchedUpNextEpisodes(batchSize: Int = Constants.Limits.maxFilterItems) async -> [[Episode]] {
+        let uuids = dataManager.allUpNextEpisodeUuids().compactMap(\.uuid)
+        let allEpisodes = dataManager.allUpNextEpisodes(from: uuids)
+
+        guard !allEpisodes.isEmpty else { return [] }
+        guard allEpisodes.count > batchSize else { return [allEpisodes] }
+
+        var result: [[Episode]] = []
+        var startIndex = 0
+        while startIndex < allEpisodes.count {
+            let endIndex = min(startIndex + batchSize, allEpisodes.count)
+            result.append(Array(allEpisodes[startIndex..<endIndex]))
+            startIndex += batchSize
+        }
+        return result
+    }
+
+    private func createPlaylists(from batches: [[Episode]]) async -> Bool {
+        guard !batches.isEmpty else { return false }
+        let firstSortPosition = max(0, dataManager.firstSortPositionForPlaylist())
+        dataManager.bumpSortPositionForAllPlaylists(adding: batches.count)
+        for (index, batch) in batches.enumerated() {
+            let playlist = newManualPlaylist(index: index + 1, sortPosition: firstSortPosition + index)
+            dataManager.save(playlist: playlist)
+            _ = dataManager.add(episodes: batch, to: playlist)
+        }
+        return true
+    }
+
+    private func newManualPlaylist(index: Int, sortPosition: Int) -> EpisodeFilter {
+        var playlistName = "\(L10n.upNext) - \(Date().monthDayString())"
+        if index > 1 {
+            playlistName += " (\(index))"
+        }
+        let playlist = EpisodeFilter()
+        playlist.uuid = UUID().uuidString
+        playlist.setTitle(playlistName, defaultTitle: L10n.playlistsDefaultNewPlaylist.localizedCapitalized)
+        playlist.manual = true
+        playlist.syncStatus = SyncStatus.notSynced.rawValue
+        playlist.isNew = false
+        playlist.sortType = PlaylistSort.dragAndDrop.rawValue
+        playlist.sortPosition = Int32(sortPosition)
+        return playlist
     }
 
     var playlistName: String {

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel+PlayAll.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel+PlayAll.swift
@@ -9,15 +9,16 @@ extension PlaylistDetailViewModel {
     func saveUpNextAndPlay() {
         Task { [weak self] in
             guard let self else { return }
-            let batches = await self.batchedUpNextEpisodes()
+            let episodes = self.currentUpNextEpisodes()
             await MainActor.run {
                 self.playAllEpisodes()
             }
-            let success = await self.createPlaylists(from: batches)
-            if success {
+            let baseName = "\(L10n.upNext) - \(Date().monthDayString())"
+            let created = self.dataManager.createManualPlaylists(from: episodes, batchSize: Constants.Limits.maxFilterItems, baseName: baseName)
+            if created > 0 {
                 await MainActor.run {
                     Toast.show(
-                        batches.count > 1 ? L10n.playlistPlayAllUpNextSavedPlural : L10n.playlistPlayAllUpNextSaved,
+                        created > 1 ? L10n.playlistPlayAllUpNextSavedPlural : L10n.playlistPlayAllUpNextSaved,
                         actions: [
                             .init(title: L10n.bookmarkAddedButtonTitle) {
                                 NavigationManager.sharedManager.navigateTo(
@@ -31,48 +32,8 @@ extension PlaylistDetailViewModel {
         }
     }
 
-    private func batchedUpNextEpisodes(batchSize: Int = Constants.Limits.maxFilterItems) async -> [[Episode]] {
+    private func currentUpNextEpisodes() -> [Episode] {
         let uuids = dataManager.allUpNextEpisodeUuids().compactMap(\.uuid)
-        let allEpisodes = dataManager.allUpNextEpisodes(from: uuids)
-
-        guard !allEpisodes.isEmpty else { return [] }
-        guard allEpisodes.count > batchSize else { return [allEpisodes] }
-
-        var result: [[Episode]] = []
-        var startIndex = 0
-
-        while startIndex < allEpisodes.count {
-            let endIndex = min(startIndex + batchSize, allEpisodes.count)
-            result.append(Array(allEpisodes[startIndex..<endIndex]))
-            startIndex += batchSize
-        }
-
-        return result
-    }
-
-    private func createPlaylists(from batches: [[Episode]]) async -> Bool {
-        let firstSortPosition = max(0, DataManager.sharedManager.firstSortPositionForPlaylist())
-        DataManager.sharedManager.bumpSortPositionForAllPlaylists(adding: batches.count)
-        for (index, batch) in batches.enumerated() {
-            let playlist = newManualPlaylist(index: index + 1, sortPosition: firstSortPosition + index)
-            DataManager.sharedManager.save(playlist: playlist)
-            DataManager.sharedManager.add(episodes: batch, to: playlist)
-        }
-        return true
-    }
-
-    private func newManualPlaylist(index: Int, sortPosition: Int) -> EpisodeFilter {
-        var playlistName = "\(L10n.upNext) - \(Date().monthDayString())"
-        if index > 1 {
-            playlistName += " (\(index))"
-        }
-        let playlist = PlaylistManager.createNewPlaylist()
-        playlist.setTitle(playlistName, defaultTitle: L10n.playlistsDefaultNewPlaylist.localizedCapitalized)
-        playlist.manual = true
-        playlist.syncStatus = SyncStatus.notSynced.rawValue
-        playlist.isNew = false
-        playlist.sortType = PlaylistSort.dragAndDrop.rawValue
-        playlist.sortPosition = Int32(sortPosition)
-        return playlist
+        return dataManager.allUpNextEpisodes(from: uuids)
     }
 }

--- a/podcasts/PlaylistManager.swift
+++ b/podcasts/PlaylistManager.swift
@@ -81,19 +81,9 @@ class PlaylistManager {
     }
 
     class func createNewPlaylist() -> EpisodeFilter {
-        let playlist = EpisodeFilter()
-        playlist.uuid = UUID().uuidString
+        let playlist = EpisodeFilter.makeDefault()
         playlist.playlistName = L10n.filtersDefaultNewFilter
-        playlist.syncStatus = SyncStatus.notSynced.rawValue
         playlist.sortPosition = nextSortPosition()
-        playlist.filterPartiallyPlayed = true
-        playlist.filterUnplayed = true
-        playlist.filterFinished = true
-        playlist.filterAudioVideoType = AudioVideoFilter.all.rawValue
-        playlist.filterAllPodcasts = true
-        playlist.filterDownloaded = true
-        playlist.filterNotDownloaded = true
-        playlist.customIcon = 0
         playlist.isNew = true
         return playlist
     }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6193,6 +6193,18 @@
 /* tv playlist detail play all button title */
 "tv_playlist_detail_play_all" = "Play all episodes";
 
+/* tv Play all dialog title, shown when starting a playlist would clear the current Up Next queue */
+"tv_playlist_play_all_clear_up_next_title" = "This will clear your Up Next";
+
+/* tv Play all dialog message, offering to save the current Up Next queue as a playlist before it is cleared */
+"tv_playlist_play_all_clear_up_next_message" = "We can save your current Up Next as a playlist";
+
+/* tv Play all dialog button that saves the current Up Next as a playlist and then plays the selected playlist */
+"tv_playlist_play_all_save_and_play" = "Save and play";
+
+/* tv Play all dialog button that plays the selected playlist without saving the current Up Next */
+"tv_playlist_play_all_play_without_saving" = "Play without saving";
+
 /* tv playlists empty title */
 "tv_playlists_empty_title" = "Your playlists live here";
 


### PR DESCRIPTION
Fixes: [POC-711](https://linear.app/a8c/issue/POC-711/implement-upnext-backup-on-playlist-play-all)

On tvOS, tapping **Play all** with a non-empty Up Next now offers to save it first. The confirmation dialog replaces the single "Replace and play" button with **Save and play** (saves the current Up Next as a manual playlist, then plays), **Play without saving**, and **Cancel** — porting the behaviour iOS already has.

The batching and manual-playlist creation now live in a shared `DataManager.createManualPlaylists(from:batchSize:baseName:)` in the DataModel module, used by both the iOS and tvOS Play All flows instead of duplicating the logic.

Also adds the `filter_type` property (and correct `save_up_next` value) to the play all analytics events to match the schema and iOS.

## To test

1. On tvOS, add a few episodes to Up Next.
2. Open a playlist with episodes and select **Play all episodes**.
3. Confirm the dialog reads "This will clear your Up Next" / "We can save your current Up Next as a playlist" with the three actions.
4. Tap **Save and play** → the playlist starts and a new "Up Next - <date>" playlist appears in Playlists (toast confirms).
5. Repeat and tap **Play without saving** → the playlist starts, no new playlist is created.
6. Repeat and tap **Cancel** → nothing plays, Up Next untouched.
7. On iOS, confirm Play All → "Save your current Up Next queue as a playlist" still saves and plays as before.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
