### PR TITLE
Fix Bookmark row artwork stretching when non-square

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix the mini player initial loading shimmer not showing up when Reduce Motion is enabled [#4713](https://github.com/Automattic/pocket-casts-ios/pull/4713)
 - Fix options picker rows like "Sort By" wrapping their labels to multiple lines when there is enough space [#4722](https://github.com/Automattic/pocket-casts-ios/pull/4722)
 - Fix the disabled Transcript action in the player being nearly invisible when the episode has no transcript [#4729](https://github.com/Automattic/pocket-casts-ios/pull/4729)
+- Fix non-square artwork being stretched in bookmark rows; it is now cropped to a square thumbnail [#4746](https://github.com/Automattic/pocket-casts-ios/pull/4746)
 
 8.16
 -----

--- a/podcasts/Bookmarks/List/BookmarkRow.swift
+++ b/podcasts/Bookmarks/List/BookmarkRow.swift
@@ -52,6 +52,7 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
     private var imageView: some View {
         if let episode = rowModel.episode {
             EpisodeImage(episode: episode)
+                .aspectRatio(contentMode: .fill)
                 .frame(width: imageSize, height: imageSize)
                 .cornerRadius(8)
         } else {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-832

Bookmark rows render the episode artwork with a plain `.resizable()` image inside a fixed square frame, so non-square artwork (e.g. embedded episode artwork) gets stretched. This adds `.aspectRatio(contentMode: .fill)` so the artwork is cropped to the square thumbnail instead, matching how `PodcastImageView` renders artwork elsewhere in the app.

## To test

1. Enable Settings → Appearance → Use Embedded Artwork.
2. Play an episode whose artwork is non-square (e.g. an episode with wide embedded artwork).
3. Add a bookmark, then open the Bookmarks tab in the full-screen player.
4. Verify the bookmark row's thumbnail is a square crop of the artwork with no stretching or distortion.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)