### PR TITLE
Migrate watch navigation to a value-based NavigationStack

### DIFF
--- a/Pocket Casts Watch App/UI/Episode Lists/Up Next/UpNextView.swift
+++ b/Pocket Casts Watch App/UI/Episode Lists/Up Next/UpNextView.swift
@@ -11,7 +11,9 @@ struct UpNextView: View {
     var body: some View {
         ItemListContainer(isEmpty: viewModel.isEmpty, noItemsTitle: L10n.watchUpNextNoItemsTitle, noItemsSubtitle: L10n.watchUpNextNoItemsSubtitle) {
             List {
-                NowPlayingRow(isPlaying: $viewModel.isPlaying, podcastName: $viewModel.upNextTitle)
+                NavigationLink(value: WatchRoute.interface(.nowPlaying)) {
+                    NowPlayingRow(isPlaying: $viewModel.isPlaying, podcastName: $viewModel.upNextTitle)
+                }
                 EpisodeListView(title: L10n.upNext.prefixSourceUnicode, showArtwork: true, episodes: $viewModel.episodes, playlist: nil)
                     .padding(.vertical, 10)
             }

--- a/Pocket Casts Watch App/UI/Main Page/InterfaceView.swift
+++ b/Pocket Casts Watch App/UI/Main Page/InterfaceView.swift
@@ -6,8 +6,6 @@ import PocketCastsUtils
 import WatchKit
 
 struct InterfaceView: View {
-    @EnvironmentObject var navigationModel: NavigationManager
-
     @StateObject var upNextViewModel: UpNextViewModel
     @StateObject var downloadsViewModel: DownloadListViewModel
     private let source: Source
@@ -42,27 +40,27 @@ struct InterfaceView: View {
             ForEach(rowList) { row in
                 switch row {
                 case .downloads:
-                    NavigationLink(destination: DownloadListView(), tag: WatchInterfaceType.downloads.indexPosition, selection: $navigationModel.currentInterface) {
+                    NavigationLink(value: WatchRoute.interface(.downloads)) {
                         MenuRow(label: L10n.downloads, icon: "filter_downloaded", count: $downloadsViewModel.downloadedCount)
                     }
                 case .podcasts:
-                    NavigationLink(destination: PodcastsListView(), tag: WatchInterfaceType.podcasts.indexPosition, selection: $navigationModel.currentInterface) {
+                    NavigationLink(value: WatchRoute.interface(.podcasts)) {
                         MenuRow(label: L10n.podcastsPlural, icon: "podcasts")
                     }
                 case .files:
-                    NavigationLink(destination: FilesListView(), tag: WatchInterfaceType.files.indexPosition, selection: $navigationModel.currentInterface) {
+                    NavigationLink(value: WatchRoute.interface(.files)) {
                         MenuRow(label: L10n.files, icon: "file")
                     }
                 case .upNext:
-                    NavigationLink(destination: UpNextView(), tag: WatchInterfaceType.upnext.indexPosition, selection: $navigationModel.currentInterface) {
+                    NavigationLink(value: WatchRoute.interface(.upnext)) {
                         MenuRow(label: L10n.upNext, icon: "upnext", count: $upNextViewModel.upNextCount)
                     }
                 case .filters:
-                    NavigationLink(destination: PlaylistsListView(), tag: WatchInterfaceType.filterList.indexPosition, selection: $navigationModel.currentInterface) {
+                    NavigationLink(value: WatchRoute.interface(.filterList)) {
                         MenuRow(label: L10n.playlists, icon: "filters")
                     }
                 case .nowPlaying:
-                    NavigationLink(destination: NowPlayingContainerView(), tag: WatchInterfaceType.nowPlaying.indexPosition, selection: $navigationModel.currentInterface) {
+                    NavigationLink(value: WatchRoute.interface(.nowPlaying)) {
                         NowPlayingRow(isPlaying: $upNextViewModel.isPlaying, podcastName: $upNextViewModel.upNextTitle)
                     }
                 }

--- a/Pocket Casts Watch App/UI/Main Page/SourceInterfaceNavigationView.swift
+++ b/Pocket Casts Watch App/UI/Main Page/SourceInterfaceNavigationView.swift
@@ -52,17 +52,17 @@ struct UserRow: View {
 
 struct SourceInterfaceNavigationView: View {
 
-    @State var activeSource: Int? = SourceManager.shared.currentSource().rawValue
-
     @StateObject var model = SourceInterfaceModel()
+
+    @StateObject private var navigationModel = NavigationManager.shared
 
     @ViewBuilder
     var sourceSection: some View {
         Section {
-            NavigationLink(destination: InterfaceView(source: .phone), tag: Source.phone.rawValue, selection: $activeSource) {
+            NavigationLink(value: WatchRoute.source(.phone)) {
                 SourceRow(sourceSymbol: L10n.phone.sourceUnicode(isWatch: false), label: L10n.phone, showPlusOnly: false, active: model.activeSource == .phone)
             }
-            NavigationLink(destination: InterfaceView(source: .watch), tag: Source.watch.rawValue, selection: $activeSource) {
+            NavigationLink(value: WatchRoute.source(.watch)) {
                 SourceRow(sourceSymbol: L10n.watch.sourceUnicode(isWatch: true), label: L10n.watch, showPlusOnly: !model.isLoggedIn || !model.isPlusUser, active: model.activeSource == .watch)
             }.disabled(!model.isPlusUser)
         } footer: {
@@ -129,7 +129,7 @@ struct SourceInterfaceNavigationView: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack(path: $navigationModel.path) {
             List {
                 sourceSection
                 dataRefreshSection
@@ -137,20 +137,24 @@ struct SourceInterfaceNavigationView: View {
                 refreshAccountSection
             }.onAppear {
                 model.willActivate()
-            }.onChange(of: activeSource) { _, newValue in
-                guard let newValue, let newSource = Source(rawValue: newValue) else {
-                    return
-                }
-                if newSource == .phone {
-                    model.phoneTapped()
-                } else {
-                    model.watchTapped()
-                }
+            }
+            .navigationDestination(for: WatchRoute.self) { route in
+                WatchRouteView(route: route)
             }
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle(L10n.watchPlaySource)
         }
-        .environmentObject(NavigationManager.shared)
+        .onChange(of: navigationModel.path.first) { _, newValue in
+            guard case .source(let source)? = newValue else {
+                return
+            }
+            if source == .phone {
+                model.phoneTapped()
+            } else {
+                model.watchTapped()
+            }
+        }
+        .environmentObject(navigationModel)
     }
 
     private func nowPlayingEpisodesMatchOnBothSources() -> Bool {

--- a/Pocket Casts Watch App/UI/Navigation/NavigationManager.swift
+++ b/Pocket Casts Watch App/UI/Navigation/NavigationManager.swift
@@ -1,19 +1,11 @@
 import Foundation
-import PocketCastsDataModel
-import PocketCastsUtils
-import WatchKit
+import SwiftUI
 
 class NavigationManager: ObservableObject {
     static let shared = NavigationManager()
 
-    @Published var currentInterface: Int?
-
-    func navigateToMainMenu() {
-        guard let topController = topMostController() else {
-            return
-        }
-        topController.popToRootController()
-    }
+    /// The app launches showing the current source's interface list.
+    @Published var path: [WatchRoute] = [.source(SourceManager.shared.currentSource())]
 
     func navigateToRestorable(name: String, context: Any?) {
         let interfaceType = WatchInterfaceType(rawValue: name)
@@ -25,8 +17,18 @@ class NavigationManager: ObservableObject {
         }
     }
 
+    /// Replaces the stack with the current source's interface list plus `type`.
     func navigateTo(_ type: WatchInterfaceType, context: Any?) {
-        currentInterface = type.interfacePosition
+        guard let route = WatchRoute(type) else { return }
+
+        path = [.source(SourceManager.shared.currentSource()), route]
+    }
+
+    /// Pushes on top of whatever is already on the stack.
+    func push(_ type: WatchInterfaceType) {
+        guard let route = WatchRoute(type) else { return }
+
+        path.append(route)
     }
 
     private var navigatingToNowPlaying = false
@@ -37,13 +39,7 @@ class NavigationManager: ObservableObject {
         if source != SourceManager.shared.currentSource() {
             SourceManager.shared.setSource(newSource: source)
         }
-        navigateTo(.nowPlaying, context: nil)
+        path = [.source(source), .interface(.nowPlaying)]
         navigatingToNowPlaying = false
-    }
-
-    private func topMostController() -> WKInterfaceController? {
-        let visibleController = WKApplication.shared().visibleInterfaceController ?? WKApplication.shared().rootInterfaceController
-
-        return visibleController
     }
 }

--- a/Pocket Casts Watch App/UI/Navigation/WatchRoute.swift
+++ b/Pocket Casts Watch App/UI/Navigation/WatchRoute.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// A screen that can be pushed onto the watch app's navigation stack.
+enum WatchRoute: Hashable {
+    case source(Source)
+    case interface(WatchInterfaceType)
+
+    /// Returns `nil` for interface types that have no screen of their own.
+    init?(_ interface: WatchInterfaceType) {
+        switch interface {
+        case .unknown, .interface, .filter:
+            return nil
+        default:
+            self = .interface(interface)
+        }
+    }
+}
+
+/// Resolves a route to the screen it pushes. Registered once on the root stack so that
+/// any screen can push any route.
+struct WatchRouteView: View {
+    let route: WatchRoute
+
+    var body: some View {
+        switch route {
+        case .source(let source):
+            InterfaceView(source: source)
+        case .interface(let interface):
+            interfaceView(for: interface)
+        }
+    }
+
+    @ViewBuilder
+    private func interfaceView(for interface: WatchInterfaceType) -> some View {
+        switch interface {
+        case .downloads:
+            DownloadListView()
+        case .podcasts:
+            PodcastsListView()
+        case .files:
+            FilesListView()
+        case .upnext:
+            UpNextView()
+        case .filterList:
+            PlaylistsListView()
+        case .nowPlaying:
+            NowPlayingContainerView()
+        case .effects:
+            EffectsView()
+        case .episodeDetails:
+            if let episode = PlaySourceHelper.playSourceViewModel.nowPlayingEpisode {
+                EpisodeView(viewModel: EpisodeDetailsViewModel(episode: episode, playlist: nil), listTitle: L10n.nowPlaying)
+            }
+        case .unknown, .interface, .filter:
+            EmptyView()
+        }
+    }
+}

--- a/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingContainerView.swift
+++ b/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingContainerView.swift
@@ -3,25 +3,20 @@ import SwiftUI
 struct NowPlayingContainerView: View {
     @StateObject private var viewModel = NowPlayingViewModel()
     @State private var selection = 2
-    @State private var presentedView: WatchInterfaceType? = nil
     @State private var optionSelected: Bool = false
 
     var body: some View {
         Group {
             if let _ = viewModel.episode {
-                ZStack {
-                    navigationHelpers
-
-                    TabView(selection: $selection) {
-                        NowPlayingOptions(viewModel: viewModel, presentView: $presentedView, optionSelected: $optionSelected)
-                            .tag(1)
-                            .animation(.none, value: selection)
-                        NowPlayingControls(viewModel: viewModel, presentView: $presentedView)
-                            .tag(2)
-                            .animation(.none, value: selection)
-                    }
-                    .animation(.easeInOut, value: selection)
+                TabView(selection: $selection) {
+                    NowPlayingOptions(viewModel: viewModel, optionSelected: $optionSelected)
+                        .tag(1)
+                        .animation(.none, value: selection)
+                    NowPlayingControls(viewModel: viewModel)
+                        .tag(2)
+                        .animation(.none, value: selection)
                 }
+                .animation(.easeInOut, value: selection)
             } else {
                 NowPlayingEmptyView()
             }
@@ -31,27 +26,6 @@ struct NowPlayingContainerView: View {
         .onChange(of: optionSelected) {
             withAnimation {
                 selection = 2
-            }
-        }
-    }
-
-    // MARK: Navigation
-
-    /// Hidden Navigation items to allow nested screens the ability to push new views outside of the paged TabView
-    var navigationHelpers: some View {
-        Group {
-            NavigationLink(destination: EffectsView(), tag: .effects, selection: $presentedView) {
-                EmptyView()
-            }.hidden()
-
-            NavigationLink(destination: UpNextView(), tag: .upnext, selection: $presentedView) {
-                EmptyView()
-            }.hidden()
-
-            if let episode = viewModel.episode {
-                NavigationLink(destination: EpisodeView(viewModel: EpisodeDetailsViewModel(episode: episode, playlist: nil), listTitle: L10n.nowPlaying), tag: .episodeDetails, selection: $presentedView) {
-                    EmptyView()
-                }.hidden()
             }
         }
     }

--- a/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingControls.swift
+++ b/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingControls.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct NowPlayingControls: View {
     @StateObject var viewModel: NowPlayingViewModel
-    @Binding var presentView: WatchInterfaceType?
+    @EnvironmentObject private var navigationModel: NavigationManager
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
@@ -92,7 +92,7 @@ struct NowPlayingControls: View {
         HStack {
             Button {
                 WKInterfaceDevice.current().play(.click)
-                presentView = .effects
+                navigationModel.push(.effects)
             } label: {
                 Image(viewModel.effectsIconName)
             }
@@ -103,7 +103,7 @@ struct NowPlayingControls: View {
 
             Button {
                 WKInterfaceDevice.current().play(.click)
-                presentView = .upnext
+                navigationModel.push(.upnext)
             } label: {
                 switch viewModel.upNextCount {
                 case 0 ... 8:
@@ -133,7 +133,8 @@ private extension Image {
 struct NowPlayingView_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(PreviewDevice.previewDevices) {
-            NowPlayingControls(viewModel: NowPlayingViewModel(), presentView: .constant(nil))
+            NowPlayingControls(viewModel: NowPlayingViewModel())
+                .environmentObject(NavigationManager.shared)
                 .previewDevice($0)
         }
     }

--- a/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingOptions.swift
+++ b/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingOptions.swift
@@ -2,8 +2,8 @@ import SwiftUI
 
 struct NowPlayingOptions: View {
     @StateObject var viewModel: NowPlayingViewModel
-    @Binding var presentView: WatchInterfaceType?
     @Binding var optionSelected: Bool
+    @EnvironmentObject private var navigationModel: NavigationManager
 
     var body: some View {
         GeometryReader { geo in
@@ -16,7 +16,7 @@ struct NowPlayingOptions: View {
                     .frame(maxWidth: geo.size.width / 2)
 
                     NowPlayingOption(iconName: "episodedetails", title: L10n.watchEpisodeDetails) {
-                        presentView = .episodeDetails
+                        navigationModel.push(.episodeDetails)
                         optionSelected.toggle()
                     }
                     .frame(maxWidth: geo.size.width / 2)
@@ -78,7 +78,8 @@ private struct NowPlayingOption: View {
 struct NowPlayingOptions_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(PreviewDevice.previewDevices) {
-            NowPlayingOptions(viewModel: NowPlayingViewModel(), presentView: .constant(nil), optionSelected: .constant(false))
+            NowPlayingOptions(viewModel: NowPlayingViewModel(), optionSelected: .constant(false))
+                .environmentObject(NavigationManager.shared)
                 .previewDevice($0)
         }
     }

--- a/Pocket Casts Watch App/UI/Now Playing/Row/NowPlayingRow.swift
+++ b/Pocket Casts Watch App/UI/Now Playing/Row/NowPlayingRow.swift
@@ -5,19 +5,17 @@ struct NowPlayingRow: View {
     @Binding var podcastName: String?
 
     var body: some View {
-        NavigationLink(destination: NowPlayingContainerView()) {
-            HStack {
-                NowPlayingImage(isPlaying: $isPlaying)
-                    .frame(width: 26, height: 26)
-                VStack(alignment: .leading) {
-                    Text(L10n.nowPlaying)
-                    Text(podcastName ?? "")
-                        .foregroundColor(.subheadlineText)
-                }
-                .font(.dynamic(size: 13))
+        HStack {
+            NowPlayingImage(isPlaying: $isPlaying)
+                .frame(width: 26, height: 26)
+            VStack(alignment: .leading) {
+                Text(L10n.nowPlaying)
+                Text(podcastName ?? "")
+                    .foregroundColor(.subheadlineText)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .font(.dynamic(size: 13))
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(-4)
     }
 }

--- a/Pocket Casts Watch App/UI/WatchInterfaceType.swift
+++ b/Pocket Casts Watch App/UI/WatchInterfaceType.swift
@@ -14,36 +14,4 @@ enum WatchInterfaceType: String {
     case nowPlaying
     case filterList
     case interface
-
-    var interfacePosition: Int? {
-        switch self {
-        case .unknown:
-            return nil
-        case .effects:
-            return 0
-        case .episodeDetails:
-            return 1
-        case .downloads:
-            return 2
-        case .podcasts:
-            return 3
-        case .files:
-            return 4
-        case .filter:
-            return 5
-        case .upnext:
-            return 6
-        case .nowPlaying:
-            return 7
-        case .filterList:
-            return 8
-        case .interface:
-            return nil
-        }
-    }
-
-    var indexPosition: Int {
-        let position = interfacePosition ?? -1
-        return position
-    }
 }


### PR DESCRIPTION
The watch app still navigated through `NavigationLink(destination:tag:selection:)`, deprecated since watchOS 9. Every link was driven by a selection binding, and `NavigationManager` tracked the pushed screen as an `Int` index left over from the old WatchKit page-based API.

This moves the whole watch app to a value-based stack:

- `NavigationManager` owns the stack as `@Published var path: [WatchRoute]`. `navigateTo` replaces the stack (matching the old tag/selection behavior, where only one link could be active at a time); the new `push` appends, for screens opened from within Now Playing.
- New `WatchRoute` enum plus `WatchRouteView`, which maps a route to its screen and is registered once via `.navigationDestination(for:)` on the root stack, so any screen can push any route.
- All rows are now `NavigationLink(value:)`.
- `SourceInterfaceNavigationView` uses `NavigationStack(path:)` instead of the deprecated `NavigationView`.
- `NowPlayingContainerView` loses the `ZStack` of hidden zero-size `NavigationLink`s that existed only so buttons inside the paged `TabView` could push. Those buttons now call `navigationModel.push(_:)`, which also removes the `presentView` binding threaded through `NowPlayingOptions` and `NowPlayingControls`.
- `NowPlayingRow` contained its own `NavigationLink`, so in `InterfaceView` it was nested inside another link. The link moved out to the two call sites (`InterfaceView`, `UpNextView`).
- Removed `WatchInterfaceType.interfacePosition` / `.indexPosition` and the now-unused `NavigationManager.navigateToMainMenu()` / `topMostController()`, which drops the last `WKInterfaceController` usage from the navigation layer.

`.unknown`, `.interface`, and `.filter` never had a destination, so `WatchRoute.init?` returns `nil` for them and they stay no-ops rather than pushing a blank screen.

No intended behavior change. The app still launches into the current source's interface list, which the old code achieved by pre-seeding the selection binding and this preserves by seeding `path`.

## To test

Requires a paired Apple Watch or the watch simulator.

1. Launch the watch app. It should open directly on the current source's list (Phone or Watch), with the source picker one back-swipe away.
2. From the source picker, tap **Phone** and then **Watch** (Plus accounts). Each should push the matching list, and the source switch side effects should still run — the active-source indicator moves and a sync/refresh is triggered when the now playing episodes differ between the two.
3. From the interface list, open each row in turn: Now Playing, Up Next, Podcasts, Playlists, Downloads, Files. Each should push its screen, and back-swipe should return.
4. Open **Now Playing**, swipe left to the options page and tap **Episode Details**. The episode should push on top of Now Playing.
5. On the Now Playing controls page, tap the effects icon and then the Up Next icon. Both should push on top of Now Playing, not replace it.
6. In **Up Next**, tap the Now Playing row at the top — it should push Now Playing once, not twice.
7. Background the app from a screen other than the root, then relaunch. State restoration should land you back on that screen.
8. With the watch app closed, start playback on the phone so watchOS auto-launches the app. It should open on Now Playing for the phone source.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.