### PR TITLE
Fix the disabled Transcript action rendering as invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix the Discover search screen background color and colors in filters on some themes [#4719](https://github.com/Automattic/pocket-casts-ios/pull/4719)
 - Fix the mini player initial loading shimmer not showing up when Reduce Motion is enabled [#4713](https://github.com/Automattic/pocket-casts-ios/pull/4713)
 - Fix options picker rows like "Sort By" wrapping their labels to multiple lines when there is enough space [#4722](https://github.com/Automattic/pocket-casts-ios/pull/4722)
+- Fix the disabled Transcript action in the player being nearly invisible when the episode has no transcript [#4729](https://github.com/Automattic/pocket-casts-ios/pull/4729)
 
 8.16
 -----

--- a/podcasts/ShelfActionsViewController+Table.swift
+++ b/podcasts/ShelfActionsViewController+Table.swift
@@ -56,8 +56,8 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
             // Disable transcript if not available
             let isTranscriptsAndIsDisable = action == .transcript && !isTranscriptEnabled
             if isTranscriptsAndIsDisable {
-                cell.actionIcon.tintColor = ThemeColor.playerContrast06()
-                cell.actionName.textColor = ThemeColor.playerContrast06()
+                cell.actionIcon.tintColor = ThemeColor.playerContrast04()
+                cell.actionName.textColor = ThemeColor.playerContrast04()
             }
         } else {
             cell.actionName.text = action.title(episode: nil)

--- a/podcasts/TranscriptShelfButton.swift
+++ b/podcasts/TranscriptShelfButton.swift
@@ -5,7 +5,7 @@ class TranscriptShelfButton: UIButton, CheckTranscriptAvailability {
     var hasGeneratedTranscripts: Bool = false
     var isTranscriptEnabled: Bool {
         didSet {
-            imageView?.tintColor = isTranscriptEnabled ? ThemeColor.playerContrast02() : ThemeColor.playerContrast06()
+            imageView?.tintColor = isTranscriptEnabled ? ThemeColor.playerContrast02() : ThemeColor.playerContrast04()
         }
     }
 


### PR DESCRIPTION
Fixes PCIOS-

When the playing episode has no transcript, the Transcript action in the player's "More Actions" sheet (and the shelf button variant) was tinted with `playerContrast06` — white at 10% alpha, a background-fill color — making it render as essentially invisible. This switches the disabled state to `playerContrast04` (~30% alpha), which reads as disabled but stays legible on all themes. Tap behavior is unchanged: the disabled action still shows the "transcript not available" toast.

| Before | After |
|:---:|:---:|
| <img width="300"  alt="Screenshot 2026-07-10 at 1 38 35 PM (1)" src="https://github.com/user-attachments/assets/344526e8-713c-45e7-9f75-fe7db40402ec" />| <img width="300" alt="Screenshot 2026-07-10 at 5 06 56 PM" src="https://github.com/user-attachments/assets/e8bf35b1-78ff-4b9c-b525-c76e09bc7712" />
 |


## To test

1. Play an episode that has no transcript.
2. Open the full-screen player and tap the "More Actions" (…) button.
3. Verify the Transcript row is dimmed but clearly visible.
4. Tap it and verify the "transcript not available" toast appears.
5. In the player, tap Edit in the More Actions sheet and move Transcript onto the shelf; verify the shelf icon is also dimmed but visible.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)