### PR TITLE
Show video toggle for downloaded episodes with HLS

### DIFF
--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -444,13 +444,18 @@ class EpisodeManager: NSObject {
     /// is not treated as HLS — this distinguishes that case from `hasHLSStream`.
     class func willPlayViaHLS(_ episode: BaseEpisode) -> Bool {
         guard hasHLSStream(episode) else { return false }
+        // The user can choose to watch a downloaded episode's video, which streams the HLS source instead
+        // of its local (audio-only) file, so this takes precedence over the downloaded-copy checks below.
+        if PlaybackManager.shared.shouldStreamVideoDespiteDownload(episode) { return true }
         if episode.downloaded(pathFinder: DownloadManager.shared) { return false }
         if let episode = episode as? Episode, episode.streamDownloaded(pathFinder: DownloadManager.shared) { return false }
         return true
     }
 
     class func urlForEpisode(_ episode: BaseEpisode, streamingOnly: Bool = false) -> URL? {
-        if !streamingOnly {
+        // Streaming the HLS video of a downloaded episode ignores the local (audio-only) file.
+        let preferStreaming = streamingOnly || PlaybackManager.shared.shouldStreamVideoDespiteDownload(episode)
+        if !preferStreaming {
             // For local playback, prefer downloaded files
             if episode.downloaded(pathFinder: DownloadManager.shared) {
                 return URL(fileURLWithPath: episode.pathToDownloadedFile(pathFinder: DownloadManager.shared))

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -34,7 +34,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
         #endif
 
         // don't reload the actions unless we need to
-        if !lastShelfLoadState.updateRequired(shelfActions: actions, episodeUuid: playingEpisode.uuid, effectsOn: PlaybackManager.shared.effects().effectsEnabled(), sleepTimerOn: PlaybackManager.shared.sleepTimerActive(), episodeStarred: playingEpisode.keepEpisode, episodeStatus: playingEpisode.episodeStatus, videoToggleAvailable: PlaybackManager.shared.canToggleVideoRendering(), videoRenderingEnabled: PlaybackManager.shared.isVideoRenderingEnabled) { return }
+        if !lastShelfLoadState.updateRequired(shelfActions: actions, episodeUuid: playingEpisode.uuid, effectsOn: PlaybackManager.shared.effects().effectsEnabled(), sleepTimerOn: PlaybackManager.shared.sleepTimerActive(), episodeStarred: playingEpisode.keepEpisode, episodeStatus: playingEpisode.episodeStatus, videoToggleAvailable: PlaybackManager.shared.canToggleVideoRendering(), videoRendering: PlaybackManager.shared.shouldRenderVideo()) { return }
 
         // load the first 4 actions into the player, followed by an overflow icon
         playerControlsStackView.removeAllSubviews()

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -59,6 +59,10 @@ extension NowPlayingPlayerItemViewController {
             floatingVideoView.isHidden = true
             episodeImage.alpha = 1.0
             episodeImage.layer.opacity = 1
+            // The player-open zoom transition (PlayerZoomAnimator) leaves the artwork subview at
+            // alpha 0 when the player opens with video showing, since the video covers it. Restore it
+            // here so the cover art reappears once video is turned off.
+            artworkImageView.alpha = 1
             if wasShowingVideo {
                 // The artwork slot was invisible while the video was showing, so its aspect-fit
                 // subview may not have been laid out yet. Force a pass so the artwork (reloaded at

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -63,6 +63,11 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// switch an HLS video stream to audio-only via the player shelf toggle. Reset per episode.
     private let videoRenderingEnabled = AtomicBool(true)
 
+    /// Whether the user has chosen to watch the current downloaded episode's video. The downloaded file
+    /// is the progressive (audio-only) enclosure, so watching video means streaming the HLS source
+    /// instead. This survives the in-place reload that switches the source and is reset per episode.
+    private let streamingVideoForDownloadedEpisode = AtomicBool()
+
     private let updateTimerInterval = 1 as TimeInterval
 
     #if !os(watchOS)
@@ -180,6 +185,11 @@ class PlaybackManager: ServerPlaybackDelegate {
         FileLog.shared.addMessage("Loading \(episode.displayableTitle()) with UUID \(episode.uuid) autoPlay \(autoPlay) overrideUpNext: \(overrideUpNext)")
 
         let episodeIsChanging = episode.uuid != currentEpisode()?.uuid
+
+        // A new episode shouldn't inherit the previous one's "watch downloaded video" choice.
+        if episodeIsChanging {
+            streamingVideoForDownloadedEpisode.value = false
+        }
 
         // if the user has built an Up Next list, preserve that but make this the currently playing episode
         if !overrideUpNext && !switchingToDifferentUpNextEpisode && queue.upNextCount() > 0 {
@@ -868,20 +878,53 @@ class PlaybackManager: ServerPlaybackDelegate {
         videoRenderingEnabled.value
     }
 
-    /// Whether the audio/video toggle should be offered for the current stream. Only HLS streams
-    /// found to carry video (not static video podcasts) can be switched to audio-only. When the global
-    /// "Audio only" setting forces audio for every episode, the per-episode toggle is hidden.
+    /// Whether the audio/video toggle should be offered for the current episode. Any episode with an HLS
+    /// stream is assumed to carry video, so the toggle is offered whether the HLS is being streamed or the
+    /// episode has been downloaded (its downloaded file is audio-only, so the toggle streams the HLS video).
+    /// When the global "Audio only" setting forces audio for every episode, the per-episode toggle is hidden.
     func canToggleVideoRendering() -> Bool {
-        FeatureFlag.hls.enabled && !isAudioOnlyForced && currentStreamContainsVideo.value && (currentEpisode() is Episode)
+        guard FeatureFlag.hls.enabled, !isAudioOnlyForced, let episode = currentEpisode(), episode is Episode else { return false }
+        return EpisodeManager.hasHLSStream(episode) || currentStreamContainsVideo.value
     }
 
-    /// Toggles whether the current HLS stream's video surface is shown. When disabled the player
-    /// shows the episode artwork instead of the video; playback and video decoding are unaffected
-    /// (this is a display-only switch).
+    /// Whether the current episode should stream its HLS video source even though a local download exists,
+    /// because the user turned the video toggle on for it. Consulted by `EpisodeManager.willPlayViaHLS` /
+    /// `urlForEpisode` when resolving the playback source.
+    func shouldStreamVideoDespiteDownload(_ episode: BaseEpisode) -> Bool {
+        streamingVideoForDownloadedEpisode.value
+            && episode.uuid == currentEpisode()?.uuid
+            && EpisodeManager.hasHLSStream(episode)
+    }
+
+    /// Toggles the video for the current episode. When streaming HLS the video is already being decoded,
+    /// so this just shows/hides the video surface (a display-only switch). When the episode is downloaded
+    /// its local file is audio-only, so we flip the streaming preference and reload playback in place to
+    /// switch between the downloaded audio file and the streamed HLS video.
     func toggleVideoRendering() {
-        guard canToggleVideoRendering() else { return }
-        videoRenderingEnabled.toggle()
+        guard canToggleVideoRendering(), let episode = currentEpisode() else { return }
+
+        if hasDownloadedFile(episode) {
+            streamingVideoForDownloadedEpisode.toggle()
+            reloadCurrentEpisodeSource()
+        } else {
+            videoRenderingEnabled.toggle()
+        }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.videoRenderingToggled)
+    }
+
+    private func hasDownloadedFile(_ episode: BaseEpisode) -> Bool {
+        episode.downloaded(pathFinder: DownloadManager.shared)
+            || (episode as? Episode)?.streamDownloaded(pathFinder: DownloadManager.shared) == true
+    }
+
+    /// Rebuilds the player for the current episode so it re-resolves its playback source, preserving the
+    /// playback position and whether it was playing. Used to switch a downloaded episode between its local
+    /// audio file and the streamed HLS video.
+    private func reloadCurrentEpisodeSource() {
+        guard let episode = currentEpisode() else { return }
+        let wasPlaying = playing()
+        recordPlaybackPosition(sendToServerImmediately: false, fireNotifications: false)
+        load(episode: episode, autoPlay: wasPlaying, overrideUpNext: false, saveCurrentEpisode: false)
     }
 
     /// Called by the player when it detects video tracks in the stream it is playing.

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -884,7 +884,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// When the global "Audio only" setting forces audio for every episode, the per-episode toggle is hidden.
     func canToggleVideoRendering() -> Bool {
         guard FeatureFlag.hls.enabled, !isAudioOnlyForced, let episode = currentEpisode(), episode is Episode else { return false }
-        return EpisodeManager.hasHLSStream(episode) || currentStreamContainsVideo.value
+        return EpisodeManager.hasHLSStream(episode)
     }
 
     /// Whether the current episode should stream its HLS video source even though a local download exists,

--- a/podcasts/ShelfLoadState.swift
+++ b/podcasts/ShelfLoadState.swift
@@ -9,10 +9,10 @@ struct ShelfLoadState {
     private var episodeIsStarred = false
     private var episodeStatus: Int32 = 0
     private var videoToggleAvailable = false
-    private var videoRenderingEnabled = true
+    private var videoRendering = true
 
-    mutating func updateRequired(shelfActions: [PlayerAction], episodeUuid: String, effectsOn: Bool, sleepTimerOn: Bool, episodeStarred: Bool, episodeStatus: Int32, videoToggleAvailable: Bool, videoRenderingEnabled: Bool) -> Bool {
-        if lastShelfActionsLoaded == shelfActions, lastShelfEpisodeUuid == episodeUuid, effectsAreOn == effectsOn, sleepTimerIsOn == sleepTimerOn, episodeIsStarred == episodeStarred, episodeStatus == self.episodeStatus, self.videoToggleAvailable == videoToggleAvailable, self.videoRenderingEnabled == videoRenderingEnabled {
+    mutating func updateRequired(shelfActions: [PlayerAction], episodeUuid: String, effectsOn: Bool, sleepTimerOn: Bool, episodeStarred: Bool, episodeStatus: Int32, videoToggleAvailable: Bool, videoRendering: Bool) -> Bool {
+        if lastShelfActionsLoaded == shelfActions, lastShelfEpisodeUuid == episodeUuid, effectsAreOn == effectsOn, sleepTimerIsOn == sleepTimerOn, episodeIsStarred == episodeStarred, episodeStatus == self.episodeStatus, self.videoToggleAvailable == videoToggleAvailable, self.videoRendering == videoRendering {
             return false
         }
 
@@ -23,7 +23,7 @@ struct ShelfLoadState {
         episodeIsStarred = episodeStarred
         self.episodeStatus = episodeStatus
         self.videoToggleAvailable = videoToggleAvailable
-        self.videoRenderingEnabled = videoRenderingEnabled
+        self.videoRendering = videoRendering
 
         return true
     }


### PR DESCRIPTION
Fixes PCIOS-850

Offers the player video toggle for any episode that has an HLS stream, including downloaded ones. Previously the toggle only appeared for HLS streams where video was detected at runtime, so it disappeared once an episode was downloaded.

- `canToggleVideoRendering()` now offers the toggle for any episode with an HLS stream (`hasHLSStream`), assuming HLS carries video.
- A downloaded episode's local file is the progressive audio-only enclosure, so turning video on streams the HLS source instead: `willPlayViaHLS` / `urlForEpisode` prefer the HLS stream when the new `streamingVideoForDownloadedEpisode` flag is set.
- `toggleVideoRendering()` reloads playback in place (preserving position and play state) to switch a downloaded episode between its local audio file and the streamed HLS video; streaming episodes keep the display-only show/hide behavior.
- Gated behind `FeatureFlag.hls` via `hasHLSStream`.

## To test

Test episode with an HLS stream: https://pca.st/episode/83bcd54d-fccc-499a-8c21-8ac26725e902 ("How AI Is Helping Recruiters Bill More" — The Resilient Recruiter).

1. Play the episode while streaming → verify the video toggle shows and toggling shows/hides the video surface.
2. Download the episode, then play it → verify the video toggle is still shown.
3. Toggle video on → verify it starts streaming the HLS video and resumes at the same position.
4. Toggle video off → verify it returns to playing the downloaded (audio) file at the same position.
5. Play a different episode → verify the video choice does not carry over.