### PR TITLE
Add on-device bookmark enrichment using Apple Foundation Models

### DIFF
--- a/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
+++ b/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
@@ -23,25 +23,31 @@ final class BookmarkFoundationModelEnricher {
     }
 
     private static let instructions = """
-        You create titles and summaries for podcast bookmarks. The user bookmarked a moment in a podcast \
-        episode, and you are given the transcript of roughly one minute of audio centered on that moment. \
-        The transcript may be preceded by PODCAST and EPISODE lines naming the show, and a \
-        TRANSCRIPT_LANGUAGE line with the transcript's detected language code.
+        You are helping a Pocket Casts user remember a moment they bookmarked in a podcast episode.
+        Generate a title and a summary for the bookmark from the transcript of roughly one minute \
+        of audio centered on the bookmarked moment.
 
-        Title requirements:
-        - 3 to 6 words, never more than 8, naming the specific topic, person, claim, or advice being \
-        discussed at the bookmarked moment (the midpoint of the transcript).
+        **Prompt Parameters**
+        - PODCAST: name of the show, when available (context only — never repeat it in the title)
+        - EPISODE: name of the episode, when available (context only — never repeat it in the title)
+        - TRANSCRIPT_LANGUAGE: the detected language code of TRANSCRIPT (e.g., "en", "es", "ja") when available
+        - TRANSCRIPT: the transcript text surrounding the bookmarked moment
+
+        **Title Requirements**
+        - Aim for around 3 to 6 words, naming the specific topic, person, claim, or advice being \
+        discussed at the bookmarked moment (the midpoint of TRANSCRIPT).
         - Sentence case, no surrounding quotes, no ending punctuation.
-        - Never use generic titles like "Podcast discussion", meta phrases like "In this segment", or \
-        the podcast or episode name.
-
-        Example: for a transcript about salting chicken ahead of cooking so the salt has time to \
+        - Never use generic titles like "Podcast discussion" or meta phrases like "In this segment".
+        - Example: for a transcript about salting chicken ahead of cooking so the salt has time to \
         penetrate, a good title is "Salt chicken hours before cooking", not "Cooking tips discussion".
 
-        Also generate a one or two sentence summary of what is being discussed.
+        **Summary Requirements**
+        - One or two sentences capturing what is being discussed.
 
-        Write the title and summary in TRANSCRIPT_LANGUAGE if provided, otherwise in the same language \
-        as the transcript. Never translate into another language.
+        **CRITICAL Requirement**
+        ⚠️ LANGUAGE: Generate the title and summary in the language specified by the \
+        TRANSCRIPT_LANGUAGE code if provided, otherwise match TRANSCRIPT language exactly. \
+        NO translation. NO defaulting to English. Match input language EXACTLY.
         """
 
     private var prewarmedSession: LanguageModelSession?
@@ -112,7 +118,7 @@ final class BookmarkFoundationModelEnricher {
 @available(iOS 26.0, *)
 @Generable
 private struct GeneratedEnrichment {
-    @Guide(description: "A specific 3-6 word title for the bookmarked moment; sentence case, no quotes, no ending punctuation")
+    @Guide(description: "A specific short title (around 3-6 words) for the bookmarked moment; sentence case, no quotes, no ending punctuation")
     let title: String
 
     @Guide(description: "A one or two sentence summary of what is being discussed")

--- a/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
+++ b/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
@@ -24,11 +24,24 @@ final class BookmarkFoundationModelEnricher {
 
     private static let instructions = """
         You create titles and summaries for podcast bookmarks. The user bookmarked a moment in a podcast \
-        episode, and you are given the transcript of roughly one minute of audio around that moment, \
-        optionally preceded by a TRANSCRIPT_LANGUAGE line with its detected language code. \
-        Generate a short, specific title of at most 8 words and a one or two sentence summary of what is \
-        being discussed. Write the title and summary in TRANSCRIPT_LANGUAGE if provided, otherwise in the \
-        same language as the transcript. Never translate into another language.
+        episode, and you are given the transcript of roughly one minute of audio centered on that moment. \
+        The transcript may be preceded by PODCAST and EPISODE lines naming the show, and a \
+        TRANSCRIPT_LANGUAGE line with the transcript's detected language code.
+
+        Title requirements:
+        - 3 to 6 words, never more than 8, naming the specific topic, person, claim, or advice being \
+        discussed at the bookmarked moment (the midpoint of the transcript).
+        - Sentence case, no surrounding quotes, no ending punctuation.
+        - Never use generic titles like "Podcast discussion", meta phrases like "In this segment", or \
+        the podcast or episode name.
+
+        Example: for a transcript about salting chicken ahead of cooking so the salt has time to \
+        penetrate, a good title is "Salt chicken hours before cooking", not "Cooking tips discussion".
+
+        Also generate a one or two sentence summary of what is being discussed.
+
+        Write the title and summary in TRANSCRIPT_LANGUAGE if provided, otherwise in the same language \
+        as the transcript. Never translate into another language.
         """
 
     private var prewarmedSession: LanguageModelSession?
@@ -43,7 +56,7 @@ final class BookmarkFoundationModelEnricher {
         prewarmedSession = session
     }
 
-    func enrich(transcriptSnippet: String) async throws -> Enrichment {
+    func enrich(transcriptSnippet: String, podcastTitle: String? = nil, episodeTitle: String? = nil) async throws -> Enrichment {
         guard Self.isAvailable else {
             throw EnrichmentError.modelUnavailable(SystemLanguageModel.default.availability)
         }
@@ -57,19 +70,31 @@ final class BookmarkFoundationModelEnricher {
             session = LanguageModelSession(instructions: Self.instructions)
         }
 
-        let prompt = Self.makePrompt(transcriptSnippet: transcriptSnippet)
+        let prompt = Self.makePrompt(transcriptSnippet: transcriptSnippet, podcastTitle: podcastTitle, episodeTitle: episodeTitle)
         let response = try await session.respond(to: prompt, generating: GeneratedEnrichment.self)
         return Enrichment(title: response.content.title, summary: response.content.summary)
     }
 
-    /// Prefixes the transcript with its detected language so the model responds in the
-    /// transcript's language instead of defaulting to English.
-    private static func makePrompt(transcriptSnippet: String) -> String {
-        guard let language = detectLanguage(from: transcriptSnippet) else {
+    /// Prefixes the transcript with the show names (context the title shouldn't repeat) and its
+    /// detected language, so the model responds in the transcript's language instead of defaulting
+    /// to English.
+    private static func makePrompt(transcriptSnippet: String, podcastTitle: String?, episodeTitle: String?) -> String {
+        var contextLines = [String]()
+        if let podcastTitle {
+            contextLines.append("PODCAST: \(podcastTitle)")
+        }
+        if let episodeTitle {
+            contextLines.append("EPISODE: \(episodeTitle)")
+        }
+        if let language = detectLanguage(from: transcriptSnippet) {
+            contextLines.append("TRANSCRIPT_LANGUAGE: \(language)")
+        }
+
+        guard !contextLines.isEmpty else {
             return transcriptSnippet
         }
         return """
-            TRANSCRIPT_LANGUAGE: \(language)
+            \(contextLines.joined(separator: "\n"))
 
             TRANSCRIPT:
             \(transcriptSnippet)
@@ -87,7 +112,7 @@ final class BookmarkFoundationModelEnricher {
 @available(iOS 26.0, *)
 @Generable
 private struct GeneratedEnrichment {
-    @Guide(description: "A short, specific title for the bookmarked moment, at most 8 words")
+    @Guide(description: "A specific 3-6 word title for the bookmarked moment; sentence case, no quotes, no ending punctuation")
     let title: String
 
     @Guide(description: "A one or two sentence summary of what is being discussed")

--- a/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
+++ b/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
@@ -1,5 +1,6 @@
 import Foundation
 import FoundationModels
+import NaturalLanguage
 
 /// Generates a title and summary for a bookmark on-device using Apple's Foundation Models,
 /// from the transcript text surrounding the bookmark's position.
@@ -23,9 +24,11 @@ final class BookmarkFoundationModelEnricher {
 
     private static let instructions = """
         You create titles and summaries for podcast bookmarks. The user bookmarked a moment in a podcast \
-        episode, and you are given the transcript of roughly one minute of audio around that moment. \
+        episode, and you are given the transcript of roughly one minute of audio around that moment, \
+        optionally preceded by a TRANSCRIPT_LANGUAGE line with its detected language code. \
         Generate a short, specific title of at most 8 words and a one or two sentence summary of what is \
-        being discussed. Respond in the same language as the transcript.
+        being discussed. Write the title and summary in TRANSCRIPT_LANGUAGE if provided, otherwise in the \
+        same language as the transcript. Never translate into another language.
         """
 
     private var prewarmedSession: LanguageModelSession?
@@ -54,8 +57,30 @@ final class BookmarkFoundationModelEnricher {
             session = LanguageModelSession(instructions: Self.instructions)
         }
 
-        let response = try await session.respond(to: transcriptSnippet, generating: GeneratedEnrichment.self)
+        let prompt = Self.makePrompt(transcriptSnippet: transcriptSnippet)
+        let response = try await session.respond(to: prompt, generating: GeneratedEnrichment.self)
         return Enrichment(title: response.content.title, summary: response.content.summary)
+    }
+
+    /// Prefixes the transcript with its detected language so the model responds in the
+    /// transcript's language instead of defaulting to English.
+    private static func makePrompt(transcriptSnippet: String) -> String {
+        guard let language = detectLanguage(from: transcriptSnippet) else {
+            return transcriptSnippet
+        }
+        return """
+            TRANSCRIPT_LANGUAGE: \(language)
+
+            TRANSCRIPT:
+            \(transcriptSnippet)
+            """
+    }
+
+    /// Detects the dominant language of the given text (e.g. "en", "es", "ja").
+    private static func detectLanguage(from text: String) -> String? {
+        let recognizer = NLLanguageRecognizer()
+        recognizer.processString(text)
+        return recognizer.dominantLanguage?.rawValue
     }
 }
 

--- a/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
+++ b/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
@@ -1,0 +1,70 @@
+import Foundation
+import FoundationModels
+
+/// Generates a title and summary for a bookmark on-device using Apple's Foundation Models,
+/// from the transcript text surrounding the bookmark's position.
+///
+/// On-device alternative to `CacheServerHandler.enrichBookmark(transcriptSnippet:)`.
+@available(iOS 26.0, *)
+final class BookmarkFoundationModelEnricher {
+    struct Enrichment {
+        let title: String
+        let summary: String
+    }
+
+    enum EnrichmentError: Error {
+        case modelUnavailable(SystemLanguageModel.Availability)
+    }
+
+    /// Whether the on-device model can be used (device eligible, Apple Intelligence enabled, model downloaded).
+    static var isAvailable: Bool {
+        SystemLanguageModel.default.isAvailable
+    }
+
+    private static let instructions = """
+        You create titles and summaries for podcast bookmarks. The user bookmarked a moment in a podcast \
+        episode, and you are given the transcript of roughly one minute of audio around that moment. \
+        Generate a short, specific title of at most 8 words and a one or two sentence summary of what is \
+        being discussed. Respond in the same language as the transcript.
+        """
+
+    private var prewarmedSession: LanguageModelSession?
+
+    /// Preloads model resources so an upcoming `enrich` call responds faster.
+    /// Call when a bookmark is about to be created (e.g. when the bookmark UI is shown).
+    func prewarm() {
+        guard Self.isAvailable, prewarmedSession == nil else { return }
+
+        let session = LanguageModelSession(instructions: Self.instructions)
+        session.prewarm()
+        prewarmedSession = session
+    }
+
+    func enrich(transcriptSnippet: String) async throws -> Enrichment {
+        guard Self.isAvailable else {
+            throw EnrichmentError.modelUnavailable(SystemLanguageModel.default.availability)
+        }
+
+        // Sessions are multi-turn and accumulate context, so each one is used for a single request.
+        let session: LanguageModelSession
+        if let prewarmedSession, !prewarmedSession.isResponding {
+            session = prewarmedSession
+            self.prewarmedSession = nil
+        } else {
+            session = LanguageModelSession(instructions: Self.instructions)
+        }
+
+        let response = try await session.respond(to: transcriptSnippet, generating: GeneratedEnrichment.self)
+        return Enrichment(title: response.content.title, summary: response.content.summary)
+    }
+}
+
+@available(iOS 26.0, *)
+@Generable
+private struct GeneratedEnrichment {
+    @Guide(description: "A short, specific title for the bookmarked moment, at most 8 words")
+    let title: String
+
+    @Guide(description: "A one or two sentence summary of what is being discussed")
+    let summary: String
+}


### PR DESCRIPTION
Fixes PCIOS-839 and PCIOS-840

Adds `BookmarkFoundationModelEnricher`, an on-device alternative to the `/mobile/bookmark/enrich` endpoint for generating bookmark titles/summaries using Apple Foundation Models (iOS 26+). Uses `@Generable` guided output, `prewarm()` to hide model-load latency, `NLLanguageRecognizer` so the output matches the transcript's language, and a prompt tuned for specific, well-formatted titles (with optional podcast/episode context). Not wired into bookmark creation yet.

Stacked on #4765.

Benchmarked on an iPhone 16 Pro against staging: pre-warmed on-device generation averaged ~0.95s per bookmark vs ~1.1–1.3s (with occasional multi-second outliers) for the server, with comparable output quality.

## To test

1. From the repo root: `git apply smart-bookmarks-fm-benchmark.patch` (attached below)
2. Build the **Pocket Casts Staging** scheme on an iOS 26+ device with Apple Intelligence enabled, logged in with a **staging** account (a production account gets 401s and is logged out).
3. Launch the app; after ~5 seconds the console prints a markdown report between `SMART BOOKMARKS BENCHMARK BEGIN/END` markers (also written to the app's Documents as `smart-bookmarks-benchmark.md`).
4. Verify the `server` and `on-device` rows show sensible titles/summaries and timings — including the non-English snippets responding in their own language.
5. Revert: `git apply -R smart-bookmarks-fm-benchmark.patch`

[smart-bookmarks-fm-benchmark.patch](https://github.com/user-attachments/files/30067910/smart-bookmarks-fm-benchmark.patch)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
