### PR TITLE
Remove Settings option from TV profile menu

### DIFF
--- a/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
@@ -75,15 +75,6 @@ struct ProfileMenuView: View {
                     .padding(.bottom, 24)
             }
 
-            // Group 1
-            Button {
-                Analytics.track(.profileSettingsButtonTapped)
-                // Settings destination not yet implemented for TV
-            } label: {
-                Label(L10n.settings, systemImage: "gearshape")
-                    .frame(minWidth: 400)
-            }
-
             Divider()
                 .frame(maxWidth: 400)
 

--- a/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/ProfileMenuView.swift
@@ -78,7 +78,6 @@ struct ProfileMenuView: View {
             Divider()
                 .frame(maxWidth: 400)
 
-            // Group 2
             Button {
                 onProfileSelected(.starred)
             } label: {
@@ -95,7 +94,6 @@ struct ProfileMenuView: View {
             Divider()
                 .frame(maxWidth: 400)
 
-            // Group 3
             Button {
                 isShowingLogoutConfirmation = true
             } label: {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Removes the non-functional **Settings** button from the TV app's profile menu. The button tracked an analytics event but had no destination implemented for tvOS (`// Settings destination not yet implemented for TV`), so it did nothing when tapped.

Also drops the now-stale `// Group 1/2/3` section comments — with the Settings section (Group 1) gone, the numbering was broken and the comments described nothing meaningful.

Note: the `profileSettingsButtonTapped` analytics event is left intact since it's still used by the iOS `ProfileViewController`.

## To test

1. Launch the TV app.
2. Open the Profile menu while signed in.
3. Confirm there is no Settings button — the menu shows profile info, Starred Episodes, Listening History, and Log Out.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.