### PR TITLE
Add frequency property to plus_promotion_upgrade_button_tapped

### DIFF
--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
@@ -139,7 +139,7 @@ class UpgradeAccountViewModel: PlusPurchaseModel {
     }
 
     func purchaseTapped() {
-        track(.plusPromotionUpgradeButtonTapped)
+        track(.plusPromotionUpgradeButtonTapped, properties: ["frequency": selectedProduct.frequency.rawValue])
 
         guard SyncManager.isUserLoggedIn() else {
             presentLogin(with: ProductInfo(plan: upgradeTier.plan, frequency: selectedFrequency))

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -26,7 +26,7 @@ class PlusLandingViewModel: PlusPurchaseModel {
     }
 
     func unlockTapped(_ product: ProductInfo) {
-        OnboardingFlow.shared.track(.plusPromotionUpgradeButtonTapped)
+        OnboardingFlow.shared.track(.plusPromotionUpgradeButtonTapped, properties: ["frequency": product.frequency.rawValue])
 
         guard SyncManager.isUserLoggedIn() else {
             presentLogin(with: product)


### PR DESCRIPTION
Fixes PCIOS-<!-- issue number, if applicable -->

The `plus_promotion_upgrade_button_tapped` analytics event does not include the billing frequency (monthly vs yearly), even though `purchase_successful` does. Without it, the upgrade funnel can't be segmented by frequency — we can see how many purchases succeeded per frequency but not how many users tapped upgrade for each.

This adds a `frequency` property to the event at both live call sites, using the same value shape as `purchase_successful` (`PlanFrequency` raw value → `monthly` / `yearly`):

- `PlusLandingViewModel.unlockTapped(_:)` — from the tapped product (`product.frequency`).
- `UpgradeAccountViewModel.purchaseTapped()` — from `selectedProduct.frequency`, mirroring exactly what `purchase_successful` reads (`productId.frequency`).

(The third reference to this event, `AnalyticsHelper.plusUpgradeConfirmed(source:)`, has no callers and no product/frequency data, so it was left untouched.)

Event Horizon schema companion PR: Automattic/EventHorizonSchemas#109

## To test

1. Enable `FeatureFlag.tracksLogging` so tracked events log to the console as `🔵 Tracked: plus_promotion_upgrade_button_tapped [... "frequency": ...]`.
2. Open an upsell / upgrade screen (e.g. Profile → Upgrade).
3. Select the **Yearly** plan and tap the upgrade button. Confirm the logged event includes `"frequency": "yearly"`.
4. Go back, select the **Monthly** plan and tap upgrade. Confirm the logged event includes `"frequency": "monthly"`.
5. Repeat across both entry points (the plus landing/upsell view and the account upgrade view) to cover both call sites.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. <!-- Internal analytics-only change, no user-facing change. -->
- [x] I have considered adding unit tests for my changes. <!-- Analytics property added to existing tracked events; no unit-testable logic. Verified via a staging build and console logging. -->
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. <!-- Automattic/EventHorizonSchemas#109 adds `frequency` to plus_promotion_upgrade_button_tapped. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)