### PR TITLE
Fix HTML entities not decoded in plain-text episode descriptions

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/Helpers/HTMLToAttributedStringConverter.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Helpers/HTMLToAttributedStringConverter.swift
@@ -14,13 +14,20 @@ public enum HTMLToAttributedStringConverter {
     public static func attributedString(from html: String) -> NSAttributedString {
         guard !html.isEmpty else { return NSAttributedString() }
 
-        guard containsHTMLTags(html) else {
-            return NSAttributedString(string: normalizedPlainText(decodingEntities(html)))
-        }
-
         do {
             let document = try SwiftSoup.parse(html)
             let root = document.body() ?? document
+
+            // Tag-free input is a plain-text description: take the decoded text
+            // directly so the author's line breaks survive, rather than letting the
+            // block builder collapse them per HTML whitespace rules.
+            if root.getChildNodes().allSatisfy({ $0 is TextNode }) {
+                let text = root.getChildNodes()
+                    .compactMap { ($0 as? TextNode)?.getWholeText() }
+                    .joined()
+                return NSAttributedString(string: normalizedPlainText(text))
+            }
+
             let builder = AttributedStringBuilder()
             try builder.append(node: root, context: InlineContext())
             let result = builder.finalized()
@@ -34,17 +41,6 @@ public enum HTMLToAttributedStringConverter {
 
     private static func plainText(from html: String) -> String {
         (try? SwiftSoup.parse(html).text()) ?? html
-    }
-
-    private static func containsHTMLTags(_ string: String) -> Bool {
-        string.range(of: "<[a-zA-Z/!][^>]*>", options: .regularExpression) != nil
-    }
-
-    /// Feeds sometimes contain entity references (`&#39;`, `&amp;`) with no tags at all,
-    /// which skips SwiftSoup parsing and would otherwise leave them undecoded.
-    private static func decodingEntities(_ text: String) -> String {
-        guard text.contains("&") else { return text }
-        return (try? Entities.unescape(text)) ?? text
     }
 
     private static func normalizedPlainText(_ text: String) -> String {

--- a/Modules/Sources/PocketCastsServer/Public/Helpers/HTMLToAttributedStringConverter.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Helpers/HTMLToAttributedStringConverter.swift
@@ -15,7 +15,7 @@ public enum HTMLToAttributedStringConverter {
         guard !html.isEmpty else { return NSAttributedString() }
 
         guard containsHTMLTags(html) else {
-            return NSAttributedString(string: normalizedPlainText(html))
+            return NSAttributedString(string: normalizedPlainText(decodingEntities(html)))
         }
 
         do {
@@ -38,6 +38,13 @@ public enum HTMLToAttributedStringConverter {
 
     private static func containsHTMLTags(_ string: String) -> Bool {
         string.range(of: "<[a-zA-Z/!][^>]*>", options: .regularExpression) != nil
+    }
+
+    /// Feeds sometimes contain entity references (`&#39;`, `&amp;`) with no tags at all,
+    /// which skips SwiftSoup parsing and would otherwise leave them undecoded.
+    private static func decodingEntities(_ text: String) -> String {
+        guard text.contains("&") else { return text }
+        return (try? Entities.unescape(text)) ?? text
     }
 
     private static func normalizedPlainText(_ text: String) -> String {

--- a/Modules/Sources/PocketCastsServer/Public/Helpers/HTMLToAttributedStringConverter.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Helpers/HTMLToAttributedStringConverter.swift
@@ -14,33 +14,33 @@ public enum HTMLToAttributedStringConverter {
     public static func attributedString(from html: String) -> NSAttributedString {
         guard !html.isEmpty else { return NSAttributedString() }
 
-        do {
-            let document = try SwiftSoup.parse(html)
-            let root = document.body() ?? document
-
-            // Tag-free input is a plain-text description: take the decoded text
-            // directly so the author's line breaks survive, rather than letting the
-            // block builder collapse them per HTML whitespace rules.
-            if root.getChildNodes().allSatisfy({ $0 is TextNode }) {
-                let text = root.getChildNodes()
-                    .compactMap { ($0 as? TextNode)?.getWholeText() }
-                    .joined()
-                return NSAttributedString(string: normalizedPlainText(text))
-            }
-
-            let builder = AttributedStringBuilder()
-            try builder.append(node: root, context: InlineContext())
-            let result = builder.finalized()
-            return result.length > 0
-                ? result
-                : NSAttributedString(string: normalizedPlainText(plainText(from: html)))
-        } catch {
-            return NSAttributedString(string: normalizedPlainText(plainText(from: html)))
+        guard let document = try? SwiftSoup.parse(html) else {
+            // Last resort: the input defeated the parser, show it as-is.
+            return NSAttributedString(string: normalizedPlainText(html))
         }
+        let root = document.body() ?? document
+
+        if let text = plainTextOnly(root) {
+            return NSAttributedString(string: normalizedPlainText(text))
+        }
+
+        let builder = AttributedStringBuilder()
+        builder.append(node: root, context: InlineContext())
+        let result = builder.finalized()
+        return result.length > 0
+            ? result
+            : NSAttributedString(string: normalizedPlainText((try? root.text()) ?? html))
     }
 
-    private static func plainText(from html: String) -> String {
-        (try? SwiftSoup.parse(html).text()) ?? html
+    /// Tag-free input is a plain-text description: returns its decoded text so the
+    /// author's line breaks survive, rather than letting the block builder collapse
+    /// them per HTML whitespace rules. Returns nil once any element is present.
+    private static func plainTextOnly(_ root: Element) -> String? {
+        let children = root.getChildNodes()
+        guard children.allSatisfy({ $0 is TextNode }) else { return nil }
+        return children
+            .compactMap { ($0 as? TextNode)?.getWholeText() }
+            .joined()
     }
 
     private static func normalizedPlainText(_ text: String) -> String {
@@ -98,13 +98,13 @@ private final class AttributedStringBuilder {
         return NSAttributedString(attributedString: output)
     }
 
-    func append(node: Node, context: InlineContext) throws {
+    func append(node: Node, context: InlineContext) {
         for child in node.getChildNodes() {
-            try appendChild(child, context: context)
+            appendChild(child, context: context)
         }
     }
 
-    private func appendChild(_ node: Node, context: InlineContext) throws {
+    private func appendChild(_ node: Node, context: InlineContext) {
         if let textNode = node as? TextNode {
             let collapsed = textNode.getWholeText()
                 .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
@@ -127,29 +127,29 @@ private final class AttributedStringBuilder {
         case "p", "div", "section", "article":
             if listStack.isEmpty {
                 ensureBlockSeparation()
-                try append(node: element, context: context)
+                append(node: element, context: context)
                 ensureBlockSeparation()
             } else {
                 // Inside a list item, a block wrapper must not inject blank lines
                 // or bump content off the marker line.
                 ensureSpace()
-                try append(node: element, context: context)
+                append(node: element, context: context)
             }
         case "strong", "b":
             var context = context
             context.presentationIntent.insert(.stronglyEmphasized)
-            try append(node: element, context: context)
+            append(node: element, context: context)
         case "em", "i":
             var context = context
             context.presentationIntent.insert(.emphasized)
-            try append(node: element, context: context)
+            append(node: element, context: context)
         case "a":
             var context = context
             if let href = try? element.attr("href").trimmingCharacters(in: .whitespaces),
                let url = safeLinkURL(href) {
                 context.link = url
             }
-            try append(node: element, context: context)
+            append(node: element, context: context)
         case "ul", "ol":
             if listStack.isEmpty {
                 ensureBlockSeparation()
@@ -157,7 +157,7 @@ private final class AttributedStringBuilder {
                 ensureNewline()
             }
             listStack.append(ListContext(ordered: tag == "ol", index: 1))
-            try append(node: element, context: context)
+            append(node: element, context: context)
             listStack.removeLast()
             if listStack.isEmpty {
                 ensureBlockSeparation()
@@ -165,20 +165,20 @@ private final class AttributedStringBuilder {
         case "li":
             ensureNewline()
             appendText(listItemPrefix(), context: context)
-            try append(node: element, context: context)
+            append(node: element, context: context)
             ensureNewline()
         case "h1", "h2", "h3", "h4", "h5", "h6":
             ensureBlockSeparation()
             var context = context
             context.presentationIntent.insert(.stronglyEmphasized)
-            try append(node: element, context: context)
+            append(node: element, context: context)
             ensureBlockSeparation()
         case "blockquote":
             ensureBlockSeparation()
-            try append(node: element, context: context)
+            append(node: element, context: context)
             ensureBlockSeparation()
         default:
-            try append(node: element, context: context)
+            append(node: element, context: context)
         }
     }
 

--- a/Modules/Tests/PocketCastsServerTests/HTMLToAttributedStringConverterTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/HTMLToAttributedStringConverterTests.swift
@@ -65,6 +65,11 @@ final class HTMLToAttributedStringConverterTests: XCTestCase {
         XCTAssertEqual(string("<p>Tom &amp; Jerry</p>"), "Tom & Jerry")
     }
 
+    func testNumericEntitiesInsideTagsAreDecoded() {
+        let html = "<p>Raised listening to his dad&#39;s old records &#8212; jazz you wouldn&#8217;t expect.</p>"
+        XCTAssertEqual(string(html), "Raised listening to his dad's old records — jazz you wouldn’t expect.")
+    }
+
     func testUnknownTagsAreStripped() {
         XCTAssertEqual(string("<span class=\"x\">Hello</span>"), "Hello")
     }

--- a/Modules/Tests/PocketCastsServerTests/HTMLToAttributedStringConverterTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/HTMLToAttributedStringConverterTests.swift
@@ -31,6 +31,10 @@ final class HTMLToAttributedStringConverterTests: XCTestCase {
         XCTAssertEqual(string(""), "")
     }
 
+    func testWhitespaceOnlyInputIsEmpty() {
+        XCTAssertEqual(string("  \n  \n"), "")
+    }
+
     func testPlainTextPassthrough() {
         XCTAssertEqual(string("Just a description."), "Just a description.")
     }
@@ -42,6 +46,19 @@ final class HTMLToAttributedStringConverterTests: XCTestCase {
 
     func testPlainTextPreservesLineBreaks() {
         XCTAssertEqual(string("Line one\nLine two"), "Line one\nLine two")
+    }
+
+    func testPlainTextNormalizesWindowsLineEndings() {
+        XCTAssertEqual(string("Line one\r\nLine two"), "Line one\nLine two")
+    }
+
+    func testPlainTextCollapsesExcessBlankLines() {
+        XCTAssertEqual(string("One\n\n\n\nTwo"), "One\n\nTwo")
+    }
+
+    func testAngleBracketBeforeNonLetterStaysText() {
+        // "<" followed by a non-letter can't open a tag, so this is still plain text.
+        XCTAssertEqual(string("I <3 podcasts & jazz"), "I <3 podcasts & jazz")
     }
 
     func testEntitiesInTagFreeTextAreDecoded() {
@@ -76,6 +93,38 @@ final class HTMLToAttributedStringConverterTests: XCTestCase {
 
     func testImagesAreDropped() {
         XCTAssertEqual(string("<p>Before<img src=\"x.png\">After</p>"), "BeforeAfter")
+    }
+
+    func testCommentsAreDropped() {
+        XCTAssertEqual(string("<p>Before<!-- hidden -->After</p>"), "BeforeAfter")
+    }
+
+    func testScriptAndStyleContentsAreDropped() {
+        // Script/style bodies are DataNodes, not TextNodes, so their contents
+        // must never leak into the rendered description.
+        XCTAssertEqual(string("<p>Hello</p><script>alert(1)</script><style>p { color: red }</style>"), "Hello")
+    }
+
+    func testWhitespaceInsideParagraphCollapses() {
+        // Inside markup, raw newlines follow HTML whitespace rules.
+        XCTAssertEqual(string("<p>Line one\n   Line two</p>"), "Line one Line two")
+    }
+
+    func testWhitespaceBetweenInlineElementsIsKept() {
+        XCTAssertEqual(string("<b>bold</b> <i>italic</i>"), "bold italic")
+    }
+
+    func testBlockquoteIsBlockSeparated() {
+        XCTAssertEqual(string("Before<blockquote>Quote</blockquote>After"), "Before\n\nQuote\n\nAfter")
+    }
+
+    func testTrailingLineBreaksAreTrimmed() {
+        XCTAssertEqual(string("<p>Hello</p><br><br>"), "Hello")
+    }
+
+    func testCDATAContentIsKept() {
+        // A feed that leaks a literal CDATA wrapper must not lose its content.
+        XCTAssertEqual(string("<![CDATA[Hello]]>"), "Hello")
     }
 
     // MARK: - Inline emphasis
@@ -151,6 +200,17 @@ final class HTMLToAttributedStringConverterTests: XCTestCase {
         let result = attributed(#"<a href="/episodes/1">Episode</a>"#)
         XCTAssertEqual(result.string, "Episode")
         XCTAssertNil(link(result, at: 0))
+    }
+
+    func testDataSchemeIsNotLinked() {
+        let result = attributed(#"<a href="data:text/plain;base64,SGVsbG8=">Tap</a>"#)
+        XCTAssertEqual(result.string, "Tap")
+        XCTAssertNil(link(result, at: 0))
+    }
+
+    func testSchemeCheckIsCaseInsensitive() {
+        XCTAssertNil(link(attributed(#"<a href="JavaScript:alert(1)">Tap</a>"#), at: 0))
+        XCTAssertEqual(link(attributed(#"<a href="HTTPS://pca.st">Tap</a>"#), at: 0), URL(string: "HTTPS://pca.st"))
     }
 
     // MARK: - Lists

--- a/Modules/Tests/PocketCastsServerTests/HTMLToAttributedStringConverterTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/HTMLToAttributedStringConverterTests.swift
@@ -44,6 +44,13 @@ final class HTMLToAttributedStringConverterTests: XCTestCase {
         XCTAssertEqual(string("Line one\nLine two"), "Line one\nLine two")
     }
 
+    func testEntitiesInTagFreeTextAreDecoded() {
+        // Real-world feed description (TED Talks Daily): no HTML tags at all,
+        // but apostrophes arrive as numeric character references.
+        let html = "Raised listening to his dad&#39;s old records, Joey Alexander plays a brand of sharp, modern piano jazz that you likely wouldn&#39;t expect to hear from a pre-teenager."
+        XCTAssertEqual(string(html), "Raised listening to his dad's old records, Joey Alexander plays a brand of sharp, modern piano jazz that you likely wouldn't expect to hear from a pre-teenager.")
+    }
+
     // MARK: - Blocks
 
     func testParagraphsBecomeBlankLineSeparated() {


### PR DESCRIPTION
Fixes PCIOS-824.

Plain-text episode descriptions containing character references — e.g. TED Talks Daily's `dad&#39;s` — rendered the raw entities on tvOS, because a regex-based tag check skipped SwiftSoup for tag-free input. The converter now always parses and decides from the DOM: text-only bodies keep their line breaks and get entities decoded; everything else goes through the attributed-string builder. Also simplifies error handling and expands the test suite from 28 to 43 tests (script/style stripping, CDATA, link-scheme and whitespace edge cases).

## To test

1. Run `PocketCastsServerTests/HTMLToAttributedStringConverterTests` — all 43 should pass.
2. On tvOS, open a TED Talks Daily episode description and verify apostrophes render as `'` rather than `&#39;`, with paragraph breaks preserved.

<img width="960" height="592" alt="Screenshot 2026-07-09 at 1 08 00 PM" src="https://github.com/user-attachments/assets/6dd4fbd6-8159-4a42-92b1-87a0a058cca1" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)