### PR TITLE
Add player_chapter_fingerprint_calculated analytics event

### DIFF
--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -495,6 +495,7 @@ enum AnalyticsEvent: String {
     case playerTabSelected
     case playerShowNotesLinkTapped
     case playerChapterSelected
+    case playerChapterFingerprintCalculated
     case playerPodcastNameTapped
 
     case playerPreviousChapterTapped

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -516,6 +516,15 @@ final class FingerprintTimingManager: NSObject {
                 return .unresolved(reason: "no_match", isStreaming: isStreaming)
             }
             let resolveDurationMs = Int(Date().timeIntervalSince(startDate) * 1000)
+            // Comparable across platforms: Android fingerprints eagerly and iOS
+            // reactively on tap, but both report the calculation time here, decoupled
+            // from `playerChapterSelected` (the tap) which stays untouched.
+            Analytics.track(.playerChapterFingerprintCalculated, properties: [
+                "duration_ms": resolveDurationMs,
+                "is_streaming": isStreaming,
+                "episode_uuid": episodeUuid,
+                "podcast_uuid": episode.parentIdentifier()
+            ])
             return .resolved(
                 playbackTime: max(referenceTime, playback),
                 usedPrior: usedPrior,


### PR DESCRIPTION
Adds the `player_chapter_fingerprint_calculated` event ([EventHorizonSchemas #110](https://github.com/Automattic/EventHorizonSchemas/pull/110)) so we can measure how long our fingerprint alignment takes.

## To test

1. Run the app
2. Play an episode with AI-generated chapters (eg.: The Daily).
3. Open the chapters list and tap a generated chapter → verify it seeks to the ad-shifted position.
4. Verify a `player_chapter_fingerprint_calculated` event fires with `duration_ms`, `is_streaming`, `episode_uuid`, and `podcast_uuid`.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [X] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
