### PR TITLE
Fix mini player controls not using the podcast tint color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 8.16
 -----
+- Fix the Liquid Glass mini player controls and progress bar not using the podcast tint color [#4701](https://github.com/Automattic/pocket-casts-ios/pull/4701)
 - Make the Liquid Glass mini player's play button translucent with a springy bounce on tap [#4677](https://github.com/Automattic/pocket-casts-ios/pull/4677)
 - Fix the smart playlist and podcast page header showing the system light/dark appearance instead of the in-app theme when scrolling on iOS 18 [#4662](https://github.com/Automattic/pocket-casts-ios/pull/4662)
 - Fix episode lists jumping when a background download finishes [#4648](https://github.com/Automattic/pocket-casts-ios/pull/4648)

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -662,18 +662,13 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         episodeTitleLabel?.textColor = .label
         timeLeftModel?.color = Color(ThemeColor.primaryText02())
 
-        // A slightly translucent accent circle lets the tab bar's glass show
-        // through for a vibrant, glassy feel (without the buggy UIGlassEffect).
-        // The skip glyphs reuse that same translucent accent so all three
-        // controls share one color.
-        let accentColor = actionColor.withAlphaComponent(0.9)
         playPauseBtn.playButtonColor = bgColor
-        playPauseBtn.circleColor = accentColor
+        playPauseBtn.circleColor = actionColor
 
-        skipBackBtn.tintColor = accentColor
-        skipFwdBtn.tintColor = accentColor
+        skipBackBtn.tintColor = actionColor
+        skipFwdBtn.tintColor = actionColor
 
-        glassProgressView?.tintColorOverride = accentColor
+        glassProgressView?.tintColorOverride = actionColor
     }
 
     private func currentPodcastTintColor() -> UIColor {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -171,10 +171,10 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         let timeLeftVibrancy = Self.makeVibrancyWrapper(style: .secondaryLabel, content: timeLeftHost.view)
 
         let progressView = MiniPlayerGlassProgressView()
+        progressView.translatesAutoresizingMaskIntoConstraints = false
         glassProgressView = progressView
-        let progressVibrancy = Self.makeVibrancyWrapper(style: .fill, content: progressView)
 
-        let bottomRow = UIStackView(arrangedSubviews: [progressVibrancy, timeLeftVibrancy])
+        let bottomRow = UIStackView(arrangedSubviews: [progressView, timeLeftVibrancy])
         bottomRow.axis = .horizontal
         bottomRow.alignment = .center
         bottomRow.spacing = 6
@@ -656,7 +656,6 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     @available(iOS 26.0, *)
     private func updateColorsLiquidGlass() {
         let actionColor = currentPodcastTintColor()
-        let iconColor = ThemeColor.podcastIcon03(podcastColor: actionColor)
         let bgColor = ThemeColor.primaryUi02()
 
         // System color so the vibrancy wrapper can modulate it.
@@ -667,14 +666,14 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         // through for a vibrant, glassy feel (without the buggy UIGlassEffect).
         // The skip glyphs reuse that same translucent accent so all three
         // controls share one color.
-        let accentColor = iconColor.withAlphaComponent(0.8)
+        let accentColor = actionColor.withAlphaComponent(0.9)
         playPauseBtn.playButtonColor = bgColor
         playPauseBtn.circleColor = accentColor
 
         skipBackBtn.tintColor = accentColor
         skipFwdBtn.tintColor = accentColor
 
-        glassProgressView?.tintColorOverride = actionColor
+        glassProgressView?.tintColorOverride = accentColor
     }
 
     private func currentPodcastTintColor() -> UIColor {


### PR DESCRIPTION
Apparently, the color was inadvertently lost when adding vibrancy.


## To test

1. On an iOS 26 device/simulator, play an episode from a podcast with a distinct color.
2. Confirm the mini player's play/pause circle, skip buttons, and progress bar all use the podcast's tint color.
3. Switch themes (esp. Dark) and confirm the tint still applies.

Before / After

<img width="320"  alt="Screenshot 2026-07-07 at 5 37 30 PM" src="https://github.com/user-attachments/assets/9970a2f0-df46-461e-a812-ece5a9bbf883" /> <img width="320" alt="Screenshot 2026-07-07 at 5 43 14 PM" src="https://github.com/user-attachments/assets/6cad47e3-3582-462c-887b-8134f9caa7ef" />

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
