### PR TITLE
TV: Enable Firebase Analytics on tvOS

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -285,6 +285,7 @@ enum XcodeSupport {
                     .product(name: "Kingfisher", package: "Kingfisher"),
                     .product(name: "SwiftSubtitles", package: "SwiftSubtitles"),
                     .product(name: "FirebaseRemoteConfig", package: "firebase-ios-sdk"),
+                    .product(name: "FirebaseAnalyticsWithoutAdIdSupport", package: "firebase-ios-sdk"),
                     .product(name: "DifferenceKit", package: "DifferenceKit"),
                 ]
             ),

--- a/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
@@ -18,8 +18,8 @@ enum DiscoverAnalytics {
         AnalyticsHelper.listImpression(listId: listId, category: nil, source: source)
     }
 
-    static func podcastTapped(listId: String, podcastUuid: String, source: String) {
-        AnalyticsHelper.podcastTappedFromList(listId: listId, podcastUuid: podcastUuid, source: source)
+    static func podcastTapped(listId: String, podcastUuid: String, dateTime: String? = nil, source: String) {
+        AnalyticsHelper.podcastTappedFromList(listId: listId, podcastUuid: podcastUuid, listDateTime: dateTime, source: source)
     }
 
     static func episodeTapped(listId: String, podcastUuid: String?, episodeUuid: String, source: String) {

--- a/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
@@ -15,11 +15,11 @@ enum DiscoverAnalytics {
     static let searchSource = "search"
 
     static func listImpression(listId: String, source: String) {
-        Analytics.track(.discoverListImpression, properties: ["list_id": listId, "source": source])
+        AnalyticsHelper.listImpression(listId: listId, category: nil, source: source)
     }
 
     static func podcastTapped(listId: String, podcastUuid: String, source: String) {
-        Analytics.track(.discoverListPodcastTapped, properties: ["list_id": listId, "podcast_uuid": podcastUuid, "source": source])
+        AnalyticsHelper.podcastTappedFromList(listId: listId, podcastUuid: podcastUuid, source: source)
     }
 
     static func episodeTapped(listId: String, podcastUuid: String?, episodeUuid: String, source: String) {
@@ -27,7 +27,7 @@ enum DiscoverAnalytics {
         if let podcastUuid {
             properties["podcast_uuid"] = podcastUuid
         }
-        Analytics.track(.discoverListEpisodeTapped, properties: properties)
+        AnalyticsHelper.podcastEpisodeTapped(fromList: listId, podcastUuid: podcastUuid ?? "", episodeUuid: episodeUuid, source: source)
     }
 
     static func categoryPillTapped(_ category: DiscoverCategory, region: String?, source: String) {

--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -33,13 +33,15 @@ struct DiscoverSection {
     let sponsoredPodcastsIDs: Set<String>
     /// Analytics list identifier for the section, used by the `discover_list_*` events.
     let listId: String?
+    let dateTime: String?
 
-    init(title: String? = nil, subtitle: String? = nil, podcasts: [DiscoverPodcast] = [], sponsoredPodcastsIDs: Set<String> = [], listId: String? = nil) {
+    init(title: String? = nil, subtitle: String? = nil, podcasts: [DiscoverPodcast] = [], sponsoredPodcastsIDs: Set<String> = [], listId: String? = nil, dateTime: String? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.podcasts = podcasts
         self.sponsoredPodcastsIDs = sponsoredPodcastsIDs
         self.listId = listId
+        self.dateTime = dateTime
     }
 }
 
@@ -147,7 +149,7 @@ actor DiscoverManager {
             }
         }
 
-        return DiscoverSection(title: podcastCollection?.title, subtitle: podcastCollection?.subtitle, podcasts: listOfPodcasts, sponsoredPodcastsIDs: Set(sponsoredPodcasts.values.compactMap({$0.uuid})), listId: listId)
+        return DiscoverSection(title: podcastCollection?.title, subtitle: podcastCollection?.subtitle, podcasts: listOfPodcasts, sponsoredPodcastsIDs: Set(sponsoredPodcasts.values.compactMap({$0.uuid})), listId: listId, dateTime: podcastCollection?.datetime)
     }
 
     func findItem(of type: DiscoverType) async -> DiscoverItem? {

--- a/Pocket Casts TV App/UI/Discover/DiscoverSectionModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSectionModel.swift
@@ -23,6 +23,8 @@ class DiscoverSectionModel {
 
     private(set) var listId: String?
 
+    private(set) var dateTime: String?
+
     init(type: DiscoverType, source: String, discoverManager: DiscoverManager = DiscoverManager.shared) {
         self.type = type
         self.item = nil
@@ -65,6 +67,7 @@ class DiscoverSectionModel {
             sponsored = section.sponsoredPodcastsIDs
             isSponsored = item?.isSponsored ?? false
             listId = section.listId
+            dateTime = section.dateTime
         }
     }
 
@@ -76,7 +79,7 @@ class DiscoverSectionModel {
 
     func trackPodcastTapped(_ podcast: DiscoverPodcast) {
         guard let listId, let podcastUuid = podcast.uuid else { return }
-        DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, source: source)
+        DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, dateTime: dateTime, source: source)
     }
 
     var focusStoreID: String {

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
@@ -57,7 +57,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = " -FIRAnalyticsDebugEnabled"
+            argument = "-FIRAnalyticsDebugEnabled"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
@@ -56,6 +56,10 @@
             argument = "-PCSimulateDataLoss"
             isEnabled = "NO">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = " -FIRAnalyticsDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts TV App.xcscheme
@@ -58,7 +58,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-FIRAnalyticsDebugEnabled"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -1,4 +1,4 @@
-#if !os(watchOS) && !os(tvOS)
+#if !os(watchOS)
     import Firebase
 #endif
 
@@ -441,7 +441,7 @@ private extension AnalyticsHelper {
         guard optedOut == false else { return }
 
         // assuming for now we don't want analytics on a watch
-        #if !os(watchOS) && !os(tvOS)
+        #if !os(watchOS)
             Firebase.Analytics.logEvent(name, parameters: parameters)
 
         if FeatureFlag.firebaseLogging.enabled {

--- a/podcasts/AnalyticsHelper.swift
+++ b/podcasts/AnalyticsHelper.swift
@@ -116,10 +116,13 @@ class AnalyticsHelper {
         bumpStat("discover_list_podcast_subscribe", parameters: properties)
     }
 
-    class func podcastTappedFromList(listId: String, podcastUuid: String, listDateTime: String? = nil) {
+    class func podcastTappedFromList(listId: String, podcastUuid: String, listDateTime: String? = nil, source: String? = nil) {
         var properties = ["list_id": listId, "podcast_uuid": podcastUuid]
         if let listDateTime {
             properties["list_datetime"] = listDateTime
+        }
+        if let source {
+            properties["source"] = source
         }
         Analytics.track(.discoverListPodcastTapped, properties: properties)
         bumpStat("discover_list_podcast_tap", parameters: properties)
@@ -135,9 +138,11 @@ class AnalyticsHelper {
         Analytics.track(.discoverAdCategorySubscribed, properties: properties)
     }
 
-    class func podcastEpisodeTapped(fromList listId: String, podcastUuid: String, episodeUuid: String) {
-        let properties = ["list_id": listId, "podcast_uuid": podcastUuid, "episode_uuid": episodeUuid]
-
+    class func podcastEpisodeTapped(fromList listId: String, podcastUuid: String, episodeUuid: String, source: String? = nil) {
+        var properties = ["list_id": listId, "podcast_uuid": podcastUuid, "episode_uuid": episodeUuid]
+        if let source {
+            properties["source"] = source
+        }
         Analytics.track(.discoverListEpisodeTapped, properties: properties)
         bumpStat("discover_list_podcast_episode_tap", parameters: properties)
     }
@@ -151,10 +156,13 @@ class AnalyticsHelper {
         bumpStat("discover_list_show_all", parameters: properties)
     }
 
-    class func listImpression(listId: String, category: String?) {
+    class func listImpression(listId: String, category: String?, source: String? = nil) {
         var properties = ["list_id": listId]
         if let category {
             properties["category"] = category
+        }
+        if let source {
+            properties["source"] = source
         }
         Analytics.track(.discoverListImpression, properties: properties)
         bumpStat("discover_list_impression", parameters: properties)


### PR DESCRIPTION
Enables Firebase Analytics on the tvOS (Pocket Casts TV) app, which was previously excluded from analytics tracking.

- Adds the `FirebaseAnalyticsWithoutAdIdSupport` product to the module dependencies.
- Removes the `!os(tvOS)` guards in `AnalyticsHelper` so the existing analytics path is reused on tvOS instead of being compiled out.
- Adds the `-FIRAnalyticsDebugEnabled` launch argument to the TV app scheme for local debugging of analytics events.

## To test

1. Run the **Pocket Casts TV App** scheme on the tvOS simulator.
2. Navigate around the app to trigger tracked events.
3. Confirm analytics events are being logged (the `-FIRAnalyticsDebugEnabled` launch arg surfaces Firebase debug logging in the console).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
