### PR TITLE
tvOS: Update Up Next home row when episodes are added or removed

### DIFF
--- a/Pocket Casts TV App/UI/Home/HomeViewModel.swift
+++ b/Pocket Casts TV App/UI/Home/HomeViewModel.swift
@@ -69,6 +69,8 @@ class HomeViewModel {
             Constants.Notifications.podcastAdded,
             Constants.Notifications.podcastDeleted,
             Constants.Notifications.upNextQueueChanged,
+            Constants.Notifications.upNextEpisodeRemoved,
+            Constants.Notifications.upNextEpisodeAdded,
             Constants.Notifications.manyEpisodesChanged,
             ServerNotifications.podcastsRefreshed,
             ServerNotifications.syncCompleted,


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

On the tvOS Home screen, the "Up Next" row was not refreshing when episodes were added to or removed from the Up Next queue through direct user intervention. The `HomeViewModel` only observed `upNextQueueChanged`, which does not fire for these individual add/remove actions.

This PR adds `upNextEpisodeRemoved` and `upNextEpisodeAdded` to the set of notifications observed by `HomeViewModel`, so the Home screen reloads and reflects the current Up Next state whenever the user adds or removes an episode.

## To test

1. Launch the tvOS app and open the Home screen.
2. Add an episode to Up Next — the Up Next row should update to include it.
3. Remove an episode from Up Next — the Up Next row should update to remove it.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
