### PR TITLE
[PC-TV] Hide authenticated Discover rows when the server has no recommendations

### DIFF
--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -161,7 +161,7 @@ actor DiscoverManager {
         let regionSource = source.replacingOccurrences(of: discoverLayout.regionCodeToken, with: regionCode)
 
         guard let podcastCollection = await discoverServerHandler.discoverPodcastCollection(source: regionSource, authenticated: sourceItem.authenticated) else {
-            throw sourceItem.authenticated == true ? DiscoverError.failedToLoadAuthenticated : DiscoverError.failedToLoad 
+            throw sourceItem.authenticated == true ? DiscoverError.failedToLoadAuthenticated : DiscoverError.failedToLoad
         }
         let listId = sourceItem.listId(collection: podcastCollection)
         guard var listOfPodcasts = podcastCollection.podcasts else {

--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -112,6 +112,7 @@ actor DiscoverManager {
     enum DiscoverError: Error {
         /// The layout or a section failed to load (network error, timeout, or bad response).
         case failedToLoad
+        case failedToLoadAuthenticated
     }
 
     private var cachedLayout: DiscoverLayout?
@@ -160,7 +161,7 @@ actor DiscoverManager {
         let regionSource = source.replacingOccurrences(of: discoverLayout.regionCodeToken, with: regionCode)
 
         guard let podcastCollection = await discoverServerHandler.discoverPodcastCollection(source: regionSource, authenticated: sourceItem.authenticated) else {
-            throw DiscoverError.failedToLoad
+            throw sourceItem.authenticated == true ? DiscoverError.failedToLoadAuthenticated : DiscoverError.failedToLoad 
         }
         let listId = sourceItem.listId(collection: podcastCollection)
         guard var listOfPodcasts = podcastCollection.podcasts else {

--- a/Pocket Casts TV App/UI/Discover/DiscoverSectionModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverSectionModel.swift
@@ -64,7 +64,11 @@ class DiscoverSectionModel {
             if let itemTitle = item?.title?.localized ?? type?.title, !itemTitle.isEmpty {
                 title = itemTitle
             }
-            state = .failed
+            if let discoverError = error as? DiscoverManager.DiscoverError, discoverError == .failedToLoadAuthenticated {
+                state = .empty
+            } else {
+                state = .failed
+            }
             return
         }
 


### PR DESCRIPTION
Fixes PCIOS-

On the TV app, an authenticated Discover item (e.g. personalized recommendations) can legitimately return no data when the server has no recommendations for the user. Previously this was treated the same as any other load failure, so the section showed an error state.

This change distinguishes that case: `DiscoverManager` throws a dedicated `failedToLoadAuthenticated` error when an authenticated source returns nothing, and `DiscoverSectionModel` maps that to an `.empty` state — hiding the row instead of showing an error, matching the iOS behavior.

## To test

1. Sign in on the TV app with an account that has no personalized recommendations available from the server.
2. Open Discover.
3. Verify the authenticated recommendation row is hidden rather than showing an error.
4. Verify non-authenticated sections still show an error state when they genuinely fail to load.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
