### PR TITLE
Don't auto-download HLS episodes being streamed

### DIFF
--- a/podcasts/PlaybackQueue.swift
+++ b/podcasts/PlaybackQueue.swift
@@ -400,6 +400,10 @@ class PlaybackQueue: NSObject {
     }
 
     private func autoDownloadIfRequired(episode: BaseEpisode) {
+        // HLS is streamed directly and never cached, so downloading it in parallel would just
+        // interrupt the stream once the download completes. Skip it. See DownloadManager.downloadParallelToStream.
+        if EpisodeManager.hasHLSStream(episode) { return }
+
         if !Settings.downloadUpNextEpisodes() || episode.queued() || episode.downloaded(pathFinder: DownloadManager.shared) { return }
 
         if Settings.autoDownloadMobileDataAllowed() || NetworkUtils.shared.isConnectedToUnexpensiveConnection() {


### PR DESCRIPTION
When an HLS episode is streamed, it gets added to Up Next and the "download Up Next episodes" feature queues a parallel download of the progressive file. HLS is streamed directly and never cached, so when that download completes `PlaybackManager` reloads the player to switch to the local file — interrupting the stream mid-playback.

This adds an HLS guard to `PlaybackQueue.autoDownloadIfRequired`, matching the existing exclusion in `DownloadManager.downloadParallelToStream`. The check is gated behind `FeatureFlag.hls.enabled` via `EpisodeManager.hasHLSStream`.

## To test

1. Enable the HLS feature flag.
2. Turn on Settings → auto-download Up Next episodes.
3. Play an episode that has an HLS stream.
4. Verify no parallel download is queued for that episode and streaming is not interrupted.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
