### PR TITLE
Homogenize milestone error handling across the release lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -462,8 +462,20 @@ platform :ios do
     UI.success "Done! New Build Code: #{build_code_current}"
 
     # Wrap up
-    set_milestone_frozen_marker(repository: GITHUB_REPO, milestone: release_version_current, freeze: false)
-    close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
+    begin
+      set_milestone_frozen_marker(repository: GITHUB_REPO, milestone: release_version_current, freeze: false)
+      close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
+    rescue StandardError => e
+      error_message = <<-MESSAGE
+        Error closing milestone `#{release_version_current}`: #{e.message}
+
+        - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.
+        - Otherwise if this is the first you are running the release task for this version, please investigate the error.
+      MESSAGE
+
+      UI.error(error_message)
+      buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci
+    end
 
     create_backmerge_pr
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1347,7 +1347,7 @@ platform :ios do
         CREATE_GITHUB_RELEASE: create_release
       }
     }
-    if is_ci?
+    if is_ci
       buildkite_pipeline_upload(**pipeline_args)
     else
       require_env_vars!('BUILDKITE_TOKEN')
@@ -1584,7 +1584,7 @@ platform :ios do
     MESSAGE
 
     UI.error(error_message)
-    buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci?
+    buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci
   end
 
   # Private helper to create backmerge Pull Requests after new betas or final build

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -466,15 +466,7 @@ platform :ios do
       set_milestone_frozen_marker(repository: GITHUB_REPO, milestone: release_version_current, freeze: false)
       close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
     rescue StandardError => e
-      error_message = <<-MESSAGE
-        Error closing milestone `#{release_version_current}`: #{e.message}
-
-        - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.
-        - Otherwise if this is the first you are running the release task for this version, please investigate the error.
-      MESSAGE
-
-      UI.error(error_message)
-      buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci
+      report_milestone_error(error_title: "Error closing the milestone `#{release_version_current}`: #{e.message}")
     end
 
     create_backmerge_pr
@@ -611,7 +603,7 @@ platform :ios do
     begin
       close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
     rescue StandardError => e
-      UI.important("Could not find a GitHub milestone for hotfix #{release_version_current} to close: #{e}")
+      report_milestone_error(error_title: "Error closing the milestone `#{release_version_current}` for the hotfix: #{e.message}")
     end
   end
 
@@ -1565,16 +1557,7 @@ platform :ios do
       )
     rescue StandardError => e
       moved_prs = []
-
-      error_message = <<-MESSAGE
-        Error freezing milestone `#{new_version}`: #{e.message}
-
-        - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.
-        - Otherwise if this is the first you are running the release task for this version, please investigate the error.
-      MESSAGE
-
-      UI.error(error_message)
-      buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci
+      report_milestone_error(error_title: "Error freezing the `#{new_version}` milestone: #{e.message}")
     end
 
     UI.message("Moved the following PRs to milestone #{next_version}: #{moved_prs.join(', ')}")
@@ -1587,6 +1570,21 @@ platform :ios do
                          + moved_prs.map { |pr_num| "[##{pr_num}](https://github.com/#{GITHUB_REPO}/pull/#{pr_num})" }.join(', ')
                      end
     buildkite_annotate(style: moved_prs.empty? ? 'success' : 'warning', context: 'start-code-freeze', message: moved_prs_info) if is_ci
+  end
+
+  # Reports a milestone-related error, both in the logs and — on CI — as a Buildkite annotation,
+  # clarifying that the error is expected when the release task is not being run for the first time.
+  #
+  def report_milestone_error(error_title:)
+    error_message = <<-MESSAGE
+      #{error_title}
+
+      - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.
+      - Otherwise if this is the first you are running the release task for this version, please investigate the error.
+    MESSAGE
+
+    UI.error(error_message)
+    buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci?
   end
 
   # Private helper to create backmerge Pull Requests after new betas or final build

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -466,7 +466,7 @@ platform :ios do
       set_milestone_frozen_marker(repository: GITHUB_REPO, milestone: release_version_current, freeze: false)
       close_milestone(repository: GITHUB_REPO, milestone: release_version_current)
     rescue StandardError => e
-      report_milestone_error(error_title: "Error closing the milestone `#{release_version_current}`: #{e.message}")
+      report_milestone_error(error_title: "Error unfreezing or closing the milestone `#{release_version_current}`: #{e.message}")
     end
 
     create_backmerge_pr
@@ -1576,7 +1576,7 @@ platform :ios do
   # clarifying that the error is expected when the release task is not being run for the first time.
   #
   def report_milestone_error(error_title:)
-    error_message = <<-MESSAGE
+    error_message = <<~MESSAGE
       #{error_title}
 
       - If this is not the first time you are running the release task (e.g. retrying because it failed on first attempt), the milestone might have already been closed and this error is expected.


### PR DESCRIPTION
Closes AINFRA-2707

- 🧵 Thread in Slack: p1784280315812929/1784270734.514819-slack-CC7L49W13
- 🔗 Companion PR in pocket-casts-android: https://github.com/Automattic/pocket-casts-android/pull/5600

## Why

Milestone manipulation across the release lanes was handled inconsistently:
 - `finalize_release` called `set_milestone_frozen_marker` + `close_milestone` with no error handling at all, so re-running the lane (when the milestone is already closed or missing) would crash it
 - `finalize_hotfix_release` only logged via `UI.important`; and `code_freeze` (through the `update_milestone` helper) already logged *and* added a Buildkite annotation.

This PR makes all of them behave the same way.

## How

It extracts a `report_milestone_error(error_title:)` helper — mirroring the convention already used in the repos for our other apps — which logs a descriptive warning and, on CI, adds a `warning` Buildkite annotation explaining that the error is expected on a re-run.

Every milestone rescue path (`code_freeze` via `update_milestone`, `finalize_release`, and `finalize_hotfix_release`) now routes through that helper, and the previously-missing `begin/rescue` around `finalize_release` is added.

Note: I also took the occasion to standardize our use of `is_ci?` to `is_ci` (both the one with or without `?` are valid methods in fastlane and alias to one another, so the idea was just to be consistent across our `Fastfile`)

## To test

This only affects release automation, so it can't be exercised from a normal build. To sanity-check the behavior, on a release branch run `bundle exec fastlane finalize_release` (or `finalize_hotfix_release`) a second time, or against a version whose milestone is already closed, and confirm the lane now logs the "Error closing the milestone" warning (plus a `warning` Buildkite annotation on CI) and completes instead of aborting.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. (Not user-facing — release automation only.)
- [x] I have considered adding unit tests for my changes. (Fastlane lanes; not unit-testable in this repo.)
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. (No analytics changes.)
