### PR TITLE
Add `alternate_enclosures` (HLS URL) support

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -46,7 +46,8 @@ class EpisodeDataManager {
         "deselectedChapters",
         "deselectedChaptersModified",
         "wasDeleted",
-        "hasGeneratedTranscript"
+        "hasGeneratedTranscript",
+        "hlsUrl"
     ]
 
     enum Constants {
@@ -1208,6 +1209,7 @@ class EpisodeDataManager {
         values.append(episode.deselectedChaptersModified)
         values.append(episode.wasDeleted)
         values.append(DBUtils.nullIfNil(value: episode.hasGeneratedTranscript))
+        values.append(DBUtils.nullIfNil(value: episode.hlsUrl))
 
         if includeIdForWhere {
             values.append(episode.id)

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -920,6 +920,16 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 75 {
+            do {
+                try db.executeUpdate("ALTER TABLE SJEpisode ADD COLUMN hlsUrl TEXT;", values: nil)
+                schemaVersion = 75
+            } catch {
+                failedAt(75)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+Encoding.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+Encoding.swift
@@ -7,6 +7,7 @@ public extension Episode {
 
         episodeMap["addedDate"] = encode(date: addedDate)
         episodeMap["downloadUrl"] = downloadUrl ?? ""
+        episodeMap["hlsUrl"] = hlsUrl ?? ""
         episodeMap["episodeDescription"] = episodeDescription ?? ""
         episodeMap["episodeStatus"] = "\(episodeStatus)"
         episodeMap["fileType"] = fileType ?? ""
@@ -36,6 +37,7 @@ public extension Episode {
     func populateFromMap(_ episodeMap: [String: String]) {
         addedDate = decodeDateFromString(date: episodeMap["addedDate"])
         downloadUrl = episodeMap["downloadUrl"]
+        hlsUrl = episodeMap["hlsUrl"]
         episodeDescription = episodeMap["episodeDescription"]
         episodeStatus = decodeInt32FromString(value: episodeMap["episodeStatus"])
         fileType = episodeMap["fileType"]

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+Encoding.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+Encoding.swift
@@ -37,7 +37,7 @@ public extension Episode {
     func populateFromMap(_ episodeMap: [String: String]) {
         addedDate = decodeDateFromString(date: episodeMap["addedDate"])
         downloadUrl = episodeMap["downloadUrl"]
-        hlsUrl = episodeMap["hlsUrl"]
+        hlsUrl = decodeOptionalStringFromString(value: episodeMap["hlsUrl"])
         episodeDescription = episodeMap["episodeDescription"]
         episodeStatus = decodeInt32FromString(value: episodeMap["episodeStatus"])
         fileType = episodeMap["fileType"]

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDatabase.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDatabase.swift
@@ -14,6 +14,7 @@ extension Episode {
         episode.downloadErrorDetails = rs.string(forColumn: "downloadErrorDetails")
         episode.downloadTaskId = rs.string(forColumn: "downloadTaskId")
         episode.downloadUrl = rs.string(forColumn: "downloadUrl")
+        episode.hlsUrl = rs.string(forColumn: "hlsUrl")
         episode.episodeDescription = rs.string(forColumn: "episodeDescription")
         episode.episodeStatus = rs.int(forColumn: "episodeStatus")
         episode.fileType = rs.string(forColumn: "fileType")

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDictionary.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDictionary.swift
@@ -17,7 +17,7 @@ extension Episode {
             return nil
         }
 
-        let hlsEnclosure = alternateEnclosures.first { ($0["type"] as? String) == hlsEnclosureType }
+        let hlsEnclosure = alternateEnclosures.first { ($0["type"] as? String)?.caseInsensitiveCompare(hlsEnclosureType) == .orderedSame }
         let sources = hlsEnclosure?["sources"] as? [[String: Any]]
         return sources?.first?["uri"] as? String
     }

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDictionary.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDictionary.swift
@@ -1,6 +1,27 @@
 import Foundation
 
 extension Episode {
+    /// MIME type advertised for HLS streams inside a feed's `alternate_enclosures`.
+    static let hlsEnclosureType = "application/x-mpegURL"
+
+    /// Extracts the HLS stream URL from a feed episode's `alternate_enclosures` array, if one is present.
+    ///
+    /// The structure looks like:
+    /// ```
+    /// "alternate_enclosures": [
+    ///   { "type": "application/x-mpegURL", "sources": [ { "uri": "https://.../file.m3u8" } ] }
+    /// ]
+    /// ```
+    public static func hlsUrl(fromEpisodeJson episodeJson: [String: Any]) -> String? {
+        guard let alternateEnclosures = episodeJson["alternate_enclosures"] as? [[String: Any]] else {
+            return nil
+        }
+
+        let hlsEnclosure = alternateEnclosures.first { ($0["type"] as? String) == hlsEnclosureType }
+        let sources = hlsEnclosure?["sources"] as? [[String: Any]]
+        return sources?.first?["uri"] as? String
+    }
+
     public static func from(episodeJson: [String: Any], podcastId: Int64, podcastUuid: String, isoFormatter: ISO8601DateFormatter) -> Episode {
         let episode = Episode()
         episode.addedDate = Date()
@@ -44,6 +65,8 @@ extension Episode {
         } else {
             episode.hasGeneratedTranscript = nil
         }
+
+        episode.hlsUrl = hlsUrl(fromEpisodeJson: episodeJson)
 
         return episode
     }

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -16,6 +16,7 @@ public class Episode: NSObject, BaseEpisode {
     @objc public var downloadErrorDetails: String?
     @objc public var downloadTaskId: String?
     @objc public var downloadUrl: String?
+    @objc public var hlsUrl: String?
     @objc public var episodeDescription: String?
     @objc public var episodeStatus = 0 as Int32
     @objc public var fileType: String?

--- a/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
@@ -131,6 +131,12 @@ extension ServerPodcastManager {
                     episodeChanged = true
                 }
 
+                let hlsUrl = Episode.hlsUrl(fromEpisodeJson: episodeJson)
+                if existingEpisode.hlsUrl != hlsUrl {
+                    existingEpisode.hlsUrl = hlsUrl
+                    episodeChanged = true
+                }
+
                 if episodeChanged {
                     DataManager.sharedManager.save(episode: existingEpisode)
                 }
@@ -196,6 +202,8 @@ extension ServerPodcastManager {
             if let type = episodeJson["has_generated_transcript"] as? Bool? {
                 episode.hasGeneratedTranscript = type
             }
+
+            episode.hlsUrl = Episode.hlsUrl(fromEpisodeJson: episodeJson)
 
             DataManager.sharedManager.save(episode: episode)
         }

--- a/Modules/Tests/PocketCastsDataModelTests/EpisodeAlternateEnclosuresTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/EpisodeAlternateEnclosuresTests.swift
@@ -28,6 +28,17 @@ final class EpisodeAlternateEnclosuresTests: XCTestCase {
         XCTAssertEqual(Episode.hlsUrl(fromEpisodeJson: json), "https://example.com/stream.m3u8")
     }
 
+    func testMatchesHlsTypeCaseInsensitively() {
+        let json: [String: Any] = [
+            "alternate_enclosures": [
+                ["type": "application/x-mpegurl",
+                 "sources": [["uri": "https://example.com/stream.m3u8"]]]
+            ]
+        ]
+
+        XCTAssertEqual(Episode.hlsUrl(fromEpisodeJson: json), "https://example.com/stream.m3u8")
+    }
+
     func testReturnsNilWhenNoHlsType() {
         let json: [String: Any] = [
             "alternate_enclosures": [

--- a/Modules/Tests/PocketCastsDataModelTests/EpisodeAlternateEnclosuresTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/EpisodeAlternateEnclosuresTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import PocketCastsDataModel
+
+/// Tests for parsing the feed's `alternate_enclosures` tag into `Episode.hlsUrl`.
+final class EpisodeAlternateEnclosuresTests: XCTestCase {
+
+    // MARK: - Helper parsing
+
+    func testExtractsHlsUrlFromAlternateEnclosures() {
+        let json: [String: Any] = [
+            "alternate_enclosures": [
+                ["type": "application/x-mpegURL",
+                 "sources": [["uri": "https://episode.example.com/hls/v/abc.m3u8"]]]
+            ]
+        ]
+
+        XCTAssertEqual(Episode.hlsUrl(fromEpisodeJson: json), "https://episode.example.com/hls/v/abc.m3u8")
+    }
+
+    func testPicksHlsEnclosureAmongstMultipleTypes() {
+        let json: [String: Any] = [
+            "alternate_enclosures": [
+                ["type": "audio/aac", "sources": [["uri": "https://example.com/audio.aac"]]],
+                ["type": "application/x-mpegURL", "sources": [["uri": "https://example.com/stream.m3u8"]]]
+            ]
+        ]
+
+        XCTAssertEqual(Episode.hlsUrl(fromEpisodeJson: json), "https://example.com/stream.m3u8")
+    }
+
+    func testReturnsNilWhenNoHlsType() {
+        let json: [String: Any] = [
+            "alternate_enclosures": [
+                ["type": "audio/aac", "sources": [["uri": "https://example.com/audio.aac"]]]
+            ]
+        ]
+
+        XCTAssertNil(Episode.hlsUrl(fromEpisodeJson: json))
+    }
+
+    func testReturnsNilWhenAlternateEnclosuresMissing() {
+        XCTAssertNil(Episode.hlsUrl(fromEpisodeJson: ["uuid": "abc"]))
+    }
+
+    func testReturnsNilWhenHlsEnclosureHasNoSources() {
+        let json: [String: Any] = [
+            "alternate_enclosures": [
+                ["type": "application/x-mpegURL", "sources": [[String: Any]]()]
+            ]
+        ]
+
+        XCTAssertNil(Episode.hlsUrl(fromEpisodeJson: json))
+    }
+
+    // MARK: - from(episodeJson:)
+
+    func testFromEpisodeJsonPopulatesHlsUrl() {
+        let json: [String: Any] = [
+            "uuid": "episode-uuid",
+            "url": "https://example.com/episode.mp3",
+            "alternate_enclosures": [
+                ["type": "application/x-mpegURL",
+                 "sources": [["uri": "https://example.com/stream.m3u8"]]]
+            ]
+        ]
+
+        let episode = Episode.from(episodeJson: json, podcastId: 1, podcastUuid: "podcast-uuid", isoFormatter: ISO8601DateFormatter())
+
+        XCTAssertEqual(episode.hlsUrl, "https://example.com/stream.m3u8")
+    }
+
+    func testFromEpisodeJsonLeavesHlsUrlNilWhenAbsent() {
+        let json: [String: Any] = [
+            "uuid": "episode-uuid",
+            "url": "https://example.com/episode.mp3"
+        ]
+
+        let episode = Episode.from(episodeJson: json, podcastId: 1, podcastUuid: "podcast-uuid", isoFormatter: ISO8601DateFormatter())
+
+        XCTAssertNil(episode.hlsUrl)
+    }
+}

--- a/Modules/Tests/PocketCastsDataModelTests/EpisodeColumnConsistencyTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/EpisodeColumnConsistencyTests.swift
@@ -74,6 +74,7 @@ final class EpisodeColumnConsistencyTests: DataManagerTestCase {
             XCTAssertEqual(loaded.fileType, original.fileType, "\(implementationName): fileType should match")
             XCTAssertEqual(loaded.contentType, original.contentType, "\(implementationName): contentType should match")
             XCTAssertEqual(loaded.downloadUrl, original.downloadUrl, "\(implementationName): downloadUrl should match")
+            XCTAssertEqual(loaded.hlsUrl, original.hlsUrl, "\(implementationName): hlsUrl should match")
             XCTAssertEqual(loaded.downloadTaskId, original.downloadTaskId, "\(implementationName): downloadTaskId should match")
             XCTAssertEqual(loaded.keepEpisode, original.keepEpisode, "\(implementationName): keepEpisode should match")
             XCTAssertEqual(loaded.cachedFrameCount, original.cachedFrameCount, "\(implementationName): cachedFrameCount should match")
@@ -163,6 +164,7 @@ final class EpisodeColumnConsistencyTests: DataManagerTestCase {
         episode.downloadErrorDetails = "Test error"
         episode.downloadTaskId = "download-task-123"
         episode.downloadUrl = "https://example.com/episode.mp3"
+        episode.hlsUrl = "https://example.com/episode.m3u8"
         episode.episodeStatus = DownloadStatus.downloaded.rawValue
         episode.fileType = "audio/mpeg"
         episode.contentType = "audio/mpeg"


### PR DESCRIPTION
Fixes PCIOS-809

Adds support for the feed's `alternate_enclosures` tag, capturing the HLS stream URL for episodes.

Podcast episode feeds can now include an `alternate_enclosures` array alongside the primary MP3 enclosure, e.g.:

```json
"alternate_enclosures": [
  { "type": "application/x-mpegURL", "sources": [ { "uri": "https://.../file.m3u8" } ] }
]
```

This PR parses the `application/x-mpegURL` entry and persists its URI on the episode as `hlsUrl`, so a later HLS playback path can use it.

### Details
- New `Episode.hlsUrl` stored property + DB migration (schema v75, `hlsUrl TEXT`).
- Reusable `Episode.hlsUrl(fromEpisodeJson:)` parser, used by `Episode.from(episodeJson:)` and both the new-episode and existing-episode update paths in `ServerPodcastManager+Update`.
- Wired through persistence: `EpisodeDataManager` column list + values, `Episode+fromDatabase`, and the watchOS transfer map in `Episode+Encoding`.
- Parsing/persistence is intentionally **not** gated behind `FeatureFlag.hls` — the URL is always captured. The flag will gate the eventual HLS playback behavior, not the data.
- No protobuf changes in this PR (but they will be needed)

### Discussion

I decided to read `alternate_enclosures` and store in a dedicated `hlsUrl` for a few reasons:

1. It's simpler. We don't need to store all the values — or even the JSON;
2. Even if we stored everything, we'd still need to handle the playback, just like we're going to do for HLS. So it's not like we'd support anything else just by having the values.

If you feel different, please let me know. :) 

## To test

1. Open [this podcast](https://pca.st/podcast/3d728640-75ca-013c-f0b5-0a4e4341158f) whose feed includes `alternate_enclosures` with an `application/x-mpegURL` entry.
4. Let the podcast refresh from the cache server.
5. Inspect the episode in the DB (or via a debug breakpoint) and confirm `hlsUrl` is populated with the `.m3u8` URI.
6. For an episode without `alternate_enclosures` (eg.: The Daily), confirm `hlsUrl` is `nil`.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
