### PR TITLE
Refactor TV Home episode rows into a reusable EpisodesHorizontalList

### DIFF
--- a/Pocket Casts TV App/UI/Home/EpisodesHorizontalList.swift
+++ b/Pocket Casts TV App/UI/Home/EpisodesHorizontalList.swift
@@ -7,7 +7,7 @@ struct EpisodesHorizontalList: View {
     let episodes: [EpisodeRowViewModel]
     let episodeContext: EpisodeActionContext
 
-    let callback: (()->())?
+    let onPlay: () -> Void
 
     var body: some View {
         RowSection(title: title, focusSection: focusSection) {
@@ -20,6 +20,8 @@ struct EpisodesHorizontalList: View {
                     }
                 }
             }
+            // Otherwise the focused-card drop shadow gets clipped at the
+            // scroll-view boundary instead of pooling below the pill.
             .scrollClipDisabled()
         }
     }
@@ -27,7 +29,7 @@ struct EpisodesHorizontalList: View {
     func episodeButton(model: EpisodeRowViewModel) -> some View {
         Button {
             model.play()
-            callback?()
+            onPlay()
         } label: {
             EpisodeRow(model: model, isActive: false)
         }

--- a/Pocket Casts TV App/UI/Home/EpisodesHorizontalList.swift
+++ b/Pocket Casts TV App/UI/Home/EpisodesHorizontalList.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct EpisodesHorizontalList: View {
+
+    let title: String
+    let focusSection: String
+    let episodes: [EpisodeRowViewModel]
+    let episodeContext: EpisodeActionContext
+
+    let callback: (()->())?
+
+    var body: some View {
+        RowSection(title: title, focusSection: focusSection) {
+            ScrollView(.horizontal) {
+                LazyHStack(spacing: 24) {
+                    ForEach(episodes) { episode in
+                        episodeButton(model: episode)
+                            .frame(width: 864)
+                            .setFocus(section: focusSection)
+                    }
+                }
+            }
+            .scrollClipDisabled()
+        }
+    }
+
+    func episodeButton(model: EpisodeRowViewModel) -> some View {
+        Button {
+            model.play()
+            callback?()
+        } label: {
+            EpisodeRow(model: model, isActive: false)
+        }
+        .buttonStyle(EpisodeRowButtonStyle())
+        .episodeContextMenu(model: model, context: episodeContext)
+    }
+}

--- a/Pocket Casts TV App/UI/Home/EpisodesHorizontalList.swift
+++ b/Pocket Casts TV App/UI/Home/EpisodesHorizontalList.swift
@@ -9,13 +9,18 @@ struct EpisodesHorizontalList: View {
 
     let onPlay: () -> Void
 
+    enum Layout {
+        static var buttonSpacing = CGFloat(24)
+        static var buttonWidth = CGFloat(864)
+    }
+
     var body: some View {
         RowSection(title: title, focusSection: focusSection) {
             ScrollView(.horizontal) {
-                LazyHStack(spacing: 24) {
+                LazyHStack(spacing: Layout.buttonSpacing) {
                     ForEach(episodes) { episode in
                         episodeButton(model: episode)
-                            .frame(width: 864)
+                            .frame(width: Layout.buttonWidth)
                             .setFocus(section: focusSection)
                     }
                 }

--- a/Pocket Casts TV App/UI/Home/EpisodesHorizontalList.swift
+++ b/Pocket Casts TV App/UI/Home/EpisodesHorizontalList.swift
@@ -42,3 +42,15 @@ struct EpisodesHorizontalList: View {
         .episodeContextMenu(model: model, context: episodeContext)
     }
 }
+
+#Preview {
+    EpisodesHorizontalList(title: "Episode",
+                           focusSection: "Episodes",
+                           episodes: MockData.makeStubEpisodes().map({EpisodeRowViewModel(episode: $0, podcast: nil, source: .unknown)}),
+                           episodeContext: .other(showGoToPodcast: true)) {
+        //no-op
+    }
+    .environment(AppCoordinator())
+    .environment(MainTabViewModel())
+    .environment(FocusStore())
+}

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -167,9 +167,12 @@ struct HomeView: View {
         }
     }
 
+    @ViewBuilder
     var newReleasesRow: some View {
-        EpisodesHorizontalList(title: L10n.tvHomeNewReleases, focusSection: Section.homeNewReleases.rawValue, episodes: model.newReleases, episodeContext: .other(showGoToPodcast: true)) {
-            showNowPlayingPlayer = true
+        if !model.newReleases.isEmpty {
+            EpisodesHorizontalList(title: L10n.tvHomeNewReleases, focusSection: Section.homeNewReleases.rawValue, episodes: model.newReleases, episodeContext: .other(showGoToPodcast: true)) {
+                showNowPlayingPlayer = true
+            }
         }
     }
 }

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -161,58 +161,16 @@ struct HomeView: View {
     @ViewBuilder
     var upNextRow: some View {
         if model.upNext.count > 1 {
-            RowSection(title: L10n.tvTabUpNext, focusSection: Section.homeUpNext.rawValue) {
-                ScrollView(.horizontal) {
-                    LazyHStack(spacing: 24) {
-                        ForEach(model.upNext) { episode in
-                            upNextButton(model: episode)
-                                .frame(width: 864)
-                                .setFocus(section: Section.homeUpNext.rawValue)
-                        }
-                    }
-                }
-                // Otherwise the focused-card drop shadow gets clipped at the
-                // scroll-view boundary instead of pooling below the pill.
-                .scrollClipDisabled()
+            EpisodesHorizontalList(title: L10n.tvTabUpNext, focusSection: Section.homeUpNext.rawValue, episodes: model.upNext, episodeContext: .upNext) {
+                showNowPlayingPlayer = true
             }
         }
-    }
-
-    func upNextButton(model: EpisodeRowViewModel) -> some View {
-        Button {
-            model.play()
-            showNowPlayingPlayer = true
-        } label: {
-            EpisodeRow(model: model, isActive: false)
-        }
-        .buttonStyle(EpisodeRowButtonStyle())
-        .episodeContextMenu(model: model, context: .upNext)
     }
 
     var newReleasesRow: some View {
-        RowSection(title: L10n.tvHomeNewReleases, focusSection: Section.homeNewReleases.rawValue) {
-            ScrollView(.horizontal) {
-                LazyHStack(spacing: 24) {
-                    ForEach(model.newReleases) { episode in
-                        newReleaseButton(model: episode)
-                            .frame(width: 864)
-                            .setFocus(section: Section.homeNewReleases.rawValue)
-                    }
-                }
-            }
-            .scrollClipDisabled()
-        }
-    }
-
-    func newReleaseButton(model: EpisodeRowViewModel) -> some View {
-        Button {
-            model.play()
+        EpisodesHorizontalList(title: L10n.tvHomeNewReleases, focusSection: Section.homeNewReleases.rawValue, episodes: model.newReleases, episodeContext: .other(showGoToPodcast: true)) {
             showNowPlayingPlayer = true
-        } label: {
-            EpisodeRow(model: model, isActive: false)
         }
-        .buttonStyle(EpisodeRowButtonStyle())
-        .episodeContextMenu(model: model, context: .other(showGoToPodcast: true))
     }
 }
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Refactors the two near-identical horizontal episode rows on the Apple TV Home screen (Up Next and New Releases) into a single reusable `EpisodesHorizontalList` view, removing the duplicated `RowSection`/`ScrollView`/`LazyHStack` scaffolding and the paired `upNextButton`/`newReleaseButton` builders from `HomeView`.

## What changed

- Extracted `EpisodesHorizontalList` (new file under `Pocket Casts TV App/UI/Home/`), taking `title`, `focusSection`, `episodes`, `episodeContext`, and an `onPlay` closure.
- `HomeView.upNextRow` and `HomeView.newReleasesRow` now delegate to the shared view.
- Hoisted the card width (`864`) and spacing (`24`) into a local `Layout` enum instead of inline magic numbers.
- `newReleasesRow` now guards on a non-empty list so an empty New Releases response no longer renders a stray section title over an empty scroll (matching the existing Up Next behavior).
- Preserved the load-bearing `.scrollClipDisabled()` rationale comment, and added a `#Preview`.

No behavior change beyond the empty-New-Releases guard; this is primarily a deduplication/readability refactor.

## To test

1. On the Apple TV app, sign in and open the Home tab.
2. Confirm the **Up Next** row (visible when more than one episode is queued) and the **New Releases** row render and scroll horizontally as before.
3. Focus a card and confirm the drop shadow pools below the card and is not clipped at the scroll edge.
4. Tap a card and confirm playback starts and the Now Playing player presents.
5. Long-press a card and confirm the context menu shows the correct actions (Up Next actions vs. New Releases' "Go to Podcast").
6. With no new releases available, confirm the New Releases title no longer appears with an empty row.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
