### PR TITLE
Fix Playlists empty state not showing when there are no playlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix the Stats screen getting stuck loading when the stats request fails [#4753](https://github.com/Automattic/pocket-casts-ios/pull/4753)
 - Fix the mini player showing empty and stuck after opening the app from an episode notification or a deep link while the full-screen player was open [#4757](https://github.com/Automattic/pocket-casts-ios/pull/4757)
 - Fix a crash when swiping down with VoiceOver on the first style in the share sheet; it now wraps to the last style [#4783](https://github.com/Automattic/pocket-casts-ios/pull/4783)
+- Fix the Playlists tab showing a blank screen instead of the empty state when there are no playlists [#4794](https://github.com/Automattic/pocket-casts-ios/pull/4794)
 
 8.16
 -----

--- a/podcasts/PlaylistsViewController.swift
+++ b/podcasts/PlaylistsViewController.swift
@@ -216,6 +216,7 @@ class PlaylistsViewController: PCViewController, FilterCreatedDelegate {
                     self.newFilterButton.isHidden = false
                     self.loadingIndicator.stopAnimating()
                     self.firstTimeLoading = false
+                    self.refreshContentUnavailable()
                 }
                 return
             }


### PR DESCRIPTION
Fixes PCIOS-842

Fixes the Playlists tab showing a blank screen instead of the empty state when the user has no playlists.

The empty state is rendered from the `didSet` on `listPlaylistItems`, but `reloadFilters()` returned early when the freshly loaded data matched the current value. With zero playlists, the empty database result matched the property's initial empty array, so the assignment never happened and `refreshContentUnavailable()` never ran. The early-return path now refreshes the empty state as well.

## To test

1. Run the app with an account/install that has no playlists (or delete all playlists first).
2. Open the Playlists tab.
3. Verify the empty state appears (icon, title, description, and "New Playlist" button) instead of a blank screen.
4. Create a playlist and verify the empty state disappears and the list shows.
5. Delete the last playlist and verify the empty state comes back.

<img width="340"  alt="Screenshot 2026-07-20 at 12 04 53 PM" src="https://github.com/user-attachments/assets/b297f702-fc07-4d4d-8043-2fd7669ff6cc" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
