### PR TITLE
Add bookmark enrich API for generating bookmark titles from transcripts

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/Cache/CacheServerHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Cache/CacheServerHandler.swift
@@ -12,9 +12,14 @@ public class CacheServerHandler {
 
     private lazy var episodeInfoHandler = ShowInfoDataRetriever()
 
-    private let tokenHelper = TokenHelper.shared
+    private let tokenHelper: TokenHelper
 
-    public init() {
+    public convenience init() {
+        self.init(tokenHelper: TokenHelper.shared)
+    }
+
+    init(tokenHelper: TokenHelper) {
+        self.tokenHelper = tokenHelper
         colorsUrlsCache = URLCache(memoryCapacity: 400.kilobytes, diskCapacity: 5.megabytes, diskPath: "colors")
     }
 
@@ -172,6 +177,37 @@ public class CacheServerHandler {
                 completion?(nil)
             }
         }
+    }
+
+    // MARK: - Bookmark Enrichment
+
+    private struct BookmarkEnrichRequest: Encodable {
+        let transcriptSnippet: String
+
+        enum CodingKeys: String, CodingKey {
+            case transcriptSnippet = "transcript_snippet"
+        }
+    }
+
+    public struct BookmarkEnrichResponse: Decodable {
+        public let title: String?
+        public let summary: String?
+        public let error: String?
+    }
+
+    /// Generates a title and summary for a bookmark from the transcript text surrounding its position.
+    public func enrichBookmark(transcriptSnippet: String) async throws -> BookmarkEnrichResponse {
+        let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/bookmark/enrich")
+        guard let request = ServerHelper.createJsonRequest(url: url, params: BookmarkEnrichRequest(transcriptSnippet: transcriptSnippet), timeout: CacheServerHandler.defaultTimeout, cachePolicy: .useProtocolCachePolicy) else {
+            throw APIError.UNKNOWN
+        }
+
+        let (response, data) = try await tokenHelper.callSecureUrl(request: request)
+        guard response?.statusCode == ServerConstants.HttpConstants.ok, let data else {
+            throw APIError.UNKNOWN
+        }
+
+        return try JSONDecoder().decode(BookmarkEnrichResponse.self, from: data)
     }
 
     // MARK: - Helper Methods

--- a/Modules/Tests/PocketCastsServerTests/CacheServerHandlerBookmarkEnrichTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/CacheServerHandlerBookmarkEnrichTests.swift
@@ -1,0 +1,56 @@
+@testable import PocketCastsServer
+import XCTest
+
+final class CacheServerHandlerBookmarkEnrichTests: XCTestCase {
+    private func makeHandler(mockHandler: @escaping MockRequestHandler.Handler) -> CacheServerHandler {
+        CacheServerHandler(tokenHelper: TokenHelper(urlConnection: URLConnection(mockHandler: mockHandler)))
+    }
+
+    func testEnrichBookmarkSendsExpectedRequest() async throws {
+        var capturedRequest: URLRequest?
+        let handler = makeHandler { request in
+            capturedRequest = request
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)
+            let data = try JSONSerialization.data(withJSONObject: ["title": "A title", "summary": "A summary"])
+            return (data, response)
+        }
+
+        let result = try await handler.enrichBookmark(transcriptSnippet: "some transcript text")
+
+        XCTAssertEqual(capturedRequest?.url?.absoluteString, ServerConstants.Urls.cache() + "mobile/bookmark/enrich")
+        XCTAssertEqual(capturedRequest?.httpMethod, "POST")
+
+        let body = try XCTUnwrap(capturedRequest?.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: String])
+        XCTAssertEqual(json, ["transcript_snippet": "some transcript text"])
+
+        XCTAssertEqual(result.title, "A title")
+        XCTAssertEqual(result.summary, "A summary")
+        XCTAssertNil(result.error)
+    }
+
+    func testEnrichBookmarkParsesErrorField() async throws {
+        let handler = makeHandler { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)
+            let data = try JSONSerialization.data(withJSONObject: ["error": "something went wrong"])
+            return (data, response)
+        }
+
+        let result = try await handler.enrichBookmark(transcriptSnippet: "some transcript text")
+
+        XCTAssertNil(result.title)
+        XCTAssertNil(result.summary)
+        XCTAssertEqual(result.error, "something went wrong")
+    }
+
+    func testEnrichBookmarkThrowsOnServerError() async {
+        let handler = makeHandler { request in
+            (nil, HTTPURLResponse(url: request.url!, statusCode: 500, httpVersion: nil, headerFields: nil))
+        }
+
+        do {
+            _ = try await handler.enrichBookmark(transcriptSnippet: "some transcript text")
+            XCTFail("Expected enrichBookmark to throw")
+        } catch {}
+    }
+}


### PR DESCRIPTION
Fixes PCIOS-837

Adds `CacheServerHandler.enrichBookmark(transcriptSnippet:)`, the Smart Bookmarks endpoint client that POSTs a transcript snippet to `mobile/bookmark/enrich` and returns the AI-generated `title`/`summary`, matching the Android implementation. Requests are authenticated with the sync bearer token, and the server environment follows the build configuration (`ServerConstants.Urls.cache()`).

## To test

1. Build and run the **"Pocket Casts Staging"** scheme — the enrich endpoint is currently only available on staging (`podcast-api.pocketcasts.net`).
2. **Important:** sign in with a **staging account**. A regular production account will get a 401 from the staging API and you will be logged out.
3. Download the attached patch and apply it from the repo root: `git apply smart-bookmarks-enrich-test.patch`. It adds a temporary trigger that calls the API with several sample transcript snippets when the Podcasts tab loads.
4. Open the Podcasts tab and watch the Xcode console for 🔖 lines showing the generated title/summary for each snippet.
5. When done, revert the temporary code with `git apply -R smart-bookmarks-enrich-test.patch`.

[smart-bookmarks-enrich-test.patch](https://github.com/user-attachments/files/30067066/smart-bookmarks-enrich-test.patch)

You'll see the following in the console:

```
🔖 enrich[normal] title: The Importance of Sleep Quality Over Quantity | summary: Research reveals that sleep quality significantly impacts performance, with fewer interruptions being more beneficial than longer, fragmented sleep. | error: nil
🔖 enrich[short] title: The Power of Brevity in Communication | summary: Exploring how concise language can enhance clarity and impact in conversations. | error: nil
🔖 enrich[unicode] title: La Revolución de la Economía Circular en la Producción | summary: La economía circular implica rediseñar sistemas de producción, lo que ha permitido a empresas reducir costos de materiales en un 40% en dos años. | error: nil
🔖 enrich[repetitive] title: The Iconic Pangram: A Typographic Exploration | summary: Discussing the significance and history of the phrase 'the quick brown fox jumps over the lazy dog'. | error: nil
```



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)