### PR TITLE
Remove FeatureFlag.listeningHistorySearch

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -70,9 +70,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// If the player is not ready to play, we should use the same logic we use when the player doesn't exist yet.
     case playerIsReadyToPlay
 
-    // Shows the searchbar in Listening History view
-    case listeningHistorySearch
-
     /// Use the Mimetype library to check the file mimetype
     case useMimetypePackage
 
@@ -368,8 +365,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .syncStats:
             true
         case .playerIsReadyToPlay:
-            true
-        case .listeningHistorySearch:
             true
         case .useMimetypePackage:
             true

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -84,9 +84,7 @@ class ListeningHistoryViewController: PCViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if FeatureFlag.listeningHistorySearch.enabled {
-            setupSearchController()
-        }
+        setupSearchController()
 
         operationQueue.maxConcurrentOperationCount = 1
         title = L10n.listeningHistory


### PR DESCRIPTION
The `listeningHistorySearch` feature flag has been enabled by default, so this removes the flag and makes the search bar in Listening History the only code path. No behavior change.

## To test

1. Open Profile → Listening History.
2. Confirm the search bar is shown and searching filters your played episodes.
3. Confirm a search with no matches shows the "No episodes found" empty state.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)