### PR TITLE
Fix player opening on Bookmarks tab in RTL languages

### DIFF
--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -23,6 +23,12 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
 
     @IBOutlet var mainScrollView: RegionCancellingScrollView! {
         didSet {
+            // The player tabs are a spatial carousel, not text, so keep the paging
+            // left-to-right in every language. Otherwise UIKit mirrors the scroll
+            // view under RTL and the index-based paging math (offset == index * width)
+            // opens the last tab (Bookmarks) instead of Now Playing. See #1952.
+            mainScrollView.semanticContentAttribute = .forceLeftToRight
+
             // We don't need to handle the scroll view because it is not dismissable in App Clip
             #if !APPCLIP
             mainScrollView.delegate = self

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -84,6 +84,11 @@ class PlayerTabsView: UIScrollView {
         showsHorizontalScrollIndicator = false
         clipsToBounds = true
 
+        // Keep the tabs left-to-right in every language so their order stays in
+        // sync with the paged player content, which is also forced LTR. See #1952.
+        semanticContentAttribute = .forceLeftToRight
+        tabsStackView.semanticContentAttribute = .forceLeftToRight
+
         updateTabs()
 
         addSubview(tabsStackView)


### PR DESCRIPTION
Closes #1952

### Problem
In a right-to-left language, tapping the mini player opens the **Bookmarks** tab instead of **Now Playing**, and the tab-bar highlight desyncs from the visible page.

### Before / After
| Before — opens on Bookmarks | After — opens on Now Playing |
|:---:|:---:|
| <img width="300" alt="pc_rtl_before" src="https://github.com/user-attachments/assets/3e64dd03-dd1a-498a-b546-3617a577624d" /> | <img width="300" alt="pc_rtl_after" src="https://github.com/user-attachments/assets/adf48cdb-ca16-4084-a468-8717a87ca914" /> |

### Cause
The full-screen player is a horizontal paged carousel. Its tabs are laid out with `leading`/`trailing` constraints, but the paging is index-based (`offset == index * width`, reset via `setContentOffset(.zero)`). Under RTL, UIKit mirrors the scroll view, so `.zero` lands on the **last** page (Bookmarks) rather than page 0 (Now Playing).

### Fix
The tabs are a spatial carousel, not text, so force both the content scroll view (`mainScrollView`) and the tab bar (`PlayerTabsView`) to lay out left-to-right in every language. This keeps the existing index math correct and the tab order in sync, without mirroring the carousel. LTR behavior is unchanged (`forceLeftToRight` is a no-op there).

### Testing
1. Set the scheme's App Language to **Right-to-Left Pseudolanguage**.
2. Play any episode, tap the mini player to expand.
3. **Before:** opens on Bookmarks. **After:** opens on Now Playing.
4. Confirmed LTR is unaffected.