### PR TITLE
Fix Download button not working in Search/Discover results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Fix the Playlists tab showing a blank screen instead of the empty state when there are no playlists [#4794](https://github.com/Automattic/pocket-casts-ios/pull/4794)
 - [tvOS] Improve thumbnail algorithm for videos [#4861](https://github.com/Automattic/pocket-casts-ios/pull/4861)
 - [tvOS] Show correct number of playlist items, and update playlists episode status on changes [#4869](https://github.com/Automattic/pocket-casts-ios/pull/4869)
+- Fix the Download button doing nothing in Search and Discover episode results [#4702](https://github.com/Automattic/pocket-casts-ios/pull/4702)
 
 8.16.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix a crash when starting episode downloads [#5001](https://github.com/Automattic/pocket-casts-ios/pull/5001)
 - Tapping a Discover collection's poster now opens the expanded collection, the same as tapping "Show All" [#5028](https://github.com/Automattic/pocket-casts-ios/pull/5028)
 - Add support for "Networks" row in "Discover" [#5026](https://github.com/Automattic/pocket-casts-ios/pull/5026)
+- Fix the Download button doing nothing in Search and Discover episode results [#4702](https://github.com/Automattic/pocket-casts-ios/pull/4702)
 
 8.19
 -----
@@ -70,7 +71,6 @@
 - Fix the Playlists tab showing a blank screen instead of the empty state when there are no playlists [#4794](https://github.com/Automattic/pocket-casts-ios/pull/4794)
 - [tvOS] Improve thumbnail algorithm for videos [#4861](https://github.com/Automattic/pocket-casts-ios/pull/4861)
 - [tvOS] Show correct number of playlist items, and update playlists episode status on changes [#4869](https://github.com/Automattic/pocket-casts-ios/pull/4869)
-- Fix the Download button doing nothing in Search and Discover episode results [#4702](https://github.com/Automattic/pocket-casts-ios/pull/4702)
 
 8.16.1
 ------

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -3,6 +3,10 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import Combine
 
+private enum EpisodeLookupError: Error {
+    case episodeNotFound
+}
+
 @MainActor
 class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
 
@@ -59,7 +63,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
     }
 
     func downloadTapped() {
-        guard let episode else { return }
+        guard let episode, !isLoadingEpisode else { return }
 
         // A search result's episode isn't necessarily in the database yet (the user might
         // not be subscribed to the podcast), so make sure it exists before queuing it for
@@ -69,18 +73,28 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
             return
         }
 
-        let uuid = episode.uuid
-        let podcastUuid = episode.podcastUuid
-        // `addMissingPodcastAndEpisode` performs a synchronous network request, so keep it off
-        // the main thread.
-        DispatchQueue.global().async {
-            ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: uuid, podcastUuid: podcastUuid) { [weak self] addedEpisode in
-                guard addedEpisode != nil else { return }
-                DispatchQueue.main.async {
-                    PlaybackActionHelper.download(episodeUuid: uuid)
-                    self?.reloadRealEpisode()
-                    self?.refreshTrigger.toggle()
+        isLoadingEpisode = true
+        Task { @MainActor in
+            let spinnerTask = Task { @MainActor in
+                try await Task.sleep(nanoseconds: UInt64(Self.loadingSpinnerDelay * TimeInterval(NSEC_PER_SEC)))
+                try Task.checkCancellation()
+                showsLoadingSpinner = true
+            }
+            defer {
+                spinnerTask.cancel()
+                isLoadingEpisode = false
+                showsLoadingSpinner = false
+            }
+            do {
+                guard try await ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: episode.uuid, podcastUuid: episode.podcastUuid) != nil else {
+                    throw EpisodeLookupError.episodeNotFound
                 }
+                PlaybackActionHelper.download(episodeUuid: episode.uuid)
+                reloadRealEpisode()
+                refreshTrigger.toggle()
+            } catch {
+                HapticsHelper.triggerErrorHaptic()
+                Toast.show(L10n.discoverEpisodeFailToLoad)
             }
         }
     }
@@ -92,8 +106,11 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
 
     func errorTapped() {
         guard let episode else { return }
-        // In search the error state is effectively always a failed download, so retry it.
-        PlaybackActionHelper.download(episodeUuid: episode.uuid)
+        if realEpisode?.playbackError() == true {
+            playTapped()
+        } else {
+            PlaybackActionHelper.download(episodeUuid: episode.uuid)
+        }
     }
 
     func waitingForWifiTapped() {

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -34,27 +34,10 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
     }
 
     func playTapped() {
-        guard let episode, !isLoadingEpisode else {
-            return
-        }
-        isLoadingEpisode = true
-        Task { @MainActor in
-            let spinnerTask = Task { @MainActor in
-                try await Task.sleep(nanoseconds: UInt64(Self.loadingSpinnerDelay * TimeInterval(NSEC_PER_SEC)))
-                try Task.checkCancellation()
-                showsLoadingSpinner = true
-            }
-            defer {
-                spinnerTask.cancel()
-                isLoadingEpisode = false
-                showsLoadingSpinner = false
-            }
-            do {
-                try await PlaybackManager.shared.playEpisodeSearchResult(episode)
-            } catch {
-                HapticsHelper.triggerErrorHaptic()
-                Toast.show(L10n.discoverEpisodeFailToLoad)
-            }
+        guard let episode else { return }
+
+        withLoadingSpinner {
+            try await PlaybackManager.shared.playEpisodeSearchResult(episode)
         }
     }
 
@@ -65,37 +48,18 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
     func downloadTapped() {
         guard let episode, !isLoadingEpisode else { return }
 
-        // A search result's episode isn't necessarily in the database yet (the user might
-        // not be subscribed to the podcast), so make sure it exists before queuing it for
-        // download — mirroring `playEpisodeSearchResult`.
-        if DataManager.sharedManager.findBaseEpisode(uuid: episode.uuid) != nil {
+        if let existingEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episode.uuid) {
+            realEpisode = existingEpisode
             PlaybackActionHelper.download(episodeUuid: episode.uuid)
             return
         }
 
-        isLoadingEpisode = true
-        Task { @MainActor in
-            let spinnerTask = Task { @MainActor in
-                try await Task.sleep(nanoseconds: UInt64(Self.loadingSpinnerDelay * TimeInterval(NSEC_PER_SEC)))
-                try Task.checkCancellation()
-                showsLoadingSpinner = true
-            }
-            defer {
-                spinnerTask.cancel()
-                isLoadingEpisode = false
-                showsLoadingSpinner = false
-            }
-            do {
-                guard try await ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: episode.uuid, podcastUuid: episode.podcastUuid) != nil else {
-                    throw EpisodeLookupError.episodeNotFound
-                }
-                PlaybackActionHelper.download(episodeUuid: episode.uuid)
-                reloadRealEpisode()
-                refreshTrigger.toggle()
-            } catch {
-                HapticsHelper.triggerErrorHaptic()
-                Toast.show(L10n.discoverEpisodeFailToLoad)
-            }
+        withLoadingSpinner { [weak self] in
+            guard let self else { return }
+            let resolvedEpisode = try await self.resolveEpisode(episode)
+            PlaybackActionHelper.download(episodeUuid: episode.uuid)
+            self.realEpisode = resolvedEpisode
+            self.refreshTrigger.toggle()
         }
     }
 
@@ -125,6 +89,44 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
     func waitingForWifiTapped() {
         guard let episode else { return }
         PlaybackActionHelper.overrideWaitingForWifi(episodeUuid: episode.uuid, autoDownloadStatus: .autoDownloaded)
+    }
+
+    /// A search result's episode isn't necessarily in the database yet (the user might not be
+    /// subscribed to the podcast), so fetch it from the server when it's missing.
+    private func resolveEpisode(_ episode: EpisodeSearchResult) async throws -> BaseEpisode {
+        if let existingEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episode.uuid) {
+            return existingEpisode
+        }
+        guard let addedEpisode = try await ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: episode.uuid, podcastUuid: episode.podcastUuid) else {
+            throw EpisodeLookupError.episodeNotFound
+        }
+        return addedEpisode
+    }
+
+    /// Runs `work`, showing the row's spinner if it doesn't finish quickly and surfacing a toast if it fails.
+    private func withLoadingSpinner(_ work: @escaping @MainActor () async throws -> Void) {
+        guard !isLoadingEpisode else { return }
+
+        isLoadingEpisode = true
+        Task { @MainActor in
+            let spinnerTask = Task { @MainActor in
+                try await Task.sleep(nanoseconds: UInt64(Self.loadingSpinnerDelay * TimeInterval(NSEC_PER_SEC)))
+                try Task.checkCancellation()
+                showsLoadingSpinner = true
+            }
+            defer {
+                spinnerTask.cancel()
+                isLoadingEpisode = false
+                showsLoadingSpinner = false
+            }
+            do {
+                try await work()
+            } catch is CancellationError {
+            } catch {
+                HapticsHelper.triggerErrorHaptic()
+                Toast.show(L10n.discoverEpisodeFailToLoad)
+            }
+        }
     }
 
     private func reloadRealEpisode() {

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -105,12 +105,21 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
     }
 
     func errorTapped() {
-        guard let episode else { return }
-        if realEpisode?.playbackError() == true {
-            playTapped()
+        guard let realEpisode else { return }
+
+        let optionsPicker = OptionsPicker(title: nil)
+        if realEpisode.playbackError() {
+            let retryAction = OptionAction(label: L10n.retry, icon: nil, action: { [weak self] in
+                self?.playTapped()
+            })
+            optionsPicker.addDescriptiveActions(title: L10n.playbackFailed, message: realEpisode.playbackErrorDetails, icon: "option-alert", actions: [retryAction])
         } else {
-            PlaybackActionHelper.download(episodeUuid: episode.uuid)
+            let retryAction = OptionAction(label: L10n.retry, icon: nil, action: { [weak self] in
+                self?.downloadTapped()
+            })
+            optionsPicker.addDescriptiveActions(title: L10n.downloadFailed, message: realEpisode.readableErrorMessage(), icon: "option-alert", actions: [retryAction])
         }
+        optionsPicker.present()
     }
 
     func waitingForWifiTapped() {

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -64,7 +64,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
     }
 
     func stopDownloadTapped() {
-        guard let episode else { return }
+        guard let episode, !isLoadingEpisode else { return }
         PlaybackActionHelper.stopDownload(episodeUuid: episode.uuid)
     }
 
@@ -87,7 +87,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
     }
 
     func waitingForWifiTapped() {
-        guard let episode else { return }
+        guard let episode, !isLoadingEpisode else { return }
         PlaybackActionHelper.overrideWaitingForWifi(episodeUuid: episode.uuid, autoDownloadStatus: .autoDownloaded)
     }
 
@@ -146,15 +146,26 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
             NotificationCenter.default.publisher(for: Constants.Notifications.playbackPaused),
         )
         .receive(on: OperationQueue.main)
-        .sink(receiveValue: { [unowned self] _ in
-            self.refreshTrigger.toggle()
+        .sink(receiveValue: { [weak self] _ in
+            self?.refreshTrigger.toggle()
         })
         .store(in: &cancellables)
 
+        // `playbackFailed` carries no episode UUID, but it only fires when playback actually fails,
+        // so reloading unconditionally is cheap.
+        NotificationCenter.default.publisher(for: Constants.Notifications.playbackFailed)
+            .receive(on: OperationQueue.main)
+            .sink(receiveValue: { [weak self] _ in
+                self?.reloadRealEpisode()
+                self?.refreshTrigger.toggle()
+            })
+            .store(in: &cancellables)
+
         NotificationCenter.default.publisher(for: Constants.Notifications.playbackProgress)
             .receive(on: OperationQueue.main)
-            .sink(receiveValue: { [unowned self] notification in
-                guard let episodeUUID = notification.object as? String ?? PlaybackManager.shared.currentEpisode?.uuid,
+            .sink(receiveValue: { [weak self] notification in
+                guard let self,
+                      let episodeUUID = notification.object as? String ?? PlaybackManager.shared.currentEpisode?.uuid,
                       episodeUUID == episode.uuid
                 else {
                     return
@@ -168,8 +179,9 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
         // finishes, or fails — otherwise the button never reflects the tap. Mirrors `EpisodeCell`.
         NotificationCenter.default.publisher(for: Constants.Notifications.downloadProgress)
             .receive(on: OperationQueue.main)
-            .sink(receiveValue: { [weak self] _ in
+            .sink(receiveValue: { [weak self] notification in
                 guard let self,
+                      notification.object as? String == episode.uuid,
                       DownloadManager.shared.progressManager.progressForEpisode(episode.uuid) != nil else { return }
                 // Only hit the DB when our cached episode doesn't yet reflect the download; live
                 // progress is read straight from the DownloadManager when the button repopulates.

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -20,9 +20,12 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
 
     private static let loadingSpinnerDelay: TimeInterval = 0.5
 
+    private var cancellables = Set<AnyCancellable>()
+
     init(episode: EpisodeSearchResult?, podcastFolder: PodcastFolderSearchResult?) {
         self.episode = episode
         self.podcastFolder = podcastFolder
+        reloadRealEpisode()
         setupObservers()
     }
 
@@ -55,15 +58,53 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
         PlaybackActionHelper.pause()
     }
 
-    func downloadTapped() {}
+    func downloadTapped() {
+        guard let episode else { return }
 
-    func stopDownloadTapped() {}
+        // A search result's episode isn't necessarily in the database yet (the user might
+        // not be subscribed to the podcast), so make sure it exists before queuing it for
+        // download — mirroring `playEpisodeSearchResult`.
+        if DataManager.sharedManager.findBaseEpisode(uuid: episode.uuid) != nil {
+            PlaybackActionHelper.download(episodeUuid: episode.uuid)
+            return
+        }
 
-    func errorTapped() {}
+        let uuid = episode.uuid
+        let podcastUuid = episode.podcastUuid
+        // `addMissingPodcastAndEpisode` performs a synchronous network request, so keep it off
+        // the main thread.
+        DispatchQueue.global().async {
+            ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: uuid, podcastUuid: podcastUuid) { [weak self] addedEpisode in
+                guard addedEpisode != nil else { return }
+                DispatchQueue.main.async {
+                    PlaybackActionHelper.download(episodeUuid: uuid)
+                    self?.reloadRealEpisode()
+                    self?.refreshTrigger.toggle()
+                }
+            }
+        }
+    }
 
-    func waitingForWifiTapped() {}
+    func stopDownloadTapped() {
+        guard let episode else { return }
+        PlaybackActionHelper.stopDownload(episodeUuid: episode.uuid)
+    }
 
-    private var cancellables = Set<AnyCancellable>()
+    func errorTapped() {
+        guard let episode else { return }
+        // In search the error state is effectively always a failed download, so retry it.
+        PlaybackActionHelper.download(episodeUuid: episode.uuid)
+    }
+
+    func waitingForWifiTapped() {
+        guard let episode else { return }
+        PlaybackActionHelper.overrideWaitingForWifi(episodeUuid: episode.uuid, autoDownloadStatus: .autoDownloaded)
+    }
+
+    private func reloadRealEpisode() {
+        guard let episode else { return }
+        realEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episode.uuid)
+    }
 
     private func setupObservers() {
         guard let episode else {
@@ -90,10 +131,37 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
                 else {
                     return
                 }
-                let realEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUUID)
-                self.realEpisode = realEpisode
+                self.realEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUUID)
                 self.refreshTrigger.toggle()
             })
             .store(in: &cancellables)
+
+        // Keep the download/play action button in sync while a download is queued, in progress,
+        // finishes, or fails — otherwise the button never reflects the tap. Mirrors `EpisodeCell`.
+        NotificationCenter.default.publisher(for: Constants.Notifications.downloadProgress)
+            .receive(on: OperationQueue.main)
+            .sink(receiveValue: { [weak self] _ in
+                guard let self,
+                      DownloadManager.shared.progressManager.progressForEpisode(episode.uuid) != nil else { return }
+                // Only hit the DB when our cached episode doesn't yet reflect the download; live
+                // progress is read straight from the DownloadManager when the button repopulates.
+                if self.realEpisode?.downloading() != true {
+                    self.reloadRealEpisode()
+                }
+                self.refreshTrigger.toggle()
+            })
+            .store(in: &cancellables)
+
+        Publishers.Merge(
+            NotificationCenter.default.publisher(for: Constants.Notifications.episodeDownloadStatusChanged),
+            NotificationCenter.default.publisher(for: Constants.Notifications.episodeDownloaded)
+        )
+        .receive(on: OperationQueue.main)
+        .sink(receiveValue: { [weak self] notification in
+            guard let self, notification.object as? String == episode.uuid else { return }
+            self.reloadRealEpisode()
+            self.refreshTrigger.toggle()
+        })
+        .store(in: &cancellables)
     }
 }

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -145,7 +145,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
             NotificationCenter.default.publisher(for: Constants.Notifications.playbackEnded),
             NotificationCenter.default.publisher(for: Constants.Notifications.playbackPaused),
         )
-        .receive(on: OperationQueue.main)
+        .receive(on: DispatchQueue.main)
         .sink(receiveValue: { [weak self] _ in
             self?.refreshTrigger.toggle()
         })
@@ -154,7 +154,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
         // `playbackFailed` carries no episode UUID, but it only fires when playback actually fails,
         // so reloading unconditionally is cheap.
         NotificationCenter.default.publisher(for: Constants.Notifications.playbackFailed)
-            .receive(on: OperationQueue.main)
+            .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] _ in
                 self?.reloadRealEpisode()
                 self?.refreshTrigger.toggle()
@@ -162,7 +162,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
             .store(in: &cancellables)
 
         NotificationCenter.default.publisher(for: Constants.Notifications.playbackProgress)
-            .receive(on: OperationQueue.main)
+            .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] notification in
                 guard let self,
                       let episodeUUID = notification.object as? String ?? PlaybackManager.shared.currentEpisode?.uuid,
@@ -178,7 +178,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
         // Keep the download/play action button in sync while a download is queued, in progress,
         // finishes, or fails — otherwise the button never reflects the tap. Mirrors `EpisodeCell`.
         NotificationCenter.default.publisher(for: Constants.Notifications.downloadProgress)
-            .receive(on: OperationQueue.main)
+            .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] notification in
                 guard let self,
                       notification.object as? String == episode.uuid,
@@ -196,7 +196,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
             NotificationCenter.default.publisher(for: Constants.Notifications.episodeDownloadStatusChanged),
             NotificationCenter.default.publisher(for: Constants.Notifications.episodeDownloaded)
         )
-        .receive(on: OperationQueue.main)
+        .receive(on: DispatchQueue.main)
         .sink(receiveValue: { [weak self] notification in
             guard let self, notification.object as? String == episode.uuid else { return }
             self.reloadRealEpisode()


### PR DESCRIPTION
Fixes PCIOS-

In the new Search UI (Search tab and Discover search, behind `searchImprovements`), tapping the **Download** button on an episode result did nothing and the cell never updated. `SearchResultCellModel`'s `downloadTapped`/`stopDownloadTapped` were empty no-ops and it never observed download notifications.

This wires the cell model up to `PlaybackActionHelper` (fetching the episode into the DB first when needed) and observes download progress/status notifications, mirroring `EpisodeCell`.

## To test

1. Ensure the **Search Improvements** feature flag is enabled.
2. Open **Search** (or **Discover → search**) and search for a term that returns episode results.
3. Set your primary row action to **Download** (Settings → General → Row Action) so rows show the download button.
4. Tap **Download** on an episode result.
5. Verify the button shows progress and ends in the downloaded state.
6. Tap again mid-download and verify it cancels and returns to the Download state.


https://github.com/user-attachments/assets/29bbe588-2bfc-40b6-85ae-43b45a16e4c6



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
-  [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
