### PR TITLE
Fix leaked Combine subscriptions in ClipPlaybackManager

### DIFF
--- a/podcasts/Sharing/Clip/ClipPlaybackManager.swift
+++ b/podcasts/Sharing/Clip/ClipPlaybackManager.swift
@@ -83,6 +83,7 @@ class ClipPlaybackManager: ObservableObject {
         currentTime = 0
         duration = 0
         removeTimeObserver()
+        cancellables.removeAll()
     }
 
     private func setupTimeObserver() {


### PR DESCRIPTION
Clear the `cancellables` set when `ClipPlaybackManager` stops. Because the manager is a shared singleton, each `play()` added `$currentTime` and `timeControlStatus` sinks that were never torn down, so they accumulated across sessions — keeping prior network `AVPlayer`s alive, writing a new clip's playback time into a stale captured `ClipTime`, and letting multiple status sinks fight over `isPlaying`. Since `play()` already calls `stop()` before starting a new player, clearing there is a single, safe teardown point.

## To test

1. Open an episode and start a clip (e.g. via Share → Clip preview).
2. Play the clip, then stop it and play a different clip several times.
3. Verify playback controls stay responsive, `isPlaying` reflects the current clip, and the scrubber/playback time tracks only the active clip.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.