### PR TITLE
Cast HLS streams correctly on Chromecast

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDictionary.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDictionary.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension Episode {
     /// MIME type advertised for HLS streams inside a feed's `alternate_enclosures`.
-    static let hlsEnclosureType = "application/x-mpegURL"
+    public static let hlsEnclosureType = "application/x-mpegURL"
 
     /// Extracts the HLS stream URL from a feed episode's `alternate_enclosures` array, if one is present.
     ///

--- a/podcasts/Google Cast/GoogleCastManager.swift
+++ b/podcasts/Google Cast/GoogleCastManager.swift
@@ -187,8 +187,12 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
         episodeToPlayOnConnect = episode
         bufferingInitialPartOfEpisode = true
 
-        // metadata about the episode to display on the Google Cast
-        let episodeMetadata = GCKMediaMetadata(metadataType: episode.videoPodcast() ? .movie : .musicTrack)
+        // metadata about the episode to display on the Google Cast.
+        // HLS streams can carry video that isn't reflected in the episode's file type, and the phone
+        // only knows for sure once it's decoded locally. To keep things simple we assume any HLS
+        // stream is video so the receiver renders it rather than presenting audio-only.
+        let isHLS = EpisodeManager.isStreamingHLS(episode)
+        let episodeMetadata = GCKMediaMetadata(metadataType: (episode.videoPodcast() || isHLS) ? .movie : .musicTrack)
 
         if let episode = episode as? Episode, let uuid = episode.parentPodcast()?.uuid {
             let episodeImage = GCKImage(url: ServerHelper.imageUrl(podcastUuid: uuid, size: 680), width: 680, height: 680)
@@ -213,7 +217,10 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
         // custom data that things like the iOS and Android app know to look for
         let episodeInfo = [episodeUuidKey: episode.uuid]
         let downloadUrl = EpisodeManager.urlForEpisode(episode, streamingOnly: true)
-        let fileType = episode.fileType ?? ""
+        // When streaming HLS, the content URL is an .m3u8 manifest, not the progressive file.
+        // The receiver needs the HLS content type to load it — the episode's file type describes
+        // the progressive enclosure and would make the receiver try to play the manifest directly.
+        let fileType = isHLS ? Episode.hlsEnclosureType : (episode.fileType ?? "")
         let mediaBuilder = GCKMediaInformationBuilder()
         mediaBuilder.contentURL = downloadUrl
         mediaBuilder.streamType = .buffered


### PR DESCRIPTION
Fixes PCIOS-812

Makes Chromecast cast HLS streams correctly. Builds on the HLS audio/video toggle work.

## To test

> [!NOTE]
> Requires a real Chromecast device.

2. Play [an episode with an HLS stream](https://pca.st/episode/ef3e31b2-e52c-4aa9-8423-1bbe493fd90d) that contains video.
3. Cast to a Chromecast (video-capable, e.g. a TV).
4. Confirm playback starts on the device **and shows video**
5. Also cast a regular (non-HLS) audio episode and a video podcast to confirm no regression.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
