### PR TITLE
Fix swipe-to-Up-Next hang in playlist episode lists

### DIFF
--- a/podcasts/New Detail/Operation/PlaylistDetailFetchOperation.swift
+++ b/podcasts/New Detail/Operation/PlaylistDetailFetchOperation.swift
@@ -37,8 +37,12 @@ class PlaylistDetailFetchOperation: Operation, @unchecked Sendable {
                 episodeUuidToAdd: playlist.episodeUuidToAddToQueries()
             )
 
+            if self.isCancelled { return }
+
             DispatchQueue.main.sync { [weak self] in
                 guard let strongSelf = self else { return }
+                if strongSelf.isCancelled { return }
+
                 strongSelf.completion(newData, archivedEpisodesCount)
             }
         }

--- a/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
+++ b/podcasts/New Detail/PlaylistDetailViewModel/PlaylistDetailViewModel.swift
@@ -161,20 +161,21 @@ class PlaylistDetailViewModel: ObservableObject {
             playlist: playlist,
             shouldShowArchived: playlist.showArchivedEpisodes
         ) { [weak self] newData, archivedEpisodeCount in
-            guard let self else { return }
-            DispatchQueue.main.async {
-                self.archivedEpisodesCount = archivedEpisodeCount
-                let isFirstReload = self.firstTimeLoading
-                self.firstTimeLoading = false
-                let changeSetTuple = self.buildChangeSet(source: self.episodes, newData: newData)
-                let contentHasChanged = changeSetTuple.0
-                if contentHasChanged {
-                    self.dataManager.updatePlaylistUpdateDate(for: self.playlist)
-                }
-                self.onChange(changeSetTuple.1, animated && !isFirstReload, contentHasChanged)
-            }
+            self?.handleFetchCompletion(newData: newData, archivedEpisodeCount: archivedEpisodeCount, animated: animated)
         }
         operationQueue.addOperation(refreshOperation)
+    }
+
+    private func handleFetchCompletion(newData: [ListEpisode], archivedEpisodeCount: Int, animated: Bool) {
+        archivedEpisodesCount = archivedEpisodeCount
+        let isFirstReload = firstTimeLoading
+        firstTimeLoading = false
+        let changeSetTuple = buildChangeSet(source: episodes, newData: newData)
+        let contentHasChanged = changeSetTuple.0
+        if contentHasChanged {
+            dataManager.updatePlaylistUpdateDate(for: playlist)
+        }
+        onChange(changeSetTuple.1, animated && !isFirstReload, contentHasChanged)
     }
 
     func totalDuration() -> String? {


### PR DESCRIPTION
Fixes PCIOS-785

Fixes the swipe-to-Up-Next action hanging in playlist episode lists. The playlist reload path stalled the swipe animation in two ways the podcast page path doesn't:

- `PlaylistDetailFetchOperation` kept running its expensive DB queries and blocked on the main thread even after being cancelled, stalling the serial operation queue and delivering stale data. Added the missing `isCancelled` checks, matching `PodcastEpisodesRefreshOperation`.
- The fetch completion deferred its work with a nested `DispatchQueue.main.async` even though it already runs on main, letting the changeset be computed against stale data during SwipeCellKit's editing state and fall back to a full `reloadData`. It now runs synchronously.

**Note:** these were recommendations from Claude. They do make the code more sound, however, they are moot due to the following previous changes:

- https://github.com/Automattic/pocket-casts-ios/pull/4187 reduces the number of reloads and stopped them during swipe (with a delay)
- https://github.com/Automattic/pocket-casts-ios/pull/4366 removed reloads on “add to queue” actions entirely – only individual cells update

## To test

1. Open a playlist with a good number of episodes.
2. Swipe an episode row and tap the Up Next action (or do a full swipe).
3. Verify the swipe animation completes smoothly and the row updates without the list freezing.
4. Repeat quickly across several rows; verify there is no hang and the episodes land in Up Next.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)