### PR TITLE
Change PR review trigger

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,8 +1,8 @@
 name: PR Review with Progress Tracking
 
 on:
-  issue_comment:
-    types: [created]
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:
   check-pr-origin:


### PR DESCRIPTION
It would be good to switch our pull request AI reviews over to Claude. This change uses the same GitHub workflow trigger that we use on the Android project.