### PR TITLE
Assume HLS episodes are video (player + list) and rename hasHLSStream

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -419,7 +419,7 @@ class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
     /// Only sets a non-empty value so we never clear an HLS url a feed refresh already provided
     /// (the server may omit alternate enclosures even when the episode has one). Not gated behind
     /// `FeatureFlag.hls` — like the feed-refresh paths, we always store the url; the flag only gates
-    /// whether it's actually used for streaming (`EpisodeManager.isStreamingHLS`).
+    /// whether it's actually used for streaming (`EpisodeManager.hasHLSStream`).
     private func updateHLSUrlIfNeeded(for baseEpisode: BaseEpisode, from episodeInfo: Api_UpNextResponse.EpisodeResponse) {
         guard let episode = baseEpisode as? Episode,
               let hlsUrl = episodeInfo.alternateEnclosures.hlsUrl, !hlsUrl.isEmpty,

--- a/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -419,7 +419,9 @@ class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
     /// Only sets a non-empty value so we never clear an HLS url a feed refresh already provided
     /// (the server may omit alternate enclosures even when the episode has one). Not gated behind
     /// `FeatureFlag.hls` — like the feed-refresh paths, we always store the url; the flag only gates
-    /// whether it's actually used for streaming (`EpisodeManager.hasHLSStream`).
+    /// whether the HLS url is eligible for use (`EpisodeManager.hasHLSStream`). Whether it's the
+    /// resolved playback source is a separate question (`EpisodeManager.willPlayViaHLS`) — a downloaded
+    /// episode still plays its local/progressive file.
     private func updateHLSUrlIfNeeded(for baseEpisode: BaseEpisode, from episodeInfo: Api_UpNextResponse.EpisodeResponse) {
         guard let episode = baseEpisode as? Episode,
               let hlsUrl = episodeInfo.alternateEnclosures.hlsUrl, !hlsUrl.isEmpty,

--- a/PocketCastsTests/Tests/Utilities/EpisodeManagerTests.swift
+++ b/PocketCastsTests/Tests/Utilities/EpisodeManagerTests.swift
@@ -222,31 +222,31 @@ final class EpisodeManagerTests: DBTestCase {
         return episode
     }
 
-    func testIsStreamingHLSWhenFlagEnabledAndHlsUrlPresent() throws {
+    func testHasHLSStreamWhenFlagEnabledAndHlsUrlPresent() throws {
         try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
-        XCTAssertTrue(EpisodeManager.isStreamingHLS(makeStreamingHLSEpisode()))
+        XCTAssertTrue(EpisodeManager.hasHLSStream(makeStreamingHLSEpisode()))
     }
 
-    func testIsNotStreamingHLSWhenFlagDisabled() throws {
+    func testDoesNotHaveHLSStreamWhenFlagDisabled() throws {
         try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: false)
-        XCTAssertFalse(EpisodeManager.isStreamingHLS(makeStreamingHLSEpisode()))
+        XCTAssertFalse(EpisodeManager.hasHLSStream(makeStreamingHLSEpisode()))
     }
 
-    func testIsNotStreamingHLSWhenHlsUrlMissingOrEmpty() throws {
+    func testDoesNotHaveHLSStreamWhenHlsUrlMissingOrEmpty() throws {
         try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
 
         let noHls = makeStreamingHLSEpisode()
         noHls.hlsUrl = nil
-        XCTAssertFalse(EpisodeManager.isStreamingHLS(noHls))
+        XCTAssertFalse(EpisodeManager.hasHLSStream(noHls))
 
         let emptyHls = makeStreamingHLSEpisode()
         emptyHls.hlsUrl = ""
-        XCTAssertFalse(EpisodeManager.isStreamingHLS(emptyHls))
+        XCTAssertFalse(EpisodeManager.hasHLSStream(emptyHls))
     }
 
-    func testIsNotStreamingHLSForUserEpisode() throws {
+    func testDoesNotHaveHLSStreamForUserEpisode() throws {
         try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
-        XCTAssertFalse(EpisodeManager.isStreamingHLS(UserEpisode()))
+        XCTAssertFalse(EpisodeManager.hasHLSStream(UserEpisode()))
     }
 
     func testUrlForEpisodeStreamsHLSWhenAvailableAndFlagEnabled() throws {

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -74,9 +74,9 @@ class AnalyticsCoordinator {
     private var currentEpisodeIsVideo: Bool {
         // For HLS we can't tell synchronously whether the stream carries video — it isn't reflected
         // in the episode's MIME type and is only detected once frames render — so assume video rather
-        // than mislabel it as audio. `isStreamingHLS` is already gated behind the HLS flag, so this
+        // than mislabel it as audio. `hasHLSStream` is already gated behind the HLS flag, so this
         // only affects analytics while HLS playback is enabled.
-        if let episode = PlaybackManager.shared.currentEpisode(), EpisodeManager.isStreamingHLS(episode) {
+        if let episode = PlaybackManager.shared.currentEpisode(), EpisodeManager.hasHLSStream(episode) {
             return true
         }
         return PlaybackManager.shared.isCurrentEpisodeVideo()

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -74,9 +74,9 @@ class AnalyticsCoordinator {
     private var currentEpisodeIsVideo: Bool {
         // For HLS we can't tell synchronously whether the stream carries video — it isn't reflected
         // in the episode's MIME type and is only detected once frames render — so assume video rather
-        // than mislabel it as audio. `hasHLSStream` is already gated behind the HLS flag, so this
-        // only affects analytics while HLS playback is enabled.
-        if let episode = PlaybackManager.shared.currentEpisode(), EpisodeManager.hasHLSStream(episode) {
+        // than mislabel it as audio. `willPlayViaHLS` is gated behind the HLS flag and only true when the
+        // current source is actually HLS, so this only affects analytics for real HLS playback.
+        if let episode = PlaybackManager.shared.currentEpisode(), EpisodeManager.willPlayViaHLS(episode) {
             return true
         }
         return PlaybackManager.shared.isCurrentEpisodeVideo()

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -85,7 +85,7 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
         // the HLS flag so it only ships while HLS playback is enabled — mirrors the web player.
         if FeatureFlag.hls.enabled, let episode {
             properties.merge(Self.hlsProtocolProperties(for: episode)) { current, _ in current }
-            if EpisodeManager.isStreamingHLS(episode), let hlsErrorDetail {
+            if EpisodeManager.hasHLSStream(episode), let hlsErrorDetail {
                 properties["hls_error_detail"] = hlsErrorDetail
             }
         }
@@ -143,7 +143,7 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     /// where the source is known. Empty unless the HLS feature flag is on.
     static func hlsProtocolProperties(for episode: BaseEpisode) -> [String: Any] {
         guard FeatureFlag.hls.enabled else { return [:] }
-        return ["playback_protocol": EpisodeManager.isStreamingHLS(episode) ? "hls" : "progressive"]
+        return ["playback_protocol": EpisodeManager.hasHLSStream(episode) ? "hls" : "progressive"]
     }
 
     /// Whether the episode advertises an HLS stream, independent of whether it's the selected source.

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -143,7 +143,7 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     /// where the source is known. Empty unless the HLS feature flag is on.
     static func hlsProtocolProperties(for episode: BaseEpisode) -> [String: Any] {
         guard FeatureFlag.hls.enabled else { return [:] }
-        return ["playback_protocol": EpisodeManager.hasHLSStream(episode) ? "hls" : "progressive"]
+        return ["playback_protocol": EpisodeManager.willPlayViaHLS(episode) ? "hls" : "progressive"]
     }
 
     /// Whether the episode advertises an HLS stream, independent of whether it's the selected source.

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -147,7 +147,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
     /// expose video via the asset's tracks, and `presentationSize` is only `0x0` until the first
     /// video frame is decoded, so we observe it and promote playback to video once it reports a size.
     private func detectVideoTracksIfNeeded(for episode: BaseEpisode, playerItem: AVPlayerItem) {
-        guard EpisodeManager.hasHLSStream(episode), !episode.videoPodcast() else { return }
+        guard isStreamingHLS, !episode.videoPodcast() else { return }
 
         let episodeUuid = episode.uuid
         presentationSizeObserver = playerItem.observe(\.presentationSize, options: [.initial, .new]) { [weak self] item, _ in

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -147,7 +147,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
     /// expose video via the asset's tracks, and `presentationSize` is only `0x0` until the first
     /// video frame is decoded, so we observe it and promote playback to video once it reports a size.
     private func detectVideoTracksIfNeeded(for episode: BaseEpisode, playerItem: AVPlayerItem) {
-        guard EpisodeManager.isStreamingHLS(episode), !episode.videoPodcast() else { return }
+        guard EpisodeManager.hasHLSStream(episode), !episode.videoPodcast() else { return }
 
         let episodeUuid = episode.uuid
         presentationSizeObserver = playerItem.observe(\.presentationSize, options: [.initial, .new]) { [weak self] item, _ in

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -378,7 +378,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
 
         guard FeatureFlag.streamAndCachePlayingEpisode.enabled,
-              !EpisodeManager.isStreamingHLS(episode), // HLS is streamed directly, never cached
+              !EpisodeManager.hasHLSStream(episode), // HLS is streamed directly, never cached
               !episode.videoPodcast(),
               !episode.isUserEpisode,
               let urlAsset = playbackItem.asset as? AVURLAsset,

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -238,7 +238,8 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             setEpisodeTitle(episode: episode)
 
             starIndicator.isHidden = !episode.keepEpisode
-            videoIndicator.isHidden = !episode.videoPodcast()
+            // Assume HLS episodes are video so we show the video indicator without parsing the stream.
+            videoIndicator.isHidden = !(episode.videoPodcast() || EpisodeManager.hasHLSStream(episode))
             videoIndicator.tintColor = ThemeColor.support01()
             setUpNextIndicator(visible: PlaybackManager.shared.inUpNext(episode: episode), animated: false)
             upNextIndicator.tintColor = ThemeColor.support01()

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -238,7 +238,8 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             setEpisodeTitle(episode: episode)
 
             starIndicator.isHidden = !episode.keepEpisode
-            // Assume HLS episodes are video so we show the video indicator without parsing the stream.
+            // Treat episodes with a usable HLS stream (HLS feature enabled + valid HLS URL) as video, so
+            // we show the video indicator without parsing the stream.
             videoIndicator.isHidden = !(episode.videoPodcast() || EpisodeManager.hasHLSStream(episode))
             videoIndicator.tintColor = ThemeColor.support01()
             setUpNextIndicator(visible: PlaybackManager.shared.inUpNext(episode: episode), animated: false)

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -421,10 +421,12 @@ class EpisodeManager: NSObject {
         return totalFilesSize
     }
 
-    /// Whether the episode should be streamed via its HLS alternate enclosure.
-    /// When a valid HLS stream is available we default to it; HLS is streamed directly and never cached.
-    /// Requires a parseable url so this stays consistent with `urlForEpisode`, which falls back to the
-    /// progressive url when the HLS string can't be turned into a `URL`.
+    /// Whether the episode has a usable HLS stream given the current feature-flag state — i.e. the HLS
+    /// feature is enabled and the episode advertises a parseable HLS URL. This is a capability check, not
+    /// a resolved-source check: a downloaded episode can still return `true` here even though it will play
+    /// its local file (use `willPlayViaHLS` for the "what will actually play" question). Requires a
+    /// parseable url so this stays consistent with `urlForEpisode`, which falls back to the progressive
+    /// url when the HLS string can't be turned into a `URL`.
     class func hasHLSStream(_ episode: BaseEpisode) -> Bool {
         guard FeatureFlag.hls.enabled, let episode = episode as? Episode, let hlsUrl = episode.hlsUrl, !hlsUrl.isEmpty else {
             return false

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -425,7 +425,7 @@ class EpisodeManager: NSObject {
     /// When a valid HLS stream is available we default to it; HLS is streamed directly and never cached.
     /// Requires a parseable url so this stays consistent with `urlForEpisode`, which falls back to the
     /// progressive url when the HLS string can't be turned into a `URL`.
-    class func isStreamingHLS(_ episode: BaseEpisode) -> Bool {
+    class func hasHLSStream(_ episode: BaseEpisode) -> Bool {
         guard FeatureFlag.hls.enabled, let episode = episode as? Episode, let hlsUrl = episode.hlsUrl, !hlsUrl.isEmpty else {
             return false
         }
@@ -434,9 +434,9 @@ class EpisodeManager: NSObject {
 
     /// Whether the episode will actually play via HLS right now. Downloaded copies take precedence over
     /// the HLS stream in `urlForEpisode`, so a downloaded episode plays its local (progressive) file and
-    /// is not treated as HLS — this distinguishes that case from `isStreamingHLS`.
+    /// is not treated as HLS — this distinguishes that case from `hasHLSStream`.
     class func willPlayViaHLS(_ episode: BaseEpisode) -> Bool {
-        guard isStreamingHLS(episode) else { return false }
+        guard hasHLSStream(episode) else { return false }
         if episode.downloaded(pathFinder: DownloadManager.shared) { return false }
         if let episode = episode as? Episode, episode.streamDownloaded(pathFinder: DownloadManager.shared) { return false }
         return true
@@ -456,7 +456,7 @@ class EpisodeManager: NSObject {
         if let episode = episode as? Episode {
             // When available, default to the HLS stream over the progressive file.
             // If the HLS url is malformed, fall through to the progressive url rather than failing.
-            if isStreamingHLS(episode), let hlsUrl = episode.hlsUrl, let url = URL(string: hlsUrl) {
+            if hasHLSStream(episode), let hlsUrl = episode.hlsUrl, let url = URL(string: hlsUrl) {
                 return url
             }
             if let url = episode.downloadUrl {

--- a/podcasts/Google Cast/GoogleCastManager.swift
+++ b/podcasts/Google Cast/GoogleCastManager.swift
@@ -191,7 +191,7 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
         // HLS streams can carry video that isn't reflected in the episode's file type, and the phone
         // only knows for sure once it's decoded locally. To keep things simple we assume any HLS
         // stream is video so the receiver renders it rather than presenting audio-only.
-        let isHLS = EpisodeManager.isStreamingHLS(episode)
+        let isHLS = EpisodeManager.hasHLSStream(episode)
         let episodeMetadata = GCKMediaMetadata(metadataType: (episode.videoPodcast() || isHLS) ? .movie : .musicTrack)
 
         if let episode = episode as? Episode, let uuid = episode.parentPodcast()?.uuid {

--- a/podcasts/Google Cast/GoogleCastManager.swift
+++ b/podcasts/Google Cast/GoogleCastManager.swift
@@ -189,8 +189,9 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
 
         // metadata about the episode to display on the Google Cast.
         // HLS streams can carry video that isn't reflected in the episode's file type, and the phone
-        // only knows for sure once it's decoded locally. To keep things simple we assume any HLS
-        // stream is video so the receiver renders it rather than presenting audio-only.
+        // only knows for sure once it's decoded locally. To keep things simple we assume an episode with
+        // a usable HLS stream (HLS feature enabled + valid HLS URL) is video, so the receiver renders it
+        // rather than presenting audio-only.
         let isHLS = EpisodeManager.hasHLSStream(episode)
         let episodeMetadata = GCKMediaMetadata(metadataType: (episode.videoPodcast() || isHLS) ? .movie : .musicTrack)
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -776,8 +776,9 @@ class PlaybackManager: ServerPlaybackDelegate {
         play()
     }
 
-    /// Whether the current episode should be presented as video, considering both the feed
-    /// metadata (`videoPodcast()`) and any video tracks detected at runtime in the stream.
+    /// Whether the current episode should be presented as video, considering the feed metadata
+    /// (`videoPodcast()`), any video tracks detected at runtime in the stream, and actual HLS playback
+    /// (`willPlayViaHLS`), which we assume is video.
     func isCurrentEpisodeVideo() -> Bool {
         guard let episode = currentEpisode() else { return false }
         // Assume HLS episodes are video so the player can go full screen immediately, without waiting to

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -781,8 +781,9 @@ class PlaybackManager: ServerPlaybackDelegate {
     func isCurrentEpisodeVideo() -> Bool {
         guard let episode = currentEpisode() else { return false }
         // Assume HLS episodes are video so the player can go full screen immediately, without waiting to
-        // detect video tracks at runtime.
-        return episode.videoPodcast() || currentStreamContainsVideo.value || EpisodeManager.hasHLSStream(episode)
+        // detect video tracks at runtime. Use willPlayViaHLS so this only applies when the current source
+        // is actually HLS (a downloaded episode plays its local file, which may not be video).
+        return episode.videoPodcast() || currentStreamContainsVideo.value || EpisodeManager.willPlayViaHLS(episode)
     }
 
     /// When the global "Audio only" setting is on (and HLS playback is enabled), every video episode

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -779,7 +779,10 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// Whether the current episode should be presented as video, considering both the feed
     /// metadata (`videoPodcast()`) and any video tracks detected at runtime in the stream.
     func isCurrentEpisodeVideo() -> Bool {
-        currentEpisode()?.videoPodcast() == true || currentStreamContainsVideo.value
+        guard let episode = currentEpisode() else { return false }
+        // Assume HLS episodes are video so the player can go full screen immediately, without waiting to
+        // detect video tracks at runtime.
+        return episode.videoPodcast() || currentStreamContainsVideo.value || EpisodeManager.hasHLSStream(episode)
     }
 
     /// When the global "Audio only" setting is on (and HLS playback is enabled), every video episode
@@ -2404,7 +2407,7 @@ class PlaybackManager: ServerPlaybackDelegate {
            !playerSwitchRequired(),
            !refreshedEpisode.videoPodcast(),
            // HLS is streamed directly (no stream-and-cache), so when playback finishes downloading we must reload to switch to the downloaded local file
-           !EpisodeManager.isStreamingHLS(refreshedEpisode) {
+           !EpisodeManager.hasHLSStream(refreshedEpisode) {
             return false
         } else {
             if !episodeIsChanging {


### PR DESCRIPTION
Assume HLS episodes are video so they show the video icon in episode lists — and open the full-screen player without waiting to detect video tracks at runtime.

### Changes

* Show the video indicator in episode lists for HLS episodes (`EpisodeCell`). HLS episodes aren't flagged `videoPodcast()` (their file type isn't `video/*`), so they were previously missing the icon.
* `PlaybackManager.isCurrentEpisodeVideo()` now treats HLS as video, so the full-screen player opens immediately instead of waiting for runtime `presentationSize` detection. Runtime detection stays as the fallback for non-HLS streams that carry video.
* Rename `EpisodeManager.isStreamingHLS` → `hasHLSStream` (a static capability check, not a streaming state) across all call sites and doc comments. `DefaultPlayer`'s private `isStreamingHLS` property is unchanged — it reflects actual streaming state.

### How to test

* [Open a list](https://pca.st/podcast/3d728640-75ca-013c-f0b5-0a4e4341158f) containing an HLS episode → it shows the video indicator.
* Play an HLS episode → the full-screen player opens right away, with no delay waiting for video detection.
* Non-HLS episodes (audio and progressive video) behave as before.