### PR TITLE
tvOS: Improve player handling of state changes

### DIFF
--- a/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
+++ b/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
@@ -35,16 +35,22 @@ struct MediaOverlayView: View {
                                 .animation(.smooth, value: isTransportBarVisible)
                             Spacer()
                         }
+                        if model.isFailed {
+                            failureOverlay
+                                .transition(.opacity)
+                        }
                         Spacer()
                     }
                 }
 
-                if model.isLoading {
+                if model.isLoading, !model.isFailed {
                     loadingOverlay
                         .transition(.opacity)
                 }
             }
             .animation(.easeInOut(duration: 0.2), value: model.isLoading)
+            .animation(.easeInOut(duration: 0.2), value: model.isFailed)
+            .background(model.isVideo ? Color.clear : Color.pcBackgroundBase)
         }
         .ignoresSafeArea()
     }
@@ -55,5 +61,14 @@ struct MediaOverlayView: View {
             .tint(.white)
             .scaleEffect(1.3)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var failureOverlay: some View {
+        Text(PlaybackManager.shared.activeError?.shortUserMessage ?? L10n.playerErrorShortPlaybackError)
+            .font(.caption)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 30)
+            .padding(.vertical, 20)
+            .glassEffect(.regular)
     }
 }

--- a/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
+++ b/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
@@ -64,7 +64,7 @@ struct MediaOverlayView: View {
     }
 
     private var failureOverlay: some View {
-        Text(PlaybackManager.shared.activeError?.shortUserMessage ?? L10n.playerErrorShortPlaybackError)
+        Text(model.errorMessage)
             .font(.caption)
             .multilineTextAlignment(.center)
             .padding(.horizontal, 30)

--- a/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
+++ b/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
@@ -41,6 +41,15 @@ struct MediaOverlayView: View {
                         }
                         Spacer()
                     }
+                } else {
+                    VStack {
+                        Spacer()
+                        if model.isFailed {
+                            failureOverlay
+                                .transition(.opacity)
+                        }
+                        Spacer()
+                    }
                 }
 
                 if model.isLoading, !model.isFailed {

--- a/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
@@ -15,7 +15,6 @@ struct NowPlayingTab: View {
                 }
             }
             .animation(.easeIn, value: isFocused)
-
             .toolbar(!isFocused ? .visible : .hidden, for: .tabBar)
     }
 }

--- a/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
@@ -17,10 +17,6 @@ struct NowPlayingTab: View {
             .animation(.easeIn, value: isFocused)
             .onAppear {
                 Analytics.track(.playerShown)
-                //This is to force the player to load the current episode
-                if !PlaybackManager.shared.playing(), !PlaybackManager.shared.isReadyToPlay() {
-                    PlaybackManager.shared.loadCurrentEpisode()
-                }
             }
             .toolbar(!isFocused ? .visible : .hidden, for: .tabBar)
     }

--- a/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingTab.swift
@@ -18,14 +18,8 @@ struct NowPlayingTab: View {
             .onAppear {
                 Analytics.track(.playerShown)
                 //This is to force the player to load the current episode
-                if !PlaybackManager.shared.playing() {
-                    DispatchQueue.main.async {
-                        PlaybackManager.shared.play(completion: {
-                            DispatchQueue.main.async {
-                                PlaybackManager.shared.pause(userInitiated: false)
-                            }
-                        }, userInitiated: false)
-                    }
+                if !PlaybackManager.shared.playing(), !PlaybackManager.shared.isReadyToPlay() {
+                    PlaybackManager.shared.loadCurrentEpisode()
                 }
             }
             .toolbar(!isFocused ? .visible : .hidden, for: .tabBar)

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -79,6 +79,7 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
         let controller = AVPlayerViewController()
+        controller.allowsPictureInPicturePlayback = true
         controller.allowedSubtitleOptionLanguages = []
         controller.delegate = context.coordinator
         controller.appliesPreferredDisplayCriteriaAutomatically = false

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -79,7 +79,6 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> AVPlayerViewController {
         let controller = AVPlayerViewController()
-        controller.allowsPictureInPicturePlayback = true
         controller.allowedSubtitleOptionLanguages = []
         controller.delegate = context.coordinator
         controller.appliesPreferredDisplayCriteriaAutomatically = false

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -332,6 +332,7 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
         // No title: the ellipsis icon already conveys "more", and the
         // action labels (Mark Played / Archive) speak for themselves.
         return UIMenu(
+            title: L10n.accessibilityMoreActions,
             image: UIImage(systemName: "ellipsis"),
             children: children
         )

--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -232,23 +232,29 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
             children: [volumeBoostOff, volumeBoostOn]
         )
 
-        let trimActions = TrimSilenceAmount.allCases.map { option in
-            UIAction(title: option.description, state: model.trimSilence == option ? .on : .off) { _ in
-                model.trimSilence = option
-                AnalyticsPlaybackHelper.shared.trimSilenceAmountChanged(amount: option)
-                ToastManager.shared.show(L10n.tvPlayerTrimSilenceSet(option.description))
+        var sections: [UIMenu] = [volumeBoostSection]
+
+        if  model.isTrimSilenceAvailable {
+            let trimActions = TrimSilenceAmount.allCases.map { option in
+                UIAction(title: option.description, state: model.trimSilence == option ? .on : .off) { _ in
+                    model.trimSilence = option
+                    AnalyticsPlaybackHelper.shared.trimSilenceAmountChanged(amount: option)
+                    ToastManager.shared.show(L10n.tvPlayerTrimSilenceSet(option.description))
+                }
             }
+
+            let trimSection = UIMenu(
+                title: L10n.tvPlayerTrimSilence,
+                options: [.displayInline, .singleSelection],
+                children: trimActions
+            )
+            sections.append(trimSection)
         }
-        let trimSection = UIMenu(
-            title: L10n.tvPlayerTrimSilence,
-            options: [.displayInline, .singleSelection],
-            children: trimActions
-        )
 
         return UIMenu(
             title: L10n.tvPlayerPlaybackEffects,
             image: UIImage(systemName: "speaker.wave.3"),
-            children: [volumeBoostSection]
+            children: sections
         )
     }
 

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -49,8 +49,9 @@ class NowPlayingViewModel: Identifiable {
         currentItemObservation = nil
     }
 
+    private var seekAfterLoad = false
+
     func load() {
-        isFailed = false
         let newEpisode = playbackManager.currentEpisode()
         guard newEpisode?.uuid != episode?.uuid else {
             return
@@ -60,6 +61,7 @@ class NowPlayingViewModel: Identifiable {
         player = playbackManager.avPlayer
         if !playbackManager.playing(), !playbackManager.isReadyToPlay {
             playbackManager.loadCurrentEpisode()
+            seekAfterLoad = true
         }
         loadEpisodeArtwork()
     }
@@ -112,6 +114,10 @@ class NowPlayingViewModel: Identifiable {
         let itemNotReady = status == .unknown
         isLoading = waiting || itemNotReady
         isFailed = status == .failed
+        if !isLoading, seekAfterLoad {
+            seekAfterLoad = false
+            playbackManager.seekToStartingPosition()
+        }
     }
 
     func loadEpisodeArtwork() {

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -246,6 +246,10 @@ class NowPlayingViewModel: Identifiable {
         EpisodeManager.unarchiveEpisode(episode: episode, fireNotification: true)
     }
 
+    var errorMessage: String {
+        return PlaybackManager.shared.activeError?.shortUserMessage ?? L10n.playerErrorShortPlaybackError
+    }
+
     fileprivate func observeUpNextChanges() {
         NotificationCenter.default.publisher(for: Constants.Notifications.playbackTrackChanged)
             .receive(on: DispatchQueue.main)

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -61,7 +61,9 @@ class NowPlayingViewModel: Identifiable {
         player = playbackManager.avPlayer
         if !playbackManager.playing(), !playbackManager.isReadyToPlay {
             playbackManager.loadCurrentEpisode()
-            seekAfterLoad = true
+            if !playbackManager.isCurrentEpisodeVideo() {
+                seekAfterLoad = true
+            }
         }
         loadEpisodeArtwork()
     }

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -49,6 +49,8 @@ class NowPlayingViewModel: Identifiable {
         currentItemObservation = nil
     }
 
+    private var seekAfterLoad = false
+
     func load() {
         let newEpisode = playbackManager.currentEpisode()
         guard newEpisode?.uuid != episode?.uuid else {
@@ -59,6 +61,7 @@ class NowPlayingViewModel: Identifiable {
         player = playbackManager.avPlayer
         if !playbackManager.playing(), !playbackManager.isReadyToPlay {
             playbackManager.loadCurrentEpisode()
+            seekAfterLoad = true
         }
         loadEpisodeArtwork()
     }
@@ -111,6 +114,10 @@ class NowPlayingViewModel: Identifiable {
         let itemNotReady = status == .unknown
         isLoading = waiting || itemNotReady
         isFailed = status == .failed
+        if !isLoading, seekAfterLoad {
+            seekAfterLoad = false
+            playbackManager.seekToStartingPosition()
+        }
     }
 
     func loadEpisodeArtwork() {

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -57,7 +57,7 @@ class NowPlayingViewModel: Identifiable {
         episode = newEpisode
         podcast = playbackManager.currentPodcast
         player = playbackManager.avPlayer
-        if !playbackManager.playing(), !playbackManager.isReadyToPlay() {
+        if !playbackManager.playing(), !playbackManager.isReadyToPlay {
             playbackManager.loadCurrentEpisode()
         }
         loadEpisodeArtwork()

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -54,6 +54,9 @@ class NowPlayingViewModel: Identifiable {
         episode = newEpisode
         podcast = playbackManager.currentPodcast
         player = playbackManager.avPlayer
+        if !playbackManager.playing(), !playbackManager.isReadyToPlay() {
+            playbackManager.loadCurrentEpisode()
+        }
         loadEpisodeArtwork()
     }
 

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -49,9 +49,8 @@ class NowPlayingViewModel: Identifiable {
         currentItemObservation = nil
     }
 
-    private var seekAfterLoad = false
-
     func load() {
+        isFailed = false
         let newEpisode = playbackManager.currentEpisode()
         guard newEpisode?.uuid != episode?.uuid else {
             return
@@ -61,7 +60,6 @@ class NowPlayingViewModel: Identifiable {
         player = playbackManager.avPlayer
         if !playbackManager.playing(), !playbackManager.isReadyToPlay {
             playbackManager.loadCurrentEpisode()
-            seekAfterLoad = true
         }
         loadEpisodeArtwork()
     }
@@ -114,10 +112,6 @@ class NowPlayingViewModel: Identifiable {
         let itemNotReady = status == .unknown
         isLoading = waiting || itemNotReady
         isFailed = status == .failed
-        if !isLoading, seekAfterLoad {
-            seekAfterLoad = false
-            playbackManager.seekToStartingPosition()
-        }
     }
 
     func loadEpisodeArtwork() {

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -231,6 +231,10 @@ class NowPlayingViewModel: Identifiable {
         return playbackManager.activeError?.shortUserMessage ?? L10n.playerErrorShortPlaybackError
     }
 
+    var isTrimSilenceAvailable: Bool {
+        return playbackManager.silenceRemovalAvailable()
+    }
+
     fileprivate func observeUpNextChanges() {
         NotificationCenter.default.publisher(for: Constants.Notifications.playbackTrackChanged)
             .receive(on: DispatchQueue.main)

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -250,7 +250,7 @@ class NowPlayingViewModel: Identifiable {
     }
 
     var errorMessage: String {
-        return PlaybackManager.shared.activeError?.shortUserMessage ?? L10n.playerErrorShortPlaybackError
+        return playbackManager.activeError?.shortUserMessage ?? L10n.playerErrorShortPlaybackError
     }
 
     fileprivate func observeUpNextChanges() {

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -129,8 +129,8 @@ class NowPlayingViewModel: Identifiable {
             return
         }
         let waiting = player.timeControlStatus == .waitingToPlayAtSpecifiedRate
-        let status = (player.currentItem?.status ?? .unknown)
-        let itemNotReady =  status != .readyToPlay && status != .failed
+        let status = player.currentItem?.status ?? .unknown
+        let itemNotReady = status == .unknown
         isLoading = waiting || itemNotReady
         isFailed = status == .failed
     }

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -73,7 +73,7 @@ class NowPlayingViewModel: Identifiable {
             return
         }
 
-        PlayerStatusAnalytics.shared.observe(player: player)
+        PlayerStatusObserver.shared.observe(player: player)
         timeControlStatusObservation = player.observe(\.timeControlStatus, options: [.new, .initial]) { [weak self] _, _ in
             Task { @MainActor [weak self] in
                 self?.updateLoadingState()

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -28,6 +28,8 @@ class NowPlayingViewModel: Identifiable {
     /// spinner by toggling `showsPlaybackControls`.
     var isLoading: Bool = true
 
+    var isFailed: Bool = false
+
     @ObservationIgnored private var timeControlStatusObservation: NSKeyValueObservation?
     @ObservationIgnored private var itemStatusObservation: NSKeyValueObservation?
     @ObservationIgnored private var currentItemObservation: NSKeyValueObservation?
@@ -120,11 +122,14 @@ class NowPlayingViewModel: Identifiable {
     private func updateLoadingState() {
         guard let player else {
             isLoading = true
+            isFailed = false
             return
         }
         let waiting = player.timeControlStatus == .waitingToPlayAtSpecifiedRate
-        let itemNotReady = (player.currentItem?.status ?? .unknown) != .readyToPlay
+        let status = (player.currentItem?.status ?? .unknown)
+        let itemNotReady =  status != .readyToPlay && status != .failed
         isLoading = waiting || itemNotReady
+        isFailed = status == .failed
     }
 
     func loadEpisodeArtwork() {

--- a/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
+++ b/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
@@ -60,7 +60,7 @@ class PlayerStatusObserver {
             AnalyticsPlaybackHelper.shared.currentSource = .player
             AnalyticsPlaybackHelper.shared.play()
             // this was triggered by the player UI so let's sync with playback manager
-            PlaybackManager.shared.play(userInitiated: false)
+            PlaybackManager.shared.ensureAudioSessionActivated()
         case .paused:
             AnalyticsPlaybackHelper.shared.currentSource = .player
             AnalyticsPlaybackHelper.shared.pause()

--- a/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
+++ b/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
@@ -1,10 +1,10 @@
 import Swift
 import AVFoundation
 
-class PlayerStatusAnalytics {
+class PlayerStatusObserver {
 
     static let shared = {
-       return PlayerStatusAnalytics()
+       return PlayerStatusObserver()
     }()
 
     private var player: AVPlayer?
@@ -59,9 +59,13 @@ class PlayerStatusAnalytics {
         case .playing:
             AnalyticsPlaybackHelper.shared.currentSource = .player
             AnalyticsPlaybackHelper.shared.play()
+            // this was triggered by the player UI so let's sync with playback manager
+            PlaybackManager.shared.play(userInitiated: false)
         case .paused:
             AnalyticsPlaybackHelper.shared.currentSource = .player
             AnalyticsPlaybackHelper.shared.pause()
+            // this was triggered by the player UI so let's sync with playback manager
+            PlaybackManager.shared.pause(userInitiated: false)
         case .waitingToPlayAtSpecifiedRate:
             break
         @unknown default:

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -319,7 +319,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
     }
 
-    func isReadyToPlay() -> Bool {
+    var isReadyToPlay: Bool {
         player?.isReadyToPlay() ?? false
     }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -239,9 +239,12 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
     }
 
-    func seekToStart() {
+    func seekToStartingPosition() {
         let startingTime = requiredStartingPosition()
-        seekTo(time: startingTime, startPlaybackAfterSeek: false)
+        player?.play { [weak self] in
+            self?.seekTo(time: startingTime, startPlaybackAfterSeek: false)
+            self?.player?.pause()
+        }
     }
 
     func ensureAudioSessionActivated() {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -228,6 +228,17 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
     }
 
+    func loadCurrentEpisode() {
+        guard let currEpisode = currentEpisode() else { return }
+        if playerSwitchRequired() {
+            load(episode: currEpisode, autoPlay: false, overrideUpNext: false)
+        }
+        if !haveCalledPlayerLoad {
+            player?.loadEpisode(currEpisode)
+            haveCalledPlayerLoad = true
+        }
+    }
+
     func play(completion: (() -> Void)? = nil, userInitiated: Bool = true) {
         guard let currEpisode = currentEpisode() else { return }
 
@@ -306,6 +317,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         } else {
             play()
         }
+    }
+
+    func isReadyToPlay() -> Bool {
+        player?.isReadyToPlay() ?? false
     }
 
     func skipBack() {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -239,6 +239,35 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
     }
 
+    func seekToStart() {
+        let startingTime = requiredStartingPosition()
+        seekTo(time: startingTime, startPlaybackAfterSeek: false)
+    }
+
+    func ensureAudioSessionActivated() {
+        guard let currEpisode = currentEpisode() else { return }
+        activateAudioSession(completion: { activated in
+            if !activated {
+                self.aboutToPlay.value = false
+                return
+            }
+
+            self.startUpdateTimer()
+            self.updateCommandCenterSkipTimes(addTarget: false)
+            self.updateExtraActions()
+
+            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackStarted)
+
+            if currEpisode.videoPodcast() {
+                self.setAudioSessionVideoProperties()
+            }
+
+            self.updateIdleTimer()
+
+            self.sleepTimerManager.restartSleepTimerIfNeeded()
+        })
+    }
+
     func play(completion: (() -> Void)? = nil, userInitiated: Bool = true) {
         guard let currEpisode = currentEpisode() else { return }
 


### PR DESCRIPTION
Improves the tvOS player's handling of playback state changes. The now-playing view now loads the episode from within the view model whenever the episode changes, adds a failed state, allows Picture-in-Picture, and abstracts the overlay message handling.

## To test

1. Open the tvOS app and start playing an episode.
2. Switch between episodes and confirm the player reflects the correct state each time.
3. Mark as played or archive, inside the player. Check if the next episode loads correctly and plays if you were playing before, or stays paused if the player was paused before.
4. Trigger a playback failure and confirm the failed state is shown.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
