### PR TITLE
Fix options picker labels wrapping to multiple lines when there is enough space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Add support for Flightcast JSON transcripts [#4706](https://github.com/Automattic/pocket-casts-ios/pull/4706)
 - Fix player opening on Bookmarks tab in RTL languages [#4696](https://github.com/Automattic/pocket-casts-ios/pull/4696)
 - Fix the mini player initial loading shimmer not showing up when Reduce Motion is enabled [#4713](https://github.com/Automattic/pocket-casts-ios/pull/4713)
-- Fix overlapping labels in options picker rows that show the current value, like "Sort By" [#4722](https://github.com/Automattic/pocket-casts-ios/pull/4722)
+- Fix options picker rows like "Sort By" wrapping their labels to multiple lines when there is enough space [#4722](https://github.com/Automattic/pocket-casts-ios/pull/4722)
 
 8.16
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add support for Flightcast JSON transcripts [#4706](https://github.com/Automattic/pocket-casts-ios/pull/4706)
 - Fix player opening on Bookmarks tab in RTL languages [#4696](https://github.com/Automattic/pocket-casts-ios/pull/4696)
 - Fix the mini player initial loading shimmer not showing up when Reduce Motion is enabled [#4713](https://github.com/Automattic/pocket-casts-ios/pull/4713)
+- Fix overlapping labels in options picker rows that show the current value, like "Sort By" [#4722](https://github.com/Automattic/pocket-casts-ios/pull/4722)
 
 8.16
 -----

--- a/podcasts/SimpleActionView.swift
+++ b/podcasts/SimpleActionView.swift
@@ -125,7 +125,7 @@ class SimpleActionView: UIView {
             previousView = imageView
         }
         if previousView != label {
-            label.trailingAnchor.constraint(equalTo: previousView.leadingAnchor, constant: -16).isActive = true
+            label.trailingAnchor.constraint(equalTo: previousView.leadingAnchor, constant: -24).isActive = true
         }
         trailingAnchor.constraint(equalTo: previousView.trailingAnchor, constant: 20).isActive = true
 

--- a/podcasts/SimpleActionView.swift
+++ b/podcasts/SimpleActionView.swift
@@ -39,6 +39,7 @@ class SimpleActionView: UIView {
         addSubview(label)
         label.setContentHuggingPriority(.defaultLow, for: .vertical)
         label.setContentCompressionResistancePriority(.required, for: .vertical)
+        label.setContentCompressionResistancePriority(.init(rawValue: 751), for: .horizontal)
         let iconTintColor = action.destructive ? AppTheme.destructiveTextColor(for: themeOverride) : AppTheme.colorForStyle(iconTintStyle, themeOverride: themeOverride)
 
         var image = action.icon.flatMap { UIImage(named: $0) }
@@ -83,15 +84,14 @@ class SimpleActionView: UIView {
             secondaryLabel.textAlignment = .right
             secondaryLabel.textColor = ThemeColor.primaryText02(for: themeOverride)
             secondaryLabel.translatesAutoresizingMaskIntoConstraints = false
+            secondaryLabel.setContentCompressionResistancePriority(.init(rawValue: 749), for: .horizontal)
             addSubview(secondaryLabel)
 
             secondaryLabelVerticalConstraints = [
                 secondaryLabel.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
                 secondaryLabel.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
             ]
-            NSLayoutConstraint.activate(secondaryLabelVerticalConstraints + [
-                label.widthAnchor.constraint(greaterThanOrEqualTo: secondaryLabel.widthAnchor, multiplier: 1)
-            ])
+            NSLayoutConstraint.activate(secondaryLabelVerticalConstraints)
             self.secondaryLabel = secondaryLabel
             previousView = secondaryLabel
         }
@@ -125,7 +125,7 @@ class SimpleActionView: UIView {
             previousView = imageView
         }
         if previousView != label {
-            label.trailingAnchor.constraint(equalTo: previousView.leadingAnchor, constant: -10).isActive = true
+            label.trailingAnchor.constraint(equalTo: previousView.leadingAnchor, constant: -16).isActive = true
         }
         trailingAnchor.constraint(equalTo: previousView.trailingAnchor, constant: 20).isActive = true
 


### PR DESCRIPTION
Fixes PCIOS-818

Options picker rows with a value on the right (e.g. "Sort By") could wrap their labels to multiple lines even when the row had enough space for both, because a constraint forced the title label to be at least as wide as the value label. This PR removes that constraint, letting compression resistance priorities decide which label gives way first, and widens the spacing between the labels.

## To test

1. Open a podcast page and tap the sort button (or Podcasts tab → ⋯ → Sort By).
2. Verify rows like "Sort By" show both labels on a single line when they fit.
3. Increase the Dynamic Type size and verify the labels only wrap when there genuinely isn't enough room.

<img width="320"  alt="Screenshot 2026-07-09 at 6 47 52 PM" src="https://github.com/user-attachments/assets/235d87fe-0981-4baf-b83f-ea792a6b7223" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.