### PR TITLE
Fix empty mini player after a non-animated full player dismissal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix the disabled Transcript action in the player being nearly invisible when the episode has no transcript [#4729](https://github.com/Automattic/pocket-casts-ios/pull/4729)
 - Fix non-square artwork being stretched in bookmark rows; it is now cropped to a square thumbnail [#4746](https://github.com/Automattic/pocket-casts-ios/pull/4746)
 - Sync Apple Watch and phone playback progress instantly when you pause [#4535](https://github.com/Automattic/pocket-casts-ios/pull/4535)
+- Fix the mini player showing empty and stuck after opening the app from an episode notification or a deep link while the full-screen player was open [#4757](https://github.com/Automattic/pocket-casts-ios/pull/4757)
 
 8.16
 -----

--- a/podcasts/MiniPlayerViewController+TransitionDelegate.swift
+++ b/podcasts/MiniPlayerViewController+TransitionDelegate.swift
@@ -1,6 +1,17 @@
 import Foundation
 
 extension MiniPlayerViewController: UIViewControllerTransitioningDelegate {
+    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        guard let fullPlayer = presented as? PlayerContainerViewController else { return nil }
+
+        let presentationController = FullPlayerPresentationController(presentedViewController: fullPlayer, presenting: presenting)
+        presentationController.onNonAnimatedDismiss = { [weak self, weak fullPlayer] in
+            guard let fullPlayer else { return }
+            self?.fullScreenPlayerDidDismiss(fullPlayer)
+        }
+        return presentationController
+    }
+
     func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         guard let fullPlayer = dismissed as? PlayerContainerViewController else {
             return nil
@@ -41,5 +52,31 @@ extension MiniPlayerViewController: UIViewControllerTransitioningDelegate {
         }
 
         return MiniPlayerToFullPlayerAnimator(fromViewController: self, toViewController: presented, transition: .presenting, miniPlayerArtwork: podcastArtwork, fullPlayerArtwork: fullPlayer.nowPlayingItem.artworkImageView)
+    }
+}
+
+/// Behaves exactly like the default presentation controller UIKit creates for
+/// `.custom` presentations, but reports dismissals that happened without a
+/// transition animation. `dismiss(animated: false)` never consults the
+/// transitioning delegate, so the animators' restore work is skipped — this is
+/// the only UIKit hook that still fires in that case. Animated dismissals are
+/// deliberately ignored: the animator's completion already handles them.
+private final class FullPlayerPresentationController: UIPresentationController {
+    var onNonAnimatedDismiss: (() -> Void)?
+
+    private var isDismissalAnimated = false
+
+    override func dismissalTransitionWillBegin() {
+        super.dismissalTransitionWillBegin()
+
+        isDismissalAnimated = presentedViewController.transitionCoordinator?.isAnimated ?? false
+    }
+
+    override func dismissalTransitionDidEnd(_ completed: Bool) {
+        super.dismissalTransitionDidEnd(completed)
+
+        guard completed, !isDismissalAnimated else { return }
+
+        onNonAnimatedDismiss?()
     }
 }

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -396,6 +396,23 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         playbackProgressDidChange()
     }
 
+    /// A `dismiss(animated: false)` anywhere up the presentation chain
+    /// (notification taps, deep links, stacked-sheet teardowns) never consults
+    /// the transitioning delegate, so the animators' dismiss completions —
+    /// which restore the contents `PlayerZoomAnimator` blanked on present and
+    /// close out `playerOpenState` — don't run, leaving the mini player
+    /// permanently empty and frozen. Called from the player's presentation
+    /// controller only for those non-animated teardowns; animated dismissals
+    /// are fully handled by the animators.
+    func fullScreenPlayerDidDismiss(_ player: PlayerContainerViewController) {
+        guard fullScreenPlayer == nil || fullScreenPlayer === player else { return }
+
+        view.alpha = 1
+        view.subviews.forEach { $0.alpha = 1 }
+        playerOpenState = .closed
+        finishedWithFullScreenPlayer()
+    }
+
     func changeHeightTo(_ height: CGFloat) {
         if heightConstraint == nil {
             heightConstraint = view.heightAnchor.constraint(equalToConstant: height)

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -383,6 +383,13 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     }
 
     func finishedWithFullScreenPlayer() {
+        // Undo the blanking `PlayerZoomAnimator` applies to the mini player when
+        // presenting the full screen player. The animated dismissal already
+        // restores this itself, so re-applying it here is a no-op there, but it
+        // keeps the mini player visible after any teardown path.
+        view.alpha = 1
+        view.subviews.forEach { $0.alpha = 1 }
+
         guard rootViewController() != nil else { return }
 
         rootViewController()?.setNeedsStatusBarAppearanceUpdate()
@@ -399,16 +406,13 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     /// A `dismiss(animated: false)` anywhere up the presentation chain
     /// (notification taps, deep links, stacked-sheet teardowns) never consults
     /// the transitioning delegate, so the animators' dismiss completions —
-    /// which restore the contents `PlayerZoomAnimator` blanked on present and
-    /// close out `playerOpenState` — don't run, leaving the mini player
-    /// permanently empty and frozen. Called from the player's presentation
-    /// controller only for those non-animated teardowns; animated dismissals
-    /// are fully handled by the animators.
+    /// which restore the mini player and close out `playerOpenState` — don't
+    /// run, leaving the mini player permanently empty and frozen. Called from
+    /// the player's presentation controller only for those non-animated
+    /// teardowns; animated dismissals are fully handled by the animators.
     func fullScreenPlayerDidDismiss(_ player: PlayerContainerViewController) {
         guard fullScreenPlayer == nil || fullScreenPlayer === player else { return }
 
-        view.alpha = 1
-        view.subviews.forEach { $0.alpha = 1 }
         playerOpenState = .closed
         finishedWithFullScreenPlayer()
     }


### PR DESCRIPTION
Fixes PCIOS-798 (**more details in the ticket!**)

On iOS 26, `PlayerZoomAnimator` hides the mini player's subviews while the full-screen player is presented and only restores them in its dismiss animation. Since UIKit skips the animator for `dismiss(animated: false)` (push notifications, deep links, stacked-sheet dismissals), the mini player stayed empty and frozen, and the player state was never closed out. (Zendesk 11349405)

The fix vends a custom `UIPresentationController` whose `dismissalTransitionDidEnd(_:)` fires for every completed dismissal; it performs the restore only when no transition animation ran, leaving animated dismissals untouched.

## To test

1. On an iOS 26 simulator, play an episode and open the full-screen player.
2. Trigger a non-animated dismissal: open `pktc://settings/storage-and-data` in Safari, or tap an episode push notification.
3. Verify the mini player still shows artwork/title/controls and keeps updating, and tapping it reopens the full player.
4. Sanity-check the animated flows: opening and swiping down the player should look unchanged.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
