### PR TITLE
Redesign TV login & create-account screens to show the pairing code

### DIFF
--- a/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
+++ b/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
@@ -69,7 +69,7 @@ struct CreateAccountView: View {
                 if case .error(_, let message) = pairing.state {
                     pairingError(message: message)
                 } else {
-                    QRCodeTile(url: pairing.pairURLComplete)
+                    QRCodeView(url: pairing.pairURLComplete)
                 }
                 fullScreenSteps
                 Spacer()
@@ -106,7 +106,7 @@ struct CreateAccountView: View {
                 pairingError(message: message)
             } else {
                 HStack(alignment: .center, spacing: 64) {
-                    QRCodeTile(url: pairing.pairURLComplete)
+                    QRCodeView(url: pairing.pairURLComplete)
                     modalSteps
                 }
             }
@@ -174,57 +174,6 @@ struct CreateAccountView: View {
                     .frame(minWidth: 300)
             }
         }
-    }
-}
-
-/// Renders the device-pairing QR code onto a white rounded tile, falling back to
-/// a spinner of the same size until the code arrives.
-private struct QRCodeTile: View {
-
-    enum Layout {
-        static let tileSize = CGFloat(268)
-        static let padding = CGFloat(22)
-        static let cornerRadius = CGFloat(24)
-    }
-
-    /// The pairing URL to encode, or `nil` while the device code is being fetched.
-    let url: String?
-
-    @State private var image: UIImage?
-    @State private var context = CIContext()
-
-    var body: some View {
-        Group {
-            if let image {
-                Image(uiImage: image)
-                    .resizable()
-                    .interpolation(.none)
-                    .scaledToFit()
-                    .padding(Layout.padding)
-                    .frame(width: Layout.tileSize, height: Layout.tileSize)
-                    .background(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous))
-            } else {
-                ProgressView()
-                    .frame(width: Layout.tileSize, height: Layout.tileSize)
-            }
-        }
-        // Regenerate on every code change, clearing first so a stale QR isn't
-        // shown while the new one is fetched.
-        .onChange(of: url, initial: true) { _, url in
-            image = url.flatMap(makeImage)
-        }
-    }
-
-    private func makeImage(from string: String) -> UIImage? {
-        let generator = CIFilter.qrCodeGenerator()
-        generator.message = Data(string.utf8)
-        generator.correctionLevel = "H"
-        guard let output = generator.outputImage else { return nil }
-        // Scale up so the QR stays crisp when enlarged on a TV screen.
-        let scaled = output.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
-        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else { return nil }
-        return UIImage(cgImage: cgImage)
     }
 }
 

--- a/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
+++ b/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
@@ -63,7 +63,7 @@ struct CreateAccountView: View {
             }
             else {
                 HStack(alignment: .center, spacing: 64) {
-                    QRCodeView(url: pairing.pairURLComplete)                    
+                    QRCodeView(url: pairing.pairURLComplete)
                     StepList(steps: steps)
                 }
                 QRCodeDigits(digits: pairing.codes)

--- a/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
+++ b/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
@@ -58,17 +58,16 @@ struct CreateAccountView: View {
     private var fullScreenLayout: some View {
         VStack(spacing: 64) {
             fullScreenHeader
-            HStack {
-                Spacer()
-                if case .error(_, let message) = pairing.state {
-                    pairingError(message: message)
-                } else {
-                    QRCodeView(url: pairing.pairURLComplete)
-                }
-                StepList(steps: steps)
-                Spacer()
+            if case .error(_, let message) = pairing.state {
+                pairingError(message: message)
             }
-            QRCodeDigits(digits: pairing.codes)
+            else {
+                HStack(alignment: .center, spacing: 64) {
+                    QRCodeView(url: pairing.pairURLComplete)                    
+                    StepList(steps: steps)
+                }
+                QRCodeDigits(digits: pairing.codes)
+            }
         }
         .padding(80)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -93,8 +92,8 @@ struct CreateAccountView: View {
                     QRCodeView(url: pairing.pairURLComplete)
                     StepList(steps: steps, spacing: 40)
                 }
+                QRCodeDigits(digits: pairing.codes)
             }
-            QRCodeDigits(digits: pairing.codes)
         }
         .padding(80)
         .frame(width: 1200, alignment: .leading)

--- a/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
+++ b/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
@@ -21,9 +21,9 @@ struct CreateAccountView: View {
     @State private var pairing = PairingSession()
 
     private let steps = [
-        L10n.tvCreateAccountModalStepScan,
-        L10n.tvCreateAccountModalStepCreate,
-        L10n.tvCreateAccountModalStepLogIn
+        L10n.tvCreateAccountModalStepScanNew,
+        L10n.tvCreateAccountModalStepCreateNew,
+        L10n.tvCreateAccountModalStepLogInNew
     ]
 
     var body: some View {
@@ -63,15 +63,18 @@ struct CreateAccountView: View {
 
     private var fullScreenLayout: some View {
         VStack(spacing: 64) {
-            Spacer()
             fullScreenHeader
-            if case .error(_, let message) = pairing.state {
-                pairingError(message: message)
-            } else {
-                QRCodeTile(url: pairing.pairURLComplete)
+            HStack {
+                Spacer()
+                if case .error(_, let message) = pairing.state {
+                    pairingError(message: message)
+                } else {
+                    QRCodeTile(url: pairing.pairURLComplete)
+                }
+                fullScreenSteps
+                Spacer()
             }
-            Spacer()
-            fullScreenSteps
+            QRCodeDigits(digits: pairing.codes)
         }
         .padding(80)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -82,21 +85,13 @@ struct CreateAccountView: View {
             Text(L10n.tvCreateAccountTitle)
                 .font(.title3.weight(.medium))
                 .foregroundStyle(Color.pcTextPrimary)
-            Text(L10n.tvCreateAccountQrInstruction)
-                .font(.body.weight(.medium))
-                .foregroundStyle(Color.pcTextSecondary)
         }
         .multilineTextAlignment(.center)
     }
 
     private var fullScreenSteps: some View {
-        HStack(spacing: 24) {
+        VStack(alignment: .leading, spacing: 24) {
             ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
-                if index > 0 {
-                    Image(systemName: "arrow.right")
-                        .font(.body)
-                        .foregroundStyle(Color.pcTextDisabled)
-                }
                 stepBadge(number: index + 1, text: step)
             }
         }
@@ -105,7 +100,7 @@ struct CreateAccountView: View {
     // MARK: - Modal
 
     private var modalLayout: some View {
-        VStack(alignment: .leading, spacing: 64) {
+        VStack(alignment: .center, spacing: 64) {
             modalHeader
             if case .error(_, let message) = pairing.state {
                 pairingError(message: message)
@@ -115,9 +110,10 @@ struct CreateAccountView: View {
                     modalSteps
                 }
             }
+            QRCodeDigits(digits: pairing.codes)
         }
         .padding(80)
-        .frame(width: 952, alignment: .leading)
+        .frame(width: 1200, alignment: .leading)
     }
 
     private var modalHeader: some View {
@@ -156,6 +152,8 @@ struct CreateAccountView: View {
             Text(text)
                 .font(.body)
                 .foregroundStyle(Color.pcTextSecondary)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
         }
         // Read each step as a single unit rather than landing on the bare badge.
         .accessibilityElement(children: .combine)

--- a/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
+++ b/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
@@ -65,7 +65,7 @@ struct CreateAccountView: View {
                 } else {
                     QRCodeView(url: pairing.pairURLComplete)
                 }
-                fullScreenSteps
+                StepList(steps: steps)
                 Spacer()
             }
             QRCodeDigits(digits: pairing.codes)
@@ -75,20 +75,10 @@ struct CreateAccountView: View {
     }
 
     private var fullScreenHeader: some View {
-        VStack(spacing: 16) {
-            Text(L10n.tvCreateAccountTitle)
-                .font(.title3.weight(.medium))
-                .foregroundStyle(Color.pcTextPrimary)
-        }
-        .multilineTextAlignment(.center)
-    }
-
-    private var fullScreenSteps: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
-                stepBadge(number: index + 1, text: step)
-            }
-        }
+        Text(L10n.tvCreateAccountTitle)
+            .font(.title3.weight(.medium))
+            .foregroundStyle(Color.pcTextPrimary)
+            .multilineTextAlignment(.center)
     }
 
     // MARK: - Modal
@@ -101,7 +91,7 @@ struct CreateAccountView: View {
             } else {
                 HStack(alignment: .center, spacing: 64) {
                     QRCodeView(url: pairing.pairURLComplete)
-                    modalSteps
+                    StepList(steps: steps, spacing: 40)
                 }
             }
             QRCodeDigits(digits: pairing.codes)
@@ -134,32 +124,7 @@ struct CreateAccountView: View {
         ]
     }
 
-    private var modalSteps: some View {
-        VStack(alignment: .leading, spacing: 40) {
-            ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
-                stepBadge(number: index + 1, text: step)
-            }
-        }
-    }
-
     // MARK: - Shared
-
-    private func stepBadge(number: Int, text: String) -> some View {
-        HStack(spacing: 12) {
-            Text("\(number)")
-                .font(.caption2)
-                .foregroundStyle(Color.pcTextSecondary)
-                .frame(width: 40, height: 40)
-                .background(Color.pcBackgroundActive20, in: Circle())
-            Text(text)
-                .font(.body)
-                .foregroundStyle(Color.pcTextSecondary)
-                .lineLimit(2)
-                .multilineTextAlignment(.leading)
-        }
-        // Read each step as a single unit rather than landing on the bare badge.
-        .accessibilityElement(children: .combine)
-    }
 
     private func pairingError(message: String) -> some View {
         ContentUnavailableView {

--- a/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
+++ b/Pocket Casts TV App/UI/Auth/CreateAccountView.swift
@@ -20,12 +20,6 @@ struct CreateAccountView: View {
 
     @State private var pairing = PairingSession()
 
-    private let steps = [
-        L10n.tvCreateAccountModalStepScanNew,
-        L10n.tvCreateAccountModalStepCreateNew,
-        L10n.tvCreateAccountModalStepLogInNew
-    ]
-
     var body: some View {
         layout
             .task {
@@ -130,6 +124,14 @@ struct CreateAccountView: View {
                 .foregroundStyle(Color.pcTextSecondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    var steps: [String] {
+        [
+            L10n.tvCreateAccountStepScan(pairing.pairURLPretty),
+            L10n.tvCreateAccountStepCreate,
+            L10n.tvCreateAccountStepConfirmCode
+        ]
     }
 
     private var modalSteps: some View {

--- a/Pocket Casts TV App/UI/Auth/QRCodeDigits.swift
+++ b/Pocket Casts TV App/UI/Auth/QRCodeDigits.swift
@@ -13,7 +13,7 @@ struct QRCodeDigits: View {
                     ForEach(Array(digits.enumerated()), id: \.offset) { _, code in
                         Text(code)
                             .font(.caption2)
-                            .foregroundStyle(Color.pcTextSecondary)
+                            .foregroundStyle(Color.pcBackgroundActive)
                             .padding(32)
                             .background(Color.pcBackgroundActive20)
                             .clipShape(Circle())

--- a/Pocket Casts TV App/UI/Auth/QRCodeDigits.swift
+++ b/Pocket Casts TV App/UI/Auth/QRCodeDigits.swift
@@ -19,6 +19,8 @@ struct QRCodeDigits: View {
                             .clipShape(Circle())
                     }
                 }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(digits.joined(separator: " ")))
             }
         }
     }

--- a/Pocket Casts TV App/UI/Auth/QRCodeDigits.swift
+++ b/Pocket Casts TV App/UI/Auth/QRCodeDigits.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct QRCodeDigits: View {
+
+    let digits: [String]
+
+    var body: some View {
+        Group {
+            if digits.isEmpty {
+                ProgressView()
+            } else {
+                HStack(spacing: 8) {
+                    ForEach(Array(digits.enumerated()), id: \.offset) { _, code in
+                        Text(code)
+                            .font(.caption2)
+                            .foregroundStyle(Color.pcTextSecondary)
+                            .padding(32)
+                            .background(Color.pcBackgroundActive20)
+                            .clipShape(Circle())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Pocket Casts TV App/UI/Auth/QRCodeView.swift
+++ b/Pocket Casts TV App/UI/Auth/QRCodeView.swift
@@ -6,9 +6,9 @@ import CoreImage.CIFilterBuiltins
 struct QRCodeView: View {
 
     enum Layout {
-        static let tileSize = CGFloat(268)
-        static let padding = CGFloat(22)
-        static let cornerRadius = CGFloat(24)
+        static let tileSize = CGFloat(272)
+        static let padding = CGFloat(14)
+        static let cornerRadius = CGFloat(8)
     }
 
     /// The pairing URL to encode, or `nil` while the device code is being fetched.

--- a/Pocket Casts TV App/UI/Auth/QRCodeView.swift
+++ b/Pocket Casts TV App/UI/Auth/QRCodeView.swift
@@ -52,7 +52,6 @@ struct QRCodeView: View {
     }
 }
 
-
 #Preview {
     QRCodeView(url: "https://pocketcasts.net/pair")
 }

--- a/Pocket Casts TV App/UI/Auth/QRCodeView.swift
+++ b/Pocket Casts TV App/UI/Auth/QRCodeView.swift
@@ -1,53 +1,57 @@
 import SwiftUI
 import CoreImage.CIFilterBuiltins
 
+/// Renders the device-pairing QR code onto a white rounded tile, falling back to
+/// a spinner of the same size until the code arrives.
 struct QRCodeView: View {
 
-    let url: String
-    @State var uiImage: UIImage?
+    enum Layout {
+        static let tileSize = CGFloat(268)
+        static let padding = CGFloat(22)
+        static let cornerRadius = CGFloat(24)
+    }
 
+    /// The pairing URL to encode, or `nil` while the device code is being fetched.
+    let url: String?
+
+    @State private var image: UIImage?
     @State private var context = CIContext()
 
-    enum Layout {
-        static let qrSize = CGFloat(240)
-    }
-
-    func generateQRImage() async {
-        var resultImage: UIImage?
-        let qrCodeGenerator = CIFilter.qrCodeGenerator()
-        qrCodeGenerator.message = url.data(using: .ascii)!
-        qrCodeGenerator.correctionLevel = "H"
-        if let outputImage = qrCodeGenerator.outputImage {
-            // Scale up so the QR code stays crisp on a TV screen
-            let transform = CGAffineTransform(scaleX: 10, y: 10)
-            let scaledImage = outputImage.transformed(by: transform)
-
-            if let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) {
-                resultImage = UIImage(cgImage: cgImage)
-            }
-        }
-        await MainActor.run {
-            uiImage = resultImage
-        }
-    }
-
     var body: some View {
-        ZStack {
-            if let uiImage {
-                Image(uiImage: uiImage)
+        Group {
+            if let image {
+                Image(uiImage: image)
                     .resizable()
-                    .frame(width: Layout.qrSize, height: Layout.qrSize)
+                    .interpolation(.none)
+                    .scaledToFit()
+                    .padding(Layout.padding)
+                    .frame(width: Layout.tileSize, height: Layout.tileSize)
+                    .background(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous))
             } else {
                 ProgressView()
+                    .frame(width: Layout.tileSize, height: Layout.tileSize)
             }
         }
-        .padding()
-        .background(.white)
-        .task {
-            await generateQRImage()
+        // Regenerate on every code change, clearing first so a stale QR isn't
+        // shown while the new one is fetched.
+        .onChange(of: url, initial: true) { _, url in
+            image = url.flatMap(makeImage)
         }
     }
+
+    private func makeImage(from string: String) -> UIImage? {
+        let generator = CIFilter.qrCodeGenerator()
+        generator.message = Data(string.utf8)
+        generator.correctionLevel = "H"
+        guard let output = generator.outputImage else { return nil }
+        // Scale up so the QR stays crisp when enlarged on a TV screen.
+        let scaled = output.transformed(by: CGAffineTransform(scaleX: 10, y: 10))
+        guard let cgImage = context.createCGImage(scaled, from: scaled.extent) else { return nil }
+        return UIImage(cgImage: cgImage)
+    }
 }
+
 
 #Preview {
     QRCodeView(url: "https://pocketcasts.net/pair")

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -45,7 +45,7 @@ struct SignInView: View {
                         if case .error(_, let message) = model.pairing.state {
                             qrCodeError(message: message)
                         } else {
-                            HStack {
+                            HStack(spacing: 64) {
                                 QRCodeView(url: model.pairing.pairURLComplete)
                                 StepList(steps: steps)
                             }
@@ -56,8 +56,7 @@ struct SignInView: View {
                 .animation(.easeInOut, value: loginType)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
-            .padding(.top, 80)
-            .offset(y: -64)
+            .padding(.top, 80)            
         }
         .task(id: loginType) {
             switch loginType {

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -76,7 +76,7 @@ struct SignInView: View {
                                 Text(enterCodePrompt(url: urlComplete))
                                     .font(.headline)
                                     .foregroundStyle(Color.pcTextSecondary)
-                                qrCodeDigits
+                                QRCodeDigits(digits: model.pairing.codes)
                             } else {
                                 ProgressView()
                             }
@@ -146,25 +146,6 @@ struct SignInView: View {
             }
         }
         .padding(.top, 64)
-    }
-
-    var qrCodeDigits: some View {
-        Group {
-            if model.pairing.codes.isEmpty {
-                ProgressView()
-            } else {
-                HStack(spacing: 8) {
-                    ForEach(Array(model.pairing.codes.enumerated()), id: \.offset) { _, code in
-                        Text(code)
-                            .font(.caption2)
-                            .foregroundStyle(Color.pcTextSecondary)
-                            .padding()
-                            .background(Color.pcBackgroundActive20)
-                            .clipShape(RoundedRectangle(cornerRadius: 12))
-                    }
-                }
-            }
-        }
     }
 
     var separator: some View {

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -44,10 +44,10 @@ struct SignInView: View {
 
     var body: some View {
         ZStack(alignment: .top) {
-            VStack(spacing: 32) {
-                Image(ImageResource.pcLogo)
+            VStack(spacing: 64) {
+                Spacer()
                 Text(L10n.tvSignInTitle)
-                    .font(.title)
+                    .font(.title3.weight(.medium))
                     .foregroundColor(Color.pcTextPrimary)
                 Picker(L10n.tvUserSignInLoginType, selection: $loginType) {
                     ForEach(LoginType.allCases, id: \.self) { type in
@@ -58,7 +58,7 @@ struct SignInView: View {
                 .frame(width: 500)
                 // Mode-specific content area, fixed height so the logo,
                 // title, and picker above never shift when switching modes.
-                VStack(spacing: 32) {
+                VStack(spacing: 64) {
                     switch loginType {
                     case .manual:
                         usernamePasswordLogin
@@ -67,19 +67,11 @@ struct SignInView: View {
                         if case .error(_, let message) = model.pairing.state {
                             qrCodeError(message: message)
                         } else {
-                            Text(L10n.tvSignInSubtitle)
-                                .font(.headline)
-                                .foregroundStyle(Color.pcTextSecondary)
-                            if let urlComplete = model.pairing.pairURLComplete {
-                                QRCodeView(url: urlComplete)
-                                separator
-                                Text(enterCodePrompt(url: urlComplete))
-                                    .font(.headline)
-                                    .foregroundStyle(Color.pcTextSecondary)
-                                QRCodeDigits(digits: model.pairing.codes)
-                            } else {
-                                ProgressView()
+                            HStack {
+                                QRCodeView(url: model.pairing.pairURLComplete)
+                                fullScreenSteps
                             }
+                            QRCodeDigits(digits: model.pairing.codes)
                         }
                     }
                 }
@@ -122,6 +114,39 @@ struct SignInView: View {
             }
         }
         .background(Color.pcBackgroundBase)
+    }
+
+    var steps: [String] {
+        [
+            L10n.tvCreateAccountStepScan(model.pairing.pairURLPretty),
+            L10n.tvCreateAccountStepLogin,
+            L10n.tvCreateAccountStepConfirmCode
+        ]
+    }
+    @ViewBuilder
+    private var fullScreenSteps: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+                stepBadge(number: index + 1, text: step)
+            }
+        }
+    }
+
+    private func stepBadge(number: Int, text: String) -> some View {
+        HStack(spacing: 12) {
+            Text("\(number)")
+                .font(.caption2)
+                .foregroundStyle(Color.pcTextSecondary)
+                .frame(width: 40, height: 40)
+                .background(Color.pcBackgroundActive20, in: Circle())
+            Text(text)
+                .font(.body)
+                .foregroundStyle(Color.pcTextSecondary)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+        }
+        // Read each step as a single unit rather than landing on the bare badge.
+        .accessibilityElement(children: .combine)
     }
 
     private func finishSignIn(source: String) {

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -35,8 +35,8 @@ struct SignInView: View {
                 }
                 .pickerStyle(.segmented)
                 .frame(width: 500)
-                // Mode-specific content area, fixed height so the logo,
-                // title, and picker above never shift when switching modes.
+                // Mode-specific content area, fixed height so the title
+                // and picker above never shift when switching modes.
                 VStack(spacing: 64) {
                     switch loginType {
                     case .manual:

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -56,7 +56,7 @@ struct SignInView: View {
                 .animation(.easeInOut, value: loginType)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             }
-            .padding(.top, 80)            
+            .padding(.top, 80)
         }
         .task(id: loginType) {
             switch loginType {

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -7,27 +7,6 @@ struct SignInView: View {
 
     @Environment(\.dismiss) private var dismiss
 
-    let manualLogin: Bool = true
-
-    enum Layout {
-        static let gridSize = CGFloat(272)
-        static let qrSize = CGFloat(240)
-    }
-
-    func enterCodePrompt(url: String) -> AttributedString {
-        let baseString = L10n.tvSignInEnterCodeInUrl(model.pairing.pairURLPretty, url)
-        var attributedString = (try? AttributedString(markdown: baseString)) ?? AttributedString(baseString)
-
-        var linkStyle = AttributeContainer()
-        linkStyle.foregroundColor = Color.pcTextPrimary
-        linkStyle.underlineStyle = .single
-
-        for run in attributedString.runs where run.link != nil {
-            attributedString[run.range].mergeAttributes(linkStyle)
-        }
-        return attributedString
-    }
-
     enum LoginType: Int, CaseIterable {
         case qr
         case manual
@@ -61,14 +40,14 @@ struct SignInView: View {
                 VStack(spacing: 64) {
                     switch loginType {
                     case .manual:
-                        usernamePasswordLogin                            
+                        usernamePasswordLogin
                     case .qr:
                         if case .error(_, let message) = model.pairing.state {
                             qrCodeError(message: message)
                         } else {
                             HStack {
                                 QRCodeView(url: model.pairing.pairURLComplete)
-                                fullScreenSteps
+                                StepList(steps: steps)
                             }
                             QRCodeDigits(digits: model.pairing.codes)
                         }
@@ -122,31 +101,6 @@ struct SignInView: View {
             L10n.tvCreateAccountStepConfirmCode
         ]
     }
-    @ViewBuilder
-    private var fullScreenSteps: some View {
-        VStack(alignment: .leading, spacing: 24) {
-            ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
-                stepBadge(number: index + 1, text: step)
-            }
-        }
-    }
-
-    private func stepBadge(number: Int, text: String) -> some View {
-        HStack(spacing: 12) {
-            Text("\(number)")
-                .font(.caption2)
-                .foregroundStyle(Color.pcTextSecondary)
-                .frame(width: 40, height: 40)
-                .background(Color.pcBackgroundActive20, in: Circle())
-            Text(text)
-                .font(.body)
-                .foregroundStyle(Color.pcTextSecondary)
-                .lineLimit(2)
-                .multilineTextAlignment(.leading)
-        }
-        // Read each step as a single unit rather than landing on the bare badge.
-        .accessibilityElement(children: .combine)
-    }
 
     private func finishSignIn(source: String) {
         Analytics.track(.userSignedIn, properties: ["source": source])
@@ -170,13 +124,6 @@ struct SignInView: View {
             }
         }
         .padding(.top, 64)
-    }
-
-    var separator: some View {
-        Rectangle()
-        .foregroundColor(.clear)
-        .frame(width: 566, height: 1)
-        .background(Color.pcTextDisabled)
     }
 
     @FocusState private var focusedField: Field?

--- a/Pocket Casts TV App/UI/Auth/SignInView.swift
+++ b/Pocket Casts TV App/UI/Auth/SignInView.swift
@@ -61,8 +61,7 @@ struct SignInView: View {
                 VStack(spacing: 64) {
                     switch loginType {
                     case .manual:
-                        usernamePasswordLogin
-                            .padding(.top, 64)
+                        usernamePasswordLogin                            
                     case .qr:
                         if case .error(_, let message) = model.pairing.state {
                             qrCodeError(message: message)
@@ -190,7 +189,7 @@ struct SignInView: View {
     @State private var password = ""
 
     var usernamePasswordLogin: some View {
-        VStack {
+        VStack(spacing: 32) {
             TextField(L10n.tvUserSignInUsernamePlaceholder, text: $username)
                 .textContentType(.username)
                 .focused($focusedField, equals: .username)

--- a/Pocket Casts TV App/UI/Auth/StepList.swift
+++ b/Pocket Casts TV App/UI/Auth/StepList.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// A vertical numbered checklist rendered as circular badges, shared by the TV
+/// auth screens to explain the QR pairing flow.
+struct StepList: View {
+
+    let steps: [String]
+    var spacing: CGFloat = 24
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: spacing) {
+            ForEach(Array(steps.enumerated()), id: \.offset) { index, step in
+                stepBadge(number: index + 1, text: step)
+            }
+        }
+    }
+
+    private func stepBadge(number: Int, text: String) -> some View {
+        HStack(spacing: 12) {
+            Text("\(number)")
+                .font(.caption2)
+                .foregroundStyle(Color.pcTextSecondary)
+                .frame(width: 40, height: 40)
+                .background(Color.pcBackgroundActive20, in: Circle())
+            Text(text)
+                .font(.body)
+                .foregroundStyle(Color.pcTextSecondary)
+                .lineLimit(2)
+                .multilineTextAlignment(.leading)
+        }
+        // Read each step as a single unit rather than landing on the bare badge.
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/Pocket Casts TV App/UI/Auth/StepList.swift
+++ b/Pocket Casts TV App/UI/Auth/StepList.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct StepList: View {
 
     let steps: [String]
-    var spacing: CGFloat = 24
+    var spacing: CGFloat = 40
 
     var body: some View {
         VStack(alignment: .leading, spacing: spacing) {

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
@@ -110,7 +110,7 @@ struct DiscoverFeaturedPodcastCell: View {
             if axis == .vertical {
                 return Layout.cardHeight
             } else {
-                return length * 0.92
+                return length * 0.9
             }
         }
         .blurredCoverBackground(size: Layout.imageSize) {
@@ -121,7 +121,7 @@ struct DiscoverFeaturedPodcastCell: View {
         .background(Color.pcBackgroundSunken)
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .focusedCardDepth(isFocused: focusedButton != nil, cornerRadius: 12)
-        .scaleEffect(focusedButton != nil ? 1 : 0.95)
+        .scaleEffect(focusedButton != nil ? 1.05 : 1)
         .animation(.default, value: focusedButton)
         .focusSection()
         .focusScope(ns)

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastsRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastsRow.swift
@@ -52,7 +52,7 @@ struct DiscoverFeaturedPodcastsRow: View {
 
     var podcastList: some View {
         ScrollView(.horizontal) {
-            LazyHStack(spacing: 48, content: {
+            LazyHStack(spacing: 64, content: {
                 ForEach(model.podcasts, id: \.uuid) { podcast in
                     DiscoverFeaturedPodcastCell(podcast: podcast, sponsored: model.sponsored.contains(podcast.uuid ?? ""), listId: model.listId, source: model.source)
                         .setFocus(section: model.focusStoreID)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6544,10 +6544,8 @@
 "tv_create_account_step_create" = "Create your account or log in";
 
 /* tv create account confirm step - confirm code */
-"tv_create_account_step_confirm_code" = "If asked, confirm the code bellow";
+"tv_create_account_step_confirm_code" = "If asked, confirm the code below";
 
 /* tv create account login step - log in to your account */
 "tv_create_account_step_login" = "Log in to your account";
-
-
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6537,14 +6537,17 @@
 /* Text of the placeholder used in the manual playlist detail screen when all episodes are archived. '%1$@' represents the number of archived episodes */
 "tv_playlist_manual_archived_episodes_placeholder" = "All %1$@ episodes of this playlist have been archived.";
 
-/* tv create account modal step - scan the QR code */
-"tv_create_account_modal_step_scan_new" = "Scan the QR code or go to pocketcasts.com/pair";
+/* tv create account step - scan the QR code */
+"tv_create_account_step_scan" = "Scan the QR code or go to %1$@";
 
-/* tv create account modal step - create your account */
-"tv_create_account_modal_step_create_new" = "Create your account or log in";
+/* tv create account create account step - create your account */
+"tv_create_account_step_create" = "Create your account or log in";
 
-/* tv create account modal step - the TV logs you in automatically */
-"tv_create_account_modal_step_log_in_new" = "If asked, confirm the code below";
+/* tv create account confirm step - confirm code */
+"tv_create_account_step_confirm_code" = "If asked, confirm the code bellow";
+
+/* tv create account login step - log in to your account */
+"tv_create_account_step_login" = "Log in to your account";
 
 
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6537,3 +6537,14 @@
 /* Text of the placeholder used in the manual playlist detail screen when all episodes are archived. '%1$@' represents the number of archived episodes */
 "tv_playlist_manual_archived_episodes_placeholder" = "All %1$@ episodes of this playlist have been archived.";
 
+/* tv create account modal step - scan the QR code */
+"tv_create_account_modal_step_scan_new" = "Scan the QR code or go to pocketcasts.com/pair";
+
+/* tv create account modal step - create your account */
+"tv_create_account_modal_step_create_new" = "Create your account or log in";
+
+/* tv create account modal step - the TV logs you in automatically */
+"tv_create_account_modal_step_log_in_new" = "If asked, confirm the code below";
+
+
+


### PR DESCRIPTION
| 📘 Fixes: [POC-748](https://linear.app/a8c/issue/POC-748/qr-login-flow-prompts-for-a-confirmation-code-that-isnt-shown-when) |
|:---:|

| 1 | 2 | 3 |
| - | - | - |
| <img width="3840" height="2160" alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-07-13 at 09 27 39" src="https://github.com/user-attachments/assets/d29fc3c1-7c73-4e37-87c2-13123a2e8d77" /> | <img width="3840" height="2160" alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-07-13 at 09 27 34" src="https://github.com/user-attachments/assets/3abd1558-812b-44f3-9f98-fed2b2eb26fd" /> | <img width="3840" height="2160" alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-07-13 at 09 26 57" src="https://github.com/user-attachments/assets/0df513fd-8a6a-4eab-8da5-f5627e3d4a6c" /> |

## Summary

Reworks the Apple TV **Sign In** and **Create Account** screens so the QR pairing flow is easier to follow on a big screen:

- **Shows the pairing code as digits** (`QRCodeDigits`) alongside the QR code, so viewers can confirm the code shown on their phone.
- **Numbered step list** (`StepList`) explains the flow — scan / create-or-log-in / confirm code — next to the QR on both screens.
- **Consolidated `QRCodeView`** into a single styled tile (rounded white tile, crisp interpolation, sized for TV) and reused it across Create Account and Sign In instead of a duplicated `QRCodeTile`. `url` is now optional so the view owns its own loading spinner.
- **Layout/spacing cleanup**: dropped the logo from Sign In, matched Sign In to the Create Account layout, and consolidated spacing.

### Cleanup (from `/simplify` + `/code-review`)
- Extracted the duplicated step-badge rendering from both views into a shared `StepList`.
- Removed dead code left behind by the redesign: `QRCodeTile`, `SignInView.separator`, `enterCodePrompt`, `manualLogin`, the unused `Layout` enum, and the standalone `qrCodeDigits`.
- Fixed a typo in a new string (`bellow` → `below`) and a stale comment referencing the removed logo.

New user-facing strings added to `Localizable.strings` (`tv_create_account_step_*`).

## To test

1. On Apple TV, open **Sign In** with the **QR** option selected.
2. Verify the QR code, the numbered steps, and the pairing-code digits all render; the digits/QR show a spinner while loading.
3. Switch to the **Password** option and back — the title and picker should not shift.
4. Open **Create Account** in both full-screen and modal styles and verify the QR, steps, and code digits render.
5. Verify the download-app modal (Playlists) QR still renders correctly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)