### PR TITLE
Add FeatureFlag.smartBookmarks

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -317,6 +317,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// A new "Troubleshooting" screen for detecting orphaned episodes and more.
     case troubleshooting
 
+    /// Enable Smart Bookmarks
+    case smartBookmarks
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -535,6 +538,8 @@ public enum FeatureFlag: String, CaseIterable {
             BuildEnvironment.current == .debug
         case .troubleshooting:
             true
+        case .smartBookmarks:
+            BuildEnvironment.current == .debug
         }
     }
 


### PR DESCRIPTION
Adds `FeatureFlag.smartBookmarks` (enabled in debug builds only) for the upcoming Smart Bookmarks work.

## To test

1. Build and run the app.
2. Confirm `smartBookmarks` appears in the Feature Flags debug menu, enabled in debug builds.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
