### PR TITLE
Ensure sponsored cells show the full description

### DIFF
--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -15,7 +15,6 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
         didSet {
             podcastDescription.style = .primaryText02
             podcastDescription.adjustsFontForContentSizeCategory = true
-            podcastDescription.updateNumberOfLines(regular: 4, accessibility: 6)
         }
     }
 
@@ -188,8 +187,9 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
     }
 
     func updateSize() {
+        let isSponsored = item?.isSponsored ?? false
         podcastTitle.updateNumberOfLines(regular: 2, accessibility: 3)
-        podcastDescription.updateNumberOfLines(regular: 4, accessibility: 6)
+        podcastDescription.updateNumberOfLines(regular: isSponsored ? 0 : 4, accessibility: 6)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -189,7 +189,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
     func updateSize() {
         let isSponsored = item?.isSponsored ?? false
         podcastTitle.updateNumberOfLines(regular: 2, accessibility: 3)
-        podcastDescription.updateNumberOfLines(regular: isSponsored ? 0 : 4, accessibility: 6)
+        podcastDescription.updateNumberOfLines(regular: isSponsored ? 0 : 4, accessibility: isSponsored ? 0 : 6)
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/podcasts/SinglePodcastViewController.xib
+++ b/podcasts/SinglePodcastViewController.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -35,24 +34,17 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text=" Title Title Title Title Title Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="loy-w1-tk4" userLabel="Title" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="140" y="38" width="219" height="45.5"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="..." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="loy-w1-tk4" userLabel="Title" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
+                            <rect key="frame" x="140" y="38" width="219" height="23"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="1000" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LaH-FA-jaA" userLabel="Description" customClass="ThemeableLabel" customModule="podcasts" customModuleProvider="target">
-                            <rect key="frame" x="140" y="89.5" width="219" height="26.5"/>
+                            <rect key="frame" x="140" y="67" width="219" height="0.0"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <attributedString key="attributedText">
-                                <fragment content="Description Description Description Description">
-                                    <attributes>
-                                        <font key="NSFont" metaFont="smallSystem"/>
-                                        <paragraphStyle key="NSParagraphStyle" alignment="natural" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
-                                    </attributes>
-                                </fragment>
-                            </attributedString>
+                            <attributedString key="attributedText"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dLq-mT-vqQ" customClass="PodcastImageView" customModule="podcasts" customModuleProvider="target">


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

| 1 | 2 | 3 | 4 |
| - | - | - | - |
|  <img width="1170" height="2532" alt="Simulator Screenshot - iPhone 14 - 2026-07-21 at 09 40 38" src="https://github.com/user-attachments/assets/477e3565-fead-46cb-a68b-4002ed1f51ef" /> | <img width="1170" height="2532" alt="Simulator Screenshot - iPhone 14 - 2026-07-21 at 09 40 33" src="https://github.com/user-attachments/assets/a6a76f33-041d-4fef-b120-d67d8996c88a" /> | <img width="1170" height="2532" alt="Simulator Screenshot - iPhone 14 - 2026-07-21 at 09 40 23" src="https://github.com/user-attachments/assets/7a905ce1-916b-4536-b71d-7f9a2aeea5be" /> | <img width="1170" height="2532" alt="Simulator Screenshot - iPhone 14 - 2026-07-21 at 09 40 20" src="https://github.com/user-attachments/assets/3dd12565-cb9e-439f-b370-cbb75fc2cac9" /> |

Sponsored discover cells were truncating their description to 4 lines (6 in accessibility text sizes), which cut off the full sponsored copy. This change lets sponsored cells show their complete description while keeping the 4-line cap for regular ("fresh pick") cells.

- `updateSize()` now uses `0` (unlimited) lines for the description when the item is sponsored, and keeps `4` for non-sponsored items. Accessibility sizing also uses the unlimited cap for sponsored cells.
- Removed the redundant `updateNumberOfLines` call from the `podcastDescription` `didSet`, since `updateSize()` is always invoked via `populate()` and now owns the sponsorship-aware line count.
- Updated the XIB to drop the stale design-time placeholder text/frames for the title and description labels.

## To test

1. Open the Discover tab.
2. Locate a sponsored podcast cell (badged "Sponsored") with a long description.
3. Confirm the full description is shown, not truncated to 4 lines.
4. Confirm a regular "Fresh pick" cell still caps its description at 4 lines.
5. Increase the system text size (accessibility sizes) and repeat: the sponsored cell should still show the full description.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
