### PR TITLE
Remove FeatureFlag.podcastsSortChanges

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -134,9 +134,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Avoid replace actions for Up Next episode queue when swapping the currently playing episode
     case avoidReplaceOnEpisodeSwap
 
-    /// Enable the new podcast sorting options
-    case podcastsSortChanges
-
     /// Recommendations including discover v3 support
     case recommendations
 
@@ -413,8 +410,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .refreshAndSaveWatchLogsOnSend:
             true
         case .avoidReplaceOnEpisodeSwap:
-            true
-        case .podcastsSortChanges:
             true
         case .recommendations:
             true

--- a/podcasts/Folders/FolderViewController.swift
+++ b/podcasts/Folders/FolderViewController.swift
@@ -118,11 +118,7 @@ class FolderViewController: PCViewController {
     @objc private func folderOptionsTapped(_ sender: UIBarButtonItem) {
         let optionsPicker = OptionsPicker(title: nil)
 
-        let sortOption: LibrarySort = if !FeatureFlag.podcastsSortChanges.enabled, folder.librarySort() == .recentlyPlayed {
-            .dateAddedNewestToOldest
-        } else {
-            folder.librarySort()
-        }
+        let sortOption = folder.librarySort()
         let sortAction = OptionAction(label: L10n.sortBy, secondaryLabel: sortOption.description, icon: "podcast-sort") {
             Analytics.track(.folderOptionsModalOptionTapped, properties: ["option": "sort_by"])
         }
@@ -188,12 +184,6 @@ class FolderViewController: PCViewController {
     private func makeSortOptions() -> OptionsPicker {
         let options = OptionsPicker(title: L10n.sortBy.localizedUppercase)
 
-        if !FeatureFlag.podcastsSortChanges.enabled, folder.librarySort() == .recentlyPlayed {
-            folder.sortType = Int32(LibrarySort.Old.dateAddedNewestToOldest.rawValue)
-            folder.syncModified = TimeFormatter.currentUTCTimeInMillis()
-            DataManager.sharedManager.save(folder: folder)
-        }
-
         let sortOption = folder.librarySort()
 
         let podcastNameAction = OptionAction(label: LibrarySort.titleAtoZ.description, selected: sortOption == .titleAtoZ) { [weak self] in
@@ -216,18 +206,11 @@ class FolderViewController: PCViewController {
             self?.changeSortOrder(.recentlyPlayed)
         }
 
-        if FeatureFlag.podcastsSortChanges.enabled {
-            options.addAction(action: subscribedOrder)
-            options.addAction(action: releaseDateAction)
-            options.addAction(action: recentlyPlayedOrder)
-            options.addAction(action: podcastNameAction)
-            options.addAction(action: dragAndDropAction)
-        } else {
-            options.addAction(action: podcastNameAction)
-            options.addAction(action: releaseDateAction)
-            options.addAction(action: subscribedOrder)
-            options.addAction(action: dragAndDropAction)
-        }
+        options.addAction(action: subscribedOrder)
+        options.addAction(action: releaseDateAction)
+        options.addAction(action: recentlyPlayedOrder)
+        options.addAction(action: podcastNameAction)
+        options.addAction(action: dragAndDropAction)
 
         return options
     }

--- a/podcasts/HomeGridDataHelper.swift
+++ b/podcasts/HomeGridDataHelper.swift
@@ -45,17 +45,13 @@ class HomeGridDataHelper {
     #if !os(watchOS)
         class func gridListItems(orderedBy: LibrarySort, badgeType: BadgeType) -> [HomeGridListItem] {
             let allPodcasts: [Podcast]
-            if FeatureFlag.podcastsSortChanges.enabled {
-                switch orderedBy {
-                case .episodeDateNewestToOldest:
-                    allPodcasts = PodcastManager.shared.allPodcastsSorted(in: .episodeDateNewestToOldest)
-                case .recentlyPlayed:
-                    allPodcasts = PodcastManager.shared.allPodcastsSorted(in: .recentlyPlayed)
-                default:
-                    allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
-                }
-            } else {
-                allPodcasts = orderedBy == .episodeDateNewestToOldest ? PodcastManager.shared.allPodcastsSorted(in: .episodeDateNewestToOldest) : DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
+            switch orderedBy {
+            case .episodeDateNewestToOldest:
+                allPodcasts = PodcastManager.shared.allPodcastsSorted(in: .episodeDateNewestToOldest)
+            case .recentlyPlayed:
+                allPodcasts = PodcastManager.shared.allPodcastsSorted(in: .recentlyPlayed)
+            default:
+                allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
             }
 
             let gridItems: [HomeGridListItem] = gridItems(orderedBy: orderedBy, sortedPodcasts: allPodcasts).map { HomeGridListItem(gridItem: $0, badgeType: badgeType, theme: Theme.sharedTheme.activeTheme) }
@@ -108,17 +104,13 @@ class HomeGridDataHelper {
 
     class func gridItems(orderedBy: LibrarySort) -> [HomeGridItem] {
         let allPodcasts: [Podcast]
-        if FeatureFlag.podcastsSortChanges.enabled {
-            switch orderedBy {
-            case .episodeDateNewestToOldest:
-                allPodcasts = PodcastManager.shared.allPodcastsSorted(in: .episodeDateNewestToOldest)
-            case .recentlyPlayed:
-                allPodcasts = PodcastManager.shared.allPodcastsSorted(in: .recentlyPlayed)
-            default:
-                allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
-            }
-        } else {
-            allPodcasts = orderedBy == .episodeDateNewestToOldest ? PodcastManager.shared.allPodcastsSorted(in: .episodeDateNewestToOldest) : DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
+        switch orderedBy {
+        case .episodeDateNewestToOldest:
+            allPodcasts = PodcastManager.shared.allPodcastsSorted(in: .episodeDateNewestToOldest)
+        case .recentlyPlayed:
+            allPodcasts = PodcastManager.shared.allPodcastsSorted(in: .recentlyPlayed)
+        default:
+            allPodcasts = DataManager.sharedManager.allPodcasts(includeUnsubscribed: false)
         }
 
         return gridItems(orderedBy: orderedBy, sortedPodcasts: allPodcasts)

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController+Search.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController+Search.swift
@@ -33,13 +33,7 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
     func makeSortOrderOptionsPicker() -> OptionsPicker {
         let options = OptionsPicker(title: L10n.sortBy.localizedUppercase)
 
-        let sortOption: LibrarySort
-        if !FeatureFlag.podcastsSortChanges.enabled, Settings.homeFolderSortOrder() == .recentlyPlayed {
-            Settings.setHomeFolderSortOrder(order: .dateAddedNewestToOldest)
-            sortOption = .dateAddedNewestToOldest
-        } else {
-            sortOption = Settings.homeFolderSortOrder()
-        }
+        let sortOption = Settings.homeFolderSortOrder()
 
         let podcastNameAction = OptionAction(label: LibrarySort.titleAtoZ.description, selected: sortOption == .titleAtoZ) { [weak self] in
             guard let strongSelf = self else { return }
@@ -81,18 +75,11 @@ extension PodcastListViewController: UIScrollViewDelegate, PCSearchBarDelegate {
             Analytics.track(.podcastsListSortOrderChanged, properties: ["sort_by": LibrarySort.recentlyPlayed])
         }
 
-        if FeatureFlag.podcastsSortChanges.enabled {
-            options.addAction(action: subscribedOrder)
-            options.addAction(action: releaseDateAction)
-            options.addAction(action: recentlyPlayedOrder)
-            options.addAction(action: podcastNameAction)
-            options.addAction(action: dragAndDropAction)
-        } else {
-            options.addAction(action: podcastNameAction)
-            options.addAction(action: releaseDateAction)
-            options.addAction(action: subscribedOrder)
-            options.addAction(action: dragAndDropAction)
-        }
+        options.addAction(action: subscribedOrder)
+        options.addAction(action: releaseDateAction)
+        options.addAction(action: recentlyPlayedOrder)
+        options.addAction(action: podcastNameAction)
+        options.addAction(action: dragAndDropAction)
 
         return options
     }

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController+Tip.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController+Tip.swift
@@ -5,7 +5,6 @@ extension PodcastListViewController: UIPopoverPresentationControllerDelegate {
     func showRecentlyPlayedSortingTipIfNeeded() {
         guard
             Settings.shouldShowRecentlyPlayedSortingTip,
-            FeatureFlag.podcastsSortChanges.enabled,
             recentlyPlayedSortingTip == nil
         else {
             return

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -425,14 +425,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
             guard let strongSelf = self else { return }
 
             let oldData = strongSelf.gridItems
-            let sortOption: LibrarySort
-            if !FeatureFlag.podcastsSortChanges.enabled, Settings.homeFolderSortOrder() == .recentlyPlayed {
-                Settings.setHomeFolderSortOrder(order: .dateAddedNewestToOldest)
-                sortOption = .dateAddedNewestToOldest
-            } else {
-                sortOption = Settings.homeFolderSortOrder()
-            }
-            var newData = HomeGridDataHelper.gridListItems(orderedBy: sortOption, badgeType: Settings.podcastBadgeType())
+            var newData = HomeGridDataHelper.gridListItems(orderedBy: Settings.homeFolderSortOrder(), badgeType: Settings.podcastBadgeType())
 
             if newData.isEmpty {
                 newData = [HomeGridListItem.empty]
@@ -477,11 +470,7 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     @objc private func podcastOptionsTapped(_ sender: UIBarButtonItem) {
         let optionsPicker = OptionsPicker(title: nil)
 
-        let sortOption: LibrarySort = if !FeatureFlag.podcastsSortChanges.enabled, Settings.homeFolderSortOrder() == .recentlyPlayed {
-            .dateAddedNewestToOldest
-        } else {
-            Settings.homeFolderSortOrder()
-        }
+        let sortOption = Settings.homeFolderSortOrder()
         let sortAction = OptionAction(label: L10n.sortBy, secondaryLabel: sortOption.description, icon: "podcast-sort") {
             Analytics.track(.podcastsListModalOptionTapped, properties: ["option": "sort_by"])
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Removes the `podcastsSortChanges` feature flag, which has been enabled by default. The new podcast sorting behavior (including the "Recently played" sort option and the updated sort menu ordering) is now permanent, and the legacy fallback paths — including the code that reset a `.recentlyPlayed` sort back to `.dateAddedNewestToOldest` when the flag was off — are deleted.

## To test

1. Open the Podcasts tab, tap ••• → Sort by, and confirm the options are: Date added, Release date, Recently played, Name, Drag and drop.
2. Select "Recently played" and confirm the grid sorts accordingly.
3. Open a folder, tap ••• → Sort by, and confirm the same options and behavior.
4. Confirm the "Recently played" sorting tooltip still appears on the Podcasts tab if it hasn't been dismissed before.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)