### PR TITLE
[Spike] Probe: can before_all decrypt in CI?

### DIFF
--- a/.buildkite/commands/install-secrets.sh
+++ b/.buildkite/commands/install-secrets.sh
@@ -2,8 +2,9 @@
 
 set -euo pipefail
 
-echo "--- :closed_lock_with_key: Installing Secrets"
+echo "--- :closed_lock_with_key: Installing a8c-secrets (PROBE: install only, no decrypt)"
 curl -fsSL https://raw.githubusercontent.com/Automattic/a8c-secrets/main/install.sh | bash
 # The installer puts the binary in ~/.local/bin, which isn't on the agent's PATH.
 export PATH="$HOME/.local/bin:$PATH"
-bundle exec fastlane configure_secrets
+# PROBE: decrypt intentionally omitted — `before_all` in the Fastfile now owns it,
+# to test whether the binary is reachable from the parent lane process.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -203,6 +203,13 @@ before_all do
   # locally, it has no effect so it's safe to run it before all lanes.
   setup_ci
 
+  # PROBE (mokagio/before-all-decrypt-ci-probe): can the parent lane process
+  # reach the `a8c-secrets` binary? `install-secrets.sh` now installs it but
+  # does not decrypt, so this call is the only decrypt path. Unguarded on
+  # purpose: if the binary isn't on PATH here, `configure_secrets` fails loudly
+  # and proves the install-secrets PATH export doesn't survive to this process.
+  configure_secrets
+
   Dotenv.load(USER_ENV_FILE_PATH)
 end
 


### PR DESCRIPTION
**Not for merge — CI investigation, stacked on #4731.**

Settles whether the decrypt can live in `before_all` in CI, or whether the `a8c-secrets` binary is only reachable inside `install-secrets.sh`'s own process.

**Setup:** `install-secrets.sh` installs the binary but no longer decrypts; `before_all` calls `configure_secrets` (unguarded) as the sole decrypt path.

**How to read the result:**

- **Green** → the parent lane process can reach the binary; decrypt in `before_all` is viable (my PATH concern was wrong).
- **Fails at `before_all` with "`a8c-secrets` was not found"** → the `install-secrets.sh` PATH export doesn't survive to the build lane; the decrypt must stay in `install-secrets.sh` and `before_all` needs the `if …which(...)` guard (or no call at all).