### PR TITLE
tvOS: Ignore analytics events from the initial seek on opening Now Playing

### DIFF
--- a/Pocket Casts TV App/UI/Player/NowPlayingView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingView.swift
@@ -200,6 +200,7 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
                 state: speed == model.playbackSpeed ? .on : .off
             ) { action in
                 model.playbackSpeed = speed
+                AnalyticsPlaybackHelper.shared.currentSource = .player
                 AnalyticsPlaybackHelper.shared.playbackSpeedChanged(to: speed)
                 if let menu = action.sender as? UIMenu {
                     menu.children.compactMap { $0 as? UIAction }.forEach { $0.state = .off }
@@ -219,11 +220,13 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
         let volumeBoostOff = UIAction(title: L10n.off, state: model.volumeBoost ? .off : .on) { _ in
             ToastManager.shared.show(L10n.tvPlayerVolumeBoostOff)
             model.volumeBoost = false
+            AnalyticsPlaybackHelper.shared.currentSource = .player
             AnalyticsPlaybackHelper.shared.volumeBoostToggled(enabled: false)
         }
         let volumeBoostOn = UIAction(title: L10n.on, state: model.volumeBoost ? .on : .off) { _ in
             ToastManager.shared.show(L10n.tvPlayerVolumeBoostOn)
             model.volumeBoost = true
+            AnalyticsPlaybackHelper.shared.currentSource = .player
             AnalyticsPlaybackHelper.shared.volumeBoostToggled(enabled: true)
         }
         let volumeBoostSection = UIMenu(
@@ -238,6 +241,7 @@ private struct NowPlayingPlayerRepresentable: UIViewControllerRepresentable {
             let trimActions = TrimSilenceAmount.allCases.map { option in
                 UIAction(title: option.description, state: model.trimSilence == option ? .on : .off) { _ in
                     model.trimSilence = option
+                    AnalyticsPlaybackHelper.shared.currentSource = .player
                     AnalyticsPlaybackHelper.shared.trimSilenceAmountChanged(amount: option)
                     ToastManager.shared.show(L10n.tvPlayerTrimSilenceSet(option.description))
                 }

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -122,6 +122,7 @@ class NowPlayingViewModel: Identifiable {
             seekAfterLoad = false
             // The delay is needed only for videos episodes.
             // For some reason the AVPlayerViewController does not accept seeks immediately after loading, and resets the position to zero
+            PlayerStatusObserver.shared.skipNextEvents(2)
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now().advanced(by: .seconds(1))) { [weak self] in
                 self?.playbackManager.seekToStartingPosition()
             }

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -122,9 +122,10 @@ class NowPlayingViewModel: Identifiable {
             seekAfterLoad = false
             // The delay is needed only for videos episodes.
             // For some reason the AVPlayerViewController does not accept seeks immediately after loading, and resets the position to zero
-            PlayerStatusObserver.shared.skipNextEvents(2)
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now().advanced(by: .seconds(1))) { [weak self] in
-                self?.playbackManager.seekToStartingPosition()
+                guard let self else { return }
+                PlayerStatusObserver.shared.skipNextEvents(2)
+                playbackManager.seekToStartingPosition()
             }
         }
     }

--- a/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
+++ b/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
@@ -11,7 +11,7 @@ class PlayerStatusObserver {
     private var timeControlStatusObservation: NSKeyValueObservation?
     private var previousTimeStatus: AVPlayer.TimeControlStatus?
 
-    private var skipNextEvents: UInt = 0
+    private var remainingEventsToSkip: UInt = 0
 
     private init() {
     }
@@ -34,7 +34,7 @@ class PlayerStatusObserver {
     }
 
     func skipNextEvents(_ amount: UInt) {
-        skipNextEvents = amount
+        remainingEventsToSkip = amount
     }
 
     private func updatePlayState() {
@@ -54,8 +54,8 @@ class PlayerStatusObserver {
         }
         previousTimeStatus = currentTimeStatus
 
-        if skipNextEvents > 0 {
-            skipNextEvents -= 1
+        if remainingEventsToSkip > 0 {
+            remainingEventsToSkip -= 1
             return
         }
 

--- a/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
+++ b/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
@@ -54,7 +54,7 @@ class PlayerStatusObserver {
         }
         previousTimeStatus = currentTimeStatus
 
-        if remainingEventsToSkip > 0 {
+        if remainingEventsToSkip > 0, currentTimeStatus == .playing || currentTimeStatus == .paused {
             remainingEventsToSkip -= 1
             return
         }

--- a/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
+++ b/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
@@ -11,6 +11,8 @@ class PlayerStatusObserver {
     private var timeControlStatusObservation: NSKeyValueObservation?
     private var previousTimeStatus: AVPlayer.TimeControlStatus?
 
+    private var skipNextEvents: UInt = 0
+
     private init() {
     }
 
@@ -31,6 +33,10 @@ class PlayerStatusObserver {
         }
     }
 
+    func skipNextEvents(_ amount: UInt) {
+        skipNextEvents = amount
+    }
+
     private func updatePlayState() {
         guard let player else {
             return
@@ -42,6 +48,11 @@ class PlayerStatusObserver {
             return
         }
 
+        if skipNextEvents > 0 {
+            skipNextEvents -= 1
+            return
+        }
+        
         guard previousTimeStatus != currentTimeStatus, previousTimeStatus == .paused || previousTimeStatus == .playing else {
             previousTimeStatus = currentTimeStatus
             return

--- a/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
+++ b/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
@@ -52,7 +52,7 @@ class PlayerStatusObserver {
             skipNextEvents -= 1
             return
         }
-        
+
         guard previousTimeStatus != currentTimeStatus, previousTimeStatus == .paused || previousTimeStatus == .playing else {
             previousTimeStatus = currentTimeStatus
             return

--- a/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
+++ b/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
@@ -48,16 +48,16 @@ class PlayerStatusObserver {
             return
         }
 
-        if skipNextEvents > 0 {
-            skipNextEvents -= 1
-            return
-        }
-
         guard previousTimeStatus != currentTimeStatus, previousTimeStatus == .paused || previousTimeStatus == .playing else {
             previousTimeStatus = currentTimeStatus
             return
         }
         previousTimeStatus = currentTimeStatus
+
+        if skipNextEvents > 0 {
+            skipNextEvents -= 1
+            return
+        }
 
         if let interval = AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction?.timeIntervalSinceNow,
              abs(interval) < 1 {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -242,6 +242,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     func seekToStartingPosition() {
         let startingTime = requiredStartingPosition()
         player?.play { [weak self] in
+            self?.analyticsPlaybackHelper.currentSource = .sync
             self?.seekTo(time: startingTime, startPlaybackAfterSeek: false)
             self?.player?.pause()
         }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

On tvOS, opening the Now Playing screen triggers an initial seek to the episode's saved starting position. That programmatic play → seek → pause sequence was being picked up by the player observers and reported as spurious play/pause and seek analytics events, polluting playback analytics.

This PR suppresses those events on the initial seek:

- **`PlayerStatusObserver`** gains a `skipNextEvents(_:)` control so the KVO play-state observer can ignore the next N `timeControlStatus` transitions. `NowPlayingViewModel` calls `skipNextEvents(2)` right before triggering `seekToStartingPosition()`, so the play/pause pair from the initial seek isn't tracked.
- **`PlaybackManager.seekToStartingPosition()`** sets `analyticsPlaybackHelper.currentSource = .sync` before seeking, so the seek itself is treated as a sync-driven seek and not reported (reusing the existing `.sync` suppression path in `AnalyticsPlaybackHelper.seek`).

## To test

1. On a tvOS device/simulator, subscribe to a podcast and start playing an episode, then leave it partway through so it has a saved position.
2. Navigate away and re-open the episode's Now Playing screen.
3. Observe that the player resumes at the saved position after the initial seek.
4. With analytics logging enabled, confirm that opening Now Playing does **not** emit spurious `playback_play` / `playback_pause` / seek events for the automatic initial seek.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
