### PR TITLE
Resolve generated chapter positions via fingerprint in the full player

### DIFF
--- a/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
@@ -322,4 +322,49 @@ final class FingerprintTimingManagerTests: XCTestCase {
         XCTAssertTrue(FingerprintTimingManager.isWithinMatchedContent(forPlaybackTime: 13.9, in: entries))
         XCTAssertFalse(FingerprintTimingManager.isWithinMatchedContent(forPlaybackTime: 14.1, in: entries))
     }
+
+    // MARK: - On-demand chapter seek: search-window bounds
+
+    func testColdSearchWindowStartsAtReferenceAndUsesColdBudget() {
+        // No prior mapping — search forward from the raw reference time.
+        let window = FingerprintTimingManager.searchWindow(referenceTime: 600, estimatedPlayback: nil)
+        XCTAssertEqual(window.start, 600, accuracy: 0.001)
+        XCTAssertEqual(window.end, 600 + FingerprintConstants.onDemandSeekColdBudgetSeconds, accuracy: 0.001)
+    }
+
+    func testWarmSearchWindowCentersOnEstimateWithinBudgets() {
+        // Warm prior with a large accumulated offset, so `estimate - backwardMax`
+        // stays above the reference time and the window brackets the estimate on
+        // both sides rather than clamping to the reference time.
+        let referenceTime = 600.0
+        let estimate = 900.0 // 300s of accumulated ad offset (> backwardMax)
+        let window = FingerprintTimingManager.searchWindow(referenceTime: referenceTime, estimatedPlayback: estimate)
+        XCTAssertEqual(window.start, estimate - FingerprintConstants.onDemandSeekBackwardMaxSeconds, accuracy: 0.001)
+        XCTAssertEqual(window.end, estimate + FingerprintConstants.onDemandSeekForwardBudgetSeconds, accuracy: 0.001)
+    }
+
+    func testWarmSearchWindowNeverStartsBelowReferenceTime() {
+        // Ad offset is non-negative, so even when the backward budget would push
+        // the start below the reference time it must clamp to the reference time.
+        let referenceTime = 30.0
+        let estimate = 40.0 // small offset; estimate - backwardMax << referenceTime
+        let window = FingerprintTimingManager.searchWindow(referenceTime: referenceTime, estimatedPlayback: estimate)
+        XCTAssertEqual(window.start, referenceTime, accuracy: 0.001)
+        XCTAssertGreaterThanOrEqual(window.end, window.start)
+    }
+
+    // MARK: - On-demand chapter seek: isolation from the continuous mapping
+
+    func testChapterResolveDoesNotMutateContinuousMapping() {
+        // The one-shot resolve must never touch `main`. Seed the continuous
+        // mapping, cancel any pending resolve (a no-op here), and assert the
+        // committed mapping is unchanged and still queryable.
+        let manager = FingerprintTimingManager()
+        manager.stubMatches((0..<5).map { i in Entry(playbackTime: Double(i) * 2, referenceTime: Double(i) * 2) })
+
+        manager.cancelPendingChapterResolve()
+
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 4)), 4, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(manager.playbackTime(forReferenceTime: 6)), 6, accuracy: 0.001)
+    }
 }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -940,6 +940,8 @@ enum AnalyticsEvent: String {
     case syncedTranscriptsUnavailable
     case syncedTranscriptsSeekFailed
     case syncedTranscriptsAutoScrollResumed
+    case syncedTranscriptsChapterSeekUsed
+    case syncedTranscriptsChapterSeekFailed
 
     // MARK: - Widgets
 

--- a/podcasts/ChapterInfo.swift
+++ b/podcasts/ChapterInfo.swift
@@ -18,6 +18,19 @@ class ChapterInfo: Equatable {
     var duration: TimeInterval = 0
     var isHidden = false
 
+    /// For generated chapters, the fingerprint-resolved position on the playback
+    /// timeline where this chapter actually starts. Dynamic ads shift it away
+    /// from `startTime`, which is on the AI reference timeline. Set when a chapter
+    /// tap resolves via `FingerprintTimingManager`; nil otherwise.
+    var resolvedPlaybackStartTime: TimeInterval?
+
+    /// The chapter's start on the playback timeline: the fingerprint-resolved
+    /// position when known, otherwise the reference `startTime`. Progress display
+    /// keys off this so a resolved chapter starts at 0% rather than mid-way.
+    var effectiveStartTime: TimeInterval {
+        resolvedPlaybackStartTime ?? startTime.seconds
+    }
+
     /// Should only be used for sync purposes, if reading for playback
     /// use `isPlayable()` instead
     var shouldPlay = true

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -63,7 +63,7 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
         if let chapter = PlaybackManager.shared.playableChapterAt(index: indexPath.row) {
             if chapter.index == PlaybackManager.shared.currentChapters().index {
                 containerDelegate?.scrollToNowPlaying()
-            } else if shouldUseFingerprintSeek {
+            } else if GeneratedChapterSeeker.isEnabled {
                 resolveAndSeek(to: chapter, at: indexPath)
             } else {
                 PlaybackManager.shared.skipToChapter(chapter, startPlaybackAfterSkip: true)
@@ -72,98 +72,25 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
         }
     }
 
-    /// Generated chapters carry reference-timeline start times that dynamic ads
-    /// have shifted in the listener's audio, so seeking to the raw start lands in
-    /// the wrong place. When both the generated-chapters and fingerprint features
-    /// are on, resolve the true playback position by fingerprinting instead.
-    /// Embedded / podcast-index chapters already carry real playback times and
-    /// must not go through the resolver.
-    private var shouldUseFingerprintSeek: Bool {
-        FeatureFlag.generatedChapters.enabled
-            && FeatureFlag.syncedTranscripts.enabled
-            && PlaybackManager.shared.chaptersAreGenerated
-            && PlaybackManager.shared.currentEpisode() != nil
-    }
-
     private func resolveAndSeek(to chapter: ChapterInfo, at indexPath: IndexPath) {
-        guard let episode = PlaybackManager.shared.currentEpisode() else {
-            PlaybackManager.shared.skipToChapter(chapter, startPlaybackAfterSkip: true)
-            PlaybackManager.shared.trackChapterEvent(.playerChapterSelected)
-            return
-        }
-
-        let episodeUuid = episode.uuid
-        let referenceTime = chapter.startTime.seconds
-        let fromPosition = PlaybackManager.shared.currentTime()
-
         // Move the spinner to the tapped row (clearing any previous one).
         if let previous = resolvingIndexPath, previous != indexPath {
             (chaptersTable.cellForRow(at: previous) as? PlayerChapterCell)?.setResolving(false)
         }
-        if let seekTime = chapter.resolvedPlaybackStartTime {
-            PlaybackManager.shared.seekTo(time: seekTime, startPlaybackAfterSeek: true)
-            Analytics.track(.syncedTranscriptsChapterSeekUsed, properties: [
-                "episode_uuid": episodeUuid,
-                "from_position_seconds": Int(fromPosition),
-                "to_position_seconds": Int(seekTime),
-                "reference_time_seconds": Int(referenceTime)
-            ])
-            return
-        }
-        resolvingIndexPath = indexPath
-        (chaptersTable.cellForRow(at: indexPath) as? PlayerChapterCell)?.setResolving(true)
-        PlaybackManager.shared.trackChapterEvent(.playerChapterSelected)
 
-        FingerprintTimingManager.shared.resolvePlaybackTime(forReferenceTime: referenceTime, episode: episode) { [weak self] result in
-            guard let self else { return }
-
-            self.resolvingIndexPath = nil
-            (self.chaptersTable.cellForRow(at: indexPath) as? PlayerChapterCell)?.setResolving(false)
-
-            // The listener switched episodes while we were resolving — the
-            // resolved position is meaningless now, so don't seek.
-            guard PlaybackManager.shared.currentEpisode()?.uuid == episodeUuid else {
-                Analytics.track(.syncedTranscriptsChapterSeekFailed, properties: [
-                    "episode_uuid": episodeUuid,
-                    "reason": "episode_changed",
-                    "synced_state": FingerprintTimingManager.shared.state.analyticsName,
-                    "is_streaming": false
-                ])
-                return
+        GeneratedChapterSeeker.seek(
+            to: chapter,
+            startPlayback: true,
+            willBeginResolving: { [weak self] in
+                self?.resolvingIndexPath = indexPath
+                (self?.chaptersTable.cellForRow(at: indexPath) as? PlayerChapterCell)?.setResolving(true)
+                PlaybackManager.shared.trackChapterEvent(.playerChapterSelected)
+            },
+            didEndResolving: { [weak self] in
+                self?.resolvingIndexPath = nil
+                (self?.chaptersTable.cellForRow(at: indexPath) as? PlayerChapterCell)?.setResolving(false)
             }
-
-            switch result {
-            case let .resolved(playbackTime, usedPrior, isStreaming, resolveDurationMs):
-                let seekTime = ceil(playbackTime)
-                // Record where the chapter actually starts on the playback timeline
-                // so its progress bar fills from 0% rather than from the ad-shifted
-                // offset (see `ChapterInfo.effectiveStartTime`).
-                chapter.resolvedPlaybackStartTime = seekTime
-                PlaybackManager.shared.seekTo(time: seekTime, startPlaybackAfterSeek: true)
-                Analytics.track(.syncedTranscriptsChapterSeekUsed, properties: [
-                    "episode_uuid": episodeUuid,
-                    "from_position_seconds": Int(fromPosition),
-                    "to_position_seconds": Int(seekTime),
-                    "reference_time_seconds": Int(referenceTime),
-                    "resolve_duration_ms": resolveDurationMs,
-                    "used_prior": usedPrior,
-                    "is_streaming": isStreaming
-                ])
-
-            case let .unresolved(reason, isStreaming):
-                // Graceful fallback: seek to the raw reference-timeline start.
-                PlaybackManager.shared.skipToChapter(chapter, startPlaybackAfterSkip: true)
-                if reason == "region_not_local" {
-                    Toast.show(L10n.transcriptTapToSeekStreamingUnavailable)
-                }
-                Analytics.track(.syncedTranscriptsChapterSeekFailed, properties: [
-                    "episode_uuid": episodeUuid,
-                    "reason": reason,
-                    "synced_state": FingerprintTimingManager.shared.state.analyticsName,
-                    "is_streaming": isStreaming
-                ])
-            }
-        }
+        )
     }
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -41,6 +41,8 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
             chapterCell.seperatorView.isHidden = (chapter.index == PlaybackManager.shared.currentChapters().index - 1 || chapter.index == PlaybackManager.shared.currentChapters().index || (indexPath.row == PlaybackManager.shared.chapterCount() - 1))
         }
 
+        chapterCell.setResolving(indexPath == resolvingIndexPath)
+
         return chapterCell
     }
 
@@ -61,9 +63,91 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
         if let chapter = PlaybackManager.shared.playableChapterAt(index: indexPath.row) {
             if chapter.index == PlaybackManager.shared.currentChapters().index {
                 containerDelegate?.scrollToNowPlaying()
+            } else if shouldUseFingerprintSeek {
+                resolveAndSeek(to: chapter, at: indexPath)
             } else {
                 PlaybackManager.shared.skipToChapter(chapter, startPlaybackAfterSkip: true)
                 PlaybackManager.shared.trackChapterEvent(.playerChapterSelected)
+            }
+        }
+    }
+
+    /// Generated chapters carry reference-timeline start times that dynamic ads
+    /// have shifted in the listener's audio, so seeking to the raw start lands in
+    /// the wrong place. When both the generated-chapters and fingerprint features
+    /// are on, resolve the true playback position by fingerprinting instead.
+    /// Embedded / podcast-index chapters already carry real playback times and
+    /// must not go through the resolver.
+    private var shouldUseFingerprintSeek: Bool {
+        FeatureFlag.generatedChapters.enabled
+            && FeatureFlag.syncedTranscripts.enabled
+            && PlaybackManager.shared.chaptersAreGenerated
+            && PlaybackManager.shared.currentEpisode() != nil
+    }
+
+    private func resolveAndSeek(to chapter: ChapterInfo, at indexPath: IndexPath) {
+        guard let episode = PlaybackManager.shared.currentEpisode() else {
+            PlaybackManager.shared.skipToChapter(chapter, startPlaybackAfterSkip: true)
+            PlaybackManager.shared.trackChapterEvent(.playerChapterSelected)
+            return
+        }
+
+        let episodeUuid = episode.uuid
+        let referenceTime = chapter.startTime.seconds
+        let fromPosition = PlaybackManager.shared.currentTime()
+
+        // Move the spinner to the tapped row (clearing any previous one).
+        if let previous = resolvingIndexPath, previous != indexPath {
+            (chaptersTable.cellForRow(at: previous) as? PlayerChapterCell)?.setResolving(false)
+        }
+        resolvingIndexPath = indexPath
+        (chaptersTable.cellForRow(at: indexPath) as? PlayerChapterCell)?.setResolving(true)
+        PlaybackManager.shared.trackChapterEvent(.playerChapterSelected)
+
+        FingerprintTimingManager.shared.resolvePlaybackTime(forReferenceTime: referenceTime, episode: episode) { [weak self] result in
+            guard let self else { return }
+
+            self.resolvingIndexPath = nil
+            (self.chaptersTable.cellForRow(at: indexPath) as? PlayerChapterCell)?.setResolving(false)
+
+            // The listener switched episodes while we were resolving — the
+            // resolved position is meaningless now, so don't seek.
+            guard PlaybackManager.shared.currentEpisode()?.uuid == episodeUuid else {
+                Analytics.track(.syncedTranscriptsChapterSeekFailed, properties: [
+                    "episode_uuid": episodeUuid,
+                    "reason": "episode_changed",
+                    "synced_state": FingerprintTimingManager.shared.state.analyticsName,
+                    "is_streaming": false
+                ])
+                return
+            }
+
+            switch result {
+            case let .resolved(playbackTime, usedPrior, isStreaming, resolveDurationMs):
+                let seekTime = ceil(playbackTime)
+                PlaybackManager.shared.seekTo(time: seekTime, startPlaybackAfterSeek: true)
+                Analytics.track(.syncedTranscriptsChapterSeekUsed, properties: [
+                    "episode_uuid": episodeUuid,
+                    "from_position_seconds": Int(fromPosition),
+                    "to_position_seconds": Int(seekTime),
+                    "reference_time_seconds": Int(referenceTime),
+                    "resolve_duration_ms": resolveDurationMs,
+                    "used_prior": usedPrior,
+                    "is_streaming": isStreaming
+                ])
+
+            case let .unresolved(reason, isStreaming):
+                // Graceful fallback: seek to the raw reference-timeline start.
+                PlaybackManager.shared.skipToChapter(chapter, startPlaybackAfterSkip: true)
+                if reason == "region_not_local" {
+                    Toast.show(L10n.transcriptTapToSeekStreamingUnavailable)
+                }
+                Analytics.track(.syncedTranscriptsChapterSeekFailed, properties: [
+                    "episode_uuid": episodeUuid,
+                    "reason": reason,
+                    "synced_state": FingerprintTimingManager.shared.state.analyticsName,
+                    "is_streaming": isStreaming
+                ])
             }
         }
     }

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -125,6 +125,10 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
             switch result {
             case let .resolved(playbackTime, usedPrior, isStreaming, resolveDurationMs):
                 let seekTime = ceil(playbackTime)
+                // Record where the chapter actually starts on the playback timeline
+                // so its progress bar fills from 0% rather than from the ad-shifted
+                // offset (see `ChapterInfo.effectiveStartTime`).
+                chapter.resolvedPlaybackStartTime = seekTime
                 PlaybackManager.shared.seekTo(time: seekTime, startPlaybackAfterSeek: true)
                 Analytics.track(.syncedTranscriptsChapterSeekUsed, properties: [
                     "episode_uuid": episodeUuid,

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -100,6 +100,16 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
         if let previous = resolvingIndexPath, previous != indexPath {
             (chaptersTable.cellForRow(at: previous) as? PlayerChapterCell)?.setResolving(false)
         }
+        if let seekTime = chapter.resolvedPlaybackStartTime {
+            PlaybackManager.shared.seekTo(time: seekTime, startPlaybackAfterSeek: true)
+            Analytics.track(.syncedTranscriptsChapterSeekUsed, properties: [
+                "episode_uuid": episodeUuid,
+                "from_position_seconds": Int(fromPosition),
+                "to_position_seconds": Int(seekTime),
+                "reference_time_seconds": Int(referenceTime)
+            ])
+            return
+        }
         resolvingIndexPath = indexPath
         (chaptersTable.cellForRow(at: indexPath) as? PlayerChapterCell)?.setResolving(true)
         PlaybackManager.shared.trackChapterEvent(.playerChapterSelected)

--- a/podcasts/ChaptersViewController.swift
+++ b/podcasts/ChaptersViewController.swift
@@ -6,6 +6,11 @@ class ChaptersViewController: PlayerItemViewController {
 
     var numberOfDeselectedChapters = 0
 
+    /// The row whose generated chapter is currently being resolved to a real
+    /// playback position via fingerprinting (shows a spinner). Nil when idle.
+    /// Drives the per-row spinner from `cellForRowAt` so it survives cell reuse.
+    var resolvingIndexPath: IndexPath?
+
     @IBOutlet var chaptersTable: UITableView! {
         didSet {
             registerCells()
@@ -34,6 +39,9 @@ class ChaptersViewController: PlayerItemViewController {
 
     override func willBeRemovedFromPlayer() {
         removeAllCustomObservers()
+        // Drop any in-flight chapter resolve so a backgrounded list can't seek later.
+        FingerprintTimingManager.shared.cancelPendingChapterResolve()
+        resolvingIndexPath = nil
     }
 
     override func themeDidChange() {

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -111,4 +111,32 @@ enum FingerprintConstants {
     /// matched anchor the gap jumps past this and highlighting stops — no ad
     /// detection, no lag. Comfortably below a typical ad break (≥15s).
     static let highlightMaxGapSeconds: Double = 8
+
+    // MARK: - On-demand chapter seek
+
+    /// Cold path (no existing mapping — the common case when a generated chapter is
+    /// tapped from the player). Forward audio searched starting at the chapter's raw
+    /// reference time. Because dynamic-ad offset only accumulates, the true playback
+    /// position is always ≥ the reference time; this caps how far ahead we look, and
+    /// hence worst-case decode/CPU/latency, before falling back to a raw skip.
+    static let onDemandSeekColdBudgetSeconds: Double = 240
+
+    /// Warm path, target ahead of the listener. Extra audio searched past the
+    /// rate-1 lower bound (`P + (T − R_now)`) to absorb ad insertions between the
+    /// current position and the target.
+    static let onDemandSeekForwardBudgetSeconds: Double = 120
+
+    /// Warm path, target behind the listener. Cap on the `[T, T + offset_now]`
+    /// search window when the current offset is large.
+    static let onDemandSeekBackwardMaxSeconds: Double = 180
+
+    /// Minimum committed anchors in the one-shot scratch mapping before a resolved
+    /// playback time is trusted. Mirrors `minimumCoverageForActive` — two anchors
+    /// give a locally-consistent rate-1 segment to interpolate on.
+    static let onDemandSeekMinAnchors: Int = 2
+
+    /// Hard timeout for a one-shot chapter resolve. On expiry the resolve is
+    /// cancelled and the caller falls back to a raw skip, so a pathological decode
+    /// can't hang the tap behind an indefinite spinner.
+    static let onDemandSeekTimeoutSeconds: TimeInterval = 5
 }

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -69,6 +69,19 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
+    /// The mutable state a fingerprint match run accumulates: the two sorted
+    /// mapping views plus the drift filter's rolling state. Extracted into a
+    /// value type so the continuous transcript path (`main`) and the one-shot
+    /// chapter resolve can each run the identical matching pipeline against
+    /// their own isolated accumulator, without the one-shot ever touching the
+    /// mapping the highlighter depends on.
+    struct MappingAccumulator {
+        var playbackToReference: [TimeMappingEntry] = []
+        var referenceToPlayback: [TimeMappingEntry] = []
+        var filterLastTrusted: TimeMappingEntry?
+        var filterCandidatePool: [TimeMappingEntry] = []
+    }
+
     // MARK: - Private State
 
     private let queue = DispatchQueue(label: "au.com.pocketcasts.FingerprintTimingManager")
@@ -79,17 +92,24 @@ final class FingerprintTimingManager: NSObject {
     private var context: GenerationContext?
     private var cancellationFlag = CancellationFlag()
     private var fetchTask: Task<Void, Never>?
-    private var playbackToReference: [TimeMappingEntry] = []
-    private var referenceToPlayback: [TimeMappingEntry] = []
+
+    /// Cancellation + task handles for the one-shot chapter resolve. Kept
+    /// separate from the continuous `cancellationFlag`/`fetchTask` so a chapter
+    /// tap never cancels (or is cancelled by) transcript preparation. Accessed
+    /// only from the main queue, where `resolvePlaybackTime` is invoked.
+    private var onDemandFlag = CancellationFlag()
+    private var onDemandTask: Task<Void, Never>?
+
+    /// Accumulator backing the continuous transcript mapping (playback↔reference
+    /// plus drift-filter state). The one-shot chapter resolve uses its own local
+    /// accumulator and never mutates this one — see `resolvePlaybackTime`.
+    private var main = MappingAccumulator()
+
     private var lastProgressPosition: Double = -1
 
     private var preparationStartDate: Date?
     private var hasReachedActive = false
     private var hasEmittedPreparationStarted = false
-
-    // Drift-filter state — see `consider(candidate:)`.
-    private var filterLastTrusted: TimeMappingEntry?
-    private var filterCandidatePool: [TimeMappingEntry] = []
 
     #if DEBUG
     private static let debugRejectionCap = 500
@@ -200,7 +220,7 @@ final class FingerprintTimingManager: NSObject {
         // map is empty) cancels that in-flight work before it can finish. The
         // delta-based branch above still catches real seeks. Once we have
         // coverage the drift-restart resumes as before.
-        if playbackToReference.isEmpty { return }
+        if main.playbackToReference.isEmpty { return }
 
         #if DEBUG
         FileLog.shared.addMessage(
@@ -211,8 +231,8 @@ final class FingerprintTimingManager: NSObject {
     }
 
     private func isWithinMappedRange(_ playbackTime: Double) -> Bool {
-        guard let first = playbackToReference.first,
-              let last = playbackToReference.last else { return false }
+        guard let first = main.playbackToReference.first,
+              let last = main.playbackToReference.last else { return false }
         let margin = FingerprintConstants.playbackRangeMarginSeconds
         return playbackTime >= first.playbackTime - margin
             && playbackTime <= last.playbackTime + margin
@@ -248,7 +268,7 @@ final class FingerprintTimingManager: NSObject {
         return queue.sync {
             Self.interpolate(
                 time: playbackTime,
-                in: playbackToReference,
+                in: main.playbackToReference,
                 keyPath: \.playbackTime,
                 valuePath: \.referenceTime
             )
@@ -260,7 +280,7 @@ final class FingerprintTimingManager: NSObject {
         return queue.sync {
             Self.interpolate(
                 time: referenceTime,
-                in: referenceToPlayback,
+                in: main.referenceToPlayback,
                 keyPath: \.referenceTime,
                 valuePath: \.playbackTime
             )
@@ -280,7 +300,7 @@ final class FingerprintTimingManager: NSObject {
     func isWithinMatchedContent(forPlaybackTime playbackTime: Double) -> Bool {
         dispatchPrecondition(condition: .notOnQueue(queue))
         return queue.sync {
-            Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: playbackToReference)
+            Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: main.playbackToReference)
         }
     }
 
@@ -292,14 +312,196 @@ final class FingerprintTimingManager: NSObject {
     func matchedReferenceTime(forPlaybackTime playbackTime: Double) -> Double? {
         dispatchPrecondition(condition: .notOnQueue(queue))
         return queue.sync {
-            guard Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: playbackToReference) else {
+            guard Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: main.playbackToReference) else {
                 return nil
             }
             return Self.interpolate(
                 time: playbackTime,
-                in: playbackToReference,
+                in: main.playbackToReference,
                 keyPath: \.playbackTime,
                 valuePath: \.referenceTime
+            )
+        }
+    }
+
+    // MARK: - On-demand chapter seek
+
+    /// Outcome of a one-shot chapter resolve. `reason` on `.unresolved` is a
+    /// stable analytics token the caller reports and can key fallback behavior on.
+    enum ChapterSeekResult {
+        case resolved(playbackTime: Double, usedPrior: Bool, isStreaming: Bool, resolveDurationMs: Int)
+        case unresolved(reason: String, isStreaming: Bool)
+    }
+
+    /// Resolve a generated chapter's reference-timeline `referenceTime` to the
+    /// playback-timeline position where that content actually occurs in the
+    /// listener's audio (which dynamic ads have shifted), by fingerprinting a
+    /// bounded region of the local file around the expected area and matching it
+    /// against the reference.
+    ///
+    /// This is a one-shot, side-effect-free operation: it uses its own reference
+    /// data, matcher, cancellation flag, and a local scratch mapping, and never
+    /// mutates the continuous transcript mapping (`main`), `context`, or `state`.
+    /// A second call supersedes any still-running one (last tap wins).
+    ///
+    /// Must be called on the main queue. `completion` is delivered on the main
+    /// queue; a superseded resolve never calls back.
+    func resolvePlaybackTime(
+        forReferenceTime referenceTime: Double,
+        episode: BaseEpisode,
+        completion: @escaping (ChapterSeekResult) -> Void
+    ) {
+        // Supersede any prior in-flight resolve.
+        onDemandFlag.cancel()
+        let flag = CancellationFlag()
+        onDemandFlag = flag
+        onDemandTask?.cancel()
+
+        onDemandTask = Task { [weak self] in
+            guard let self else { return }
+
+            // Hard timeout: cancel the flag after the deadline so a slow decode
+            // can't leave the tap spinning indefinitely. The decode loop observes
+            // the flag once per chunk.
+            let timeoutTask = Task {
+                try? await Task.sleep(
+                    nanoseconds: UInt64(FingerprintConstants.onDemandSeekTimeoutSeconds * 1_000_000_000)
+                )
+                flag.cancel()
+            }
+            defer { timeoutTask.cancel() }
+
+            let result = await self.performResolve(
+                forReferenceTime: referenceTime,
+                episode: episode,
+                flag: flag
+            )
+
+            await MainActor.run {
+                // Drop the result if a newer resolve superseded us (last tap wins).
+                guard self.onDemandFlag === flag else { return }
+                completion(result)
+            }
+        }
+    }
+
+    /// Cancel any in-flight one-shot chapter resolve without delivering a result.
+    /// Called on view teardown so a backgrounded chapters list can't seek later.
+    func cancelPendingChapterResolve() {
+        onDemandFlag.cancel()
+        onDemandTask?.cancel()
+    }
+
+    private func performResolve(
+        forReferenceTime referenceTime: Double,
+        episode: BaseEpisode,
+        flag: CancellationFlag
+    ) async -> ChapterSeekResult {
+        let startDate = Date()
+        let episodeUuid = episode.uuid
+
+        // Snapshot the warm prior (if the transcript flow already has a mapping
+        // for this episode) read-only on `queue`: its reference data lets us skip
+        // disk/network, and the existing mapping estimates the ad offset at the
+        // target so we can tighten the search window.
+        let prior: (referenceData: Data?, estimatedPlayback: Double?) = queue.sync {
+            guard let ctx = context, ctx.episodeUuid == episodeUuid else { return (nil, nil) }
+            let estimate = Self.interpolate(
+                time: referenceTime,
+                in: main.referenceToPlayback,
+                keyPath: \.referenceTime,
+                valuePath: \.playbackTime
+            )
+            return (ctx.referenceData, estimate)
+        }
+
+        // Resolve reference data: warm context → disk → server.
+        var referenceData = prior.referenceData ?? loadReference(for: episode)?.data
+        if referenceData == nil {
+            referenceData = await FingerprintReferenceRetriever.shared.fetchReferenceData(
+                podcastUuid: episode.parentIdentifier(),
+                episodeUuid: episodeUuid
+            )
+            if let referenceData { saveReferenceData(referenceData, for: episode) }
+        }
+
+        if flag.isCancelled { return .unresolved(reason: "timeout", isStreaming: false) }
+        guard let referenceData,
+              let reference = ReferenceFingerprint.decode(from: referenceData) else {
+            return .unresolved(reason: "no_reference", isStreaming: false)
+        }
+
+        let duration = episode.duration
+        guard duration > 0,
+              let (matcher, _) = buildMatcher(from: reference, episodeUuid: episodeUuid, audioDuration: duration) else {
+            return .unresolved(reason: "no_reference", isStreaming: false)
+        }
+
+        let usedPrior = prior.estimatedPlayback != nil
+        let window = Self.searchWindow(
+            referenceTime: referenceTime,
+            estimatedPlayback: prior.estimatedPlayback
+        )
+        let alignedStart = Self.alignToWindowGrid(window.start)
+        let searchEnd = window.end
+
+        let source = resolveAudioSource(for: episode)
+        let audioURL: URL
+        let isStreaming: Bool
+        switch source {
+        case .downloaded(let url): audioURL = url; isStreaming = false
+        case .streaming(let url): audioURL = url; isStreaming = true
+        }
+
+        if flag.isCancelled { return .unresolved(reason: "timeout", isStreaming: isStreaming) }
+
+        // Fingerprint + match the bounded region into a local scratch accumulator
+        // on `generationQueue` (heavy decode) while matching stays serialized on
+        // `queue` — `main` is never touched.
+        let outcome: Result<MappingAccumulator, StreamError> = await withCheckedContinuation { continuation in
+            generationQueue.async {
+                var scratch = MappingAccumulator()
+                do {
+                    try self.streamFingerprintBounded(
+                        audioFileURL: audioURL,
+                        startSeconds: alignedStart,
+                        endSeconds: searchEnd,
+                        matcher: matcher,
+                        flag: flag,
+                        into: &scratch
+                    )
+                    continuation.resume(returning: .success(scratch))
+                } catch let error as StreamError {
+                    continuation.resume(returning: .failure(error))
+                } catch {
+                    continuation.resume(returning: .failure(.bufferAllocationFailed))
+                }
+            }
+        }
+
+        switch outcome {
+        case .failure(.cancelled):
+            return .unresolved(reason: "timeout", isStreaming: isStreaming)
+        case .failure(.regionUnavailable):
+            return .unresolved(reason: "region_not_local", isStreaming: isStreaming)
+        case .failure:
+            return .unresolved(reason: "no_match", isStreaming: isStreaming)
+        case .success(let scratch):
+            guard scratch.playbackToReference.count >= FingerprintConstants.onDemandSeekMinAnchors,
+                  let playback = Self.interpolate(
+                      time: referenceTime,
+                      in: scratch.referenceToPlayback,
+                      keyPath: \.referenceTime,
+                      valuePath: \.playbackTime
+                  ) else {
+                return .unresolved(reason: "no_match", isStreaming: isStreaming)
+            }
+            let resolveDurationMs = Int(Date().timeIntervalSince(startDate) * 1000)
+            return .resolved(
+                playbackTime: max(referenceTime, playback),
+                usedPrior: usedPrior,
+                isStreaming: isStreaming,
+                resolveDurationMs: resolveDurationMs
             )
         }
     }
@@ -312,7 +514,7 @@ final class FingerprintTimingManager: NSObject {
 
     func debugMappingSnapshot() -> [TimeMappingEntry] {
         dispatchPrecondition(condition: .notOnQueue(queue))
-        return queue.sync { playbackToReference }
+        return queue.sync { main.playbackToReference }
     }
 
     /// Candidates that reached the drift filter but were rejected. The debug
@@ -332,21 +534,19 @@ final class FingerprintTimingManager: NSObject {
         cancellationFlag.cancel()
         cancellationFlag = CancellationFlag()
         context = nil
-        playbackToReference.removeAll()
-        referenceToPlayback.removeAll()
+        main = MappingAccumulator()
         lastProgressPosition = -1
         preparationStartDate = nil
         hasReachedActive = false
         hasEmittedPreparationStarted = false
-        resetFilterState()
         #if DEBUG
         debugRejections.removeAll()
         #endif
     }
 
     private func resetFilterState() {
-        filterLastTrusted = nil
-        filterCandidatePool.removeAll()
+        main.filterLastTrusted = nil
+        main.filterCandidatePool.removeAll()
     }
 
     private func track(_ event: AnalyticsEvent, properties: [String: Sendable] = [:]) {
@@ -452,40 +652,15 @@ final class FingerprintTimingManager: NSObject {
             return
         }
 
-        let matcher = CheckpointMatcher()
-        let duration_s = reference.checkpointDurationSeconds
-        let rawCheckpointCount = reference.checkpoints.count
-        let libraryCheckpoints = reference.libraryCheckpoints()
-
-        FileLog.shared.addMessage(
-            "FingerprintTimingManager: reference for \(uuid) — "
-                + "totalDuration=\(reference.totalDuration)s, "
-                + "checkpointInterval=\(reference.checkpointInterval), "
-                + "checkpointDuration=\(reference.checkpointDuration)s, "
-                + "timestampQuantum=\(reference.timestampQuantum), "
-                + "raw=\(rawCheckpointCount), decoded=\(libraryCheckpoints.count)"
-        )
-        if let first = libraryCheckpoints.first, let last = libraryCheckpoints.last {
-            FileLog.shared.addMessage(
-                "FingerprintTimingManager: checkpoint timestamps span "
-                    + "\(String(format: "%.1f", first.timestampSeconds))s..\(String(format: "%.1f", last.timestampSeconds))s "
-                    + "(audio duration \(String(format: "%.1f", duration))s)"
-            )
-        }
-
-        guard !libraryCheckpoints.isEmpty else {
+        guard let (matcher, checkpointCount) = buildMatcher(
+            from: reference,
+            episodeUuid: uuid,
+            audioDuration: duration
+        ) else {
             updateState(.unavailable)
             track(.syncedTranscriptsUnavailable, properties: ["reason": "no_reference"])
             FileLog.shared.addMessage("FingerprintTimingManager: reference for \(uuid) has no usable checkpoints")
             return
-        }
-
-        for checkpoint in libraryCheckpoints {
-            matcher.add(
-                timestamp: checkpoint.timestampSeconds,
-                hashes: checkpoint.hashes,
-                duration: duration_s
-            )
         }
 
         let flag = cancellationFlag
@@ -515,7 +690,7 @@ final class FingerprintTimingManager: NSObject {
             hasEmittedPreparationStarted = true
         }
         FileLog.shared.addMessage(
-            "FingerprintTimingManager: preparing for \(uuid) (\(libraryCheckpoints.count) checkpoints)"
+            "FingerprintTimingManager: preparing for \(uuid) (\(checkpointCount) checkpoints)"
         )
 
         // Capture once so the range check, log, and stream start all use the same position.
@@ -536,11 +711,11 @@ final class FingerprintTimingManager: NSObject {
             // by `playbackTime`), so assign it directly and sort once for the
             // reference-keyed view — avoids the O(n²) cost of routing every
             // entry through `insertMapping`'s per-entry `Array.insert`.
-            playbackToReference = cached.entries
-            referenceToPlayback = cached.entries.sorted { $0.referenceTime < $1.referenceTime }
+            main.playbackToReference = cached.entries
+            main.referenceToPlayback = cached.entries.sorted { $0.referenceTime < $1.referenceTime }
 
             if isWithinMappedRange(currentTime) {
-                filterLastTrusted = cached.entries.last
+                main.filterLastTrusted = cached.entries.last
                 let coverage = cached.entries.count
                 updateState(.active(coverage: coverage))
                 if !hasReachedActive {
@@ -563,6 +738,48 @@ final class FingerprintTimingManager: NSObject {
         }
 
         startStream(context: newContext, fromPosition: currentTime)
+    }
+
+    /// Build a `CheckpointMatcher` populated from every usable checkpoint in
+    /// `reference`, plus the decoded checkpoint count. Returns nil when the
+    /// reference has no usable checkpoints. Shared by the continuous transcript
+    /// path (`configureForReference`) and the one-shot chapter resolve.
+    private func buildMatcher(
+        from reference: ReferenceFingerprint,
+        episodeUuid: String,
+        audioDuration: Double
+    ) -> (matcher: CheckpointMatcher, checkpointCount: Int)? {
+        let duration_s = reference.checkpointDurationSeconds
+        let rawCheckpointCount = reference.checkpoints.count
+        let libraryCheckpoints = reference.libraryCheckpoints()
+
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: reference for \(episodeUuid) — "
+                + "totalDuration=\(reference.totalDuration)s, "
+                + "checkpointInterval=\(reference.checkpointInterval), "
+                + "checkpointDuration=\(reference.checkpointDuration)s, "
+                + "timestampQuantum=\(reference.timestampQuantum), "
+                + "raw=\(rawCheckpointCount), decoded=\(libraryCheckpoints.count)"
+        )
+        if let first = libraryCheckpoints.first, let last = libraryCheckpoints.last {
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: checkpoint timestamps span "
+                    + "\(String(format: "%.1f", first.timestampSeconds))s..\(String(format: "%.1f", last.timestampSeconds))s "
+                    + "(audio duration \(String(format: "%.1f", audioDuration))s)"
+            )
+        }
+
+        guard !libraryCheckpoints.isEmpty else { return nil }
+
+        let matcher = CheckpointMatcher()
+        for checkpoint in libraryCheckpoints {
+            matcher.add(
+                timestamp: checkpoint.timestampSeconds,
+                hashes: checkpoint.hashes,
+                duration: duration_s
+            )
+        }
+        return (matcher, libraryCheckpoints.count)
     }
 
     // MARK: - Streaming Fingerprint Processing
@@ -648,6 +865,26 @@ final class FingerprintTimingManager: NSObject {
         return max(0, floor(time / stride) * stride)
     }
 
+    /// Bounded region of local audio to fingerprint when resolving a chapter's
+    /// reference time to a playback position. Dynamic-ad offset is non-negative
+    /// and non-decreasing, so the true playback position is never below
+    /// `referenceTime` — the window always starts at or after it.
+    ///
+    /// - Warm (`estimatedPlayback` from an existing mapping): center on the
+    ///   estimate, allowing it to be earlier (a smaller offset earlier in the
+    ///   episode) by up to `onDemandSeekBackwardMaxSeconds` and later (more
+    ///   intervening ads) by up to `onDemandSeekForwardBudgetSeconds`.
+    /// - Cold (no mapping — the common case): search forward from the raw
+    ///   reference time up to `onDemandSeekColdBudgetSeconds`.
+    static func searchWindow(referenceTime: Double, estimatedPlayback: Double?) -> (start: Double, end: Double) {
+        if let estimate = estimatedPlayback {
+            let start = max(referenceTime, estimate - FingerprintConstants.onDemandSeekBackwardMaxSeconds)
+            let end = max(start, estimate + FingerprintConstants.onDemandSeekForwardBudgetSeconds)
+            return (start, end)
+        }
+        return (referenceTime, referenceTime + FingerprintConstants.onDemandSeekColdBudgetSeconds)
+    }
+
     private func streamFingerprint(context ctx: GenerationContext, startingAt startSeconds: Double) throws {
         // Force the reader to hand us non-interleaved Float32 PCM so
         // `buffer.floatChannelData` is never nil regardless of the on-disk format.
@@ -695,6 +932,76 @@ final class FingerprintTimingManager: NSObject {
         let tail = streamer.flush()
         if !tail.isEmpty {
             dispatchProcessMatches(windows: tail, startOffset: startSeconds, context: ctx)
+        }
+    }
+
+    /// Bounded, one-shot variant of `streamFingerprint` used by the chapter
+    /// resolve. Decodes only `[startSeconds, endSeconds]` of `audioFileURL`,
+    /// matching each window against `matcher` into `acc`. Unlike the continuous
+    /// variant it stops at `endSeconds` (not EOF), skips the lookahead throttle,
+    /// and never touches shared manager state — matching runs on `queue` (so the
+    /// drift filter and DEBUG rejection log stay serialized) while decode stays
+    /// on the calling `generationQueue`. Throws `.regionUnavailable` when the
+    /// local file doesn't yet reach `startSeconds` (a streaming episode whose
+    /// buffer hasn't advanced to the target chapter).
+    private func streamFingerprintBounded(
+        audioFileURL: URL,
+        startSeconds: Double,
+        endSeconds: Double,
+        matcher: CheckpointMatcher,
+        flag: CancellationFlag,
+        into acc: inout MappingAccumulator
+    ) throws {
+        let audioFile = try AVAudioFile(
+            forReading: audioFileURL,
+            commonFormat: .pcmFormatFloat32,
+            interleaved: false
+        )
+        let format = audioFile.processingFormat
+        let sampleRate = UInt32(format.sampleRate)
+        let channels = UInt16(format.channelCount)
+
+        let fileDurationSeconds = Double(audioFile.length) / format.sampleRate
+        guard startSeconds < fileDurationSeconds else { throw StreamError.regionUnavailable }
+
+        let startFrame = AVAudioFramePosition(startSeconds * format.sampleRate)
+        if startFrame > 0 { audioFile.framePosition = startFrame }
+        let endFrame = min(AVAudioFramePosition(endSeconds * format.sampleRate), audioFile.length)
+
+        let streamer = StreamingWindowedFingerprinter(
+            sampleRate: sampleRate,
+            channels: channels,
+            windowDurationMs: FingerprintConstants.windowDurationMs,
+            windowIntervalMs: FingerprintConstants.windowIntervalMs
+        )
+
+        let chunkFrames = AVAudioFrameCount(format.sampleRate * FingerprintConstants.streamChunkSeconds)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
+            throw StreamError.bufferAllocationFailed
+        }
+
+        while audioFile.framePosition < endFrame {
+            if flag.isCancelled { throw StreamError.cancelled }
+            let framesRemaining = AVAudioFrameCount(endFrame - audioFile.framePosition)
+            let framesToRead = min(framesRemaining, chunkFrames)
+            try audioFile.read(into: buffer, frameCount: framesToRead)
+            if buffer.frameLength == 0 { break }
+
+            let interleaved = Self.interleavedSamples(from: buffer)
+            let windows = streamer.pushSamplesF32(samples: interleaved, channels: channels)
+            if !windows.isEmpty {
+                queue.sync {
+                    self.matchWindows(windows: windows, startOffset: startSeconds, matcher: matcher, into: &acc)
+                }
+            }
+        }
+
+        if flag.isCancelled { throw StreamError.cancelled }
+        let tail = streamer.flush()
+        if !tail.isEmpty {
+            queue.sync {
+                self.matchWindows(windows: tail, startOffset: startSeconds, matcher: matcher, into: &acc)
+            }
         }
     }
 
@@ -875,7 +1182,7 @@ final class FingerprintTimingManager: NSObject {
         guard !ctx.isStreaming else { return }
         queue.async { [weak self] in
             guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
-            let snapshot = self.playbackToReference
+            let snapshot = self.main.playbackToReference
             self.generationQueue.async {
                 FingerprintMappingCache.save(
                     snapshot,
@@ -953,6 +1260,9 @@ final class FingerprintTimingManager: NSObject {
     private enum StreamError: Error {
         case cancelled
         case bufferAllocationFailed
+        /// The requested audio region isn't present in the local file yet (a
+        /// streaming episode whose buffer hasn't reached the target chapter).
+        case regionUnavailable
     }
 
     private func processMatches(
@@ -960,6 +1270,33 @@ final class FingerprintTimingManager: NSObject {
         startOffset: Double,
         context ctx: GenerationContext
     ) {
+        matchWindows(windows: windows, startOffset: startOffset, matcher: ctx.matcher, into: &main)
+
+        let coverage = main.playbackToReference.count
+        if coverage >= FingerprintConstants.minimumCoverageForActive {
+            updateState(.active(coverage: coverage))
+            if !hasReachedActive {
+                hasReachedActive = true
+                track(.syncedTranscriptsPreparationCompleted, properties: [
+                    "duration_ms": preparationDurationMs,
+                    "is_streaming": context?.isStreaming ?? false
+                ])
+            }
+        }
+    }
+
+    /// The core match loop shared by the continuous transcript path and the
+    /// one-shot chapter resolve: run each window through `matcher`, apply the
+    /// score/dominance gates, and route survivors through the drift filter into
+    /// `acc`. Returns the number of mappings committed this call. Mutates only
+    /// `acc` (plus `debugRejections` in DEBUG builds), so it MUST run on `queue`.
+    @discardableResult
+    private func matchWindows(
+        windows: [WindowedFingerprint],
+        startOffset: Double,
+        matcher: CheckpointMatcher,
+        into acc: inout MappingAccumulator
+    ) -> Int {
         var inserted = 0
         #if DEBUG
         var bestScoreOverall: Float = 0
@@ -971,7 +1308,7 @@ final class FingerprintTimingManager: NSObject {
             // Pull top-2 so we can check how dominant the winner is — ambiguous
             // wins (top-1 barely beats top-2) are the hallmark of correlated
             // false positives from non-matching audio.
-            let matches = ctx.matcher.findTopMatches(
+            let matches = matcher.findTopMatches(
                 queryHashes: window.hashes,
                 maxResults: 2
             )
@@ -1011,19 +1348,7 @@ final class FingerprintTimingManager: NSObject {
                 continue
             }
 
-            inserted += consider(candidate: candidate)
-        }
-
-        let coverage = playbackToReference.count
-        if coverage >= FingerprintConstants.minimumCoverageForActive {
-            updateState(.active(coverage: coverage))
-            if !hasReachedActive {
-                hasReachedActive = true
-                track(.syncedTranscriptsPreparationCompleted, properties: [
-                    "duration_ms": preparationDurationMs,
-                    "is_streaming": context?.isStreaming ?? false
-                ])
-            }
+            inserted += consider(candidate: candidate, into: &acc)
         }
 
         #if DEBUG
@@ -1036,10 +1361,11 @@ final class FingerprintTimingManager: NSObject {
         FileLog.shared.addMessage(
             "FingerprintTimingManager: processed \(windows.count) windows, "
                 + "committed \(inserted) mappings "
-                + "(coverage: \(coverage), bestScore: \(String(format: "%.3f", bestScoreOverall)), "
+                + "(coverage: \(acc.playbackToReference.count), bestScore: \(String(format: "%.3f", bestScoreOverall)), "
                 + "nonZero: \(nonZeroScoreCount), avgNonZero: \(String(format: "%.3f", avgNonZero)))"
         )
         #endif
+        return inserted
     }
 
     // MARK: - Drift Filter
@@ -1063,27 +1389,27 @@ final class FingerprintTimingManager: NSObject {
     /// and for post-trusted jumps, so a single lucky pair can never admit an
     /// anchor — what the user was seeing as "jump-arounds" in the debug UI.
     @discardableResult
-    private func consider(candidate: TimeMappingEntry) -> Int {
-        if let trusted = filterLastTrusted, Self.isInTrend(candidate, relativeTo: trusted) {
+    private func consider(candidate: TimeMappingEntry, into acc: inout MappingAccumulator) -> Int {
+        if let trusted = acc.filterLastTrusted, Self.isInTrend(candidate, relativeTo: trusted) {
             // Sequential continuation. Anything that had collected in the pool
             // was a jump attempt that never stabilized — reject it.
-            flushPoolAsRejected(reason: "returned to trend")
-            insertMapping(candidate)
-            filterLastTrusted = candidate
+            flushPoolAsRejected(reason: "returned to trend", into: &acc)
+            insertMapping(candidate, into: &acc)
+            acc.filterLastTrusted = candidate
             return 1
         }
 
-        filterCandidatePool.append(candidate)
+        acc.filterCandidatePool.append(candidate)
         let n = FingerprintConstants.driftBootstrapCount
 
-        guard filterCandidatePool.count >= n else { return 0 }
+        guard acc.filterCandidatePool.count >= n else { return 0 }
 
-        let recent = Array(filterCandidatePool.suffix(n))
+        let recent = Array(acc.filterCandidatePool.suffix(n))
         if Self.formsConsistentSequence(recent) {
             // Confirmed new anchor. Anything older in the pool is noise.
-            let keepStart = filterCandidatePool.count - n
+            let keepStart = acc.filterCandidatePool.count - n
             if keepStart > 0 {
-                for entry in filterCandidatePool.prefix(keepStart) {
+                for entry in acc.filterCandidatePool.prefix(keepStart) {
                     recordRejection(entry, reason: "pool evicted by confirmed anchor")
                 }
             }
@@ -1096,25 +1422,25 @@ final class FingerprintTimingManager: NSObject {
             )
             #endif
             for entry in recent {
-                insertMapping(entry)
+                insertMapping(entry, into: &acc)
             }
-            filterLastTrusted = recent.last
-            filterCandidatePool.removeAll()
+            acc.filterLastTrusted = recent.last
+            acc.filterCandidatePool.removeAll()
             return n
         }
 
         // Not consistent yet — evict oldest and keep waiting for the window to
         // roll onto a consistent stretch.
-        let evicted = filterCandidatePool.removeFirst()
+        let evicted = acc.filterCandidatePool.removeFirst()
         recordRejection(evicted, reason: "pool evicted, no consistent run")
         return 0
     }
 
-    private func flushPoolAsRejected(reason: String) {
-        for entry in filterCandidatePool {
+    private func flushPoolAsRejected(reason: String, into acc: inout MappingAccumulator) {
+        for entry in acc.filterCandidatePool {
             recordRejection(entry, reason: reason)
         }
-        filterCandidatePool.removeAll()
+        acc.filterCandidatePool.removeAll()
     }
 
     /// Two entries are in-trend when `Δreference ≈ Δplayback` (rate ≈ 1),
@@ -1152,7 +1478,7 @@ final class FingerprintTimingManager: NSObject {
     /// Test seam: inserts a mapping on the manager's serial queue so queries are
     /// consistent with production insertions that happen from within `processMatches`.
     func insert(mapping: TimeMappingEntry) {
-        queue.sync { insertMapping(mapping) }
+        queue.sync { insertMapping(mapping, into: &main) }
     }
 
     /// Test seam: routes a sequence of candidates through the drift filter
@@ -1161,17 +1487,17 @@ final class FingerprintTimingManager: NSObject {
     func stubMatches(_ entries: [TimeMappingEntry]) {
         queue.sync {
             for entry in entries {
-                _ = consider(candidate: entry)
+                _ = consider(candidate: entry, into: &main)
             }
         }
     }
 
-    private func insertMapping(_ entry: TimeMappingEntry) {
-        let pbIdx = playbackToReference.sortedInsertionIndex { $0.playbackTime < entry.playbackTime }
-        playbackToReference.insert(entry, at: pbIdx)
+    private func insertMapping(_ entry: TimeMappingEntry, into acc: inout MappingAccumulator) {
+        let pbIdx = acc.playbackToReference.sortedInsertionIndex { $0.playbackTime < entry.playbackTime }
+        acc.playbackToReference.insert(entry, at: pbIdx)
 
-        let refIdx = referenceToPlayback.sortedInsertionIndex { $0.referenceTime < entry.referenceTime }
-        referenceToPlayback.insert(entry, at: refIdx)
+        let refIdx = acc.referenceToPlayback.sortedInsertionIndex { $0.referenceTime < entry.referenceTime }
+        acc.referenceToPlayback.insert(entry, at: refIdx)
     }
 
     static func interpolate(

--- a/podcasts/Fingerprint/GeneratedChapterSeeker.swift
+++ b/podcasts/Fingerprint/GeneratedChapterSeeker.swift
@@ -1,0 +1,110 @@
+import Foundation
+import PocketCastsUtils
+
+/// Routes generated-chapter navigation through the fingerprint resolver.
+///
+/// Generated chapters carry reference-timeline start times that dynamic ads have
+/// shifted in the listener's audio, so seeking to the raw `startTime` lands in the
+/// wrong place. Both the chapters list (tap-to-seek) and the full player's
+/// next/previous chapter controls go through here so they resolve the true
+/// playback position first, with a graceful fallback to the raw seek. Embedded /
+/// podcast-index chapters already carry real playback times and must not be
+/// routed here.
+enum GeneratedChapterSeeker {
+
+    /// Whether generated-chapter navigation should resolve via fingerprinting
+    /// rather than seeking to the raw reference start.
+    static var isEnabled: Bool {
+        FeatureFlag.generatedChapters.enabled
+            && FeatureFlag.syncedTranscripts.enabled
+            && PlaybackManager.shared.chaptersAreGenerated
+            && PlaybackManager.shared.currentEpisode() != nil
+    }
+
+    /// Resolve `chapter` to its real playback position and seek there.
+    ///
+    /// - `willBeginResolving` / `didEndResolving` bracket the async fingerprint
+    ///   resolve so callers can show a spinner. Neither fires on the
+    ///   already-resolved cache hit, which seeks synchronously.
+    /// - `startPlayback` matches each call site's existing behaviour: the chapters
+    ///   list starts playback on a tap, the player's skip buttons don't.
+    ///
+    /// Must be called on the main queue.
+    static func seek(
+        to chapter: ChapterInfo,
+        startPlayback: Bool,
+        willBeginResolving: (() -> Void)? = nil,
+        didEndResolving: (() -> Void)? = nil
+    ) {
+        guard let episode = PlaybackManager.shared.currentEpisode() else {
+            PlaybackManager.shared.skipToChapter(chapter, startPlaybackAfterSkip: startPlayback)
+            return
+        }
+
+        let episodeUuid = episode.uuid
+        let referenceTime = chapter.startTime.seconds
+        let fromPosition = PlaybackManager.shared.currentTime()
+
+        // Already resolved this session — seek straight there without re-fingerprinting.
+        if let seekTime = chapter.resolvedPlaybackStartTime {
+            PlaybackManager.shared.seekTo(time: seekTime, startPlaybackAfterSeek: startPlayback)
+            Analytics.track(.syncedTranscriptsChapterSeekUsed, properties: [
+                "episode_uuid": episodeUuid,
+                "from_position_seconds": Int(fromPosition),
+                "to_position_seconds": Int(seekTime),
+                "reference_time_seconds": Int(referenceTime)
+            ])
+            return
+        }
+
+        willBeginResolving?()
+
+        FingerprintTimingManager.shared.resolvePlaybackTime(forReferenceTime: referenceTime, episode: episode) { result in
+            didEndResolving?()
+
+            // The listener switched episodes while we were resolving — the resolved
+            // position is meaningless now, so don't seek.
+            guard PlaybackManager.shared.currentEpisode()?.uuid == episodeUuid else {
+                Analytics.track(.syncedTranscriptsChapterSeekFailed, properties: [
+                    "episode_uuid": episodeUuid,
+                    "reason": "episode_changed",
+                    "synced_state": FingerprintTimingManager.shared.state.analyticsName,
+                    "is_streaming": false
+                ])
+                return
+            }
+
+            switch result {
+            case let .resolved(playbackTime, usedPrior, isStreaming, resolveDurationMs):
+                let seekTime = ceil(playbackTime)
+                // Record where the chapter actually starts on the playback timeline
+                // so its progress bar fills from 0% rather than from the ad-shifted
+                // offset (see `ChapterInfo.effectiveStartTime`).
+                chapter.resolvedPlaybackStartTime = seekTime
+                PlaybackManager.shared.seekTo(time: seekTime, startPlaybackAfterSeek: startPlayback)
+                Analytics.track(.syncedTranscriptsChapterSeekUsed, properties: [
+                    "episode_uuid": episodeUuid,
+                    "from_position_seconds": Int(fromPosition),
+                    "to_position_seconds": Int(seekTime),
+                    "reference_time_seconds": Int(referenceTime),
+                    "resolve_duration_ms": resolveDurationMs,
+                    "used_prior": usedPrior,
+                    "is_streaming": isStreaming
+                ])
+
+            case let .unresolved(reason, isStreaming):
+                // Graceful fallback: seek to the raw reference-timeline start.
+                PlaybackManager.shared.skipToChapter(chapter, startPlaybackAfterSkip: startPlayback)
+                if reason == "region_not_local" {
+                    Toast.show(L10n.transcriptTapToSeekStreamingUnavailable)
+                }
+                Analytics.track(.syncedTranscriptsChapterSeekFailed, properties: [
+                    "episode_uuid": episodeUuid,
+                    "reason": reason,
+                    "synced_state": FingerprintTimingManager.shared.state.analyticsName,
+                    "is_streaming": isStreaming
+                ])
+            }
+        }
+    }
+}

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -149,7 +149,7 @@ extension NowPlayingPlayerItemViewController {
             return
         }
 
-        let remainingTime = chapter.duration + chapter.startTime.seconds - playheadPosition
+        let remainingTime = chapter.duration + chapter.effectiveStartTime - playheadPosition
         chapterTimeLeftLabel.text = TimeFormatter.shared.singleUnitFormattedShortestTime(time: remainingTime)
         let percentageCompleted = 1 - (remainingTime / chapter.duration)
         chapterProgress.startingAngle = CGFloat((percentageCompleted * 360) - 90)

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -477,14 +477,85 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     }
 
     @IBAction func chapterSkipBackTapped(_ sender: Any) {
-        PlaybackManager.shared.skipToPreviousChapter()
         PlaybackManager.shared.trackChapterEvent(.playerPreviousChapterTapped)
+
+        #if !APPCLIP
+        // Generated chapters carry reference-timeline starts that dynamic ads have
+        // shifted, so resolve the true playback position by fingerprinting before
+        // seeking — matching the chapters-list tap flow.
+        if GeneratedChapterSeeker.isEnabled,
+           let previous = PlaybackManager.shared.previousPlayableChapter() {
+            GeneratedChapterSeeker.seek(
+                to: previous,
+                startPlayback: false,
+                willBeginResolving: { [weak self] in self?.setChapterSkipResolving(true, forward: false) },
+                didEndResolving: { [weak self] in self?.setChapterSkipResolving(false, forward: false) }
+            )
+            return
+        }
+        #endif
+
+        PlaybackManager.shared.skipToPreviousChapter()
     }
 
     @IBAction func chapterSkipForwardTapped(_ sender: Any) {
-        PlaybackManager.shared.skipToNextChapter()
         PlaybackManager.shared.trackChapterEvent(.playerNextChapterTapped)
+
+        #if !APPCLIP
+        if GeneratedChapterSeeker.isEnabled {
+            guard let next = PlaybackManager.shared.nextPlayableChapter() else {
+                // No next chapter — respect the producer's end of the last chapter
+                // (the same fallback `skipToNextChapter` makes). This isn't a
+                // chapter start, so there's nothing to fingerprint-resolve.
+                PlaybackManager.shared.skipToEndOfLastChapter()
+                return
+            }
+            GeneratedChapterSeeker.seek(
+                to: next,
+                startPlayback: false,
+                willBeginResolving: { [weak self] in self?.setChapterSkipResolving(true, forward: true) },
+                didEndResolving: { [weak self] in self?.setChapterSkipResolving(false, forward: true) }
+            )
+            return
+        }
+        #endif
+
+        PlaybackManager.shared.skipToNextChapter()
     }
+
+    #if !APPCLIP
+    /// Show/hide a spinner over the tapped chapter-skip button while its generated
+    /// chapter is being fingerprint-resolved. The button is dimmed to alpha 0
+    /// (which also stops it receiving taps) so a slow resolve can't be double-fired.
+    private func setChapterSkipResolving(_ resolving: Bool, forward: Bool) {
+        let button = forward ? chapterSkipFwdBtn : chapterSkipBackBtn
+        let spinner = forward ? chapterSkipFwdSpinner : chapterSkipBackSpinner
+        button?.alpha = resolving ? 0 : 1
+        if resolving {
+            spinner.startAnimating()
+        } else {
+            spinner.stopAnimating()
+        }
+    }
+
+    private lazy var chapterSkipBackSpinner = makeChapterSkipSpinner(centeredOn: chapterSkipBackBtn)
+    private lazy var chapterSkipFwdSpinner = makeChapterSkipSpinner(centeredOn: chapterSkipFwdBtn)
+
+    private func makeChapterSkipSpinner(centeredOn button: UIButton?) -> UIActivityIndicatorView {
+        let spinner = UIActivityIndicatorView(style: .medium)
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        spinner.hidesWhenStopped = true
+        spinner.color = ThemeColor.playerContrast01()
+        if let button, let container = button.superview {
+            container.addSubview(spinner)
+            NSLayoutConstraint.activate([
+                spinner.centerXAnchor.constraint(equalTo: button.centerXAnchor),
+                spinner.centerYAnchor.constraint(equalTo: button.centerYAnchor)
+            ])
+        }
+        return spinner
+    }
+    #endif
 
     @objc private func chapterLinkTapped() {
         let chapters = PlaybackManager.shared.currentChapters()

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -366,6 +366,17 @@ class PlaybackManager: ServerPlaybackDelegate {
         seekTo(time: ceil(chapter.startTime.seconds), startPlaybackAfterSeek: startPlaybackAfterSkip)
     }
 
+    /// The chapter the next/previous skip controls would move to. Exposed so
+    /// callers can resolve a generated chapter's true playback position via
+    /// fingerprinting before seeking (see `GeneratedChapterSeeker`).
+    func nextPlayableChapter() -> ChapterInfo? {
+        chapterManager.nextVisiblePlayableChapter()
+    }
+
+    func previousPlayableChapter() -> ChapterInfo? {
+        chapterManager.previousVisibleChapter()
+    }
+
     func skipToEndOfLastChapter() {
         if let lastChapter = chapterManager.lastChapter {
             seekTo(time: ceil(lastChapter.startTime.seconds) + lastChapter.duration)

--- a/podcasts/PlayerChapterCell.swift
+++ b/podcasts/PlayerChapterCell.swift
@@ -184,7 +184,7 @@ class PlayerChapterCell: UITableViewCell {
 
         layoutIfNeeded()
 
-        let lapsedTime = PlaybackManager.shared.currentTime() - chapter.startTime.seconds
+        let lapsedTime = PlaybackManager.shared.currentTime() - chapter.effectiveStartTime
         let percentageLapsed = CGFloat(lapsedTime / chapter.duration.seconds)
 
         if percentageLapsed.isFinite, !percentageLapsed.isNaN {

--- a/podcasts/PlayerChapterCell.swift
+++ b/podcasts/PlayerChapterCell.swift
@@ -50,6 +50,20 @@ class PlayerChapterCell: UITableViewCell {
 
     private var isChapterToggleEnabled: Bool = false
 
+    /// Shown in place of the chapter number while a fingerprint-based seek is being
+    /// resolved for this row (generated chapters — see `ChaptersViewController`).
+    private lazy var resolvingSpinner: UIActivityIndicatorView = {
+        let spinner = UIActivityIndicatorView(style: .medium)
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        spinner.hidesWhenStopped = true
+        contentView.addSubview(spinner)
+        NSLayoutConstraint.activate([
+            spinner.centerXAnchor.constraint(equalTo: chapterNumber.centerXAnchor),
+            spinner.centerYAnchor.constraint(equalTo: chapterNumber.centerYAnchor)
+        ])
+        return spinner
+    }()
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -121,6 +135,20 @@ class PlayerChapterCell: UITableViewCell {
         toggleChapterButton.isHidden = false
         chapterButtonWidth.constant = 48
         setColors(dim: chapter?.isPlayable() == false)
+    }
+
+    /// Toggle the resolving spinner for this row. Driven from
+    /// `ChaptersViewController`'s `resolvingIndexPath` in `cellForRowAt` so it
+    /// survives cell reuse.
+    func setResolving(_ resolving: Bool) {
+        if resolving {
+            resolvingSpinner.color = ThemeColor.playerContrast01()
+            resolvingSpinner.startAnimating()
+            chapterNumber.isHidden = true
+        } else {
+            resolvingSpinner.stopAnimating()
+            chapterNumber.isHidden = false
+        }
     }
 
     @IBAction func linkTapped(_ sender: Any) {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

Generated ("smart") chapters carry start times on the AI **reference timeline**, which dynamic ads shift away from the listener's actual **playback timeline** — so seeking to a chapter's raw `startTime` lands in the wrong place. This branch resolves the true playback position by fingerprinting a bounded region of the audio and matching it against the reference.

The tap-to-seek flow in the chapters list already did this. This PR closes the remaining gap: the **full player's next/previous chapter controls** now go through the same resolver.

### What changed
- **`GeneratedChapterSeeker`** (new) — extracts the resolve → seek → analytics → fallback core (previously inline in `ChaptersViewController+Table`) into one place, so the chapters list and the player controls behave identically. Honours the per-chapter `resolvedPlaybackStartTime` cache, guards against the listener switching episodes mid-resolve, and gracefully falls back to the raw reference seek on failure.
- **`ChaptersViewController+Table`** — `resolveAndSeek` now delegates to the shared helper, keeping only its per-row spinner bookkeeping.
- **`PlaybackManager`** — exposes `nextPlayableChapter()` / `previousPlayableChapter()` so the player can resolve the skip target before seeking.
- **`NowPlayingPlayerItemViewController`** — the next/previous chapter buttons route through `GeneratedChapterSeeker` for generated episodes (fenced with `#if !APPCLIP`, since the App Clip doesn't compile the Fingerprint sources), and show a spinner over the tapped button while the async resolve runs. Non-generated chapters keep the plain skip behaviour.

Gated behind `FeatureFlag.generatedChapters` + `FeatureFlag.syncedTranscripts`.

## To test

1. Enable the `generatedChapters` and `syncedTranscripts` feature flags.
2. Play an episode that has generated chapters and dynamic ads (so the reference and playback timelines diverge).
3. Open the full player.
4. Tap the **next chapter** control — confirm a brief spinner shows on the button, then playback lands at the actual start of the next chapter's content (not offset by the ad shift).
5. Tap the **previous chapter** control — same expectation.
6. Compare against tapping a row in the chapters list: both should land at the same resolved position.
7. On the last chapter, tap next — confirm it still skips to the end of the last chapter.
8. Confirm a non-generated (embedded / podcast-index) chapter episode still skips instantly with no spinner.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
