### PR TITLE
Generate bookmark title suggestions from transcripts in the add-bookmark sheet

### DIFF
--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -142,7 +142,7 @@ class BookmarkManager {
         if #available(iOS 26.0, *), BookmarkFoundationModelEnricher.isAvailable,
            let enricher = foundationModelEnricher as? BookmarkFoundationModelEnricher {
             do {
-                return try await enricher.enrich(transcriptSnippet: transcriptSnippet, podcastTitle: podcastTitle, episodeTitle: episodeTitle).title
+                return try await enricher.generateTitle(transcriptSnippet: transcriptSnippet, podcastTitle: podcastTitle, episodeTitle: episodeTitle)
             } catch {
                 FileLog.shared.addMessage("[Bookmarks] On-device title generation failed, falling back to the server: \(error)")
             }

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -126,7 +126,6 @@ class BookmarkManager {
     #endif
 
     /// Preloads on-device model resources so an upcoming `generateTitle` call responds faster.
-    /// Call when a bookmark is about to be created (e.g. when the bookmark UI is shown).
     func prewarmTitleGeneration() {
         #if canImport(FoundationModels)
         if #available(iOS 26.0, *) {
@@ -135,8 +134,6 @@ class BookmarkManager {
         #endif
     }
 
-    /// Generates a title for a bookmark from the transcript text surrounding its position.
-    /// Prefers the on-device model when it's available, falling back to the server otherwise.
     func generateTitle(transcriptSnippet: String, podcastTitle: String? = nil, episodeTitle: String? = nil) async throws -> String {
         #if canImport(FoundationModels)
         if #available(iOS 26.0, *), BookmarkFoundationModelEnricher.isAvailable,
@@ -158,7 +155,6 @@ class BookmarkManager {
     }
 
     enum TitleGenerationError: Error {
-        /// The server responded without a usable title
         case noTitleReturned
     }
 

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -2,12 +2,14 @@ import Foundation
 import AVFoundation
 import Combine
 import PocketCastsDataModel
+import PocketCastsServer
 import PocketCastsUtils
 
 class BookmarkManager {
     private let dataManager: BookmarkDataManager
     private let generalManager: DataManager
     private let playbackManager: PlaybackManager
+    private let cacheServerHandler: CacheServerHandler
 
     /// Called when a bookmark is created
     let onBookmarkCreated = PassthroughSubject<Event.Created, Never>()
@@ -20,10 +22,12 @@ class BookmarkManager {
 
     init(dataManager: BookmarkDataManager = DataManager.sharedManager.bookmarks,
          generalManager: DataManager = .sharedManager,
-         playbackManager: PlaybackManager = .shared) {
+         playbackManager: PlaybackManager = .shared,
+         cacheServerHandler: CacheServerHandler = .shared) {
         self.dataManager = dataManager
         self.generalManager = generalManager
         self.playbackManager = playbackManager
+        self.cacheServerHandler = cacheServerHandler
     }
 
     /// Plays the "bookmark created" tone
@@ -107,6 +111,55 @@ class BookmarkManager {
     /// Gets the `BaseEpisode` for the given bookmark
     func episode(for bookmark: Bookmark) -> BaseEpisode? {
         generalManager.findBaseEpisode(uuid: bookmark.episodeUuid)
+    }
+
+    // MARK: - Title Generation
+
+    #if canImport(FoundationModels)
+    /// Stored as `Any` because stored properties can't be marked potentially unavailable.
+    private lazy var foundationModelEnricher: Any? = {
+        if #available(iOS 26.0, *) {
+            return BookmarkFoundationModelEnricher()
+        }
+        return nil
+    }()
+    #endif
+
+    /// Preloads on-device model resources so an upcoming `generateTitle` call responds faster.
+    /// Call when a bookmark is about to be created (e.g. when the bookmark UI is shown).
+    func prewarmTitleGeneration() {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *) {
+            (foundationModelEnricher as? BookmarkFoundationModelEnricher)?.prewarm()
+        }
+        #endif
+    }
+
+    /// Generates a title for a bookmark from the transcript text surrounding its position.
+    /// Prefers the on-device model when it's available, falling back to the server otherwise.
+    func generateTitle(transcriptSnippet: String, podcastTitle: String? = nil, episodeTitle: String? = nil) async throws -> String {
+        #if canImport(FoundationModels)
+        if #available(iOS 26.0, *), BookmarkFoundationModelEnricher.isAvailable,
+           let enricher = foundationModelEnricher as? BookmarkFoundationModelEnricher {
+            do {
+                return try await enricher.enrich(transcriptSnippet: transcriptSnippet, podcastTitle: podcastTitle, episodeTitle: episodeTitle).title
+            } catch {
+                FileLog.shared.addMessage("[Bookmarks] On-device title generation failed, falling back to the server: \(error)")
+            }
+        }
+        #endif
+
+        let response = try await cacheServerHandler.enrichBookmark(transcriptSnippet: transcriptSnippet)
+        guard let title = response.title, !title.isEmpty else {
+            FileLog.shared.addMessage("[Bookmarks] Server title generation returned no title\(response.error.map { ": \($0)" } ?? "")")
+            throw TitleGenerationError.noTitleReturned
+        }
+        return title
+    }
+
+    enum TitleGenerationError: Error {
+        /// The server responded without a usable title
+        case noTitleReturned
     }
 
     // MARK: - Named Events

--- a/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
+++ b/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
@@ -10,21 +10,13 @@ import NaturalLanguage
 final class BookmarkFoundationModelEnricher {
     enum EnrichmentError: Error {
         case modelUnavailable(SystemLanguageModel.Availability)
-        /// The model responded with something that can't be a title
-        /// (empty, or long enough to be a refusal/explanation instead).
         case unexpectedResponse
     }
 
-    /// The model configured with permissive content-transformation guardrails,
-    /// so titling transcripts that cover heavy podcast topics (true crime,
-    /// health, violent news) isn't rejected with a `guardrailViolation`
-    /// ("May contain sensitive content").
-    ///
-    /// IMPORTANT: the permissive guardrails only apply when generating a plain
-    /// `String` — with guided generation (`@Generable`) the default guardrails
-    /// still run and the error comes back. That's why this class generates only
-    /// the title, as raw text, instead of using guided generation.
-    /// https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/guardrails/permissivecontenttransformations
+    /// Permissive guardrails keep transcripts covering heavy podcast topics (true crime,
+    /// health, violent news) from being rejected with a `guardrailViolation`. They only
+    /// apply to plain `String` generation — with guided generation (`@Generable`) the
+    /// default guardrails still run — which is why this class generates the title as raw text.
     private static let model = SystemLanguageModel(guardrails: .permissiveContentTransformations)
 
     /// Whether the on-device model can be used (device eligible, Apple Intelligence enabled, model downloaded).
@@ -32,9 +24,8 @@ final class BookmarkFoundationModelEnricher {
         model.isAvailable
     }
 
-    /// Titles longer than this many words are treated as the model explaining
-    /// or refusing rather than titling, and rejected (the caller falls back to
-    /// the server). The instructions ask for around 3 to 6 words.
+    /// Responses longer than this are treated as the model explaining or refusing
+    /// rather than titling, and rejected. The instructions ask for around 3 to 6 words.
     private static let maxTitleWordCount = 12
 
     private static let instructions = """
@@ -68,7 +59,6 @@ final class BookmarkFoundationModelEnricher {
     private var prewarmedSession: LanguageModelSession?
 
     /// Preloads model resources so an upcoming `generateTitle` call responds faster.
-    /// Call when a bookmark is about to be created (e.g. when the bookmark UI is shown).
     func prewarm() {
         guard Self.isAvailable, prewarmedSession == nil else { return }
 

--- a/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
+++ b/podcasts/Bookmarks/BookmarkFoundationModelEnricher.swift
@@ -2,29 +2,44 @@ import Foundation
 import FoundationModels
 import NaturalLanguage
 
-/// Generates a title and summary for a bookmark on-device using Apple's Foundation Models,
+/// Generates a title for a bookmark on-device using Apple's Foundation Models,
 /// from the transcript text surrounding the bookmark's position.
 ///
 /// On-device alternative to `CacheServerHandler.enrichBookmark(transcriptSnippet:)`.
 @available(iOS 26.0, *)
 final class BookmarkFoundationModelEnricher {
-    struct Enrichment {
-        let title: String
-        let summary: String
-    }
-
     enum EnrichmentError: Error {
         case modelUnavailable(SystemLanguageModel.Availability)
+        /// The model responded with something that can't be a title
+        /// (empty, or long enough to be a refusal/explanation instead).
+        case unexpectedResponse
     }
+
+    /// The model configured with permissive content-transformation guardrails,
+    /// so titling transcripts that cover heavy podcast topics (true crime,
+    /// health, violent news) isn't rejected with a `guardrailViolation`
+    /// ("May contain sensitive content").
+    ///
+    /// IMPORTANT: the permissive guardrails only apply when generating a plain
+    /// `String` — with guided generation (`@Generable`) the default guardrails
+    /// still run and the error comes back. That's why this class generates only
+    /// the title, as raw text, instead of using guided generation.
+    /// https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/guardrails/permissivecontenttransformations
+    private static let model = SystemLanguageModel(guardrails: .permissiveContentTransformations)
 
     /// Whether the on-device model can be used (device eligible, Apple Intelligence enabled, model downloaded).
     static var isAvailable: Bool {
-        SystemLanguageModel.default.isAvailable
+        model.isAvailable
     }
+
+    /// Titles longer than this many words are treated as the model explaining
+    /// or refusing rather than titling, and rejected (the caller falls back to
+    /// the server). The instructions ask for around 3 to 6 words.
+    private static let maxTitleWordCount = 12
 
     private static let instructions = """
         You are helping a Pocket Casts user remember a moment they bookmarked in a podcast episode.
-        Generate a title and a summary for the bookmark from the transcript of roughly one minute \
+        Generate a title for the bookmark from the transcript of roughly one minute \
         of audio centered on the bookmarked moment.
 
         **Prompt Parameters**
@@ -41,30 +56,30 @@ final class BookmarkFoundationModelEnricher {
         - Example: for a transcript about salting chicken ahead of cooking so the salt has time to \
         penetrate, a good title is "Salt chicken hours before cooking", not "Cooking tips discussion".
 
-        **Summary Requirements**
-        - One or two sentences capturing what is being discussed.
+        **Output Format**
+        Respond with ONLY the title text — no label, no quotes, no explanation.
 
         **CRITICAL Requirement**
-        ⚠️ LANGUAGE: Generate the title and summary in the language specified by the \
+        ⚠️ LANGUAGE: Generate the title in the language specified by the \
         TRANSCRIPT_LANGUAGE code if provided, otherwise match TRANSCRIPT language exactly. \
         NO translation. NO defaulting to English. Match input language EXACTLY.
         """
 
     private var prewarmedSession: LanguageModelSession?
 
-    /// Preloads model resources so an upcoming `enrich` call responds faster.
+    /// Preloads model resources so an upcoming `generateTitle` call responds faster.
     /// Call when a bookmark is about to be created (e.g. when the bookmark UI is shown).
     func prewarm() {
         guard Self.isAvailable, prewarmedSession == nil else { return }
 
-        let session = LanguageModelSession(instructions: Self.instructions)
+        let session = Self.makeSession()
         session.prewarm()
         prewarmedSession = session
     }
 
-    func enrich(transcriptSnippet: String, podcastTitle: String? = nil, episodeTitle: String? = nil) async throws -> Enrichment {
+    func generateTitle(transcriptSnippet: String, podcastTitle: String? = nil, episodeTitle: String? = nil) async throws -> String {
         guard Self.isAvailable else {
-            throw EnrichmentError.modelUnavailable(SystemLanguageModel.default.availability)
+            throw EnrichmentError.modelUnavailable(Self.model.availability)
         }
 
         // Sessions are multi-turn and accumulate context, so each one is used for a single request.
@@ -73,12 +88,23 @@ final class BookmarkFoundationModelEnricher {
             session = prewarmedSession
             self.prewarmedSession = nil
         } else {
-            session = LanguageModelSession(instructions: Self.instructions)
+            session = Self.makeSession()
         }
 
         let prompt = Self.makePrompt(transcriptSnippet: transcriptSnippet, podcastTitle: podcastTitle, episodeTitle: episodeTitle)
-        let response = try await session.respond(to: prompt, generating: GeneratedEnrichment.self)
-        return Enrichment(title: response.content.title, summary: response.content.summary)
+        let response = try await session.respond(to: prompt)
+
+        let title = response.content
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"“”'’"))
+        guard !title.isEmpty, title.split(whereSeparator: \.isWhitespace).count <= Self.maxTitleWordCount else {
+            throw EnrichmentError.unexpectedResponse
+        }
+        return title
+    }
+
+    private static func makeSession() -> LanguageModelSession {
+        LanguageModelSession(model: model, instructions: instructions)
     }
 
     /// Prefixes the transcript with the show names (context the title shouldn't repeat) and its
@@ -113,14 +139,4 @@ final class BookmarkFoundationModelEnricher {
         recognizer.processString(text)
         return recognizer.dominantLanguage?.rawValue
     }
-}
-
-@available(iOS 26.0, *)
-@Generable
-private struct GeneratedEnrichment {
-    @Guide(description: "A specific short title (around 3-6 words) for the bookmarked moment; sentence case, no quotes, no ending punctuation")
-    let title: String
-
-    @Guide(description: "A one or two sentence summary of what is being discussed")
-    let summary: String
 }

--- a/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
+++ b/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
@@ -4,15 +4,12 @@ import PocketCastsUtils
 
 extension BookmarkManager {
 
-    /// Whether bookmark title suggestions can be generated at all.
     static var isTitleSuggestionEnabled: Bool {
         FeatureFlag.smartBookmarks.enabled
     }
 
-    /// Generates a suggested title for the bookmark from the transcript text
-    /// surrounding its position. Returns nil when suggestions are disabled, the
-    /// episode has no usable transcript, or generation fails — the bookmark
-    /// keeps its original title in every failure case.
+    /// Returns nil when suggestions are disabled, the episode has no usable
+    /// transcript, or generation fails.
     func suggestTitle(for bookmark: Bookmark) async -> String? {
         guard Self.isTitleSuggestionEnabled, let episode = episode(for: bookmark) else {
             return nil

--- a/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
+++ b/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
@@ -1,0 +1,36 @@
+import Foundation
+import PocketCastsDataModel
+import PocketCastsUtils
+
+extension BookmarkManager {
+
+    /// Whether bookmark title suggestions can be generated at all.
+    static var isTitleSuggestionEnabled: Bool {
+        FeatureFlag.smartBookmarks.enabled
+    }
+
+    /// Generates a suggested title for the bookmark from the transcript text
+    /// surrounding its position. Returns nil when suggestions are disabled, the
+    /// episode has no usable transcript, or generation fails — the bookmark
+    /// keeps its original title in every failure case.
+    func suggestTitle(for bookmark: Bookmark) async -> String? {
+        guard Self.isTitleSuggestionEnabled, let episode = episode(for: bookmark) else {
+            return nil
+        }
+
+        // Let the on-device model load while the transcript is fetched.
+        prewarmTitleGeneration()
+
+        guard let snippet = await BookmarkTranscriptSnippetExtractor().snippet(forTime: bookmark.time, episode: episode) else {
+            return nil
+        }
+
+        let podcastTitle = bookmark.podcastUuid.flatMap { DataManager.sharedManager.findPodcast(uuid: $0)?.title }
+        do {
+            return try await generateTitle(transcriptSnippet: snippet, podcastTitle: podcastTitle, episodeTitle: episode.title)
+        } catch {
+            FileLog.shared.addMessage("[Bookmarks] Title suggestion failed: \(error)")
+            return nil
+        }
+    }
+}

--- a/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
+++ b/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
@@ -1,0 +1,107 @@
+import Foundation
+import NaturalLanguage
+import PocketCastsDataModel
+import PocketCastsUtils
+
+/// Extracts the transcript text surrounding a bookmark's position, used as the
+/// input for generating a bookmark title/summary.
+///
+/// Generated transcripts are timed against a reference copy of the episode
+/// audio, which dynamic ads shift relative to what the listener actually
+/// hears — so the bookmark's playback time is first resolved to the reference
+/// timeline by fingerprinting the local audio around it (see
+/// `docs/transcripts.md`), falling back to the raw playback time when a
+/// confident mapping isn't available.
+struct BookmarkTranscriptSnippetExtractor {
+
+    /// The capture window is asymmetric: by the time a user acts on a moment
+    /// they want to keep, that moment is already behind the playhead — so we
+    /// reach much further back than forward.
+    static let backwardWindowSeconds: TimeInterval = 25
+    static let forwardWindowSeconds: TimeInterval = 5
+
+    /// Snippets with fewer words than this carry too little signal to generate
+    /// a meaningful title from, so extraction aborts instead.
+    static let minimumWordCount = 10
+
+    /// Extracts the transcript snippet around `time` (a playback-timeline
+    /// position, e.g. `Bookmark.time`) for the given episode. Returns nil when
+    /// the episode has no usable timed transcript or the window holds fewer
+    /// than `minimumWordCount` words.
+    func snippet(forTime time: TimeInterval, episode: BaseEpisode) async -> String? {
+        let transcriptManager = TranscriptManager(episodeUUID: episode.uuid, podcastUUID: episode.parentIdentifier())
+        guard let model = try? await transcriptManager.loadTranscript() else {
+            return nil
+        }
+
+        // Only generated transcripts have a reference fingerprint published, so
+        // only they can (and need to) be re-anchored to the reference timeline.
+        var center = time
+        if transcriptManager.isDisplayingGeneratedTranscript, FeatureFlag.syncedTranscripts.enabled,
+           let referenceTime = await FingerprintTimingManager.shared.resolveReferenceTime(forPlaybackTime: time, episode: episode) {
+            center = referenceTime
+        }
+
+        return Self.extractSnippet(from: model, at: center)
+    }
+
+    /// Pure extraction: the cues overlapping `[time - backward, time + forward]`,
+    /// expanded outward to whole sentences, with speaker lines excluded and
+    /// whitespace normalized.
+    static func extractSnippet(from model: TranscriptModel, at time: TimeInterval) -> String? {
+        let windowStart = max(0, time - backwardWindowSeconds)
+        let windowEnd = time + forwardWindowSeconds
+
+        let overlapping = model.cues.filter { $0.startTime < windowEnd && $0.endTime > windowStart }
+        guard let first = overlapping.first, let last = overlapping.last else {
+            return nil
+        }
+
+        let location = first.characterRange.location
+        let windowRange = NSRange(location: location, length: last.characterRange.upperBound - location)
+        let snappedRange = snapToSentenceBoundaries(windowRange, in: model.attributedText.string)
+
+        let raw = plainText(in: snappedRange, of: model.attributedText)
+        let words = raw.split(whereSeparator: \.isWhitespace)
+        guard words.count >= minimumWordCount else {
+            return nil
+        }
+        return words.joined(separator: " ")
+    }
+
+    /// Expands `range` outward so it starts at the beginning of the sentence
+    /// containing its first character and ends at the end of the sentence
+    /// containing its last one. Never shrinks the range.
+    private static func snapToSentenceBoundaries(_ range: NSRange, in text: String) -> NSRange {
+        guard let stringRange = Range(range, in: text), !stringRange.isEmpty else {
+            return range
+        }
+
+        let tokenizer = NLTokenizer(unit: .sentence)
+        tokenizer.string = text
+
+        let startSentence = tokenizer.tokenRange(at: stringRange.lowerBound)
+        let endSentence = tokenizer.tokenRange(at: text.index(before: stringRange.upperBound))
+
+        let lowerBound = min(startSentence.lowerBound, stringRange.lowerBound)
+        let upperBound = max(endSentence.upperBound, stringRange.upperBound)
+        return NSRange(lowerBound..<upperBound, in: text)
+    }
+
+    /// The plain text within `range`, skipping speaker-name runs the transcript
+    /// model interleaves between cues (marked with `.transcriptSpeaker`).
+    private static func plainText(in range: NSRange, of attributedText: NSAttributedString) -> String {
+        let clamped = NSIntersectionRange(range, NSRange(location: 0, length: attributedText.length))
+        guard clamped.length > 0 else {
+            return ""
+        }
+
+        var parts = [String]()
+        let string = attributedText.string as NSString
+        attributedText.enumerateAttribute(.transcriptSpeaker, in: clamped, options: []) { value, subrange, _ in
+            guard value == nil else { return }
+            parts.append(string.substring(with: subrange))
+        }
+        return parts.joined(separator: " ")
+    }
+}

--- a/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
+++ b/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
@@ -4,38 +4,29 @@ import PocketCastsDataModel
 import PocketCastsUtils
 
 /// Extracts the transcript text surrounding a bookmark's position, used as the
-/// input for generating a bookmark title/summary.
+/// input for generating a bookmark title.
 ///
-/// Generated transcripts are timed against a reference copy of the episode
-/// audio, which dynamic ads shift relative to what the listener actually
-/// hears — so the bookmark's playback time is first resolved to the reference
-/// timeline by fingerprinting the local audio around it (see
-/// `docs/transcripts.md`), falling back to the raw playback time when a
-/// confident mapping isn't available.
+/// Generated transcripts are timed against a reference copy of the episode audio
+/// that dynamic ads shift away from, so the bookmark's playback time is first
+/// resolved to the reference timeline (see `docs/transcripts.md`), falling back
+/// to the raw playback time when a confident mapping isn't available.
 struct BookmarkTranscriptSnippetExtractor {
 
-    /// The capture window is asymmetric: by the time a user acts on a moment
-    /// they want to keep, that moment is already behind the playhead — so we
-    /// reach much further back than forward.
+    /// The window reaches further back than forward: by the time a user bookmarks
+    /// a moment, that moment is already behind the playhead.
     static let backwardWindowSeconds: TimeInterval = 25
     static let forwardWindowSeconds: TimeInterval = 5
 
-    /// Snippets with fewer words than this carry too little signal to generate
-    /// a meaningful title from, so extraction aborts instead.
+    /// Snippets with fewer words than this carry too little signal to generate a meaningful title from
     static let minimumWordCount = 10
 
-    /// Extracts the transcript snippet around `time` (a playback-timeline
-    /// position, e.g. `Bookmark.time`) for the given episode. Returns nil when
-    /// the episode has no usable timed transcript or the window holds fewer
-    /// than `minimumWordCount` words.
     func snippet(forTime time: TimeInterval, episode: BaseEpisode) async -> String? {
         let transcriptManager = TranscriptManager(episodeUUID: episode.uuid, podcastUUID: episode.parentIdentifier())
         guard let model = try? await transcriptManager.loadTranscript() else {
             return nil
         }
 
-        // Only generated transcripts have a reference fingerprint published, so
-        // only they can (and need to) be re-anchored to the reference timeline.
+        // Only generated transcripts have a reference fingerprint to re-anchor against.
         var center = time
         if transcriptManager.isDisplayingGeneratedTranscript, FeatureFlag.syncedTranscripts.enabled,
            let referenceTime = await FingerprintTimingManager.shared.resolveReferenceTime(forPlaybackTime: time, episode: episode) {
@@ -45,9 +36,6 @@ struct BookmarkTranscriptSnippetExtractor {
         return Self.extractSnippet(from: model, at: center)
     }
 
-    /// Pure extraction: the cues overlapping `[time - backward, time + forward]`,
-    /// expanded outward to whole sentences, with speaker lines excluded and
-    /// whitespace normalized.
     static func extractSnippet(from model: TranscriptModel, at time: TimeInterval) -> String? {
         let windowStart = max(0, time - backwardWindowSeconds)
         let windowEnd = time + forwardWindowSeconds
@@ -69,9 +57,6 @@ struct BookmarkTranscriptSnippetExtractor {
         return words.joined(separator: " ")
     }
 
-    /// Expands `range` outward so it starts at the beginning of the sentence
-    /// containing its first character and ends at the end of the sentence
-    /// containing its last one. Never shrinks the range.
     private static func snapToSentenceBoundaries(_ range: NSRange, in text: String) -> NSRange {
         guard let stringRange = Range(range, in: text), !stringRange.isEmpty else {
             return range
@@ -88,8 +73,7 @@ struct BookmarkTranscriptSnippetExtractor {
         return NSRange(lowerBound..<upperBound, in: text)
     }
 
-    /// The plain text within `range`, skipping speaker-name runs the transcript
-    /// model interleaves between cues (marked with `.transcriptSpeaker`).
+    /// The plain text within `range`, skipping the speaker-name runs interleaved between cues
     private static func plainText(in range: NSRange, of attributedText: NSAttributedString) -> String {
         let clamped = NSIntersectionRange(range, NSRange(location: 0, length: attributedText.length))
         guard clamped.length > 0 else {

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleView.swift
@@ -11,6 +11,15 @@ struct BookmarkEditTitleView: View {
     @State private var textFieldSize: CGSize = .zero
     @FocusState private var focusedField: Field?
 
+    /// Whether the user has changed the title themselves. Once they have, an
+    /// arriving suggestion is offered below the field instead of replacing
+    /// their text.
+    @State private var hasEdited = false
+
+    /// The value about to be written into `bookmarkTitle` programmatically, so
+    /// its `onChange` doesn't count it as a user edit.
+    @State private var pendingSuggestion: String?
+
     init(viewModel: BookmarkEditViewModel, theme: BookmarkEditTheme) {
         self.viewModel = viewModel
         self.theme = theme
@@ -44,11 +53,57 @@ struct BookmarkEditTitleView: View {
         VStack(spacing: EditConstants.padding) {
             headerView
             Spacer()
-            textField
+            titleSection
             Spacer()
             saveButton
         }
         .padding(.top, EditConstants.padding)
+    }
+
+    /// The title field plus the suggestion affordances that ride along with it:
+    /// a spinner on the field's trailing side while a suggestion is generated,
+    /// and — when the user edited the title before it arrived — the suggestion
+    /// itself below the field, tappable to apply.
+    private var titleSection: some View {
+        VStack(spacing: EditConstants.suggestionSpacing) {
+            textField
+                .overlay(alignment: .trailing) {
+                    if viewModel.titleSuggestion == .generating, !hasEdited {
+                        ProgressView()
+                            .tint(theme.subTitle)
+                    }
+                }
+
+            if case .available(let suggestion) = viewModel.titleSuggestion {
+                suggestionView(suggestion)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: viewModel.titleSuggestion)
+        .onReceive(viewModel.autoApplySuggestion) { suggestion in
+            apply(suggestion: suggestion)
+        }
+    }
+
+    /// A generated title suggestion the user can tap to use
+    private func suggestionView(_ suggestion: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "sparkles")
+            Text(suggestion)
+                .lineLimit(2)
+        }
+        .font(style: .callout)
+        .foregroundStyle(theme.subTitle)
+        .buttonize {
+            apply(suggestion: suggestion)
+            viewModel.suggestionHandled()
+        }
+        .accessibilityLabel(L10n.bookmarkSuggestedTitle(suggestion))
+        .transition(.opacity.combined(with: .move(edge: .top)))
+    }
+
+    private func apply(suggestion: String) {
+        pendingSuggestion = suggestion
+        bookmarkTitle = suggestion
     }
 
     /// The title and subtitle views
@@ -125,8 +180,15 @@ struct BookmarkEditTitleView: View {
                 // Force the height to be equal to the invisible text view
                 .frame(height: textFieldSize.height)
 
-                // Enforce the max length of the title
+                // Track user edits and enforce the max length of the title
                 .onChange(of: bookmarkTitle) { _, newValue in
+                    if newValue == pendingSuggestion {
+                        pendingSuggestion = nil
+                    } else {
+                        hasEdited = true
+                        viewModel.userDidEditTitle()
+                    }
+
                     let max = Constants.Values.bookmarkMaxTitleLength
                     guard newValue.count > max else { return }
 
@@ -148,6 +210,7 @@ struct BookmarkEditTitleView: View {
 
     private enum EditConstants {
         static let padding = 18.0
+        static let suggestionSpacing = 12.0
     }
 }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleView.swift
@@ -11,9 +11,6 @@ struct BookmarkEditTitleView: View {
     @State private var textFieldSize: CGSize = .zero
     @FocusState private var focusedField: Field?
 
-    /// Whether the user has changed the title themselves. Once they have, an
-    /// arriving suggestion is offered below the field instead of replacing
-    /// their text.
     @State private var hasEdited = false
 
     /// The value about to be written into `bookmarkTitle` programmatically, so
@@ -60,10 +57,6 @@ struct BookmarkEditTitleView: View {
         .padding(.top, EditConstants.padding)
     }
 
-    /// The title field plus the suggestion affordances that ride along with it:
-    /// a spinner on the field's trailing side while a suggestion is generated,
-    /// and — when the user edited the title before it arrived — the suggestion
-    /// itself below the field, tappable to apply.
     private var titleSection: some View {
         VStack(spacing: EditConstants.suggestionSpacing) {
             textField

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -25,8 +25,7 @@ class BookmarkEditViewModel: ObservableObject {
     /// A title suggestion generated from the transcript around the bookmark's position
     @Published private(set) var titleSuggestion: TitleSuggestion = .none
 
-    /// Emits a generated title that should directly replace the field's text,
-    /// because the user hasn't edited it yet.
+    /// Emits a generated title that should directly replace the field's text (the user hasn't edited it yet)
     let autoApplySuggestion = PassthroughSubject<String, Never>()
 
     private let bookmarkManager: BookmarkManager
@@ -67,9 +66,6 @@ class BookmarkEditViewModel: ObservableObject {
 
     // MARK: - Title Suggestion
 
-    /// Kicks off generating a title suggestion for a newly created bookmark
-    /// from the transcript text around its position. Fails silently — the
-    /// suggestion simply never appears.
     private func generateTitleSuggestion() {
         guard editState == .adding, BookmarkManager.isTitleSuggestionEnabled else { return }
 
@@ -87,8 +83,7 @@ class BookmarkEditViewModel: ObservableObject {
                 }
 
                 if self.userHasEditedTitle {
-                    // Never replace the user's own words — offer the
-                    // suggestion below the field instead.
+                    // Never replace the user's own words — offer the suggestion instead
                     self.titleSuggestion = .available(trimmed)
                 } else {
                     self.titleSuggestion = .none
@@ -98,26 +93,18 @@ class BookmarkEditViewModel: ObservableObject {
         }
     }
 
-    /// The view calls this when the user changes the title themselves, so an
-    /// arriving suggestion is offered rather than applied.
     func userDidEditTitle() {
         userHasEditedTitle = true
     }
 
-    /// The view calls this once it has consumed the current suggestion
-    /// (applied it to the title field).
+    /// The view calls this once it has applied the current suggestion to the title field
     func suggestionHandled() {
         titleSuggestion = .none
     }
 
     enum TitleSuggestion: Equatable {
-        /// Nothing to show: suggestions are disabled, generation failed, or the suggestion was consumed
         case none
-
-        /// A suggestion is being generated
         case generating
-
-        /// A suggestion is ready and waiting for the user to accept it
         case available(String)
     }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import PocketCastsDataModel
 
@@ -21,8 +22,18 @@ class BookmarkEditViewModel: ObservableObject {
 
     @Published var didAppear = false
 
+    /// A title suggestion generated from the transcript around the bookmark's position
+    @Published private(set) var titleSuggestion: TitleSuggestion = .none
+
+    /// Emits a generated title that should directly replace the field's text,
+    /// because the user hasn't edited it yet.
+    let autoApplySuggestion = PassthroughSubject<String, Never>()
+
     private let bookmarkManager: BookmarkManager
     private let bookmark: Bookmark
+
+    private var suggestionTask: Task<Void, Never>?
+    private var userHasEditedTitle = false
 
     var analyticsSource: BookmarkAnalyticsSource = .unknown
 
@@ -42,19 +53,83 @@ class BookmarkEditViewModel: ObservableObject {
             headerSubTitle = L10n.changeBookmarkSubtitle
             saveButtonTitle = L10n.changeBookmarkTitle
         }
+
+        generateTitleSuggestion()
+    }
+
+    deinit {
+        suggestionTask?.cancel()
     }
 
     func viewDidAppear() {
         didAppear = true
     }
 
+    // MARK: - Title Suggestion
+
+    /// Kicks off generating a title suggestion for a newly created bookmark
+    /// from the transcript text around its position. Fails silently — the
+    /// suggestion simply never appears.
+    private func generateTitleSuggestion() {
+        guard editState == .adding, BookmarkManager.isTitleSuggestionEnabled else { return }
+
+        titleSuggestion = .generating
+        suggestionTask = Task { [weak self, bookmarkManager, bookmark, maxTitleLength] in
+            let suggestion = await bookmarkManager.suggestTitle(for: bookmark)
+            guard !Task.isCancelled else { return }
+
+            let trimmed = suggestion.map { String($0.trim().prefix(maxTitleLength)) }
+            await MainActor.run {
+                guard let self else { return }
+                guard let trimmed, !trimmed.isEmpty else {
+                    self.titleSuggestion = .none
+                    return
+                }
+
+                if self.userHasEditedTitle {
+                    // Never replace the user's own words — offer the
+                    // suggestion below the field instead.
+                    self.titleSuggestion = .available(trimmed)
+                } else {
+                    self.titleSuggestion = .none
+                    self.autoApplySuggestion.send(trimmed)
+                }
+            }
+        }
+    }
+
+    /// The view calls this when the user changes the title themselves, so an
+    /// arriving suggestion is offered rather than applied.
+    func userDidEditTitle() {
+        userHasEditedTitle = true
+    }
+
+    /// The view calls this once it has consumed the current suggestion
+    /// (applied it to the title field).
+    func suggestionHandled() {
+        titleSuggestion = .none
+    }
+
+    enum TitleSuggestion: Equatable {
+        /// Nothing to show: suggestions are disabled, generation failed, or the suggestion was consumed
+        case none
+
+        /// A suggestion is being generated
+        case generating
+
+        /// A suggestion is ready and waiting for the user to accept it
+        case available(String)
+    }
+
     // MARK: - View Methods
 
     func cancel() {
+        suggestionTask?.cancel()
         router?.dismiss()
     }
 
     func save(title: String) {
+        suggestionTask?.cancel()
         Task {
             let title = String(title.trim().prefix(maxTitleLength))
 

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -139,4 +139,26 @@ enum FingerprintConstants {
     /// cancelled and the caller falls back to a raw skip, so a pathological decode
     /// can't hang the tap behind an indefinite spinner.
     static let onDemandSeekTimeoutSeconds: TimeInterval = 5
+
+    // MARK: - Bookmark position resolve
+
+    /// Local audio fingerprinted around a bookmark's playback position when
+    /// resolving it to the reference timeline (for transcript snippet
+    /// extraction). Unlike the chapter seek there's no searching involved — the
+    /// audio at the bookmark's playback offset IS the moment we want to
+    /// identify — so the region only needs to be big enough to commit anchors
+    /// bracketing the position (windows are 8s long at a 1s stride, and the
+    /// drift filter needs 3 consecutive rate-1 candidates). Reaches further
+    /// back than forward to mirror the transcript capture window.
+    static let bookmarkResolveBackwardSeconds: Double = 35
+    static let bookmarkResolveForwardSeconds: Double = 10
+
+    /// Minimum committed anchors in the one-shot scratch mapping before a
+    /// resolved reference time is trusted. Mirrors `onDemandSeekMinAnchors`.
+    static let bookmarkResolveMinAnchors: Int = 2
+
+    /// Hard timeout for a one-shot bookmark position resolve. On expiry the
+    /// caller falls back to the raw playback time — snippet alignment degrades
+    /// gracefully instead of stalling title generation.
+    static let bookmarkResolveTimeoutSeconds: TimeInterval = 5
 }

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -142,14 +142,10 @@ enum FingerprintConstants {
 
     // MARK: - Bookmark position resolve
 
-    /// Local audio fingerprinted around a bookmark's playback position when
-    /// resolving it to the reference timeline (for transcript snippet
-    /// extraction). Unlike the chapter seek there's no searching involved — the
-    /// audio at the bookmark's playback offset IS the moment we want to
-    /// identify — so the region only needs to be big enough to commit anchors
-    /// bracketing the position (windows are 8s long at a 1s stride, and the
-    /// drift filter needs 3 consecutive rate-1 candidates). Reaches further
-    /// back than forward to mirror the transcript capture window.
+    /// Local audio region fingerprinted around a bookmark's playback position when
+    /// resolving it to the reference timeline. Unlike the chapter seek there's no
+    /// searching involved, so the region only needs to be big enough to commit
+    /// anchors bracketing the position.
     static let bookmarkResolveBackwardSeconds: Double = 35
     static let bookmarkResolveForwardSeconds: Double = 10
 
@@ -158,7 +154,6 @@ enum FingerprintConstants {
     static let bookmarkResolveMinAnchors: Int = 2
 
     /// Hard timeout for a one-shot bookmark position resolve. On expiry the
-    /// caller falls back to the raw playback time — snippet alignment degrades
-    /// gracefully instead of stalling title generation.
+    /// caller falls back to the raw playback time.
     static let bookmarkResolveTimeoutSeconds: TimeInterval = 5
 }

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -534,6 +534,132 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
+    // MARK: - On-demand bookmark position resolve
+
+    /// Resolve a playback-timeline position (e.g. a bookmark's time) to the
+    /// reference timeline, so reference-timed content like a generated
+    /// transcript can be read at the right spot despite dynamic-ad shifting.
+    ///
+    /// The inverse of the chapter resolve, and simpler: the audio at
+    /// `playbackTime` in the local file IS the moment to identify, so there's
+    /// no search window — we fingerprint a bounded region around it, match
+    /// against the reference, and interpolate. Like `resolvePlaybackTime`
+    /// this is one-shot and side-effect-free: it uses its own matcher,
+    /// cancellation flag, and scratch mapping, and never mutates the
+    /// continuous transcript mapping (`main`), `context`, or `state` — except
+    /// for the warm fast path, which reads the continuous mapping when it
+    /// already confidently covers `playbackTime`.
+    ///
+    /// Returns nil when no reference exists for the episode, the audio region
+    /// isn't local, no confident match is found, or the timeout expires —
+    /// callers should fall back to the raw playback time.
+    func resolveReferenceTime(forPlaybackTime playbackTime: Double, episode: BaseEpisode) async -> Double? {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+        let episodeUuid = episode.uuid
+
+        // Warm fast path: the continuous transcript mapping already brackets
+        // this position with confident anchors — interpolate straight off it.
+        let warm: Double? = queue.sync {
+            guard let ctx = context, ctx.episodeUuid == episodeUuid,
+                  Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: main.playbackToReference) else {
+                return nil
+            }
+            return Self.interpolate(
+                time: playbackTime,
+                in: main.playbackToReference,
+                keyPath: \.playbackTime,
+                valuePath: \.referenceTime
+            )
+        }
+        if let warm { return warm }
+
+        // Hard timeout: the flag is observed once per decoded chunk, so a slow
+        // decode can't stall the caller indefinitely.
+        let flag = CancellationFlag()
+        let timeoutTask = Task {
+            try? await Task.sleep(
+                nanoseconds: UInt64(FingerprintConstants.bookmarkResolveTimeoutSeconds * 1_000_000_000)
+            )
+            flag.cancel()
+        }
+        defer { timeoutTask.cancel() }
+
+        // Resolve reference data: warm context → disk → server.
+        var referenceData: Data? = queue.sync {
+            guard let ctx = context, ctx.episodeUuid == episodeUuid else { return nil }
+            return ctx.referenceData
+        }
+        referenceData = referenceData ?? loadReference(for: episode)?.data
+        if referenceData == nil {
+            referenceData = await FingerprintReferenceRetriever.shared.fetchReferenceData(
+                podcastUuid: episode.parentIdentifier(),
+                episodeUuid: episodeUuid
+            )
+            if let referenceData { saveReferenceData(referenceData, for: episode) }
+        }
+
+        guard !flag.isCancelled,
+              let referenceData,
+              let reference = ReferenceFingerprint.decode(from: referenceData) else {
+            return nil
+        }
+
+        let duration = episode.duration
+        guard duration > 0,
+              let (matcher, _) = buildMatcher(from: reference, episodeUuid: episodeUuid, audioDuration: duration) else {
+            return nil
+        }
+
+        let start = Self.alignToWindowGrid(
+            max(0, playbackTime - FingerprintConstants.bookmarkResolveBackwardSeconds)
+        )
+        let end = playbackTime + FingerprintConstants.bookmarkResolveForwardSeconds
+
+        let audioURL: URL
+        switch resolveAudioSource(for: episode) {
+        case .downloaded(let url), .streaming(let url):
+            audioURL = url
+        }
+
+        // Fingerprint + match the bounded region into a local scratch
+        // accumulator on `onDemandQueue`; matching stays serialized on `queue`
+        // inside `streamFingerprintBounded`. `main` is never touched.
+        let scratch: MappingAccumulator? = await withCheckedContinuation { continuation in
+            onDemandQueue.async {
+                var acc = MappingAccumulator()
+                do {
+                    try self.streamFingerprintBounded(
+                        audioFileURL: audioURL,
+                        startSeconds: start,
+                        endSeconds: end,
+                        matcher: matcher,
+                        flag: flag,
+                        into: &acc
+                    )
+                    continuation.resume(returning: acc)
+                } catch {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+
+        guard let scratch,
+              scratch.playbackToReference.count >= FingerprintConstants.bookmarkResolveMinAnchors,
+              let referenceTime = Self.interpolate(
+                  time: playbackTime,
+                  in: scratch.playbackToReference,
+                  keyPath: \.playbackTime,
+                  valuePath: \.referenceTime
+              ) else {
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: bookmark resolve found no confident match "
+                    + "at playback \(String(format: "%.1f", playbackTime))s for \(episodeUuid)"
+            )
+            return nil
+        }
+        return referenceTime
+    }
+
     #if DEBUG
     var totalDuration: Double? {
         dispatchPrecondition(condition: .notOnQueue(queue))

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -536,29 +536,22 @@ final class FingerprintTimingManager: NSObject {
 
     // MARK: - On-demand bookmark position resolve
 
-    /// Resolve a playback-timeline position (e.g. a bookmark's time) to the
+    /// Resolves a playback-timeline position (e.g. a bookmark's time) to the
     /// reference timeline, so reference-timed content like a generated
     /// transcript can be read at the right spot despite dynamic-ad shifting.
     ///
-    /// The inverse of the chapter resolve, and simpler: the audio at
-    /// `playbackTime` in the local file IS the moment to identify, so there's
-    /// no search window — we fingerprint a bounded region around it, match
-    /// against the reference, and interpolate. Like `resolvePlaybackTime`
-    /// this is one-shot and side-effect-free: it uses its own matcher,
-    /// cancellation flag, and scratch mapping, and never mutates the
-    /// continuous transcript mapping (`main`), `context`, or `state` — except
-    /// for the warm fast path, which reads the continuous mapping when it
-    /// already confidently covers `playbackTime`.
+    /// Like `resolvePlaybackTime` this is one-shot and side-effect-free: it uses
+    /// its own matcher, cancellation flag, and scratch mapping, and never mutates
+    /// the continuous transcript mapping (`main`), `context`, or `state`.
     ///
-    /// Returns nil when no reference exists for the episode, the audio region
-    /// isn't local, no confident match is found, or the timeout expires —
-    /// callers should fall back to the raw playback time.
+    /// Returns nil when no confident match is found (no reference, audio not
+    /// local, timeout) — callers should fall back to the raw playback time.
     func resolveReferenceTime(forPlaybackTime playbackTime: Double, episode: BaseEpisode) async -> Double? {
         dispatchPrecondition(condition: .notOnQueue(queue))
         let episodeUuid = episode.uuid
 
-        // Warm fast path: the continuous transcript mapping already brackets
-        // this position with confident anchors — interpolate straight off it.
+        // Warm fast path: interpolate off the continuous transcript mapping when
+        // it already confidently covers this position.
         let warm: Double? = queue.sync {
             guard let ctx = context, ctx.episodeUuid == episodeUuid,
                   Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: main.playbackToReference) else {
@@ -573,8 +566,7 @@ final class FingerprintTimingManager: NSObject {
         }
         if let warm { return warm }
 
-        // Hard timeout: the flag is observed once per decoded chunk, so a slow
-        // decode can't stall the caller indefinitely.
+        // Hard timeout, observed once per decoded chunk
         let flag = CancellationFlag()
         let timeoutTask = Task {
             try? await Task.sleep(
@@ -621,9 +613,8 @@ final class FingerprintTimingManager: NSObject {
             audioURL = url
         }
 
-        // Fingerprint + match the bounded region into a local scratch
-        // accumulator on `onDemandQueue`; matching stays serialized on `queue`
-        // inside `streamFingerprintBounded`. `main` is never touched.
+        // Fingerprint + match the bounded region into a local scratch accumulator;
+        // matching stays serialized on `queue` inside `streamFingerprintBounded`.
         let scratch: MappingAccumulator? = await withCheckedContinuation { continuation in
             onDemandQueue.async {
                 var acc = MappingAccumulator()

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4495,6 +4495,9 @@
 /* The default title to use for a bookmark */
 "bookmark_default_title" = "Bookmark";
 
+/* Accessibility label for a tappable bookmark title suggestion generated from the episode transcript. '%1$@' is the suggested title. */
+"bookmark_suggested_title" = "Suggested title: %1$@";
+
 /* The title of a view where the user can edit their bookmark title */
 "change_bookmark_title" = "Change title";
 


### PR DESCRIPTION
Fixes PCIOS-838

Generates a title suggestion for newly created bookmarks from the transcript around the bookmark position. Stacked on #4766, gated on `FeatureFlag.smartBookmarks` (debug-only).

- **Snippet extraction** (`BookmarkTranscriptSnippetExtractor`): 25s back / 5s forward of the bookmark (backward-weighted for reaction time), snapped to sentence boundaries, ≥10-word guard. For generated transcripts, playback time is first resolved to the reference timeline via a one-shot fingerprint match (`FingerprintTimingManager.resolveReferenceTime`), falling back to the raw time.
- **Generation**: on-device Foundation Models first, server enrich fallback (`BookmarkManager.generateTitle`). The on-device enricher now produces **only the title, as a plain string**: [`.permissiveContentTransformations`](https://developer.apple.com/documentation/foundationmodels/systemlanguagemodel/guardrails/permissivecontenttransformations) — needed so transcripts on heavy topics aren't rejected with "May contain sensitive content" — only applies to plain string output, not `@Generable` guided generation. The summary wasn't used anyway.
- **UI (temporary)**: spinner on the right side of the title while generating; the suggestion replaces the default title if untouched, otherwise shows as a tappable row under the field. The loading behavior hasn't been specified yet, so treat this UX as a placeholder.

## To test

1. Build the Staging scheme on an iOS 26+ device with Apple Intelligence enabled, logged in with a staging account (for the server fallback).
2. Play an episode with a transcript and create a bookmark from the player.
3. Verify a spinner appears at the right of the default title, then the suggested title replaces it.
4. Create another bookmark and start typing before generation finishes — the suggestion should appear under the field, and tapping it applies it.
5. Create a bookmark on an episode without a transcript — the default title stays and the sheet behaves as before.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)