### PR TITLE
Upload App Store metadata during release finalization

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -440,7 +440,7 @@ platform :ios do
   lane :finalize_release do |skip_confirm: false|
     UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if current_version_hotfix?
 
-    require_env_vars!('GITHUB_TOKEN')
+    require_env_vars!('GITHUB_TOKEN', *ASC_API_KEY_ENV_VARS)
 
     # Verify that there's nothing in progress in the working copy
     ensure_git_status_clean

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,6 +2,7 @@
 
 require 'dotenv'
 require 'open3'
+require 'tmpdir'
 
 fastlane_version '2.0'
 
@@ -430,6 +431,7 @@ platform :ios do
   # app binaries; Releases V2 starts those per-platform tasks separately.
   #
   #  - Refreshes and lints localized strings and App Store Connect metadata
+  #  - Uploads localized App Store metadata for iOS and tvOS, excluding release notes
   #  - Bumps final version number
   #  - Removes branch protection and close milestone
   #
@@ -453,6 +455,8 @@ platform :ios do
 
     download_localized_strings_and_metadata_from_glotpress
     lint_localizations
+    update_metadata_on_app_store_connect(with_release_notes: false)
+    update_metadata_on_app_store_connect_tvos(with_release_notes: false)
 
     # Bump the build code
     UI.message 'Bumping build code...'
@@ -1145,13 +1149,17 @@ platform :ios do
   # Upload the localized iOS metadata (from `fastlane/metadata/`) to App Store Connect
   #
   # @param with_screenshots [Boolean] If true, will also upload the latest screenshot files to ASC (default: false)
+  # @param with_release_notes [Boolean] If true, will also upload localized release notes (default: true)
   #
-  lane :update_metadata_on_app_store_connect do |with_screenshots: false|
+  lane :update_metadata_on_app_store_connect do |with_screenshots: false, with_release_notes: true|
+    require_env_vars!(*ASC_API_KEY_ENV_VARS)
+
     upload_metadata_to_app_store_connect(
       platform: 'ios',
       metadata_path: APP_STORE_METADATA_FOLDER,
       screenshots_path: APP_STORE_SCREENSHOTS_FOLDER,
-      with_screenshots: with_screenshots
+      with_screenshots: with_screenshots,
+      with_release_notes: with_release_notes
     )
   end
 
@@ -1161,13 +1169,17 @@ platform :ios do
   # once tvOS screenshots are present in `fastlane/screenshots-tvos/`.
   #
   # @param with_screenshots [Boolean] If true, will also upload the latest screenshot files to ASC (default: false)
+  # @param with_release_notes [Boolean] If true, will also upload localized release notes (default: true)
   #
-  lane :update_metadata_on_app_store_connect_tvos do |with_screenshots: false|
+  lane :update_metadata_on_app_store_connect_tvos do |with_screenshots: false, with_release_notes: true|
+    require_env_vars!(*ASC_API_KEY_ENV_VARS)
+
     upload_metadata_to_app_store_connect(
       platform: 'appletvos',
       metadata_path: APP_STORE_TVOS_METADATA_FOLDER,
       screenshots_path: APP_STORE_TVOS_SCREENSHOTS_FOLDER,
-      with_screenshots: with_screenshots
+      with_screenshots: with_screenshots,
+      with_release_notes: with_release_notes
     )
   end
 
@@ -1503,12 +1515,21 @@ platform :ios do
   # @param metadata_path [String] Path to the Fastlane deliver metadata folder for this platform
   # @param screenshots_path [String] Path to the Fastlane deliver screenshots folder for this platform
   # @param with_screenshots [Boolean] If true, will also upload the latest screenshot files to ASC
+  # @param with_release_notes [Boolean] If true, will also upload localized release notes
   #
-  def upload_metadata_to_app_store_connect(platform:, metadata_path:, screenshots_path:, with_screenshots:)
+  def upload_metadata_to_app_store_connect(platform:, metadata_path:, screenshots_path:, with_screenshots:, with_release_notes:)
     # Skip screenshots by default. The naming is "with" to make it clear that
     # callers need to opt-in to adding screenshots. The naming of the deliver
     # (upload_to_app_store) parameter, on the other hand, uses the skip verb.
     skip_screenshots = with_screenshots == false
+
+    temporary_metadata_path = nil
+    unless with_release_notes
+      temporary_metadata_path = Dir.mktmpdir('pocket-casts-app-store-metadata')
+      FileUtils.cp_r(File.join(metadata_path, '.'), temporary_metadata_path)
+      Dir.glob(File.join(temporary_metadata_path, '**', 'release_notes.txt')).each { |path| FileUtils.rm_f(path) }
+      metadata_path = temporary_metadata_path
+    end
 
     upload_to_app_store(
       app_identifier: APP_BUNDLE_IDENTIFIER_APP_STORE,
@@ -1523,6 +1544,8 @@ platform :ios do
       precheck_include_in_app_purchases: false,
       api_key: app_store_connect_api_key
     )
+  ensure
+    FileUtils.remove_entry(temporary_metadata_path) unless temporary_metadata_path.nil?
   end
 
   # Update the milestone of still-open PRs

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1523,6 +1523,8 @@ platform :ios do
     # (upload_to_app_store) parameter, on the other hand, uses the skip verb.
     skip_screenshots = with_screenshots == false
 
+    # Fastlane loads every release_notes.txt in metadata_path and cannot skip only release notes.
+    # Use a filtered copy to upload the remaining metadata without changing the existing release notes.
     temporary_metadata_path = nil
     unless with_release_notes
       temporary_metadata_path = Dir.mktmpdir('pocket-casts-app-store-metadata')


### PR DESCRIPTION
Uploads localized iOS and tvOS App Store metadata during release finalization, immediately after downloading translations from GlotPress.

Release notes remain excluded (for now) so their existing manual process is unchanged. Binary and TestFlight uploads also remain separate.

## To test

In the next release cycle, verify `finalize_release` invokes both metadata upload lanes with `with_release_notes: false`.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.