### PR TITLE
PCIOS-785: iOS: Swipe-to-add-to-Up-Next hangs inside Playlists before the action completes

### DIFF
--- a/podcasts/New Detail/Operation/PlaylistDetailFetchOperation.swift
+++ b/podcasts/New Detail/Operation/PlaylistDetailFetchOperation.swift
@@ -37,8 +37,10 @@ class PlaylistDetailFetchOperation: Operation, @unchecked Sendable {
                 episodeUuidToAdd: playlist.episodeUuidToAddToQueries()
             )
 
+            if self.isCancelled { return }
             DispatchQueue.main.sync { [weak self] in
                 guard let strongSelf = self else { return }
+                if strongSelf.isCancelled { return }
                 strongSelf.completion(newData, archivedEpisodesCount)
             }
         }

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -162,17 +162,15 @@ class PlaylistDetailViewModel: ObservableObject {
             shouldShowArchived: playlist.showArchivedEpisodes
         ) { [weak self] newData, archivedEpisodeCount in
             guard let self else { return }
-            DispatchQueue.main.async {
-                self.archivedEpisodesCount = archivedEpisodeCount
-                let isFirstReload = self.firstTimeLoading
-                self.firstTimeLoading = false
-                let changeSetTuple = self.buildChangeSet(source: self.episodes, newData: newData)
-                let contentHasChanged = changeSetTuple.0
-                if contentHasChanged {
-                    self.dataManager.updatePlaylistUpdateDate(for: self.playlist)
-                }
-                self.onChange(changeSetTuple.1, animated && !isFirstReload, contentHasChanged)
+            self.archivedEpisodesCount = archivedEpisodeCount
+            let isFirstReload = self.firstTimeLoading
+            self.firstTimeLoading = false
+            let changeSetTuple = self.buildChangeSet(source: self.episodes, newData: newData)
+            let contentHasChanged = changeSetTuple.0
+            if contentHasChanged {
+                self.dataManager.updatePlaylistUpdateDate(for: self.playlist)
             }
+            self.onChange(changeSetTuple.1, animated && !isFirstReload, contentHasChanged)
         }
         operationQueue.addOperation(refreshOperation)
     }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-785/ios-swipe-to-add-to-up-next-hangs-inside-playlists-before-the-action

## Summary
Fixes a UI hang when swiping episodes in Playlists to add to Up Next. The swipe action would freeze for a noticeable duration before completing, though the add-to-queue operation itself succeeded. This did not happen in podcast show pages or Downloads.

## Changes
- **`PlaylistDetailFetchOperation.swift`** — Added `isCancelled` checks after the database query and inside the `DispatchQueue.main.sync` block, matching the pattern used in `PodcastEpisodesRefreshOperation`. Previously, cancelled operations would still execute the expensive DB query, block on `main.sync`, and deliver stale data to the completion handler, stalling the serial operation queue.
- **`PlaylistDetailViewModel.swift`** — Removed the nested `DispatchQueue.main.async` inside the fetch operation's completion handler. The completion already runs on the main thread (via `main.sync` in the operation), so the nested async dispatch deferred the DifferenceKit changeset computation to a later run-loop cycle with potentially stale data. This could cause batch update failures that fell back to `reloadData()` during SwipeCellKit's editing animation, freezing the UI. The podcast page equivalent runs this work synchronously without issue.

## Verification
- **Lint**: PASS
- **Tests**: SKIP — build has pre-existing CarPlay API failures unrelated to these changes
- **Diff review**: PASS — confirmed only the two intended files were changed with minimal, scoped edits
- **Secret scan**: PASS — no credentials in diff

## Confidence
**MEDIUM** — The root cause analysis is well-supported by comparing the playlist path with the working podcast page path (which has proper isCancelled checks and no nested main.async). The fix aligns both paths. However, the original report could not be reproduced by the HE on a newer device, so the hang may be data-size or device-speed dependent, making it difficult to verify the fix without the reporter's specific playlist data.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/PCIOS-785/ios-swipe-to-add-to-up-next-hangs-inside-playlists-before-the-action)