### PR TITLE
More playful play button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.16
 -----
+- Make the Liquid Glass mini player's play button translucent with a springy bounce on tap [#4677](https://github.com/Automattic/pocket-casts-ios/pull/4677)
 - Fix the smart playlist and podcast page header showing the system light/dark appearance instead of the in-app theme when scrolling on iOS 18 [#4662](https://github.com/Automattic/pocket-casts-ios/pull/4662)
 - Fix episode lists jumping when a background download finishes [#4648](https://github.com/Automattic/pocket-casts-ios/pull/4648)
 - Fix a rare crash during playback when an audio buffer fails to allocate [#4645](https://github.com/Automattic/pocket-casts-ios/pull/4645)

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -185,6 +185,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         textStack.alignment = .leading
         textStack.spacing = 2
 
+        addPlayButtonBounce()
         let buttonStack = UIStackView(arrangedSubviews: [skipBackBtn, playPauseBtn, skipFwdBtn])
         buttonStack.translatesAutoresizingMaskIntoConstraints = false
         buttonStack.axis = .horizontal
@@ -218,6 +219,30 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         view.registerForTraitChanges([UITraitTabAccessoryEnvironment.self]) { (view: UIView, _) in
             view.setNeedsUpdateConstraints()
+        }
+    }
+
+    /// Adds a springy scale-down-and-bounce-back response to the play/pause
+    /// button so the translucent accent circle feels tactile on tap.
+    private func addPlayButtonBounce() {
+        playPauseBtn.addTarget(self, action: #selector(playButtonTouchedDown), for: .touchDown)
+        playPauseBtn.addTarget(self, action: #selector(playButtonReleased), for: [.touchUpInside, .touchUpOutside, .touchCancel])
+    }
+
+    @objc private func playButtonTouchedDown() {
+        guard !UIAccessibility.isReduceMotionEnabled else { return }
+        UIView.animate(withDuration: 0.12, delay: 0, options: [.allowUserInteraction, .beginFromCurrentState]) {
+            self.playPauseBtn.transform = CGAffineTransform(scaleX: 0.86, y: 0.86)
+        }
+    }
+
+    @objc private func playButtonReleased() {
+        guard !UIAccessibility.isReduceMotionEnabled else {
+            playPauseBtn.transform = .identity
+            return
+        }
+        UIView.animate(withDuration: 0.55, delay: 0, usingSpringWithDamping: 0.35, initialSpringVelocity: 0.7, options: [.allowUserInteraction, .beginFromCurrentState]) {
+            self.playPauseBtn.transform = .identity
         }
     }
 
@@ -620,8 +645,10 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         episodeTitleLabel?.textColor = .label
         timeLeftModel?.color = Color(ThemeColor.primaryText02())
 
+        // A slightly translucent accent circle lets the tab bar's glass show
+        // through for a vibrant, glassy feel (without the buggy UIGlassEffect).
         playPauseBtn.playButtonColor = bgColor
-        playPauseBtn.circleColor = iconColor
+        playPauseBtn.circleColor = iconColor.withAlphaComponent(0.8)
 
         skipBackBtn.tintColor = iconColor
         skipFwdBtn.tintColor = iconColor

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -222,7 +222,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         }
     }
 
-    /// Adds a springy scale-down-and-bounce-back response to the play/pause
+    /// Adds a springy scale-up-and-settle-back response to the play/pause
     /// button so the translucent accent circle feels tactile on tap.
     private func addPlayButtonBounce() {
         playPauseBtn.addTarget(self, action: #selector(playButtonTouchedDown), for: .touchDown)
@@ -231,18 +231,21 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
     @objc private func playButtonTouchedDown() {
         guard !UIAccessibility.isReduceMotionEnabled else { return }
-        UIView.animate(withDuration: 0.12, delay: 0, options: [.allowUserInteraction, .beginFromCurrentState]) {
-            self.playPauseBtn.transform = CGAffineTransform(scaleX: 0.86, y: 0.86)
+        UIView.animate(withDuration: 0.18, delay: 0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.8, options: [.allowUserInteraction, .beginFromCurrentState]) {
+            self.playPauseBtn.transform = CGAffineTransform(scaleX: 1.2, y: 1.2)
+            self.playPauseBtn.alpha = 0.75
         }
     }
 
     @objc private func playButtonReleased() {
         guard !UIAccessibility.isReduceMotionEnabled else {
             playPauseBtn.transform = .identity
+            playPauseBtn.alpha = 1
             return
         }
         UIView.animate(withDuration: 0.55, delay: 0, usingSpringWithDamping: 0.35, initialSpringVelocity: 0.7, options: [.allowUserInteraction, .beginFromCurrentState]) {
             self.playPauseBtn.transform = .identity
+            self.playPauseBtn.alpha = 1
         }
     }
 
@@ -647,11 +650,14 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
         // A slightly translucent accent circle lets the tab bar's glass show
         // through for a vibrant, glassy feel (without the buggy UIGlassEffect).
+        // The skip glyphs reuse that same translucent accent so all three
+        // controls share one color.
+        let accentColor = iconColor.withAlphaComponent(0.8)
         playPauseBtn.playButtonColor = bgColor
-        playPauseBtn.circleColor = iconColor.withAlphaComponent(0.8)
+        playPauseBtn.circleColor = accentColor
 
-        skipBackBtn.tintColor = iconColor
-        skipFwdBtn.tintColor = iconColor
+        skipBackBtn.tintColor = accentColor
+        skipFwdBtn.tintColor = accentColor
 
         glassProgressView?.tintColorOverride = actionColor
     }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Just a small suggestion to make it a bit more lively.

## To test

1. Run on an iOS 26 device/simulator with Liquid Glass.
2. Start playing an episode so the mini player appears in the tab bar.
3. Confirm the play/pause circle looks slightly translucent (tab bar glass shows through) and the glyph stays legible in both light and dark themes.
4. Tap play/pause and confirm the button scales down and springs back with a bounce.



https://github.com/user-attachments/assets/08794bea-3db9-4fe8-93dc-59d879afc59c




## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
