### PR TITLE
Fix bottom bars turning gray under some conditions on home grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.16
 -----
+- Fix the floating tab bar and mini player turning gray over the podcast grid under Liquid Glass on iOS 26 [#4689](https://github.com/Automattic/pocket-casts-ios/pull/4689)
 - Fix the smart playlist and podcast page header showing the system light/dark appearance instead of the in-app theme when scrolling on iOS 18 [#4662](https://github.com/Automattic/pocket-casts-ios/pull/4662)
 - Fix episode lists jumping when a background download finishes [#4648](https://github.com/Automattic/pocket-casts-ios/pull/4648)
 - Fix a rare crash during playback when an audio buffer fails to allocate [#4645](https://github.com/Automattic/pocket-casts-ios/pull/4645)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 8.16
 -----
-- Fix the floating tab bar and mini player turning gray over the podcast grid under Liquid Glass on iOS 26 [#4689](https://github.com/Automattic/pocket-casts-ios/pull/4689)
 - Fix the smart playlist and podcast page header showing the system light/dark appearance instead of the in-app theme when scrolling on iOS 18 [#4662](https://github.com/Automattic/pocket-casts-ios/pull/4662)
 - Fix episode lists jumping when a background download finishes [#4648](https://github.com/Automattic/pocket-casts-ios/pull/4648)
 - Fix a rare crash during playback when an audio buffer fails to allocate [#4645](https://github.com/Automattic/pocket-casts-ios/pull/4645)
@@ -11,6 +10,7 @@
 - Fix a crash on Apple Watch when a background sync starts while the app is being suspended [#4622](https://github.com/Automattic/pocket-casts-ios/pull/4622)
 - Fix non-square chapter artwork being cropped and losing rounded corners when opening the full-screen player [#4621](https://github.com/Automattic/pocket-casts-ios/pull/4621)
 - Fix a rare crash when loading embedded episode artwork [#4619](https://github.com/Automattic/pocket-casts-ios/pull/4619)
+- Fix the floating tab bar and mini player turning gray over the podcast grid under some conditions [#4689](https://github.com/Automattic/pocket-casts-ios/pull/4689)
 - Fix a rare crash when an episode is deleted while its download status is updating [#4642](https://github.com/Automattic/pocket-casts-ios/pull/4642)
 - Fix a potential rare crash when playback fails to start [#4641](https://github.com/Automattic/pocket-casts-ios/pull/4641)
 - Fix a potential crash and wrong-podcast taps when opening a Discover category list that shows a sponsored podcast [#4652](https://github.com/Automattic/pocket-casts-ios/pull/4652)

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
@@ -57,8 +57,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
@@ -57,8 +57,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/podcasts/Main/MainTabBarController+Animations.swift
+++ b/podcasts/Main/MainTabBarController+Animations.swift
@@ -139,7 +139,7 @@ extension MainTabBarController {
     /// compact pill. There's no public "is minimized" API, but UIKit sets the
     /// bottom accessory's `tabAccessoryEnvironment` trait to `.inline` exactly
     /// while the tab bar is minimized, so we read it back off the mini player.
-    private var isTabBarMinimized: Bool {
+    var isTabBarMinimized: Bool {
         guard #available(iOS 26.0, *) else { return false }
         return bottomAccessory?.contentView.traitCollection.tabAccessoryEnvironment == .inline
     }

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController+Search.swift
@@ -8,6 +8,10 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        // The tab bar collapses/expands as the grid scrolls, so keep the fade's overshoot in
+        // step with it. Cheap: only mutates the constraint when the collapsed state flips.
+        updateBottomFadeOvershoot()
+
         guard searchControllerView?.superview == nil else { return } // don't send scroll events while the search results are up
 
         searchController.parentScrollViewDidScroll(scrollView)

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -45,15 +45,22 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
 
     private var lastWillLayoutWidth: CGFloat = 0
 
-    /// Base height of the soft bottom fade edge shown over the grid under Liquid Glass,
-    /// measured from the bottom safe area upward. The bottom safe area inset is added on
-    /// top of this so the fade always clears the home indicator / floating bar.
-    /// The gradient fade means only the lower portion reads strongly, so this can be
-    /// generous without looking like a solid bar.
-    private static let bottomFadeHeight: CGFloat = 16
+    /// Gap left below the grid under Liquid Glass so its last content clears the floating
+    /// tab bar / mini player, expressed as a fraction of the bottom safe area so it tracks
+    /// the home indicator / floating bar / mini player as those insets change. The fade
+    /// fills the rest of the safe area above the gap. Applied only when the bottom fade is
+    /// enabled (see `setupBottomFade`).
+    private static let bottomSpacingFraction: CGFloat = 0.2
 
     private lazy var bottomFadeView = ProgressiveFadeView()
-    private var bottomFadeHeightConstraint: NSLayoutConstraint?
+
+    /// Pins the grid's bottom to the view's bottom; its constant is raised to a fraction
+    /// of the bottom safe area (`bottomSpacingFraction`) while the bottom fade is enabled.
+    @IBOutlet private var collectionViewBottomConstraint: NSLayoutConstraint!
+
+    /// Whether the Liquid Glass bottom fade / spacing is active, so the safe-area-driven
+    /// spacing keeps updating as insets change.
+    private var isBottomFadeEnabled = false
 
     private var homeGridDataHelper = HomeGridDataHelper()
 
@@ -309,45 +316,51 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         }
     }
 
-    /// Adds a soft progressive fade edge to the bottom of the grid under Liquid Glass.
+    /// Adds a soft progressive fade edge to the bottom of the grid under Liquid Glass on
+    /// iPhone.
     ///
     /// The system scroll edge effect samples the scrolling content, so over a grid of
     /// colorful artwork it washes out and barely registers — which is what hurts the
-    /// readability of the floating tab bar / mini player. A dedicated fade overlay,
-    /// pinned to the bottom of the screen behind the bar, dissolves the artwork into the
-    /// grid's own background for a consistently visible soft edge, replacing the system
-    /// scroll edge effect.
+    /// readability of the floating tab bar / mini player. Instead we leave a gap below the
+    /// grid (a fraction of the bottom safe area, see `updateBottomSpacing`) and draw a
+    /// dedicated fade overlay spanning from the top of the bottom safe area down to the
+    /// grid's bottom edge, dissolving the artwork into the grid's background for a
+    /// consistently visible soft edge, replacing the system scroll edge effect.
     @available(iOS 26, *)
     private func setupBottomFade() {
-        guard LiquidGlass.isEnabled else { return }
+        guard LiquidGlass.isEnabled, traitCollection.userInterfaceIdiom == .phone else { return }
+
+        isBottomFadeEnabled = true
+
+        // Size the gap below the grid and paint the exposed strip in the grid's own
+        // background color so the fade dissolves into it seamlessly.
+        updateBottomSpacing()
+        (view as? ThemeableView)?.style = .primaryUi02
 
         bottomFadeView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(bottomFadeView)
-        let heightConstraint = bottomFadeView.heightAnchor.constraint(equalToConstant: bottomFadeHeight)
-        bottomFadeHeightConstraint = heightConstraint
         NSLayoutConstraint.activate([
             bottomFadeView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomFadeView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            bottomFadeView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            heightConstraint
+            // Ramp smoothly from transparent at the top of the bottom safe area (where the
+            // floating bar begins) down to solid at the grid's bottom edge.
+            bottomFadeView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            bottomFadeView.bottomAnchor.constraint(equalTo: podcastsCollectionView.bottomAnchor)
         ])
         podcastsCollectionView.bottomEdgeEffect.isHidden = true
         updateBottomFadeColor()
     }
 
-    /// The fade is pinned to the very bottom of the view, so it must cover the bottom
-    /// safe area (home indicator / floating bar) plus the base fade height above it.
-    private var bottomFadeHeight: CGFloat {
-        Self.bottomFadeHeight + view.safeAreaInsets.bottom
+    /// Sizes the gap below the grid as a fraction of the current bottom safe area, so it
+    /// keeps clearing the floating bar / mini player as those insets change.
+    private func updateBottomSpacing() {
+        guard isBottomFadeEnabled else { return }
+        collectionViewBottomConstraint.constant = view.safeAreaInsets.bottom * Self.bottomSpacingFraction
     }
 
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
-        guard let bottomFadeHeightConstraint else { return }
-        bottomFadeHeightConstraint.constant = bottomFadeHeight
-        UIView.animate(withDuration: 0.3) {
-            self.view.layoutIfNeeded()
-        }
+        updateBottomSpacing()
     }
 
     /// Fades the grid into its own background color toward the bottom edge, so the

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -45,25 +45,22 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
 
     private var lastWillLayoutWidth: CGFloat = 0
 
-    /// Gap left below the grid under Liquid Glass so its last content clears the floating
-    /// tab bar / mini player, expressed as a fraction of the bottom safe area so it tracks
-    /// the home indicator / floating bar / mini player as those insets change. The fade
-    /// fills the rest of the safe area above the gap. Applied only when the bottom fade is
-    /// enabled (see `setCustomBottomFadeEnabled`).
+    /// Gap below the grid (as a fraction of the bottom safe area) so its last content clears
+    /// the floating tab bar / mini player. The fade fills the safe area above the gap. Only
+    /// applied while the bottom fade is enabled.
     private static let bottomSpacingFraction: CGFloat = 0.2
 
-    /// How far the fade's top extends above the bottom safe area edge, so the fade is taller
-    /// and eases in before the floating bar begins.
-    private static let bottomFadeTopOvershoot: CGFloat = 28
+    /// How far the fade's top extends above the bottom safe area edge, so it's taller and
+    /// eases in earlier.
+    private static let bottomFadeTopOvershoot: CGFloat = 9
 
     private lazy var bottomFadeView = ProgressiveFadeView()
 
-    /// Pins the grid's bottom to the view's bottom; its constant is raised to a fraction
-    /// of the bottom safe area (`bottomSpacingFraction`) while the bottom fade is enabled.
+    /// Pins the grid's bottom to the view's bottom; raised by `bottomSpacingFraction` of the
+    /// bottom safe area while the fade is enabled.
     @IBOutlet private var collectionViewBottomConstraint: NSLayoutConstraint!
 
-    /// Whether the Liquid Glass bottom fade / spacing is active, so the safe-area-driven
-    /// spacing keeps updating as insets change.
+    /// Whether the Liquid Glass bottom fade / spacing is active.
     private var isBottomFadeEnabled = false
 
     private var homeGridDataHelper = HomeGridDataHelper()
@@ -317,12 +314,11 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     }
 
     /// Re-evaluates whether the custom bottom fade should be active for the current traits
-    /// and toggles it to match. Called on load and whenever the trait collection changes,
-    /// so the fade follows the idiom (e.g. an iPhone app resized on iPad / Mac) rather than
-    /// being decided once at load.
+    /// and toggles it. Called on load and on trait changes so the fade follows the idiom
+    /// (e.g. an iPhone app resized on iPad / Mac).
     ///
-    /// Scoped to iOS 26: iOS 27+ is expected to render the system scroll edge effect
-    /// acceptably over the grid, so the custom fade is only a stopgap for iOS 26.
+    /// Scoped to iOS 26 only — a stopgap until iOS 27 is expected to render the system
+    /// scroll edge effect acceptably over the grid.
     private func updateCustomBottomFade() {
         guard isViewLoaded else { return }
         if #available(iOS 26, *) { // Only on iOS 26 for now
@@ -335,13 +331,10 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     /// Enables or disables a soft progressive fade edge at the bottom of the grid under
     /// Liquid Glass on iPhone.
     ///
-    /// The system scroll edge effect samples the scrolling content, so over a grid of
-    /// colorful artwork it washes out and barely registers — which is what hurts the
+    /// The system scroll edge effect washes out over the colorful artwork grid, hurting the
     /// readability of the floating tab bar / mini player. Instead we leave a gap below the
-    /// grid (a fraction of the bottom safe area, see `updateBottomSpacing`) and draw a
-    /// dedicated fade overlay spanning from the top of the bottom safe area down to the
-    /// grid's bottom edge, dissolving the artwork into the grid's background for a
-    /// consistently visible soft edge, replacing the system scroll edge effect.
+    /// grid (see `updateBottomSpacing`) and draw a fade overlay that dissolves the artwork
+    /// into the grid's background for a consistently visible soft edge.
     ///
     /// Disabling restores the default layout and the system scroll edge effect.
     @available(iOS 26, *)
@@ -368,9 +361,9 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         updateBottomFadeColor()
     }
 
-    /// Adds the fade overlay to the view hierarchy the first time the fade is enabled,
-    /// pinned to span from the top of the bottom safe area (where the floating bar begins)
-    /// down to the grid's bottom edge. Subsequent toggles just show/hide it.
+    /// Adds the fade overlay to the hierarchy the first time the fade is enabled, spanning
+    /// from the top of the bottom safe area to the grid's bottom edge. Later toggles just
+    /// show/hide it.
     private func installBottomFadeViewIfNeeded() {
         guard bottomFadeView.superview == nil else { return }
 
@@ -379,8 +372,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         NSLayoutConstraint.activate([
             bottomFadeView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomFadeView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            // Ramp smoothly from transparent down to solid at the grid's bottom edge. The top
-            // starts a bit above the bottom safe area (where the floating bar begins) so the
+            // Start a bit above the bottom safe area (where the floating bar begins) so the
             // fade is taller and eases in earlier.
             bottomFadeView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -Self.bottomFadeTopOvershoot),
             bottomFadeView.bottomAnchor.constraint(equalTo: podcastsCollectionView.bottomAnchor)
@@ -388,10 +380,10 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     }
 
     /// Sizes the gap below the grid as a fraction of the current bottom safe area, so it
-    /// keeps clearing the floating bar / mini player as those insets change.
+    /// keeps clearing the floating bar / mini player.
     private func updateBottomSpacing() {
         guard isBottomFadeEnabled else { return }
-        collectionViewBottomConstraint.constant = max(36, view.safeAreaInsets.bottom * Self.bottomSpacingFraction)
+        collectionViewBottomConstraint.constant = max(16, view.safeAreaInsets.bottom * Self.bottomSpacingFraction)
     }
 
     override func viewSafeAreaInsetsDidChange() {
@@ -404,8 +396,8 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         updateCustomBottomFade()
     }
 
-    /// Fades the grid into its own background color toward the bottom edge, so the
-    /// artwork dissolves out cleanly behind the floating bar in both themes.
+    /// Fades the grid into its own background color, so the artwork dissolves cleanly
+    /// behind the floating bar in both themes.
     private func updateBottomFadeColor() {
         guard LiquidGlass.isEnabled else { return }
         bottomFadeView.setColor(ThemeColor.primaryUi02())

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -52,6 +52,10 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     /// enabled (see `setCustomBottomFadeEnabled`).
     private static let bottomSpacingFraction: CGFloat = 0.2
 
+    /// How far the fade's top extends above the bottom safe area edge, so the fade is taller
+    /// and eases in before the floating bar begins.
+    private static let bottomFadeTopOvershoot: CGFloat = 28
+
     private lazy var bottomFadeView = ProgressiveFadeView()
 
     /// Pins the grid's bottom to the view's bottom; its constant is raised to a fraction
@@ -375,9 +379,10 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         NSLayoutConstraint.activate([
             bottomFadeView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomFadeView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            // Ramp smoothly from transparent at the top of the bottom safe area (where the
-            // floating bar begins) down to solid at the grid's bottom edge.
-            bottomFadeView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            // Ramp smoothly from transparent down to solid at the grid's bottom edge. The top
+            // starts a bit above the bottom safe area (where the floating bar begins) so the
+            // fade is taller and eases in earlier.
+            bottomFadeView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -Self.bottomFadeTopOvershoot),
             bottomFadeView.bottomAnchor.constraint(equalTo: podcastsCollectionView.bottomAnchor)
         ])
     }
@@ -386,7 +391,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     /// keeps clearing the floating bar / mini player as those insets change.
     private func updateBottomSpacing() {
         guard isBottomFadeEnabled else { return }
-        collectionViewBottomConstraint.constant = view.safeAreaInsets.bottom * Self.bottomSpacingFraction
+        collectionViewBottomConstraint.constant = max(36, view.safeAreaInsets.bottom * Self.bottomSpacingFraction)
     }
 
     override func viewSafeAreaInsetsDidChange() {

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -50,11 +50,15 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     /// applied while the bottom fade is enabled.
     private static let bottomSpacingFraction: CGFloat = 0.2
 
-    /// How far the fade's top extends above the bottom safe area edge, so it's taller and
-    /// eases in earlier.
+    /// How far the fade's top extends above the bottom safe area edge while the tab bar is
+    /// expanded, so it's taller and eases in earlier. Dropped to 0 when the bar collapses to
+    /// its compact pill (see `updateBottomFadeOvershoot`), which needs less covering.
     private static let bottomFadeTopOvershoot: CGFloat = 9
 
     private lazy var bottomFadeView = ProgressiveFadeView()
+
+    /// The fade's top constraint, kept so its constant can track the tab bar's collapsed state.
+    private var bottomFadeTopConstraint: NSLayoutConstraint?
 
     /// Pins the grid's bottom to the view's bottom; raised by `bottomSpacingFraction` of the
     /// bottom safe area while the fade is enabled.
@@ -351,6 +355,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
 
         installBottomFadeViewIfNeeded()
         bottomFadeView.isHidden = false
+        updateBottomFadeOvershoot()
 
         // Size the gap below the grid and paint the exposed strip in the grid's own
         // background color so the fade dissolves into it seamlessly.
@@ -369,14 +374,26 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
 
         bottomFadeView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(bottomFadeView)
+        // Start a bit above the bottom safe area (where the floating bar begins) so the fade
+        // is taller and eases in earlier. The overshoot is dropped when the bar collapses.
+        let topConstraint = bottomFadeView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -Self.bottomFadeTopOvershoot)
+        bottomFadeTopConstraint = topConstraint
         NSLayoutConstraint.activate([
             bottomFadeView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bottomFadeView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            // Start a bit above the bottom safe area (where the floating bar begins) so the
-            // fade is taller and eases in earlier.
-            bottomFadeView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -Self.bottomFadeTopOvershoot),
+            topConstraint,
             bottomFadeView.bottomAnchor.constraint(equalTo: podcastsCollectionView.bottomAnchor)
         ])
+    }
+
+    /// The fade overshoots above the safe area only while the tab bar is expanded. When it
+    /// collapses to its compact pill there's less bar to cover, so drop the overshoot.
+    func updateBottomFadeOvershoot() {
+        guard isBottomFadeEnabled, let bottomFadeTopConstraint else { return }
+        let minimized = (tabBarController as? MainTabBarController)?.isTabBarMinimized ?? false
+        let constant = -(minimized ? 0 : Self.bottomFadeTopOvershoot)
+        guard bottomFadeTopConstraint.constant != constant else { return }
+        bottomFadeTopConstraint.constant = constant
     }
 
     /// Sizes the gap below the grid as a fraction of the current bottom safe area, so it

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -49,7 +49,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     /// tab bar / mini player, expressed as a fraction of the bottom safe area so it tracks
     /// the home indicator / floating bar / mini player as those insets change. The fade
     /// fills the rest of the safe area above the gap. Applied only when the bottom fade is
-    /// enabled (see `setupBottomFade`).
+    /// enabled (see `setCustomBottomFadeEnabled`).
     private static let bottomSpacingFraction: CGFloat = 0.2
 
     private lazy var bottomFadeView = ProgressiveFadeView()
@@ -95,11 +95,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         podcastsCollectionView.dropDelegate = self
         podcastsCollectionView.dragInteractionEnabled = false
         podcastsCollectionView.reorderingCadence = .immediate
-        if #available(iOS 26, *) { // Only on iOS 26 for now
-            if #unavailable(iOS 27) {
-                setupBottomFade()
-            }
-        }
+        updateCustomBottomFade()
 
         adjustSettingsForGridType()
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: podcastsCollectionView)
@@ -316,8 +312,24 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         }
     }
 
-    /// Adds a soft progressive fade edge to the bottom of the grid under Liquid Glass on
-    /// iPhone.
+    /// Re-evaluates whether the custom bottom fade should be active for the current traits
+    /// and toggles it to match. Called on load and whenever the trait collection changes,
+    /// so the fade follows the idiom (e.g. an iPhone app resized on iPad / Mac) rather than
+    /// being decided once at load.
+    ///
+    /// Scoped to iOS 26: iOS 27+ is expected to render the system scroll edge effect
+    /// acceptably over the grid, so the custom fade is only a stopgap for iOS 26.
+    private func updateCustomBottomFade() {
+        guard isViewLoaded else { return }
+        if #available(iOS 26, *) { // Only on iOS 26 for now
+            if #unavailable(iOS 27) {
+                setCustomBottomFadeEnabled(LiquidGlass.isEnabled && traitCollection.userInterfaceIdiom == .phone)
+            }
+        }
+    }
+
+    /// Enables or disables a soft progressive fade edge at the bottom of the grid under
+    /// Liquid Glass on iPhone.
     ///
     /// The system scroll edge effect samples the scrolling content, so over a grid of
     /// colorful artwork it washes out and barely registers — which is what hurts the
@@ -326,16 +338,37 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     /// dedicated fade overlay spanning from the top of the bottom safe area down to the
     /// grid's bottom edge, dissolving the artwork into the grid's background for a
     /// consistently visible soft edge, replacing the system scroll edge effect.
+    ///
+    /// Disabling restores the default layout and the system scroll edge effect.
     @available(iOS 26, *)
-    private func setupBottomFade() {
-        guard LiquidGlass.isEnabled, traitCollection.userInterfaceIdiom == .phone else { return }
+    private func setCustomBottomFadeEnabled(_ enabled: Bool) {
+        guard enabled != isBottomFadeEnabled else { return }
+        isBottomFadeEnabled = enabled
 
-        isBottomFadeEnabled = true
+        guard enabled else {
+            bottomFadeView.isHidden = true
+            collectionViewBottomConstraint.constant = 0
+            podcastsCollectionView.bottomEdgeEffect.isHidden = false
+            return
+        }
+
+        installBottomFadeViewIfNeeded()
+        bottomFadeView.isHidden = false
 
         // Size the gap below the grid and paint the exposed strip in the grid's own
         // background color so the fade dissolves into it seamlessly.
         updateBottomSpacing()
         (view as? ThemeableView)?.style = .primaryUi02
+
+        podcastsCollectionView.bottomEdgeEffect.isHidden = true
+        updateBottomFadeColor()
+    }
+
+    /// Adds the fade overlay to the view hierarchy the first time the fade is enabled,
+    /// pinned to span from the top of the bottom safe area (where the floating bar begins)
+    /// down to the grid's bottom edge. Subsequent toggles just show/hide it.
+    private func installBottomFadeViewIfNeeded() {
+        guard bottomFadeView.superview == nil else { return }
 
         bottomFadeView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(bottomFadeView)
@@ -347,8 +380,6 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
             bottomFadeView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             bottomFadeView.bottomAnchor.constraint(equalTo: podcastsCollectionView.bottomAnchor)
         ])
-        podcastsCollectionView.bottomEdgeEffect.isHidden = true
-        updateBottomFadeColor()
     }
 
     /// Sizes the gap below the grid as a fraction of the current bottom safe area, so it
@@ -361,6 +392,11 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         updateBottomSpacing()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        updateCustomBottomFade()
     }
 
     /// Fades the grid into its own background color toward the bottom edge, so the

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.xib
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.xib
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PodcastListViewController" customModule="podcasts" customModuleProvider="target">
             <connections>
+                <outlet property="collectionViewBottomConstraint" destination="BRV-dL-hXc" id="kZ1-fq-Xb9"/>
                 <outlet property="podcastsCollectionView" destination="4" id="hAI-hG-gPY"/>
                 <outlet property="view" destination="1" id="3"/>
             </connections>

--- a/podcasts/Utilities/ProgressiveFadeView.swift
+++ b/podcasts/Utilities/ProgressiveFadeView.swift
@@ -1,18 +1,15 @@
 import UIKit
 
-/// A vertical gradient overlay that fades from fully transparent at the top to a solid
-/// color at the bottom, producing a soft fade-out edge.
+/// A vertical gradient overlay fading from transparent at the top to a solid color at the
+/// bottom, giving a soft fade-out edge.
 ///
-/// The system scroll edge effect samples the scrolling content, so over busy,
-/// multicolor content (such as a grid of podcast artwork) it washes out and barely
-/// registers. Rather than blur, this view fades the content into its own background
-/// color toward the bottom so it dissolves cleanly behind floating bottom bars.
+/// Used instead of the system scroll edge effect, which washes out over busy multicolor
+/// content like a grid of podcast artwork. Fading the content into its own background
+/// color dissolves it cleanly behind floating bottom bars.
 ///
-/// The fade is drawn as the layer's own gradient content — not an opaque view behind a
-/// `CAGradientLayer` mask. A masked-opaque approach flashes solid at the top edge while
-/// the Liquid Glass tab bar captures its backdrop snapshot on expand (the snapshot path
-/// doesn't honor the layer mask), so baking the alpha straight into the gradient avoids
-/// ever presenting an opaque rectangle.
+/// The alpha is baked into the gradient rather than masking an opaque view with a
+/// `CAGradientLayer`: the mask isn't honored when the Liquid Glass tab bar snapshots its
+/// backdrop on expand, which would flash a solid rectangle at the top edge.
 final class ProgressiveFadeView: UIView {
     override class var layerClass: AnyClass { CAGradientLayer.self }
 
@@ -27,6 +24,7 @@ final class ProgressiveFadeView: UIView {
 
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
         gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
+        gradientLayer.locations = [0, 0.33, 1]
         setColor(color)
     }
 
@@ -34,10 +32,10 @@ final class ProgressiveFadeView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// Sets the fade color: transparent at the top ramping linearly to this solid color at
-    /// the bottom. Pass `nil` for no fade.
+    /// Sets the fade color: transparent at the top ramping to solid at the bottom.
+    /// Pass `nil` for no fade.
     func setColor(_ color: UIColor?) {
         let color = color ?? .clear
-        gradientLayer.colors = [color.withAlphaComponent(0).cgColor, color.cgColor]
+        gradientLayer.colors = [color.withAlphaComponent(0).cgColor, color.withAlphaComponent(0.5).cgColor, color.cgColor]
     }
 }

--- a/podcasts/Utilities/ProgressiveFadeView.swift
+++ b/podcasts/Utilities/ProgressiveFadeView.swift
@@ -27,7 +27,6 @@ final class ProgressiveFadeView: UIView {
 
         gradientLayer.startPoint = CGPoint(x: 0.5, y: 0)
         gradientLayer.endPoint = CGPoint(x: 0.5, y: 1)
-        gradientLayer.locations = [0, 0.25, 0.8, 1]
         setColor(color)
     }
 
@@ -35,10 +34,10 @@ final class ProgressiveFadeView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// Sets the fade color: transparent at the top ramping to this color, which then
-    /// holds solid across the lower portion. Pass `nil` for no fade.
+    /// Sets the fade color: transparent at the top ramping linearly to this solid color at
+    /// the bottom. Pass `nil` for no fade.
     func setColor(_ color: UIColor?) {
         let color = color ?? .clear
-        gradientLayer.colors = [color.withAlphaComponent(0).cgColor, color.withAlphaComponent(0.66).cgColor, color.cgColor, color.cgColor]
+        gradientLayer.colors = [color.withAlphaComponent(0).cgColor, color.cgColor]
     }
 }


### PR DESCRIPTION
Under Liquid Glass on iOS 26, the floating tab bar / mini player turned gray/dark over the All Podcasts grid because the system scroll edge effect washes out over the colorful artwork.

Leaving a full gap with no content at the bottom of the grid (plus a soft fade into the background) seems to solve it — no guarantee, but it holds up in my testing. Visually it looks about the same as before, and the collapsed tab bar state is a bit improved.

## To test

1. On an iOS 26 device/simulator with Liquid Glass enabled, open the **Podcasts** tab.
2. Scroll the grid and confirm the floating tab bar / mini player stays legible instead of turning gray/dark.
3. Start playback and repeat with the mini player showing.
4. On iOS 27 and iPad, check that the fade is not used

Before, the bar sometimes turning gray due to dynamic sampling

<img width="360" alt="IMG_7708" src="https://github.com/user-attachments/assets/325b200b-debc-4637-b200-5641db6bf261" />


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
