### PR TITLE
Remove onboarding feature flags

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -164,9 +164,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enabled the attributed text view in the Data Usage warning Sheet
     case useDescriptiveActionAttributedTextView
 
-    /// Use the new upgrade screens
-    case newOnboardingUpgrade
-
     /// Use the new upgrade screens with Variant B timeline before features
     case newOnboardingVariant
 
@@ -182,9 +179,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Limit playback position changes when switching episodes
     case limitPlaybackPositionChanges
 
-    /// Use the new upgrade screens for account creation
-    case newOnboardingAccountCreation
-
     /// Adds a sharing button to the transcript view
     case shareTranscripts
 
@@ -193,9 +187,6 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// Do not show the free trial timeline on the upgrade screens on all variants
     case newOnboardingUpgradeTrialTimeline
-
-    /// Use the new interests and recommendations flow
-    case newOnboardingRecommendationChanges
 
     /// Use the new predictive endpoint and show predictions
     case searchPredictive
@@ -432,8 +423,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .useDescriptiveActionAttributedTextView:
             true
-        case .newOnboardingUpgrade:
-            true
         case .newOnboardingVariant:
             true
         case .retryWithoutUserAgent:
@@ -444,15 +433,11 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .limitPlaybackPositionChanges:
             true
-        case .newOnboardingAccountCreation:
-            true
         case .shareTranscripts:
             true
         case .doNotSwitchToDownloadedFile:
             true
         case .newOnboardingUpgradeTrialTimeline:
-            true
-        case .newOnboardingRecommendationChanges:
             true
         case .searchPredictive:
             true

--- a/podcasts/AccountViewController+TableView.swift
+++ b/podcasts/AccountViewController+TableView.swift
@@ -7,7 +7,7 @@ import UIKit
 extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if section == 0, FeatureFlag.newOnboardingUpgrade.enabled {
+        if section == 0 {
             return 1
         }
         return UITableView.automaticDimension
@@ -279,7 +279,7 @@ extension AccountViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        if section == 0, FeatureFlag.newOnboardingUpgrade.enabled {
+        if section == 0 {
             let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 2))
             view.backgroundColor = AppTheme.colorForStyle(.primaryUi03, themeOverride: nil)
             return view

--- a/podcasts/AccountViewController.swift
+++ b/podcasts/AccountViewController.swift
@@ -44,12 +44,8 @@ class AccountViewController: UIViewController, ChangeEmailDelegate {
         let headerView = AccountHeaderView(viewModel: headerViewModel)
 
         let view = headerView.themedUIView
-        if FeatureFlag.newOnboardingUpgrade.enabled {
-            view.backgroundColor = AppTheme.colorForStyle(.primaryUi03, themeOverride: nil)
-            self.tableView.themeStyle =  ThemeStyle.primaryUi03
-        } else {
-            view.backgroundColor = .clear
-        }
+        view.backgroundColor = AppTheme.colorForStyle(.primaryUi03, themeOverride: nil)
+        self.tableView.themeStyle =  ThemeStyle.primaryUi03
 
         return view
     }()

--- a/podcasts/NewEmailViewController.swift
+++ b/podcasts/NewEmailViewController.swift
@@ -25,11 +25,7 @@ class NewEmailViewController: PCViewController, UITextFieldDelegate {
         didSet {
             nextButton.isEnabled = false
             nextButton.buttonStyle = .primaryInteractive01Disabled
-            if FeatureFlag.newOnboardingAccountCreation.enabled {
-                nextButton.setTitle(L10n.createAccount, for: .normal)
-            } else {
-                nextButton.setTitle(L10n.next, for: .normal)
-            }
+            nextButton.setTitle(L10n.createAccount, for: .normal)
             nextButton.titleLabel?.adjustsFontForContentSizeCategory = true
             nextButton.titleLabel?.numberOfLines = 0
 
@@ -108,12 +104,7 @@ class NewEmailViewController: PCViewController, UITextFieldDelegate {
         super.viewDidLoad()
         title = L10n.createAccount
         activityIndicator.isHidden = true
-        let backImage: UIImage?
-        if FeatureFlag.newOnboardingAccountCreation.enabled {
-            backImage = UIImage(systemName: "chevron.backward", withConfiguration: UIImage.SymbolConfiguration(textStyle: UIFont.TextStyle(rawValue: "UICTFontTextStyleEmphasizedBody"), scale: .default))
-        } else {
-            backImage = UIImage(named: "nav-back")
-        }
+        let backImage = UIImage(systemName: "chevron.backward", withConfiguration: UIImage.SymbolConfiguration(textStyle: UIFont.TextStyle(rawValue: "UICTFontTextStyleEmphasizedBody"), scale: .default))
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: backImage, style: .done, target: self, action: #selector(backTapped))
         navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
 

--- a/podcasts/Notifications/NotificationsPermissionsView.swift
+++ b/podcasts/Notifications/NotificationsPermissionsView.swift
@@ -111,22 +111,8 @@ struct NotificationsPermissionsView: View {
         ZStack(alignment: .bottom) {
             ScrollView {
                 VStack(spacing: 0) {
-                    if FeatureFlag.newOnboardingAccountCreation.enabled {
-                        Spacer()
-                            .frame(maxHeight: 136)
-                    } else {
-                        Button(action: {
-                            Analytics.track(.notificationsPermissionsNotNowTapped)
-                            dismissAction()
-                        }) {
-                            HStack {
-                                Spacer()
-                                Text(L10n.eoyNotNow)
-                                    .foregroundStyle(theme.primaryInteractive01)
-                                    .font(.body.weight(.medium))
-                            }
-                        }
-                    }
+                    Spacer()
+                        .frame(maxHeight: 136)
                     Image("notifications_permissions_banner")
                     Spacer().frame(height: 24)
                     Text(L10n.notificationsPermissionsTitle)
@@ -139,15 +125,13 @@ struct NotificationsPermissionsView: View {
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
                     Spacer()
-                    if FeatureFlag.newOnboardingAccountCreation.enabled {
-                        VStack(alignment: .leading, spacing: 24) {
-                            optionRow(for: .newsletter)
-                            optionRow(for: .notifications)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.vertical, 34)
-                        .padding(.horizontal, 4)
+                    VStack(alignment: .leading, spacing: 24) {
+                        optionRow(for: .newsletter)
+                        optionRow(for: .notifications)
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 34)
+                    .padding(.horizontal, 4)
                     Spacer()
                     Rectangle().fill(.clear).frame(height: 44)
                 }
@@ -165,7 +149,7 @@ struct NotificationsPermissionsView: View {
                         dismissAction()
                     }
                 }) {
-                    Text(FeatureFlag.newOnboardingAccountCreation.enabled ? L10n.notificationsPermissionsSavePreferences : L10n.notificationsPermissionsAction)
+                    Text(L10n.notificationsPermissionsSavePreferences)
                         .textStyle(RoundedButton())
                 }
             }

--- a/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalView.swift
+++ b/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalView.swift
@@ -71,7 +71,7 @@ struct InformationalModalView: View {
 
     private var buttons: some View {
         VStack(spacing: 0) {
-            Button(FeatureFlag.newOnboardingAccountCreation.enabled ? L10n.createAccount : L10n.eacInformationalViewModalGetStartedButton) {
+            Button(L10n.createAccount) {
                 viewModel.getStarted()
             }
             .buttonStyle(RoundedButtonStyle(theme: theme))

--- a/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalViewModel.swift
+++ b/podcasts/Onboarding/Encourage Account Creation/Modal/InformationalModalViewModel.swift
@@ -40,7 +40,7 @@ class InformationalModalViewModel: NSObject, OnboardingModel {
     }
 
     private func pushOnboarding() {
-        let controller = OnboardingFlow.shared.begin(flow: FeatureFlag.newOnboardingAccountCreation.enabled ? .loggedOut : .initialOnboarding, in: navigationController, source: .unknown)
+        let controller = OnboardingFlow.shared.begin(flow: .loggedOut, in: navigationController, source: .unknown)
         navigationController?.pushViewController(controller, animated: true)
     }
 

--- a/podcasts/Onboarding/Login/LoginLandingHostingController.swift
+++ b/podcasts/Onboarding/Login/LoginLandingHostingController.swift
@@ -7,13 +7,6 @@ class LoginLandingHostingController<Content>: OnboardingHostingViewController<Co
         super.viewWillAppear(animated)
         guard let viewModel = viewModel as? LoginCoordinator else { return }
 
-        if !FeatureFlag.newOnboardingAccountCreation.enabled {
-            let imageView = ThemeableImageView(frame: .zero)
-            imageView.imageNameFunc = AppTheme.pcLogoSmallHorizontalForBackgroundImageName
-            imageView.accessibilityLabel = L10n.setupAccount
-            navigationItem.titleView = imageView
-        }
-
         navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
 
         if navigationController?.viewControllers.first == self {
@@ -23,12 +16,10 @@ class LoginLandingHostingController<Content>: OnboardingHostingViewController<Co
             navigationItem.rightBarButtonItem = dismissItem
         }
 
-        if FeatureFlag.newOnboardingAccountCreation.enabled {
-            let dismissItem = UIBarButtonItem(title: L10n.eoyNotNow, style: .plain, target: viewModel, action: #selector(viewModel.dismissTapped))
-            dismissItem.setTitleTextAttributes([NSAttributedString.Key.font: UIFont.font(with: .body, weight: .regular),
-                                                NSAttributedString.Key.foregroundColor: iconTintColor], for: .normal)
-            navigationItem.rightBarButtonItem = dismissItem
-        }
+        let dismissItem = UIBarButtonItem(title: L10n.eoyNotNow, style: .plain, target: viewModel, action: #selector(viewModel.dismissTapped))
+        dismissItem.setTitleTextAttributes([NSAttributedString.Key.font: UIFont.font(with: .body, weight: .regular),
+                                            NSAttributedString.Key.foregroundColor: iconTintColor], for: .normal)
+        navigationItem.rightBarButtonItem = dismissItem
 
         navigationController?.navigationBar.isHidden = false
     }

--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -49,47 +49,33 @@ private struct LoginLandingContent: View {
     @State var headerHeightOffset: CGFloat = 0
 
     private var title: String {
-        FeatureFlag.newOnboardingAccountCreation.enabled ? L10n.loginLandingTitle : L10n.loginTitle
+        L10n.loginLandingTitle
     }
 
     private var subtitle: String {
-        FeatureFlag.newOnboardingAccountCreation.enabled ? L10n.loginLandingSubtitle : L10n.loginSubtitle
+        L10n.loginLandingSubtitle
     }
 
     var body: some View {
         let backgroundColor = AppTheme.color(for: .primaryUi01, theme: theme)
         let headerHeight = loginHeaderHeight - headerHeightOffset
-        let topPadding = fullScreenMode ? Config.topPadding : Config.padding
 
         ZStack(alignment: .top) {
             GeometryReader { viewSizeProxy in
-                if FeatureFlag.newOnboardingAccountCreation.enabled {
-                    // Title and Subtitle
-                    VStack(spacing: 0) {
-                        VStack(spacing: 16) {
-                            LoginLabel(title.preventWidows(), for: .title)
-                            LoginLabel(subtitle.preventWidows(), for: .subtitle)
-                        }
-                        .padding(.horizontal, Config.padding)
-                        .padding(.top, coordinator.isOnboarding ? Config.topPadding : headerHeightOffset)
-
-                        LoginHeader(models: calculatedModels, topPadding: coordinator.isOnboarding ? 0 : -Config.padding)
-                            .clipped()
+                // Title and Subtitle
+                VStack(spacing: 0) {
+                    VStack(spacing: 16) {
+                        LoginLabel(title.preventWidows(), for: .title)
+                        LoginLabel(subtitle.preventWidows(), for: .subtitle)
                     }
-                } else {
-                    LoginHeader(models: calculatedModels, topPadding: topPadding)
+                    .padding(.horizontal, Config.padding)
+                    .padding(.top, coordinator.isOnboarding ? Config.topPadding : headerHeightOffset)
+
+                    LoginHeader(models: calculatedModels, topPadding: coordinator.isOnboarding ? 0 : -Config.padding)
                         .clipped()
                 }
 
                 VStack(spacing: 0) {
-                    if !FeatureFlag.newOnboardingAccountCreation.enabled {
-                        // Title and Subtitle
-                        VStack(spacing: 8) {
-                            LoginLabel(title, for: .title)
-                            LoginLabel(subtitle, for: .subtitle)
-                        }
-                        .padding(.horizontal, Config.padding)
-                    }
                     Spacer()
                     Rectangle().frame(height: 10)
                         .foregroundStyle(Color.clear)
@@ -101,7 +87,7 @@ private struct LoginLandingContent: View {
                         }
                     HStack(spacing: 0) {
                         Spacer()
-                        LoginButtons(coordinator: coordinator, shouldShowLogin: !coordinator.isOnboarding || !FeatureFlag.newOnboardingAccountCreation.enabled)
+                        LoginButtons(coordinator: coordinator, shouldShowLogin: !coordinator.isOnboarding)
                         Spacer()
                     }
                     .padding(.horizontal, Config.padding)
@@ -127,17 +113,6 @@ private struct LoginLandingContent: View {
                                 // padding to ensure it's visible
                                 headerHeightOffset = willOverflow ? contentHeight - viewHeight : 0
                             }
-                        }
-
-                        if showGradient == true, !FeatureFlag.newOnboardingAccountCreation.enabled {
-                            // Determine how much of the login header takes up of the height
-                            // Then make sure the gradient stops there so the content is covered in a solid background
-                            let headerPercentage = headerHeight / viewHeight
-
-                            LinearGradient(gradient: Gradient(stops: [
-                                Gradient.Stop(color: backgroundColor.opacity(0.0), location: 0.0),
-                                Gradient.Stop(color: backgroundColor, location: headerPercentage),
-                            ]), startPoint: .top, endPoint: .bottom)
                         }
                     }
                 )
@@ -353,7 +328,7 @@ private struct LoginButtons: View {
         VStack(spacing: 16) {
             SocialLoginButtons(coordinator: coordinator)
 
-            Button(FeatureFlag.newOnboardingAccountCreation.enabled ? "Sign up with email" : "Sign Up") {
+            Button("Sign up with email") {
                 coordinator.signUpTapped()
             }.buttonStyle(RoundedButtonStyle(theme: theme, maxContentSizeCategory: .accessibilityMedium))
 

--- a/podcasts/Onboarding/Login/LoginLandingView.swift
+++ b/podcasts/Onboarding/Login/LoginLandingView.swift
@@ -328,7 +328,7 @@ private struct LoginButtons: View {
         VStack(spacing: 16) {
             SocialLoginButtons(coordinator: coordinator)
 
-            Button("Sign up with email") {
+            Button(L10n.loginLandingSignUpWithEmail) {
                 coordinator.signUpTapped()
             }.buttonStyle(RoundedButtonStyle(theme: theme, maxContentSizeCategory: .accessibilityMedium))
 

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -56,15 +56,9 @@ class LoginCoordinator: NSObject, OnboardingModel {
     func loginTapped() {
         socialAuthProvider = nil
         OnboardingFlow.shared.track(.setupAccountButtonTapped, properties: ["button": "sign_in"])
-        if FeatureFlag.newOnboardingAccountCreation.enabled {
-            let vc = OnboardingHostingViewController(rootView: SyncSigninView(coordinator: self, loginAgain: false, onCompleted: { self.navigationController?.presentingViewController?.dismiss(animated: true) }).environmentObject(Theme.sharedTheme))
-            vc.viewModel = self
-            navigationController?.pushViewController(vc, animated: true)
-        } else {
-            let controller = SyncSigninViewController()
-            controller.delegate = self
-            navigationController?.pushViewController(controller, animated: true)
-        }
+        let vc = OnboardingHostingViewController(rootView: SyncSigninView(coordinator: self, loginAgain: false, onCompleted: { self.navigationController?.presentingViewController?.dismiss(animated: true) }).environmentObject(Theme.sharedTheme))
+        vc.viewModel = self
+        navigationController?.pushViewController(vc, animated: true)
     }
 
     func signUpTapped() {
@@ -77,21 +71,13 @@ class LoginCoordinator: NSObject, OnboardingModel {
 
     func getStartedTapped() {
         OnboardingFlow.shared.updateAnalyticsSource(.onboardingRecommendations)
-        let hostingController: UIViewController
-        if FeatureFlag.newOnboardingRecommendationChanges.enabled {
-            let view = InterestsView(continueCallback: { categories in
-                self.interestsContinueTapped(categories: categories)
-            }) {
-                self.interestsContinueTapped(categories: nil)
-            }
-            let controller = OnboardingHostingViewController(rootView: view.setupDefaultEnvironment())
-            controller.viewModel = self
-            hostingController = controller
-        } else {
-            let controller = OnboardingHostingViewController(rootView: OnboardingRecommendationsView(coordinator: self).setupDefaultEnvironment())
-            controller.viewModel = self
-            hostingController = controller
+        let view = InterestsView(continueCallback: { categories in
+            self.interestsContinueTapped(categories: categories)
+        }) {
+            self.interestsContinueTapped(categories: nil)
         }
+        let hostingController = OnboardingHostingViewController(rootView: view.setupDefaultEnvironment())
+        hostingController.viewModel = self
 
         hostingController.navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
         navigationController?.pushViewController(hostingController, animated: true)
@@ -261,22 +247,14 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
     private func goToPlus(from source: PlusLandingViewModel.Source) {
         // Update the flow to make sure the correct analytics source is passed on
         OnboardingFlow.shared.updateAnalyticsSource(source == .login ? .login: .accountCreated)
-        if FeatureFlag.newOnboardingUpgrade.enabled {
-            let controller = UpgradeAccountViewModel.make(in: navigationController,
-                                                          flowSource: source,
-                                                          viewSource: .onboarding,
-                                                          plan: .plus,
-                                                          frequency: .yearly,
-                                                          )
-            controller.modalPresentationStyle = .fullScreen
-            navigationController?.setViewControllers([controller], animated: true)
-        } else {
-            let controller = PlusLandingViewModel.make(in: navigationController,
-                                                       from: source,
-                                                       viewSource: .onboarding,
-                                                       config: .init(continuePurchasing: continuePurchasing))
-            navigationController?.setViewControllers([controller], animated: true)
-        }
+        let controller = UpgradeAccountViewModel.make(in: navigationController,
+                                                      flowSource: source,
+                                                      viewSource: .onboarding,
+                                                      plan: .plus,
+                                                      frequency: .yearly,
+                                                      )
+        controller.modalPresentationStyle = .fullScreen
+        navigationController?.setViewControllers([controller], animated: true)
     }
 }
 
@@ -290,7 +268,7 @@ extension LoginCoordinator {
 
         let controller: UIViewController
 
-        if FeatureFlag.newOnboardingAccountCreation.enabled && isOnboarding {
+        if isOnboarding {
             let view = IntroCarouselView(coordinator: coordinator)
                 .setupDefaultEnvironment()
             let hostingController = IntroCarouselHostingController(rootView: view)

--- a/podcasts/Onboarding/Models/PlusPurchaseModel.swift
+++ b/podcasts/Onboarding/Models/PlusPurchaseModel.swift
@@ -87,11 +87,7 @@ class PlusPurchaseModel: PlusPricingInfoModel, OnboardingModel {
         if SubscriptionHelper.activeTier == .patron {
             controller = PatronWelcomeViewModel.make(in: navigationController)
         } else {
-            if !FeatureFlag.newOnboardingAccountCreation.enabled {
-                controller = WelcomeViewModel.make(in: navigationController, displayType: .plus)
-            } else {
-                controller = nil
-            }
+            controller = nil
         }
 
         let presentNextBlock: () -> Void = {

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -31,36 +31,20 @@ struct OnboardingFlow: AnalyticsSourceProvider {
         case .plusAccountUpgrade:
             self.source = source
             let product = context?["product"] as? ProductInfo
-            if FeatureFlag.newOnboardingUpgrade.enabled {
-                flowController = UpgradeAccountViewModel.make(in: controller,
-                                                              flowSource: .accountScreen,
-                                                              viewSource: source,
-                                                              plan: product?.plan ?? .plus,
-                                                              frequency: product?.frequency ?? .yearly)
-            } else {
-                flowController = PlusPurchaseModel.make(in: controller,
-                                                        plan: product?.plan ?? .plus,
-                                                        selectedPrice: product?.frequency ?? .yearly,
-                                                        customTitle: customTitle)
-            }
+            flowController = UpgradeAccountViewModel.make(in: controller,
+                                                          flowSource: .accountScreen,
+                                                          viewSource: source,
+                                                          plan: product?.plan ?? .plus,
+                                                          frequency: product?.frequency ?? .yearly)
 
         case .patronAccountUpgrade:
             self.source = source
-            if FeatureFlag.newOnboardingUpgrade.enabled {
-                flowController = UpgradeAccountViewModel.make(in: controller,
-                                                              flowSource: .upsell,
-                                                              viewSource: source,
-                                                              plan: .patron,
-                                                              frequency: .yearly,
-                                                              )
-            } else {
-                let config = PlusLandingViewModel.Config(products: [.patron], displayProduct: .init(plan: .patron, frequency: .yearly))
-                flowController = PlusLandingViewModel.make(in: navigationController,
-                                                           from: .upsell,
-                                                           viewSource: source,
-                                                           config: config,
-                                                           customTitle: customTitle)
-            }
+            flowController = UpgradeAccountViewModel.make(in: controller,
+                                                          flowSource: .upsell,
+                                                          viewSource: source,
+                                                          plan: .patron,
+                                                          frequency: .yearly,
+                                                          )
 
         case .plusAccountUpgradeNeedsLogin:
             flowController = LoginCoordinator.make(in: navigationController, continuePurchasing: .init(plan: .plus, frequency: .yearly))
@@ -79,19 +63,11 @@ struct OnboardingFlow: AnalyticsSourceProvider {
 
     private func upgradeController(in controller: UINavigationController?, viewSource: PlusUpgradeViewSource, context: Context?, customTitle: String? = nil) -> UIViewController {
         let product = context?["product"] as? ProductInfo
-        if FeatureFlag.newOnboardingUpgrade.enabled {
-            return UpgradeAccountViewModel.make(in: controller,
-                                                flowSource: .upsell,
-                                                viewSource: viewSource,
-                                                plan: product?.plan ?? .plus,
-                                                frequency: product?.frequency ?? .yearly)
-        } else {
-            return PlusLandingViewModel.make(in: controller,
-                                             from: .upsell,
-                                             viewSource: viewSource,
-                                             config: .init(displayProduct: product),
-                                             customTitle: customTitle)
-        }
+        return UpgradeAccountViewModel.make(in: controller,
+                                            flowSource: .upsell,
+                                            viewSource: viewSource,
+                                            plan: product?.plan ?? .plus,
+                                            frequency: product?.frequency ?? .yearly)
     }
 
     /// Resets the internal flow state to none and clears any analytics sources

--- a/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
+++ b/podcasts/Onboarding/Plus/Account Prompt/PlusAccountPromptTableCell.swift
@@ -15,23 +15,11 @@ class PlusAccountPromptTableCell: ThemeableCell {
 
         super.init(style: .default, reuseIdentifier: reuseIdentifier)
 
-        let view: UIView
-        if FeatureFlag.newOnboardingUpgrade.enabled {
-            view = UpgradeBannerView(viewModel: UpgradeAccountViewModel(upgradeTier: .plus, selectedProduct: .yearly, viewSource: .profile, flowSource: .accountScreen), onSubscribeTap: {
-                Analytics.track(.plusPromotionBannerButtonTapped, properties: ["source": PlusUpgradeViewSource.profile.rawValue, "flow": OnboardingFlow.Flow.plusAccountUpgrade.rawValue])
-                let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: model.parentController, source: .profile, context: nil)
-                model.parentController?.present(controller, animated: true)
-            }).themedUIView
-        } else if FeatureFlag.newAccountUpgradePromptFlow.enabled {
-            let _ = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: model.parentController, source: .profile, context: nil)
-            view = UpgradePrompt(viewModel: PlusLandingViewModel(source: .accountScreen, viewSource: .profile)) { [weak self] size in
-                self?.contentSizeUpdated?(size)
-            }.themedUIView
-        } else {
-            view = PlusAccountUpgradePrompt(viewModel: model, contentSizeUpdated: { [weak self] size in
-                self?.contentSizeUpdated?(size)
-            }).themedUIView
-        }
+        let view = UpgradeBannerView(viewModel: UpgradeAccountViewModel(upgradeTier: .plus, selectedProduct: .yearly, viewSource: .profile, flowSource: .accountScreen), onSubscribeTap: {
+            Analytics.track(.plusPromotionBannerButtonTapped, properties: ["source": PlusUpgradeViewSource.profile.rawValue, "flow": OnboardingFlow.Flow.plusAccountUpgrade.rawValue])
+            let controller = OnboardingFlow.shared.begin(flow: .plusAccountUpgrade, in: model.parentController, source: .profile, context: nil)
+            model.parentController?.present(controller, animated: true)
+        }).themedUIView
         view.backgroundColor = .clear
 
         contentView.addSubview(view)
@@ -47,10 +35,8 @@ class PlusAccountPromptTableCell: ThemeableCell {
         ])
 
         view.layoutIfNeeded()
-        if FeatureFlag.newOnboardingUpgrade.enabled {
-            self.separatorInset = UIEdgeInsets(top: 0, left: .greatestFiniteMagnitude, bottom: 0, right: 0)
-            self.style = .primaryUi03
-        }
+        self.separatorInset = UIEdgeInsets(top: 0, left: .greatestFiniteMagnitude, bottom: 0, right: 0)
+        self.style = .primaryUi03
     }
 
     // Update the model's parent so we can present the modal
@@ -65,9 +51,6 @@ class PlusAccountPromptTableCell: ThemeableCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        guard FeatureFlag.newOnboardingUpgrade.enabled else {
-            return
-        }
 
         for view in self.subviews {
             if view == self.contentView {

--- a/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/UpgradeAccountViewModel.swift
@@ -121,17 +121,11 @@ class UpgradeAccountViewModel: PlusPurchaseModel {
     func dismissTapped(originalDismiss dismiss: DismissAction?) {
         track(.plusPromotionDismissed)
 
-        guard flowSource == .accountCreated, !FeatureFlag.newOnboardingAccountCreation.enabled, let navigationController else {
-            if navigationController == nil {
-                dismiss?()
-            } else {
-                navigationController?.dismiss(animated: true)
-            }
-            return
+        if navigationController == nil {
+            dismiss?()
+        } else {
+            navigationController?.dismiss(animated: true)
         }
-
-        let controller = WelcomeViewModel.make(in: navigationController, displayType: .newAccount)
-        navigationController.pushViewController(controller, animated: true)
     }
 
     var title: String {

--- a/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
+++ b/podcasts/Onboarding/Plus/PlusLandingViewModel.swift
@@ -64,13 +64,7 @@ class PlusLandingViewModel: PlusPurchaseModel {
         }
         OnboardingFlow.shared.track(.plusPromotionDismissed)
 
-        guard source == .accountCreated && !FeatureFlag.newOnboardingAccountCreation.enabled else {
-            navigationController?.dismiss(animated: true)
-            return
-        }
-
-        let controller = WelcomeViewModel.make(in: navigationController, displayType: .newAccount)
-        navigationController?.pushViewController(controller, animated: true)
+        navigationController?.dismiss(animated: true)
     }
 
     func changedSubscriptionTier(_ index: Int) {

--- a/podcasts/Onboarding/Plus/UpgradeTier.swift
+++ b/podcasts/Onboarding/Plus/UpgradeTier.swift
@@ -29,7 +29,7 @@ struct UpgradeTier: Identifiable {
 extension UpgradeTier {
 
     static var plus: UpgradeTier {
-        UpgradeTier(tier: .plus, iconName: "plusGold", title: "Plus", plan: .plus, header: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.upgradeAccountTitle : L10n.plusMarketingTitle, description: L10n.accountDetailsPlusTitle, buttonLabel: L10n.plusSubscribeTo, buttonForegroundColor: Color.plusButtonFilledTextColor, monthlyFeatures: plusMonthlyFeatures, yearlyFeatures: plusYearlyFeatures,
+        UpgradeTier(tier: .plus, iconName: "plusGold", title: "Plus", plan: .plus, header: L10n.upgradeAccountTitle, description: L10n.accountDetailsPlusTitle, buttonLabel: L10n.plusSubscribeTo, buttonForegroundColor: Color.plusButtonFilledTextColor, monthlyFeatures: plusMonthlyFeatures, yearlyFeatures: plusYearlyFeatures,
                     background: RadialGradient(colors: [Color(hex: "FFDE64").opacity(0.5), Color(hex: "121212")], center: .leading, startRadius: 0, endRadius: 500))
     }
 
@@ -39,75 +39,41 @@ extension UpgradeTier {
     }
 
     static var plusMonthlyFeatures: [UpgradeTier.TierFeature] {
-        if FeatureFlag.newOnboardingUpgrade.enabled {
-            return [
-                bannerAdsFeature,
-                generatedTranscriptsFeature,
-                foldersFeature,
-                upNextShuffleFeature,
-                bookmarksFeature,
-                deselectChaptersFeature,
-                cloudFeature,
-                extraThemesIconsFeature,
-                watchFeature,
-                libroFm
-            ].compactMap { $0 }
-        }
-        else {
-            return [
-                bannerAdsFeature,
-                generatedTranscriptsFeature,
-                foldersFeature,
-                upNextShuffleFeature,
-                bookmarksFeature,
-                deselectChaptersFeature,
-                cloudFeature,
-                watchFeature,
-                extraThemesIconsFeature,
-                libroFm
-            ].compactMap { $0 }
-        }
+        return [
+            bannerAdsFeature,
+            generatedTranscriptsFeature,
+            foldersFeature,
+            upNextShuffleFeature,
+            bookmarksFeature,
+            deselectChaptersFeature,
+            cloudFeature,
+            extraThemesIconsFeature,
+            watchFeature,
+            libroFm
+        ].compactMap { $0 }
     }
 
     static var plusYearlyFeatures: [UpgradeTier.TierFeature] {
-        if FeatureFlag.newOnboardingUpgrade.enabled {
-            return [
-                bannerAdsFeature,
-                generatedTranscriptsFeature,
-                foldersFeature,
-                upNextShuffleFeature,
-                bookmarksFeature,
-                deselectChaptersFeature,
-                cloudFeature,
-                extraThemesIconsFeature,
-                watchFeature,
-                slumber,
-                libroFm
-            ].compactMap { $0 }
-        }
-        else {
-            return [
-                bannerAdsFeature,
-                generatedTranscriptsFeature,
-                foldersFeature,
-                upNextShuffleFeature,
-                bookmarksFeature,
-                deselectChaptersFeature,
-                cloudFeature,
-                watchFeature,
-                FeatureFlag.slumber.enabled && FeatureFlag.upgradeExperiment.enabled ? slumber : nil,
-                extraThemesIconsFeature,
-                FeatureFlag.upgradeExperiment.enabled ? nil : slumberOrUndyingGratitude,
-                libroFm
-            ].compactMap { $0 }
-        }
+        return [
+            bannerAdsFeature,
+            generatedTranscriptsFeature,
+            foldersFeature,
+            upNextShuffleFeature,
+            bookmarksFeature,
+            deselectChaptersFeature,
+            cloudFeature,
+            extraThemesIconsFeature,
+            watchFeature,
+            slumber,
+            libroFm
+        ].compactMap { $0 }
     }
 
     static var patronFeatures: [UpgradeTier.TierFeature] {
         [
-            TierFeature(iconName: "patron-everything", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingAllPlusFeatures : L10n.patronFeatureEverythingInPlus),
-            TierFeature(iconName: "patron-early-access", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingEarlyAccess : L10n.patronFeatureEarlyAccess),
-            TierFeature(iconName: "plus-feature-cloud", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingCloudStorage(Settings.patronCloudStorageLimit.localized()) : L10n.patronCloudStorageLimit),
+            TierFeature(iconName: "patron-everything", title: L10n.featureMarketingAllPlusFeatures),
+            TierFeature(iconName: "patron-early-access", title: L10n.featureMarketingEarlyAccess),
+            TierFeature(iconName: "plus-feature-cloud", title: L10n.featureMarketingCloudStorage(Settings.patronCloudStorageLimit.localized())),
             TierFeature(iconName: "patron-badge", title: L10n.patronFeatureProfileBadge),
             TierFeature(iconName: "patron-icons", title: L10n.patronFeatureProfileIcons),
             TierFeature(iconName: "plus-feature-love", title: L10n.plusFeatureGratitude)
@@ -123,27 +89,27 @@ extension UpgradeTier {
     }
 
     static var foldersFeature: UpgradeTier.TierFeature {
-        TierFeature(iconName: "plus-feature-folders", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingFolders : L10n.plusMarketingFoldersTitle)
+        TierFeature(iconName: "plus-feature-folders", title: L10n.featureMarketingFolders)
     }
 
     static var upNextShuffleFeature: UpgradeTier.TierFeature {
-        TierFeature(iconName: "plus-feature-up-next-shuffle", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingUpNextShuffle : L10n.plusMarketingUpNextShuffle)
+        TierFeature(iconName: "plus-feature-up-next-shuffle", title: L10n.featureMarketingUpNextShuffle)
     }
 
     static var bookmarksFeature: UpgradeTier.TierFeature {
-        TierFeature(iconName: "plus-feature-bookmarks", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingBookmarks : L10n.plusMarketingBookmarksTitle)
+        TierFeature(iconName: "plus-feature-bookmarks", title: L10n.featureMarketingBookmarks)
     }
 
     static var deselectChaptersFeature: UpgradeTier.TierFeature? {
-        PaidFeature.deselectChapters.tier == .plus ? TierFeature(iconName: "rounded-selected", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingSkipChapters : L10n.skipChapters) : nil
+        PaidFeature.deselectChapters.tier == .plus ? TierFeature(iconName: "rounded-selected", title: L10n.featureMarketingSkipChapters) : nil
     }
 
     static var cloudFeature: UpgradeTier.TierFeature {
-        TierFeature(iconName: "plus-feature-cloud", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingCloudStorage(Settings.plusCloudStorageLimit.localized()) : L10n.plusCloudStorageLimit)
+        TierFeature(iconName: "plus-feature-cloud", title: L10n.featureMarketingCloudStorage(Settings.plusCloudStorageLimit.localized()))
     }
 
     static var watchFeature: UpgradeTier.TierFeature {
-        TierFeature(iconName: "plus-feature-watch", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingWatchPlayback: L10n.plusMarketingWatchPlaybackTitle)
+        TierFeature(iconName: "plus-feature-watch", title: L10n.featureMarketingWatchPlayback)
     }
 
     static var slumberOrUndyingGratitude: TierFeature {
@@ -151,7 +117,7 @@ extension UpgradeTier {
     }
 
     static var extraThemesIconsFeature: TierFeature {
-        TierFeature(iconName: "plus-feature-extra", title: FeatureFlag.newOnboardingUpgrade.enabled ? L10n.featureMarketingExtraThemesIcons : L10n.plusFeatureThemesIcons )
+        TierFeature(iconName: "plus-feature-extra", title: L10n.featureMarketingExtraThemesIcons)
     }
 
     static var loveFeature: TierFeature {
@@ -159,12 +125,7 @@ extension UpgradeTier {
     }
 
     static var slumber: TierFeature {
-        let message: String
-        if FeatureFlag.newOnboardingUpgrade.enabled {
-            message = L10n.featureMarketingSlumber.slumberStudiosWithUrl
-        } else {
-            message = FeatureFlag.upgradeExperiment.enabled ? L10n.plusFeatureSlumberNew.newSlumberStudiosWithUrl : L10n.plusFeatureSlumber.slumberStudiosWithUrl
-        }
+        let message = L10n.featureMarketingSlumber.slumberStudiosWithUrl
         return TierFeature(iconName: "plus-feature-slumber", title: message)
     }
 

--- a/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
+++ b/podcasts/Profile - SwiftUI/Account/AccountHeaderView.swift
@@ -10,7 +10,7 @@ struct AccountHeaderView: View {
 
     var body: some View {
         container { _ in
-            VStack(spacing: FeatureFlag.newOnboardingUpgrade.enabled ? 8 : Constants.padding.vertical) {
+            VStack(spacing: 8) {
                 SubscriptionProfileImage(viewModel: viewModel)
                     .frame(width: Constants.imageSize, height: Constants.imageSize)
                 ProfileInfoLabels(profile: viewModel.profile, alignment: .center, spacing: Constants.spacing)
@@ -19,7 +19,7 @@ struct AccountHeaderView: View {
                     SubscriptionBadge(tier: $0.tier)
                 }
                 let (title, label, action) = subscriptionLabels
-                if label == nil, FeatureFlag.newAccountUpgradePromptFlow.enabled || FeatureFlag.newOnboardingUpgrade.enabled {
+                if label == nil {
                     Text(title)
                         .fixedSize(horizontal: false, vertical: true)
                         .foregroundColor(theme.primaryText02)
@@ -57,10 +57,7 @@ struct AccountHeaderView: View {
             // Show the free account status and the total listening time the user has
             return (
                 L10n.accountDetailsFreeAccount,
-                (FeatureFlag.newAccountUpgradePromptFlow.enabled || FeatureFlag.newOnboardingUpgrade.enabled) ? nil :
-                viewModel.stats.listeningTime.seconds.localizedTimeDescription.map {
-                    Text(L10n.accountDetailsListenedFor($0))
-                },
+                nil,
                 nil
             )
         case .activeSubscription(_, let frequency, let expirationDate):

--- a/podcasts/Referrals/ReferralsCoordinator.swift
+++ b/podcasts/Referrals/ReferralsCoordinator.swift
@@ -74,12 +74,7 @@ class ReferralsCoordinator {
                 onComplete?()
             })
             viewModel.onComplete = {
-                viewController.dismiss(animated: true) {
-                    if viewModel.accountCreated && !FeatureFlag.newOnboardingAccountCreation.enabled {
-                        let welcomeVC = WelcomeViewModel.make(in: nil, displayType: .newAccount)
-                        viewController.present(welcomeVC, animated: true)
-                    }
-                }
+                viewController.dismiss(animated: true)
                 onComplete?()
             }
             let referralClaimPassVC = ReferralClaimPassVC(viewModel: viewModel)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4312,6 +4312,9 @@
 /* Subtitle of the login view */
 "login_landing_subtitle" = "Your podcasts, always in sync. Keep your library safe, and enjoy Pocket Casts on web and desktop.";
 
+/* Label of a button on the login landing view that lets the user sign up for an account using their email address */
+"login_landing_sign_up_with_email" = "Sign up with email";
+
 /* Title of the plus marketing view */
 "plus_marketing_title" = "Everything you love about Pocket Casts, plus more";
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

Removes the `newOnboardingUpgrade`, `newOnboardingRecommendationChanges`, and `newOnboardingAccountCreation` feature flags now that the new onboarding experience is fully rolled out, and keeps only the code that ran when each flag was **enabled**.

### What changed
- **`FeatureFlag.swift`** — removed the three `case` declarations and their `defaultValue` switch entries.
- **17 usage sites** — collapsed each guard / `if` / ternary to its enabled branch:
  - `if flag.enabled { A } else { B }` → `A`
  - `flag.enabled ? A : B` → `A`
  - Inverted checks (`!flag.enabled`, `... && !flag.enabled`) that became always-false → deleted the dead legacy paths (e.g. the old `WelcomeViewModel` flows in `ReferralsCoordinator`, `PlusPurchaseModel`, `PlusLandingViewModel`, `UpgradeAccountViewModel`; the legacy landing/signup UI in `LoginLandingView`/`LoginCoordinator`).
- Removed a now-orphaned local (`topPadding` in `LoginLandingView`).

### Notes for reviewers
- The helpers `loveFeature` / `slumberOrUndyingGratitude` in `UpgradeTier.swift` are now only referenced from removed branches, but they aren't gated by these flags, so I left them in place rather than expand scope. Happy to prune them if preferred.
- No behavior change is expected since all three flags defaulted to enabled.

## To test

1. Launch onboarding from a logged-out state and confirm the intro carousel, sign-up-with-email, and login flows appear as before.
2. Go through account creation and verify the newsletter/notifications permissions screen and the upgrade screens display and dismiss correctly.
3. From Profile → Account, confirm the upgrade banner and account header render correctly.
4. Trigger a Plus/Patron upgrade from the account screen and an upsell, and confirm the new upgrade screens appear.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.