### PR TITLE
Add empty state track events (tvOS)

### DIFF
--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -71,6 +71,7 @@ struct PlaylistsView: View {
             Text(L10n.tvPlaylistsEmptySubtitle)
         } actions: {
             Button(L10n.tvPlaylistsEmptyActionTitle) {
+                Analytics.track(.filterCreateButtonTapped)
                 showDownloadModal = true
             }
         }

--- a/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastsView.swift
@@ -68,6 +68,7 @@ struct PodcastsView<ViewModel: PodcastsViewModelProtocol>: View {
             Text(L10n.tvPodcastsEmptySubtitle)
         } actions: {
             Button(L10n.tvPodcastsEmptyActionTitle) {
+                Analytics.track(.podcastsListDiscoverButtonTapped)
                 tabRouter.selectedTab = .home
             }
         }

--- a/Pocket Casts TV App/UI/UpNext/UpNextView.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextView.swift
@@ -108,6 +108,7 @@ struct UpNextView: View {
             Text(L10n.tvUpNextEmptySubtitle)
         } actions: {
             Button(L10n.tvUpNextEmptyActionTitle) {
+                Analytics.track(.upNextDiscoverButtonTapped)
                 tabRouter.selectedTab = .home
             }
         }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Adds analytics tracking to the empty-state action buttons in the tvOS app. Each of the three empty states (Playlists, Podcasts, Up Next) now tracks when the user taps its call-to-action button, so we can measure how often users engage with these screens.

- **Playlists** empty state → tracks `filterCreateButtonTapped`
- **Podcasts** empty state → tracks `podcastsListDiscoverButtonTapped`
- **Up Next** empty state → tracks `upNextDiscoverButtonTapped`

All three reuse existing analytics events.

## To test

1. On an Apple TV (or tvOS simulator) with a fresh account, open the **Podcasts** tab with no subscriptions and tap the empty-state button — confirm a `podcastsListDiscoverButtonTapped` event is logged.
2. Open the **Playlists** tab with no filters and tap the empty-state button — confirm a `filterCreateButtonTapped` event is logged.
3. Open the **Up Next** tab with an empty queue and tap the empty-state button — confirm an `upNextDiscoverButtonTapped` event is logged.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I [have updated](https://github.com/Automattic/EventHorizonSchemas/pull/112) (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
