### PR TITLE
Add a Troubleshooting screen to remove orphaned/duplicate episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.16
 -----
+- Add a Troubleshooting screen under Help & Feedback to find and remove orphaned duplicate episodes [#4697](https://github.com/Automattic/pocket-casts-ios/pull/4697)
 - Make the Liquid Glass mini player's play button translucent with a springy bounce on tap [#4677](https://github.com/Automattic/pocket-casts-ios/pull/4677)
 - Fix the smart playlist and podcast page header showing the system light/dark appearance instead of the in-app theme when scrolling on iOS 18 [#4662](https://github.com/Automattic/pocket-casts-ios/pull/4662)
 - Fix episode lists jumping when a background download finishes [#4648](https://github.com/Automattic/pocket-casts-ios/pull/4648)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 8.16
 -----
-- Add a Troubleshooting screen under Help & Feedback to find and remove orphaned duplicate episodes [#4697](https://github.com/Automattic/pocket-casts-ios/pull/4697)
 - Make the Liquid Glass mini player's play button translucent with a springy bounce on tap [#4677](https://github.com/Automattic/pocket-casts-ios/pull/4677)
 - Fix the smart playlist and podcast page header showing the system light/dark appearance instead of the in-app theme when scrolling on iOS 18 [#4662](https://github.com/Automattic/pocket-casts-ios/pull/4662)
 - Fix episode lists jumping when a background download finishes [#4648](https://github.com/Automattic/pocket-casts-ios/pull/4648)
@@ -24,6 +23,7 @@
 - Fix separator alignment and list background color on the Discover category list [#4653](https://github.com/Automattic/pocket-casts-ios/pull/4653)
 - Add episode sorting to the podcast screen on tvOS [#4650](https://github.com/Automattic/pocket-casts-ios/pull/4650)
 - Scale the mini player title with Dynamic Type under Liquid Glass [#4676](https://github.com/Automattic/pocket-casts-ios/pull/4676)
+- Add a Troubleshooting screen under Help & Feedback to find and remove orphaned duplicate episodes [#4697](https://github.com/Automattic/pocket-casts-ios/pull/4697)
 
 8.15
 -----

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -1261,3 +1261,48 @@ extension EpisodeDataManager {
         return loadMultiple(query: query, values: nil, dbQueue: dbQueue)
     }
 }
+
+// MARK: - Orphaned Episodes (duplicate uuid, phantom podcast_id)
+
+extension EpisodeDataManager {
+    // Distinct from findGhostEpisodes: that join is keyed on podcastUuid, so it misses rows whose
+    // podcastUuid still resolves to a real podcast but whose internal podcast_id does not.
+    func findOrphanedEpisodes(_ dbQueue: PCDBQueue) -> [Episode] {
+        let query = """
+        SELECT SJEpisode.*
+        FROM SJEpisode
+        LEFT JOIN SJPodcast ON SJEpisode.podcast_id = SJPodcast.id
+        WHERE SJPodcast.id IS NULL
+        """
+
+        return loadMultiple(query: query, values: nil, dbQueue: dbQueue)
+    }
+
+    func deleteOrphanedEpisodes(ids: [Int64], dbQueue: PCDBQueue) {
+        guard !ids.isEmpty else { return }
+
+        dbQueue.write { db in
+            let query = "DELETE FROM \(DataManager.episodeTableName) WHERE id IN (\(ids.map(String.init).joined(separator: ",")))"
+
+            try? db.executeUpdate(query, values: nil)
+        }
+    }
+
+    /// Repoints `survivorId` at `realPodcastId` and deletes `idsToDelete` in the same write, so a crash
+    /// mid-migration can't commit the repoint without also removing the now-redundant duplicate row(s)
+    /// (which would otherwise become permanently invisible to `findOrphanedEpisodes`).
+    func reconcileOrphanedEpisode(survivorId: Int64, realPodcastId: Int64, idsToDelete: [Int64], dbQueue: PCDBQueue) {
+        dbQueue.write { db in
+            do {
+                try db.executeUpdate("UPDATE \(DataManager.episodeTableName) SET podcast_id = ? WHERE id = ?", values: [realPodcastId, survivorId])
+
+                if !idsToDelete.isEmpty {
+                    let query = "DELETE FROM \(DataManager.episodeTableName) WHERE id IN (\(idsToDelete.map(String.init).joined(separator: ",")))"
+                    try db.executeUpdate(query, values: nil)
+                }
+            } catch {
+                FileLog.shared.addMessage("EpisodeDataManager.reconcileOrphanedEpisode error: \(error)")
+            }
+        }
+    }
+}

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1267,6 +1267,23 @@ public extension DataManager {
     }
 }
 
+// MARK: - Orphaned Episode Cleanup
+
+public extension DataManager {
+    func findOrphanedEpisodes() -> [Episode] {
+        episodeManager.findOrphanedEpisodes(dbQueue)
+    }
+
+    /// Deletes episode rows by internal id (not uuid), so a duplicate "live" row sharing the same uuid is left untouched.
+    func deleteOrphanedEpisodes(ids: [Int64]) {
+        episodeManager.deleteOrphanedEpisodes(ids: ids, dbQueue: dbQueue)
+    }
+
+    func reconcileOrphanedEpisode(survivorId: Int64, realPodcastId: Int64, idsToDelete: [Int64]) {
+        episodeManager.reconcileOrphanedEpisode(survivorId: survivorId, realPodcastId: realPodcastId, idsToDelete: idsToDelete, dbQueue: dbQueue)
+    }
+}
+
 // MARK: - End of Year stats
 
 public extension DataManager {

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -325,6 +325,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable HLS streaming playback
     case hls
 
+    /// A new "Troubleshooting" screen for detecting orphaned episodes and more.
+    case troubleshooting
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -549,6 +552,8 @@ public enum FeatureFlag: String, CaseIterable {
             BuildEnvironment.current == .debug
         case .hls:
             BuildEnvironment.current == .debug
+        case .troubleshooting:
+            true
         }
     }
 

--- a/Modules/Tests/PocketCastsDataModelTests/OrphanedEpisodeDataManagerTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/OrphanedEpisodeDataManagerTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import PocketCastsDataModel
+
+/// Regression coverage for Zendesk 11385087: a duplicate SJEpisode row shares a uuid with the "live"
+/// episode, but its podcast_id points at a podcast that was never persisted (podcastUuid still resolves fine).
+/// Fixture values below are a trimmed subset of the customer's DB export: podcast "When In Romance"
+/// (uuid 9e4aed70-e1df-0135-c259-7d73a919276a) and episode uuid 830f91c2-f7f6-4127-8373-8114ed332ab1,
+/// which has exactly this live/orphan pair.
+final class OrphanedEpisodeDataManagerTests: DataManagerTestCase {
+    private let episodeUuid = "830f91c2-f7f6-4127-8373-8114ed332ab1"
+    private let podcastUuid = "9e4aed70-e1df-0135-c259-7d73a919276a"
+    private let phantomPodcastId: Int64 = 3_655_752_526_629_178_403
+
+    private struct Fixture {
+        let podcast: Podcast
+        let live: Episode
+        let orphan: Episode
+    }
+
+    private func makeFixture(dataManager: DataManager) -> Fixture {
+        let podcast = createTestPodcast(uuid: podcastUuid, title: "When In Romance", dataManager: dataManager)
+
+        let live = createTestEpisode(
+            uuid: episodeUuid,
+            podcast: podcast,
+            title: "When in Romance Ep. #0: Welcome to Romancelandia",
+            publishedDate: Date(timeIntervalSince1970: 1_516_378_780),
+            episodeStatus: DownloadStatus.notDownloaded.rawValue,
+            playingStatus: PlayingStatus.notPlayed.rawValue,
+            dataManager: dataManager
+        )
+
+        let orphan = Episode()
+        orphan.uuid = episodeUuid
+        orphan.podcastUuid = podcastUuid
+        orphan.podcast_id = phantomPodcastId
+        orphan.title = live.title
+        orphan.addedDate = Date(timeIntervalSince1970: 1_659_215_875)
+        orphan.publishedDate = live.publishedDate
+        orphan.episodeStatus = DownloadStatus.downloaded.rawValue
+        orphan.playingStatus = PlayingStatus.inProgress.rawValue
+        orphan.archived = true
+        dataManager.save(episode: orphan)
+
+        return Fixture(podcast: podcast, live: live, orphan: orphan)
+    }
+
+    func testOrphanedEpisodeIsNotCaughtByGhostEpisodeCleanup() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let fixture = self.makeFixture(dataManager: dataManager)
+
+            let ghosts = dataManager.findGhostEpisodes()
+
+            XCTAssertFalse(ghosts.contains(where: { $0.id == fixture.orphan.id }), "\(impl): ghost-episode cleanup joins on podcastUuid, which is still valid here, so it should miss this orphan")
+        }
+    }
+
+    func testFindOrphanedEpisodesReturnsOnlyThePhantomRow() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let fixture = self.makeFixture(dataManager: dataManager)
+
+            let orphans = dataManager.findOrphanedEpisodes()
+
+            XCTAssertEqual(orphans.map(\.id), [fixture.orphan.id], "\(impl): should find only the row whose podcast_id has no matching SJPodcast row")
+        }
+    }
+
+    func testDeleteOrphanedEpisodesRemovesOnlyTheOrphanRow() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let fixture = self.makeFixture(dataManager: dataManager)
+
+            let orphans = dataManager.findOrphanedEpisodes()
+            dataManager.deleteOrphanedEpisodes(ids: orphans.map(\.id))
+
+            let remaining = dataManager.findEpisodesWhere(customWhere: "uuid = ?", arguments: [self.episodeUuid])
+            XCTAssertEqual(remaining.map(\.id), [fixture.live.id], "\(impl): only the live row should remain")
+            XCTAssertNotNil(dataManager.findPodcast(uuid: self.podcastUuid, includeUnsubscribed: true), "\(impl): the real podcast should be untouched")
+        }
+    }
+
+    func testReconcileOrphanedEpisodeRepointsSurvivorAndDeletesOthersInOneWrite() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let fixture = self.makeFixture(dataManager: dataManager)
+
+            dataManager.reconcileOrphanedEpisode(survivorId: fixture.orphan.id, realPodcastId: fixture.podcast.id, idsToDelete: [fixture.live.id])
+
+            let remaining = dataManager.findEpisodesWhere(customWhere: "uuid = ?", arguments: [self.episodeUuid])
+            XCTAssertEqual(remaining.map(\.id), [fixture.orphan.id], "\(impl): the survivor should remain, the stale live row should be gone")
+            XCTAssertEqual(remaining.first?.podcast_id, fixture.podcast.id, "\(impl): the survivor should be repointed at the real podcast")
+        }
+    }
+}

--- a/PocketCastsTests/Tests/Utilities/PodcastManagerTests.swift
+++ b/PocketCastsTests/Tests/Utilities/PodcastManagerTests.swift
@@ -96,6 +96,50 @@ final class PodcastManagerTests: DBTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: DownloadManager.shared.pathForEpisode(refreshedEpisode)))
     }
 
+    func testDeleteOrphanedEpisodesIfNeededRepointsInteractedOrphanAndDropsStaleLiveRow() throws {
+        let podcast = Podcast()
+        podcast.uuid = UUID().uuidString
+        podcast.subscribed = 1
+        podcast.addedDate = Date()
+        dataManager.save(podcast: podcast)
+
+        let episodeUuid = UUID().uuidString
+
+        // The "live" row: visible to podcast_id-scoped queries, but pristine.
+        let live = Episode()
+        live.uuid = episodeUuid
+        live.podcastUuid = podcast.uuid
+        live.podcast_id = podcast.id
+        live.addedDate = Date()
+        live.playingStatus = PlayingStatus.notPlayed.rawValue
+        dataManager.save(episode: live)
+
+        // The orphan: same uuid, phantom podcast_id, holds the real user state.
+        let orphan = Episode()
+        orphan.uuid = episodeUuid
+        orphan.podcastUuid = podcast.uuid
+        orphan.podcast_id = 999_999_999
+        orphan.addedDate = Date()
+        orphan.playingStatus = PlayingStatus.inProgress.rawValue
+        orphan.playedUpTo = 123.4
+        orphan.archived = true
+        orphan.lastPlaybackInteractionDate = Date()
+        dataManager.save(episode: orphan)
+
+        let podcastManager = PodcastManager(dataManager: dataManager, downloadManager: downloadManager)
+        podcastManager.deleteOrphanedEpisodesIfNeeded()
+
+        let remaining = dataManager.findEpisodesWhere(customWhere: "uuid = ?", arguments: [episodeUuid])
+        XCTAssertEqual(remaining.map(\.id), [orphan.id], "The row with real interaction should survive, repointed at the real podcast")
+
+        let survivor = try XCTUnwrap(remaining.first)
+        XCTAssertEqual(survivor.podcast_id, podcast.id)
+        XCTAssertEqual(survivor.playingStatus, PlayingStatus.inProgress.rawValue)
+        XCTAssertEqual(survivor.playedUpTo, 123.4)
+        XCTAssertTrue(survivor.archived)
+        XCTAssertNotNil(dataManager.findPodcast(uuid: podcast.uuid, includeUnsubscribed: true))
+    }
+
     private func makeDownloadedPodcastAndEpisode() -> (Podcast, Episode) {
         let podcast = Podcast()
         podcast.uuid = UUID().uuidString

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -25,6 +25,9 @@
 
 /* Begin PBXBuildFile section */
 		0C364CA72FAB8BAA00B46BDA /* MiniPlayerLongPressPreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C364CA62FAB8BAA00B46BDA /* MiniPlayerLongPressPreviewViewController.swift */; };
+		0C52E9EA2FFD8D9B00C2B9D1 /* TroubleshootingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C52E9E92FFD8D9B00C2B9D1 /* TroubleshootingViewModel.swift */; };
+		0C52E9EC2FFD8DAD00C2B9D1 /* TroubleshootingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C52E9EB2FFD8DAD00C2B9D1 /* TroubleshootingView.swift */; };
+		0C52E9EE2FFD8DB600C2B9D1 /* OrphanedEpisodesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C52E9ED2FFD8DB600C2B9D1 /* OrphanedEpisodesListView.swift */; };
 		0C7BFA882FAD2A8C00C1E5FF /* LiquidGlass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF26A9984A1B5C2D00000003 /* LiquidGlass.swift */; };
 		0CB804A62FB50B31007D0402 /* PlayerZoomAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB804A52FB50B31007D0402 /* PlayerZoomAnimator.swift */; };
 		0CCC37A62FA3C30200BA79D1 /* SmartPlaylistRulesSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCC37A52FA3C30200BA79D1 /* SmartPlaylistRulesSectionView.swift */; };
@@ -1618,6 +1621,9 @@
 
 /* Begin PBXFileReference section */
 		0C364CA62FAB8BAA00B46BDA /* MiniPlayerLongPressPreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerLongPressPreviewViewController.swift; sourceTree = "<group>"; };
+		0C52E9E92FFD8D9B00C2B9D1 /* TroubleshootingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TroubleshootingViewModel.swift; sourceTree = "<group>"; };
+		0C52E9EB2FFD8DAD00C2B9D1 /* TroubleshootingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TroubleshootingView.swift; sourceTree = "<group>"; };
+		0C52E9ED2FFD8DB600C2B9D1 /* OrphanedEpisodesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrphanedEpisodesListView.swift; sourceTree = "<group>"; };
 		0CB804A52FB50B31007D0402 /* PlayerZoomAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerZoomAnimator.swift; sourceTree = "<group>"; };
 		0CCC37A52FA3C30200BA79D1 /* SmartPlaylistRulesSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartPlaylistRulesSectionView.swift; sourceTree = "<group>"; };
 		10097D272CC7DADA00E682A3 /* UpNext.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = UpNext.xcassets; sourceTree = "<group>"; };
@@ -4800,6 +4806,9 @@
 				BD40D7BC19C1A08D00FB8023 /* Launch Screen.xib */,
 				460C375026D83171008B3609 /* Resources */,
 				BDBD53F817019B2A0048C8C5 /* Supporting Files */,
+				0C52E9E92FFD8D9B00C2B9D1 /* TroubleshootingViewModel.swift */,
+				0C52E9EB2FFD8DAD00C2B9D1 /* TroubleshootingView.swift */,
+				0C52E9ED2FFD8DB600C2B9D1 /* OrphanedEpisodesListView.swift */,
 			);
 			name = "Pocket Casts";
 			path = podcasts;
@@ -7142,6 +7151,7 @@
 				10756F8B2C5945C00089D34F /* KidsProfileSubmitScreen.swift in Sources */,
 				9A66BE612E96879A007516A5 /* PlaylistDetailViewModel+Archive.swift in Sources */,
 				9A156AB32CF8BEE3007BA8D9 /* CancelSubscriptionPlanRow.swift in Sources */,
+				0C52E9EE2FFD8DB600C2B9D1 /* OrphanedEpisodesListView.swift in Sources */,
 				400A3F032277CB3A007361C7 /* NewEmailViewController.swift in Sources */,
 				BDF9DDDB1B8AD29C00E77B35 /* TimeSliderLayer.swift in Sources */,
 				BDB1E4ED1B8C5BCF009AD30F /* FeaturedSummaryViewController.swift in Sources */,
@@ -7183,6 +7193,7 @@
 				8B087FC929DC976F0027EAE5 /* PodcastImage.swift in Sources */,
 				BD95ED6A1BAFA532004335B0 /* CountryChooserViewController.swift in Sources */,
 				8B5BD0B82C50235400C687CB /* Episode+Transcript.swift in Sources */,
+				0C52E9EA2FFD8D9B00C2B9D1 /* TroubleshootingViewModel.swift in Sources */,
 				C713D4F52A04C90500A78468 /* ProfileImage.swift in Sources */,
 				466DE3F6278794D50046F722 /* EpisodeListTableViewCell.swift in Sources */,
 				9AD809AF2EA12D940050649B /* PlaylistDetailFetchOperation.swift in Sources */,
@@ -7330,6 +7341,7 @@
 				408529A3247C9A53007FE8AA /* PodcastSupporterCell.swift in Sources */,
 				8BD256D22A5C7090006648BE /* SharingHelper+swipeButton.swift in Sources */,
 				8B4C6FE52BD6EC2E00D0BB9D /* CustomStepper.swift in Sources */,
+				0C52E9EC2FFD8DAD00C2B9D1 /* TroubleshootingView.swift in Sources */,
 				4006E31423AC453700174DEB /* ExpandedCollectionViewController+CollectionView.swift in Sources */,
 				BD27B8C92756FA20007A0EA7 /* ModalCloseButton.swift in Sources */,
 				462EE0AF26FCCF97003D67DC /* PCMessageSupportViewModel.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -736,6 +736,11 @@ enum AnalyticsEvent: String {
     case settingsLeaveFeedback
     case exportDatabaseTapped
 
+    // MARK: - Settings: Troubleshooting
+
+    case troubleshootingOrphanedEpisodesRemoveConfirmed
+    case troubleshootingOrphanedEpisodesRemoved
+
     // MARK: - Settings: Import / Export OPML
 
     case settingsImportShown

--- a/podcasts/OnlineSupportController.swift
+++ b/podcasts/OnlineSupportController.swift
@@ -117,6 +117,9 @@ class OnlineSupportController: PCViewController, WKNavigationDelegate, UIAdaptiv
             UIAction(title: L10n.settingsConnectionStatus) { [weak self] _ in
                 self?.showStatusPage()
             },
+            UIAction(title: L10n.troubleshootingTitle) { [weak self] _ in
+                self?.showTroubleshooting()
+            },
             UIAction(title: L10n.exportDatabase) { [weak self] _ in
                 guard let self, let sender = customRightBtn else { return }
                 export(sender)
@@ -130,6 +133,11 @@ class OnlineSupportController: PCViewController, WKNavigationDelegate, UIAdaptiv
 
     private func showStatusPage() {
         let hostingController = ThemedHostingController(rootView: StatusPageView(source: source))
+        navigationController?.pushViewController(hostingController, animated: true)
+    }
+
+    private func showTroubleshooting() {
+        let hostingController = ThemedHostingController(rootView: TroubleshootingView(source: source))
         navigationController?.pushViewController(hostingController, animated: true)
     }
 

--- a/podcasts/OnlineSupportController.swift
+++ b/podcasts/OnlineSupportController.swift
@@ -1,6 +1,7 @@
 import MessageUI
 import SwiftUI
 import PocketCastsServer
+import PocketCastsUtils
 import UIKit
 import WebKit
 
@@ -117,9 +118,9 @@ class OnlineSupportController: PCViewController, WKNavigationDelegate, UIAdaptiv
             UIAction(title: L10n.settingsConnectionStatus) { [weak self] _ in
                 self?.showStatusPage()
             },
-            UIAction(title: L10n.troubleshootingTitle) { [weak self] _ in
+            FeatureFlag.troubleshooting.enabled ? UIAction(title: L10n.troubleshootingTitle) { [weak self] _ in
                 self?.showTroubleshooting()
-            },
+            } : nil,
             UIAction(title: L10n.exportDatabase) { [weak self] _ in
                 guard let self, let sender = customRightBtn else { return }
                 export(sender)
@@ -128,7 +129,7 @@ class OnlineSupportController: PCViewController, WKNavigationDelegate, UIAdaptiv
                 guard let self, let sender = customRightBtn else { return }
                 viewLogs(sender)
             },
-        ])
+        ].compactMap { $0 })
     }
 
     private func showStatusPage() {

--- a/podcasts/OrphanedEpisodesListView.swift
+++ b/podcasts/OrphanedEpisodesListView.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+import PocketCastsDataModel
+
+struct OrphanedEpisodesListView: View {
+    @EnvironmentObject var theme: Theme
+
+    let episodes: [Episode]
+
+    @State private var expandedGroupIDs: Set<String>
+
+    init(episodes: [Episode]) {
+        self.episodes = episodes
+        // Expanded by default: these lists are short, and the point is to surface the diagnostic
+        // info immediately rather than hide it behind a tap.
+        _expandedGroupIDs = State(initialValue: Set(episodes.map(\.podcastUuid)))
+    }
+
+    private struct PodcastGroup: Identifiable {
+        let id: String
+        let title: String
+        let episodes: [Episode]
+    }
+
+    private var groups: [PodcastGroup] {
+        Dictionary(grouping: episodes, by: \.podcastUuid)
+            .map { podcastUuid, episodes in
+                let title = DataManager.sharedManager.findPodcast(uuid: podcastUuid, includeUnsubscribed: true)?.title ?? podcastUuid
+                let sortedEpisodes = episodes.sorted { ($0.publishedDate ?? .distantPast) > ($1.publishedDate ?? .distantPast) }
+                return PodcastGroup(id: podcastUuid, title: title, episodes: sortedEpisodes)
+            }
+            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+    }
+
+    var body: some View {
+        List {
+            ForEach(groups) { group in
+                DisclosureGroup(isExpanded: isExpanded(group.id)) {
+                    ForEach(group.episodes, id: \.id) { episode in
+                        episodeRow(episode)
+                    }
+                } label: {
+                    groupLabel(group)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .navigationTitle(L10n.troubleshootingViewOrphanedEpisodes)
+        .applyDefaultThemeOptions()
+    }
+
+    private func groupLabel(_ group: PodcastGroup) -> some View {
+        HStack(alignment: .center, spacing: 10) {
+            PodcastImage(uuid: group.id, size: .list)
+                .frame(width: 32, height: 32)
+                .cornerRadius(6)
+
+            Text(group.title)
+                .font(.headline)
+                .foregroundColor(theme.primaryText01)
+                .lineLimit(1)
+
+            Spacer()
+
+            Text("\(group.episodes.count)")
+                .foregroundColor(theme.primaryText02)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func episodeRow(_ episode: Episode) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(episode.title ?? episode.uuid)
+                .font(.subheadline)
+                .foregroundColor(theme.primaryText01)
+
+            if let date = episode.publishedDate ?? episode.addedDate {
+                Text(date.formatted(date: .abbreviated, time: .omitted))
+                    .font(.footnote)
+                    .foregroundColor(theme.primaryText02)
+            }
+        }
+        .listRowInsets(EdgeInsets(top: 8, leading: 38, bottom: 8, trailing: 16))
+    }
+
+    private func isExpanded(_ id: String) -> Binding<Bool> {
+        Binding(
+            get: { expandedGroupIDs.contains(id) },
+            set: { expanded in
+                if expanded {
+                    expandedGroupIDs.insert(id)
+                } else {
+                    expandedGroupIDs.remove(id)
+                }
+            }
+        )
+    }
+}
+
+struct OrphanedEpisodesListView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            OrphanedEpisodesListView(episodes: [])
+        }
+        .setupDefaultEnvironment()
+    }
+}

--- a/podcasts/PodcastManager+Cleanup.swift
+++ b/podcasts/PodcastManager+Cleanup.swift
@@ -54,6 +54,45 @@ extension PodcastManager {
         FileLog.shared.addMessage("Deleted \(deleted_count) Ghost Episodes")
     }
 
+    func deleteOrphanedEpisodesIfNeeded() {
+        let orphans = dataManager.findOrphanedEpisodes()
+        guard !orphans.isEmpty else {
+            return
+        }
+
+        FileLog.shared.addMessage("Found \(orphans.count) Orphaned Episodes")
+
+        var deletedCount = 0
+
+        for (uuid, orphanRows) in Dictionary(grouping: orphans, by: \.uuid) {
+            // Only act when there's exactly one unambiguous "live" row (valid podcast_id) to reconcile
+            // against; anything else is a different/rarer shape of duplicate and is left alone.
+            let liveRows = dataManager.findEpisodesWhere(customWhere: "uuid = ? AND podcast_id IN (SELECT id FROM \(DataManager.podcastTableName))", arguments: [uuid])
+            guard liveRows.count == 1, let live = liveRows.first else {
+                continue
+            }
+
+            let survivor = orphanRows
+                .filter { $0.userHasInteractedWithEpisode() }
+                .max { ($0.lastPlaybackInteractionDate ?? $0.addedDate ?? .distantPast) < ($1.lastPlaybackInteractionDate ?? $1.addedDate ?? .distantPast) }
+
+            if let survivor {
+                // The orphan already holds the real state (podcastUuid is still correct, only
+                // podcast_id is dangling), so repoint it at the real podcast instead of copying
+                // its fields onto the stale, pristine "live" row. Repoint + delete happen in one
+                // write so a crash mid-migration can't commit one without the other.
+                let otherOrphanIds = orphanRows.filter { $0.id != survivor.id }.map(\.id)
+                dataManager.reconcileOrphanedEpisode(survivorId: survivor.id, realPodcastId: live.podcast_id, idsToDelete: [live.id] + otherOrphanIds)
+                deletedCount += 1 + otherOrphanIds.count
+            } else {
+                dataManager.deleteOrphanedEpisodes(ids: orphanRows.map(\.id))
+                deletedCount += orphanRows.count
+            }
+        }
+
+        FileLog.shared.addMessage("Deleted \(deletedCount) Orphaned Episodes")
+    }
+
     func checkForUnusedPodcasts() async {
         let podcasts = dataManager.allUnsubscribedPodcasts()
         for podcast in podcasts {

--- a/podcasts/TroubleshootingView.swift
+++ b/podcasts/TroubleshootingView.swift
@@ -36,6 +36,9 @@ struct TroubleshootingView: View {
                 .disabled(!canRemove)
             } header: {
                 Text(L10n.troubleshootingOrphanedEpisodesHeader)
+            } footer: {
+                Text(L10n.troubleshootingOrphanedEpisodesDescription)
+                    .foregroundColor(theme.primaryText02)
             }
         }
         .scrollContentBackground(.hidden)
@@ -63,29 +66,21 @@ struct TroubleshootingView: View {
     }
 
     private var headerView: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "wrench.and.screwdriver.fill")
-                .font(.system(size: 32))
-                .foregroundColor(theme.primaryIcon02)
-
-            Text(L10n.troubleshootingOrphanedEpisodesDescription)
-                .font(.subheadline)
-                .foregroundColor(theme.primaryText02)
-                .multilineTextAlignment(.center)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 24)
-        .padding(.horizontal, 32)
+        Image(systemName: "wrench.and.screwdriver.fill")
+            .font(.system(size: 32))
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 8)
     }
 
     private var emptyStateView: some View {
         VStack(spacing: 8) {
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 28))
-                .foregroundColor(theme.support02)
+                .foregroundStyle(.green)
 
             Text(L10n.troubleshootingOrphanedEpisodesNoneFound)
-                .foregroundColor(theme.primaryText02)
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
         }
         .frame(maxWidth: .infinity)

--- a/podcasts/TroubleshootingView.swift
+++ b/podcasts/TroubleshootingView.swift
@@ -13,6 +13,12 @@ struct TroubleshootingView: View {
     var body: some View {
         List {
             Section {
+                headerView
+            }
+            .listRowBackground(Color.clear)
+            .listRowInsets(EdgeInsets())
+
+            Section {
                 statusRow
 
                 if let lastRemovedCount = viewModel.lastRemovedCount {
@@ -30,9 +36,6 @@ struct TroubleshootingView: View {
                 .disabled(!canRemove)
             } header: {
                 Text(L10n.troubleshootingOrphanedEpisodesHeader)
-            } footer: {
-                Text(L10n.troubleshootingOrphanedEpisodesDescription)
-                    .foregroundColor(theme.primaryText02)
             }
         }
         .scrollContentBackground(.hidden)
@@ -59,6 +62,36 @@ struct TroubleshootingView: View {
         return false
     }
 
+    private var headerView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "wrench.and.screwdriver.fill")
+                .font(.system(size: 32))
+                .foregroundColor(theme.primaryIcon02)
+
+            Text(L10n.troubleshootingOrphanedEpisodesDescription)
+                .font(.subheadline)
+                .foregroundColor(theme.primaryText02)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 24)
+        .padding(.horizontal, 32)
+    }
+
+    private var emptyStateView: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 28))
+                .foregroundColor(theme.support02)
+
+            Text(L10n.troubleshootingOrphanedEpisodesNoneFound)
+                .foregroundColor(theme.primaryText02)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+    }
+
     @ViewBuilder
     private var statusRow: some View {
         switch viewModel.orphanedEpisodesState {
@@ -67,8 +100,7 @@ struct TroubleshootingView: View {
         case .removing:
             busyRow(L10n.troubleshootingOrphanedEpisodesRemoving)
         case .found(let episodes) where episodes.isEmpty:
-            Text(L10n.troubleshootingOrphanedEpisodesNoneFound)
-                .foregroundColor(theme.primaryText02)
+            emptyStateView
         case .found(let episodes):
             // Environment objects aren't reliably propagated across a NavigationLink push when the
             // source view has no ancestor NavigationView/NavigationStack (this screen is pushed onto

--- a/podcasts/TroubleshootingView.swift
+++ b/podcasts/TroubleshootingView.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+import PocketCastsDataModel
+
+struct TroubleshootingView: View {
+    @EnvironmentObject var theme: Theme
+    @StateObject private var viewModel: TroubleshootingViewModel
+    @State private var showRemoveConfirmation = false
+
+    init(source: OnlineSupportController.Source) {
+        _viewModel = StateObject(wrappedValue: TroubleshootingViewModel(source: source))
+    }
+
+    var body: some View {
+        List {
+            Section {
+                statusRow
+
+                if let lastRemovedCount = viewModel.lastRemovedCount {
+                    Text(removedResultText(for: lastRemovedCount))
+                        .foregroundColor(theme.support02)
+                }
+
+                Button(role: .destructive) {
+                    showRemoveConfirmation = true
+                } label: {
+                    Text(L10n.troubleshootingRemoveOrphanedEpisodes)
+                        .foregroundColor(theme.support05)
+                        .opacity(canRemove ? 1 : 0.5)
+                }
+                .disabled(!canRemove)
+            } header: {
+                Text(L10n.troubleshootingOrphanedEpisodesHeader)
+            } footer: {
+                Text(L10n.troubleshootingOrphanedEpisodesDescription)
+                    .foregroundColor(theme.primaryText02)
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(theme.primaryUi04)
+        .navigationTitle(L10n.troubleshootingTitle)
+        .applyDefaultThemeOptions()
+        .onAppear {
+            viewModel.checkOrphanedEpisodes()
+        }
+        .alert(L10n.troubleshootingRemoveOrphanedEpisodesConfirmTitle, isPresented: $showRemoveConfirmation) {
+            Button(L10n.troubleshootingRemoveOrphanedEpisodes, role: .destructive) {
+                viewModel.removeOrphanedEpisodes()
+            }
+            Button(L10n.cancel, role: .cancel) {}
+        } message: {
+            Text(L10n.troubleshootingRemoveOrphanedEpisodesConfirmMessage)
+        }
+    }
+
+    private var canRemove: Bool {
+        if case .found(let episodes) = viewModel.orphanedEpisodesState {
+            return !episodes.isEmpty
+        }
+        return false
+    }
+
+    @ViewBuilder
+    private var statusRow: some View {
+        switch viewModel.orphanedEpisodesState {
+        case .checking:
+            busyRow(L10n.troubleshootingOrphanedEpisodesChecking)
+        case .removing:
+            busyRow(L10n.troubleshootingOrphanedEpisodesRemoving)
+        case .found(let episodes) where episodes.isEmpty:
+            Text(L10n.troubleshootingOrphanedEpisodesNoneFound)
+                .foregroundColor(theme.primaryText02)
+        case .found(let episodes):
+            // Environment objects aren't reliably propagated across a NavigationLink push when the
+            // source view has no ancestor NavigationView/NavigationStack (this screen is pushed onto
+            // a UIKit UINavigationController directly), so inject theme explicitly to avoid a crash.
+            NavigationLink {
+                OrphanedEpisodesListView(episodes: episodes)
+                    .environmentObject(theme)
+            } label: {
+                Text(countText(for: episodes.count))
+            }
+        }
+    }
+
+    private func busyRow(_ text: String) -> some View {
+        HStack {
+            Text(text)
+                .foregroundColor(theme.primaryText02)
+            Spacer()
+            ProgressView()
+        }
+    }
+
+    private func countText(for count: Int) -> String {
+        count == 1 ? L10n.troubleshootingOrphanedEpisodesFoundSingular : L10n.troubleshootingOrphanedEpisodesFoundPluralFormat(count.localized())
+    }
+
+    private func removedResultText(for count: Int) -> String {
+        if count == 0 {
+            return L10n.troubleshootingRemoveOrphanedEpisodesResultNone
+        }
+        return count == 1 ? L10n.troubleshootingRemoveOrphanedEpisodesResultSingular : L10n.troubleshootingRemoveOrphanedEpisodesResultPluralFormat(count.localized())
+    }
+}
+
+struct TroubleshootingView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            TroubleshootingView(source: .settings)
+        }
+        .setupDefaultEnvironment()
+    }
+}

--- a/podcasts/TroubleshootingViewModel.swift
+++ b/podcasts/TroubleshootingViewModel.swift
@@ -1,0 +1,62 @@
+import Foundation
+import PocketCastsDataModel
+
+@MainActor
+class TroubleshootingViewModel: ObservableObject {
+    enum OrphanedEpisodesState {
+        case checking
+        case found(episodes: [Episode])
+        case removing
+    }
+
+    @Published private(set) var orphanedEpisodesState: OrphanedEpisodesState = .checking
+    @Published private(set) var lastRemovedCount: Int?
+
+    private let source: OnlineSupportController.Source
+
+    init(source: OnlineSupportController.Source) {
+        self.source = source
+    }
+
+    func checkOrphanedEpisodes() {
+        orphanedEpisodesState = .checking
+
+        Task.detached(priority: .userInitiated) { [weak self] in
+            let episodes = DataManager.sharedManager.findOrphanedEpisodes()
+            await self?.setFound(episodes: episodes)
+        }
+    }
+
+    func removeOrphanedEpisodes() {
+        let countBefore = episodeCount
+        orphanedEpisodesState = .removing
+        lastRemovedCount = nil
+
+        Analytics.track(.troubleshootingOrphanedEpisodesRemoveConfirmed, properties: ["source": source.rawValue])
+
+        Task.detached(priority: .userInitiated) { [weak self] in
+            PodcastManager.shared.deleteOrphanedEpisodesIfNeeded()
+            let remaining = DataManager.sharedManager.findOrphanedEpisodes()
+            await self?.finishRemoving(countBefore: countBefore, remaining: remaining)
+        }
+    }
+
+    private var episodeCount: Int {
+        if case .found(let episodes) = orphanedEpisodesState {
+            return episodes.count
+        }
+        return 0
+    }
+
+    private func setFound(episodes: [Episode]) {
+        orphanedEpisodesState = .found(episodes: episodes)
+    }
+
+    private func finishRemoving(countBefore: Int, remaining: [Episode]) {
+        let removedCount = max(0, countBefore - remaining.count)
+        lastRemovedCount = removedCount
+        orphanedEpisodesState = .found(episodes: remaining)
+
+        Analytics.track(.troubleshootingOrphanedEpisodesRemoved, properties: ["source": source.rawValue, "removed": removedCount, "remaining": remaining.count])
+    }
+}

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2983,6 +2983,51 @@
 /* Failure message for the podcast host check. */
 "settings_status_host_failure_message" = "The most common cause is that you have an ad-blocker configured on your phone or network. You’ll need to unblock this domain to download podcasts. Please note Pocket Casts doesn’t host or choose where podcasts are hosted, that’s up to the author of the show and is out of our control.";
 
+/* Title of the Troubleshooting screen, reachable from the Help & Feedback "more" menu. */
+"troubleshooting_title" = "Troubleshooting";
+
+/* Section header for the orphaned episodes troubleshooting tool. */
+"troubleshooting_orphaned_episodes_header" = "Orphaned Episodes";
+
+/* Explains what orphaned episodes are and what problems they can cause, shown below the orphaned episodes section. */
+"troubleshooting_orphaned_episodes_description" = "A rare syncing issue can leave behind duplicate episode entries that are no longer linked to their podcast. These can cause an episode's download or playback status to appear incorrect in some parts of the app.";
+
+/* Shown while the app is counting how many orphaned episodes exist on the device. */
+"troubleshooting_orphaned_episodes_checking" = "Checking for orphaned episodes…";
+
+/* Shown when no orphaned episodes are found on the device. */
+"troubleshooting_orphaned_episodes_none_found" = "No orphaned episodes were found";
+
+/* Shown when exactly 1 orphaned episode is found on the device, as a tappable row that leads to the list of episodes. */
+"troubleshooting_orphaned_episodes_found_singular" = "1 orphaned episode";
+
+/* Shown when more than 1 orphaned episode is found on the device, as a tappable row that leads to the list of episodes. %1$@ is the number found. */
+"troubleshooting_orphaned_episodes_found_plural_format" = "%1$@ orphaned episodes";
+
+/* Shown while orphaned episodes are being removed. */
+"troubleshooting_orphaned_episodes_removing" = "Removing orphaned episodes…";
+
+/* Button that pushes a screen listing the orphaned episodes found on the device, grouped by podcast. */
+"troubleshooting_view_orphaned_episodes" = "View Orphaned Episodes";
+
+/* Button, and destructive confirmation action, that removes orphaned episodes from the device. */
+"troubleshooting_remove_orphaned_episodes" = "Remove Orphaned Episodes";
+
+/* Title of the confirmation alert shown before removing orphaned episodes. */
+"troubleshooting_remove_orphaned_episodes_confirm_title" = "Remove Orphaned Episodes?";
+
+/* Message of the confirmation alert shown before removing orphaned episodes, warning this is destructive but best-effort preserves episode state. */
+"troubleshooting_remove_orphaned_episodes_confirm_message" = "This will delete the duplicate episode entries found on this device. This action can't be undone, but Pocket Casts will do its best to preserve your playback progress, download status, and other episode details before removing them.";
+
+/* Shown after removing orphaned episodes when none could be removed. */
+"troubleshooting_remove_orphaned_episodes_result_none" = "No orphaned episodes were removed";
+
+/* Shown after removing orphaned episodes when exactly 1 was removed. */
+"troubleshooting_remove_orphaned_episodes_result_singular" = "1 orphaned episode was removed";
+
+/* Shown after removing orphaned episodes when more than 1 was removed. %1$@ is the number removed. */
+"troubleshooting_remove_orphaned_episodes_result_plural_format" = "%1$@ orphaned episodes were removed";
+
 /* Title for the options for the user to configure their account. */
 "setup_account" = "Set Up Account";
 


### PR DESCRIPTION
Fixes PCIOS-806.

## RCA

The issue reproduces for podcasts that have duplicated (and orphaned*) episodes.

When you open the episode list, it shows the live episode (resolved via the local podcast id). Most operations on episodes act on `uuid` (the cross-platform foreign id) and pick up the orphaned row instead. The Episode Details screen also reads by `uuid`, so it shows the orphaned episode - which is why it displays the "correct" state while the list doesn't.

> \*An orphaned episode points at the id of a podcast row that no longer exists.

### Timeline

- Prior to Aug 2022, unsubscribing from a podcast could leave orphaned episodes behind.
- In Aug 2022 the issue was fixed and a migration was added (#137) to remove existing orphaned episodes. That migration missed users who subsequently resubscribed to a podcast they'd previously deleted, which left duplicated episodes in their database.

## Solution

Running another healing migration for every user is high risk for a problem that only affects a tiny portion of power users carrying duplicate episodes from 2022 or earlier. Instead of running it unconditionally, this adds a self-serve "Troubleshooting" screen under Help & Feedback's "..." menu that:

- proactively counts orphaned episodes and explains the symptoms they can cause (incorrect download/playback status)
- lets you view them grouped by podcast
- lets you remove them on demand, behind a confirmation that it's destructive

Removal repoints the surviving row at the real podcast instead of deleting blindly, so playback progress, download status, and archive state are preserved on a best-effort basis. Tested against the DB export from the user who originally reported the issue.

## To test

1. Go to Profile > Help & Feedback, tap the "..." menu, tap "Troubleshooting".
2. On a normal account it should show "No orphaned episodes were found" and the Remove button should be disabled.
3. To exercise the repair flow, load a database containing duplicate `SJEpisode` rows that share a `uuid` with different `podcast_id` values (one pointing at a real podcast row, one dangling). Reopen Troubleshooting - it should show a count, and tapping it lists the episodes grouped by podcast.
4. Tap "Remove Orphaned Episodes", confirm the warning alert, and verify the count drops and playback progress/download status/archived state is preserved on the surviving episode.
5. Run `PocketCastsDataModelTests/OrphanedEpisodeDataManagerTests` and `PocketCastsTests/Tests/Utilities/PodcastManagerTests` - all should pass.

Here's the recoding of the issues, the troublshooting, and the fix.

https://github.com/user-attachments/assets/1493bd6b-e423-4754-b236-d5f241a70c38

### Screenshot

<img width="320" alt="Screenshot 2026-07-07 at 4 31 58 PM" src="https://github.com/user-attachments/assets/e7bc4af1-8f76-4b82-84b7-7a345d3fd8b3" />


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.