### PR TITLE
Play HLS stream when available

### DIFF
--- a/PocketCastsTests/Tests/Utilities/EpisodeManagerTests.swift
+++ b/PocketCastsTests/Tests/Utilities/EpisodeManagerTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import podcasts
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 
 final class EpisodeManagerTests: DBTestCase {
 
@@ -203,5 +204,83 @@ final class EpisodeManagerTests: DBTestCase {
       // Then
       XCTAssertFalse(FileManager.default.fileExists(atPath: oldFilePath), "Old file should be removed")
       XCTAssertTrue(FileManager.default.fileExists(atPath: recentFilePath), "Recent file should be kept")
+    }
+
+    // MARK: - HLS streaming
+
+    override func tearDown() {
+        FeatureFlagOverrideStore().resetOverrides()
+        super.tearDown()
+    }
+
+    private func makeStreamingHLSEpisode() -> Episode {
+        let episode = Episode()
+        episode.uuid = "hls-episode"
+        episode.episodeStatus = DownloadStatus.notDownloaded.rawValue
+        episode.downloadUrl = "https://example.com/episode.mp3"
+        episode.hlsUrl = "https://example.com/stream.m3u8"
+        return episode
+    }
+
+    func testIsStreamingHLSWhenFlagEnabledAndHlsUrlPresent() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+        XCTAssertTrue(EpisodeManager.isStreamingHLS(makeStreamingHLSEpisode()))
+    }
+
+    func testIsNotStreamingHLSWhenFlagDisabled() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: false)
+        XCTAssertFalse(EpisodeManager.isStreamingHLS(makeStreamingHLSEpisode()))
+    }
+
+    func testIsNotStreamingHLSWhenHlsUrlMissingOrEmpty() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+
+        let noHls = makeStreamingHLSEpisode()
+        noHls.hlsUrl = nil
+        XCTAssertFalse(EpisodeManager.isStreamingHLS(noHls))
+
+        let emptyHls = makeStreamingHLSEpisode()
+        emptyHls.hlsUrl = ""
+        XCTAssertFalse(EpisodeManager.isStreamingHLS(emptyHls))
+    }
+
+    func testIsNotStreamingHLSForUserEpisode() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+        XCTAssertFalse(EpisodeManager.isStreamingHLS(UserEpisode()))
+    }
+
+    func testUrlForEpisodeStreamsHLSWhenAvailableAndFlagEnabled() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+
+        let url = EpisodeManager.urlForEpisode(makeStreamingHLSEpisode())
+
+        XCTAssertEqual(url?.absoluteString, "https://example.com/stream.m3u8", "Should stream the HLS url when available")
+    }
+
+    func testUrlForEpisodeStreamsHLSWhenStreamingOnly() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+
+        let url = EpisodeManager.urlForEpisode(makeStreamingHLSEpisode(), streamingOnly: true)
+
+        XCTAssertEqual(url?.absoluteString, "https://example.com/stream.m3u8", "Should stream the HLS url when available")
+    }
+
+    func testUrlForEpisodeUsesProgressiveWhenHLSFlagDisabled() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: false)
+
+        let url = EpisodeManager.urlForEpisode(makeStreamingHLSEpisode())
+
+        XCTAssertEqual(url?.absoluteString, "https://example.com/episode.mp3", "Should fall back to the progressive file when the flag is off")
+    }
+
+    func testUrlForEpisodeUsesProgressiveWhenNoHLS() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+
+        let episode = makeStreamingHLSEpisode()
+        episode.hlsUrl = nil
+
+        let url = EpisodeManager.urlForEpisode(episode)
+
+        XCTAssertEqual(url?.absoluteString, "https://example.com/episode.mp3", "Should use the progressive file when there is no HLS url")
     }
 }

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -72,7 +72,7 @@ class AnalyticsCoordinator {
     var currentSource: AnalyticsSource?
 
     private var currentEpisodeIsVideo: Bool {
-        PlaybackManager.shared.currentEpisode()?.videoPodcast() ?? false
+        PlaybackManager.shared.isCurrentEpisodeVideo()
     }
 
     var currentAnalyticsSource: AnalyticsSource {

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -30,6 +30,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
     private var playerStatusObserver: NSKeyValueObservation?
     private var playerItemStatusObserver: NSKeyValueObservation?
     private var timeControlStatusObserver: NSKeyValueObservation?
+    private var presentationSizeObserver: NSKeyValueObservation?
 
     private var playToEndObserver: NSObjectProtocol?
     private var playFailedObserver: NSObjectProtocol?
@@ -103,6 +104,30 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         #endif
 
         configurePlayer(videoPodcast: episode.videoPodcast())
+
+        detectVideoTracksIfNeeded(for: episode, playerItem: playerItem)
+    }
+
+    /// An HLS stream can carry video that isn't reflected in the episode's file type. HLS doesn't
+    /// expose video via the asset's tracks, and `presentationSize` is only `0x0` until the first
+    /// video frame is decoded, so we observe it and promote playback to video once it reports a size.
+    private func detectVideoTracksIfNeeded(for episode: BaseEpisode, playerItem: AVPlayerItem) {
+        guard EpisodeManager.isStreamingHLS(episode), !episode.videoPodcast() else { return }
+
+        let episodeUuid = episode.uuid
+        presentationSizeObserver = playerItem.observe(\.presentationSize, options: [.initial, .new]) { [weak self] item, _ in
+            let size = item.presentationSize
+            guard size.width > 0, size.height > 0 else { return }
+
+            DispatchQueue.main.async {
+                guard let self, self.presentationSizeObserver != nil else { return }
+                self.presentationSizeObserver = nil
+#if !os(watchOS)
+                self.player?.allowsExternalPlayback = true
+#endif
+                PlaybackManager.shared.handleVideoTracksDetected(forEpisode: episodeUuid)
+            }
+        }
     }
 
     func isReadyToPlay() -> Bool {
@@ -879,6 +904,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         playerStatusObserver = nil
         playerItemStatusObserver = nil
         timeControlStatusObserver = nil
+        presentationSizeObserver = nil
 
         if let endObserver = playToEndObserver {
             NotificationCenter.default.removeObserver(endObserver)

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -378,6 +378,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
 
         guard FeatureFlag.streamAndCachePlayingEpisode.enabled,
+              !EpisodeManager.isStreamingHLS(episode), // HLS is streamed directly, never cached
               !episode.videoPodcast(),
               !episode.isUserEpisode,
               let urlAsset = playbackItem.asset as? AVURLAsset,

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -442,9 +442,10 @@ class EpisodeManager: NSObject {
 
         // For streaming or when no local files, return remote URL
         if let episode = episode as? Episode {
-            // When available, default to the HLS stream over the progressive file
-            if isStreamingHLS(episode), let hlsUrl = episode.hlsUrl {
-                return URL(string: hlsUrl)
+            // When available, default to the HLS stream over the progressive file.
+            // If the HLS url is malformed, fall through to the progressive url rather than failing.
+            if isStreamingHLS(episode), let hlsUrl = episode.hlsUrl, let url = URL(string: hlsUrl) {
+                return url
             }
             if let url = episode.downloadUrl {
                 return URL(string: url)

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -421,6 +421,15 @@ class EpisodeManager: NSObject {
         return totalFilesSize
     }
 
+    /// Whether the episode should be streamed via its HLS alternate enclosure.
+    /// When an HLS stream is available we default to it; HLS is streamed directly and never cached.
+    class func isStreamingHLS(_ episode: BaseEpisode) -> Bool {
+        guard FeatureFlag.hls.enabled, let episode = episode as? Episode, let hlsUrl = episode.hlsUrl else {
+            return false
+        }
+        return !hlsUrl.isEmpty
+    }
+
     class func urlForEpisode(_ episode: BaseEpisode, streamingOnly: Bool = false) -> URL? {
         if !streamingOnly {
             // For local playback, prefer downloaded files
@@ -432,8 +441,14 @@ class EpisodeManager: NSObject {
         }
 
         // For streaming or when no local files, return remote URL
-        if let episode = episode as? Episode, let url = episode.downloadUrl {
-            return URL(string: url)
+        if let episode = episode as? Episode {
+            // When available, default to the HLS stream over the progressive file
+            if isStreamingHLS(episode), let hlsUrl = episode.hlsUrl {
+                return URL(string: hlsUrl)
+            }
+            if let url = episode.downloadUrl {
+                return URL(string: url)
+            }
         } else if let episode = episode as? UserEpisode {
             if let token = ServerSettings.syncingV2Token, episode.uploadStatus != UploadStatus.missing.rawValue {
                 return URL(string: "\(ServerConstants.Urls.api())files/url/\(episode.uuid)?token=\(token)")

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -422,12 +422,14 @@ class EpisodeManager: NSObject {
     }
 
     /// Whether the episode should be streamed via its HLS alternate enclosure.
-    /// When an HLS stream is available we default to it; HLS is streamed directly and never cached.
+    /// When a valid HLS stream is available we default to it; HLS is streamed directly and never cached.
+    /// Requires a parseable url so this stays consistent with `urlForEpisode`, which falls back to the
+    /// progressive url when the HLS string can't be turned into a `URL`.
     class func isStreamingHLS(_ episode: BaseEpisode) -> Bool {
-        guard FeatureFlag.hls.enabled, let episode = episode as? Episode, let hlsUrl = episode.hlsUrl else {
+        guard FeatureFlag.hls.enabled, let episode = episode as? Episode, let hlsUrl = episode.hlsUrl, !hlsUrl.isEmpty else {
             return false
         }
-        return !hlsUrl.isEmpty
+        return URL(string: hlsUrl) != nil
     }
 
     class func urlForEpisode(_ episode: BaseEpisode, streamingOnly: Bool = false) -> URL? {

--- a/podcasts/MiniPlayerToFullPlayerAnimator.swift
+++ b/podcasts/MiniPlayerToFullPlayerAnimator.swift
@@ -42,7 +42,7 @@ class MiniPlayerToFullPlayerAnimator: NSObject, UIViewControllerAnimatedTransiti
     }
 
     private var isVideoPodcast: Bool {
-        PlaybackManager.shared.currentEpisode()?.videoPodcast() ?? false
+        PlaybackManager.shared.isCurrentEpisodeVideo()
     }
 
     init?(fromViewController: UIViewController, toViewController: UIViewController, transition: Transition, miniPlayerArtwork: PodcastImageView, fullPlayerArtwork: UIImageView, dismissVelocity: CGFloat = 0, fullPlayerYPosition: CGFloat = 0) {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -380,6 +380,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     func addUINotificationObservers() {
         addCustomObserver(Constants.Notifications.playbackStarting, selector: #selector(playbackStarting))
         addCustomObserver(Constants.Notifications.playbackStarted, selector: #selector(playbackStarted))
+        addCustomObserver(Constants.Notifications.videoPlaybackEngineSwitched, selector: #selector(videoPlaybackEngineSwitched))
         addCustomObserver(Constants.Notifications.playbackEnded, selector: #selector(playbackStateDidChange))
         addCustomObserver(Constants.Notifications.playbackPaused, selector: #selector(playbackStateDidChange))
         addCustomObserver(Constants.Notifications.playbackTrackChanged, selector: #selector(playbackStateDidChange))
@@ -481,23 +482,37 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         if let episode = PlaybackManager.shared.currentEpisode() {
             setupForEpisode(episode)
             showMiniPlayer()
-            let shouldOpenAutomatically: Bool
-            if FeatureFlag.newSettingsStorage.enabled {
-                shouldOpenAutomatically = SettingsStore.appSettings.openPlayer
-            } else {
-                shouldOpenAutomatically = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openPlayerAutomatically)
-            }
-            if shouldOpenAutomatically || episode.videoPodcast(), lastEpisodeUuidAutoOpened != episode.uuid {
-                lastEpisodeUuidAutoOpened = episode.uuid
-
-                // we called show mini player above, which might have spent time animating itself into view, so give that time to finish
-                DispatchQueue.main.asyncAfter(deadline: .now() + Constants.Animation.defaultAnimationTime) {
-                    self.openFullScreenPlayer()
-                }
-            }
+            autoOpenFullScreenPlayerIfNeeded(for: episode)
         } else {
             hideMiniPlayer(true)
         }
+    }
+
+    /// Opens the full screen player automatically when the user's setting is on, or when the
+    /// current episode is video. For HLS the video isn't known at playback start, so this is also
+    /// called when video is detected at runtime (via `videoPlaybackEngineSwitched`).
+    private func autoOpenFullScreenPlayerIfNeeded(for episode: BaseEpisode) {
+        let shouldOpenAutomatically: Bool
+        if FeatureFlag.newSettingsStorage.enabled {
+            shouldOpenAutomatically = SettingsStore.appSettings.openPlayer
+        } else {
+            shouldOpenAutomatically = UserDefaults.standard.bool(forKey: Constants.UserDefaults.openPlayerAutomatically)
+        }
+        if shouldOpenAutomatically || PlaybackManager.shared.isCurrentEpisodeVideo(), lastEpisodeUuidAutoOpened != episode.uuid {
+            lastEpisodeUuidAutoOpened = episode.uuid
+
+            // we called show mini player above, which might have spent time animating itself into view, so give that time to finish
+            DispatchQueue.main.asyncAfter(deadline: .now() + Constants.Animation.defaultAnimationTime) {
+                self.openFullScreenPlayer()
+            }
+        }
+    }
+
+    @objc private func videoPlaybackEngineSwitched() {
+        // Video can be detected after playback starts (e.g. an HLS stream), so give it the same
+        // automatic full screen treatment a video podcast gets.
+        guard let episode = PlaybackManager.shared.currentEpisode() else { return }
+        autoOpenFullScreenPlayerIfNeeded(for: episode)
     }
 
     @objc private func playbackStarting() {

--- a/podcasts/NowPlayingHelper.swift
+++ b/podcasts/NowPlayingHelper.swift
@@ -68,8 +68,7 @@ class NowPlayingHelper {
         var nowPlayingInfo = [String: AnyObject]()
 
         nowPlayingInfo[MPMediaItemPropertyMediaType] = NSNumber(value: MPMediaType.podcast.rawValue)
-        let isVideo = episode.videoPodcast() || (PlaybackManager.shared.currentEpisode()?.uuid == episode.uuid && PlaybackManager.shared.currentStreamContainsVideo)
-        let nowPlayingMediaType = isVideo ? MPNowPlayingInfoMediaType.video.rawValue : MPNowPlayingInfoMediaType.audio.rawValue
+        let nowPlayingMediaType = PlaybackManager.shared.isCurrentEpisodeVideo() ? MPNowPlayingInfoMediaType.video.rawValue : MPNowPlayingInfoMediaType.audio.rawValue
         nowPlayingInfo[MPNowPlayingInfoPropertyMediaType] = NSNumber(value: nowPlayingMediaType)
         nowPlayingInfo[MPMediaItemPropertyAlbumTrackCount] = NSNumber(value: 1)
         nowPlayingInfo[MPMediaItemPropertyAlbumTrackNumber] = NSNumber(value: 1)

--- a/podcasts/NowPlayingHelper.swift
+++ b/podcasts/NowPlayingHelper.swift
@@ -68,7 +68,8 @@ class NowPlayingHelper {
         var nowPlayingInfo = [String: AnyObject]()
 
         nowPlayingInfo[MPMediaItemPropertyMediaType] = NSNumber(value: MPMediaType.podcast.rawValue)
-        let nowPlayingMediaType = episode.videoPodcast() ? MPNowPlayingInfoMediaType.video.rawValue : MPNowPlayingInfoMediaType.audio.rawValue
+        let isVideo = episode.videoPodcast() || (PlaybackManager.shared.currentEpisode()?.uuid == episode.uuid && PlaybackManager.shared.currentStreamContainsVideo)
+        let nowPlayingMediaType = isVideo ? MPNowPlayingInfoMediaType.video.rawValue : MPNowPlayingInfoMediaType.audio.rawValue
         nowPlayingInfo[MPNowPlayingInfoPropertyMediaType] = NSNumber(value: nowPlayingMediaType)
         nowPlayingInfo[MPMediaItemPropertyAlbumTrackCount] = NSNumber(value: 1)
         nowPlayingInfo[MPMediaItemPropertyAlbumTrackNumber] = NSNumber(value: 1)

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -36,12 +36,14 @@ extension NowPlayingPlayerItemViewController {
 
     @objc private func videoPlaybackEngineSwitched() {
         floatingVideoView.player = PlaybackManager.shared.internalPlayerForVideoPlayback()
+        // Video may have been detected at runtime (e.g. an HLS stream), so refresh to reveal the view
+        update(notification: nil)
     }
 
     @objc func update(notification: NSNotification?) {
         guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return }
 
-        if playingEpisode.videoPodcast() {
+        if PlaybackManager.shared.isCurrentEpisodeVideo() {
             if floatingVideoView.isHidden {
                 floatingVideoView.isHidden = false
                 floatingVideoView.player = PlaybackManager.shared.internalPlayerForVideoPlayback()

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -511,9 +511,9 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     }
 
     @objc private func videoTapped() {
-        guard let episode = PlaybackManager.shared.currentEpisode() else { return }
+        guard PlaybackManager.shared.currentEpisode() != nil else { return }
 
-        if episode.videoPodcast() {
+        if PlaybackManager.shared.isCurrentEpisodeVideo() {
             let videoController = VideoViewController()
             videoViewController = videoController
             videoViewController?.modalTransitionStyle = .crossDissolve

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -757,6 +757,8 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard currentEpisode()?.uuid == episodeUuid, !currentStreamContainsVideo.value else { return }
         currentStreamContainsVideo.value = true
         setAudioSessionVideoProperties()
+        // Force a full now playing rebuild so the lock screen / Control Center switch to the video media type
+        refreshNowPlayingInfo(forceFullRebuild: true)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.videoPlaybackEngineSwitched)
     }
 
@@ -1696,6 +1698,13 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     @objc private func updateNowPlayingInfo() {
+        refreshNowPlayingInfo(forceFullRebuild: false)
+    }
+
+    /// - Parameter forceFullRebuild: when `true`, rebuilds the whole now playing payload instead of
+    ///   only refreshing progress. Needed when a value like the media type changes for the same
+    ///   episode (e.g. an HLS stream promoted to video), which the progress-only path won't pick up.
+    private func refreshNowPlayingInfo(forceFullRebuild: Bool) {
         #if os(watchOS) || APPCLIP || os(tvOS)
             let connectedToExternalDevice = false
         #else
@@ -1713,9 +1722,17 @@ class PlaybackManager: ServerPlaybackDelegate {
             return
         }
         #if os(watchOS)
-            WatchNowPlayingHelper.updateNowPlayingInfo(for: episode, duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
+            if forceFullRebuild {
+                WatchNowPlayingHelper.setAllNowPlayingInfo(for: episode, duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
+            } else {
+                WatchNowPlayingHelper.updateNowPlayingInfo(for: episode, duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
+            }
         #else
-            NowPlayingHelper.updateNowPlayingInfo(for: episode, currentChapters: currentChapters(), duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
+            if forceFullRebuild {
+                NowPlayingHelper.setAllNowPlayingInfo(for: episode, currentChapters: currentChapters(), duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
+            } else {
+                NowPlayingHelper.updateNowPlayingInfo(for: episode, currentChapters: currentChapters(), duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
+            }
         #endif
     }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -50,7 +50,8 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// Set at runtime when the currently playing stream is found to contain video tracks
     /// (e.g. an HLS stream carrying video). Complements `Episode.videoPodcast()`, which is
     /// based on the progressive file's MIME type and can't see into an HLS alternate enclosure.
-    private(set) var currentStreamContainsVideo = false
+    /// Atomic because it's read from now-playing updates that can run off the main queue.
+    private let currentStreamContainsVideo = AtomicBool()
 
     private let updateTimerInterval = 1 as TimeInterval
 
@@ -747,14 +748,14 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// Whether the current episode should be presented as video, considering both the feed
     /// metadata (`videoPodcast()`) and any video tracks detected at runtime in the stream.
     func isCurrentEpisodeVideo() -> Bool {
-        currentEpisode()?.videoPodcast() == true || currentStreamContainsVideo
+        currentEpisode()?.videoPodcast() == true || currentStreamContainsVideo.value
     }
 
     /// Called by the player when it detects video tracks in the stream it is playing.
     /// Used for HLS streams whose video content isn't reflected in the episode's file type.
     func handleVideoTracksDetected(forEpisode episodeUuid: String) {
-        guard currentEpisode()?.uuid == episodeUuid, !currentStreamContainsVideo else { return }
-        currentStreamContainsVideo = true
+        guard currentEpisode()?.uuid == episodeUuid, !currentStreamContainsVideo.value else { return }
+        currentStreamContainsVideo.value = true
         setAudioSessionVideoProperties()
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.videoPlaybackEngineSwitched)
     }
@@ -1415,7 +1416,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     private func cleanupCurrentPlayer(permanent: Bool) {
         haveCalledPlayerLoad = false
-        currentStreamContainsVideo = false
+        currentStreamContainsVideo.value = false
         seekingTo = PlaybackManager.notSeeking
         FileLog.shared.addMessage("cleanupCurrentPlayer permanent? \(permanent)")
         if let player {
@@ -2296,6 +2297,7 @@ class PlaybackManager: ServerPlaybackDelegate {
            !playerSwitchRequired(),
            !refreshedEpisode.videoPodcast(),
            // HLS is streamed directly (no stream-and-cache), so when playback finishes downloading we must reload to switch to the downloaded local file
+           !EpisodeManager.isStreamingHLS(refreshedEpisode) {
             return false
         } else {
             if !episodeIsChanging {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -47,6 +47,11 @@ class PlaybackManager: ServerPlaybackDelegate {
     private let shouldDeactivateSession = AtomicBool()
     private var haveCalledPlayerLoad = false
 
+    /// Set at runtime when the currently playing stream is found to contain video tracks
+    /// (e.g. an HLS stream carrying video). Complements `Episode.videoPodcast()`, which is
+    /// based on the progressive file's MIME type and can't see into an HLS alternate enclosure.
+    private(set) var currentStreamContainsVideo = false
+
     private let updateTimerInterval = 1 as TimeInterval
 
     #if !os(watchOS)
@@ -739,6 +744,21 @@ class PlaybackManager: ServerPlaybackDelegate {
         play()
     }
 
+    /// Whether the current episode should be presented as video, considering both the feed
+    /// metadata (`videoPodcast()`) and any video tracks detected at runtime in the stream.
+    func isCurrentEpisodeVideo() -> Bool {
+        currentEpisode()?.videoPodcast() == true || currentStreamContainsVideo
+    }
+
+    /// Called by the player when it detects video tracks in the stream it is playing.
+    /// Used for HLS streams whose video content isn't reflected in the episode's file type.
+    func handleVideoTracksDetected(forEpisode episodeUuid: String) {
+        guard currentEpisode()?.uuid == episodeUuid, !currentStreamContainsVideo else { return }
+        currentStreamContainsVideo = true
+        setAudioSessionVideoProperties()
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.videoPlaybackEngineSwitched)
+    }
+
     func internalPlayerForVideoPlayback() -> AVPlayer? {
         if let episode = currentEpisode(), player == nil {
             load(episode: episode, autoPlay: false, overrideUpNext: false)
@@ -1395,6 +1415,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     private func cleanupCurrentPlayer(permanent: Bool) {
         haveCalledPlayerLoad = false
+        currentStreamContainsVideo = false
         seekingTo = PlaybackManager.notSeeking
         FileLog.shared.addMessage("cleanupCurrentPlayer permanent? \(permanent)")
         if let player {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2294,7 +2294,9 @@ class PlaybackManager: ServerPlaybackDelegate {
            !episodeIsChanging,
            effects().trimSilence == .off,
            !playerSwitchRequired(),
-           !refreshedEpisode.videoPodcast() {
+           !refreshedEpisode.videoPodcast(),
+           // HLS is streamed directly, not cached to the downloaded file, so we must reload to switch to it
+           !EpisodeManager.isStreamingHLS(refreshedEpisode) {
             return false
         } else {
             if !episodeIsChanging {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2295,8 +2295,7 @@ class PlaybackManager: ServerPlaybackDelegate {
            effects().trimSilence == .off,
            !playerSwitchRequired(),
            !refreshedEpisode.videoPodcast(),
-           // HLS is streamed directly, not cached to the downloaded file, so we must reload to switch to it
-           !EpisodeManager.isStreamingHLS(refreshedEpisode) {
+           // HLS is streamed directly (no stream-and-cache), so when playback finishes downloading we must reload to switch to the downloaded local file
             return false
         } else {
             if !episodeIsChanging {

--- a/podcasts/PlayerZoomAnimator.swift
+++ b/podcasts/PlayerZoomAnimator.swift
@@ -14,7 +14,7 @@ final class PlayerZoomAnimator: NSObject, UIViewControllerAnimatedTransitioning 
     private var isInteractive: Bool { interactiveVelocity != 0 }
 
     private var isVideoPodcast: Bool {
-        PlaybackManager.shared.currentEpisode()?.videoPodcast() ?? false
+        PlaybackManager.shared.isCurrentEpisodeVideo()
     }
 
     private var presentDuration: TimeInterval { isInteractive ? 0.45 : 0.5 }

--- a/podcasts/VideoViewController.swift
+++ b/podcasts/VideoViewController.swift
@@ -285,7 +285,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     }
 
     @objc private func trackChanged() {
-        guard let currentEpisode = PlaybackManager.shared.currentEpisode(), currentEpisode.videoPodcast() else {
+        guard PlaybackManager.shared.currentEpisode() != nil, PlaybackManager.shared.isCurrentEpisodeVideo() else {
             dismiss(animated: true, completion: nil)
             return
         }


### PR DESCRIPTION
Fixes POC-708

Plays the HLS stream instead of the progressive file when an episode has one, and gives HLS video episodes the same experience as native video podcasts. Builds on the `alternate_enclosures` → `hlsUrl` support from #4671.

### Behavior
- When an episode has an `hlsUrl` (and `FeatureFlag.hls` is on), streaming defaults to the HLS stream over the progressive file.
- HLS is streamed directly and is **never cached** (the stream-and-cache path is skipped for HLS). Progressive episodes keep their existing cache-while-streaming behavior.
- **Downloads are unchanged and take precedence** — a downloaded/local file always plays locally, regardless of HLS.
- HLS streams are often video. Since the HLS content type doesn't declare audio vs video and `presentationSize` is `0x0` until the first frame decodes, `DefaultPlayer` observes `presentationSize` and promotes playback to video at runtime once a size is reported. A new `PlaybackManager.isCurrentEpisodeVideo()` combines the feed's `videoPodcast()` with this runtime detection, and the video-podcast behaviors (auto-open full player, tap-to-fullscreen, mini↔full/zoom animations, lock-screen media type) now route through it.

All of this is gated behind `FeatureFlag.hls`.

## To test

`hls` feature flag should be enabled on `DEBUG` builds.

### Video HLS episode plays as video
1. Open this episode: https://pca.st/episode/a9ffd026-87d9-42f5-af16-1de8342682bc
2. Tap play (stream it — do **not** download it first).
3. Expect: the full-screen player **opens automatically** shortly after playback starts, and the **video renders** in the player.
4. Tap the video → expect it goes **full screen** (`VideoViewController`).
5. On the lock screen / Control Center, expect the now-playing artwork behaves as video.

### Downloads still take precedence (and are progressive)
1. On the same episode, download it.
2. Play it. Expect it plays the downloaded local file (offline works); HLS is not used when a local file exists.

### Non-HLS episode is unchanged
1. Open this episode (no HLS): https://pca.st/episode/3f86afb2-a16d-4683-88f7-0dcf3e09b56b
2. Stream it. Expect: plays the progressive file exactly as before, with the usual stream-and-cache behavior (no regression).

### Flag off = no change
1. Turn the `hls` flag off and relaunch.
2. Play the first episode. Expect: it streams the progressive file as audio (pre-existing behavior), no auto-open/video.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
