### PR TITLE
Add opt-in SQL statement tracing and remove no-op busy_timeout pragma

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -10,8 +10,6 @@ class DatabaseHelper {
         var databaseWasCreated = false
         queue.write { db in
             do {
-                _ = try db.executeQuery("PRAGMA busy_timeout = 10000", values: nil)
-
                 let startingSchemaVersion = db.pragmaUserVersion() ?? 0
                 databaseWasCreated = startingSchemaVersion < 1
 

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -1,5 +1,6 @@
 import GRDB
 import Foundation
+import OSLog
 import PocketCastsUtils
 import SQLite3
 
@@ -47,6 +48,20 @@ public class DataManager {
 
         var config = Configuration()
         config.busyMode = .timeout(10)
+#if DEBUG
+        // Launch with `-PCSQLTracing` (Edit Scheme ▸ Run ▸ Arguments, off by default) to log
+        // every SQL statement with its arguments to the unified logging system.
+        // Filter with `subsystem:<bundle id> category:SQL`.
+        if ProcessInfo.processInfo.arguments.contains("-PCSQLTracing") {
+            let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "PocketCasts", category: "SQL")
+            config.publicStatementArguments = true
+            config.prepareDatabase { db in
+                db.trace(options: .statement) { event in
+                    logger.debug("\(event, privacy: .public)")
+                }
+            }
+        }
+#endif
         let dbPool = try! DatabasePool(path: DataManager.pathToDb(), configuration: config)
         let dbQueue = GRDBQueue(dbPool: dbPool, logger: Self.logger)
         DataManager.setDatabaseFileProtectionToNone()

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
@@ -82,12 +82,12 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-FIRInfoEnabled"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "-PCSQLTracing"
             isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-FIRInfoEnabled"
+            isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
       <StoreKitConfigurationFileReference

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
@@ -85,6 +85,10 @@
             argument = "-FIRInfoEnabled"
             isEnabled = "YES">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-PCSQLTracing"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
       <StoreKitConfigurationFileReference
          identifier = "../../Pocket Casts Configuration.storekit">


### PR DESCRIPTION
This PR addressed the following comment from Copilot: https://github.com/Automattic/pocket-casts-ios/pull/4745#discussion_r3575154591.

Adds an easy way to see every SQL statement the app runs, and removes a dead statement found along the way:

- **Opt-in SQL tracing**: launching a debug build with the `-PCSQLTracing` argument logs every SQL statement (with arguments) to the unified logging system under `category:SQL`, following the same OSLog pattern as `AnalyticsOSLogAdapter`. The argument is included in the shared `pocketcasts` scheme, disabled by default, so enabling it is a single checkbox. Compiled only in `DEBUG`.
- **Remove no-op `PRAGMA busy_timeout`**: the manual pragma in `DatabaseHelper.setup` was redundant — GRDB's `Configuration.busyMode = .timeout(10)` already configures the same 10-second busy timeout on every connection.

I verified with the new SQL tracing that `busy_timeout` pragma it not executed. With GRBD, [this code](https://github.com/Automattic/pocket-casts-ios/blob/700f6e395250e81e27160abb67ec318749fe9fe2/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift#L49) handles the busy errors.

## To test

1. Open Edit Scheme ▸ Run ▸ Arguments for the `pocketcasts` scheme and enable `-PCSQLTracing`.
2. Run the app and browse around (open a podcast, play an episode).
3. In the Xcode console (or Console.app filtering on `category:SQL`), verify every SQL statement is logged with its arguments.
4. Disable the argument and relaunch — verify no SQL logging occurs.
5. Verify normal app behavior (database reads/writes, playback, sync) is unchanged.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.