### PR TITLE
Fix PodcastIndex chapter fetch retry after network failure

### DIFF
--- a/podcasts/PodcastIndexChapterDataRetriever.swift
+++ b/podcasts/PodcastIndexChapterDataRetriever.swift
@@ -38,12 +38,15 @@ public actor PodcastIndexChapterDataRetriever {
             return try chapters(from: cachedResponse.data)
         }
 
+        defer {
+            dataRequestMap[urlString] = nil
+        }
+
         let task = Task<PodcastIndexEvelope, Error> { [weak self] in
             guard let self else { throw TaskError.nilSelf }
             let (data, response) = try await URLSession.shared.data(for: request)
             let responseToCache = CachedURLResponse(response: response, data: data)
             podcastIndexChaptersCache.storeCachedResponse(responseToCache, for: request)
-            await setDataRequestMapToNil(for: urlString)
 
             return try await chapters(from: data)
         }
@@ -51,10 +54,6 @@ public actor PodcastIndexChapterDataRetriever {
         dataRequestMap[urlString] = task
 
         return try await task.value
-    }
-
-    private func setDataRequestMapToNil(for urlString: String) {
-        dataRequestMap[urlString] = nil
     }
 
     private func chapters(from data: Data) throws -> PodcastIndexEvelope {


### PR DESCRIPTION
Fixes the retrieval of PodcastIndex chapter data when a network request fails.

Previously, the entry in `dataRequestMap` was only cleared inside the fetch `Task`, on the success path (after the response was cached). If the network request threw, the failed `Task` stayed in the map, so every subsequent call for that URL returned the same failed task and chapters could never be re-fetched.

This moves the cleanup into a `defer` block in `loadChapters(_:)`, so the map entry is cleared once the call completes regardless of success or failure — a later call can retry. The now-redundant `setDataRequestMapToNil(for:)` helper is removed.

## To test

1. Play an episode that has PodcastIndex chapters while offline (or with the network otherwise failing).
2. Confirm chapters fail to load.
3. Restore connectivity and trigger a chapter fetch again for the same episode.
4. Verify the chapters now load rather than returning the earlier failed result.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
