### PR TITLE
HLS playback analytics (protocol, availability, failures)

### DIFF
--- a/PocketCastsTests/Tests/Analytics/AnalyticsPlaybackHelperTests.swift
+++ b/PocketCastsTests/Tests/Analytics/AnalyticsPlaybackHelperTests.swift
@@ -1,8 +1,122 @@
 import XCTest
+import PocketCastsDataModel
+import PocketCastsUtils
 
 @testable import podcasts
 
 class AnalyticsPlaybackHelperTests: XCTestCase {
+    override func tearDown() {
+        FeatureFlagOverrideStore().resetOverrides()
+        super.tearDown()
+    }
+
+    private func makeHLSEpisode() -> Episode {
+        let episode = Episode()
+        episode.uuid = "hls-episode"
+        episode.downloadUrl = "https://example.com/episode.mp3"
+        episode.hlsUrl = "https://example.com/stream.m3u8"
+        return episode
+    }
+
+    private func makeProgressiveEpisode() -> Episode {
+        let episode = Episode()
+        episode.uuid = "progressive-episode"
+        episode.downloadUrl = "https://example.com/episode.mp3"
+        return episode
+    }
+
+    // MARK: - hlsLifecycleProperties
+
+    func testHlsLifecyclePropertiesReportsAvailabilityWhenFlagEnabled() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+
+        XCTAssertEqual(AnalyticsPlaybackHelper.hlsLifecycleProperties(for: makeHLSEpisode())["hls_available"] as? Bool, true)
+        XCTAssertEqual(AnalyticsPlaybackHelper.hlsLifecycleProperties(for: makeProgressiveEpisode())["hls_available"] as? Bool, false)
+    }
+
+    func testHlsLifecyclePropertiesAreEmptyWhenFlagDisabled() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: false)
+
+        XCTAssertTrue(AnalyticsPlaybackHelper.hlsLifecycleProperties(for: makeHLSEpisode()).isEmpty)
+    }
+
+    func testHlsLifecyclePropertiesReportNoAvailabilityForNilEpisode() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+
+        XCTAssertEqual(AnalyticsPlaybackHelper.hlsLifecycleProperties(for: nil)["hls_available"] as? Bool, false)
+    }
+
+    // MARK: - hlsProtocolProperties
+
+    func testHlsProtocolPropertiesReportProtocolWhenFlagEnabled() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+
+        XCTAssertEqual(AnalyticsPlaybackHelper.hlsProtocolProperties(for: makeHLSEpisode())["playback_protocol"] as? String, "hls")
+        XCTAssertEqual(AnalyticsPlaybackHelper.hlsProtocolProperties(for: makeProgressiveEpisode())["playback_protocol"] as? String, "progressive")
+    }
+
+    func testHlsProtocolPropertiesAreEmptyWhenFlagDisabled() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: false)
+
+        XCTAssertTrue(AnalyticsPlaybackHelper.hlsProtocolProperties(for: makeHLSEpisode()).isEmpty)
+    }
+
+    // MARK: - playbackFailed
+
+    func testPlaybackFailedIncludesHLSContextForHLSEpisodeWhenFlagEnabled() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+        let helper = AnalyticsPlaybackHelperMock()
+
+        helper.playbackFailed(episode: makeHLSEpisode(), error: "boom", hlsErrorDetail: "internet_connection", player: nil)
+
+        XCTAssertEqual(helper.lastEvent?.event, .playbackFailed)
+        XCTAssertEqual(helper.lastEvent?.properties?["playback_protocol"] as? String, "hls")
+        XCTAssertEqual(helper.lastEvent?.properties?["hls_error_detail"] as? String, "internet_connection")
+    }
+
+    func testPlaybackFailedOmitsErrorDetailForProgressiveEpisode() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+        let helper = AnalyticsPlaybackHelperMock()
+
+        helper.playbackFailed(episode: makeProgressiveEpisode(), error: "boom", hlsErrorDetail: "internet_connection", player: nil)
+
+        XCTAssertEqual(helper.lastEvent?.properties?["playback_protocol"] as? String, "progressive")
+        XCTAssertNil(helper.lastEvent?.properties?["hls_error_detail"], "hls_error_detail is only meaningful for HLS")
+    }
+
+    func testPlaybackFailedOmitsHLSContextWhenFlagDisabled() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: false)
+        let helper = AnalyticsPlaybackHelperMock()
+
+        helper.playbackFailed(episode: makeHLSEpisode(), error: "boom", hlsErrorDetail: "internet_connection", player: nil)
+
+        XCTAssertNil(helper.lastEvent?.properties?["playback_protocol"])
+        XCTAssertNil(helper.lastEvent?.properties?["hls_error_detail"])
+        XCTAssertEqual(helper.lastEvent?.properties?["episode_uuid"] as? String, "hls-episode")
+    }
+
+    // MARK: - playbackSourceResolved
+
+    func testPlaybackSourceResolvedReportsProtocolWhenFlagEnabled() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+        let helper = AnalyticsPlaybackHelperMock()
+
+        helper.playbackSourceResolved(for: makeHLSEpisode())
+
+        XCTAssertEqual(helper.lastEvent?.event, .playbackSourceResolved)
+        XCTAssertEqual(helper.lastEvent?.properties?["playback_protocol"] as? String, "hls")
+        XCTAssertEqual(helper.lastEvent?.properties?["episode_uuid"] as? String, "hls-episode")
+    }
+
+    func testPlaybackSourceResolvedIsNotEmittedWhenFlagDisabled() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: false)
+        let helper = AnalyticsPlaybackHelperMock()
+
+        helper.playbackSourceResolved(for: makeHLSEpisode())
+
+        XCTAssertNil(helper.lastEvent, "playback_source_resolved must not fire while the HLS flag is off")
+    }
+
     func testCurrentSourceIsRemovedAfterEventIsTriggered() {
         AnalyticsPlaybackHelper.shared.currentSource = .unknown
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -279,6 +279,10 @@ enum AnalyticsEvent: String {
     case playbackErrorShown
     case playbackErrorTapped
 
+    /// Emitted once playback actually starts, reporting the protocol the source resolved to
+    /// (`hls`/`progressive`). Gated behind `FeatureFlag.hls`.
+    case playbackSourceResolved
+
     // MARK: - Autoplay
     case playbackEpisodeAutoplayed
     case autoplayStarted

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -72,7 +72,14 @@ class AnalyticsCoordinator {
     var currentSource: AnalyticsSource?
 
     private var currentEpisodeIsVideo: Bool {
-        PlaybackManager.shared.isCurrentEpisodeVideo()
+        // For HLS we can't tell synchronously whether the stream carries video — it isn't reflected
+        // in the episode's MIME type and is only detected once frames render — so assume video rather
+        // than mislabel it as audio. `isStreamingHLS` is already gated behind the HLS flag, so this
+        // only affects analytics while HLS playback is enabled.
+        if let episode = PlaybackManager.shared.currentEpisode(), EpisodeManager.isStreamingHLS(episode) {
+            return true
+        }
+        return PlaybackManager.shared.isCurrentEpisodeVideo()
     }
 
     var currentAnalyticsSource: AnalyticsSource {

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -10,7 +10,7 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     private var ignoreNextSeek = false
 
     func play() {
-        track(.playbackPlay)
+        track(.playbackPlay, properties: Self.hlsLifecycleProperties(for: PlaybackManager.shared.currentEpisode()))
     }
 
     func pause() {
@@ -76,10 +76,34 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
         track(.playbackEffectSettingsChanged, properties: ["settings": currentSettings])
     }
 
-    func playbackFailed(episodeUUID: String, error: String, player: PlaybackProtocol?) {
-        track(.playbackFailed, properties: ["episode_uuid": episodeUUID,
-                                            "error": error,
-                                            "player": playerString(player: player)])
+    func playbackFailed(episode: BaseEpisode?, error: String, hlsErrorDetail: String?, player: PlaybackProtocol?) {
+        var properties: [String: Any] = ["episode_uuid": episode?.uuid ?? "unknown",
+                                         "error": error,
+                                         "player": playerString(player: player)]
+
+        // HLS context so HLS failures can be told apart from progressive (MP3) ones. Gated behind
+        // the HLS flag so it only ships while HLS playback is enabled — mirrors the web player.
+        if FeatureFlag.hls.enabled, let episode {
+            properties.merge(Self.hlsProtocolProperties(for: episode)) { current, _ in current }
+            if EpisodeManager.isStreamingHLS(episode), let hlsErrorDetail {
+                properties["hls_error_detail"] = hlsErrorDetail
+            }
+        }
+
+        track(.playbackFailed, properties: properties)
+    }
+
+    /// Emitted once playback actually starts, reporting the protocol the source resolved to.
+    /// Empty/no-op unless the HLS feature flag is on. Mirrors the web player's
+    /// `playback_source_resolved` event.
+    func playbackSourceResolved(for episode: BaseEpisode?) {
+        guard FeatureFlag.hls.enabled, let episode else { return }
+
+        var properties: [String: Any] = ["episode_uuid": episode.uuid,
+                                         "podcast_uuid": episode.parentIdentifier()]
+        properties.merge(Self.hlsProtocolProperties(for: episode)) { current, _ in current }
+
+        track(.playbackSourceResolved, properties: properties)
     }
 
     enum PlayerSource: String {
@@ -101,6 +125,31 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
             properties?["settings"] = currentSettings
         }
         track(event, properties: properties)
+    }
+
+    // MARK: - HLS
+
+    /// HLS-related properties for playback lifecycle events (play / completed / autoplayed).
+    /// Returns an empty dictionary unless the HLS feature flag is on, so these properties only ship
+    /// while HLS playback is enabled — mirrors the web player's `getHlsPlaybackProperties`.
+    /// `hls_available` reflects whether the episode *offers* an HLS stream; the protocol actually
+    /// played is reported separately via `playback_source_resolved`.
+    static func hlsLifecycleProperties(for episode: BaseEpisode?) -> [String: Any] {
+        guard FeatureFlag.hls.enabled else { return [:] }
+        return ["hls_available": episodeOffersHLS(episode)]
+    }
+
+    /// The protocol an episode's source resolves to for playback (`hls`/`progressive`), for events
+    /// where the source is known. Empty unless the HLS feature flag is on.
+    static func hlsProtocolProperties(for episode: BaseEpisode) -> [String: Any] {
+        guard FeatureFlag.hls.enabled else { return [:] }
+        return ["playback_protocol": EpisodeManager.isStreamingHLS(episode) ? "hls" : "progressive"]
+    }
+
+    /// Whether the episode advertises an HLS stream, independent of whether it's the selected source.
+    private static func episodeOffersHLS(_ episode: BaseEpisode?) -> Bool {
+        guard let episode = episode as? Episode, let hlsUrl = episode.hlsUrl else { return false }
+        return !hlsUrl.isEmpty
     }
 
     func playerString(player: PlaybackProtocol?) -> String {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -47,6 +47,11 @@ class PlaybackManager: ServerPlaybackDelegate {
     private let shouldDeactivateSession = AtomicBool()
     private var haveCalledPlayerLoad = false
 
+    /// Tracks whether `playback_source_resolved` has been reported for the current player, so it's
+    /// emitted once when playback actually starts (not on resume/seek) and again after the player
+    /// is rebuilt for a new episode. Reset in `cleanupCurrentPlayer`.
+    private var hasReportedSourceResolved = false
+
     /// Set at runtime when the currently playing stream is found to contain video tracks
     /// (e.g. an HLS stream carrying video). Complements `Episode.videoPodcast()`, which is
     /// based on the progressive file's MIME type and can't see into an HLS alternate enclosure.
@@ -247,6 +252,8 @@ class PlaybackManager: ServerPlaybackDelegate {
             haveCalledPlayerLoad = true
         }
 
+        let shouldReportSourceResolved = !hasReportedSourceResolved
+
         activateAudioSession(completion: { activated in
             if !activated {
                 self.aboutToPlay.value = false
@@ -261,6 +268,13 @@ class PlaybackManager: ServerPlaybackDelegate {
             self.updateExtraActions()
 
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackStarted)
+
+            // Report the source the player resolved now that playback has actually started, once per
+            // player (resumes/seeks reuse the same player and don't re-report).
+            if shouldReportSourceResolved {
+                self.hasReportedSourceResolved = true
+                self.analyticsPlaybackHelper.playbackSourceResolved(for: currEpisode)
+            }
 
             if currEpisode.videoPodcast() {
                 self.setAudioSessionVideoProperties()
@@ -1123,6 +1137,23 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
 
         static let knownURLErrors: [Int] = [NSURLErrorResourceUnavailable, NSURLErrorBadServerResponse, NSURLErrorUserAuthenticationRequired, NSURLErrorFileDoesNotExist, NSURLErrorZeroByteResource]
+
+        /// A short, stable, human-readable category for the failure, reported as `hls_error_detail`
+        /// on `playback_failed` (mirrors the web player). Distinct from the free-form `logMessage`.
+        var analyticsDetail: String {
+            switch self {
+            case .internetConnection:
+                return "internet_connection"
+            case .episodeNotAvailable:
+                return "episode_not_available"
+            case .fileCorrupted:
+                return "file_corrupted"
+            case .chromecastError:
+                return "chromecast_error"
+            case .playbackError:
+                return "playback_error"
+            }
+        }
     }
 
     var activeError: PlaybackError?
@@ -1130,7 +1161,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     func playbackDidFail(error: PlaybackError, fallbackToDefaultPlayer: Bool = false) {
         FileLog.shared.addMessage("[PlaybackManager] Playback did fail with error: \(error.logMessage ?? "No error detail provided")")
 
-        AnalyticsPlaybackHelper.shared.playbackFailed(episodeUUID: currentEpisode()?.uuid ?? "unknown", error: error.logMessage ?? "Unknown", player: player)
+        AnalyticsPlaybackHelper.shared.playbackFailed(episode: currentEpisode(), error: error.logMessage ?? "Unknown", hlsErrorDetail: error.analyticsDetail, player: player)
 
         #if !os(watchOS)
         if fallbackToDefaultPlayer, let episode = currentEpisode() {
@@ -1223,7 +1254,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             Analytics.track(.playerEpisodeCompleted, properties: [
                 "podcast_uuid": episode.parentIdentifier(),
                 "episode_uuid": episode.uuid
-            ])
+            ].merging(AnalyticsPlaybackHelper.hlsLifecycleProperties(for: episode)) { current, _ in current })
             episode.playingStatus = PlayingStatus.completed.rawValue
             episode.playedUpTo = episode.duration
 
@@ -1418,6 +1449,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     private func cleanupCurrentPlayer(permanent: Bool) {
         haveCalledPlayerLoad = false
+        hasReportedSourceResolved = false
         currentStreamContainsVideo.value = false
         seekingTo = PlaybackManager.notSeeking
         FileLog.shared.addMessage("cleanupCurrentPlayer permanent? \(permanent)")
@@ -2402,7 +2434,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             if let nextEpisode = AutoplayHelper.shared.nextEpisode(currentEpisodeUuid: episode.uuid) {
                 FileLog.shared.addMessage("Autoplaying next episode: \(nextEpisode.displayableTitle())")
                 queue.add(episode: nextEpisode, fireNotification: false)
-                Analytics.track(.playbackEpisodeAutoplayed, properties: ["episode_uuid": nextEpisode.uuid])
+                Analytics.track(.playbackEpisodeAutoplayed, properties: ["episode_uuid": nextEpisode.uuid].merging(AnalyticsPlaybackHelper.hlsLifecycleProperties(for: nextEpisode)) { current, _ in current })
                 return
             } else {
                 Analytics.track(.autoplayFinishedLastEpisode)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -49,8 +49,9 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     /// Tracks whether `playback_source_resolved` has been reported for the current player, so it's
     /// emitted once when playback actually starts (not on resume/seek) and again after the player
-    /// is rebuilt for a new episode. Reset in `cleanupCurrentPlayer`.
-    private var hasReportedSourceResolved = false
+    /// is rebuilt for a new episode. Reset in `cleanupCurrentPlayer`. Atomic because it's mutated
+    /// from the `activateAudioSession` completion, which can run off the main queue.
+    private let hasReportedSourceResolved = AtomicBool()
 
     /// Set at runtime when the currently playing stream is found to contain video tracks
     /// (e.g. an HLS stream carrying video). Complements `Episode.videoPodcast()`, which is
@@ -256,9 +257,9 @@ class PlaybackManager: ServerPlaybackDelegate {
         // calls can't each capture `true` and report twice for the same player. Only engaged when
         // the HLS flag is on, so the state stays consistent (and reportable) if the flag is enabled
         // later in the session.
-        let shouldReportSourceResolved = FeatureFlag.hls.enabled && !hasReportedSourceResolved
+        let shouldReportSourceResolved = FeatureFlag.hls.enabled && !hasReportedSourceResolved.value
         if shouldReportSourceResolved {
-            hasReportedSourceResolved = true
+            hasReportedSourceResolved.value = true
         }
 
         activateAudioSession(completion: { activated in
@@ -266,7 +267,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 self.aboutToPlay.value = false
                 // Playback didn't start, so allow a later retry to report the resolved source.
                 if shouldReportSourceResolved {
-                    self.hasReportedSourceResolved = false
+                    self.hasReportedSourceResolved.value = false
                 }
                 return
             }
@@ -1461,7 +1462,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     private func cleanupCurrentPlayer(permanent: Bool) {
         haveCalledPlayerLoad = false
-        hasReportedSourceResolved = false
+        hasReportedSourceResolved.value = false
         currentStreamContainsVideo.value = false
         seekingTo = PlaybackManager.notSeeking
         FileLog.shared.addMessage("cleanupCurrentPlayer permanent? \(permanent)")

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -281,8 +281,10 @@ class PlaybackManager: ServerPlaybackDelegate {
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackStarted)
 
             // Report the source the player resolved now that playback has actually started, once per
-            // player (resumes/seeks reuse the same player and don't re-report).
-            if shouldReportSourceResolved {
+            // player (resumes/seeks reuse the same player and don't re-report). Only report if the
+            // current episode still matches the one we started: activation can run async, and if the
+            // user has since switched episodes the new play cycle reports its own resolved source.
+            if shouldReportSourceResolved, self.currentEpisode()?.uuid == currEpisode.uuid {
                 self.analyticsPlaybackHelper.playbackSourceResolved(for: currEpisode)
             }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -252,11 +252,22 @@ class PlaybackManager: ServerPlaybackDelegate {
             haveCalledPlayerLoad = true
         }
 
-        let shouldReportSourceResolved = !hasReportedSourceResolved
+        // Marked synchronously (before the async audio-session activation) so concurrent `play()`
+        // calls can't each capture `true` and report twice for the same player. Only engaged when
+        // the HLS flag is on, so the state stays consistent (and reportable) if the flag is enabled
+        // later in the session.
+        let shouldReportSourceResolved = FeatureFlag.hls.enabled && !hasReportedSourceResolved
+        if shouldReportSourceResolved {
+            hasReportedSourceResolved = true
+        }
 
         activateAudioSession(completion: { activated in
             if !activated {
                 self.aboutToPlay.value = false
+                // Playback didn't start, so allow a later retry to report the resolved source.
+                if shouldReportSourceResolved {
+                    self.hasReportedSourceResolved = false
+                }
                 return
             }
 
@@ -272,7 +283,6 @@ class PlaybackManager: ServerPlaybackDelegate {
             // Report the source the player resolved now that playback has actually started, once per
             // player (resumes/seeks reuse the same player and don't re-report).
             if shouldReportSourceResolved {
-                self.hasReportedSourceResolved = true
                 self.analyticsPlaybackHelper.playbackSourceResolved(for: currEpisode)
             }
 


### PR DESCRIPTION
| 📘 Part of: #709 |
|:---:|

Fixes PCIOS-814

Adds HLS-vs-progressive context to our playback analytics so we can tell HLS playback apart from regular (MP3) playback, and HLS failures apart from MP3 failures — mirroring the web player's [HLS playback analytics PR](https://github.com/Automattic/pocket-casts-webplayer/pull/4688).

All HLS properties are **gated behind the `hls` feature flag** (debug-only for now), so they don't change production analytics until HLS ships.

### Events updated

**`playback_play`, `player_episode_completed`, `playback_episode_autoplayed`** — added (when the flag is on):

| Property | Type | Meaning |
|---|---|---|
| `hls_available` | bool | Whether the episode advertises an HLS stream (`episode.hlsUrl`) |

**`playback_source_resolved`** (new) — emitted once when playback actually starts (not on resume/seek; re-armed after the player is rebuilt for a new episode), so we capture the protocol actually played — including the malformed-HLS-URL → progressive fallback:

| Property | Type | Meaning |
|---|---|---|
| `playback_protocol` | `hls` \| `progressive` | The protocol actually used to play (via `EpisodeManager.isStreamingHLS`) |
| `episode_uuid` / `podcast_uuid` | string | The episode involved |

**`playback_failed`** — added HLS context so HLS failures are distinguishable from MP3 ones:

| Property | Type | Meaning |
|---|---|---|
| `playback_protocol` | `hls` \| `progressive` | The protocol in use at failure time |
| `hls_error_detail` | string | Failure category (`internet_connection`, `episode_not_available`, `file_corrupted`, `chromecast_error`, `playback_error`) — HLS only |

**`content_type`** — for HLS episodes this now reports `video` rather than `audio`. iOS can't tell synchronously whether an HLS stream carries video (it isn't in the episode's MIME type and is only detected once frames render), so we assume `video` rather than mislabel it. Scoped to analytics only — the audio-session / now-playing media-type logic that also reads `isCurrentEpisodeVideo()` is untouched.

### Deliberately not mirrored (don't map to iOS)

- **`hls_engine`** (hls.js vs native) — iOS always plays HLS through native AVFoundation, so it'd be a constant.
- **`audio_only_mode` / `playback_hls_toggled`** — there's no audio/video rendition toggle in the iOS player (the `AudioVideoFilter` enum is only a playlist filter).

## To test

> Requires the `hls` feature flag (on by default in debug builds) and an episode that serves an HLS stream. Use the in-app Tracks debug logging to inspect events.

1. Play a **progressive (MP3)** episode. Confirm `playback_play` has `hls_available: false` and no `playback_protocol`.
2. Confirm a `playback_source_resolved` fires with `playback_protocol: progressive` once playback starts.
3. Play an **HLS** episode. Confirm `playback_play` has `hls_available: true` and `content_type: video`.
4. Confirm a `playback_source_resolved` fires with `playback_protocol: hls`, `episode_uuid`, and `podcast_uuid`.
5. Pause and resume the HLS episode — confirm `playback_source_resolved` does **not** re-fire.
6. Let an HLS episode finish. Confirm `player_episode_completed` carries `hls_available: true`.
7. Turn your WI-fi off, play a HLS episode. Confirm `playback_failed` reports `playback_protocol: hls` and an `hls_error_detail`.
8. Confirm `playback_source_resolved` does **not** fire for an episode that is loaded but never played.
9. With the flag off, confirm none of the new HLS properties appear and `playback_source_resolved` is not emitted.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
