### PR TITLE
PCIOS-798: Mini Player Bar Empty After Opening via Notification Tap

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -395,7 +395,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         addCustomObserver(Constants.Notifications.upNextQueueChanged, selector: #selector(upNextListChanged))
         addCustomObserver(Constants.Notifications.podcastDeleted, selector: #selector(upNextListChanged))
 
-        addCustomObserver(UIApplication.didBecomeActiveNotification, selector: #selector(playbackStateDidChange))
+        addCustomObserver(UIApplication.didBecomeActiveNotification, selector: #selector(appDidBecomeActive))
 
         addCustomObserver(Constants.Notifications.themeChanged, selector: #selector(themeChanged))
         addCustomObserver(Constants.Notifications.currentlyPlayingEpisodeUpdated, selector: #selector(updateRequired))
@@ -528,6 +528,26 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
     @objc private func upNextListChanged() {
         playbackStateDidChange()
+    }
+
+    @objc private func appDidBecomeActive() {
+        playbackStateDidChange()
+
+        guard #available(iOS 26.0, *), LiquidGlass.isEnabled else { return }
+        guard let tabBarController = parent as? UITabBarController,
+              tabBarController.bottomAccessory != nil else { return }
+
+        // When the app returns from background, iOS purges the GPU-backed
+        // rendering state of views inside the tab accessory. If the episode
+        // hasn't changed, setupForEpisode() short-circuits without marking
+        // any view as needing layout/display, so the content stays blank.
+        // Force a full layout + display pass to restore the rendered content.
+        episodeTitleLabel?.setNeedsLayout()
+        glassProgressView?.setNeedsLayout()
+        glassProgressView?.setNeedsDisplay()
+        podcastArtwork.setNeedsDisplay()
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
     }
 
     @objc private func playbackStateDidChange() {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-798/mini-player-bar-empty-after-opening-via-notification-tap

## Summary
- When the app returns from background on iOS 26+ (Liquid Glass), the mini player bar shows empty content because setupForEpisode() short-circuits when the episode hasn't changed, and showMiniPlayer() returns early because the tab accessory already exists. No view gets setNeedsLayout/setNeedsDisplay, so after iOS purges rendering state during backgrounding, the content stays blank until a user interaction forces a layout pass.
- Added a dedicated appDidBecomeActive() handler that, under Liquid Glass, forces layout and display invalidation on the mini player's key views after the normal playback state update.

## Changes
- Changed didBecomeActiveNotification observer from playbackStateDidChange to new appDidBecomeActive method
- appDidBecomeActive() calls playbackStateDidChange() then forces setNeedsLayout/setNeedsDisplay on the title label, progress view, artwork, and root view, followed by layoutIfNeeded() — only under Liquid Glass when the tab accessory is already installed

## Verification
- **Lint**: PASS
- **Tests**: FAIL — pre-existing build failure in CarPlaySceneDelegate+Convert.swift (CPPlaybackConfiguration not in current SDK). Unrelated to this change.
- **Diff review**: PASS — single file changed, minimal and targeted fix

## Confidence
**MEDIUM** — The fix addresses the clear code path where no visual invalidation occurs after background return under Liquid Glass. Cannot verify on-device without the specific iOS 26 environment.

## Known Issues
- Pre-existing build failure in CarPlaySceneDelegate+Convert.swift — not related to this change.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/PCIOS-798/mini-player-bar-empty-after-opening-via-notification-tap)