### PR TITLE
Remove no-op PCDBResultSet.close()

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBResultSet.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/DB/GRDB/GRDBResultSet.swift
@@ -6,21 +6,11 @@ class GRDBResultSet: PCDBResultSet {
     private let rowCursor: RowCursor
     private var row: Row!
 
-    private var closed = false
-
     init(rowCursor: RowCursor) {
         self.rowCursor = rowCursor
     }
 
-    func close() {
-        closed = true
-    }
-
     func next() -> Bool {
-        if closed {
-            fatalError("Result set is closed")
-        }
-
         // Reset `row` before stepping so a cursor error (e.g. SQLITE_BUSY /
         // SQLITE_IOERR) surfaces as end-of-results instead of leaving the
         // previous row in place, which would make `while next()` loops spin.

--- a/Modules/Sources/PocketCastsDataModel/Private/DB/PCDBResultSet.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/DB/PCDBResultSet.swift
@@ -1,8 +1,6 @@
 import Foundation
 
 public protocol PCDBResultSet {
-    func close()
-
     func next() -> Bool
 
     func int(forColumnIndex: Int32) -> Int32

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/AutoAddQueueDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/AutoAddQueueDataManager.swift
@@ -68,7 +68,6 @@ public struct AutoAddCandidatesDataManager {
 
                 let resultSet = try db.executeQuery(query, values: nil)
 
-                defer { resultSet.close() }
                 while resultSet.next() {
                     if let result = AutoAddCandidate(from: resultSet) {
                         results.append(result)

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/EndOfYearDataManager.swift
@@ -33,7 +33,6 @@ class EndOfYearDataManager {
                             LIMIT 1
                             """
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     isEligible = true
@@ -67,7 +66,6 @@ class EndOfYearDataManager {
                             LIMIT 1
                             """
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     isFullListeningHistory = true
@@ -92,7 +90,6 @@ class EndOfYearDataManager {
                             \(listenedEpisodes(year: year))
                             """
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     numberOfEpisodes = Int(resultSet.int(forColumn: "numberOfEpisodes"))
@@ -117,7 +114,6 @@ class EndOfYearDataManager {
             do {
                 let query = "SELECT DISTINCT \(DataManager.episodeTableName).uuid, SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE \(listenedEpisodes(year: year))"
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     listeningTime = resultSet.double(forColumn: "totalPlayedTime")
@@ -154,7 +150,6 @@ class EndOfYearDataManager {
 """
 
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     let numberOfPodcasts = Int(resultSet.int(forColumn: "numberOfPodcasts"))
@@ -194,7 +189,6 @@ class EndOfYearDataManager {
                             """
 
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     let numberOfPodcasts = Int(resultSet.int(forColumn: "podcasts"))
@@ -227,7 +221,6 @@ class EndOfYearDataManager {
                             LIMIT \(limit)
                             """
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     let numberOfPlayedEpisodes = Int(resultSet.int(forColumn: "played_episodes"))
@@ -261,7 +254,6 @@ class EndOfYearDataManager {
                             LIMIT 1
                             """
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     episode = Episode.from(resultSet: resultSet)
@@ -285,7 +277,6 @@ class EndOfYearDataManager {
                                 \(listenedEpisodes(year: year))
                             """
                 let resultSet = try db.executeQuery(query, values: uuids)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     if let uuid = resultSet.string(forColumn: "uuid") {
@@ -311,7 +302,6 @@ class EndOfYearDataManager {
                         LIMIT 1
                         """
             let resultSet = try db.executeQuery(query, values: nil)
-            defer { resultSet.close() }
 
             if resultSet.next() {
                 numberOfItemsInListeningHistory = Int(resultSet.int(forColumn: "total"))
@@ -333,7 +323,6 @@ class EndOfYearDataManager {
             do {
                 let query = "SELECT DISTINCT \(DataManager.episodeTableName).uuid, SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE \(listenedEpisodes(year: year)) UNION ALL SELECT DISTINCT \(DataManager.episodeTableName).uuid, SUM(playedUpTo) as totalPlayedTime from \(DataManager.episodeTableName) WHERE \(listenedEpisodes(year: year - 1))"
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     listeningTimeThisYear = resultSet.double(forColumn: "totalPlayedTime")
@@ -360,7 +349,6 @@ class EndOfYearDataManager {
             do {
                 let query = "SELECT COUNT(DISTINCT \(DataManager.episodeTableName).uuid) as episodesPlayed from \(DataManager.episodeTableName) WHERE (playingStatus = 3 OR playedUpTo >= 0.9 * duration) AND \(listenedEpisodes(year: year)) UNION SELECT COUNT(DISTINCT \(DataManager.episodeTableName).uuid) as episodesPlayed from \(DataManager.episodeTableName) WHERE \(listenedEpisodes(year: year))"
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     completed = Int(resultSet.int(forColumn: "episodesPlayed"))

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -80,7 +80,6 @@ class EpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: [PlayingStatus.completed.rawValue])
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     let uuid = DBUtils.nonNilStringFromColumn(resultSet: resultSet, columnName: "uuid")
@@ -106,7 +105,6 @@ class EpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     let uuid = DBUtils.nonNilStringFromColumn(resultSet: resultSet, columnName: "uuid")
@@ -127,7 +125,6 @@ class EpisodeDataManager {
             dbQueue.read { db in
                 do {
                     let resultSet = try db.executeQuery(query, values: [podcastId])
-                    defer { resultSet.close() }
 
                     if resultSet.next() {
                         count = Int(resultSet.int(forColumn: "Count"))
@@ -146,7 +143,6 @@ class EpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT id from \(DataManager.episodeTableName) WHERE episodeStatus = ? AND uuid = ?", values: [DownloadStatus.downloaded.rawValue, uuid])
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     found = true
@@ -233,7 +229,6 @@ class EpisodeDataManager {
                     ORDER BY listenDate ASC
                     """
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     if let day = resultSet.string(forColumn: "listenDate") {
@@ -314,7 +309,6 @@ class EpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: values)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     episode = self.createEpisodeFrom(resultSet: resultSet)
@@ -332,7 +326,6 @@ class EpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: values)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     if let episode = self.createEpisodeFrom(resultSet: resultSet) {
@@ -353,7 +346,6 @@ class EpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     count = Int(resultSet.int(forColumn: "Count"))
@@ -372,7 +364,6 @@ class EpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     count = Int(resultSet.int(forColumn: "Count"))
@@ -392,7 +383,6 @@ class EpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     date = resultSet.date(forColumn: "lastDownloadAttemptDate")
@@ -651,7 +641,6 @@ class EpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT cachedFrameCount from \(DataManager.episodeTableName) WHERE id = ?", values: [episodeId])
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     frameCount = resultSet.longLongInt(forColumn: "cachedFrameCount")

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
@@ -136,7 +136,6 @@ class FolderDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT * from \(DataManager.folderTableName)", values: nil)
-                defer { resultSet.close() }
 
                 var newFolders = [Folder]()
                 while resultSet.next() {

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/FolderHistoryManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/FolderHistoryManager.swift
@@ -33,7 +33,6 @@ public class FolderHistoryManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT COUNT(*) as count, date FROM PodcastFoldersHistory GROUP BY (date) ORDER BY date DESC", values: nil)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     if let date = resultSet.date(forColumn: "date") {
@@ -53,7 +52,6 @@ public class FolderHistoryManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT podcastUuid, folderUuid FROM PodcastFoldersHistory WHERE date = ?", values: [entry])
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     if let podcastUuid = resultSet.string(forColumn: "podcastUuid"),

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/PlaylistDataManager.swift
@@ -39,7 +39,6 @@ class PlaylistDataManager {
             do {
                 let query = includeDeleted ? "SELECT COUNT(*) from \(DataManager.playlistsTableName)" : "SELECT COUNT(*) from \(DataManager.playlistsTableName) WHERE wasDeleted = 0"
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     count = resultSet.long(forColumnIndex: 0)
@@ -57,7 +56,6 @@ class PlaylistDataManager {
             do {
                 let query = PlaylistQueryBuilder.query(clause: clause, for: playlist, episodeUuidToAdd: episodeUuidToAdd, shouldShowArchived: shouldShowArchived)
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     count = resultSet.long(forColumnIndex: 0)
@@ -76,7 +74,6 @@ class PlaylistDataManager {
             do {
                 let query = PlaylistQueryBuilder.podcastExistsInPlaylistEpisodesQuery(includeDeleted: includeDeleted)
                 let resultSet = try db.executeQuery(query, values: [podcastUuid])
-                defer { resultSet.close() }
 
                 exists = resultSet.next()
             } catch {
@@ -107,7 +104,6 @@ class PlaylistDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT * from \(DataManager.playlistsTableName) WHERE uuid = ?", values: [uuid])
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     playlist = self.createPlaylistFrom(resultSet: resultSet)
@@ -146,7 +142,6 @@ class PlaylistDataManager {
                 }
 
                 let resultSet = try db.executeQuery(query, values: [episodeUuid])
-                defer { resultSet.close() }
 
                 exists = resultSet.next()
             } catch {
@@ -168,7 +163,6 @@ class PlaylistDataManager {
                         GROUP BY playlist_uuid
                     """
                 let resultSet = try db.executeQuery(query, values: [episodeUUID])
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     if let uuid = resultSet.string(forColumn: "playlist_uuid") {
@@ -200,7 +194,6 @@ class PlaylistDataManager {
             do {
                 // Load existing order (id + episodeUuid) for this playlist
                 let rs = try db.executeQuery("SELECT id, episodeUuid FROM \(DataManager.playlistEpisodeTableName) WHERE playlist_uuid = ? ORDER BY episodePosition ASC", values: [playlist.uuid])
-                defer { rs.close() }
 
                 var items = [(id: Int64, uuid: String)]()
                 while rs.next() {
@@ -248,7 +241,6 @@ class PlaylistDataManager {
 
                 // Reindex remaining
                 let rs = try db.executeQuery("SELECT id FROM \(DataManager.playlistEpisodeTableName) WHERE playlist_uuid = ? ORDER BY episodePosition ASC", values: [playlist.uuid])
-                defer { rs.close() }
                 var ids = [Int64]()
                 while rs.next() { ids.append(rs.longLongInt(forColumn: "id")) }
                 for (index, id) in ids.enumerated() {
@@ -376,7 +368,6 @@ class PlaylistDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: values)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     let filter = self.createPlaylistFrom(resultSet: resultSet)
@@ -395,7 +386,6 @@ class PlaylistDataManager {
             do {
                 let query = "SELECT MAX(sortPosition) from \(DataManager.playlistsTableName)"
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     highestPosition = resultSet.long(forColumnIndex: 0)
@@ -414,7 +404,6 @@ class PlaylistDataManager {
             do {
                 let query = "SELECT MIN(sortPosition) from \(DataManager.playlistsTableName)"
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     lowestPosition = resultSet.long(forColumnIndex: 0)
@@ -467,7 +456,6 @@ class PlaylistDataManager {
                 var startPosition: Int32 = 0
                 do {
                     let rs = try db.executeQuery("SELECT COALESCE(MAX(episodePosition), 0) FROM \(DataManager.playlistEpisodeTableName) WHERE playlist_uuid = ?", values: [playlist.uuid])
-                    defer { rs.close() }
                     if rs.next() {
                         startPosition = rs.int(forColumnIndex: 0)
                     }

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -146,7 +146,6 @@ class PodcastDataManager {
                 }
                 let query = "SELECT DISTINCT p.id, p.* FROM \(DataManager.podcastTableName) p LEFT JOIN \(DataManager.episodeTableName) e ON p.id = e.podcast_id AND e.id = (SELECT e.id FROM \(DataManager.episodeTableName) e WHERE e.podcast_id = p.id AND e.playingStatus != 3 AND e.archived = 0 ORDER BY e.publishedDate DESC LIMIT 1) \(whereClause) ORDER BY CASE WHEN e.publishedDate IS NULL THEN 1 ELSE 0 END, e.publishedDate DESC, p.latestEpisodeDate DESC"
                 let resultSet = try db.executeQuery(query, values: values)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     let podcast = self.createPodcastFrom(resultSet: resultSet)
@@ -174,7 +173,6 @@ class PodcastDataManager {
                 }
                 let query = "SELECT DISTINCT p.id, p.* FROM \(DataManager.podcastTableName) p LEFT JOIN \(DataManager.episodeTableName) e ON p.id = e.podcast_id AND e.id = (SELECT e.id FROM \(DataManager.episodeTableName) e WHERE e.podcast_id = p.id ORDER BY e.lastPlaybackInteractionDate DESC LIMIT 1) \(whereClause) ORDER BY CASE WHEN e.lastPlaybackInteractionDate IS NULL THEN 1 ELSE 0 END, e.lastPlaybackInteractionDate DESC"
                 let resultSet = try db.executeQuery(query, values: values)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     let podcast = self.createPodcastFrom(resultSet: resultSet)
@@ -196,7 +194,6 @@ class PodcastDataManager {
             do {
                 let query = "SELECT * FROM SJPodcast ORDER BY RANDOM() LIMIT 5"
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     let podcast = self.createPodcastFrom(resultSet: resultSet)
@@ -370,7 +367,6 @@ class PodcastDataManager {
             do {
                 let query = "SELECT p.uuid as uuid, count(e.id) as count FROM \(DataManager.episodeTableName) e, \(DataManager.podcastTableName) p WHERE e.podcast_id = p.id AND playingStatus <> \(PlayingStatus.completed.rawValue) AND archived = 0 GROUP BY p.uuid"
                 let rs = try db.executeQuery(query, values: nil)
-                defer { rs.close() }
 
                 while rs.next() {
                     guard let uuid = rs.string(forColumn: "uuid") else { continue }
@@ -592,7 +588,6 @@ class PodcastDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT * from \(DataManager.podcastTableName)", values: nil)
-                defer { resultSet.close() }
 
                 var newPodcasts = [String: Podcast]()
                 while resultSet.next() {

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/UpNextChangesDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/UpNextChangesDataManager.swift
@@ -16,7 +16,6 @@ class UpNextChangesDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT * from \(DataManager.upNextChangesTableName) WHERE type = ?", values: [UpNextChanges.Actions.replace.rawValue])
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     replaceAction = self.createFrom(resultSet: resultSet)
@@ -34,7 +33,6 @@ class UpNextChangesDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT * from \(DataManager.upNextChangesTableName) WHERE type != ?", values: [UpNextChanges.Actions.replace.rawValue])
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     let action = self.createFrom(resultSet: resultSet)

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/UpNextDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/UpNextDataManager.swift
@@ -255,7 +255,6 @@ class UpNextDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT * from \(DataManager.playlistEpisodeTableName) WHERE playlist_id = ? ORDER by episodePosition", values: [UpNextDataManager.upNextPlaylistId])
-                defer { resultSet.close() }
 
                 var newItems = [PlaylistEpisode]()
                 var uuids = Set<String>()

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/UpNextHistoryManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/UpNextHistoryManager.swift
@@ -38,7 +38,6 @@ public class UpNextHistoryManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT COUNT(*) as count, date FROM PlaylistEpisodeHistory GROUP BY (date) ORDER BY date DESC", values: nil)
-                defer { resultSet.close() }
 
                 while resultSet.next(), let date = resultSet.date(forColumn: "date") {
                     entries.append(UpNextHistoryEntry(date: date, episodeCount: Int(resultSet.int(forColumn: "count"))))
@@ -56,7 +55,6 @@ public class UpNextHistoryManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT episodeUuid FROM PlaylistEpisodeHistory WHERE date = ? ORDER BY episodePosition ASC", values: [entry])
-                defer { resultSet.close() }
 
                 while resultSet.next(), let episodeUuid = resultSet.string(forColumn: "episodeUuid") {
                     episodesUuid.append(episodeUuid)

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/UserEpisodeDataManager.swift
@@ -138,7 +138,6 @@ class UserEpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: values)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     episode = self.createEpisodeFrom(resultSet: resultSet)
@@ -157,7 +156,6 @@ class UserEpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery("SELECT cachedFrameCount from \(DataManager.userEpisodeTableName) WHERE id = ?", values: [episodeId])
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     frameCount = resultSet.longLongInt(forColumn: "cachedFrameCount")
@@ -175,7 +173,6 @@ class UserEpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: values)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     let episode = self.createEpisodeFrom(resultSet: resultSet)
@@ -195,7 +192,6 @@ class UserEpisodeDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: nil)
-                defer { resultSet.close() }
 
                 if resultSet.next() {
                     count = Int(resultSet.int(forColumn: "Count"))

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -10,7 +10,7 @@ class DatabaseHelper {
         var databaseWasCreated = false
         queue.write { db in
             do {
-                try db.executeQuery("PRAGMA busy_timeout = 10000", values: nil).close()
+                _ = try db.executeQuery("PRAGMA busy_timeout = 10000", values: nil)
 
                 let startingSchemaVersion = db.pragmaUserVersion() ?? 0
                 databaseWasCreated = startingSchemaVersion < 1

--- a/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -133,7 +133,6 @@ public struct BookmarkDataManager {
         dbQueue.read { db in
             do {
                 let resultSet = try db.executeQuery(query, values: [episodeUuid])
-                defer { resultSet.close() }
                 if resultSet.next() {
                     count = resultSet.long(forColumnIndex: 0)
                 }
@@ -284,7 +283,6 @@ private extension BookmarkDataManager {
                 """
 
                 let resultSet = try db.executeQuery(query, values: values)
-                defer { resultSet.close() }
 
                 while resultSet.next() {
                     if let bookmark = Bookmark(from: resultSet) {

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1146,7 +1146,6 @@ public class DataManager {
                 if resultSet.next() {
                     count = resultSet.long(forColumnIndex: 0)
                 }
-                resultSet.close()
             } catch {
                 FileLog.shared.addMessage("DataManager.count error: \(error)")
             }

--- a/Modules/Tests/PocketCastsDataModelTests/PlaylistEpisodeManipulationTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/PlaylistEpisodeManipulationTests.swift
@@ -92,7 +92,6 @@ final class PlaylistEpisodeManipulationTests: DataManagerTestCase {
         dataManager.testDbQueue.read { db in
             do {
                 let rs = try db.executeQuery(sql, values: [playlistUuid])
-                defer { rs.close() }
                 while rs.next() {
                     actual.append(DBUtils.nonNilStringFromColumn(resultSet: rs, columnName: "episodeUuid"))
                 }
@@ -111,7 +110,6 @@ final class PlaylistEpisodeManipulationTests: DataManagerTestCase {
                     "SELECT COUNT(*) c FROM \(DataManager.playlistEpisodeTableName) WHERE playlist_uuid = ?",
                     values: [playlistUuid]
                 )
-                defer { rs.close() }
                 if rs.next() { count = rs.long(forColumn: "c") }
             } catch {
                 count = -1

--- a/Modules/Tests/PocketCastsDataModelTests/UpNextEpisodeFetchTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/UpNextEpisodeFetchTests.swift
@@ -299,7 +299,6 @@ final class UpNextEpisodeFetchTests: DataManagerTestCase {
                     "SELECT episodeUuid FROM \(DataManager.playlistEpisodeTableName) WHERE playlist_uuid = ? ORDER BY episodePosition ASC",
                     values: [playlistUuid]
                 )
-                defer { rs.close() }
                 while rs.next() {
                     order.append(DBUtils.nonNilStringFromColumn(resultSet: rs, columnName: "episodeUuid"))
                 }


### PR DESCRIPTION
As discussed, removing the no-op `PCDBResultSet.close()` since it's no longer needed with GRDB.

## To test

1. Run the app and browse around (podcasts, episodes, filters, Up Next, bookmarks) — all data loading goes through these result sets and should behave exactly as before.
2. Run the DataModel module tests.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)