### PR TITLE
Avoid duplicate player tracking events on TV app

### DIFF
--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -194,8 +194,7 @@ class AppCoordinator {
         UserDefaults.standard.synchronize()
     }
 
-    func remotePlayPauseToggle() {
-        PlaybackManager.shared.remotePlayPauseToggle()
-        AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction = .now
-    }
+func remotePlayPauseToggle() {
+    AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction = .now
+    PlaybackManager.shared.remotePlayPauseToggle()
 }

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -194,7 +194,8 @@ class AppCoordinator {
         UserDefaults.standard.synchronize()
     }
 
-func remotePlayPauseToggle() {
-    AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction = .now
-    PlaybackManager.shared.remotePlayPauseToggle()
+    func remotePlayPauseToggle() {
+        AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction = .now
+        PlaybackManager.shared.remotePlayPauseToggle()
+    }
 }

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -196,5 +196,6 @@ class AppCoordinator {
 
     func remotePlayPauseToggle() {
         PlaybackManager.shared.remotePlayPauseToggle()
+        AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction = .now
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
@@ -72,6 +72,7 @@ struct DiscoverFeaturedPodcastCell: View {
                     HStack(spacing: 24) {
                         Button(L10n.tvDiscoverFeaturedPlayLatestEpisode) {
                             Task {
+                                AnalyticsPlaybackHelper.shared.currentSource = .discover
                                 let successPlay = await TVDataManager.shared.playLatestEpisode(of: podcast)
                                 await MainActor.run {
                                     if successPlay {

--- a/Pocket Casts TV App/UI/History/ListeningHistoryViewModel.swift
+++ b/Pocket Casts TV App/UI/History/ListeningHistoryViewModel.swift
@@ -39,7 +39,7 @@ class ListeningHistoryViewModel {
 
     nonisolated private func loadEpisodeViewModels(using dataManager: DataManager) -> [EpisodeRowViewModel] {
         dataManager.fetchHistoryEpisodes().map { episode in
-            EpisodeRowViewModel(episode: episode, podcast: episode.parentPodcast(dataManager: dataManager))
+            EpisodeRowViewModel(episode: episode, podcast: episode.parentPodcast(dataManager: dataManager), source: .listeningHistory)
         }
     }
 

--- a/Pocket Casts TV App/UI/Home/HomeViewModel.swift
+++ b/Pocket Casts TV App/UI/Home/HomeViewModel.swift
@@ -60,7 +60,7 @@ class HomeViewModel {
 
     private func makeRowViewModel(for episode: BaseEpisode) -> EpisodeRowViewModel {
         let podcast = (episode as? Episode).flatMap { $0.parentPodcast(dataManager: dataManager) }
-        return EpisodeRowViewModel(episode: episode, podcast: podcast)
+        return EpisodeRowViewModel(episode: episode, podcast: podcast, source: .home)
     }
 
     private func observeDataChanges() {

--- a/Pocket Casts TV App/UI/Player/EpisodePlayerButton.swift
+++ b/Pocket Casts TV App/UI/Player/EpisodePlayerButton.swift
@@ -21,5 +21,5 @@ struct EpisodePlayerButton: View {
 }
 
 #Preview {
-    EpisodePlayerButton(model: EpisodeRowViewModel(episode: MockData.makeStubEpisodes().first!, podcast: MockData.makeStubPodcasts().first!))
+    EpisodePlayerButton(model: EpisodeRowViewModel(episode: MockData.makeStubEpisodes().first!, podcast: MockData.makeStubPodcasts().first!, source: .unknown))
 }

--- a/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingRow.swift
@@ -71,7 +71,7 @@ private struct NowPlayingRowLabel: View {
 
 
 #Preview {
-    NowPlayingRow(model: EpisodeRowViewModel(episode: MockData.makeStubEpisodes().first!, podcast: MockData.makeStubPodcasts().first!))
+    NowPlayingRow(model: EpisodeRowViewModel(episode: MockData.makeStubEpisodes().first!, podcast: MockData.makeStubPodcasts().first!, source: .unknown))
     .environment(AppCoordinator())
     .environment(MainTabViewModel())
 }

--- a/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
@@ -16,7 +16,6 @@ struct NowPlayingTab: View {
             }
             .animation(.easeIn, value: isFocused)
             .onAppear {
-                Analytics.track(.playerShown)
                 //This is to force the player to load the current episode
                 if !PlaybackManager.shared.playing(), !PlaybackManager.shared.isReadyToPlay() {
                     PlaybackManager.shared.loadCurrentEpisode()

--- a/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
@@ -18,14 +18,8 @@ struct NowPlayingTab: View {
             .onAppear {
                 Analytics.track(.playerShown)
                 //This is to force the player to load the current episode
-                if !PlaybackManager.shared.playing() {
-                    DispatchQueue.main.async {
-                        PlaybackManager.shared.play(completion: {
-                            DispatchQueue.main.async {
-                                PlaybackManager.shared.pause(userInitiated: false)
-                            }
-                        }, userInitiated: false)
-                    }
+                if !PlaybackManager.shared.playing(), !PlaybackManager.shared.isReadyToPlay() {
+                    PlaybackManager.shared.loadCurrentEpisode()
                 }
             }
             .toolbar(!isFocused ? .visible : .hidden, for: .tabBar)

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -20,6 +20,7 @@ struct NowPlayingView: View {
         )
         .onAppear {
             model.load()
+            Analytics.track(.playerShown)
         }
         .requireAccountSupport()
         .sheet(isPresented: $isShowingDescription) {

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -22,6 +22,9 @@ struct NowPlayingView: View {
             model.load()
             Analytics.track(.playerShown)
         }
+        .onDisappear {
+            Analytics.track(.playerDismissed)
+        }
         .requireAccountSupport()
         .sheet(isPresented: $isShowingDescription) {
             if let episode = model.episode {

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -68,10 +68,10 @@ class NowPlayingViewModel: Identifiable {
             return
         }
 
+        PlayerStatusAnalytics.shared.observe(player: player)
         timeControlStatusObservation = player.observe(\.timeControlStatus, options: [.new, .initial]) { [weak self] _, _ in
             Task { @MainActor [weak self] in
                 self?.updateLoadingState()
-                self?.updatePlayState()
             }
         }
 
@@ -92,46 +92,6 @@ class NowPlayingViewModel: Identifiable {
             Task { @MainActor [weak self] in
                 self?.updateLoadingState()
             }
-        }
-    }
-
-    private var previousTimeStatus: AVPlayer.TimeControlStatus?
-
-    private func updatePlayState() {
-        guard let player else {
-            return
-        }
-        let currentTimeStatus = player.timeControlStatus
-        if previousTimeStatus == nil {
-            //ignore first change on load, or changes that are not coming from play/pause
-            previousTimeStatus = currentTimeStatus
-            return
-        }
-
-        guard previousTimeStatus != currentTimeStatus, previousTimeStatus == .paused || previousTimeStatus == .playing else {
-            previousTimeStatus = currentTimeStatus
-            return
-        }
-        previousTimeStatus = currentTimeStatus
-
-        if let interval = AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction?.timeIntervalSinceNow,
-             abs(interval) < 1 {
-            // Do not need to track playback changes made by remote just now
-            AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction = nil
-            return
-        }
-
-        switch currentTimeStatus {
-        case .playing:
-            AnalyticsPlaybackHelper.shared.currentSource = .player
-            AnalyticsPlaybackHelper.shared.play()
-        case .paused:
-            AnalyticsPlaybackHelper.shared.currentSource = .player
-            AnalyticsPlaybackHelper.shared.pause()
-        case .waitingToPlayAtSpecifiedRate:
-            break
-        @unknown default:
-            break
         }
     }
 

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -108,10 +108,14 @@ class NowPlayingViewModel: Identifiable {
             return
         }
         previousTimeStatus = currentTimeStatus
-        guard AnalyticsPlaybackHelper.shared.currentSource != .nowPlayingWidget else {
-            // Do not need to track changes made by remote
+
+        if let interval = AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction?.timeIntervalSinceNow,
+             abs(interval) < 1 {
+            // Do not need to track playback changes made by remote just now
+            AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction = nil
             return
         }
+
         switch currentTimeStatus {
         case .playing:
             AnalyticsPlaybackHelper.shared.currentSource = .player

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -99,10 +99,19 @@ class NowPlayingViewModel: Identifiable {
             return
         }
         let currentTimeStatus = player.timeControlStatus
+        if previousTimeStatus == nil {
+            //ignore first change on load
+            previousTimeStatus = currentTimeStatus
+            return
+        }
         guard previousTimeStatus != currentTimeStatus else {
             return
         }
         previousTimeStatus = currentTimeStatus
+        guard AnalyticsPlaybackHelper.shared.currentSource != .nowPlayingWidget else {
+            // Do not need to track changes made by remote
+            return
+        }
         switch currentTimeStatus {
         case .playing:
             AnalyticsPlaybackHelper.shared.currentSource = .player

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -100,11 +100,13 @@ class NowPlayingViewModel: Identifiable {
         }
         let currentTimeStatus = player.timeControlStatus
         if previousTimeStatus == nil {
-            //ignore first change on load
+            //ignore first change on load, or changes that are not coming from play/pause
             previousTimeStatus = currentTimeStatus
             return
         }
-        guard previousTimeStatus != currentTimeStatus else {
+
+        guard previousTimeStatus != currentTimeStatus, previousTimeStatus == .paused || previousTimeStatus == .playing else {
+            previousTimeStatus = currentTimeStatus
             return
         }
         previousTimeStatus = currentTimeStatus

--- a/Pocket Casts TV App/UI/Player/PlayerStatusAnalytics.swift
+++ b/Pocket Casts TV App/UI/Player/PlayerStatusAnalytics.swift
@@ -1,0 +1,71 @@
+import Swift
+import AVFoundation
+
+class PlayerStatusAnalytics {
+
+    static let shared = {
+       return PlayerStatusAnalytics()
+    }()
+
+    private var player: AVPlayer?
+    private var timeControlStatusObservation: NSKeyValueObservation?
+    private var previousTimeStatus: AVPlayer.TimeControlStatus?
+
+    private init() {
+    }
+
+    deinit {
+        timeControlStatusObservation?.invalidate()
+    }
+
+    func observe(player: AVPlayer) {
+        guard self.player != player else {
+            return
+        }
+        timeControlStatusObservation?.invalidate()
+        self.player = player
+        timeControlStatusObservation = player.observe(\.timeControlStatus, options: [.new, .initial]) { [weak self] _, _ in
+            Task { @MainActor [weak self] in
+                self?.updatePlayState()
+            }
+        }
+    }
+
+    private func updatePlayState() {
+        guard let player else {
+            return
+        }
+        let currentTimeStatus = player.timeControlStatus
+        if previousTimeStatus == nil {
+            //ignore first change on load, or changes that are not coming from play/pause
+            previousTimeStatus = currentTimeStatus
+            return
+        }
+
+        guard previousTimeStatus != currentTimeStatus, previousTimeStatus == .paused || previousTimeStatus == .playing else {
+            previousTimeStatus = currentTimeStatus
+            return
+        }
+        previousTimeStatus = currentTimeStatus
+
+        if let interval = AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction?.timeIntervalSinceNow,
+             abs(interval) < 1 {
+            // Do not need to track playback changes made by remote just now
+            AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction = nil
+            return
+        }
+
+        switch currentTimeStatus {
+        case .playing:
+            AnalyticsPlaybackHelper.shared.currentSource = .player
+            AnalyticsPlaybackHelper.shared.play()
+        case .paused:
+            AnalyticsPlaybackHelper.shared.currentSource = .player
+            AnalyticsPlaybackHelper.shared.pause()
+        case .waitingToPlayAtSpecifiedRate:
+            break
+        @unknown default:
+            break
+        }
+    }
+}

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -212,7 +212,7 @@ struct PlaylistDetailView: View {
         List {
             Section {
                 ForEach(model.episodes, id: \.uuid) { episode in
-                    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: episode, podcast: nil), context: .other(showGoToPodcast: true), focus: $rowFocus, detailsDismissed: {
+                    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: episode, podcast: nil, source: .filters), context: .other(showGoToPodcast: true), focus: $rowFocus, detailsDismissed: {
                         currentFocus = lastFocus
                     })
                     .focused($currentFocus, equals: episode.uuid)

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -391,7 +391,7 @@ extension View {
 
 #Preview {
     @Previewable @FocusState var focus: EpisodeRowFocus?
-    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: MockData.makeStubEpisodes().first!, podcast: MockData.makeStubPodcasts().first!), focus: $focus)
+    EpisodeRowWithActions(model: EpisodeRowViewModel(episode: MockData.makeStubEpisodes().first!, podcast: MockData.makeStubPodcasts().first!, source: .unknown), focus: $focus)
     .environment(AppCoordinator())
     .environment(MainTabViewModel())
 }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -15,13 +15,15 @@ class EpisodeRowViewModel: Identifiable {
     var podcast: Podcast?
     var progress: Double
     var id: String { episode.uuid }
+    var source: AnalyticsSource
 
     private var cancellables: Set<AnyCancellable> = []
     private let playbackManager: PlaybackManager
 
-    init(episode: BaseEpisode, podcast: Podcast?, playbackManager: PlaybackManager = PlaybackManager.shared) {
+    init(episode: BaseEpisode, podcast: Podcast?, source: AnalyticsSource, playbackManager: PlaybackManager = PlaybackManager.shared) {
         self.episode = episode
         self.podcast = podcast
+        self.source = source
         self.playbackManager = playbackManager
         self.progress = 0
         setupObservers()
@@ -80,6 +82,7 @@ class EpisodeRowViewModel: Identifiable {
 
     func play() {
         guard !playbackManager.isActivelyPlaying(episodeUuid: episode.uuid) else { return }
+        AnalyticsPlaybackHelper.shared.currentSource = source
         PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
     }
 

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -90,7 +90,7 @@ class PodcastDetailViewModel {
                 return
             }
             let allEpisodes = dataManager.fetchEpisodes(podcast: podcast, includeArchived: showArchived).map {
-                EpisodeRowViewModel(episode: $0, podcast: podcast)
+                EpisodeRowViewModel(episode: $0, podcast: podcast, source: .podcastScreen)
             }
             await MainActor.run {
                 self.podcast = podcast

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -106,6 +106,7 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                             "result_type": "episode"
                         ])
                         Task {
+                            
                             let playSuccess = await model.playEpisode(episode)
                             await MainActor.run {
                                 if playSuccess {

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -106,7 +106,7 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                             "result_type": "episode"
                         ])
                         Task {
-                            
+
                             let playSuccess = await model.playEpisode(episode)
                             await MainActor.run {
                                 if playSuccess {

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -205,6 +205,7 @@ class SearchViewModel: SearchableViewModel {
     }
 
     func playEpisode(_ episode: EpisodeSearchResult) async -> Bool {
+        AnalyticsPlaybackHelper.shared.currentSource = .search
         return await tvDataManager.playEpisode(episode)
     }
 }

--- a/Pocket Casts TV App/UI/Starred/StarredEpisodesViewModel.swift
+++ b/Pocket Casts TV App/UI/Starred/StarredEpisodesViewModel.swift
@@ -57,7 +57,7 @@ class StarredEpisodesViewModel {
 
     nonisolated private func loadEpisodeViewModels(using dataManager: DataManager) -> [EpisodeRowViewModel] {
         dataManager.fetchStarredEpisodes().map { episode in
-            EpisodeRowViewModel(episode: episode, podcast: episode.parentPodcast(dataManager: dataManager))
+            EpisodeRowViewModel(episode: episode, podcast: episode.parentPodcast(dataManager: dataManager), source: .starred)
         }
     }
 

--- a/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
@@ -50,7 +50,7 @@ class UpNextViewModel {
     private func loadEpisodeViewModels(using dataManager: DataManager) -> [EpisodeRowViewModel] {
         dataManager.allUpNextEpisodes().dropFirst().map { episode in
             let podcast = (episode as? Episode).flatMap { $0.parentPodcast(dataManager: dataManager) }
-            return EpisodeRowViewModel(episode: episode, podcast: podcast)
+            return EpisodeRowViewModel(episode: episode, podcast: podcast, source: .upNext)
         }
     }
 

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -62,6 +62,8 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case userSatisfactionSurvey = "user_satisfaction_survey"
     case recommendations
     case playlistEditor = "playlist_editor"
+    case home
+    case search
     case unknown
 
     var analyticsDescription: String { rawValue }

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -9,7 +9,8 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     /// Whether to ignore the next seek event
     private var ignoreNextSeek = false
 
-    // variable track play/pause actions time for tv remote
+    /// Timestamp of the last tvOS remote play/pause action, used to de-duplicate analytics events between
+    /// remote handlers and TV player observation.
     var timestampOfLastRemoteAction: Date?
 
     func play() {

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -9,7 +9,7 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     /// Whether to ignore the next seek event
     private var ignoreNextSeek = false
 
-    /// Set when the TV remote triggers play/pause, so the AVPlayer status observer can skip re-tracking that same action.
+    // variable track play/pause actions time for tv remote
     var timestampOfLastRemoteAction: Date?
 
     func play() {

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -9,7 +9,7 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     /// Whether to ignore the next seek event
     private var ignoreNextSeek = false
 
-    // variable track play/pause actions time for tv remote
+    /// Set when the TV remote triggers play/pause, so the AVPlayer status observer can skip re-tracking that same action.
     var timestampOfLastRemoteAction: Date?
 
     func play() {

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -9,6 +9,9 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     /// Whether to ignore the next seek event
     private var ignoreNextSeek = false
 
+    // variable track play/pause actions time for tv remote
+    var timestampOfLastRemoteAction: Date?
+
     func play() {
         track(.playbackPlay)
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -250,7 +250,13 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         aboutToPlay.value = true
 
-        loadCurrentEpisode()
+        if playerSwitchRequired() {
+            load(episode: currEpisode, autoPlay: false, overrideUpNext: false)
+        }
+        if !haveCalledPlayerLoad {
+            player?.loadEpisode(currEpisode)
+            haveCalledPlayerLoad = true
+        }
 
         activateAudioSession(completion: { activated in
             if !activated {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -228,6 +228,17 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
     }
 
+    func loadCurrentEpisode() {
+        guard let currEpisode = currentEpisode() else { return }
+        if playerSwitchRequired() {
+            load(episode: currEpisode, autoPlay: false, overrideUpNext: false)
+        }
+        if !haveCalledPlayerLoad {
+            player?.loadEpisode(currEpisode)
+            haveCalledPlayerLoad = true
+        }
+    }
+
     func play(completion: (() -> Void)? = nil, userInitiated: Bool = true) {
         guard let currEpisode = currentEpisode() else { return }
 
@@ -306,6 +317,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         } else {
             play()
         }
+    }
+
+    func isReadyToPlay() -> Bool {
+        player?.isReadyToPlay() ?? false
     }
 
     func skipBack() {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -250,13 +250,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         aboutToPlay.value = true
 
-        if playerSwitchRequired() {
-            load(episode: currEpisode, autoPlay: false, overrideUpNext: false)
-        }
-        if !haveCalledPlayerLoad {
-            player?.loadEpisode(currEpisode)
-            haveCalledPlayerLoad = true
-        }
+        loadCurrentEpisode()
 
         activateAudioSession(completion: { activated in
             if !activated {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-823](https://linear.app/a8c/issue/PCIOS-823/analytics-duplicate-and-missing-events)<!-- issue number, if applicable -->

On the TV app, opening the Now Playing tab was triggering duplicate playback tracking events. To force the player to load the current episode the tab was calling `play()` immediately followed by `pause()`, which generated spurious `playback_play` / `playback_pause` analytics events and briefly started playback.

This PR:

- Replaces the `play()`/`pause()` dance in `NowPlayingTab` with a new `PlaybackManager.loadCurrentEpisode()` that just loads the current episode without playing it (guarded by a new `isReadyToPlay()` check).
- Ignores the very first `timeControlStatus` change in `NowPlayingViewModel`, since that change is only caused by loading the media item and should not be tracked.
- Tracks the timestamp of the last TV remote play/pause action (`AnalyticsPlaybackHelper.timestampOfLastRemoteAction`) so that the automatic playback status change caused by a remote action is not tracked a second time by the player observer.

## To test

1. Launch the TV app and start playing an episode.
2. Navigate away from and back to the Now Playing tab.
3. Confirm that opening the Now Playing tab no longer starts/stops playback and no duplicate `playback_play` / `playback_pause` events are logged.
4. Use the TV remote play/pause toggle and confirm a single play/pause event is tracked per action (no duplicates from the player observer).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
