### PR TITLE
tvOS: Add Discover sponsored podcast analytics

### DIFF
--- a/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
@@ -44,7 +44,19 @@ enum DiscoverAnalytics {
         AnalyticsHelper.adTapped(categoryName: categoryName ?? "unknown", region: region ?? "unknown", podcastUUID: podcastUUID, categoryID: categoryID ?? 0)
     }
 
-    static func podcastSubscribedFromList(listId: String, podcastUuid: String, listDateTime: String? = nil) {
-        AnalyticsHelper.podcastSubscribedFromList(listId: listId, podcastUuid: podcastUuid, listDateTime: listDateTime)
+    static func discoverPodcastSubscribed(podcastUuid: String) {
+        Task {
+            if let listID = await DiscoverManager.shared.listIdForPodcast(podcastUuid) {
+                AnalyticsHelper.podcastSubscribedFromList(listId: listID, podcastUuid: podcastUuid, listDateTime: nil)
+            }
+        }
+    }
+
+    static func discoverPodcastPlayed(podcastUuid: String) {
+        Task {
+            if let listID = await DiscoverManager.shared.listIdForPodcast(podcastUuid) {
+                AnalyticsHelper.podcastEpisodePlayedFromList(listId: listID, podcastUuid: podcastUuid)
+            }
+        }
     }
 }

--- a/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
@@ -43,10 +43,17 @@ enum DiscoverAnalytics {
         AnalyticsHelper.adTapped(categoryName: categoryName ?? "unknown", region: region ?? "unknown", podcastUUID: podcastUUID, categoryID: categoryID ?? 0)
     }
 
+    static var currentFeaturedPodcast: String?
+
     static func discoverPodcastSubscribed(podcastUuid: String) {
         Task {
             if let listID = await DiscoverManager.shared.listIdForPodcast(podcastUuid) {
                 AnalyticsHelper.podcastSubscribedFromList(listId: listID, podcastUuid: podcastUuid, listDateTime: nil)
+            }
+            let isFeatured = currentFeaturedPodcast == podcastUuid
+            if isFeatured {
+                Analytics.track(.discoverFeaturedPodcastSubscribed, properties: ["podcast_uuid": podcastUuid])
+                AnalyticsHelper.subscribedToFeaturedPodcast()
             }
         }
     }

--- a/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
@@ -1,4 +1,5 @@
 import PocketCastsServer
+import SwiftUI
 
 /// Centralizes the tvOS Discover list analytics events.
 ///
@@ -37,5 +38,13 @@ enum DiscoverAnalytics {
             "id": category.id ?? -1,
             "source": source
         ])
+    }
+
+    static func adTapped(categoryName: String?, region: String?, podcastUUID: String, categoryID: Int?) {
+        AnalyticsHelper.adTapped(categoryName: categoryName ?? "unknown", region: region ?? "unknown", podcastUUID: podcastUUID, categoryID: categoryID ?? 0)
+    }
+
+    static func podcastSubscribedFromList(listId: String, podcastUuid: String, listDateTime: String? = nil) {
+        AnalyticsHelper.podcastSubscribedFromList(listId: listId, podcastUuid: podcastUuid, listDateTime: listDateTime)
     }
 }

--- a/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
@@ -1,5 +1,4 @@
 import PocketCastsServer
-import SwiftUI
 
 /// Centralizes the tvOS Discover list analytics events.
 ///

--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -34,14 +34,16 @@ struct DiscoverSection {
     /// Analytics list identifier for the section, used by the `discover_list_*` events.
     let listId: String?
     let dateTime: String?
+    let region: String?
 
-    init(title: String? = nil, subtitle: String? = nil, podcasts: [DiscoverPodcast] = [], sponsoredPodcastsIDs: Set<String> = [], listId: String? = nil, dateTime: String? = nil) {
+    init(title: String? = nil, subtitle: String? = nil, podcasts: [DiscoverPodcast] = [], sponsoredPodcastsIDs: Set<String> = [], listId: String? = nil, dateTime: String? = nil, region: String?) {
         self.title = title
         self.subtitle = subtitle
         self.podcasts = podcasts
         self.sponsoredPodcastsIDs = sponsoredPodcastsIDs
         self.listId = listId
         self.dateTime = dateTime
+        self.region = region
     }
 }
 
@@ -63,10 +65,14 @@ struct DiscoverEpisodesSection {
 struct DiscoverCategorySection {
     let categoryDetails: DiscoverCategoryDetails
     let sponsoredPodcastsIDs: Set<String>
+    let listId: String?
+    let region: String?
 
-    init(categoryDetails: DiscoverCategoryDetails, sponsoredPodcastsIDs: Set<String> = []) {
+    init(categoryDetails: DiscoverCategoryDetails, sponsoredPodcastsIDs: Set<String> = [], listId: String?, region: String?) {
         self.categoryDetails = categoryDetails
         self.sponsoredPodcastsIDs = sponsoredPodcastsIDs
+        self.listId = listId
+        self.region = region
     }
 }
 
@@ -131,7 +137,7 @@ actor DiscoverManager {
 
     func loadDiscoverSection(sourceItem: DiscoverItem) async -> DiscoverSection {
         guard  let discoverLayout = await getLayout(), let source = sourceItem.source else {
-            return DiscoverSection(title: nil, podcasts: [], listId: sourceItem.listId(collection: nil))
+            return DiscoverSection(title: nil, podcasts: [], listId: sourceItem.listId(collection: nil), region: nil)
         }
         let regionCode = regionCode(for: discoverLayout)
         let regionSource = source.replacingOccurrences(of: discoverLayout.regionCodeToken, with: regionCode)
@@ -139,7 +145,7 @@ actor DiscoverManager {
         let podcastCollection = await discoverServerHandler.discoverPodcastCollection(source: regionSource, authenticated: sourceItem.authenticated)
         let listId = sourceItem.listId(collection: podcastCollection)
         guard var listOfPodcasts = podcastCollection?.podcasts else {
-            return DiscoverSection(title: podcastCollection?.title, podcasts: [], listId: listId)
+            return DiscoverSection(title: podcastCollection?.title, podcasts: [], listId: listId, region: nil)
         }
 
         let sponsoredPodcasts = await loadSponsoredPodcasts(item: sourceItem)
@@ -149,7 +155,7 @@ actor DiscoverManager {
             }
         }
 
-        return DiscoverSection(title: podcastCollection?.title, subtitle: podcastCollection?.subtitle, podcasts: listOfPodcasts, sponsoredPodcastsIDs: Set(sponsoredPodcasts.values.compactMap({$0.uuid})), listId: listId, dateTime: podcastCollection?.datetime)
+        return DiscoverSection(title: podcastCollection?.title, subtitle: podcastCollection?.subtitle, podcasts: listOfPodcasts, sponsoredPodcastsIDs: Set(sponsoredPodcasts.values.compactMap({$0.uuid})), listId: listId, dateTime: podcastCollection?.datetime, region: regionCode)
     }
 
     func findItem(of type: DiscoverType) async -> DiscoverItem? {
@@ -159,7 +165,7 @@ actor DiscoverManager {
 
     func loadDiscoverSection(type: DiscoverType) async -> DiscoverSection {
         guard let sourceItem = await findItem(of: type) else {
-            return DiscoverSection(title: nil, podcasts: [])
+            return DiscoverSection(title: nil, podcasts: [], region: nil)
         }
 
         return await loadDiscoverSection(sourceItem: sourceItem)
@@ -208,17 +214,20 @@ actor DiscoverManager {
         }
 
         var sponsoredUuids = Set<String>()
+        var listId: String?
         for item in discoverLayout.layout ?? [] {
             if item.categoryID == category.id,
                item.isSponsored == true,
                let source = item.source,
-               let podcasts = await discoverServerHandler.discoverPodcastCollection(source: source, authenticated: item.authenticated == true)?.podcasts {
+               let collection = await discoverServerHandler.discoverPodcastCollection(source: source, authenticated: item.authenticated == true),
+               let podcasts = collection.podcasts {
+                listId = item.listId(collection: collection)
                 details.podcasts?.append(contentsOf: podcasts)
                 sponsoredUuids = sponsoredUuids.union(Set(podcasts.compactMap({$0.uuid})))
             }
         }
 
-        return DiscoverCategorySection(categoryDetails: details, sponsoredPodcastsIDs: sponsoredUuids)
+        return DiscoverCategorySection(categoryDetails: details, sponsoredPodcastsIDs: sponsoredUuids, listId: listId, region: regionCode)
     }
 
     func loadSponsoredPodcasts(item: DiscoverItem) async -> [Int: DiscoverPodcast] {

--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -166,6 +166,12 @@ actor DiscoverManager {
             }
         }
 
+        for podcast in listOfPodcasts {
+            if let podcastUuid = podcast.uuid {
+                podcastListCache[podcastUuid] = listId
+            }
+        }
+
         return DiscoverSection(title: podcastCollection?.title, subtitle: podcastCollection?.subtitle, podcasts: listOfPodcasts, sponsoredPodcastsIDs: Set(sponsoredPodcasts.values.compactMap({$0.uuid})), listId: listId, dateTime: podcastCollection?.datetime, region: regionCode)
     }
 
@@ -240,12 +246,24 @@ actor DiscoverManager {
         for podcastUuid in sponsoredUuids {
             sponsoredPodcastsCache[podcastUuid] = listId
         }
+        if let podcasts = details.podcasts {
+            for podcast in podcasts {
+                if let podcastUuid = podcast.uuid {
+                    podcastListCache[podcastUuid] = listId
+                }
+            }
+        }
         return DiscoverCategorySection(categoryDetails: details, sponsoredPodcastsIDs: sponsoredUuids, listId: listId, region: regionCode)
     }
 
     private var sponsoredPodcastsCache: [String: String] = [:]
+    private var podcastListCache: [String: String] = [:]
 
     func listIdForPodcast(_ uuid: String) -> String? {
+        return podcastListCache[uuid]
+    }
+
+    func listIdForSponsoredPodcast(_ uuid: String) -> String? {
         return sponsoredPodcastsCache[uuid]
     }
 

--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -152,6 +152,17 @@ actor DiscoverManager {
         for position in Array(sponsoredPodcasts.keys).sorted() {
             if let podcast = sponsoredPodcasts[position] {
                 listOfPodcasts.insert(podcast, at: position)
+                if let uuid = podcast.uuid {
+                    sponsoredPodcastsCache[uuid] = listId
+                }
+            }
+        }
+
+        if sourceItem.isSponsored == true {
+            for podcast in listOfPodcasts {
+                if let uuid = podcast.uuid {
+                    sponsoredPodcastsCache[uuid] = listId
+                }
             }
         }
 
@@ -226,8 +237,16 @@ actor DiscoverManager {
                 sponsoredUuids = sponsoredUuids.union(Set(podcasts.compactMap({$0.uuid})))
             }
         }
-
+        for podcastUuid in sponsoredUuids {
+            sponsoredPodcastsCache[podcastUuid] = listId
+        }
         return DiscoverCategorySection(categoryDetails: details, sponsoredPodcastsIDs: sponsoredUuids, listId: listId, region: regionCode)
+    }
+
+    private var sponsoredPodcastsCache: [String: String] = [:]
+
+    func listIdForPodcast(_ uuid: String) -> String? {
+        return sponsoredPodcastsCache[uuid]
     }
 
     func loadSponsoredPodcasts(item: DiscoverItem) async -> [Int: DiscoverPodcast] {
@@ -269,7 +288,6 @@ actor DiscoverManager {
         guard let listOfEpisodes = podcastCollection?.episodes else {
             return DiscoverEpisodesSection(listId: listId)
         }
-
         return DiscoverEpisodesSection(title: podcastCollection?.title, subtitle: podcastCollection?.subtitle, episodes: listOfEpisodes, listId: listId)
     }
 

--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -36,7 +36,7 @@ struct DiscoverSection {
     let dateTime: String?
     let region: String?
 
-    init(title: String? = nil, subtitle: String? = nil, podcasts: [DiscoverPodcast] = [], sponsoredPodcastsIDs: Set<String> = [], listId: String? = nil, dateTime: String? = nil, region: String?) {
+    init(title: String? = nil, subtitle: String? = nil, podcasts: [DiscoverPodcast] = [], sponsoredPodcastsIDs: Set<String> = [], listId: String? = nil, dateTime: String? = nil, region: String? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.podcasts = podcasts
@@ -68,7 +68,7 @@ struct DiscoverCategorySection {
     let listId: String?
     let region: String?
 
-    init(categoryDetails: DiscoverCategoryDetails, sponsoredPodcastsIDs: Set<String> = [], listId: String?, region: String?) {
+    init(categoryDetails: DiscoverCategoryDetails, sponsoredPodcastsIDs: Set<String> = [], listId: String? = nil, region: String? = nil) {
         self.categoryDetails = categoryDetails
         self.sponsoredPodcastsIDs = sponsoredPodcastsIDs
         self.listId = listId
@@ -137,7 +137,7 @@ actor DiscoverManager {
 
     func loadDiscoverSection(sourceItem: DiscoverItem) async -> DiscoverSection {
         guard  let discoverLayout = await getLayout(), let source = sourceItem.source else {
-            return DiscoverSection(title: nil, podcasts: [], listId: sourceItem.listId(collection: nil), region: nil)
+            return DiscoverSection(title: nil, podcasts: [], listId: sourceItem.listId(collection: nil))
         }
         let regionCode = regionCode(for: discoverLayout)
         let regionSource = source.replacingOccurrences(of: discoverLayout.regionCodeToken, with: regionCode)
@@ -145,7 +145,7 @@ actor DiscoverManager {
         let podcastCollection = await discoverServerHandler.discoverPodcastCollection(source: regionSource, authenticated: sourceItem.authenticated)
         let listId = sourceItem.listId(collection: podcastCollection)
         guard var listOfPodcasts = podcastCollection?.podcasts else {
-            return DiscoverSection(title: podcastCollection?.title, podcasts: [], listId: listId, region: nil)
+            return DiscoverSection(title: podcastCollection?.title, podcasts: [], listId: listId)
         }
 
         let sponsoredPodcasts = await loadSponsoredPodcasts(item: sourceItem)
@@ -176,7 +176,7 @@ actor DiscoverManager {
 
     func loadDiscoverSection(type: DiscoverType) async -> DiscoverSection {
         guard let sourceItem = await findItem(of: type) else {
-            return DiscoverSection(title: nil, podcasts: [], region: nil)
+            return DiscoverSection(title: nil, podcasts: [])
         }
 
         return await loadDiscoverSection(sourceItem: sourceItem)

--- a/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
@@ -37,11 +37,6 @@ struct DiscoverAllView: View {
                 }
             }
         }
-        .navigationDestination(for: DiscoverPodcast.self) { podcast in
-            if let uuid = podcast.uuid {
-                PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid))
-            }
-        }
         .navigationDestination(for: DiscoverCategory.self) { discoverCategory in
             DiscoverPodcastsListView(category: discoverCategory)
         }

--- a/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverAllView.swift
@@ -38,7 +38,7 @@ struct DiscoverAllView: View {
             }
         }
         .navigationDestination(for: DiscoverCategory.self) { discoverCategory in
-            DiscoverPodcastsListView(category: discoverCategory)
+            DiscoverPodcastsListView(category: discoverCategory, source: DiscoverAnalytics.searchSource)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoriesRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoriesRow.swift
@@ -38,7 +38,7 @@ struct DiscoverCategoriesRow: View {
                 ForEach(Array(model.categories.enumerated()), id: \.element.id) { index, category in
                     if category.id != nil {
                         NavigationLink(value: category) {
-                            DiscoverCategoryCell(category: category, colorIndex: index)
+                            DiscoverCategoryCell(category: category, colorIndex: index, source: model.source)
                                 .frame(width: Layout.cellWidth, height: Layout.cellHeight)
                         }
                         .buttonStyle(.card)

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoryCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoryCell.swift
@@ -16,8 +16,8 @@ struct DiscoverCategoryCell: View {
         static let iconSize = CGFloat(48)
     }
 
-    init(category: DiscoverCategory, colorIndex: Int) {
-        _model = State(wrappedValue: DiscoverCategoryModel(category: category))
+    init(category: DiscoverCategory, colorIndex: Int, source: String) {
+        _model = State(wrappedValue: DiscoverCategoryModel(category: category, source: source))
         self.colorIndex = colorIndex
     }
 
@@ -89,7 +89,7 @@ struct DiscoverCategoryCell: View {
 }
 
 #Preview {
-    DiscoverCategoryCell(category: DiscoverCategory(id: 1, name: "True Crime"), colorIndex: 0)
+    DiscoverCategoryCell(category: DiscoverCategory(id: 1, name: "True Crime"), colorIndex: 0, source: DiscoverAnalytics.searchSource)
         .environment(AppCoordinator())
         .environment(MainTabViewModel())
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoryModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoryModel.swift
@@ -16,6 +16,8 @@ class DiscoverCategoryModel {
 
     var sponsoredPodcastsUuids: Set<String> = []
 
+    var listId: String?
+
     let sponsoredPosition: Int
 
     init(category: DiscoverCategory, discoverManager: DiscoverManager = DiscoverManager.shared, sponsoredPosition: Int = 5) {
@@ -46,6 +48,7 @@ class DiscoverCategoryModel {
             if let podcasts = categorySection?.categoryDetails.podcasts {
                 self.coverPodcastsUuids = podcasts.compactMap { $0.uuid }
             }
+            self.listId = categorySection?.listId
         }
     }
 
@@ -65,5 +68,17 @@ class DiscoverCategoryModel {
             return false
         }
         return sponsoredPodcastsUuids.contains(uuid)
+    }
+
+    func trackPodcastTapped(_ podcast: DiscoverPodcast) {
+        guard let podcastUuid = podcast.uuid else { return }
+
+        if let listId {
+            DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, dateTime: nil, source: "discover")
+        }
+
+        if isSponsored(podcast: podcast) {
+            DiscoverAnalytics.adTapped(categoryName: category.name, region: categorySection?.region, podcastUUID: podcastUuid, categoryID: category.id)
+        }
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverCategoryModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverCategoryModel.swift
@@ -16,12 +16,15 @@ class DiscoverCategoryModel {
 
     var sponsoredPodcastsUuids: Set<String> = []
 
+    var source: String
+
     var listId: String?
 
     let sponsoredPosition: Int
 
-    init(category: DiscoverCategory, discoverManager: DiscoverManager = DiscoverManager.shared, sponsoredPosition: Int = 5) {
+    init(category: DiscoverCategory, source: String, discoverManager: DiscoverManager = DiscoverManager.shared, sponsoredPosition: Int = 5) {
         self.category = category
+        self.source = source
         self.discoverManager = discoverManager
         self.sponsoredPosition = sponsoredPosition
     }
@@ -74,7 +77,7 @@ class DiscoverCategoryModel {
         guard let podcastUuid = podcast.uuid else { return }
 
         if let listId {
-            DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, dateTime: nil, source: "discover")
+            DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, dateTime: nil, source: source)
         }
 
         if isSponsored(podcast: podcast) {

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
@@ -87,9 +87,14 @@ struct DiscoverFeaturedPodcastCell: View {
                             Text(L10n.tvDiscoverFeaturedGoToPodcast)
                         }
                         .simultaneousGesture(TapGesture().onEnded {
-                            if let listId, let podcastUuid = podcast.uuid {
+                            guard let podcastUuid = podcast.uuid else {
+                                return
+                            }
+                            if let listId {
                                 DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, source: source)
                             }
+                            Analytics.track(.discoverFeaturedPodcastTapped, properties: ["uuid": podcastUuid])
+                            AnalyticsHelper.openedFeaturedPodcast()
                         })
                         .focused($focusedButton, equals: FocusValues.goPodcast)
                     }

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
@@ -95,6 +95,7 @@ struct DiscoverFeaturedPodcastCell: View {
                             }
                             Analytics.track(.discoverFeaturedPodcastTapped, properties: ["uuid": podcastUuid])
                             AnalyticsHelper.openedFeaturedPodcast()
+                            DiscoverAnalytics.currentFeaturedPodcast = podcastUuid
                         })
                         .focused($focusedButton, equals: FocusValues.goPodcast)
                     }

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
@@ -71,6 +71,9 @@ struct DiscoverPodcastsListView: View {
                     DiscoverPodcastCell(podcastUuid: podcast.uuid ?? "", isSponsored: model.isSponsored(podcast: podcast))
                 }
                 .buttonStyle(.card)
+                .simultaneousGesture(TapGesture().onEnded {
+                    model.trackPodcastTapped(podcast)
+                })
             }
         }
     }

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastsListView.swift
@@ -12,8 +12,8 @@ struct DiscoverPodcastsListView: View {
 
     @State private var model: DiscoverCategoryModel
 
-    init(category: DiscoverCategory) {
-        _model = State(wrappedValue: DiscoverCategoryModel(category: category))
+    init(category: DiscoverCategory, source: String) {
+        _model = State(wrappedValue: DiscoverCategoryModel(category: category, source: source))
     }
 
     let gridColumns: [GridItem] = (0..<6).map { _ in
@@ -80,7 +80,7 @@ struct DiscoverPodcastsListView: View {
 }
 
 #Preview {
-    DiscoverPodcastsListView(category: DiscoverCategory(id: 1, name: "A"))
+    DiscoverPodcastsListView(category: DiscoverCategory(id: 1, name: "A"), source: DiscoverAnalytics.homeSource)
         .environment(AppCoordinator())
         .environment(MainTabViewModel())
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverSectionModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSectionModel.swift
@@ -6,6 +6,8 @@ class DiscoverSectionModel {
 
     var state: State = .loading
 
+    private var section: DiscoverSection?
+
     var podcasts = [DiscoverPodcast]()
 
     var sponsored = Set<String>()
@@ -57,6 +59,7 @@ class DiscoverSectionModel {
         }
 
         await MainActor.run {
+            self.section = section
             state = section.podcasts.isEmpty ? .empty : .ready
             podcasts = section.podcasts
             var composedTitle = section.title?.localized ?? ""
@@ -80,6 +83,10 @@ class DiscoverSectionModel {
     func trackPodcastTapped(_ podcast: DiscoverPodcast) {
         guard let listId, let podcastUuid = podcast.uuid else { return }
         DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, dateTime: dateTime, source: source)
+
+        if isSponsored {
+            DiscoverAnalytics.adTapped(categoryName: "unknown", region: section?.region, podcastUUID: podcastUuid, categoryID: item?.categoryID)
+        }
     }
 
     var focusStoreID: String {

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -98,7 +98,7 @@ struct HomeView: View {
                 }
             }
             .navigationDestination(for: DiscoverCategory.self) { discoverCategory in
-                DiscoverPodcastsListView(category: discoverCategory)
+                DiscoverPodcastsListView(category: discoverCategory, source: DiscoverAnalytics.homeSource)
             }
             .navigationDestination(for: Podcast.self) { podcast in
                 PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: podcast.uuid))

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -94,7 +94,7 @@ struct HomeView: View {
             }
             .navigationDestination(for: DiscoverPodcast.self) { podcast in
                 if let uuid = podcast.uuid {
-                    PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid))
+                    PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid, isDiscovery: true))
                 }
             }
             .navigationDestination(for: DiscoverCategory.self) { discoverCategory in

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -94,7 +94,7 @@ struct HomeView: View {
             }
             .navigationDestination(for: DiscoverPodcast.self) { podcast in
                 if let uuid = podcast.uuid {
-                    PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid, isDiscovery: true))
+                    PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid, isDiscover: true))
                 }
             }
             .navigationDestination(for: DiscoverCategory.self) { discoverCategory in

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -15,15 +15,17 @@ class EpisodeRowViewModel: Identifiable {
     var podcast: Podcast?
     var progress: Double
     var id: String { episode.uuid }
+    var isDiscover: Bool
 
     private var cancellables: Set<AnyCancellable> = []
     private let playbackManager: PlaybackManager
 
-    init(episode: BaseEpisode, podcast: Podcast?, playbackManager: PlaybackManager = PlaybackManager.shared) {
+    init(episode: BaseEpisode, podcast: Podcast?, isDiscover: Bool = false, playbackManager: PlaybackManager = PlaybackManager.shared) {
         self.episode = episode
         self.podcast = podcast
         self.playbackManager = playbackManager
         self.progress = 0
+        self.isDiscover = isDiscover
         setupObservers()
         self.progress = calculateSafeProgress(from: episode)
     }
@@ -81,7 +83,7 @@ class EpisodeRowViewModel: Identifiable {
     func play() {
         guard !playbackManager.isActivelyPlaying(episodeUuid: episode.uuid) else { return }
         PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
-        if let podcastUuid {
+        if isDiscover, let podcastUuid {
             DiscoverAnalytics.discoverPodcastPlayed(podcastUuid: podcastUuid)
         }
     }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -81,6 +81,9 @@ class EpisodeRowViewModel: Identifiable {
     func play() {
         guard !playbackManager.isActivelyPlaying(episodeUuid: episode.uuid) else { return }
         PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
+        if let podcastUuid {
+            DiscoverAnalytics.discoverPodcastPlayed(podcastUuid: podcastUuid)
+        }
     }
 
     func playNext() {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -94,7 +94,7 @@ class PodcastDetailViewModel {
                 return
             }
             let allEpisodes = dataManager.fetchEpisodes(podcast: podcast, includeArchived: showArchived).map {
-                EpisodeRowViewModel(episode: $0, podcast: podcast)
+                EpisodeRowViewModel(episode: $0, podcast: podcast, isDiscover: isDiscovery)
             }
             await MainActor.run {
                 self.podcast = podcast

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -27,6 +27,7 @@ class PodcastDetailViewModel {
     var isFollowing: Bool = false
     var showArchived: Bool = false
     var sortOrder: PodcastEpisodeSortOrder = .newestToOldest
+    var isDiscovery: Bool
 
     private static func archiveStorageKey(for podcastUuid: String) -> String {
         "showArchived_podcast_\(podcastUuid)"
@@ -57,6 +58,7 @@ class PodcastDetailViewModel {
     }
 
     init(podcastUuid: String,
+         isDiscovery: Bool = false,
          dataManager: TVDataManager = TVDataManager.shared,
          serverPodcastManager: ServerPodcastManager = ServerPodcastManager.shared,
          podcastManager: PodcastManager = PodcastManager.shared) {
@@ -65,6 +67,7 @@ class PodcastDetailViewModel {
         self.serverPodcastManager = serverPodcastManager
         self.podcastManager = podcastManager
         self.showArchived = UserDefaults.standard.bool(forKey: Self.archiveStorageKey(for: podcastUuid))
+        self.isDiscovery = isDiscovery
         setupObservers()
     }
 
@@ -73,6 +76,7 @@ class PodcastDetailViewModel {
                      serverPodcastManager: ServerPodcastManager = ServerPodcastManager.shared,
                      podcastManager: PodcastManager = PodcastManager.shared) {
         self.init(podcastUuid: podcast.uuid,
+                  isDiscovery: false,
                   dataManager: dataManager,
                   serverPodcastManager: serverPodcastManager,
                   podcastManager: podcastManager)
@@ -107,7 +111,9 @@ class PodcastDetailViewModel {
         guard let podcast else { return }
         Analytics.track(.podcastScreenSubscribeTapped)
         Analytics.track(.podcastSubscribed, properties: ["source": "podcast_screen", "uuid": podcast.uuid])
-        DiscoverAnalytics.discoverPodcastSubscribed(podcastUuid: podcast.uuid)
+        if isDiscovery {
+            DiscoverAnalytics.discoverPodcastSubscribed(podcastUuid: podcast.uuid)
+        }
         isFollowing = true
         serverPodcastManager.subscribe(to: podcast.uuid, completion: nil)
     }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -107,6 +107,7 @@ class PodcastDetailViewModel {
         guard let podcast else { return }
         Analytics.track(.podcastScreenSubscribeTapped)
         Analytics.track(.podcastSubscribed, properties: ["source": "podcast_screen", "uuid": podcast.uuid])
+        DiscoverAnalytics.discoverPodcastSubscribed(podcastUuid: podcast.uuid)
         isFollowing = true
         serverPodcastManager.subscribe(to: podcast.uuid, completion: nil)
     }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -27,7 +27,7 @@ class PodcastDetailViewModel {
     var isFollowing: Bool = false
     var showArchived: Bool = false
     var sortOrder: PodcastEpisodeSortOrder = .newestToOldest
-    var isDiscovery: Bool
+    var isDiscover: Bool
 
     private static func archiveStorageKey(for podcastUuid: String) -> String {
         "showArchived_podcast_\(podcastUuid)"
@@ -58,7 +58,7 @@ class PodcastDetailViewModel {
     }
 
     init(podcastUuid: String,
-         isDiscovery: Bool = false,
+         isDiscover: Bool = false,
          dataManager: TVDataManager = TVDataManager.shared,
          serverPodcastManager: ServerPodcastManager = ServerPodcastManager.shared,
          podcastManager: PodcastManager = PodcastManager.shared) {
@@ -67,7 +67,7 @@ class PodcastDetailViewModel {
         self.serverPodcastManager = serverPodcastManager
         self.podcastManager = podcastManager
         self.showArchived = UserDefaults.standard.bool(forKey: Self.archiveStorageKey(for: podcastUuid))
-        self.isDiscovery = isDiscovery
+        self.isDiscover = isDiscover
         setupObservers()
     }
 
@@ -76,7 +76,7 @@ class PodcastDetailViewModel {
                      serverPodcastManager: ServerPodcastManager = ServerPodcastManager.shared,
                      podcastManager: PodcastManager = PodcastManager.shared) {
         self.init(podcastUuid: podcast.uuid,
-                  isDiscovery: false,
+                  isDiscover: false,
                   dataManager: dataManager,
                   serverPodcastManager: serverPodcastManager,
                   podcastManager: podcastManager)
@@ -94,7 +94,7 @@ class PodcastDetailViewModel {
                 return
             }
             let allEpisodes = dataManager.fetchEpisodes(podcast: podcast, includeArchived: showArchived).map {
-                EpisodeRowViewModel(episode: $0, podcast: podcast, isDiscover: isDiscovery)
+                EpisodeRowViewModel(episode: $0, podcast: podcast, isDiscover: isDiscover)
             }
             await MainActor.run {
                 self.podcast = podcast
@@ -111,7 +111,7 @@ class PodcastDetailViewModel {
         guard let podcast else { return }
         Analytics.track(.podcastScreenSubscribeTapped)
         Analytics.track(.podcastSubscribed, properties: ["source": "podcast_screen", "uuid": podcast.uuid])
-        if isDiscovery {
+        if isDiscover {
             DiscoverAnalytics.discoverPodcastSubscribed(podcastUuid: podcast.uuid)
         }
         isFollowing = true

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -55,7 +55,7 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
         }
         .navigationDestination(for: DiscoverPodcast.self) { podcast in
             if let uuid = podcast.uuid {
-                PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid))
+                PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid, isDiscovery: true))
             }
         }
         .animation(.easeInOut, value: model.state)

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -55,7 +55,7 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
         }
         .navigationDestination(for: DiscoverPodcast.self) { podcast in
             if let uuid = podcast.uuid {
-                PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid, isDiscovery: true))
+                PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: uuid, isDiscover: true))
             }
         }
         .animation(.easeInOut, value: model.state)


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

Adds Discover analytics for the **tvOS** app, focused on sponsored podcasts. tvOS has no dedicated Discover screen and no `AnalyticsSourceProvider`, so these events reuse the iOS `discover_list_*` / ad event names and attribute a source ("home" / "search").

### What changed
- **Ad tap tracking** — fires `adTapped` (category name, region, podcast UUID, category ID) when a sponsored podcast is tapped, from both home/search sections (`DiscoverSectionModel`) and category lists (`DiscoverCategoryModel`).
- **List attribution for sponsored podcasts** — `DiscoverManager` now keeps a `sponsoredPodcastsCache` (podcast UUID → `listId`) populated when sponsored sections/categories load, plus `region`/`listId` on the section models. `listIdForPodcast(_:)` lets the detail screen recover the originating list.
- **Subscribe / play from Discover** — `PodcastDetailViewModel` and `EpisodeRowViewModel` carry an `isDiscover` flag (set when navigating from Home/Search Discover) and fire `podcastSubscribedFromList` / `podcastEpisodePlayedFromList` using the cached `listId`.
- **Navigation cleanup** — removed the duplicate `.navigationDestination(for: DiscoverPodcast.self)` in `DiscoverAllView`; the enclosing `SearchResultsView` already provides it (and now passes `isDiscover: true`), which also avoids SwiftUI's duplicate-destination warning.
- **`simplify` commit** — defaulted the new `region:`/`listId:` init params to `nil` to drop redundant `region: nil` call sites, and removed an unused `import SwiftUI`.

## To test
1. On tvOS, open the **Home** tab (or **Search** with no query) so Discover content loads.
2. Tap a sponsored podcast in a section or category → verify an `ad_tapped` event with category/region/uuid.
3. From a Discover podcast's detail screen, subscribe and play an episode → verify `podcast_subscribed_from_list` / `podcast_episode_played_from_list` fire with the correct `list_id`.

## Notes for reviewers
- Targets `release/8.16`; changes are scoped to `Pocket Casts TV App/` only.
- **Known scope decision:** subscribe/play "from-list" attribution currently fires only for *sponsored* podcasts (the cache is sponsored-only), while tap-from-list fires for all Discover podcasts. If non-sponsored Discover podcasts should also get subscribe/play attribution, that would need the section `listId` threaded in rather than the cache.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I [have updated ](https://github.com/Automattic/EventHorizonSchemas/pull/106)(or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
