### PR TITLE
PCIOS-829: iOS: "We haven't seen you in a while" re-engagement notification is back (regression of PCIOS-90)

### DIFF
--- a/podcasts/Notifications/NotificationsCoordinator.swift
+++ b/podcasts/Notifications/NotificationsCoordinator.swift
@@ -134,6 +134,8 @@ enum NotificationType: String {
                 return Settings.suggestedFoldersUpsellCount < 2 && Settings.appVersion() == "7.90"
             case .reengagementDownloads:
                 return NotificationsCoordinator.shared.numberOfDownloadsAvailable() > 0
+            case .reengagementWeekly:
+                return false
             default:
                 return true
         }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-829/ios-we-havent-seen-you-in-a-while-re-engagement-notification-is-back

## Summary
Disables the weekly re-engagement notification ("We miss you!") that was re-introduced during the notifications revamp. This is a regression of PCIOS-90 which originally disabled this notification in Aug 2025.

## Changes
- Added explicit `case .reengagementWeekly: return false` in the `shouldSend` computed property of `NotificationType`, preventing the notification from ever being scheduled.

## Root Cause
The notifications revamp added `.reengagementWeekly` to the `.newFeaturesAndTips` group, but its `shouldSend` fell through to `default: return true`, causing it to be scheduled whenever that group was enabled. The notification was also not controllable via the "Daily Reminders" toggle since it belongs to a different group (`.newFeaturesAndTips`).

## Verification
- **Lint**: PASS — formatter ran cleanly
- **Tests**: N/A — `GenerateCredentials` script phase fails in worktree (pre-existing environment issue, not related to this change)
- **Diff review**: PASS — minimal 2-line addition, no unintended changes
- **Secret scan**: PASS — no secrets in diff

## Confidence
**HIGH** — The fix is a single explicit `return false` for the `reengagementWeekly` case in `shouldSend`, directly preventing the notification from being scheduled. This matches the intent of the original PCIOS-90 fix.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/PCIOS-829/ios-we-havent-seen-you-in-a-while-re-engagement-notification-is-back)