### PR TITLE
Fix AudioClipExporter progress poll interval and Sendable warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 - Fix the disabled Transcript action in the player being nearly invisible when the episode has no transcript [#4729](https://github.com/Automattic/pocket-casts-ios/pull/4729)
 - Fix non-square artwork being stretched in bookmark rows; it is now cropped to a square thumbnail [#4746](https://github.com/Automattic/pocket-casts-ios/pull/4746)
 - Sync Apple Watch and phone playback progress instantly when you pause [#4535](https://github.com/Automattic/pocket-casts-ios/pull/4535)
-- Fix excessive CPU and battery use while exporting an audio clip for sharing [#4751](https://github.com/Automattic/pocket-casts-ios/pull/4751)
 
 8.16
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix the disabled Transcript action in the player being nearly invisible when the episode has no transcript [#4729](https://github.com/Automattic/pocket-casts-ios/pull/4729)
 - Fix non-square artwork being stretched in bookmark rows; it is now cropped to a square thumbnail [#4746](https://github.com/Automattic/pocket-casts-ios/pull/4746)
 - Sync Apple Watch and phone playback progress instantly when you pause [#4535](https://github.com/Automattic/pocket-casts-ios/pull/4535)
+- Fix excessive CPU and battery use while exporting an audio clip for sharing [#4751](https://github.com/Automattic/pocket-casts-ios/pull/4751)
 
 8.16
 -----

--- a/podcasts/Sharing/Clip/AudioClipExporter.swift
+++ b/podcasts/Sharing/Clip/AudioClipExporter.swift
@@ -45,16 +45,18 @@ class AudioClipExporter {
         let progressObserver = Task {
             while !Task.isCancelled {
                 progress.completedUnitCount = Int64(exportSession.progress * 100)
-                try await Task.sleep(nanoseconds: 100*1000)
+                try await Task.sleep(for: .milliseconds(100))
             }
         }
 
+        // cancelExport() is documented as safe to call from any thread.
+        let cancellableSession = UnsafeTransfer(exportSession)
         await withTaskCancellationHandler {
             FileLog.shared.addMessage("AudioClipExporter Started Audio Export: \(date.timeIntervalSinceNow)")
             await exportSession.export()
             FileLog.shared.addMessage("AudioClipExporter Ended Audio Export: \(date.timeIntervalSinceNow)")
         } onCancel: {
-            exportSession.cancelExport()
+            cancellableSession.wrappedValue.cancelExport()
         }
 
         progressObserver.cancel()


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

The audio clip export progress loop slept `100*1000` nanoseconds (0.1 ms) instead of the intended 100 ms, waking ~10,000 times per second for the duration of every export and burning CPU/battery. Switched to `Task.sleep(for: .milliseconds(100))` so the unit is explicit and this class of unit-factor mistake can't recur.

Also fixed the Swift 6 concurrency warning in the same function — `AVAssetExportSession` (non-`Sendable`) was captured in the `@Sendable` `onCancel:` closure. It's now passed through the existing `UnsafeTransfer` wrapper, which is sound because `cancelExport()` is documented as safe to call from any thread.

Note: the `.audio` share style that drives this exporter appears to be unused — I couldn't find a way to reach it in the UI (`SharingView` filters it out of the style carousel: `ShareImageStyle.allCases.filter { $0 != .audio }`), which is why there's no CHANGELOG entry. The change is clearly safe regardless.

## To test

Since the `.audio` style doesn't appear reachable in the sharing UI, this is verified by build + code review:

1. Confirm the app builds without the previous Sendable capture warning in `AudioClipExporter.swift`.
2. Confirm `.milliseconds(100)` matches the intended poll interval (the old code slept 0.1 ms).
3. Sanity-check clip sharing still works: open an episode → Share → Clip → share a clip with any available style.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)