### PR TITLE
Fix leaked task in UpNextShuffleAnimationView

### DIFF
--- a/podcasts/Onboarding/Plus/NewUpgrade/Animations/UpNextShuffleAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/Animations/UpNextShuffleAnimationView.swift
@@ -122,11 +122,13 @@ struct UpNextShuffleAnimationView: View {
             }
         }
         .task {
-            Task {
+            do {
                 while true {
                     try await Task.sleep(for: .seconds(1.6))
                     nextAnimation()
                 }
+            } catch {
+                // Do nothing
             }
         }
     }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

The `.task` modifier in `UpNextShuffleAnimationView` spawned an inner unstructured `Task` running an infinite loop. Since the inner task wasn't tied to the view's lifecycle, it was never cancelled and kept running (and retaining its captures) after the view disappeared. This change runs the loop directly in the `.task` body, so SwiftUI cancels it automatically when the view goes away (`Task.sleep` throws on cancellation, exiting the loop).

## To test

1. Open the Plus upgrade screen and swipe to the Up Next Shuffle feature card.
2. Verify the shuffle animation still cycles through its states (every ~1.6s).
3. Dismiss the screen and confirm the animation task no longer lingers (e.g., no repeated timer firing in the debugger).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.