### PR TITLE
Include currently now playing in auto-downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix the Stats screen getting stuck loading when the stats request fails [#4753](https://github.com/Automattic/pocket-casts-ios/pull/4753)
 - Fix the mini player showing empty and stuck after opening the app from an episode notification or a deep link while the full-screen player was open [#4757](https://github.com/Automattic/pocket-casts-ios/pull/4757)
 - Fix a crash when swiping down with VoiceOver on the first style in the share sheet; it now wraps to the last style [#4783](https://github.com/Automattic/pocket-casts-ios/pull/4783)
+- Fix an issue where the now playing episode was not being auto-downloaded when setting was active for UpNext [#4792](https://github.com/Automattic/pocket-casts-ios/pull/4792)
 
 8.16
 -----

--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -392,7 +392,7 @@ class PlaybackQueue: NSObject {
 
         DispatchQueue.global().async { [weak self] in
             guard let self else { return }
-            let episodes = self.allEpisodes(includeNowPlaying: !FeatureFlag.streamAndCachePlayingEpisode.enabled)
+            let episodes = self.allEpisodes(includeNowPlaying: true)
             for episode in episodes {
                 self.autoDownloadIfRequired(episode: episode)
             }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-787

The currently playing episode was excluded from auto-downloads whenever the `streamAndCachePlayingEpisode` feature flag was enabled. This meant that when the now playing episode was in Up Next, it would not be downloaded automatically.

This change always includes the currently playing episode when evaluating which Up Next episodes to auto-download, so the now playing episode is downloaded regardless of the `streamAndCachePlayingEpisode` flag state.

## To test

1. Enable auto-download for Up Next episodes in Settings.
2. Add an episode to Up Next and start playing it.
3. Verify the currently playing episode gets auto-downloaded.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
