### PR TITLE
Fix mini player button height not expanding to full height

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -188,7 +188,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         let buttonStack = UIStackView(arrangedSubviews: [skipBackBtn, playPauseBtn, skipFwdBtn])
         buttonStack.translatesAutoresizingMaskIntoConstraints = false
         buttonStack.axis = .horizontal
-        buttonStack.alignment = .center
+        buttonStack.alignment = .fill
         glassButtonStack = buttonStack
 
         view.addSubview(podcastArtwork)


### PR DESCRIPTION
Before: 

- previous/next – 46pt 
- play - 40pt

<img width="468" height="197" alt="Screenshot 2026-07-02 at 3 25 32 PM" src="https://github.com/user-attachments/assets/3502dc3e-93aa-4988-b25c-f6f7a42853da" />

After:

- previous/next – 48pt 
- play - 48pt

<img width="452" height="210" alt="Screenshot 2026-07-02 at 3 42 25 PM" src="https://github.com/user-attachments/assets/6b6244b3-e820-493c-99ef-79677f768516" />


## To test

1. Start playing an episode so the mini player appears in the tab accessory.
2. Confirm the skip back / play-pause / skip forward buttons extend to the full height of the mini player and are tappable across the whole vertical extent.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
