### PR TITLE
Load podcasts earlier in PodcastListViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 8.18
 -----
-
+- Load the podcasts grid earlier so it's populated by the time the tab is shown [#4715](https://github.com/Automattic/pocket-casts-ios/pull/4715)
 
 8.17
 -----

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -43,6 +43,10 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     var isEditingOrder = false
     var savedRightBarButtonItem: UIBarButtonItem?
 
+    /// The initial grid load is kicked off in viewDidLoad; this lets the first viewDidAppear skip
+    /// its redundant refresh so we don't run the (potentially expensive) badge queries twice at launch.
+    private var didLoadInitialGridItems = false
+
     private var lastWillLayoutWidth: CGFloat = 0
 
     /// Gap below the grid (as a fraction of the bottom safe area) so its last content clears
@@ -104,13 +108,24 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
 
         adjustSettingsForGridType()
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: podcastsCollectionView)
+
+        refreshGridItems()
+        didLoadInitialGridItems = true
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
         updateInsets()
-        refreshGridItems()
+
+        // The initial load already ran in viewDidLoad; skip the first redundant refresh but keep
+        // refreshing on every subsequent appearance so returning to the tab reflects changes.
+        if didLoadInitialGridItems {
+            didLoadInitialGridItems = false
+        } else {
+            refreshGridItems()
+        }
+
         addEventObservers()
         updateNavigationButtons()
 


### PR DESCRIPTION
The podcasts grid was only loaded in `viewDidAppear`, which fires after the appearance transition completes — leaving a brief empty-grid flash on launch/tab-switch until the async fetch lands. It makes a big difference when opening the app especially when the previous tab wasn't home.

This kicks off the initial load in `viewDidLoad` instead, so the background DB fetch overlaps with layout / the appearance transition and the grid is populated by the time the view is shown. A one-shot flag makes the first `viewDidAppear` skip its now-redundant refresh so the (potentially expensive) badge queries don't run twice at launch; subsequent appearances still refresh so returning to the tab reflects changes.

## To test

1. Cold-launch the app with the Podcasts tab selected.
2. Confirm the grid appears populated with no empty-grid flash.
3. Switch to another tab and back to Podcasts — the grid still updates to reflect any changes.
4. Add/remove a podcast (or complete a sync) while on the Podcasts tab and confirm the grid refreshes.
5. Verify badges (Unplayed / Latest episode) still display correctly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
