### PR TITLE
Add discover analytics events to featured & video Discover rows (tvOS)

### DIFF
--- a/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
@@ -58,9 +58,13 @@ enum DiscoverAnalytics {
         }
     }
 
-    static func discoverPodcastPlayed(podcastUuid: String) {
+    static func discoverPodcastPlayed(podcastUuid: String, listID: String? = nil) {
         Task {
-            if let listID = await DiscoverManager.shared.listIdForPodcast(podcastUuid) {
+            var solvedListID = listID
+            if solvedListID == nil {
+                solvedListID = await DiscoverManager.shared.listIdForPodcast(podcastUuid)
+            }
+            if let listID = solvedListID {
                 AnalyticsHelper.podcastEpisodePlayedFromList(listId: listID, podcastUuid: podcastUuid)
             }
         }

--- a/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
@@ -60,7 +60,11 @@ enum DiscoverAnalytics {
 
     static func discoverPodcastPlayed(podcastUuid: String, listID: String? = nil) {
         Task {
-            if let listID = await (listID ?? DiscoverManager.shared.listIdForPodcast(podcastUuid)) {
+            var solvedListID = listID
+            if solvedListID == nil {
+                solvedListID = await DiscoverManager.shared.listIdForPodcast(podcastUuid)
+            }
+            if let listID = solvedListID {
                 AnalyticsHelper.podcastEpisodePlayedFromList(listId: listID, podcastUuid: podcastUuid)
             }
         }

--- a/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/DiscoverAnalytics.swift
@@ -60,11 +60,7 @@ enum DiscoverAnalytics {
 
     static func discoverPodcastPlayed(podcastUuid: String, listID: String? = nil) {
         Task {
-            var solvedListID = listID
-            if solvedListID == nil {
-                solvedListID = await DiscoverManager.shared.listIdForPodcast(podcastUuid)
-            }
-            if let listID = solvedListID {
+            if let listID = await (listID ?? DiscoverManager.shared.listIdForPodcast(podcastUuid)) {
                 AnalyticsHelper.podcastEpisodePlayedFromList(listId: listID, podcastUuid: podcastUuid)
             }
         }

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
@@ -74,6 +74,9 @@ struct DiscoverFeaturedPodcastCell: View {
                             Task {
                                 AnalyticsPlaybackHelper.shared.currentSource = .discover
                                 let successPlay = await TVDataManager.shared.playLatestEpisode(of: podcast)
+                                if successPlay {
+                                    trackEpisodeTapped()
+                                }
                                 await MainActor.run {
                                     if successPlay {
                                         showNowPlayingPlayer = true
@@ -129,6 +132,16 @@ struct DiscoverFeaturedPodcastCell: View {
             NowPlayingView()
                 .ignoresSafeArea()
         }
+    }
+
+    private func trackEpisodeTapped() {
+        guard let episodeUuid = PlaybackManager.shared.currentEpisode()?.uuid,
+              let podcastUuid = podcast.uuid,
+              let listId else {
+            return
+        }
+        DiscoverAnalytics.episodeTapped(listId: listId, podcastUuid: podcastUuid, episodeUuid: episodeUuid, source: source)
+        DiscoverAnalytics.discoverPodcastPlayed(podcastUuid: podcastUuid, listID: listId)
     }
 }
 

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -116,6 +116,9 @@ struct DiscoverVideoEpisodeCell: View {
     private func trackEpisodeTapped() {
         guard let listId, let episodeUuid = model.episode.uuid else { return }
         DiscoverAnalytics.episodeTapped(listId: listId, podcastUuid: model.episode.podcastUuid, episodeUuid: episodeUuid, source: source)
+        if let podcastUuid = model.episode.podcastUuid {
+            DiscoverAnalytics.discoverPodcastPlayed(podcastUuid: podcastUuid, listID: listId)
+        }
     }
 
     private func trackPodcastTapped() {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

<!-- Fixes PCIOS- -->

Extends the tvOS Discover list analytics so the *featured podcast* cell and the *video episode* cell emit the same events that other Discover rows already do.

**What changed**
- `DiscoverVideoEpisodeCell` and `DiscoverFeaturedPodcastCell` now fire `DiscoverAnalytics.discoverPodcastPlayed(...)` (in addition to the existing `episodeTapped`) when an episode is played from those rows.
- The featured cell only tracks the play once playback actually succeeds, and passes the known `listId`/`source` through.
- `DiscoverAnalytics.discoverPodcastPlayed` gained an optional `listID` parameter so callers that already know the list id can pass it directly, avoiding an extra `DiscoverManager` lookup; it falls back to the lookup only when no id is supplied.

**Why**
Featured and video Discover rows were missing the "podcast episode played from list" analytics that the other rows emit, leaving a gap in Discover engagement data on tvOS.

## To test

1. Launch the tvOS app and open the Home / Discover tab.
2. Play the latest episode from a **featured** podcast cell — confirm playback starts and the play analytics fire (with the correct `list_id`/`source`).
3. Play an episode from a **video** Discover row — confirm the same.
4. Confirm no duplicate or spurious events fire when playback fails.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)