### PR TITLE
Load episode details show notes and artwork earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix Up Next multi-select keeping episodes selected after they leave the queue, causing a wrong count and bulk actions on episodes no longer queued [#4709](https://github.com/Automattic/pocket-casts-ios/pull/4709)
 - Fix the Help & Feedback screen following the system/in-app dark theme and using incorrect colors in the navigation bar [#4698](https://github.com/Automattic/pocket-casts-ios/pull/4698)
 - Add support for Flightcast JSON transcripts [#4706](https://github.com/Automattic/pocket-casts-ios/pull/4706)
+- Episode details loads show notes and artwork a little bit faster [#4714](https://github.com/Automattic/pocket-casts-ios/pull/4714)
 - Fix player opening on Bookmarks tab in RTL languages [#4696](https://github.com/Automattic/pocket-casts-ios/pull/4696)
 - Fix Add to Playlist dropping selections made while searching [#4712](https://github.com/Automattic/pocket-casts-ios/pull/4712)
 - Fix the Discover search screen background color and colors in filters on some themes [#4719](https://github.com/Automattic/pocket-casts-ios/pull/4719)

--- a/podcasts/Episode/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+ShowNotes.swift
@@ -33,6 +33,7 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
 
     func loadShowNotes() {
         if downloadingShowNotes { return }
+        downloadingShowNotes = true
 
         loadingIndicator.startAnimating()
         hideErrorMessage(hide: true)

--- a/podcasts/Episode/EpisodeDetailViewController.swift
+++ b/podcasts/Episode/EpisodeDetailViewController.swift
@@ -252,13 +252,13 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
 
         updateDisplayedData()
         updateColors()
+
+        loadShowNotes()
+        loadEpisodeArtwork()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
-        loadShowNotes()
-        loadEpisodeArtwork()
 
         bookmarksController.view.isHidden = false
 


### PR DESCRIPTION
Moves show notes and episode artwork loading from `viewDidAppear` to `viewWillAppear` so they start loading before the view is on screen and appear a little sooner.

Also fixes the `downloadingShowNotes` re-entrancy guard, which was checked but never actually set to `true`. Because the guard was dead, repeated/overlapping `loadShowNotes()` calls each re-ran the transcript branch and added a new `ThemedHostingController` without removing the previous one, stacking duplicate transcript excerpt views and leaking child view controllers. Setting the guard at load start makes moving the load into `viewWillAppear` (which can fire more than once) safe.

## To test

1. Open an episode details page for an episode that has show notes and a transcript.
2. Confirm show notes and artwork appear as the screen transitions in.
3. Navigate away and back, and tap "Try Again" a few times — confirm only a single transcript excerpt is shown (no stacked duplicates).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.