### PR TITLE
[PC TV] Keep and restore episode focus after dismissing details

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -205,13 +205,24 @@ struct PlaylistDetailView: View {
 
     @Namespace private var episodeListNamespace
 
+    @State private var lastFocus: String?
+    @FocusState private var currentFocus: String?
+
     var episodeList: some View {
         List {
             Section {
                 ForEach(model.episodes, id: \.uuid) { episode in
-                    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: episode, podcast: nil), context: .other(showGoToPodcast: true), focus: $rowFocus)
-                        .prefersDefaultFocus(episode.uuid == model.episodes.first?.uuid, in: episodeListNamespace)
-                        .listRowInsets(Layout.rowInsets)
+                    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: episode, podcast: nil), context: .other(showGoToPodcast: true), focus: $rowFocus, detailsDismissed: {
+                        currentFocus = lastFocus
+                    })
+                    .focused($currentFocus, equals: episode.uuid)
+                    .onChange(of: rowFocus) { _, new in
+                        if let new {
+                            lastFocus = new.episodeID
+                        }
+                    }
+                    .prefersDefaultFocus(episode.uuid == model.episodes.first?.uuid, in: episodeListNamespace)
+                    .listRowInsets(Layout.rowInsets)
                 }
             } header: {
                 HStack {
@@ -220,6 +231,9 @@ struct PlaylistDetailView: View {
                 }
                 .padding(.bottom, 32)
             }
+        }
+        .onAppear() {
+            currentFocus = lastFocus
         }
         .focusScope(episodeListNamespace)
         .padding(.horizontal, 24)

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -232,7 +232,7 @@ struct PlaylistDetailView: View {
                 .padding(.bottom, 32)
             }
         }
-        .onAppear() {
+        .onAppear {
             currentFocus = lastFocus
         }
         .focusScope(episodeListNamespace)

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -216,11 +216,6 @@ struct PlaylistDetailView: View {
                         currentFocus = lastFocus
                     })
                     .focused($currentFocus, equals: episode.uuid)
-                    .onChange(of: rowFocus) { _, new in
-                        if let new {
-                            lastFocus = new.episodeID
-                        }
-                    }
                     .prefersDefaultFocus(episode.uuid == model.episodes.first?.uuid, in: episodeListNamespace)
                     .listRowInsets(Layout.rowInsets)
                 }
@@ -230,6 +225,11 @@ struct PlaylistDetailView: View {
                     archivedFilterMenu
                 }
                 .padding(.bottom, 32)
+            }
+        }
+        .onChange(of: rowFocus) { _, new in
+            if let new {
+                lastFocus = new.episodeID
             }
         }
         .onAppear {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -138,6 +138,8 @@ struct EpisodeRowWithActions: View {
     var context: EpisodeActionContext = .other(showGoToPodcast: false)
     @FocusState.Binding var focus: EpisodeRowFocus?
     var customPlayDisplayAction: (() -> ())? = nil
+    var detailsDismissed: (() -> ())? = nil
+
     @State private var isPlaying = false
     @State private var isShowingActions = false
     @State private var isShowingShowNotes = false
@@ -212,6 +214,11 @@ struct EpisodeRowWithActions: View {
                     focus = .more(model.id)
                     restoreFocus = false
                 }
+            }
+        }
+        .onChange(of: isShowingShowNotes) { _, showing in
+            if !showing {
+                detailsDismissed?()
             }
         }
         .fullScreenCover(isPresented: $isPlaying) {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -143,11 +143,6 @@ struct PodcastDetailView: View {
             currentFocus = lastFocus
         })
         .focused($currentFocus, equals: episode.id)
-        .onChange(of: rowFocus) { _, new in
-            if let new {
-                lastFocus = new.episodeID
-            }
-        }
     }
 
     private var sortMenu: some View {
@@ -272,6 +267,11 @@ struct PodcastDetailView: View {
         .padding(.horizontal, 24)
         .contentMargins(.bottom, 24, for: .scrollContent)
         .focused($focusedSection, equals: .episodes)
+        .onChange(of: rowFocus) { _, new in
+            if let new {
+                lastFocus = new.episodeID
+            }
+        }
         .onAppear {
             currentFocus = lastFocus
         }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -272,7 +272,7 @@ struct PodcastDetailView: View {
         .padding(.horizontal, 24)
         .contentMargins(.bottom, 24, for: .scrollContent)
         .focused($focusedSection, equals: .episodes)
-        .onAppear() {
+        .onAppear {
             currentFocus = lastFocus
         }
     }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailView.swift
@@ -135,8 +135,19 @@ struct PodcastDetailView: View {
         }
     }
 
+    @State private var lastFocus: String?
+    @FocusState private var currentFocus: String?
+
     private func episodeRow(for episode: EpisodeRowViewModel) -> some View {
-        EpisodeRowWithActions(model: episode, focus: $rowFocus)
+        EpisodeRowWithActions(model: episode, focus: $rowFocus, detailsDismissed: {
+            currentFocus = lastFocus
+        })
+        .focused($currentFocus, equals: episode.id)
+        .onChange(of: rowFocus) { _, new in
+            if let new {
+                lastFocus = new.episodeID
+            }
+        }
     }
 
     private var sortMenu: some View {
@@ -261,6 +272,9 @@ struct PodcastDetailView: View {
         .padding(.horizontal, 24)
         .contentMargins(.bottom, 24, for: .scrollContent)
         .focused($focusedSection, equals: .episodes)
+        .onAppear() {
+            currentFocus = lastFocus
+        }
     }
 }
 

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -12,6 +12,9 @@ struct UpNextView: View {
     @Namespace private var rowNamespace
     @FocusState private var rowFocus: EpisodeRowFocus?
 
+    @State private var lastFocus: String?
+    @FocusState private var currentFocus: String?
+
     init(model: UpNextViewModel) {
         _model = State(wrappedValue: model)
     }
@@ -27,6 +30,7 @@ struct UpNextView: View {
                 emptyView
             }
         }
+        .focusScope(rowNamespace)
         .task {
             Analytics.track(.upNextShown, properties: ["source": "tab_bar"])
             model.load()
@@ -43,14 +47,24 @@ struct UpNextView: View {
                 LazyVStack(alignment: .leading, spacing: 24) {
                     headerRow
                     ForEach(model.episodes) { episode in
-                        EpisodeRowWithActions(model: episode, context: .upNext, focus: $rowFocus) {
+                        EpisodeRowWithActions(model: episode, context: .upNext, focus: $rowFocus, customPlayDisplayAction: {
                             tabRouter.showFullScreenPlayer = true
-                        }
+                        }, detailsDismissed: {
+                            currentFocus = lastFocus
+                        })
                         .frame(width: 1160)
-                        .prefersDefaultFocus(episode.id == model.episodes.first?.id, in: rowNamespace)
+                        .focused($currentFocus, equals: episode.id)
                     }
                 }
-                .focusScope(rowNamespace)
+            }
+            .focusSection()
+            .onChange(of: rowFocus) { _, new in
+                if let new {
+                    lastFocus = new.episodeID
+                }
+            }
+            .onAppear() {
+                currentFocus = lastFocus
             }
             .navigationDestination(for: Podcast.self) { podcast in
                 PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: podcast.uuid))

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -63,7 +63,7 @@ struct UpNextView: View {
                     lastFocus = new.episodeID
                 }
             }
-            .onAppear() {
+            .onAppear {
                 currentFocus = lastFocus
             }
             .navigationDestination(for: Podcast.self) { podcast in


### PR DESCRIPTION
Fixes [PCIOS-819](https://linear.app/a8c/issue/PCIOS-819/up-next-row-showing-details-focus-does-not-come-back-to-same-row) <!-- issue number, if applicable -->

On the Pocket Casts TV app, opening an episode's details (show notes) and dismissing it would drop focus out of the episode list, and navigating away from and back to a list would not restore the previously focused episode. This PR keeps and restores focus to the last focused episode row in the **Up Next**, **Podcast detail**, and **Playlist detail** screens.

Changes:
- Add a `detailsDismissed` callback to `EpisodeRowWithActions` that fires when the show notes sheet is dismissed, so the enclosing list can restore focus.
- Track the last focused episode per list and restore it on details dismissal and when the list reappears (`onAppear`).
- Up Next now wraps its rows in a `focusSection()` / `focusScope` so focus is kept within the list.
- The `rowFocus` observer is registered once at list level (instead of once per row) across all three screens for consistency and to avoid redundant observers.

## To test

1. Open the Pocket Casts TV app.
2. Go to **Up Next**, move focus to an episode that is not the first one.
3. Open that episode's **… (more)** menu and open **Show notes**, then dismiss it.
   - Expected: focus returns to the same episode row (not the top of the list / tab bar).
4. Repeat step 2–3 in a **Podcast** detail screen and in a **Playlist** detail screen.
5. From a list, focus an episode, navigate into a podcast/detail and back.
   - Expected: focus is restored to the previously focused episode.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
