### PR TITLE
PCIOS-176: Time left display does not factor in deselected chapters.

### DIFF
--- a/podcasts/ChapterManager.swift
+++ b/podcasts/ChapterManager.swift
@@ -219,6 +219,21 @@ class ChapterManager {
         Chapters(chapters: chapters.filter { $0.startTime.seconds <= time && ($0.startTime.seconds + $0.duration) > time })
     }
 
+    func deselectedDuration(after time: TimeInterval) -> TimeInterval {
+        visibleChapters
+            .filter { !$0.isPlayable() }
+            .reduce(0) { total, chapter in
+                let chapterEnd = chapter.startTime.seconds + chapter.duration
+                if chapterEnd <= time {
+                    return total
+                } else if chapter.startTime.seconds >= time {
+                    return total + chapter.duration
+                } else {
+                    return total + (chapterEnd - time)
+                }
+            }
+    }
+
     var chaptersAnalyticsProperties: [String: Any] {
         return ["origin": chaptersOrigin.analyticsDescription]
     }

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -619,7 +619,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
         }
 
         if let timeLeftModel {
-            let remaining = max(0, duration - currentTime)
+            let remaining = max(0, duration - currentTime - PlaybackManager.shared.remainingDeselectedDuration())
             let newText = remaining > 0 ? "-" + TimeFormatter.shared.playTimeFormat(time: remaining) : ""
             if timeLeftModel.text != newText {
                 let animate = animateNextTimeLeftChange && !UIAccessibility.isReduceMotionEnabled

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -181,7 +181,7 @@ extension NowPlayingPlayerItemViewController {
     }
 
     func updateUpTo(upTo: TimeInterval, duration: TimeInterval, moveSlider: Bool) {
-        let remaining = max(0, duration - upTo)
+        let remaining = max(0, duration - upTo - PlaybackManager.shared.remainingDeselectedDuration())
         updateTimeLabels(upTo: upTo, remaining: remaining)
         updateChapterInfoWithChapters(PlaybackManager.shared.chaptersForTime(time: upTo))
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -494,6 +494,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         chapterManager.chaptersForTime(time)
     }
 
+    func remainingDeselectedDuration() -> TimeInterval {
+        chapterManager.deselectedDuration(after: currentTime())
+    }
+
     func playableChaptersUpdated() {
         // Check if current chapter still needs to be played
         if currentChapters().visibleChapter?.isPlayable() == false {

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -109,7 +109,7 @@ class UpNextNowPlayingCell: ThemeableCell {
 
         guard duration > 0, currentTime.isFinite else { return }
 
-        let remaining = duration - currentTime
+        let remaining = max(0, duration - currentTime - PlaybackManager.shared.remainingDeselectedDuration())
         timeRemainingLabel.text = L10n.queueTimeRemaining(TimeFormatter.shared.multipleUnitFormattedShortTime(time: remaining))
 
         let percentageLapsed = CGFloat(currentTime / duration)

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -432,7 +432,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     @objc func updateTimeRemainingLabel() {
         var totalDuration = PlaybackManager.shared.queue.upNextTotalDuration(includePlayingEpisode: false)
         if let episode = PlaybackManager.shared.currentEpisode() {
-            totalDuration += episode.duration.seconds - PlaybackManager.shared.currentTime()
+            totalDuration += episode.duration.seconds - PlaybackManager.shared.currentTime() - PlaybackManager.shared.remainingDeselectedDuration()
         }
         let time = TimeFormatter.shared.multipleUnitFormattedShortTime(time: totalDuration)
         let count = PlaybackManager.shared.queue.upNextCount()

--- a/podcasts/VideoViewController.swift
+++ b/podcasts/VideoViewController.swift
@@ -319,7 +319,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     }
 
     func updateUpTo(upTo: TimeInterval, duration: TimeInterval, moveSlider: Bool) {
-        let remaining = max(0, duration - upTo)
+        let remaining = max(0, duration - upTo - PlaybackManager.shared.remainingDeselectedDuration())
         updateTimeLabels(upTo: upTo, remaining: remaining)
 
         if moveSlider {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-176/time-left-display-does-not-factor-in-deselected-chapters

## Summary
The time left display for the currently playing episode now subtracts the duration of deselected (skipped) chapters, so the remaining time reflects only the content that will actually be played.

## Changes
- Added ChapterManager.deselectedDuration(after:) to compute total duration of deselected chapters remaining after a given playback position
- Added PlaybackManager.remainingDeselectedDuration() convenience wrapper
- Adjusted time-remaining calculation in full-screen player, mini player, Up Next now-playing cell, video player, and Up Next total time label

## Verification
- Lint: PASS
- Tests: FAIL - pre-existing GenerateCredentials build script failure, unrelated to this change. Zero Swift compilation errors.
- Diff review: PASS

## Confidence
MEDIUM - The logic is straightforward and compiles without errors. The fix adjusts the currently playing episode time remaining only (chapter data is only loaded for the active episode).

## Known Issues
- Build and tests fail due to pre-existing GenerateCredentials script failure in the worktree environment, not caused by these changes.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/PCIOS-176/time-left-display-does-not-factor-in-deselected-chapters)