### PR TITLE
[PC-TV] Fix initial position on video

### DIFF
--- a/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
+++ b/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
@@ -63,7 +63,7 @@ struct MediaOverlayView: View {
             }
             .animation(.easeInOut(duration: 0.2), value: model.isLoading)
             .animation(.easeInOut(duration: 0.2), value: model.isFailed)
-            .background(model.isVideo ? Color.clear : Color.pcBackgroundBase)
+            .background(model.isVideo && !model.isLoading && !model.isFailed ? Color.clear : Color.pcBackgroundBase)
         }
         .ignoresSafeArea()
     }

--- a/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
+++ b/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
@@ -16,7 +16,7 @@ struct MediaOverlayView: View {
     var body: some View {
         GeometryReader() { proxy in
             ZStack {
-                if !model.isVideo || model.isLoading, let uiImage = model.displayImage {
+                if !model.isVideo || model.isLoading || model.isFailed, let uiImage = model.displayImage {
                     VStack(alignment: .center) {
                         if isTransportBarVisible {
                             Spacer().frame(height: 100)

--- a/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
+++ b/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
@@ -16,7 +16,7 @@ struct MediaOverlayView: View {
     var body: some View {
         GeometryReader() { proxy in
             ZStack {
-                if !model.isVideo, let uiImage = model.displayImage {
+                if !model.isVideo || model.isLoading, let uiImage = model.displayImage {
                     VStack(alignment: .center) {
                         if isTransportBarVisible {
                             Spacer().frame(height: 100)
@@ -44,9 +44,13 @@ struct MediaOverlayView: View {
                 } else {
                     VStack {
                         Spacer()
-                        if model.isFailed {
-                            failureOverlay
-                                .transition(.opacity)
+                        HStack {
+                            Spacer()
+                            if model.isFailed {
+                                failureOverlay
+                                    .transition(.opacity)
+                            }
+                            Spacer()
                         }
                         Spacer()
                     }

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -61,9 +61,7 @@ class NowPlayingViewModel: Identifiable {
         player = playbackManager.avPlayer
         if !playbackManager.playing(), !playbackManager.isReadyToPlay {
             playbackManager.loadCurrentEpisode()
-            if !playbackManager.isCurrentEpisodeVideo() {
-                seekAfterLoad = true
-            }
+            seekAfterLoad = true
         }
         loadEpisodeArtwork()
     }
@@ -118,7 +116,9 @@ class NowPlayingViewModel: Identifiable {
         isFailed = status == .failed
         if !isLoading, seekAfterLoad {
             seekAfterLoad = false
-            playbackManager.seekToStartingPosition()
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now().advanced(by: .seconds(1))) {
+                self.playbackManager.seekToStartingPosition()
+            }
         }
     }
 

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -116,8 +116,8 @@ class NowPlayingViewModel: Identifiable {
         isFailed = status == .failed
         if !isLoading, seekAfterLoad {
             seekAfterLoad = false
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now().advanced(by: .seconds(1))) {
-                self.playbackManager.seekToStartingPosition()
+            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now().advanced(by: .seconds(1))) { [weak self] in
+                self?.playbackManager.seekToStartingPosition()
             }
         }
     }

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -116,6 +116,8 @@ class NowPlayingViewModel: Identifiable {
         isFailed = status == .failed
         if !isLoading, seekAfterLoad {
             seekAfterLoad = false
+            // The delay is needed only for videos episodes.
+            // For some reason the AVPlayerViewController does not accept seeks immediately after loading, and resets the position to zero
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now().advanced(by: .seconds(1))) { [weak self] in
                 self?.playbackManager.seekToStartingPosition()
             }

--- a/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
+++ b/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
@@ -61,7 +61,7 @@ class PlayerStatusObserver {
             AnalyticsPlaybackHelper.shared.play()
         case .paused:
             AnalyticsPlaybackHelper.shared.currentSource = .player
-            AnalyticsPlaybackHelper.shared.pause()            
+            AnalyticsPlaybackHelper.shared.pause()
         case .waitingToPlayAtSpecifiedRate:
             break
         @unknown default:

--- a/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
+++ b/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
@@ -59,13 +59,9 @@ class PlayerStatusObserver {
         case .playing:
             AnalyticsPlaybackHelper.shared.currentSource = .player
             AnalyticsPlaybackHelper.shared.play()
-            // this was triggered by the player UI so let's sync with playback manager
-            PlaybackManager.shared.ensureAudioSessionActivated()
         case .paused:
             AnalyticsPlaybackHelper.shared.currentSource = .player
-            AnalyticsPlaybackHelper.shared.pause()
-            // this was triggered by the player UI so let's sync with playback manager
-            PlaybackManager.shared.pause(userInitiated: false)
+            AnalyticsPlaybackHelper.shared.pause()            
         case .waitingToPlayAtSpecifiedRate:
             break
         @unknown default:


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Sets correct initial position when starting an episode that was already played in the past

## To test

- Start the TV app
- Start playing an episode that was played before and was in the middle
- Check if it starts in the correct position
- Stop the app
- Start again
- Open directly the Now Playing tab
- Tap play
- Check if it starts at the right position
- Check also with a video episode

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
