### PR TITLE
Add Generated chapters playback setting

### DIFF
--- a/Modules/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -1223,6 +1223,15 @@ nonisolated struct Api_ChangeableSettings: @unchecked Sendable {
   /// Clears the value of `audioOnly`. Subsequent reads from it will return its default value.
   mutating func clearAudioOnly() {_uniqueStorage()._audioOnly = nil}
 
+  var disableAiChapters: Api_BoolSetting {
+    get {_storage._disableAiChapters ?? Api_BoolSetting()}
+    set {_uniqueStorage()._disableAiChapters = newValue}
+  }
+  /// Returns true if `disableAiChapters` has been explicitly set.
+  var hasDisableAiChapters: Bool {_storage._disableAiChapters != nil}
+  /// Clears the value of `disableAiChapters`. Subsequent reads from it will return its default value.
+  mutating func clearDisableAiChapters() {_uniqueStorage()._disableAiChapters = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
@@ -2128,6 +2137,15 @@ nonisolated struct Api_NamedSettings: @unchecked Sendable {
   var hasAudioOnly: Bool {_storage._audioOnly != nil}
   /// Clears the value of `audioOnly`. Subsequent reads from it will return its default value.
   mutating func clearAudioOnly() {_uniqueStorage()._audioOnly = nil}
+
+  var disableAiChapters: SwiftProtobuf.Google_Protobuf_BoolValue {
+    get {_storage._disableAiChapters ?? SwiftProtobuf.Google_Protobuf_BoolValue()}
+    set {_uniqueStorage()._disableAiChapters = newValue}
+  }
+  /// Returns true if `disableAiChapters` has been explicitly set.
+  var hasDisableAiChapters: Bool {_storage._disableAiChapters != nil}
+  /// Clears the value of `disableAiChapters`. Subsequent reads from it will return its default value.
+  mutating func clearDisableAiChapters() {_uniqueStorage()._disableAiChapters = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3042,6 +3060,15 @@ nonisolated struct Api_NamedSettingsResponse: @unchecked Sendable {
   var hasAudioOnly: Bool {_storage._audioOnly != nil}
   /// Clears the value of `audioOnly`. Subsequent reads from it will return its default value.
   mutating func clearAudioOnly() {_uniqueStorage()._audioOnly = nil}
+
+  var disableAiChapters: Api_BoolSetting {
+    get {_storage._disableAiChapters ?? Api_BoolSetting()}
+    set {_uniqueStorage()._disableAiChapters = newValue}
+  }
+  /// Returns true if `disableAiChapters` has been explicitly set.
+  var hasDisableAiChapters: Bool {_storage._disableAiChapters != nil}
+  /// Clears the value of `disableAiChapters`. Subsequent reads from it will return its default value.
+  mutating func clearDisableAiChapters() {_uniqueStorage()._disableAiChapters = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -8964,7 +8991,7 @@ nonisolated extension Api_NamedSettingsRequest: SwiftProtobuf.Message, SwiftProt
 
 nonisolated extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".ChangeableSettings"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}grid_layout\0\u{3}grid_order\0\u{3}show_played\0\u{1}theme\0\u{3}skip_forward\0\u{3}skip_back\0\u{3}web_version\0\u{1}language\0\u{3}recommendations_on\0\u{4}\u{2}use_embedded_artwork\0\u{3}playback_speed\0\u{4}\u{2}volume_boost\0\u{1}badges\0\u{3}free_gift_acknowledgement\0\u{3}marketing_opt_in\0\u{3}auto_archive_played_episodes\0\u{3}auto_archive_includes_starred\0\u{1}region\0\u{3}row_action\0\u{3}up_next_swipe\0\u{3}episode_grouping\0\u{3}show_archived\0\u{3}open_links\0\u{3}media_actions\0\u{3}media_actions_order\0\u{3}keep_screen_awake\0\u{3}open_player\0\u{3}intelligent_resumption\0\u{3}play_up_next_on_tap\0\u{3}remote_skip_chapters\0\u{3}playback_actions\0\u{3}legacy_bluetooth\0\u{3}multi_select_gesture\0\u{3}chapter_titles\0\u{1}notifications\0\u{3}notification_actions\0\u{3}play_over_notifications\0\u{3}hide_notification_on_pause\0\u{3}app_badge\0\u{3}app_badge_filter\0\u{3}auto_archive_played\0\u{3}auto_archive_inactive\0\u{3}auto_up_next_limit\0\u{3}auto_up_next_limit_reached\0\u{3}warn_data_usage\0\u{3}files_auto_up_next\0\u{3}files_after_playing_delete_local\0\u{3}files_after_playing_delete_cloud\0\u{3}privacy_analytics\0\u{3}privacy_crash_reports\0\u{3}privacy_link_account\0\u{3}player_shelf\0\u{3}auto_subscribe_to_played\0\u{3}auto_show_played\0\u{3}auto_play_enabled\0\u{3}auto_play_last_list_uuid\0\u{3}trim_silence\0\u{3}show_artwork_on_lock_screen\0\u{3}headphone_controls_next_action\0\u{3}headphone_controls_previous_action\0\u{3}headphone_controls_play_bookmark_confirmation_sound\0\u{3}dark_theme_preference\0\u{3}light_theme_preference\0\u{3}use_system_theme\0\u{3}episode_bookmarks_sort_type\0\u{3}player_bookmarks_sort_type\0\u{3}podcast_bookmarks_sort_type\0\u{3}use_dark_up_next_theme\0\u{3}use_dynamic_colors_for_widget\0\u{3}files_sort_order\0\u{3}background_refresh\0\u{3}auto_download_unmetered_only\0\u{3}auto_download_only_when_charging\0\u{3}auto_download_up_next\0\u{3}cloud_auto_upload\0\u{3}cloud_auto_download\0\u{3}cloud_download_unmetered_only\0\u{3}use_rss_artwork\0\u{3}bookmarks_sort_order\0\u{3}auto_archive_played_episodes_global\0\u{3}auto_archive_includes_starred_global\0\u{3}files_auto_up_next_global\0\u{3}files_after_playing_delete_local_global\0\u{3}files_after_playing_delete_cloud_global\0\u{3}player_shelf_global\0\u{3}row_action_global\0\u{3}use_embedded_artwork_global\0\u{3}recommendations_on_global\0\u{3}grid_layout_global\0\u{3}volume_boost_global\0\u{3}badges_global\0\u{4}\u{2}smart_folders_number_of_times_shown\0\u{3}smart_folders_last_date_shown\0\u{3}save_up_next_on_playlists_play_all\0\u{3}do_not_sell_or_share\0\u{3}live_analytics_url\0\u{3}listening_time_stats\0\u{3}up_next_sort_tooltip_seen\0\u{3}audio_only\0\u{b}stream_by_default\0\u{b}silence_removal\0\u{c}\u{a}\u{1}\u{c}\u{d}\u{1}")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}grid_layout\0\u{3}grid_order\0\u{3}show_played\0\u{1}theme\0\u{3}skip_forward\0\u{3}skip_back\0\u{3}web_version\0\u{1}language\0\u{3}recommendations_on\0\u{4}\u{2}use_embedded_artwork\0\u{3}playback_speed\0\u{4}\u{2}volume_boost\0\u{1}badges\0\u{3}free_gift_acknowledgement\0\u{3}marketing_opt_in\0\u{3}auto_archive_played_episodes\0\u{3}auto_archive_includes_starred\0\u{1}region\0\u{3}row_action\0\u{3}up_next_swipe\0\u{3}episode_grouping\0\u{3}show_archived\0\u{3}open_links\0\u{3}media_actions\0\u{3}media_actions_order\0\u{3}keep_screen_awake\0\u{3}open_player\0\u{3}intelligent_resumption\0\u{3}play_up_next_on_tap\0\u{3}remote_skip_chapters\0\u{3}playback_actions\0\u{3}legacy_bluetooth\0\u{3}multi_select_gesture\0\u{3}chapter_titles\0\u{1}notifications\0\u{3}notification_actions\0\u{3}play_over_notifications\0\u{3}hide_notification_on_pause\0\u{3}app_badge\0\u{3}app_badge_filter\0\u{3}auto_archive_played\0\u{3}auto_archive_inactive\0\u{3}auto_up_next_limit\0\u{3}auto_up_next_limit_reached\0\u{3}warn_data_usage\0\u{3}files_auto_up_next\0\u{3}files_after_playing_delete_local\0\u{3}files_after_playing_delete_cloud\0\u{3}privacy_analytics\0\u{3}privacy_crash_reports\0\u{3}privacy_link_account\0\u{3}player_shelf\0\u{3}auto_subscribe_to_played\0\u{3}auto_show_played\0\u{3}auto_play_enabled\0\u{3}auto_play_last_list_uuid\0\u{3}trim_silence\0\u{3}show_artwork_on_lock_screen\0\u{3}headphone_controls_next_action\0\u{3}headphone_controls_previous_action\0\u{3}headphone_controls_play_bookmark_confirmation_sound\0\u{3}dark_theme_preference\0\u{3}light_theme_preference\0\u{3}use_system_theme\0\u{3}episode_bookmarks_sort_type\0\u{3}player_bookmarks_sort_type\0\u{3}podcast_bookmarks_sort_type\0\u{3}use_dark_up_next_theme\0\u{3}use_dynamic_colors_for_widget\0\u{3}files_sort_order\0\u{3}background_refresh\0\u{3}auto_download_unmetered_only\0\u{3}auto_download_only_when_charging\0\u{3}auto_download_up_next\0\u{3}cloud_auto_upload\0\u{3}cloud_auto_download\0\u{3}cloud_download_unmetered_only\0\u{3}use_rss_artwork\0\u{3}bookmarks_sort_order\0\u{3}auto_archive_played_episodes_global\0\u{3}auto_archive_includes_starred_global\0\u{3}files_auto_up_next_global\0\u{3}files_after_playing_delete_local_global\0\u{3}files_after_playing_delete_cloud_global\0\u{3}player_shelf_global\0\u{3}row_action_global\0\u{3}use_embedded_artwork_global\0\u{3}recommendations_on_global\0\u{3}grid_layout_global\0\u{3}volume_boost_global\0\u{3}badges_global\0\u{4}\u{2}smart_folders_number_of_times_shown\0\u{3}smart_folders_last_date_shown\0\u{3}save_up_next_on_playlists_play_all\0\u{3}do_not_sell_or_share\0\u{3}live_analytics_url\0\u{3}listening_time_stats\0\u{3}up_next_sort_tooltip_seen\0\u{3}audio_only\0\u{3}disable_ai_chapters\0\u{b}stream_by_default\0\u{b}silence_removal\0\u{c}\u{a}\u{1}\u{c}\u{d}\u{1}")
 
   fileprivate class _StorageClass {
     var _gridLayout: Api_Int32Setting? = nil
@@ -9066,6 +9093,7 @@ nonisolated extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtob
     var _listeningTimeStats: Api_BoolSetting? = nil
     var _upNextSortTooltipSeen: Api_BoolSetting? = nil
     var _audioOnly: Api_BoolSetting? = nil
+    var _disableAiChapters: Api_BoolSetting? = nil
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -9175,6 +9203,7 @@ nonisolated extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtob
       _listeningTimeStats = source._listeningTimeStats
       _upNextSortTooltipSeen = source._upNextSortTooltipSeen
       _audioOnly = source._audioOnly
+      _disableAiChapters = source._disableAiChapters
     }
   }
 
@@ -9292,6 +9321,7 @@ nonisolated extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtob
         case 100: try { try decoder.decodeSingularMessageField(value: &_storage._listeningTimeStats) }()
         case 101: try { try decoder.decodeSingularMessageField(value: &_storage._upNextSortTooltipSeen) }()
         case 102: try { try decoder.decodeSingularMessageField(value: &_storage._audioOnly) }()
+        case 103: try { try decoder.decodeSingularMessageField(value: &_storage._disableAiChapters) }()
         default: break
         }
       }
@@ -9600,6 +9630,9 @@ nonisolated extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtob
       } }()
       try { if let v = _storage._audioOnly {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 102)
+      } }()
+      try { if let v = _storage._disableAiChapters {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 103)
       } }()
     }
     try unknownFields.traverse(visitor: &visitor)
@@ -9709,6 +9742,7 @@ nonisolated extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtob
         if _storage._listeningTimeStats != rhs_storage._listeningTimeStats {return false}
         if _storage._upNextSortTooltipSeen != rhs_storage._upNextSortTooltipSeen {return false}
         if _storage._audioOnly != rhs_storage._audioOnly {return false}
+        if _storage._disableAiChapters != rhs_storage._disableAiChapters {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -9720,7 +9754,7 @@ nonisolated extension Api_ChangeableSettings: SwiftProtobuf.Message, SwiftProtob
 
 nonisolated extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".NamedSettings"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}grid_layout\0\u{3}grid_order\0\u{3}show_played\0\u{1}theme\0\u{3}skip_forward\0\u{3}skip_back\0\u{3}web_version\0\u{1}language\0\u{3}recommendations_on\0\u{4}\u{2}use_embedded_artwork\0\u{3}playback_speed\0\u{4}\u{2}volume_boost\0\u{1}badges\0\u{3}free_gift_acknowledgement\0\u{3}marketing_opt_in\0\u{3}auto_archive_played_episodes\0\u{3}auto_archive_includes_starred\0\u{1}region\0\u{3}row_action\0\u{3}up_next_swipe\0\u{3}episode_grouping\0\u{3}show_archived\0\u{3}open_links\0\u{3}media_actions\0\u{3}media_actions_order\0\u{3}keep_screen_awake\0\u{3}open_player\0\u{3}intelligent_resumption\0\u{3}play_up_next_on_tap\0\u{3}remote_skip_chapters\0\u{3}playback_actions\0\u{3}legacy_bluetooth\0\u{3}multi_select_gesture\0\u{3}chapter_titles\0\u{1}notifications\0\u{3}notification_actions\0\u{3}play_over_notifications\0\u{3}hide_notification_on_pause\0\u{3}app_badge\0\u{3}app_badge_filter\0\u{3}auto_archive_played\0\u{3}auto_archive_inactive\0\u{3}auto_up_next_limit\0\u{3}auto_up_next_limit_reached\0\u{3}warn_data_usage\0\u{3}files_auto_up_next\0\u{3}files_after_playing_delete_local\0\u{3}files_after_playing_delete_cloud\0\u{3}privacy_analytics\0\u{3}privacy_crash_reports\0\u{3}privacy_link_account\0\u{3}player_shelf\0\u{3}auto_subscribe_to_played\0\u{3}auto_show_played\0\u{3}auto_play_enabled\0\u{3}auto_play_last_list_uuid\0\u{3}trim_silence\0\u{3}show_artwork_on_lock_screen\0\u{3}headphone_controls_next_action\0\u{3}headphone_controls_previous_action\0\u{3}headphone_controls_play_bookmark_confirmation_sound\0\u{3}dark_theme_preference\0\u{3}light_theme_preference\0\u{3}use_system_theme\0\u{3}episode_bookmarks_sort_type\0\u{3}player_bookmarks_sort_type\0\u{3}podcast_bookmarks_sort_type\0\u{3}use_dark_up_next_theme\0\u{3}use_dynamic_colors_for_widget\0\u{3}files_sort_order\0\u{3}background_refresh\0\u{3}auto_download_unmetered_only\0\u{3}auto_download_only_when_charging\0\u{3}auto_download_up_next\0\u{3}cloud_auto_upload\0\u{3}cloud_auto_download\0\u{3}cloud_download_unmetered_only\0\u{3}use_rss_artwork\0\u{3}bookmarks_sort_order\0\u{3}auto_archive_played_episodes_global\0\u{3}auto_archive_includes_starred_global\0\u{3}files_auto_up_next_global\0\u{3}files_after_playing_delete_local_global\0\u{3}files_after_playing_delete_cloud_global\0\u{3}player_shelf_global\0\u{3}row_action_global\0\u{3}use_embedded_artwork_global\0\u{3}recommendations_on_global\0\u{3}grid_layout_global\0\u{3}volume_boost_global\0\u{3}badges_global\0\u{4}\u{2}smart_folders_number_of_times_shown\0\u{3}smart_folders_last_date_shown\0\u{3}save_up_next_on_playlists_play_all\0\u{3}do_not_sell_or_share\0\u{3}live_analytics_url\0\u{3}listening_time_stats\0\u{3}up_next_sort_tooltip_seen\0\u{3}audio_only\0\u{b}stream_by_default\0\u{b}silence_removal\0\u{c}\u{a}\u{1}\u{c}\u{d}\u{1}")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}grid_layout\0\u{3}grid_order\0\u{3}show_played\0\u{1}theme\0\u{3}skip_forward\0\u{3}skip_back\0\u{3}web_version\0\u{1}language\0\u{3}recommendations_on\0\u{4}\u{2}use_embedded_artwork\0\u{3}playback_speed\0\u{4}\u{2}volume_boost\0\u{1}badges\0\u{3}free_gift_acknowledgement\0\u{3}marketing_opt_in\0\u{3}auto_archive_played_episodes\0\u{3}auto_archive_includes_starred\0\u{1}region\0\u{3}row_action\0\u{3}up_next_swipe\0\u{3}episode_grouping\0\u{3}show_archived\0\u{3}open_links\0\u{3}media_actions\0\u{3}media_actions_order\0\u{3}keep_screen_awake\0\u{3}open_player\0\u{3}intelligent_resumption\0\u{3}play_up_next_on_tap\0\u{3}remote_skip_chapters\0\u{3}playback_actions\0\u{3}legacy_bluetooth\0\u{3}multi_select_gesture\0\u{3}chapter_titles\0\u{1}notifications\0\u{3}notification_actions\0\u{3}play_over_notifications\0\u{3}hide_notification_on_pause\0\u{3}app_badge\0\u{3}app_badge_filter\0\u{3}auto_archive_played\0\u{3}auto_archive_inactive\0\u{3}auto_up_next_limit\0\u{3}auto_up_next_limit_reached\0\u{3}warn_data_usage\0\u{3}files_auto_up_next\0\u{3}files_after_playing_delete_local\0\u{3}files_after_playing_delete_cloud\0\u{3}privacy_analytics\0\u{3}privacy_crash_reports\0\u{3}privacy_link_account\0\u{3}player_shelf\0\u{3}auto_subscribe_to_played\0\u{3}auto_show_played\0\u{3}auto_play_enabled\0\u{3}auto_play_last_list_uuid\0\u{3}trim_silence\0\u{3}show_artwork_on_lock_screen\0\u{3}headphone_controls_next_action\0\u{3}headphone_controls_previous_action\0\u{3}headphone_controls_play_bookmark_confirmation_sound\0\u{3}dark_theme_preference\0\u{3}light_theme_preference\0\u{3}use_system_theme\0\u{3}episode_bookmarks_sort_type\0\u{3}player_bookmarks_sort_type\0\u{3}podcast_bookmarks_sort_type\0\u{3}use_dark_up_next_theme\0\u{3}use_dynamic_colors_for_widget\0\u{3}files_sort_order\0\u{3}background_refresh\0\u{3}auto_download_unmetered_only\0\u{3}auto_download_only_when_charging\0\u{3}auto_download_up_next\0\u{3}cloud_auto_upload\0\u{3}cloud_auto_download\0\u{3}cloud_download_unmetered_only\0\u{3}use_rss_artwork\0\u{3}bookmarks_sort_order\0\u{3}auto_archive_played_episodes_global\0\u{3}auto_archive_includes_starred_global\0\u{3}files_auto_up_next_global\0\u{3}files_after_playing_delete_local_global\0\u{3}files_after_playing_delete_cloud_global\0\u{3}player_shelf_global\0\u{3}row_action_global\0\u{3}use_embedded_artwork_global\0\u{3}recommendations_on_global\0\u{3}grid_layout_global\0\u{3}volume_boost_global\0\u{3}badges_global\0\u{4}\u{2}smart_folders_number_of_times_shown\0\u{3}smart_folders_last_date_shown\0\u{3}save_up_next_on_playlists_play_all\0\u{3}do_not_sell_or_share\0\u{3}live_analytics_url\0\u{3}listening_time_stats\0\u{3}up_next_sort_tooltip_seen\0\u{3}audio_only\0\u{3}disable_ai_chapters\0\u{b}stream_by_default\0\u{b}silence_removal\0\u{c}\u{a}\u{1}\u{c}\u{d}\u{1}")
 
   fileprivate class _StorageClass {
     var _gridLayout: SwiftProtobuf.Google_Protobuf_Int32Value? = nil
@@ -9822,6 +9856,7 @@ nonisolated extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._M
     var _listeningTimeStats: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
     var _upNextSortTooltipSeen: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
     var _audioOnly: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
+    var _disableAiChapters: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -9931,6 +9966,7 @@ nonisolated extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._M
       _listeningTimeStats = source._listeningTimeStats
       _upNextSortTooltipSeen = source._upNextSortTooltipSeen
       _audioOnly = source._audioOnly
+      _disableAiChapters = source._disableAiChapters
     }
   }
 
@@ -10048,6 +10084,7 @@ nonisolated extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._M
         case 100: try { try decoder.decodeSingularMessageField(value: &_storage._listeningTimeStats) }()
         case 101: try { try decoder.decodeSingularMessageField(value: &_storage._upNextSortTooltipSeen) }()
         case 102: try { try decoder.decodeSingularMessageField(value: &_storage._audioOnly) }()
+        case 103: try { try decoder.decodeSingularMessageField(value: &_storage._disableAiChapters) }()
         default: break
         }
       }
@@ -10357,6 +10394,9 @@ nonisolated extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._M
       try { if let v = _storage._audioOnly {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 102)
       } }()
+      try { if let v = _storage._disableAiChapters {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 103)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -10465,6 +10505,7 @@ nonisolated extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._M
         if _storage._listeningTimeStats != rhs_storage._listeningTimeStats {return false}
         if _storage._upNextSortTooltipSeen != rhs_storage._upNextSortTooltipSeen {return false}
         if _storage._audioOnly != rhs_storage._audioOnly {return false}
+        if _storage._disableAiChapters != rhs_storage._disableAiChapters {return false}
         return true
       }
       if !storagesAreEqual {return false}
@@ -10476,7 +10517,7 @@ nonisolated extension Api_NamedSettings: SwiftProtobuf.Message, SwiftProtobuf._M
 
 nonisolated extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".NamedSettingsResponse"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}grid_layout\0\u{3}grid_order\0\u{3}show_played\0\u{1}theme\0\u{3}skip_forward\0\u{3}skip_back\0\u{3}web_version\0\u{1}language\0\u{3}recommendations_on\0\u{4}\u{2}use_embedded_artwork\0\u{3}playback_speed\0\u{4}\u{2}volume_boost\0\u{1}badges\0\u{3}free_gift_acknowledgement\0\u{3}marketing_opt_in\0\u{3}auto_archive_played_episodes\0\u{3}auto_archive_includes_starred\0\u{1}region\0\u{3}row_action\0\u{3}up_next_swipe\0\u{3}episode_grouping\0\u{3}show_archived\0\u{3}open_links\0\u{3}media_actions\0\u{3}media_actions_order\0\u{3}keep_screen_awake\0\u{3}open_player\0\u{3}intelligent_resumption\0\u{3}play_up_next_on_tap\0\u{3}remote_skip_chapters\0\u{3}playback_actions\0\u{3}legacy_bluetooth\0\u{3}multi_select_gesture\0\u{3}chapter_titles\0\u{1}notifications\0\u{3}notification_actions\0\u{3}play_over_notifications\0\u{3}hide_notification_on_pause\0\u{3}app_badge\0\u{3}app_badge_filter\0\u{3}auto_archive_played\0\u{3}auto_archive_inactive\0\u{3}auto_up_next_limit\0\u{3}auto_up_next_limit_reached\0\u{3}warn_data_usage\0\u{3}files_auto_up_next\0\u{3}files_after_playing_delete_local\0\u{3}files_after_playing_delete_cloud\0\u{3}privacy_analytics\0\u{3}privacy_crash_reports\0\u{3}privacy_link_account\0\u{3}player_shelf\0\u{3}auto_subscribe_to_played\0\u{3}auto_show_played\0\u{3}auto_play_enabled\0\u{3}auto_play_last_list_uuid\0\u{3}trim_silence\0\u{3}show_artwork_on_lock_screen\0\u{3}headphone_controls_next_action\0\u{3}headphone_controls_previous_action\0\u{3}headphone_controls_play_bookmark_confirmation_sound\0\u{3}dark_theme_preference\0\u{3}light_theme_preference\0\u{3}use_system_theme\0\u{3}episode_bookmarks_sort_type\0\u{3}player_bookmarks_sort_type\0\u{3}podcast_bookmarks_sort_type\0\u{3}use_dark_up_next_theme\0\u{3}use_dynamic_colors_for_widget\0\u{3}files_sort_order\0\u{3}background_refresh\0\u{3}auto_download_unmetered_only\0\u{3}auto_download_only_when_charging\0\u{3}auto_download_up_next\0\u{3}cloud_auto_upload\0\u{3}cloud_auto_download\0\u{3}cloud_download_unmetered_only\0\u{3}use_rss_artwork\0\u{3}bookmarks_sort_order\0\u{3}auto_archive_played_episodes_global\0\u{3}auto_archive_includes_starred_global\0\u{3}files_auto_up_next_global\0\u{3}files_after_playing_delete_local_global\0\u{3}files_after_playing_delete_cloud_global\0\u{3}player_shelf_global\0\u{3}row_action_global\0\u{3}use_embedded_artwork_global\0\u{3}recommendations_on_global\0\u{3}grid_layout_global\0\u{3}volume_boost_global\0\u{3}badges_global\0\u{1}developer\0\u{3}smart_folders_number_of_times_shown\0\u{3}smart_folders_last_date_shown\0\u{3}save_up_next_on_playlists_play_all\0\u{3}do_not_sell_or_share\0\u{3}live_analytics_url\0\u{3}listening_time_stats\0\u{3}up_next_sort_tooltip_seen\0\u{3}audio_only\0\u{b}stream_by_default\0\u{b}silence_removal\0\u{c}\u{a}\u{1}\u{c}\u{d}\u{1}")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}grid_layout\0\u{3}grid_order\0\u{3}show_played\0\u{1}theme\0\u{3}skip_forward\0\u{3}skip_back\0\u{3}web_version\0\u{1}language\0\u{3}recommendations_on\0\u{4}\u{2}use_embedded_artwork\0\u{3}playback_speed\0\u{4}\u{2}volume_boost\0\u{1}badges\0\u{3}free_gift_acknowledgement\0\u{3}marketing_opt_in\0\u{3}auto_archive_played_episodes\0\u{3}auto_archive_includes_starred\0\u{1}region\0\u{3}row_action\0\u{3}up_next_swipe\0\u{3}episode_grouping\0\u{3}show_archived\0\u{3}open_links\0\u{3}media_actions\0\u{3}media_actions_order\0\u{3}keep_screen_awake\0\u{3}open_player\0\u{3}intelligent_resumption\0\u{3}play_up_next_on_tap\0\u{3}remote_skip_chapters\0\u{3}playback_actions\0\u{3}legacy_bluetooth\0\u{3}multi_select_gesture\0\u{3}chapter_titles\0\u{1}notifications\0\u{3}notification_actions\0\u{3}play_over_notifications\0\u{3}hide_notification_on_pause\0\u{3}app_badge\0\u{3}app_badge_filter\0\u{3}auto_archive_played\0\u{3}auto_archive_inactive\0\u{3}auto_up_next_limit\0\u{3}auto_up_next_limit_reached\0\u{3}warn_data_usage\0\u{3}files_auto_up_next\0\u{3}files_after_playing_delete_local\0\u{3}files_after_playing_delete_cloud\0\u{3}privacy_analytics\0\u{3}privacy_crash_reports\0\u{3}privacy_link_account\0\u{3}player_shelf\0\u{3}auto_subscribe_to_played\0\u{3}auto_show_played\0\u{3}auto_play_enabled\0\u{3}auto_play_last_list_uuid\0\u{3}trim_silence\0\u{3}show_artwork_on_lock_screen\0\u{3}headphone_controls_next_action\0\u{3}headphone_controls_previous_action\0\u{3}headphone_controls_play_bookmark_confirmation_sound\0\u{3}dark_theme_preference\0\u{3}light_theme_preference\0\u{3}use_system_theme\0\u{3}episode_bookmarks_sort_type\0\u{3}player_bookmarks_sort_type\0\u{3}podcast_bookmarks_sort_type\0\u{3}use_dark_up_next_theme\0\u{3}use_dynamic_colors_for_widget\0\u{3}files_sort_order\0\u{3}background_refresh\0\u{3}auto_download_unmetered_only\0\u{3}auto_download_only_when_charging\0\u{3}auto_download_up_next\0\u{3}cloud_auto_upload\0\u{3}cloud_auto_download\0\u{3}cloud_download_unmetered_only\0\u{3}use_rss_artwork\0\u{3}bookmarks_sort_order\0\u{3}auto_archive_played_episodes_global\0\u{3}auto_archive_includes_starred_global\0\u{3}files_auto_up_next_global\0\u{3}files_after_playing_delete_local_global\0\u{3}files_after_playing_delete_cloud_global\0\u{3}player_shelf_global\0\u{3}row_action_global\0\u{3}use_embedded_artwork_global\0\u{3}recommendations_on_global\0\u{3}grid_layout_global\0\u{3}volume_boost_global\0\u{3}badges_global\0\u{1}developer\0\u{3}smart_folders_number_of_times_shown\0\u{3}smart_folders_last_date_shown\0\u{3}save_up_next_on_playlists_play_all\0\u{3}do_not_sell_or_share\0\u{3}live_analytics_url\0\u{3}listening_time_stats\0\u{3}up_next_sort_tooltip_seen\0\u{3}audio_only\0\u{3}disable_ai_chapters\0\u{b}stream_by_default\0\u{b}silence_removal\0\u{c}\u{a}\u{1}\u{c}\u{d}\u{1}")
 
   fileprivate class _StorageClass {
     var _gridLayout: Api_Int32Setting? = nil
@@ -10579,6 +10620,7 @@ nonisolated extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftPro
     var _listeningTimeStats: Api_BoolSetting? = nil
     var _upNextSortTooltipSeen: Api_BoolSetting? = nil
     var _audioOnly: Api_BoolSetting? = nil
+    var _disableAiChapters: Api_BoolSetting? = nil
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -10689,6 +10731,7 @@ nonisolated extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftPro
       _listeningTimeStats = source._listeningTimeStats
       _upNextSortTooltipSeen = source._upNextSortTooltipSeen
       _audioOnly = source._audioOnly
+      _disableAiChapters = source._disableAiChapters
     }
   }
 
@@ -10807,6 +10850,7 @@ nonisolated extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftPro
         case 100: try { try decoder.decodeSingularMessageField(value: &_storage._listeningTimeStats) }()
         case 101: try { try decoder.decodeSingularMessageField(value: &_storage._upNextSortTooltipSeen) }()
         case 102: try { try decoder.decodeSingularMessageField(value: &_storage._audioOnly) }()
+        case 103: try { try decoder.decodeSingularMessageField(value: &_storage._disableAiChapters) }()
         default: break
         }
       }
@@ -11119,6 +11163,9 @@ nonisolated extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftPro
       try { if let v = _storage._audioOnly {
         try visitor.visitSingularMessageField(value: v, fieldNumber: 102)
       } }()
+      try { if let v = _storage._disableAiChapters {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 103)
+      } }()
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -11228,6 +11275,7 @@ nonisolated extension Api_NamedSettingsResponse: SwiftProtobuf.Message, SwiftPro
         if _storage._listeningTimeStats != rhs_storage._listeningTimeStats {return false}
         if _storage._upNextSortTooltipSeen != rhs_storage._upNextSortTooltipSeen {return false}
         if _storage._audioOnly != rhs_storage._audioOnly {return false}
+        if _storage._disableAiChapters != rhs_storage._disableAiChapters {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/Modules/Sources/PocketCastsServer/Public/ServerSettings.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ServerSettings.swift
@@ -164,6 +164,25 @@ public class ServerSettings {
         UserDefaults.standard.set(false, forKey: ServerConstants.UserDefaults.audioOnlyNeedsSyncKey)
     }
 
+    // MARK: Disable AI Chapters
+
+    public class func setDisableAiChapters(_ value: Bool) {
+        UserDefaults.standard.set(value, forKey: ServerConstants.UserDefaults.disableAiChaptersKey)
+        UserDefaults.standard.set(true, forKey: ServerConstants.UserDefaults.disableAiChaptersNeedsSyncKey)
+    }
+
+    public class func disableAiChapters() -> Bool {
+        UserDefaults.standard.bool(forKey: ServerConstants.UserDefaults.disableAiChaptersKey)
+    }
+
+    public class func disableAiChaptersNeedsSyncing() -> Bool {
+        UserDefaults.standard.bool(forKey: ServerConstants.UserDefaults.disableAiChaptersNeedsSyncKey)
+    }
+
+    public class func disableAiChaptersSynced() {
+        UserDefaults.standard.set(false, forKey: ServerConstants.UserDefaults.disableAiChaptersNeedsSyncKey)
+    }
+
     // MARK: Date of Latest UnsentSubscription Purchase Receipt
 
     private static let iapUnverifiedPurchaseReceipDatetKey = "SJIapDateUnverifiedPurchaseReceipt"
@@ -334,7 +353,7 @@ public class ServerSettings {
     }
 
     public class func syncSettings() {
-        guard SyncManager.isUserLoggedIn(), ServerSettings.marketingOptInNeedsSyncing() || ServerSettings.audioOnlyNeedsSyncing() || SubscriptionHelper.subscriptionGiftAcknowledgementNeedsSyncing() else { return }
+        guard SyncManager.isUserLoggedIn(), ServerSettings.marketingOptInNeedsSyncing() || ServerSettings.audioOnlyNeedsSyncing() || ServerSettings.disableAiChaptersNeedsSyncing() || SubscriptionHelper.subscriptionGiftAcknowledgementNeedsSyncing() else { return }
 
         ApiServerHandler.shared.syncSettings()
     }

--- a/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -158,6 +158,8 @@ public enum ServerConstants {
         static let marketingOptInNeedsSyncKey = "SJMarketingOptInNeedsSync"
         public static let audioOnlyKey = "SJAudioOnly"
         static let audioOnlyNeedsSyncKey = "SJAudioOnlyNeedsSync"
+        public static let disableAiChaptersKey = "SJDisableAiChapters"
+        static let disableAiChaptersNeedsSyncKey = "SJDisableAiChaptersNeedsSync"
         static let subscriptionGiftAcknowledgementNeedsSyncKey = "SJGiftAcknowledgementNeedsSync"
         static let filesLastModifiedKey = "UserFilesLastModified"
         static let statsStartDate = "StatsStartDate"

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -23,6 +23,9 @@ class SyncSettingsTask: ApiBaseTask, @unchecked Sendable {
             if ServerSettings.audioOnlyNeedsSyncing() {
                 settingsRequest.settings.audioOnly.value = ServerSettings.audioOnly()
             }
+            if ServerSettings.disableAiChaptersNeedsSyncing() {
+                settingsRequest.settings.disableAiChapters.value = ServerSettings.disableAiChapters()
+            }
             if SubscriptionHelper.subscriptionGiftAcknowledgementNeedsSyncing() {
                 settingsRequest.settings.freeGiftAcknowledgement.value = SubscriptionHelper.subscriptionGiftAcknowledgement()
             }
@@ -70,6 +73,10 @@ class SyncSettingsTask: ApiBaseTask, @unchecked Sendable {
                 ServerSettings.setAudioOnly(settings.audioOnly.value.value)
             }
 
+            if settings.disableAiChapters.changed.value {
+                ServerSettings.setDisableAiChapters(settings.disableAiChapters.value.value)
+            }
+
             if settings.freeGiftAcknowledgement.changed.value {
                 let acknowledgement = settings.freeGiftAcknowledgement.value.value
                 SubscriptionHelper.setSubscriptionGiftAcknowledgement(acknowledgement)
@@ -85,6 +92,7 @@ class SyncSettingsTask: ApiBaseTask, @unchecked Sendable {
             ServerSettings.setSkipForwardSynced()
             ServerSettings.marketingOptInSynced()
             ServerSettings.audioOnlySynced()
+            ServerSettings.disableAiChaptersSynced()
             ServerSettings.setHomeGridSortOrderSynced()
             SubscriptionHelper.subscriptionGiftAcknowledgementSynced()
         } catch {

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -653,6 +653,7 @@ enum AnalyticsEvent: String {
     case settingsGeneralLegacyBluetoothToggled
     case settingsGeneralMultiSelectGestureToggled
     case settingsGeneralPublishChapterTitlesToggled
+    case settingsGeneralGeneratedChaptersToggled
     case settingsGeneralAutoplayToggled
     case settingsGeneralAutoSleepTimerRestartToggled
     case settingsGeneralShakeToResetSleepTimerToggled

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -61,6 +61,7 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         }
 
         if FeatureFlag.generatedChapters.enabled,
+           !Settings.disableAiChapters,
            let chapters = try? await generatedEpisodeMetadataRetriever.loadMetadata(podcastUuid: podcastUuid, episodeUuid: episodeUuid).chapters,
            !chapters.isEmpty {
             return (nil, nil, chapters)

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -12,11 +12,14 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
 
     let debounce = Debounce(delay: Constants.defaultDebounceTime)
 
-    enum TableRow { case skipForward, skipBack, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, autoplay, autoRestartSleepTimer, shakeToRestartSleepTimer, isLockScreenScrubberDisabled, voiceBoostN, audioOnly }
+    enum TableRow { case skipForward, skipBack, keepScreenAwake, openPlayer, intelligentPlaybackResumption, defaultRowAction, extraMediaActions, defaultAddToUpNextSwipe, defaultGrouping, defaultArchive, playUpNextOnTap, legacyBluetooth, multiSelectGesture, openLinksInBrowser, publishChapterTitles, generatedChapters, autoplay, autoRestartSleepTimer, shakeToRestartSleepTimer, isLockScreenScrubberDisabled, voiceBoostN, audioOnly }
     private var tableData: [[TableRow]] {
         var data: [[TableRow]] = [[.defaultRowAction, .defaultGrouping, .defaultArchive, .defaultAddToUpNextSwipe, .openLinksInBrowser], [.skipForward, .skipBack, .keepScreenAwake, .openPlayer, .isLockScreenScrubberDisabled, .intelligentPlaybackResumption], [.autoRestartSleepTimer], [.shakeToRestartSleepTimer], [.playUpNextOnTap], [.extraMediaActions], [.legacyBluetooth], [.multiSelectGesture], [.publishChapterTitles], [.autoplay]]
         if FeatureFlag.hls.enabled {
             data.insert([.audioOnly], at: 2)
+        }
+        if FeatureFlag.generatedChapters.enabled {
+            data.append([.generatedChapters])
         }
         if FeatureFlag.voiceBoostN.enabled {
             data.append([.voiceBoostN])
@@ -265,6 +268,17 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
 
             return cell
 
+        case .generatedChapters:
+            let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
+
+            cell.cellLabel.text = L10n.settingsGeneralGeneratedChapters
+            cell.cellSwitch.isOn = !Settings.disableAiChapters
+
+            cell.cellSwitch.removeTarget(self, action: nil, for: .valueChanged)
+            cell.cellSwitch.addTarget(self, action: #selector(generatedChaptersToggled(_:)), for: .valueChanged)
+
+            return cell
+
         case .autoplay:
             let cell = tableView.dequeueReusableCell(withIdentifier: switchCellId, for: indexPath) as! SwitchCell
 
@@ -463,6 +477,8 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
             return L10n.settingsGeneralMultiSelectGestureSubtitle
         case .publishChapterTitles:
             return L10n.settingsGeneralPublishChapterTitlesSubtitle
+        case .generatedChapters:
+            return L10n.settingsGeneralGeneratedChaptersSubtitle
         case .autoplay:
             return L10n.settingsGeneralAutoplaySubtitle
         case .audioOnly:
@@ -570,6 +586,13 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
         Settings.autoplay = sender.isOn
 
         Settings.trackValueToggled(.settingsGeneralAutoplayToggled, enabled: sender.isOn)
+    }
+
+    @objc private func generatedChaptersToggled(_ sender: UISwitch) {
+        Settings.disableAiChapters = !sender.isOn
+        ServerSettings.syncSettings()
+
+        Settings.trackValueToggled(.settingsGeneralGeneratedChaptersToggled, enabled: sender.isOn)
     }
 
     @objc private func audioOnlyToggled(_ sender: UISwitch) {

--- a/podcasts/GeneralSettingsViewController.swift
+++ b/podcasts/GeneralSettingsViewController.swift
@@ -592,6 +592,9 @@ class GeneralSettingsViewController: PCViewController, UITableViewDelegate, UITa
         Settings.disableAiChapters = !sender.isOn
         ServerSettings.syncSettings()
 
+        // Re-parse the current episode's chapters so the player and Now Playing info react immediately
+        PlaybackManager.shared.forceUpdateChapterInfo()
+
         Settings.trackValueToggled(.settingsGeneralGeneratedChaptersToggled, enabled: sender.isOn)
     }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -978,6 +978,19 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Generated chapters
+
+    /// When enabled, AI-generated chapters are hidden from the player. Stored as the inverse of the positive
+    /// "Generated chapters" toggle and backed by `ServerSettings` so it syncs globally with the server.
+    static var disableAiChapters: Bool {
+        set {
+            ServerSettings.setDisableAiChapters(newValue)
+        }
+        get {
+            ServerSettings.disableAiChapters()
+        }
+    }
+
     // MARK: - Sleep Timer
 
     static var autoRestartSleepTimer: Bool {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2683,6 +2683,12 @@
 /* Subtitle explaining the toggle to publish chapter titles. */
 "settings_general_publish_chapter_titles_subtitle" = "If on, this will send chapter titles over Bluetooth and other connected devices instead of the episode title.";
 
+/* Setting toggle to show automatically generated chapters in the player. */
+"settings_general_generated_chapters" = "Generated chapters";
+
+/* Subtitle explaining the toggle to show automatically generated chapters. */
+"settings_general_generated_chapters_subtitle" = "Show automatically generated chapters when available.";
+
 /* Setting toggle to change the behavior of the skip button on external devices. */
 "settings_general_remote_skips_chapters" = "Remote Skips Chapters";
 


### PR DESCRIPTION
Fixes PCIOS-836

Adds a **Generated chapters** toggle to Settings → General. When enabled (the default), AI-generated chapters are shown in the player; when disabled, they are hidden while publisher-provided chapters (embedded / Podcast Index / show-notes) remain available. Mirrors the [web player setting](https://github.com/Automattic/pocket-casts-webplayer/pull/4729) and [pocket-casts-android#5564](https://github.com/Automattic/pocket-casts-android/pull/5564).

The setting is a positive UI toggle stored as the inverse global named setting `disableAiChapters`, synced to the server via the new `disable_ai_chapters` named setting ([pocket-casts-sync-api#1424](https://github.com/Automattic/pocket-casts-sync-api/pull/1424)) — mirroring the existing `audioOnly` / `marketingOptIn` sync path. The row is gated behind `FeatureFlag.generatedChapters`, so it is hidden in production until that flag ships.

Toggling the setting re-parses the current episode's chapters via `PlaybackManager.forceUpdateChapterInfo()`, so the player Chapters tab, Now Playing info, lock screen, mini player, CarPlay, and Watch all react immediately without needing to reopen the episode.

## To test

1. Build the app using the `StagingDebug` scheme.
2. Login (or create an account).
3. Go to **Settings → General** and confirm a new **Generated chapters** toggle appears, **defaulting to on**, with the "Show automatically generated chapters when available." description.
4. Open **The Daily** and play an episode whose only chapters are AI-generated. Confirm the **Chapters** tab appears in the player and the generated chapters are listed.
5. While that episode is playing, return to **Settings → General** and turn **Generated chapters off**. Go back to the player and confirm the **Chapters** tab and chapter info disappear immediately (no reopen needed).
6. Turn **Generated chapters on** again and confirm the Chapters tab and generated chapter list return immediately.
7. Open a podcast episode with **publisher-provided** chapters (eg.: **The Changelog**) with the setting **off**, and confirm its Chapters tab and chapters are still shown and usable.

### Verify it syncs

8. Access `https://pocketcasts.net/podcasts`.
9. Login to the same account.
10. Go to `https://pocketcasts.net/settings/playback`.
11. Confirm **Generated chapters** matches the state set on iOS (toggle it on web and confirm iOS reflects it after a refresh/sync as well).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. <!-- Behind FeatureFlag.generatedChapters / not user-facing in production yet -->
- [ ] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. <!-- settings_general_generated_chapters_toggled { enabled } — registered in EventHorizonSchemas#108 -->
