### PR TITLE
Track heatmap info button tap on Stats screen

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -145,6 +145,7 @@ enum AnalyticsEvent: String {
 
     case statsShown
     case statsDismissed
+    case heatmapInfoOpened
 
     // MARK: - Folders
 

--- a/podcasts/StatsViewController.swift
+++ b/podcasts/StatsViewController.swift
@@ -249,6 +249,8 @@ class StatsViewController: UIViewController, UITableViewDelegate, UITableViewDat
     }
 
     @objc private func showHeatmapInfo() {
+        Analytics.track(.heatmapInfoOpened)
+
         let view = ModalMessageView(
             title: L10n.statsListeningActivityInfoTitle,
             message: L10n.statsListeningActivityInfoMessage,


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Adds analytics tracking for the info button in the heatmap section on the Stats screen. Fires a new `heatmapInfoOpened` event, matching the `heatmap_info_opened` event already defined for iOS in the Event Horizon schema.

## To test

1. Open Profile → Stats.
2. Tap the info (i) button next to the listening activity heatmap section header.
3. Confirm the `heatmap_info_opened` analytics event fires (e.g. via Tracks debug logging).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
