### PR TITLE
Fix slow Bookmarks tab caused by blocking episode lookups on the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add support for Flightcast JSON transcripts [#4706](https://github.com/Automattic/pocket-casts-ios/pull/4706)
 - Fix player opening on Bookmarks tab in RTL languages [#4696](https://github.com/Automattic/pocket-casts-ios/pull/4696)
 - Fix the Discover search screen background color and colors in filters on some themes [#4719](https://github.com/Automattic/pocket-casts-ios/pull/4719)
+- Fix the Bookmarks tab being slow to open when bookmarks reference episodes that are no longer available locally [#4721](https://github.com/Automattic/pocket-casts-ios/pull/4721)
 - Fix the mini player initial loading shimmer not showing up when Reduce Motion is enabled [#4713](https://github.com/Automattic/pocket-casts-ios/pull/4713)
 - Fix options picker rows like "Sort By" wrapping their labels to multiple lines when there is enough space [#4722](https://github.com/Automattic/pocket-casts-ios/pull/4722)
 

--- a/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -147,6 +147,7 @@ public class ServerPodcastManager: NSObject {
 
     /// Soft-deprecated: performs synchronous networking, blocking the calling thread, and never calls
     /// the completion on failure. Use the async ``addMissingPodcastAndEpisode(episodeUuid:podcastUuid:shouldUpdateEpisode:)`` instead.
+    @available(*, deprecated, message: "Performs synchronous networking and blocks the calling thread. Use the async addMissingPodcastAndEpisode(episodeUuid:podcastUuid:shouldUpdateEpisode:) instead.")
     public func addMissingPodcastAndEpisode(episodeUuid: String, podcastUuid: String, shouldUpdateEpisode: Bool = false, completion: ((Episode?) -> ())? = nil) {
         let url = ServerConstants.Urls.cache() + "mobile/podcast/findbyepisode/\(podcastUuid)/\(episodeUuid)"
 

--- a/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsDataModel
+import PocketCastsUtils
 
 public class ServerPodcastManager: NSObject {
     private static let maxAutoDownloadSeperationTime = 12.hours
@@ -144,6 +145,8 @@ public class ServerPodcastManager: NSObject {
         return nil
     }
 
+    /// Soft-deprecated: performs synchronous networking, blocking the calling thread, and never calls
+    /// the completion on failure. Use the async ``addMissingPodcastAndEpisode(episodeUuid:podcastUuid:shouldUpdateEpisode:)`` instead.
     public func addMissingPodcastAndEpisode(episodeUuid: String, podcastUuid: String, shouldUpdateEpisode: Bool = false, completion: ((Episode?) -> ())? = nil) {
         let url = ServerConstants.Urls.cache() + "mobile/podcast/findbyepisode/\(podcastUuid)/\(episodeUuid)"
 
@@ -155,6 +158,27 @@ public class ServerPodcastManager: NSObject {
 
             let episode = addEpisode(podcastInfo: info, shouldUpdate: shouldUpdateEpisode)
             completion?(episode)
+        }
+    }
+
+    @discardableResult
+    public func addMissingPodcastAndEpisode(episodeUuid: String, podcastUuid: String, shouldUpdateEpisode: Bool = false) async throws -> Episode? {
+        let url = ServerConstants.Urls.cache() + "mobile/podcast/findbyepisode/\(podcastUuid)/\(episodeUuid)"
+
+        do {
+            guard let info = try await loadFrom(url: url) else {
+                return nil
+            }
+
+            // Ensure podcast is added, otherwise episode won't be
+            if !PodcastExistsHelper.shared.exists(uuid: podcastUuid) {
+                _ = addPodcast(podcastInfo: info, subscribe: false, lastModified: nil)
+            }
+
+            return addEpisode(podcastInfo: info, shouldUpdate: shouldUpdateEpisode)
+        } catch {
+            FileLog.shared.addMessage("ServerPodcastManager: failed to load missing episode \(episodeUuid): \(error)")
+            throw error
         }
     }
 
@@ -311,6 +335,27 @@ public class ServerPodcastManager: NSObject {
         decoder.dateDecodingStrategy = .iso8601
 
         return try decoder.decode(PodcastCollection.self, from: data)
+    }
+
+    /// Sends the request and returns the parsed JSON, or nil when the server responds with 304 Not Modified
+    private func loadFrom(url: String) async throws -> [String: Any]? {
+        var request = URLRequest(url: ServerHelper.asUrl(url), cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 10)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: ServerConstants.HttpHeaders.accept)
+        request.setValue("application/json; charset=UTF8", forHTTPHeaderField: ServerConstants.HttpHeaders.contentType)
+        request.addLocalizationHeaders()
+
+        let (data, response) = try await urlConnection.send(request: request)
+
+        if (response as? HTTPURLResponse)?.statusCode == ServerConstants.HttpConstants.notModified {
+            return nil
+        }
+
+        guard let data else {
+            return nil
+        }
+
+        return try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
     }
 
     private func loadFrom(url: String) -> [String: Any]? {

--- a/podcasts/Bookmarks/List/BookmarkRow.swift
+++ b/podcasts/Bookmarks/List/BookmarkRow.swift
@@ -4,7 +4,7 @@ import PocketCastsDataModel
 
 struct BookmarkRow<Style: BookmarksStyle>: View {
     @EnvironmentObject var viewModel: BookmarkListViewModel
-    @ObservedObject var rowModel: BookmarkRowViewModel
+    @StateObject private var rowModel = BookmarkRowViewModel()
 
     private let bookmark: Bookmark
 
@@ -14,7 +14,6 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
     @ScaledMetricWithMaxSize(relativeTo: .body, maxSize: .xxLarge) private var imageSize = 56
 
     init(bookmark: Bookmark, style: Style) {
-        self.rowModel = .init(bookmark: bookmark)
         self.bookmark = bookmark
         self.style = style
     }
@@ -43,6 +42,10 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
 
         .background(selected ? style.rowSelected : nil)
         .animation(.linear, value: selected)
+
+        .task(id: bookmark.id) {
+            await rowModel.configure(with: bookmark)
+        }
     }
 
     @ViewBuilder
@@ -70,11 +73,11 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
                         .lineLimit(1)
                 }
 
-                Text(rowModel.title)
+                Text(bookmark.title)
                     .foregroundStyle(style.primaryText)
                     .font(style: .subheadline, weight: .medium)
 
-                Text(rowModel.subtitle)
+                Text(subtitle)
                     .foregroundStyle(style.tertiaryText)
                     .font(style: .caption, weight: .semibold)
                     .lineLimit(1)
@@ -91,9 +94,13 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
         }
     }
 
+    private var subtitle: String {
+        DateFormatter.localizedString(from: bookmark.created, dateStyle: .medium, timeStyle: .short)
+    }
+
     /// Displays the play button view, and adds the action to it
     private var playButtonView: some View {
-        PlayButton(title: rowModel.playButton, style: style).buttonize {
+        PlayButton(title: TimeFormatter.shared.playTimeFormat(time: bookmark.time), style: style).buttonize {
             viewModel.bookmarkPlayTapped(bookmark)
         } customize: { config in
             config.label

--- a/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
@@ -3,45 +3,44 @@ import PocketCastsUtils
 import PocketCastsDataModel
 import PocketCastsServer
 
+@MainActor
 class BookmarkRowViewModel: ObservableObject {
-    @Published var heading: String?
-    let title: String
-    let subtitle: String
-    let playButton: String
-    @Published var episode: BaseEpisode?
+    @Published private(set) var heading: String?
+    @Published private(set) var episode: BaseEpisode?
 
-    init(bookmark: Bookmark) {
-        self.episode = bookmark.episode
-        self.title = bookmark.title
-        self.playButton = TimeFormatter.shared.playTimeFormat(time: bookmark.time)
-        self.subtitle = DateFormatter.localizedString(from: bookmark.created,
-                                                      dateStyle: .medium,
-                                                      timeStyle: .short)
-        if let episode {
-            updateFromEpisode(episode)
-        } else {
-            loadEpisode(from: bookmark)
-        }
-    }
+    private var episodeUuid: String?
 
-    private func updateFromEpisode(_ episode: BaseEpisode) {
-        self.episode = episode
-        self.heading = episode.title
-    }
+    /// Loads the bookmark's episode so the row can display its title and artwork
+    func configure(with bookmark: Bookmark) async {
+        guard episodeUuid != bookmark.episodeUuid else { return }
+        episodeUuid = bookmark.episodeUuid
 
-    private func loadEpisode(from bookmark: Bookmark) {
-        // Get the bookmark's BaseEpisode so we can load it
-        let dataManager = DataManager.sharedManager
-        if let episode = bookmark.episode ?? dataManager.findBaseEpisode(uuid: bookmark.episodeUuid) {
-            updateFromEpisode(episode)
-        } else if let podcastUuid = bookmark.podcastUuid {
-            ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: bookmark.episodeUuid, podcastUuid: podcastUuid) { [weak self] episode in
-                if let episode {
-                    DispatchQueue.main.async {
-                        self?.updateFromEpisode(episode)
-                    }
-                }
+        let episode = await Self.loadEpisode(for: bookmark)
+
+        if Task.isCancelled {
+            // Let the next appearance retry the interrupted load
+            if episodeUuid == bookmark.episodeUuid {
+                episodeUuid = nil
             }
+            return
         }
+
+        if let episode {
+            self.episode = episode
+            self.heading = episode.title
+        }
+    }
+
+    @concurrent
+    nonisolated private static func loadEpisode(for bookmark: Bookmark) async -> BaseEpisode? {
+        if let episode = bookmark.episode ?? DataManager.sharedManager.findBaseEpisode(uuid: bookmark.episodeUuid) {
+            return episode
+        }
+
+        guard let podcastUuid = bookmark.podcastUuid else {
+            return nil
+        }
+
+        return try? await ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: bookmark.episodeUuid, podcastUuid: podcastUuid)
     }
 }

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -354,7 +354,6 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
 
         listenForBookmarkChanges()
         setupLogin()
-        setupBookmarkViewModel()
 
         setupRefreshControl()
 
@@ -1709,9 +1708,10 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
             }
         case .bookmarks:
             if bookmarkViewModel == nil {
-                setupBookmarkViewModel()
+                setupBookmarkViewModel() // Reloads on init
+            } else {
+                bookmarkViewModel?.reload()
             }
-            bookmarkViewModel?.reload()
         }
         Analytics.track(.podcastsScreenTabTapped, properties: ["value": mode.analyticsValue])
         reloadData()


### PR DESCRIPTION
Fixes PCIOS-817.

Opening the Bookmarks tab was slow when bookmarks referenced episodes missing locally: each orphaned bookmark fired a synchronous network lookup (10s timeout) on the main thread during row rendering.

- Added async `addMissingPodcastAndEpisode` to `ServerPodcastManager`; the old completion-based variant (synchronous networking) is soft-deprecated
- `BookmarkRow` now owns `BookmarkRowViewModel` as `@StateObject` and loads the missing episode in `.task(id:)`, off the main actor, once per episode
- Bookmark title/date/play-time render immediately from the bookmark; episode heading/artwork fill in when the load completes
- `PodcastViewController` creates its bookmarks list view model lazily on first switch to the Bookmarks tab instead of in `viewDidLoad`

## To test

To reproduce the missing-episode scenario locally, apply the attached debug patch — it deletes the local episodes referenced by the podcast's bookmarks every time the Bookmarks tab is opened, forcing rows through the `addMissingPodcastAndEpisode` path:

[debug-delete-bookmarked-episodes.patch](https://github.com/user-attachments/files/29901229/debug-delete-bookmarked-episodes.patch)

1. Download the patch and apply it from the repo root: `git apply ~/Downloads/debug-delete-bookmarked-episodes.patch`
2. Add a few bookmarks to episodes of a subscribed podcast (or sign in to an account that already has some)
3. Open the podcast page and switch to the Bookmarks tab — the tab should open instantly; each row shows the bookmark title, date, and play time right away, and the episode name + artwork fill in once fetched from the server
4. Scroll away and back — rows shouldn't refetch episodes they already loaded
5. Tap play on a bookmark and confirm playback starts at the bookmarked time
6. Discard the patch when done: `git checkout -- "podcasts/Podcasts/Podcast Page/PodcastViewController.swift"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)