### PR TITLE
tvOS: Add missing analytics events

### DIFF
--- a/Pocket Casts TV App/PocketCastsTVApp.swift
+++ b/Pocket Casts TV App/PocketCastsTVApp.swift
@@ -12,7 +12,6 @@ struct PocketCastsTVApp: App {
         DataLossSimulator.simulateIfRequested()
 
         AnalyticsSetup.setupIfNeeded()
-        _ = appLifecycleAnalytics.checkApplicationInstalledOrUpgraded()
     }
 
     var body: some Scene {

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -74,6 +74,7 @@ struct HomeView: View {
                         lovedByListenersOfRow
                         trendingRow
                         BannerRow(type: .discoverMore, focusSection: Section.homeBanner.rawValue) {
+                            Analytics.track(.bannerRowTapped, properties: ["type": "discover_more"])
                             tabRouter.selectedTab = .search
                         }
                     } else {

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -81,12 +81,14 @@ struct HomeView: View {
                         featuredRow
                         videoRow
                         BannerRow(type: .createAccount, focusSection: Section.homeBanner.rawValue) {
+                            Analytics.track(.bannerRowTapped, properties: ["type": "create_account"])
                             tabRouter.pendingAuthFlow = .createAccount
                         }
                         trendingRow
                         categoriesRow
                         curatedRow
                         BannerRow(type: .discoverMore, focusSection: Section.homeBanner.rawValue) {
+                            Analytics.track(.bannerRowTapped, properties: ["type": "discover_more"])
                             tabRouter.selectedTab = .search
                         }
                     }

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -6,7 +6,6 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
 
     @Bindable var model: ViewModel
     @State private var searchText = ""
-    @State private var didTrackShown = false
 
     @State private var path = StackPath()
 
@@ -54,8 +53,6 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
                 Analytics.track(.searchFilterTapped, properties: ["source": "search", "filter": newValue.analyticsDescription])
             }
             .onAppear {
-                guard !didTrackShown else { return }
-                didTrackShown = true
                 Analytics.track(.searchShown, properties: ["source": "search"])
             }
         }

--- a/Pocket Casts TV App/UI/WelcomeView.swift
+++ b/Pocket Casts TV App/UI/WelcomeView.swift
@@ -53,6 +53,7 @@ struct WelcomeView: View {
                     Spacer()
                     Button(L10n.tvWelcomeBrowseWithoutAccount) {
                         coordinator.state = .browsing
+                        Analytics.track(.browseNoAccountTapped)
                     }
                 }
             }

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -1049,4 +1049,9 @@ enum AnalyticsEvent: String {
     case deviceSetupAccountTapped
     case deviceApproveSuccessful
     case deviceApproveFailed
+
+    // MARK: TV
+
+    case browseNoAccountTapped
+    case bannerRowTapped
 }

--- a/podcasts/Analytics/AppLifecyleAnalytics.swift
+++ b/podcasts/Analytics/AppLifecyleAnalytics.swift
@@ -25,7 +25,7 @@ extension AppLifecycleAnalytics {
     /// Drives the open/closed events from SwiftUI `scenePhase` changes, for apps
     /// that use the SwiftUI app lifecycle instead of an `AppDelegate` (e.g. tvOS).
     func handle(scenePhase: ScenePhase) {
-        let _ = checkApplicationInstalledOrUpgraded()
+        _ = checkApplicationInstalledOrUpgraded()
         switch scenePhase {
         case .active:
             didBecomeActive()

--- a/podcasts/Analytics/AppLifecyleAnalytics.swift
+++ b/podcasts/Analytics/AppLifecyleAnalytics.swift
@@ -25,9 +25,9 @@ extension AppLifecycleAnalytics {
     /// Drives the open/closed events from SwiftUI `scenePhase` changes, for apps
     /// that use the SwiftUI app lifecycle instead of an `AppDelegate` (e.g. tvOS).
     func handle(scenePhase: ScenePhase) {
-        _ = checkApplicationInstalledOrUpgraded()
         switch scenePhase {
         case .active:
+            _ = checkApplicationInstalledOrUpgraded()
             didBecomeActive()
         case .background:
             didEnterBackground()

--- a/podcasts/Analytics/AppLifecyleAnalytics.swift
+++ b/podcasts/Analytics/AppLifecyleAnalytics.swift
@@ -25,6 +25,7 @@ extension AppLifecycleAnalytics {
     /// Drives the open/closed events from SwiftUI `scenePhase` changes, for apps
     /// that use the SwiftUI app lifecycle instead of an `AppDelegate` (e.g. tvOS).
     func handle(scenePhase: ScenePhase) {
+        let _ = checkApplicationInstalledOrUpgraded()
         switch scenePhase {
         case .active:
             didBecomeActive()


### PR DESCRIPTION
This adds several missing analytics events for the tvOS app and fixes a couple of tracking issues:

- Track button taps for **Browse without account** (`browseNoAccountTapped`) and the home **banner rows** (`bannerRowTapped`, with a `type` of `create_account` / `discover_more`).
- Fix the `searchShown` event not being sent — the `didTrackShown` guard was suppressing repeat sends on `onAppear`.
- Check for app install/update on scene activation (moved into the SwiftUI scene-phase handler) so the tvOS app fires `applicationInstalled` / `applicationUpdated`.

## To test

1. Fresh install / update the tvOS app → confirm `applicationInstalled` / `applicationUpdated` fires.
2. On the Home screen, tap the **Create account** and **Discover more** banner rows → confirm `bannerRowTapped` fires with the correct `type`.
3. From the welcome screen, tap **Browse without account** → confirm `browseNoAccountTapped` fires.
4. Open Search → confirm `searchShown` fires each time it appears.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have [updated](https://github.com/Automattic/EventHorizonSchemas/pull/111) (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
