### PR TITLE
Show empty state for playlists with no episodes on tvOS

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -72,7 +72,7 @@ struct PlaylistDetailView: View {
             VStack {
                 HStack {
                     Spacer()
-                    Text(L10n.playlistManualArchivedEpisodesPlaceholder(model.allEpisodesCount))
+                    Text(L10n.tvPlaylistManualArchivedEpisodesPlaceholder(model.allEpisodesCount))
                     Spacer()
                 }
             }.padding(24)
@@ -140,9 +140,9 @@ struct PlaylistDetailView: View {
         switch images.count {
         case 0:
             ZStack {
-                Image(systemName: "list.bullet")
+                Image(ImageResource.pcLogo)
                     .resizable()
-                    .frame(width: Layout.mosaicSize * 0.5, height: Layout.mosaicSize * 0.5)
+                    .frame(width: Layout.mosaicSize * 0.75, height: Layout.mosaicSize * 0.75)
             }
             .frame(width: Layout.mosaicSize, height: Layout.mosaicSize)
             .background(Color.pcBackgroundSurface)

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -65,15 +65,33 @@ struct PlaylistDetailView: View {
         ProgressView()
     }
 
+    var allArchivedEmptyView: some View {
+        ContentUnavailableView {
+            Label(L10n.tvPlaylistEmptyTitle, systemImage: "info.circle")
+        } description: {
+            VStack {
+                HStack {
+                    Spacer()
+                    Text(L10n.playlistManualArchivedEpisodesPlaceholder(model.allEpisodesCount))
+                    Spacer()
+                }
+            }.padding(24)
+        } actions: {
+            VStack {
+                Button(L10n.tvPodcastDetailShowArchived) {
+                    model.setShowArchived(true)
+                }
+                Spacer()
+            }
+        }
+    }
+
     var emptyView: some View {
         ContentUnavailableView {
             Label(L10n.tvPlaylistEmptyTitle, systemImage: "info.circle")
         } description: {
             VStack {
-                Text(L10n.tvPlaylistEmptySubtitle)
-                if model.hasDownloadFilter {
-                    Text(L10n.tvPlaylistDownloadRulesUnsupported)
-                }
+                model.hasDownloadFilter ? Text(L10n.tvPlaylistDownloadRulesUnsupported) : Text(L10n.tvPlaylistEmptySubtitle)
             }.padding(24)
         } actions: {
             Button(L10n.ok) {
@@ -86,7 +104,11 @@ struct PlaylistDetailView: View {
         HStack(alignment: .top, spacing: Layout.gutter) {
             playlistInfo
                 .frame(width: Layout.infoPanelWidth)
-            episodeList
+            if model.areAllEpisodesArchived {
+                allArchivedEmptyView
+            } else {
+                episodeList
+            }
         }
         .blurredCoverBackground(size: Layout.mosaicSize) {
             blurredMosaic
@@ -117,10 +139,14 @@ struct PlaylistDetailView: View {
         let images = model.coverPodcastsUuids
         switch images.count {
         case 0:
-            Image(ImageResource.pcLogo)
-                .resizable()
-                .frame(width: Layout.mosaicSize, height: Layout.mosaicSize)
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+            ZStack {
+                Image(systemName: "list.bullet")
+                    .resizable()
+                    .frame(width: Layout.mosaicSize * 0.5, height: Layout.mosaicSize * 0.5)
+            }
+            .frame(width: Layout.mosaicSize, height: Layout.mosaicSize)
+            .background(Color.pcBackgroundSurface)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
         case 1...3:
             PodcastImage(uuid: images[0], size: .page)
                 .frame(width: Layout.mosaicSize, height: Layout.mosaicSize)

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -4,6 +4,8 @@ import PocketCastsDataModel
 struct PlaylistDetailView: View {
 
     @Environment(MainTabViewModel.self) var tabRouter: MainTabViewModel
+    @Environment(\.dismiss) var dismiss
+
     let model: PlaylistDetailsViewModel
     @FocusState private var focusedSection: FocusSection?
     @FocusState private var rowFocus: EpisodeRowFocus?
@@ -28,8 +30,11 @@ struct PlaylistDetailView: View {
                 loadingView
             case .ready:
                 playlistView
+            case .empty:
+                emptyView
             }
         }
+        .animation(.smooth, value: model.state)
         .toolbar(.hidden, for: .tabBar)
         .defaultFocus($focusedSection, .episodes)
         .confirmationDialog(
@@ -58,6 +63,18 @@ struct PlaylistDetailView: View {
 
     var loadingView: some View {
         ProgressView()
+    }
+
+    var emptyView: some View {
+        ContentUnavailableView {
+            Label(L10n.tvPlaylistEmptyTitle, systemImage: "info.circle")
+        } description: {
+            Text(L10n.tvPlaylistEmptySubtitle)
+        } actions: {
+            Button(L10n.ok) {
+                dismiss()
+            }
+        }
     }
 
     var playlistView: some View {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -69,7 +69,12 @@ struct PlaylistDetailView: View {
         ContentUnavailableView {
             Label(L10n.tvPlaylistEmptyTitle, systemImage: "info.circle")
         } description: {
-            Text(L10n.tvPlaylistEmptySubtitle)
+            VStack {
+                Text(L10n.tvPlaylistEmptySubtitle)
+                if model.hasDownloadFilter {
+                    Text(L10n.tvPlaylistDownloadRulesUnsupported)
+                }
+            }.padding(24)
         } actions: {
             Button(L10n.ok) {
                 dismiss()

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -133,6 +133,14 @@ class PlaylistDetailsViewModel {
         return L10n.tvPlaylistDetailEpisodeCount(episodes.count)
     }
 
+    var allEpisodesCount: Int {
+        return allEpisodes.count
+    }
+
+    var areAllEpisodesArchived: Bool {
+        return episodes.isEmpty && !allEpisodes.isEmpty
+    }
+
     private func refreshPlaylistColor() {
         if let uuid = episodes.first?.podcastUuid,
            let podcast = dataManager.findPodcast(uuid: uuid, includeUnsubscribed: true),

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -24,6 +24,8 @@ class PlaylistDetailsViewModel {
     var showArchived: Bool = false
     var playlistColor: Color
 
+    var hasDownloadFilter: Bool { playlist.filterDownloaded }
+
     private var allEpisodes: [Episode] = []
     private let dataManager: DataManager
     private let playbackManager: PlaybackManager

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -24,7 +24,7 @@ class PlaylistDetailsViewModel {
     var showArchived: Bool = false
     var playlistColor: Color
 
-    var hasDownloadFilter: Bool { playlist.filterDownloaded }
+    var hasDownloadFilter: Bool { playlist.isDownloadFilterActive }
 
     private var allEpisodes: [Episode] = []
     private let dataManager: DataManager

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -10,6 +10,7 @@ class PlaylistDetailsViewModel {
 
     enum State: Equatable, Hashable {
         case loading
+        case empty
         case ready
     }
 
@@ -74,7 +75,7 @@ class PlaylistDetailsViewModel {
                 allEpisodes = playlistEpisodes
                 applyArchivedFilter()
                 refreshPlaylistColor()
-                state = .ready
+                state = playlistEpisodes.isEmpty ? .empty : .ready
             }
         }
     }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
@@ -25,7 +25,17 @@ class PlaylistsViewModel {
     var playlists: [EpisodeFilter] = []
 
     func load() async {
-        let playlists = dataManager.allPlaylists(includeDeleted: false)
+        let originalPlaylists = dataManager.allPlaylists(includeDeleted: false)
+        let playlists = originalPlaylists.sorted { a, b in
+            switch (a.isDownloadFilterActive, b.isDownloadFilterActive) {
+            case (true, true), (false, false):
+                return a.sortPosition < b.sortPosition
+            case (true, false):
+                return false
+            case (false, true):
+                return true
+            }
+        }
         await MainActor.run {
             self.playlists = playlists
             self.state = playlists.isEmpty ? .empty : .ready
@@ -44,5 +54,12 @@ class PlaylistsViewModel {
             }
         }
         .store(in: &cancellables)
+    }
+}
+
+extension EpisodeFilter {
+
+    var isDownloadFilterActive: Bool {
+        return !(filterDownloaded && filterDownloading && filterNotDownloaded) && (filterDownloaded)
     }
 }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6461,3 +6461,9 @@
 "tv_podcast_error_message" = "Check your internet connection and try again";
 
 "chapters_generated_warning_message" = "These chapters are automatically generated and may not be perfectly accurate.";
+
+/* Title shown when a playlist has no episodes on the TV app */
+"tv_playlist_empty_title" = "No episodes";
+
+/* Subtitle shown when a playlist has no episodes on the TV app */
+"tv_playlist_empty_subtitle" = "Either it's time to celebrate completing this list or edit your rules in the mobile app to get some more";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6458,7 +6458,7 @@
 "tv_podcast_error_title" = "Couldn't load podcast details";
 
 /* Message to shown when failed to load a podcast information*/
-"tv_podcast_error_message" = "Check your internet connection and try again";
+"tv_podcast_error_message" = "Check your internet connection and try again.";
 
 "chapters_generated_warning_message" = "These chapters are automatically generated and may not be perfectly accurate.";
 
@@ -6466,7 +6466,7 @@
 "tv_playlist_empty_title" = "No episodes";
 
 /* Subtitle shown when a playlist has no episodes on the TV app */
-"tv_playlist_empty_subtitle" = "Either it's time to celebrate completing this list or edit your rules in the mobile app to get some more";
+"tv_playlist_empty_subtitle" = "Either it's time to celebrate completing this list or edit your rules in the mobile app to get some more.";
 
 /* Note shown on the empty playlist screen when the playlist uses a download filter, which the TV app can't apply */
-"tv_playlist_download_rules_unsupported" = "Download rules are only supported on the mobile apps";
+"tv_playlist_download_rules_unsupported" = "This playlist filters by downloaded episodes. TV's storage is tight, so downloads aren't supported.";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6467,3 +6467,6 @@
 
 /* Subtitle shown when a playlist has no episodes on the TV app */
 "tv_playlist_empty_subtitle" = "Either it's time to celebrate completing this list or edit your rules in the mobile app to get some more";
+
+/* Note shown on the empty playlist screen when the playlist uses a download filter, which the TV app can't apply */
+"tv_playlist_download_rules_unsupported" = "Download rules are only supported on the mobile apps";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6470,3 +6470,7 @@
 
 /* Note shown on the empty playlist screen when the playlist uses a download filter, which the TV app can't apply */
 "tv_playlist_download_rules_unsupported" = "This playlist filters by downloaded episodes. TV's storage is tight, so downloads aren't supported.";
+
+/* Text of the placeholder used in the manual playlist detail screen when all episodes are archived. '%1$@' represents the number of archived episodes */
+"tv_playlist_manual_archived_episodes_placeholder" = "All %1$@ episodes of this playlist have been archived.";
+


### PR DESCRIPTION
Fixes: [POC-712](https://linear.app/a8c/issue/POC-712/implement-special-empty-state-for-smart-playlist-with-download-rule)
|:---:|

Adds a dedicated empty state to the TV playlist detail screen. When a playlist resolves to zero episodes, the screen now shows a `ContentUnavailableView` (title, subtitle, and an OK button that dismisses) instead of an empty playlist layout. The transition between loading/empty/ready is animated with `.smooth`.

### Changes
- New `.empty` case in `PlaylistDetailsViewModel.State`, set when the resolved episode list is empty.
- New `emptyView` in `PlaylistDetailView` using `ContentUnavailableView`.
- New localized strings `tv_playlist_empty_title` / `tv_playlist_empty_subtitle` (snake_case, matching the existing `tv_` key convention).

## To test

1. On the tvOS app, open a playlist/filter that currently matches no episodes (or edit its rules so it resolves empty).
2. Open the playlist detail screen.
3. Confirm the "No episodes" empty state appears with its subtitle and an OK button.
4. Tap OK and confirm it dismisses the screen.
5. Confirm a non-empty playlist still shows its episodes normally.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.