### PR TITLE
tvOS: Ensure media session is configured when entering background

### DIFF
--- a/Pocket Casts TV App/PocketCastsTVApp.swift
+++ b/Pocket Casts TV App/PocketCastsTVApp.swift
@@ -5,6 +5,7 @@ struct PocketCastsTVApp: App {
     @Environment(\.scenePhase) private var scenePhase
 
     private let appLifecycleAnalytics = AppLifecycleAnalytics()
+    private let backgroundPlaybackManagement = BackgroundPlaybackManagement()
 
     init() {
         // Before anything opens the database, so a requested wipe hits a closed file.
@@ -23,6 +24,7 @@ struct PocketCastsTVApp: App {
         }
         .onChange(of: scenePhase) { _, newPhase in
             appLifecycleAnalytics.handle(scenePhase: newPhase)
+            backgroundPlaybackManagement.handle(scenePhase: newPhase)
         }
     }
 }

--- a/Pocket Casts TV App/UI/Player/BackgroundPlaybackManagement.swift
+++ b/Pocket Casts TV App/UI/Player/BackgroundPlaybackManagement.swift
@@ -20,7 +20,7 @@ class BackgroundPlaybackManagement {
         }
     }
 
-    func didEnterBackground() {        
-        playbackManager.ensureAudioSessionActivated()
+    func didEnterBackground() {
+        playbackManager.ensureBackgroundMediaSessionConfiguration()
     }
 }

--- a/Pocket Casts TV App/UI/Player/BackgroundPlaybackManagement.swift
+++ b/Pocket Casts TV App/UI/Player/BackgroundPlaybackManagement.swift
@@ -9,8 +9,9 @@ class BackgroundPlaybackManagement {
         self.playbackManager = playbackManager
     }
 
-    /// Drives the open/closed events from SwiftUI `scenePhase` changes, for apps
-    /// that use the SwiftUI app lifecycle instead of an `AppDelegate` (e.g. tvOS).
+    /// Configures the background media session in response to SwiftUI `scenePhase`
+    /// changes, for apps that use the SwiftUI app lifecycle instead of an
+    /// `AppDelegate` (e.g. tvOS).
     func handle(scenePhase: ScenePhase) {
         switch scenePhase {
         case .background:

--- a/Pocket Casts TV App/UI/Player/BackgroundPlaybackManagement.swift
+++ b/Pocket Casts TV App/UI/Player/BackgroundPlaybackManagement.swift
@@ -20,8 +20,7 @@ class BackgroundPlaybackManagement {
         }
     }
 
-    func didEnterBackground() {
-        playbackManager.refreshNowPlayingInfo(forceFullRebuild: true)
+    func didEnterBackground() {        
         playbackManager.ensureAudioSessionActivated()
     }
 }

--- a/Pocket Casts TV App/UI/Player/BackgroundPlaybackManagement.swift
+++ b/Pocket Casts TV App/UI/Player/BackgroundPlaybackManagement.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftUI
+
+class BackgroundPlaybackManagement {
+
+    let playbackManager: PlaybackManager
+
+    init(playbackManager: PlaybackManager = .shared) {
+        self.playbackManager = playbackManager
+    }
+
+    /// Drives the open/closed events from SwiftUI `scenePhase` changes, for apps
+    /// that use the SwiftUI app lifecycle instead of an `AppDelegate` (e.g. tvOS).
+    func handle(scenePhase: ScenePhase) {
+        switch scenePhase {
+        case .background:
+            didEnterBackground()
+        default:
+            break
+        }
+    }
+
+    func didEnterBackground() {
+        playbackManager.refreshNowPlayingInfo(forceFullRebuild: true)
+        playbackManager.ensureAudioSessionActivated()
+    }
+}

--- a/Pocket Casts TV App/UI/Player/BackgroundPlaybackManagement.swift
+++ b/Pocket Casts TV App/UI/Player/BackgroundPlaybackManagement.swift
@@ -14,7 +14,7 @@ class BackgroundPlaybackManagement {
     /// `AppDelegate` (e.g. tvOS).
     func handle(scenePhase: ScenePhase) {
         switch scenePhase {
-        case .background:
+        case .background, .inactive:
             didEnterBackground()
         default:
             break

--- a/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
+++ b/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
@@ -16,7 +16,7 @@ struct MediaOverlayView: View {
     var body: some View {
         GeometryReader() { proxy in
             ZStack {
-                if !model.isVideo || model.isLoading || model.isFailed, let uiImage = model.displayImage {
+                if !model.isVideo || model.isFirstLoad || model.isFailed, let uiImage = model.displayImage {
                     VStack(alignment: .center) {
                         if isTransportBarVisible {
                             Spacer().frame(height: 100)
@@ -63,7 +63,7 @@ struct MediaOverlayView: View {
             }
             .animation(.easeInOut(duration: 0.2), value: model.isLoading)
             .animation(.easeInOut(duration: 0.2), value: model.isFailed)
-            .background(model.isVideo && !model.isLoading && !model.isFailed ? Color.clear : Color.pcBackgroundBase)
+            .background(model.isVideo && !model.isFirstLoad && !model.isFailed ? Color.clear : Color.pcBackgroundBase)
         }
         .ignoresSafeArea()
     }

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -27,7 +27,7 @@ class NowPlayingViewModel: Identifiable {
     /// `MediaOverlayView` and lets `NowPlayingView` suppress AVKit's system
     /// spinner by toggling `showsPlaybackControls`.
     var isLoading: Bool = true
-    var isFirstLoad: Bool = true
+    var isFirstLoad: Bool = false
     var isFailed: Bool = false
 
     @ObservationIgnored private var timeControlStatusObservation: NSKeyValueObservation?

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -115,8 +115,10 @@ class NowPlayingViewModel: Identifiable {
         let itemNotReady = status == .unknown
         isLoading = waiting || itemNotReady
         isFailed = status == .failed
-        if !isLoading, seekAfterLoad {
+        if !isLoading {
             isFirstLoad = false
+        }
+        if !isLoading, seekAfterLoad {
             seekAfterLoad = false
             // The delay is needed only for videos episodes.
             // For some reason the AVPlayerViewController does not accept seeks immediately after loading, and resets the position to zero

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -27,7 +27,7 @@ class NowPlayingViewModel: Identifiable {
     /// `MediaOverlayView` and lets `NowPlayingView` suppress AVKit's system
     /// spinner by toggling `showsPlaybackControls`.
     var isLoading: Bool = true
-
+    var isFirstLoad: Bool = true
     var isFailed: Bool = false
 
     @ObservationIgnored private var timeControlStatusObservation: NSKeyValueObservation?
@@ -57,6 +57,7 @@ class NowPlayingViewModel: Identifiable {
             return
         }
         episode = newEpisode
+        isFirstLoad = true
         podcast = playbackManager.currentPodcast
         player = playbackManager.avPlayer
         if !playbackManager.playing(), !playbackManager.isReadyToPlay {
@@ -115,6 +116,7 @@ class NowPlayingViewModel: Identifiable {
         isLoading = waiting || itemNotReady
         isFailed = status == .failed
         if !isLoading, seekAfterLoad {
+            isFirstLoad = false
             seekAfterLoad = false
             // The delay is needed only for videos episodes.
             // For some reason the AVPlayerViewController does not accept seeks immediately after loading, and resets the position to zero

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -250,24 +250,12 @@ class PlaybackManager: ServerPlaybackDelegate {
     func ensureAudioSessionActivated() {
         guard let currEpisode = currentEpisode() else { return }
         activateAudioSession(completion: { activated in
-            if !activated {
-                self.aboutToPlay.value = false
-                return
-            }
-
-            self.startUpdateTimer()
             self.updateCommandCenterSkipTimes(addTarget: false)
             self.updateExtraActions()
-
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackStarted)
 
             if currEpisode.videoPodcast() {
                 self.setAudioSessionVideoProperties()
             }
-
-            self.updateIdleTimer()
-
-            self.sleepTimerManager.restartSleepTimerIfNeeded()
         })
     }
 
@@ -1745,14 +1733,14 @@ class PlaybackManager: ServerPlaybackDelegate {
         playing() ? player?.playbackRate() : nil
     }
 
-    @objc private func updateNowPlayingInfo() {
+    @objc func updateNowPlayingInfo() {
         refreshNowPlayingInfo(forceFullRebuild: false)
     }
 
     /// - Parameter forceFullRebuild: when `true`, rebuilds the whole now playing payload instead of
     ///   only refreshing progress. Needed when a value like the media type changes for the same
     ///   episode (e.g. an HLS stream promoted to video), which the progress-only path won't pick up.
-    private func refreshNowPlayingInfo(forceFullRebuild: Bool) {
+    public func refreshNowPlayingInfo(forceFullRebuild: Bool) {
         #if os(watchOS) || APPCLIP || os(tvOS)
             let connectedToExternalDevice = false
         #else

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1733,7 +1733,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         playing() ? player?.playbackRate() : nil
     }
 
-    @objc func updateNowPlayingInfo() {
+    @objc private func updateNowPlayingInfo() {
         refreshNowPlayingInfo(forceFullRebuild: false)
     }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -247,10 +247,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
     }
 
-    func ensureAudioSessionActivated() {
+    func ensureBackgroundMediaSessionConfiguration() {
         guard let currEpisode = currentEpisode() else { return }
         refreshNowPlayingInfo(forceFullRebuild: true)
-        activateAudioSession(completion: { activated in
+        activateAudioSession(completion: { _ in
             self.updateCommandCenterSkipTimes(addTarget: false)
             self.updateExtraActions()
             if currEpisode.videoPodcast() {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -249,10 +249,10 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func ensureAudioSessionActivated() {
         guard let currEpisode = currentEpisode() else { return }
+        refreshNowPlayingInfo(forceFullRebuild: true)
         activateAudioSession(completion: { activated in
             self.updateCommandCenterSkipTimes(addTarget: false)
             self.updateExtraActions()
-
             if currEpisode.videoPodcast() {
                 self.setAudioSessionVideoProperties()
             }
@@ -1740,7 +1740,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// - Parameter forceFullRebuild: when `true`, rebuilds the whole now playing payload instead of
     ///   only refreshing progress. Needed when a value like the media type changes for the same
     ///   episode (e.g. an HLS stream promoted to video), which the progress-only path won't pick up.
-    public func refreshNowPlayingInfo(forceFullRebuild: Bool) {
+    private func refreshNowPlayingInfo(forceFullRebuild: Bool) {
         #if os(watchOS) || APPCLIP || os(tvOS)
             let connectedToExternalDevice = false
         #else


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

## Summary

On tvOS the app uses the SwiftUI app lifecycle (`scenePhase`) rather than an `AppDelegate`, so the media session / now-playing configuration was not being (re)applied when the app entered the background. This PR wires up that path.

- Adds `BackgroundPlaybackManagement`, a thin tvOS adapter that observes `scenePhase` changes (mirroring the existing `AppLifecycleAnalytics.handle(scenePhase:)` pattern) and, on entering background, asks `PlaybackManager` to configure the media session.
- Centralizes the session/now-playing configuration in `PlaybackManager` as `ensureBackgroundMediaSessionConfiguration()` (renamed and pared down from the previously-unused `ensureAudioSessionActivated()`): it forces a full now-playing rebuild, activates the audio session, refreshes command-center skip times / extra actions, and applies video session properties when needed.
- Wires the new manager into `PocketCastsTVApp` alongside the existing lifecycle-analytics handler.

## To test

1. On an Apple TV, start playing an episode in Pocket Casts.
2. Send the app to the background (press the TV/Home button).
3. Verify playback continues and the now-playing / media controls remain correctly populated (artwork, title, skip controls).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)