### PR TITLE
Always animate the mini player buffering shimmer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 8.17
 -----
 - Fix player opening on Bookmarks tab in RTL languages [#4696](https://github.com/Automattic/pocket-casts-ios/pull/4696)
+- Fix the mini player initial loading shimmer not showing up when Reduce Motion is enabled [#4713](https://github.com/Automattic/pocket-casts-ios/pull/4713)
 
 8.16
 -----

--- a/podcasts/MiniPlayerGlassProgressView.swift
+++ b/podcasts/MiniPlayerGlassProgressView.swift
@@ -21,7 +21,7 @@ final class MiniPlayerGlassProgressView: UIView {
             guard indeterminate != oldValue else { return }
             updateBufferVisibility()
             indeterminateLayer.isHidden = !indeterminate
-            if indeterminate, !UIAccessibility.isReduceMotionEnabled {
+            if indeterminate {
                 startIndeterminateAnimation()
             } else {
                 indeterminateLayer.removeAllAnimations()


### PR DESCRIPTION
The indeterminate buffering shimmer on the Liquid Glass mini player progress bar was suppressed in the `indeterminate` property observer when Reduce Motion was enabled. However, `layoutSubviews` restarts the same animation unconditionally, so the shimmer would still appear (just inconsistently, e.g. after a relayout). This removes the Reduce Motion guard so the buffering indicator animates consistently and always reflects playback state.

We don't want the indeterminate progress doing nothing when motion is reduced. I think it was Copilot overstepping a bit with its suggestions.

## To test

1. Start playing an episode that needs to buffer (or throttle your connection) so the mini player shows the indeterminate buffering state.
2. Confirm the shimmer animates across the progress bar.
3. Repeat with **Settings → Accessibility → Motion → Reduce Motion** enabled and confirm the buffering shimmer still animates consistently.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
