### PR TITLE
TV: Refresh folder and playlist cells when sync updates names or membership

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -115,7 +115,7 @@ public class EpisodeFilter: NSObject {
     override public func isEqual(_ object: Any?) -> Bool {
         guard let otherFilter = object as? EpisodeFilter else { return false }
 
-        return otherFilter.uuid == uuid && otherFilter.playlistName == playlistName
+        return otherFilter.uuid == uuid && otherFilter.playlistName == playlistName && otherFilter.playlistUpdateDate == playlistUpdateDate
     }
 
     override public var hash: Int {

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -115,7 +115,7 @@ public class EpisodeFilter: NSObject {
     override public func isEqual(_ object: Any?) -> Bool {
         guard let otherFilter = object as? EpisodeFilter else { return false }
 
-        return otherFilter.uuid == uuid
+        return otherFilter.uuid == uuid && otherFilter.playlistName == playlistName
     }
 
     override public var hash: Int {

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -115,7 +115,7 @@ public class EpisodeFilter: NSObject {
     override public func isEqual(_ object: Any?) -> Bool {
         guard let otherFilter = object as? EpisodeFilter else { return false }
 
-        return otherFilter.uuid == uuid && otherFilter.playlistName == playlistName && otherFilter.playlistUpdateDate == playlistUpdateDate
+        return otherFilter.uuid == uuid
     }
 
     override public var hash: Int {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -3,10 +3,10 @@ import PocketCastsDataModel
 
 struct PlaylistCell: View {
 
-    var playlist: EpisodeFilter
+    var playlist: PlaylistItem
     @State var model: PlaylistDetailsViewModel
 
-    init(playlist: EpisodeFilter) {
+    init(playlist: PlaylistItem) {
         self.playlist = playlist
         self.model = PlaylistDetailsViewModel(playlist: playlist)
     }
@@ -78,7 +78,7 @@ struct PlaylistCell: View {
 }
 
 #Preview {
-    PlaylistCell(playlist: MockData.makeStubPlaylists().first!)
+    PlaylistCell(playlist: PlaylistItem(playlist: MockData.makeStubPlaylists().first!))
         .environment(AppCoordinator())
         .environment(MainTabViewModel())
 }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistCell.swift
@@ -2,9 +2,12 @@ import SwiftUI
 import PocketCastsDataModel
 
 struct PlaylistCell: View {
+
+    var playlist: EpisodeFilter
     @State var model: PlaylistDetailsViewModel
 
     init(playlist: EpisodeFilter) {
+        self.playlist = playlist
         self.model = PlaylistDetailsViewModel(playlist: playlist)
     }
 
@@ -65,6 +68,10 @@ struct PlaylistCell: View {
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .focusedCardDepth(isFocused: isFocused, cornerRadius: 16, style: .content)
         .task {
+            model.load()
+        }
+        .onChange(of: playlist) {
+            model.playlist = playlist
             model.load()
         }
     }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -269,7 +269,7 @@ struct PlaylistDetailView: View {
 
 #Preview {
     let router = MainTabViewModel()
-    PlaylistDetailView(model: PlaylistDetailsViewModel(playlist: MockData.makeStubPlaylists().first!))
+    PlaylistDetailView(model: PlaylistDetailsViewModel(playlist: PlaylistItem(playlist: MockData.makeStubPlaylists().first!)))
         .environment(AppCoordinator())
         .environment(router)
 }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -19,7 +19,7 @@ class PlaylistDetailsViewModel {
     var isShowingReplaceUpNextConfirmation = false
     var isShowingNowPlaying = false
 
-    let playlist: EpisodeFilter
+    var playlist: EpisodeFilter
     var episodes: [Episode] = []
     var showArchived: Bool = false
     var playlistColor: Color

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -19,12 +19,12 @@ class PlaylistDetailsViewModel {
     var isShowingReplaceUpNextConfirmation = false
     var isShowingNowPlaying = false
 
-    var playlist: EpisodeFilter
+    var playlist: PlaylistItem
     var episodes: [Episode] = []
     var showArchived: Bool = false
     var playlistColor: Color
 
-    var hasDownloadFilter: Bool { playlist.isDownloadFilterActive }
+    var hasDownloadFilter: Bool { playlist.playlist.isDownloadFilterActive }
 
     private var allEpisodes: [Episode] = []
     private let dataManager: DataManager
@@ -34,14 +34,14 @@ class PlaylistDetailsViewModel {
         "showArchived_playlist_\(playlist.uuid)"
     }
 
-    init(playlist: EpisodeFilter,
+    init(playlist: PlaylistItem,
          dataManager: DataManager = DataManager.sharedManager,
          playbackManager: PlaybackManager = PlaybackManager.shared) {
         self.playlist = playlist
         self.dataManager = dataManager
         self.playbackManager = playbackManager
-        self.showArchived = UserDefaults.standard.bool(forKey: Self.archiveStorageKey(for: playlist))
-        self.playlistColor = Self.fallbackPillColor(for: playlist.uuid)
+        self.showArchived = UserDefaults.standard.bool(forKey: Self.archiveStorageKey(for: playlist.playlist))
+        self.playlistColor = Self.fallbackPillColor(for: playlist.playlist.uuid)
         observePodcastColorDownloads()
     }
 
@@ -68,7 +68,7 @@ class PlaylistDetailsViewModel {
             // with `shouldShowArchived: true` and let the local toggle decide what to display.
             let query = PlaylistQueryBuilder.query(
                 clause: .episode,
-                for: playlist,
+                for: playlist.playlist,
                 limit: Self.playlistEpisodeLimit,
                 shouldShowArchived: true
             )
@@ -91,7 +91,7 @@ class PlaylistDetailsViewModel {
         showArchived = value
         applyArchivedFilter()
         refreshPlaylistColor()
-        UserDefaults.standard.set(value, forKey: Self.archiveStorageKey(for: playlist))
+        UserDefaults.standard.set(value, forKey: Self.archiveStorageKey(for: playlist.playlist))
     }
 
     private func applyArchivedFilter() {
@@ -103,7 +103,7 @@ class PlaylistDetailsViewModel {
 
         Analytics.track(.filterPlayAllTapped, properties: analyticsProperties())
 
-        if playbackManager.playIfSafe(playlist: playlist, episodeIDs: episodes.map(\.uuid)) {
+        if playbackManager.playIfSafe(playlist: playlist.playlist, episodeIDs: episodes.map(\.uuid)) {
             isShowingNowPlaying = true
         } else {
             isShowingReplaceUpNextConfirmation = true
@@ -120,7 +120,7 @@ class PlaylistDetailsViewModel {
         let baseName = "\(L10n.upNext) - \(Date().monthDayString())"
         let created = dataManager.createManualPlaylists(from: episodes, batchSize: Constants.Limits.maxFilterItems, baseName: baseName)
         await MainActor.run {
-            self.playbackManager.play(playlist: self.playlist)
+            self.playbackManager.play(playlist: self.playlist.playlist)
             self.isShowingNowPlaying = true
 
             if created > 0 {
@@ -132,7 +132,7 @@ class PlaylistDetailsViewModel {
 
     func playWithoutSaving() {
         Analytics.track(.filterPlayAllReplaceAndPlayTapped, properties: analyticsProperties(["save_up_next": false]))
-        playbackManager.play(playlist: playlist)
+        playbackManager.play(playlist: playlist.playlist)
         isShowingNowPlaying = true
     }
 
@@ -152,11 +152,11 @@ class PlaylistDetailsViewModel {
     }
 
     var playlistName: String {
-        return playlist.playlistName
+        return playlist.playlist.playlistName
     }
 
     var isManual: Bool {
-        return playlist.manual
+        return playlist.playlist.manual
     }
 
     var totalDuration: String {
@@ -182,7 +182,7 @@ class PlaylistDetailsViewModel {
            let color = Self.pillColor(from: ColorManager.lightThemeTintForPodcast(podcast)) {
             playlistColor = color
         } else {
-            playlistColor = Self.fallbackPillColor(for: playlist.uuid)
+            playlistColor = Self.fallbackPillColor(for: playlist.playlist.uuid)
         }
     }
 

--- a/Pocket Casts TV App/UI/Playlists/PlaylistItem.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistItem.swift
@@ -1,0 +1,17 @@
+import Foundation
+import PocketCastsDataModel
+
+struct PlaylistItem: Identifiable, Equatable, Hashable {
+
+    let playlist: EpisodeFilter
+
+    var id: String {
+        return playlist.uuid
+    }
+
+    static func == (lhs: PlaylistItem, rhs: PlaylistItem) -> Bool {
+        return lhs.playlist.uuid == rhs.playlist.uuid &&
+        lhs.playlist.playlistUpdateDate == rhs.playlist.playlistUpdateDate &&
+        lhs.playlist.playlistName == rhs.playlist.playlistName
+    }
+}

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -84,7 +84,7 @@ struct PlaylistsView: View {
 
     var playlistsCollection: some View {
         LazyVGrid(columns: items, spacing: 48, content: {
-            ForEach(model.playlists, id: \.uuid) { playlist in
+            ForEach(model.playlists) { playlist in
                 NavigationLink(value: playlist) {
                     PlaylistCell(playlist: playlist)
                 }
@@ -93,7 +93,7 @@ struct PlaylistsView: View {
             }
         })
         .focusScope(listNamespace)
-        .navigationDestination(for: EpisodeFilter.self) { playlist in
+        .navigationDestination(for: PlaylistItem.self) { playlist in
             PlaylistDetailView(model: PlaylistDetailsViewModel(playlist: playlist))
         }
     }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
@@ -22,7 +22,7 @@ class PlaylistsViewModel {
         self.dataManager = dataManager
         observePlaylistChanges()
     }
-    var playlists: [EpisodeFilter] = []
+    var playlists: [PlaylistItem] = []
 
     func load() async {
         let originalPlaylists = dataManager.allPlaylists(includeDeleted: false)
@@ -37,7 +37,9 @@ class PlaylistsViewModel {
             }
         }
         await MainActor.run {
-            self.playlists = playlists
+            self.playlists = playlists.map({ playlist in
+                PlaylistItem(playlist: playlist)
+            })
             self.state = playlists.isEmpty ? .empty : .ready
         }
     }

--- a/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
@@ -3,9 +3,11 @@ import PocketCastsDataModel
 
 struct FolderCardView: View {
 
+    var folder: Folder
     @State var model: FolderCardViewModel
 
     init(folder: Folder) {
+        self.folder = folder
         self.model = FolderCardViewModel(folder: folder)
     }
 
@@ -34,6 +36,9 @@ struct FolderCardView: View {
         .focusedCardDepth(cornerRadius: 12, style: .surface)
         .task {
             model.load()
+        }
+        .onChange(of: folder) { _, _ in
+            model.folder = folder
         }
     }
 

--- a/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderCardView.swift
@@ -37,8 +37,9 @@ struct FolderCardView: View {
         .task {
             model.load()
         }
-        .onChange(of: folder) { _, _ in
+        .onChange(of: folder) {
             model.folder = folder
+            model.load()
         }
     }
 

--- a/Pocket Casts TV App/UI/Podcasts/FolderCardViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/FolderCardViewModel.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 @Observable
 class FolderCardViewModel {
 
-    let folder: Folder
+    var folder: Folder
     let dataManager: DataManager
 
     var topPodcastsUuids: [String] = []


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

## Summary

On the TV app, folder and playlist cells did not reflect changes coming from a sync (a folder/playlist renamed on another device, or a playlist's membership changing). The stale name/contents stayed on screen until the app was restarted.

The root cause was two-fold:

1. **View models were captured once and never updated.** `PlaylistCell` and `FolderCardView` create their `@Observable` view model in `init` and store it in `@State`. `@State` is only initialized on the first render, so when the parent re-supplied an updated `EpisodeFilter`/`Folder`, the view model kept pointing at the old value. The fix stores the incoming value as a plain `var` (which SwiftUI refreshes on every parent update) and uses `.onChange(of:)` to push the new value into the view model and reload.

2. **`EpisodeFilter` equality ignored the name.** `EpisodeFilter.isEqual` compared only `uuid`, so SwiftUI's `onChange`/diffing could not detect a rename (same uuid, new name). Equality now also compares `playlistName`, so a renamed playlist is seen as changed.

`FolderCardViewModel.folder` and `PlaylistDetailsViewModel.playlist` were changed from `let` to `var` so the updated value can be assigned.

## To test

1. Sign in on the TV app and on another device (phone/web) with the same account.
2. On the other device, rename a folder and a playlist, and add/remove podcasts/episodes from a playlist.
3. On the TV app, trigger a sync/refresh.
4. Verify the folder and playlist cells update their names (and the playlist contents/cover art) without needing to restart the app.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.
