### PR TITLE
HLS playback fixes: audio/video sync, 2x cap, and effects gating

### DIFF
--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -92,7 +92,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
         isWaitingForInitialPlayback = true
 
-        isStreamingHLS = EpisodeManager.isStreamingHLS(episode)
+        isStreamingHLS = EpisodeManager.willPlayViaHLS(episode)
 
         // Set the pitch algorithm once here rather than re-applying it on every rate change. For HLS,
         // give the pipeline more buffered audio so higher playback rates don't starve it and stall.

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -21,6 +21,17 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
     private var isPlayingLocalFile = false
 
+    /// Whether the current episode is being streamed over HLS. HLS is streamed directly (never cached),
+    /// so it needs extra buffering headroom and a capped playback rate to avoid stalling.
+    private var isStreamingHLS = false
+
+    /// Larger forward buffer for HLS so higher playback rates don't starve the pipeline and stall.
+    private static let hlsForwardBufferDuration: TimeInterval = 60
+
+    /// HLS streams can't reliably sustain playback above this rate, and the time-domain pitch
+    /// algorithm degrades past it, so the applied rate is capped here for HLS.
+    private static let hlsMaxPlaybackRate: Double = 2.0
+
     // Keep track of the previous playback and waiting state
     private var previousReasonForWaiting: AVPlayer.WaitingReason?
     private var previousTimeControlStatus: AVPlayer.TimeControlStatus?
@@ -81,6 +92,15 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
         isWaitingForInitialPlayback = true
 
+        isStreamingHLS = EpisodeManager.isStreamingHLS(episode)
+
+        // Set the pitch algorithm once here rather than re-applying it on every rate change. For HLS,
+        // give the pipeline more buffered audio so higher playback rates don't starve it and stall.
+        playerItem.audioTimePitchAlgorithm = .timeDomain
+        if isStreamingHLS {
+            playerItem.preferredForwardBufferDuration = Self.hlsForwardBufferDuration
+        }
+
         player = AVPlayer(playerItem: playerItem)
 
         episodeUuid = episode.uuid
@@ -105,7 +125,22 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
 
         configurePlayer(videoPodcast: episode.videoPodcast())
 
+        disableSubtitles(for: playerItem)
+
         detectVideoTracksIfNeeded(for: episode, playerItem: playerItem)
+    }
+
+    /// We don't offer a subtitle/caption UI, but AVPlayer will otherwise turn subtitles on by default
+    /// when a stream has a `DEFAULT=YES` legible rendition or when the system "Closed Captions + SDH"
+    /// accessibility setting is enabled. Prevent automatic selection and deselect any legible track.
+    private func disableSubtitles(for playerItem: AVPlayerItem) {
+        player?.appliesMediaSelectionCriteriaAutomatically = false
+
+        Task { @MainActor in
+            if let group = try? await playerItem.asset.loadMediaSelectionGroup(for: .legible) {
+                playerItem.select(nil, in: group)
+            }
+        }
     }
 
     /// An HLS stream can carry video that isn't reflected in the episode's file type. HLS doesn't
@@ -346,8 +381,14 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             }
 
             #if !os(watchOS)
-                createAudioMix()
-                player?.currentItem?.audioMix = audioMix
+                // The volume-boost audio mix uses an MTAudioProcessingTap, which requires a concrete
+                // audio asset track. HLS streams don't expose one (asset.tracks is empty), so attaching
+                // the mix breaks audio playback at non-1x rates — the audio ignores the rate while the
+                // video honors it. Only attach it when we actually found an audio track.
+                if assetTrack != nil {
+                    createAudioMix()
+                    player?.currentItem?.audioMix = audioMix
+                }
             #endif
 
             isWaitingForInitialPlayback = false
@@ -694,9 +735,10 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             requiredPlaybackRate = 1.0
         }
 
-        player?.rate = Float(requiredPlaybackRate)
+        // Cap the applied rate for HLS streams; they can't sustain higher rates without stalling.
+        let effectiveRate = isStreamingHLS ? min(requiredPlaybackRate, Self.hlsMaxPlaybackRate) : requiredPlaybackRate
 
-        player?.currentItem?.audioTimePitchAlgorithm = .timeDomain
+        player?.rate = Float(effectiveRate)
     }
 
     private func jumpToStartingPosition() {
@@ -890,7 +932,15 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         playStalledObserver = nc.addObserver(forName: NSNotification.Name.AVPlayerItemPlaybackStalled, object: nil, queue: nil) { [weak self] _ in
             guard let self else { return }
             FileLog.shared.addMessage("Received notification of playback stall")
-            if self.shouldKeepPlaying {
+            guard self.shouldKeepPlaying else { return }
+
+            if self.isStreamingHLS {
+                // Recovering an HLS stall via play() re-seeks to the resume position, which flushes the
+                // HLS buffer and triggers another stall — a runaway loop at higher rates. Just re-apply
+                // the rate and let AVPlayer resume once it has buffered enough, without seeking.
+                FileLog.shared.addMessage("Trying to recover from HLS stall without seeking")
+                self.performSetPlaybackRate()
+            } else {
                 FileLog.shared.addMessage("Trying to recover from stall by playing")
                 self.play(completion: nil)
             }

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -432,12 +432,19 @@ class EffectsViewController: SimpleNotificationsViewController {
 
     private func updateSpeedBtn() {
         let effects = PlaybackManager.shared.effects()
+        // HLS can't play above 2x, so never show a higher speed even if the stored global/podcast speed
+        // is higher. The applied rate is already capped in DefaultPlayer; this keeps the display honest
+        // without persisting a change to the user's non-HLS preference.
+        var displaySpeed = effects.playbackSpeed
+        if let episode = PlaybackManager.shared.currentEpisode(), EpisodeManager.willPlayViaHLS(episode) {
+            displaySpeed = min(displaySpeed, 2)
+        }
         speedBtn.fillColor = ThemeColor.playerContrast01()
-        speedBtn.isOn = (effects.playbackSpeed != 1)
-        speedBtn.buttonTitle = "  " + L10n.playbackSpeed(effects.playbackSpeed.localized())
+        speedBtn.isOn = (displaySpeed != 1)
+        speedBtn.buttonTitle = "  " + L10n.playbackSpeed(displaySpeed.localized())
         speedBtn.strokeColor = speedBtn.isOn ? ThemeColor.playerContrast01() : ThemeColor.playerContrast02()
         speedBtn.textColor = speedBtn.isOn ? PlayerColorHelper.playerBackgroundColor01() : ThemeColor.playerContrast01()
-        speedBtn.accessibilityLabel = L10n.accessibilityPlayerEffectsPlaybackSpeed(effects.playbackSpeed.localized(.spellOut))
+        speedBtn.accessibilityLabel = L10n.accessibilityPlayerEffectsPlaybackSpeed(displaySpeed.localized(.spellOut))
 
         // Post accessibility notification for speed changes
         UIAccessibility.post(notification: .announcement, argument: speedBtn.accessibilityLabel)

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -358,11 +358,13 @@ class EffectsViewController: SimpleNotificationsViewController {
     }
 
     @objc private func updateControls() {
+        let volumeBoostAvailable = PlaybackManager.shared.volumeBoostAvailable()
         trimSilenceSwitch.isEnabled = PlaybackManager.shared.silenceRemovalAvailable()
-        volumeBoostSwitch.isEnabled = PlaybackManager.shared.volumeBoostAvailable()
+        volumeBoostSwitch.isEnabled = volumeBoostAvailable
 
         let effects = PlaybackManager.shared.effects()
-        volumeBoostSwitch.isOn = effects.volumeBoost
+        // When the effect isn't available (e.g. HLS) show it as off rather than on-but-disabled.
+        volumeBoostSwitch.isOn = volumeBoostAvailable && effects.volumeBoost
         updateRemoveSilenceViews()
         updateSpeedBtn()
         updateClearView()
@@ -386,9 +388,9 @@ class EffectsViewController: SimpleNotificationsViewController {
 
     private func updateRemoveSilenceViews() {
         let effects = PlaybackManager.shared.effects()
-        trimSilenceSwitch.isOn = effects.trimSilence.isEnabled()
-
-        let isEnabled = effects.trimSilence.isEnabled()
+        // When the effect isn't available (e.g. HLS) show it as off rather than on-but-disabled.
+        let isEnabled = PlaybackManager.shared.silenceRemovalAvailable() && effects.trimSilence.isEnabled()
+        trimSilenceSwitch.isOn = isEnabled
 
         trimSilenceSpeedsToLabelConstraint.isActive = isEnabled
         let wasHidden = trimSilenceAmountControl.isHidden

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -432,6 +432,16 @@ class EpisodeManager: NSObject {
         return URL(string: hlsUrl) != nil
     }
 
+    /// Whether the episode will actually play via HLS right now. Downloaded copies take precedence over
+    /// the HLS stream in `urlForEpisode`, so a downloaded episode plays its local (progressive) file and
+    /// is not treated as HLS — this distinguishes that case from `isStreamingHLS`.
+    class func willPlayViaHLS(_ episode: BaseEpisode) -> Bool {
+        guard isStreamingHLS(episode) else { return false }
+        if episode.downloaded(pathFinder: DownloadManager.shared) { return false }
+        if let episode = episode as? Episode, episode.streamDownloaded(pathFinder: DownloadManager.shared) { return false }
+        return true
+    }
+
     class func urlForEpisode(_ episode: BaseEpisode, streamingOnly: Bool = false) -> URL? {
         if !streamingOnly {
             // For local playback, prefer downloaded files

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1476,7 +1476,9 @@ class PlaybackManager: ServerPlaybackDelegate {
         #endif
 
         #if !os(watchOS) && !os(tvOS)
-        if !playingOverAirplay(), !currEpisode.videoPodcast(), (currEpisode.downloaded(pathFinder: DownloadManager.shared) && effects().trimSilence != .off) || currEpisode.bufferedForStreaming() {
+        // HLS must be played by AVPlayer (DefaultPlayer): EffectsPlayer is an audio-only AVAudioEngine
+        // pipeline that can't render video, and routing HLS through it desyncs audio from the video surface.
+        if !playingOverAirplay(), !currEpisode.videoPodcast(), !EpisodeManager.isStreamingHLS(currEpisode), (currEpisode.downloaded(pathFinder: DownloadManager.shared) && effects().trimSilence != .off) || currEpisode.bufferedForStreaming() {
             possiblePlayers.append(EffectsPlayer.self)
         }
         #endif

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1489,7 +1489,8 @@ class PlaybackManager: ServerPlaybackDelegate {
         #if !os(watchOS) && !os(tvOS)
         // HLS must be played by AVPlayer (DefaultPlayer): EffectsPlayer is an audio-only AVAudioEngine
         // pipeline that can't render video, and routing HLS through it desyncs audio from the video surface.
-        if !playingOverAirplay(), !currEpisode.videoPodcast(), !EpisodeManager.willPlayViaHLS(currEpisode), (currEpisode.downloaded(pathFinder: DownloadManager.shared) && effects().trimSilence != .off) || currEpisode.bufferedForStreaming() {
+        let audioReadyForEffectsPlayer = (currEpisode.downloaded(pathFinder: DownloadManager.shared) && effects().trimSilence != .off) || currEpisode.bufferedForStreaming()
+        if !playingOverAirplay(), !currEpisode.videoPodcast(), !EpisodeManager.willPlayViaHLS(currEpisode), audioReadyForEffectsPlayer {
             possiblePlayers.append(EffectsPlayer.self)
         }
         #endif

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -979,6 +979,9 @@ class PlaybackManager: ServerPlaybackDelegate {
         let playbackEffects = effects()
         if playbackEffects.playbackSpeed > 4.9 { return }
 
+        // HLS streams can't sustain playback above 2x, so don't let the speed be raised past it.
+        if let episode = currentEpisode(), EpisodeManager.willPlayViaHLS(episode), playbackEffects.playbackSpeed >= 2 { return }
+
         playbackEffects.playbackSpeed = playbackEffects.playbackSpeed + 0.1
         changeEffects(playbackEffects)
     }
@@ -1027,13 +1030,14 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func silenceRemovalAvailable() -> Bool {
+        // Trim silence relies on the EffectsPlayer audio engine; HLS plays through AVPlayer, which can't do it.
         #if APPCLIP
         if let episode = currentEpisode() {
-            return !episode.videoPodcast()
+            return !episode.videoPodcast() && !EpisodeManager.willPlayViaHLS(episode)
         }
         #elseif !os(watchOS) && !os(tvOS)
             if let episode = currentEpisode() {
-                return !episode.videoPodcast() && !GoogleCastManager.sharedManager.connectedOrConnectingToDevice()
+                return !episode.videoPodcast() && !EpisodeManager.willPlayViaHLS(episode) && !GoogleCastManager.sharedManager.connectedOrConnectingToDevice()
             }
         #endif
 
@@ -1041,6 +1045,13 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func volumeBoostAvailable() -> Bool {
+        // Volume boost uses an audio processing tap, which needs a concrete audio track that HLS streams don't expose.
+        #if !os(watchOS) && !os(tvOS)
+        if let episode = currentEpisode(), EpisodeManager.willPlayViaHLS(episode) {
+            return false
+        }
+        #endif
+
         #if APPCLIP || os(tvOS)
             return true
         #elseif os(watchOS)
@@ -1478,7 +1489,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         #if !os(watchOS) && !os(tvOS)
         // HLS must be played by AVPlayer (DefaultPlayer): EffectsPlayer is an audio-only AVAudioEngine
         // pipeline that can't render video, and routing HLS through it desyncs audio from the video surface.
-        if !playingOverAirplay(), !currEpisode.videoPodcast(), !EpisodeManager.isStreamingHLS(currEpisode), (currEpisode.downloaded(pathFinder: DownloadManager.shared) && effects().trimSilence != .off) || currEpisode.bufferedForStreaming() {
+        if !playingOverAirplay(), !currEpisode.videoPodcast(), !EpisodeManager.willPlayViaHLS(currEpisode), (currEpisode.downloaded(pathFinder: DownloadManager.shared) && effects().trimSilence != .off) || currEpisode.bufferedForStreaming() {
             possiblePlayers.append(EffectsPlayer.self)
         }
         #endif

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1045,8 +1045,9 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func volumeBoostAvailable() -> Bool {
-        // Volume boost uses an audio processing tap, which needs a concrete audio track that HLS streams don't expose.
-        #if !os(watchOS) && !os(tvOS)
+        // Volume boost uses an audio processing tap, which needs a concrete audio track that HLS streams don't
+        // expose. The tap logic in DefaultPlayer is compiled on tvOS too, so exclude HLS there as well.
+        #if !os(watchOS)
         if let episode = currentEpisode(), EpisodeManager.willPlayViaHLS(episode) {
             return false
         }


### PR DESCRIPTION
Fixes several issues with HLS video/audio playback.

## Problems fixed

**Audio/video desync at 2x (the main one).** `DefaultPlayer` unconditionally attached an `MTAudioProcessingTap` (volume-boost audio mix) to every item. HLS streaming assets don't expose a concrete audio `AVAssetTrack` (`asset.tracks` is empty), so the tap was attached with no track — and audio taps aren't supported for HLS. The result: audio ignored the playback rate (played ~1x) while video ran at 2x. We now only attach the audio mix when a real audio track exists, which excludes HLS. Progressive video (which has a track) is unaffected.

**HLS routed to the wrong player.** An HLS episode isn't flagged `videoPodcast()` (video is detected at runtime), so it could be selected for `EffectsPlayer` — an audio-only `AVAudioEngine` pipeline that can't render video. HLS now always uses `DefaultPlayer` (`AVPlayer`).

**Runaway stalls at higher rates.** On an HLS stall, recovery called `play()`, which re-seeks to the resume position and flushes the HLS buffer, causing another stall. HLS stalls now re-apply the rate without seeking, and HLS items get a larger `preferredForwardBufferDuration`.

**Playback above 2x is unreliable on HLS**, so the applied rate and the UI are capped at 2x for HLS streams.

**Subtitles turning on by default.** Video (and the system "Closed Captions + SDH" setting) could auto-enable a legible track. We now disable automatic media selection and deselect the legible group. (Independent of HLS; bundled here as playback-correctness.)

## Effects UI gating for HLS

The Playback Effects panel now reflects what `AVPlayer`/HLS can actually do:
- **Speed** stops at 2x.
- **Volume Boost** and **Trim Silence** are shown **off and disabled** (not on-but-greyed). Display-only — the stored settings are untouched and restore on non-HLS episodes.

Introduces `EpisodeManager.willPlayViaHLS()` (HLS *and* not playing a downloaded local copy) as the single condition for all HLS-specific behavior, so downloaded episodes that happen to have an `hlsUrl` aren't wrongly restricted.

## Testing

> [!NOTE]
> Test on a real device, as some of these problems didn't show up in Simulator.

1. Stream an [HLS **video** episode](https://pocketcasts.com/podcast/live-beyond-the-norms/3d728640-75ca-013c-f0b5-0a4e4341158f/your-glasses-are-making-your-eyes-lazier-and-vision-worse-with-dr-bryce-appelbaum/206dc533-383e-428e-aa9a-4c2707386241?q=Your+Glasses+Are+Making+Your+Eyes+Lazier+and+Vision+Worse+With+Dr.+Bryce+Appelbaum) at 2x → audio and video stay in sync; video no longer races ahead.
2. In Playback Effects on that episode: speed won't go above 2x; Volume Boost and Trim Silence appear off and disabled.
3. Play [a **progressive** video episode](https://pocketcasts.com/podcast/twit-news-video/6abd90b0-0b51-012e-fad7-00163e1b201c/meta-connect-2024-meta-orion-ar-glasses-meta-ai-meta-quest-3s/b7633ef6-e488-47df-9826-2e59ca615b85) → full speed range, effects work, stays in sync (unaffected).
4. Play an audio-only episode → unaffected.