### PR TITLE
Enable HLS streaming playback flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.17
 -----
+- Enable HLS streaming playback [#4775](https://github.com/Automattic/pocket-casts-ios/pull/4775)
 - Fix intro-skipped time not syncing to your account when it is the only listening stat that changed [#4755](https://github.com/Automattic/pocket-casts-ios/pull/4755)
 - Fix Up Next multi-select keeping episodes selected after they leave the queue, causing a wrong count and bulk actions on episodes no longer queued [#4709](https://github.com/Automattic/pocket-casts-ios/pull/4709)
 - Fix the Help & Feedback screen following the system/in-app dark theme and using incorrect colors in the navigation bar [#4698](https://github.com/Automattic/pocket-casts-ios/pull/4698)

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -535,7 +535,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .generatedChapters:
             BuildEnvironment.current == .debug
         case .hls:
-            BuildEnvironment.current == .debug
+            true
         case .troubleshooting:
             true
         case .smartBookmarks:


### PR DESCRIPTION
Flips the `hls` feature flag default from debug-only to `true`, enabling HLS streaming playback in all build environments.

## To test

1. Build the app on a release/staging configuration.
2. Verify the `hls` feature flag is enabled by default (Settings → Developer / feature flag overrides).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics.