### PR TITLE
Fix VoiceOver decrement crash on the first share style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix misaligned time values in the Stats screen's Time Saved rows; they are now right-aligned and no longer wrap when there is enough space [#4754](https://github.com/Automattic/pocket-casts-ios/pull/4754)
 - Fix the Stats screen getting stuck loading when the stats request fails [#4753](https://github.com/Automattic/pocket-casts-ios/pull/4753)
 - Fix the mini player showing empty and stuck after opening the app from an episode notification or a deep link while the full-screen player was open [#4757](https://github.com/Automattic/pocket-casts-ios/pull/4757)
+- Fix a crash when swiping down with VoiceOver on the first style in the share sheet; it now wraps to the last style [#4783](https://github.com/Automattic/pocket-casts-ios/pull/4783)
 
 8.16
 -----

--- a/podcasts/Sharing/SharingView.swift
+++ b/podcasts/Sharing/SharingView.swift
@@ -174,7 +174,7 @@ struct SharingView: View {
                 case .increment:
                     nextIndex = currentIndex.advanced(by: 1) % styles.count
                 case .decrement:
-                    nextIndex = currentIndex.advanced(by: -1) % styles.count
+                    nextIndex = (currentIndex - 1 + styles.count) % styles.count
                 default:
                     nextIndex = nil
                 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

In the sharing view, the VoiceOver adjustable action computed the previous tab index as `(currentIndex - 1) % styles.count`. Swift's `%` is a remainder operator that keeps the sign of the dividend, so at index 0 it returns `-1`, and `styles[-1]` crashes with index-out-of-range when a VoiceOver user swipes down on the first style.

The fix uses `(currentIndex - 1 + styles.count) % styles.count`: adding `count` first keeps the dividend non-negative, so the result is always in `0..<count` and decrementing from the first style wraps to the last one.

## To test

1. Enable VoiceOver
2. Open an episode and tap Share
3. Focus the share style carousel
4. With the first style selected, swipe down (decrement) — the selection should wrap to the last style instead of crashing

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)