### PR TITLE
Fix an issue with main thread blocked by networking when playing episodes from search

### DIFF
--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -107,7 +107,7 @@ extension BookmarkListViewModel {
             do {
                 try await self?.router?.bookmarkPlay(bookmark)
             } catch {
-                HapticsHelper.triggerEpisodeLoadFailedHaptic()
+                HapticsHelper.triggerErrorHaptic()
                 Toast.show(L10n.discoverEpisodeFailToLoad)
             }
 

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -107,6 +107,7 @@ extension BookmarkListViewModel {
             do {
                 try await self?.router?.bookmarkPlay(bookmark)
             } catch {
+                HapticsHelper.triggerEpisodeLoadFailedHaptic()
                 Toast.show(L10n.discoverEpisodeFailToLoad)
             }
 

--- a/podcasts/HapticsHelper.swift
+++ b/podcasts/HapticsHelper.swift
@@ -29,6 +29,10 @@ class HapticsHelper {
         triggerImpactOccurredHaptic(style: .heavy)
     }
 
+    class func triggerEpisodeLoadFailedHaptic() {
+        triggerErrorHaptic()
+    }
+
     #if os(tvOS)
     enum FeedbackStyle {
         case heavy
@@ -42,6 +46,10 @@ class HapticsHelper {
     private class func triggerSuccessHaptic() {
         //No op
     }
+
+    private class func triggerErrorHaptic() {
+        //No op
+    }
     #else
     private class func triggerImpactOccurredHaptic(style: UIImpactFeedbackGenerator.FeedbackStyle) {
         let feedbackGenerator = UIImpactFeedbackGenerator(style: style)
@@ -51,6 +59,11 @@ class HapticsHelper {
     private class func triggerSuccessHaptic() {
         let feedbackGenerator = UINotificationFeedbackGenerator()
         feedbackGenerator.notificationOccurred(.success)
+    }
+
+    private class func triggerErrorHaptic() {
+        let feedbackGenerator = UINotificationFeedbackGenerator()
+        feedbackGenerator.notificationOccurred(.error)
     }
     #endif
 }

--- a/podcasts/HapticsHelper.swift
+++ b/podcasts/HapticsHelper.swift
@@ -29,10 +29,6 @@ class HapticsHelper {
         triggerImpactOccurredHaptic(style: .heavy)
     }
 
-    class func triggerEpisodeLoadFailedHaptic() {
-        triggerErrorHaptic()
-    }
-
     #if os(tvOS)
     enum FeedbackStyle {
         case heavy
@@ -47,7 +43,7 @@ class HapticsHelper {
         //No op
     }
 
-    private class func triggerErrorHaptic() {
+    class func triggerErrorHaptic() {
         //No op
     }
     #else
@@ -61,7 +57,7 @@ class HapticsHelper {
         feedbackGenerator.notificationOccurred(.success)
     }
 
-    private class func triggerErrorHaptic() {
+    class func triggerErrorHaptic() {
         let feedbackGenerator = UINotificationFeedbackGenerator()
         feedbackGenerator.notificationOccurred(.error)
     }

--- a/podcasts/New Search/Views/Results/SearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCell.swift
@@ -200,8 +200,16 @@ private extension SearchResultCell {
                         .foregroundStyle(AppTheme.episodeCellPlayedIndicatorColor().color)
                         .frame(width: 48, height: 48)
                 } else if !showEpisodeAddButton {
-                    EpisodeActionButton(model: self.model)
-                        .frame(width: 48, height: 48)
+                    ZStack {
+                        if model.showsLoadingSpinner {
+                            ProgressView()
+                                .tint(AppTheme.color(for: .primaryIcon01, theme: theme))
+                        } else {
+                            EpisodeActionButton(model: self.model)
+                        }
+                    }
+                    .allowsHitTesting(!model.isLoadingEpisode)
+                    .frame(width: 48, height: 48)
                 }
                 if showEpisodeAddButton {
                     Button(action: {

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -43,6 +43,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
             do {
                 try await PlaybackManager.shared.playEpisodeSearchResult(episode)
             } catch {
+                HapticsHelper.triggerEpisodeLoadFailedHaptic()
                 Toast.show(L10n.discoverEpisodeFailToLoad)
             }
         }

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -11,6 +11,14 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
 
     @Published var refreshTrigger: Bool = true
 
+    /// True while the episode is being fetched from the server before playback can start.
+    @Published private(set) var isLoadingEpisode = false
+
+    /// Delayed so the spinner doesn't flash when the episode loads quickly.
+    @Published private(set) var showsLoadingSpinner = false
+
+    private static let loadingSpinnerDelay: TimeInterval = 0.5
+
     init(episode: EpisodeSearchResult?, podcastFolder: PodcastFolderSearchResult?) {
         self.episode = episode
         self.podcastFolder = podcastFolder
@@ -18,10 +26,26 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
     }
 
     func playTapped() {
-        guard let episode else {
+        guard let episode, !isLoadingEpisode else {
             return
         }
-        PlaybackManager.shared.playEpisodeSearchResult(episode)
+        isLoadingEpisode = true
+        Task { @MainActor in
+            let spinnerTask = Task { @MainActor in
+                try await Task.sleep(nanoseconds: UInt64(Self.loadingSpinnerDelay * TimeInterval(NSEC_PER_SEC)))
+                showsLoadingSpinner = true
+            }
+            defer {
+                spinnerTask.cancel()
+                isLoadingEpisode = false
+                showsLoadingSpinner = false
+            }
+            do {
+                try await PlaybackManager.shared.playEpisodeSearchResult(episode)
+            } catch {
+                Toast.show(L10n.discoverEpisodeFailToLoad)
+            }
+        }
     }
 
     func pauseTapped() {

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -43,7 +43,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
             do {
                 try await PlaybackManager.shared.playEpisodeSearchResult(episode)
             } catch {
-                HapticsHelper.triggerEpisodeLoadFailedHaptic()
+                HapticsHelper.triggerErrorHaptic()
                 Toast.show(L10n.discoverEpisodeFailToLoad)
             }
         }

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -33,6 +33,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
         Task { @MainActor in
             let spinnerTask = Task { @MainActor in
                 try await Task.sleep(nanoseconds: UInt64(Self.loadingSpinnerDelay * TimeInterval(NSEC_PER_SEC)))
+                try Task.checkCancellation()
                 showsLoadingSpinner = true
             }
             defer {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2743,18 +2743,21 @@ extension PlaybackManager {
 // MARK: - SearchResults
 extension PlaybackManager {
 
-    func playEpisodeSearchResult(_ searchEpisode: EpisodeSearchResult, firstTry: Bool = true) {
-        let dataManager = DataManager.sharedManager
+    enum SearchResultPlayError: Error {
+        case episodeNotFound
+    }
 
-        // Get the bookmark's BaseEpisode so we can load it
-        guard let episode = dataManager.findBaseEpisode(uuid: searchEpisode.uuid) else {
-            guard firstTry else { return }
-            ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: searchEpisode.uuid, podcastUuid: searchEpisode.podcastUuid) { [weak self] episode in
-                if episode != nil {
-                    self?.playEpisodeSearchResult(searchEpisode, firstTry: false)
-                }
-            }
-            return
+    @MainActor
+    func playEpisodeSearchResult(_ searchEpisode: EpisodeSearchResult) async throws {
+        // Get the search result's BaseEpisode so we can load it, fetching it from the server if it's missing
+        var foundEpisode = DataManager.sharedManager.findBaseEpisode(uuid: searchEpisode.uuid)
+
+        if foundEpisode == nil {
+            foundEpisode = try await ServerPodcastManager.shared.addMissingPodcastAndEpisode(episodeUuid: searchEpisode.uuid, podcastUuid: searchEpisode.podcastUuid)
+        }
+
+        guard let episode = foundEpisode else {
+            throw SearchResultPlayError.episodeNotFound
         }
 
         #if !os(watchOS)


### PR DESCRIPTION
Playing an episode from search results used the deprecated `addMissingPodcastAndEpisode` (synchronous networking, silent failures). Now:

- `playEpisodeSearchResult` is async throwing and uses the async/await `addMissingPodcastAndEpisode`.
- The play button is disabled while the episode is fetched, showing a spinner after 0.5s (no flash on fast loads).
- Failures show a toast and fire an error haptic (haptic also added to the matching bookmark play flow).

## To test

Apply the testing patch attached in the comments — it deletes the local copy of the episode on every play tap so the server fetch always fires: `git apply search-result-play-force-server-fetch.patch`

1. Search for an episode and tap play — playback starts (spinner only appears if loading takes over 0.5s).
2. With a slow connection (e.g. Network Link Conditioner), tap play — the button turns into a spinner and is disabled until playback starts.
3. In Airplane Mode (or use breakpoints in Proxyman) tap play — an error haptic fires and a "The episode couldn't be loaded" toast appears at the bottom.
4. Revert the patch and confirm regular playback from search still works.

<img width="340"  alt="Screenshot 2026-07-16 at 1 48 03 PM" src="https://github.com/user-attachments/assets/9a76c7b9-6dbc-4c80-aa89-c487901c3e48" /> <img width="340" alt="Screenshot 2026-07-16 at 1 48 13 PM" src="https://github.com/user-attachments/assets/59d7283d-56b6-41d0-9ee6-3581dbb3b0ce" />


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
