### PR TITLE
Fix Claude review workflow: persist checkout credentials

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -57,7 +57,9 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
-          persist-credentials: false
+          # Credentials must persist so claude-code-action can `git fetch` the
+          # PR branch; the job's token is read-only for contents anyway.
+          persist-credentials: true
 
       - name: PR Review with Progress Tracking
         uses: anthropics/claude-code-action@4633baf5267540f3f8cb58b684f79901d564c280 # v1.0.160


### PR DESCRIPTION
Fixes the "Claude Review" workflow (`claude-review.yml`), which fails on any PR it tries to review:

```
fatal: could not read Username for 'https://github.com': No such device or address
Error: Command failed: git fetch origin --depth=20 <pr-branch>
```

The checkout step sets `persist-credentials: false`, so no auth token is written into the workspace's git config. `claude-code-action` then runs its own `git fetch origin <pr-branch>` to check out the PR head and has no way to authenticate. This PR sets `persist-credentials: true` explicitly (with a comment explaining why, so a future security lint doesn't flip it back). It's safe: the job's token only has `contents: read`, so the persisted credential can fetch but not push.

Same fix as Automattic/pocket-casts-webplayer#4725 and Automattic/pocket-casts-android#5573 — this workflow is shared between the Android, iOS, and Web Player repos, and its header asks for changes to be applied to all three.

## To test

1. Merge, then push to any open PR (or re-run a failed "Claude Review" run)
2. Verify the review job checks out the PR branch and posts a review instead of failing at `git fetch`

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. — n/a, CI workflow only, not user-facing
- [x] I have considered adding unit tests for my changes. — n/a, GitHub Actions config
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. — n/a
