### PR TITLE
Let the user pick which transcript passage a bookmark captures

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Extensions/UI/UITextView+scrollToRange.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/UI/UITextView+scrollToRange.swift
@@ -2,7 +2,7 @@
 import UIKit
 
 extension UITextView {
-    public func scrollToRange(_ range: NSRange, verticalAnchor: CGFloat = 0.5) {
+    public func scrollToRange(_ range: NSRange, verticalAnchor: CGFloat = 0.5, animated: Bool = true) {
         let clampedAnchor = min(max(verticalAnchor, 0), 1)
 
         // Ensure layout is up-to-date
@@ -29,7 +29,7 @@ extension UITextView {
             return
         }
 
-        scrollRectToVisible(visibleRect, animated: true)
+        scrollRectToVisible(visibleRect, animated: animated)
     }
 }
 #endif

--- a/PocketCastsTests/Tests/Bookmarks/BookmarkTranscriptSnippetExtractorTests.swift
+++ b/PocketCastsTests/Tests/Bookmarks/BookmarkTranscriptSnippetExtractorTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+@testable import podcasts
+
+final class BookmarkTranscriptSnippetExtractorTests: XCTestCase {
+
+    private let transcript = """
+    WEBVTT
+
+    0:00:00.000 --> 0:00:05.000
+    <v Speaker 1>that's the thing about selective admissions.
+
+    0:00:05.000 --> 0:00:10.000
+    <v Speaker 1>The difference between the kid who gets in and the kid who doesn't is often basically noise.
+
+    0:00:10.000 --> 0:00:15.000
+    <v Speaker 2>Right, and that's why some researchers have floated the lottery idea.
+    """
+
+    private func makeModel() throws -> TranscriptModel {
+        try XCTUnwrap(TranscriptModel.makeModel(from: transcript, format: .vtt))
+    }
+
+    func testSnippetCoversTheCuesAroundTheTime() throws {
+        let model = try makeModel()
+        let snippet = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.extractSnippet(from: model, at: 12))
+
+        XCTAssertTrue(snippet.text.hasPrefix("that's the thing about selective admissions."))
+        XCTAssertTrue(snippet.text.hasSuffix("floated the lottery idea."))
+    }
+
+    func testSnippetIsNilWithoutEnoughWords() throws {
+        let model = try XCTUnwrap(TranscriptModel.makeModel(from: """
+        WEBVTT
+
+        0:00:00.000 --> 0:00:05.000
+        Too short to title.
+        """, format: .vtt))
+
+        XCTAssertNil(BookmarkTranscriptSnippetExtractor.extractSnippet(from: model, at: 2))
+    }
+
+    func testTextSkipsSpeakerNamesAndCollapsesCueBreaks() throws {
+        let model = try makeModel()
+        let fullRange = NSRange(location: 0, length: model.attributedText.length)
+
+        let text = BookmarkTranscriptSnippetExtractor.text(in: fullRange, of: model.attributedText)
+
+        XCTAssertFalse(text.contains("Speaker 1"))
+        XCTAssertFalse(text.contains("Speaker 2"))
+        XCTAssertFalse(text.contains("\n"))
+        XCTAssertFalse(text.contains("  "))
+    }
+
+    func testSentenceRangeExpandsAnIndexToTheSentenceAroundIt() throws {
+        let model = try makeModel()
+        let text = model.attributedText.string
+        let index = (text as NSString).range(of: "gets in").location
+        XCTAssertNotEqual(index, NSNotFound)
+
+        let range = BookmarkTranscriptSnippetExtractor.sentenceRange(containing: index, in: text)
+        let sentence = BookmarkTranscriptSnippetExtractor.text(in: range, of: model.attributedText)
+
+        XCTAssertEqual(sentence, "The difference between the kid who gets in and the kid who doesn't is often basically noise.")
+    }
+
+    func testSentenceRangeIsEmptyForAnEmptyTranscript() {
+        XCTAssertEqual(BookmarkTranscriptSnippetExtractor.sentenceRange(containing: 0, in: ""),
+                       NSRange(location: 0, length: 0))
+    }
+}

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -10,6 +10,7 @@ class BookmarkManager {
     private let generalManager: DataManager
     private let playbackManager: PlaybackManager
     private let cacheServerHandler: CacheServerHandler
+    private let userDefaults: UserDefaults
 
     /// Called when a bookmark is created
     let onBookmarkCreated = PassthroughSubject<Event.Created, Never>()
@@ -23,11 +24,13 @@ class BookmarkManager {
     init(dataManager: BookmarkDataManager = DataManager.sharedManager.bookmarks,
          generalManager: DataManager = .sharedManager,
          playbackManager: PlaybackManager = .shared,
-         cacheServerHandler: CacheServerHandler = .shared) {
+         cacheServerHandler: CacheServerHandler = .shared,
+         userDefaults: UserDefaults = .standard) {
         self.dataManager = dataManager
         self.generalManager = generalManager
         self.playbackManager = playbackManager
         self.cacheServerHandler = cacheServerHandler
+        self.userDefaults = userDefaults
     }
 
     /// Plays the "bookmark created" tone
@@ -94,6 +97,8 @@ class BookmarkManager {
     /// Removes an array of bookmarks
     func remove(_ bookmarks: [Bookmark]) async -> Bool {
         await dataManager.remove(bookmarks: bookmarks).when(true) {
+            bookmarks.forEach { setPassage(nil, for: $0) }
+
             onBookmarksDeleted.send(.init(items: bookmarks.map {
                 .init(uuid: $0.uuid, episode: $0.episodeUuid, podcast: $0.podcastUuid)
             }))
@@ -111,6 +116,29 @@ class BookmarkManager {
     /// Gets the `BaseEpisode` for the given bookmark
     func episode(for bookmark: Bookmark) -> BaseEpisode? {
         generalManager.findBaseEpisode(uuid: bookmark.episodeUuid)
+    }
+
+    // MARK: - Passage
+
+    /// The transcript passage the bookmark captures.
+    ///
+    /// Temporarily kept in `UserDefaults`, until the passage is stored with the bookmark itself.
+    func passage(for bookmark: Bookmark) -> String? {
+        userDefaults.string(forKey: Self.passageKey(for: bookmark))
+    }
+
+    /// Passing `nil` removes the stored passage
+    func setPassage(_ passage: String?, for bookmark: Bookmark) {
+        let key = Self.passageKey(for: bookmark)
+        if let passage {
+            userDefaults.set(passage, forKey: key)
+        } else {
+            userDefaults.removeObject(forKey: key)
+        }
+    }
+
+    private static func passageKey(for bookmark: Bookmark) -> String {
+        "bookmark.passage.\(bookmark.uuid)"
     }
 
     // MARK: - Title Generation

--- a/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
+++ b/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
@@ -8,10 +8,10 @@ extension BookmarkManager {
         FeatureFlag.smartBookmarks.enabled
     }
 
-    /// The transcript text surrounding the bookmark, which the title is generated from.
+    /// The transcript passage surrounding the bookmark, which the title is generated from.
     ///
     /// Returns nil when suggestions are disabled or the episode has no usable transcript.
-    func transcriptSnippet(for bookmark: Bookmark, episode: BaseEpisode) async -> String? {
+    func transcriptSnippet(for bookmark: Bookmark, episode: BaseEpisode) async -> BookmarkTranscriptSnippet? {
         guard Self.isTitleSuggestionEnabled else {
             return nil
         }

--- a/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
+++ b/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
@@ -3,8 +3,8 @@ import NaturalLanguage
 import PocketCastsDataModel
 import PocketCastsUtils
 
-/// The transcript passage captured for a bookmark, kept alongside the transcript
-/// it was taken from so the passage can be re-selected later.
+/// The transcript passage captured for a bookmark, kept alongside the transcript it was
+/// taken from so it can be re-selected later.
 struct BookmarkTranscriptSnippet {
     let transcript: TranscriptModel
     var range: NSRange
@@ -67,8 +67,6 @@ struct BookmarkTranscriptSnippetExtractor {
         return snippet
     }
 
-    /// The range of the sentence `index` falls in, used to turn a tap on the transcript
-    /// into a passage
     static func sentenceRange(containing index: Int, in text: String) -> NSRange {
         let length = (text as NSString).length
         guard length > 0 else {

--- a/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
+++ b/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
@@ -3,6 +3,17 @@ import NaturalLanguage
 import PocketCastsDataModel
 import PocketCastsUtils
 
+/// The transcript passage captured for a bookmark, kept alongside the transcript
+/// it was taken from so the passage can be re-selected later.
+struct BookmarkTranscriptSnippet {
+    let transcript: TranscriptModel
+    var range: NSRange
+
+    var text: String {
+        BookmarkTranscriptSnippetExtractor.text(in: range, of: transcript.attributedText)
+    }
+}
+
 /// Extracts the transcript text surrounding a bookmark's position, used as the
 /// input for generating a bookmark title.
 ///
@@ -20,7 +31,7 @@ struct BookmarkTranscriptSnippetExtractor {
     /// Snippets with fewer words than this carry too little signal to generate a meaningful title from
     static let minimumWordCount = 10
 
-    func snippet(forTime time: TimeInterval, episode: BaseEpisode) async -> String? {
+    func snippet(forTime time: TimeInterval, episode: BaseEpisode) async -> BookmarkTranscriptSnippet? {
         let transcriptManager = TranscriptManager(episodeUUID: episode.uuid, podcastUUID: episode.parentIdentifier())
         guard let model = try? await transcriptManager.loadTranscript() else {
             return nil
@@ -36,7 +47,7 @@ struct BookmarkTranscriptSnippetExtractor {
         return Self.extractSnippet(from: model, at: center)
     }
 
-    static func extractSnippet(from model: TranscriptModel, at time: TimeInterval) -> String? {
+    static func extractSnippet(from model: TranscriptModel, at time: TimeInterval) -> BookmarkTranscriptSnippet? {
         let windowStart = max(0, time - backwardWindowSeconds)
         let windowEnd = time + forwardWindowSeconds
 
@@ -49,12 +60,23 @@ struct BookmarkTranscriptSnippetExtractor {
         let windowRange = NSRange(location: location, length: last.characterRange.upperBound - location)
         let snappedRange = snapToSentenceBoundaries(windowRange, in: model.attributedText.string)
 
-        let raw = plainText(in: snappedRange, of: model.attributedText)
-        let words = raw.split(whereSeparator: \.isWhitespace)
-        guard words.count >= minimumWordCount else {
+        let snippet = BookmarkTranscriptSnippet(transcript: model, range: snappedRange)
+        guard snippet.text.split(whereSeparator: \.isWhitespace).count >= minimumWordCount else {
             return nil
         }
-        return words.joined(separator: " ")
+        return snippet
+    }
+
+    /// The range of the sentence `index` falls in, used to turn a tap on the transcript
+    /// into a passage
+    static func sentenceRange(containing index: Int, in text: String) -> NSRange {
+        let length = (text as NSString).length
+        guard length > 0 else {
+            return NSRange(location: 0, length: 0)
+        }
+
+        let clamped = min(max(index, 0), length - 1)
+        return snapToSentenceBoundaries(NSRange(location: clamped, length: 1), in: text)
     }
 
     private static func snapToSentenceBoundaries(_ range: NSRange, in text: String) -> NSRange {
@@ -73,8 +95,9 @@ struct BookmarkTranscriptSnippetExtractor {
         return NSRange(lowerBound..<upperBound, in: text)
     }
 
-    /// The plain text within `range`, skipping the speaker-name runs interleaved between cues
-    private static func plainText(in range: NSRange, of attributedText: NSAttributedString) -> String {
+    /// The plain text within `range`, skipping the speaker-name runs interleaved between
+    /// cues and collapsing the line breaks between them
+    static func text(in range: NSRange, of attributedText: NSAttributedString) -> String {
         let clamped = NSIntersectionRange(range, NSRange(location: 0, length: attributedText.length))
         guard clamped.length > 0 else {
             return ""
@@ -86,6 +109,6 @@ struct BookmarkTranscriptSnippetExtractor {
             guard value == nil else { return }
             parts.append(string.substring(with: subrange))
         }
-        return parts.joined(separator: " ")
+        return parts.joined(separator: " ").split(whereSeparator: \.isWhitespace).joined(separator: " ")
     }
 }

--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -33,14 +33,16 @@ struct BookmarkDetailsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 viewModel.podcastTitle.map {
                     Text($0)
-                        .font(style: .footnote, weight: .medium)
+                        .font(size: 11, style: .caption2, weight: .semibold)
+                        .kerning(-0.4)
                         .foregroundStyle(theme.primaryText02)
                         .lineLimit(1)
                 }
 
                 viewModel.episode.map {
                     Text($0.displayableTitle())
-                        .font(style: .subheadline, weight: .semibold)
+                        .font(size: 15, style: .subheadline, weight: .semibold)
+                        .kerning(-0.4)
                         .foregroundStyle(theme.primaryText01)
                         .lineLimit(2)
                 }

--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -1,0 +1,154 @@
+import PocketCastsDataModel
+import PocketCastsUtils
+import SwiftUI
+
+/// A single bookmark in full: the episode it was taken from, and the transcript passage
+/// it captured.
+struct BookmarkDetailsView: View {
+    @ObservedObject var viewModel: BookmarkDetailsViewModel
+
+    @EnvironmentObject private var theme: Theme
+
+    @ScaledMetricWithMaxSize(relativeTo: .body, maxSize: .xxLarge) private var imageSize = 56
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+                content
+            }
+            .padding(16)
+        }
+        .frame(maxWidth: .infinity)
+        .background(theme.primaryUi01.ignoresSafeArea())
+        .miniPlayerSafeAreaInset()
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            artwork
+
+            VStack(alignment: .leading, spacing: 2) {
+                viewModel.podcastTitle.map {
+                    Text($0)
+                        .font(style: .footnote, weight: .medium)
+                        .foregroundStyle(theme.primaryText02)
+                        .lineLimit(1)
+                }
+
+                viewModel.episode.map {
+                    Text($0.displayableTitle())
+                        .font(style: .subheadline, weight: .semibold)
+                        .foregroundStyle(theme.primaryText01)
+                        .lineLimit(2)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            playButton
+        }
+    }
+
+    @ViewBuilder
+    private var artwork: some View {
+        if let episode = viewModel.episode {
+            EpisodeImage(episode: episode)
+                .aspectRatio(contentMode: .fill)
+                .frame(width: imageSize, height: imageSize)
+                .cornerRadius(8)
+        } else {
+            RoundedRectangle(cornerRadius: 8)
+                .foregroundStyle(theme.primaryUi05)
+                .frame(width: imageSize, height: imageSize)
+        }
+    }
+
+    private var playButton: some View {
+        HStack(spacing: 8) {
+            Text(timestamp)
+                .font(style: .subheadline, weight: .medium)
+                .fixedSize()
+
+            Image("bookmarks-icon-play")
+                .renderingMode(.template)
+        }
+        .foregroundStyle(theme.primaryInteractive02)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(theme.primaryInteractive01)
+        .clipShape(Capsule())
+        .buttonize {
+            viewModel.onPlay()
+        }
+        .accessibilityLabel(L10n.play)
+    }
+
+    // MARK: - Content
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(created)
+                .font(style: .footnote, weight: .medium)
+                .foregroundStyle(theme.primaryText02)
+
+            Text(viewModel.bookmark.title)
+                .font(size: 22, style: .title3, weight: .bold)
+                .foregroundStyle(theme.primaryText01)
+                .padding(.bottom, 4)
+
+            Text(timestamp)
+                .font(style: .footnote, weight: .medium)
+                .foregroundStyle(theme.primaryText02)
+
+            viewModel.passage.map {
+                Text($0)
+                    .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
+                    .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
+                    .foregroundStyle(theme.primaryText02)
+                    .padding(.top, 4)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var timestamp: String {
+        TimeFormatter.shared.playTimeFormat(time: viewModel.bookmark.time)
+    }
+
+    private var created: String {
+        DateFormatter.localizedString(from: viewModel.bookmark.created, dateStyle: .medium, timeStyle: .short)
+    }
+}
+
+// MARK: - Preview
+
+struct BookmarkDetailsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            BookmarkDetailsView(viewModel: .init(bookmark: Self.previewBookmark(title: "Why admissions feel like a lottery",
+                                                                                time: 1390,
+                                                                                created: .now),
+                                                 passage: previewPassage,
+                                                 episode: previewEpisode,
+                                                 podcastTitle: "Radio Atlantic",
+                                                 bookmarkManager: .init()))
+        }
+        .setupDefaultEnvironment()
+    }
+
+    private static var previewEpisode: Episode {
+        let episode = Episode()
+        episode.title = "Higher Educations Identify Crisis"
+        return episode
+    }
+
+    private static let previewPassage = """
+    that's the thing about selective admissions — the difference between the kid who gets in \
+    and the kid who doesn't is often basically noise. Right, and that's why some researchers \
+    have floated the lottery idea. You set a bar for who's qualified, and past that, you just \
+    draw names. It sounds radical, but it's arguably more honest than pretending there's a \
+    meaningful distinction between applicant 1,800 and applicant 2,100.
+    """
+}

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewController.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewController.swift
@@ -1,0 +1,145 @@
+import PocketCastsDataModel
+import SwiftUI
+
+/// Hosts `BookmarkDetailsView` and performs the actions its navigation bar offers.
+class BookmarkDetailsViewController: ThemedHostingController<BookmarkDetailsView> {
+    private let bookmarkManager: BookmarkManager
+    private let playbackManager: PlaybackManager
+    private let analyticsSource: BookmarkAnalyticsSource
+    private let viewModel: BookmarkDetailsViewModel
+
+    init(bookmark: Bookmark,
+         bookmarkManager: BookmarkManager = PlaybackManager.shared.bookmarkManager,
+         playbackManager: PlaybackManager = .shared,
+         source: BookmarkAnalyticsSource = .unknown) {
+        self.bookmarkManager = bookmarkManager
+        self.playbackManager = playbackManager
+        self.analyticsSource = source
+
+        let viewModel = BookmarkDetailsViewModel(bookmark: bookmark, bookmarkManager: bookmarkManager)
+        self.viewModel = viewModel
+
+        super.init(rootView: .init(viewModel: viewModel))
+
+        viewModel.onPlay = { [weak self] in
+            self?.play()
+        }
+    }
+
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = L10n.bookmarkDetailsTitle
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "more"),
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(moreTapped))
+        navigationItem.rightBarButtonItem?.accessibilityLabel = L10n.accessibilityMoreActions
+    }
+}
+
+// MARK: - Actions
+
+private extension BookmarkDetailsViewController {
+    var bookmark: Bookmark {
+        viewModel.bookmark
+    }
+
+    func play() {
+        Task {
+            do {
+                try await playbackManager.playBookmark(bookmark, source: analyticsSource)
+            } catch {
+                HapticsHelper.triggerErrorHaptic()
+                Toast.show(L10n.discoverEpisodeFailToLoad)
+            }
+        }
+    }
+
+    @objc func moreTapped() {
+        let optionPicker = OptionsPicker(title: nil)
+
+        var actions: [OptionAction] = [
+            .init(label: L10n.edit, icon: "folder-edit") { [weak self] in
+                self?.edit()
+            }
+        ]
+
+        if viewModel.episode is Episode {
+            actions.append(.init(label: L10n.share, icon: "podcast-share") { [weak self] in
+                self?.share()
+            })
+        }
+
+        let delete = OptionAction(label: L10n.delete, icon: "delete") { [weak self] in
+            self?.confirmDeletion()
+        }
+        delete.destructive = true
+        actions.append(delete)
+
+        optionPicker.addActions(actions)
+        optionPicker.present()
+    }
+
+    func edit() {
+        let controller = BookmarkEditTitleViewController(manager: bookmarkManager,
+                                                         bookmark: bookmark,
+                                                         state: .updating) { [weak self] _, _ in
+            self?.viewModel.refresh()
+        }
+
+        controller.source = analyticsSource
+
+        present(controller, animated: true)
+    }
+
+    func share() {
+        guard let episode = viewModel.episode as? Episode else { return }
+
+        Analytics.track(.bookmarkShareTapped, source: analyticsSource, properties: ["podcast_uuid": episode.podcastUuid, "episode_uuid": bookmark.episodeUuid])
+
+        SharingModal.show(option: .bookmark(episode, bookmark.time), from: .bookmark, in: self)
+    }
+
+    func confirmDeletion() {
+        let alert = UIAlertController(title: L10n.bookmarkDeleteWarningTitle,
+                                      message: L10n.bookmarkDeleteWarningBody,
+                                      preferredStyle: .alert)
+
+        alert.addAction(.init(title: L10n.cancel, style: .cancel, handler: { [analyticsSource] _ in
+            Analytics.track(.bookmarkDeleteFormDismissed, source: analyticsSource)
+        }))
+
+        alert.addAction(.init(title: L10n.delete, style: .destructive, handler: { [weak self, analyticsSource] _ in
+            Analytics.track(.bookmarkDeleteFormSubmitted, source: analyticsSource)
+            self?.delete()
+        }))
+
+        Analytics.track(.bookmarkDeleteFormShown, source: analyticsSource)
+
+        present(alert, animated: true)
+    }
+
+    func delete() {
+        Task {
+            guard await bookmarkManager.remove([bookmark]) else { return }
+
+            Analytics.track(.bookmarkDeleted, source: analyticsSource)
+
+            close()
+        }
+    }
+
+    /// Pushed onto a list's navigation stack, or presented over the player
+    func close() {
+        if let navigationController, navigationController.viewControllers.first != self {
+            navigationController.popViewController(animated: true)
+        } else {
+            dismiss(animated: true)
+        }
+    }
+}

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
@@ -1,0 +1,54 @@
+import Foundation
+import PocketCastsDataModel
+
+/// What the bookmark details show, kept in one place so the hosting controller can
+/// refresh it after the bookmark is edited.
+@MainActor
+class BookmarkDetailsViewModel: ObservableObject {
+    @Published private(set) var bookmark: Bookmark
+
+    /// The captured transcript passage, absent for bookmarks made before it was captured
+    @Published private(set) var passage: String?
+
+    let episode: BaseEpisode?
+    let podcastTitle: String?
+
+    /// Assigned by the hosting controller, which owns playback
+    var onPlay: () -> Void = {}
+
+    private let bookmarkManager: BookmarkManager
+
+    init(bookmark: Bookmark,
+         passage: String?,
+         episode: BaseEpisode?,
+         podcastTitle: String?,
+         bookmarkManager: BookmarkManager = PlaybackManager.shared.bookmarkManager) {
+        self.bookmark = bookmark
+        self.passage = passage
+        self.episode = episode
+        self.podcastTitle = podcastTitle
+        self.bookmarkManager = bookmarkManager
+    }
+
+    convenience init(bookmark: Bookmark, bookmarkManager: BookmarkManager) {
+        let episode = bookmark.episode ?? bookmarkManager.episode(for: bookmark)
+
+        self.init(bookmark: bookmark,
+                  passage: bookmarkManager.passage(for: bookmark),
+                  episode: episode,
+                  podcastTitle: Self.podcastTitle(for: bookmark, episode: episode),
+                  bookmarkManager: bookmarkManager)
+    }
+
+    func refresh() {
+        guard let bookmark = bookmarkManager.bookmark(for: bookmark.uuid) else { return }
+
+        self.bookmark = bookmark
+        self.passage = bookmarkManager.passage(for: bookmark)
+    }
+
+    private static func podcastTitle(for bookmark: Bookmark, episode: BaseEpisode?) -> String? {
+        let uuid = bookmark.podcastUuid ?? (episode as? Episode)?.podcastUuid
+        return uuid.flatMap { DataManager.sharedManager.findPodcast(uuid: $0)?.title }
+    }
+}

--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -48,8 +48,7 @@ struct BookmarkEditView: View {
                 closeButton
             }
 
-            // The sheet is painted in the player's colors, which the bar's own title
-            // knows nothing about
+            // The bar's own title knows nothing about the player's colors
             ToolbarItem(placement: .principal) {
                 Text(viewModel.headerTitle)
                     .font(style: .headline, weight: .semibold)
@@ -86,8 +85,7 @@ struct BookmarkEditView: View {
         .animation(.easeInOut(duration: 0.2), value: viewModel.titleSuggestion)
     }
 
-    /// A section of the form, e.g. the title field. The header is styled as a label, so
-    /// a section that only needs one passes its `Text` and nothing else.
+    /// A section of the form, with its header styled as a label
     private func section<Header: View>(@ViewBuilder header: () -> Header,
                                        @ViewBuilder content: () -> some View) -> some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -139,8 +137,6 @@ struct BookmarkEditView: View {
             }
     }
 
-    /// The transcript the title was generated from, so the user can see the captured
-    /// moment and pick a different passage
     @ViewBuilder
     private var transcriptSection: some View {
         if viewModel.snippet != nil || viewModel.isCapturingTranscript {
@@ -154,7 +150,6 @@ struct BookmarkEditView: View {
                         editTranscriptButton
                     }
                 }
-                // Set in towards the passage below, which its own padding insets
                 .padding(.horizontal, 8)
             } content: {
                 if let snippet = viewModel.snippet {
@@ -180,8 +175,8 @@ struct BookmarkEditView: View {
             .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 
-    /// Stands in for the passage while the transcript loads. It's never read: the
-    /// redaction blocks it out, it only gives the placeholder the shape of a passage.
+    /// Stands in for the passage while the transcript loads. The redaction blocks it out,
+    /// so it's never read, it only gives the placeholder the shape of a passage.
     private static let transcriptPlaceholder = """
     The passage captured around this moment lands here once the episode transcript has \
     been fetched, and it runs long enough to fill out the four lines it is given.

--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -8,44 +8,74 @@ struct BookmarkEditView: View {
 
     @FocusState private var isTitleFocused: Bool
 
-    var body: some View {
-        ZStack(alignment: .topTrailing) {
-            VStack(spacing: 18) {
-                header
-                titleSection
-                transcriptSection
-                Spacer()
-                saveButton
-            }
-            .padding(.top, 18)
-            .animation(.easeInOut(duration: 0.2), value: viewModel.transcript)
+    /// The title is only focused the first time the form appears, so coming back from
+    /// the transcript editor doesn't pop the keyboard and select the title again
+    @State private var hasFocusedTitle = false
 
-            closeButton
-        }
-        .frame(maxWidth: .infinity)
-        .padding()
-        .background(theme.background)
-        .onAppear {
-            isTitleFocused = true
+    @State private var isEditingTranscript = false
+
+    var body: some View {
+        NavigationStack {
+            form
+                .navigationDestination(isPresented: $isEditingTranscript) {
+                    transcriptEditor
+                }
         }
     }
 
     // MARK: - Views
 
-    @ViewBuilder
-    private var header: some View {
-        Text(viewModel.headerTitle)
-            .foregroundStyle(theme.title)
-            .font(size: 19, style: .title3, weight: .bold)
+    private var form: some View {
+        VStack(spacing: 0) {
+            VStack(spacing: 32) {
+                titleSection
+                transcriptSection
+            }
 
-        Text(viewModel.headerSubTitle)
-            .foregroundStyle(theme.subTitle)
-            .font(style: .callout)
+            Spacer(minLength: 32)
+
+            saveButton
+        }
+        .animation(.easeInOut(duration: 0.2), value: viewModel.snippet?.text)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.isCapturingTranscript)
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(theme.background.ignoresSafeArea())
+        .navigationTitle(viewModel.headerTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                closeButton
+            }
+
+            // The sheet is painted in the player's colors, which the bar's own title
+            // knows nothing about
+            ToolbarItem(placement: .principal) {
+                Text(viewModel.headerTitle)
+                    .font(style: .headline, weight: .semibold)
+                    .foregroundStyle(theme.title)
+            }
+        }
+        .onAppear {
+            guard !hasFocusedTitle else { return }
+
+            hasFocusedTitle = true
+            isTitleFocused = true
+        }
+    }
+
+    @ViewBuilder
+    private var transcriptEditor: some View {
+        if let transcript = viewModel.snippet?.transcript {
+            BookmarkTranscriptEditView(transcript: transcript, selection: $viewModel.transcriptRange, theme: theme)
+        }
     }
 
     private var titleSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            section(L10n.bookmarkTitleLabel) {
+            section {
+                Text(L10n.bookmarkTitleLabel)
+            } content: {
                 titleField
             }
 
@@ -56,12 +86,15 @@ struct BookmarkEditView: View {
         .animation(.easeInOut(duration: 0.2), value: viewModel.titleSuggestion)
     }
 
-    /// A labelled section of the form, e.g. the title field
-    private func section(_ label: String, @ViewBuilder content: () -> some View) -> some View {
+    /// A section of the form, e.g. the title field. The header is styled as a label, so
+    /// a section that only needs one passes its `Text` and nothing else.
+    private func section<Header: View>(@ViewBuilder header: () -> Header,
+                                       @ViewBuilder content: () -> some View) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(label)
+            header()
                 .font(style: .footnote)
                 .foregroundStyle(theme.subTitle)
+                .frame(maxWidth: .infinity, alignment: .leading)
 
             content()
         }
@@ -71,22 +104,24 @@ struct BookmarkEditView: View {
     /// An empty line of the same font pins the field to a single line height, so it
     /// doesn't jump around as the text scales down to fit
     private var titleField: some View {
-        Text(" ")
-            .titleFont()
-            .frame(maxWidth: .infinity)
-            .hidden()
-            .overlay { textField }
-            .overlay(alignment: .bottom) {
-                Divider()
-                    .background(theme.textFieldUnderline)
-                    .offset(y: 6)
+        ZStack {
+            Text(" ")
+                .titleFont()
+                .frame(maxWidth: .infinity)
+                .hidden()
+            textField
+        }
+        .overlay(alignment: .bottom) {
+            Divider()
+                .background(theme.textFieldUnderline)
+                .offset(y: 6)
+        }
+        .overlay(alignment: .trailing) {
+            if viewModel.titleSuggestion == .generating {
+                ProgressView()
+                    .tint(theme.subTitle)
             }
-            .overlay(alignment: .trailing) {
-                if viewModel.titleSuggestion == .generating {
-                    ProgressView()
-                        .tint(theme.subTitle)
-                }
-            }
+        }
     }
 
     private var textField: some View {
@@ -104,21 +139,63 @@ struct BookmarkEditView: View {
             }
     }
 
-    /// The transcript the title was generated from, so the user can see the captured moment
+    /// The transcript the title was generated from, so the user can see the captured
+    /// moment and pick a different passage
     @ViewBuilder
     private var transcriptSection: some View {
-        if let transcript = viewModel.transcript {
-            section(L10n.bookmarkTranscriptCaptured) {
-                Text(transcript)
-                    .font(style: .subheadline)
-                    .foregroundStyle(theme.title)
-                    .lineLimit(4)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(16)
-                    .background(theme.transcriptBackground)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+        if viewModel.snippet != nil || viewModel.isCapturingTranscript {
+            section {
+                HStack {
+                    Text(L10n.bookmarkTranscriptCaptured)
+
+                    Spacer()
+
+                    if viewModel.snippet != nil {
+                        editTranscriptButton
+                    }
+                }
+                // Set in towards the passage below, which its own padding insets
+                .padding(.horizontal, 8)
+            } content: {
+                if let snippet = viewModel.snippet {
+                    transcript(snippet.text)
+                } else {
+                    transcript(Self.transcriptPlaceholder)
+                        .redacted(reason: .placeholder)
+                        .accessibilityHidden(true)
+                }
             }
         }
+    }
+
+    private func transcript(_ text: String) -> some View {
+        Text(text)
+            .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
+            .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
+            .foregroundStyle(theme.title)
+            .lineLimit(4)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(16)
+            .background(theme.transcriptBackground)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    /// Stands in for the passage while the transcript loads. It's never read: the
+    /// redaction blocks it out, it only gives the placeholder the shape of a passage.
+    private static let transcriptPlaceholder = """
+    The passage captured around this moment lands here once the episode transcript has \
+    been fetched, and it runs long enough to fill out the four lines it is given.
+    """
+
+    private var editTranscriptButton: some View {
+        Text(L10n.edit)
+            .font(style: .footnote)
+            .foregroundStyle(theme.editButton)
+            .buttonize {
+                isTitleFocused = false
+                isEditingTranscript = true
+            }
+            .accessibilityLabel(L10n.bookmarkEditTranscriptTitle)
     }
 
     /// A generated title suggestion the user can tap to use
@@ -145,12 +222,14 @@ struct BookmarkEditView: View {
     }
 
     private var closeButton: some View {
-        Image("close")
-            .renderingMode(.template)
-            .foregroundStyle(theme.closeButton)
-            .buttonize {
-                viewModel.cancel()
-            }
+        Button {
+            viewModel.cancel()
+        } label: {
+            Image("close")
+                .renderingMode(.template)
+                .foregroundStyle(theme.closeButton)
+        }
+        .accessibilityLabel(L10n.accessibilityCloseDialog)
     }
 }
 
@@ -158,6 +237,7 @@ struct BookmarkEditView: View {
 
 private extension BookmarkEditTheme {
     var transcriptBackground: Color { theme.playerContrast06 }
+    var editButton: Color { textFieldAccent }
 }
 
 // MARK: - Private Extensions
@@ -166,7 +246,7 @@ private extension View {
     func titleFont() -> some View {
         self
             .lineLimit(1)
-            .minimumScaleFactor(0.5)
+            .minimumScaleFactor(0.7)
             .font(size: 24, style: .title2, weight: .bold)
     }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -37,7 +37,6 @@ class BookmarkEditViewModel: ObservableObject {
     /// A title suggestion generated from the transcript around the bookmark's position
     @Published private(set) var titleSuggestion: TitleSuggestion = .none
 
-    /// The transcript passage captured around the bookmark's position, once it's available
     @Published private(set) var snippet: BookmarkTranscriptSnippet?
 
     /// Whether the transcript is still being fetched, so the passage can be shown as a
@@ -45,8 +44,8 @@ class BookmarkEditViewModel: ObservableObject {
     @Published private(set) var isCapturingTranscript = false
 
     /// The captured passage, which the transcript editor changes as the user picks a
-    /// different one. It deliberately doesn't regenerate the title: the suggestion
-    /// belongs to the moment that was bookmarked, not to whatever is selected after.
+    /// different one. It deliberately doesn't regenerate the title, which belongs to the
+    /// moment that was bookmarked.
     var transcriptRange: NSRange {
         get { snippet?.range ?? NSRange(location: 0, length: 0) }
         set { snippet?.range = newValue }

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -37,7 +37,15 @@ class BookmarkEditViewModel: ObservableObject {
     /// A title suggestion generated from the transcript around the bookmark's position
     @Published private(set) var titleSuggestion: TitleSuggestion = .none
 
-    @Published private(set) var snippet: BookmarkTranscriptSnippet?
+    /// Storing the passage as it's captured, and again on every change, keeps it around
+    /// even when the sheet is dismissed without saving the title
+    @Published private(set) var snippet: BookmarkTranscriptSnippet? {
+        didSet {
+            guard let snippet, snippet.range != oldValue?.range else { return }
+
+            bookmarkManager.setPassage(snippet.text, for: bookmark)
+        }
+    }
 
     /// Whether the transcript is still being fetched, so the passage can be shown as a
     /// placeholder rather than appearing out of nowhere

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -10,7 +10,6 @@ class BookmarkEditViewModel: ObservableObject {
 
     /// Localized Strings
     let headerTitle: String
-    let headerSubTitle: String
     let saveButtonTitle: String
     let placeholder: String = L10n.bookmarkDefaultTitle
 
@@ -38,8 +37,20 @@ class BookmarkEditViewModel: ObservableObject {
     /// A title suggestion generated from the transcript around the bookmark's position
     @Published private(set) var titleSuggestion: TitleSuggestion = .none
 
-    /// The transcript captured around the bookmark's position, once it's available
-    @Published private(set) var transcript: String?
+    /// The transcript passage captured around the bookmark's position, once it's available
+    @Published private(set) var snippet: BookmarkTranscriptSnippet?
+
+    /// Whether the transcript is still being fetched, so the passage can be shown as a
+    /// placeholder rather than appearing out of nowhere
+    @Published private(set) var isCapturingTranscript = false
+
+    /// The captured passage, which the transcript editor changes as the user picks a
+    /// different one. It deliberately doesn't regenerate the title: the suggestion
+    /// belongs to the moment that was bookmarked, not to whatever is selected after.
+    var transcriptRange: NSRange {
+        get { snippet?.range ?? NSRange(location: 0, length: 0) }
+        set { snippet?.range = newValue }
+    }
 
     private let bookmarkManager: BookmarkManager
     private let bookmark: Bookmark
@@ -58,11 +69,9 @@ class BookmarkEditViewModel: ObservableObject {
         switch editState {
         case .adding:
             headerTitle = L10n.addBookmark
-            headerSubTitle = L10n.addBookmarkSubtitle
             saveButtonTitle = L10n.saveBookmark
         case .updating:
             headerTitle = L10n.changeBookmarkTitle
-            headerSubTitle = L10n.changeBookmarkSubtitle
             saveButtonTitle = L10n.changeBookmarkTitle
         }
 
@@ -80,12 +89,14 @@ class BookmarkEditViewModel: ObservableObject {
               let episode = bookmarkManager.episode(for: bookmark) else { return }
 
         titleSuggestion = .generating
+        isCapturingTranscript = true
         suggestionTask = Task { [weak self, bookmarkManager, bookmark, maxTitleLength] in
             let snippet = await bookmarkManager.transcriptSnippet(for: bookmark, episode: episode)
             guard !Task.isCancelled else { return }
 
             await MainActor.run {
-                self?.transcript = snippet
+                self?.snippet = snippet
+                self?.isCapturingTranscript = false
             }
 
             guard let snippet else {
@@ -93,7 +104,7 @@ class BookmarkEditViewModel: ObservableObject {
                 return
             }
 
-            let suggestion = await bookmarkManager.suggestTitle(from: snippet, for: bookmark, episode: episode)
+            let suggestion = await bookmarkManager.suggestTitle(from: snippet.text, for: bookmark, episode: episode)
             guard !Task.isCancelled else { return }
 
             let trimmed = suggestion.map { String($0.trim().prefix(maxTitleLength)) }

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
@@ -24,7 +24,6 @@ struct BookmarkTranscriptEditView: View {
         .frame(maxWidth: .infinity)
         .padding([.horizontal, .top])
         .background(theme.background.ignoresSafeArea())
-        // The transcript runs off the bottom of the screen rather than stopping short of it
         .ignoresSafeArea(edges: .bottom)
         .navigationTitle(L10n.bookmarkEditTranscriptTitle)
         .navigationBarTitleDisplayMode(.inline)
@@ -34,8 +33,7 @@ struct BookmarkTranscriptEditView: View {
                 backButton
             }
 
-            // The screen is painted in the player's colors, which the bar's own title
-            // knows nothing about
+            // The bar's own title knows nothing about the player's colors
             ToolbarItem(placement: .principal) {
                 Text(L10n.bookmarkEditTranscriptTitle)
                     .font(style: .headline, weight: .semibold)
@@ -67,11 +65,9 @@ struct BookmarkTranscriptEditView: View {
 
 // MARK: - TranscriptSelectionTextView
 
-/// The transcript as selectable text, scrolled to the bookmark's passage.
-///
-/// The passage is UIKit's own text selection, so it's adjusted with the standard grab
-/// handles. A tap selects the sentence it lands in rather than collapsing the selection
-/// to a caret, which would leave the bookmark with no passage at all.
+/// The transcript as selectable text, scrolled to the bookmark's passage. A tap selects
+/// the sentence it lands in, rather than collapsing the selection to a caret and leaving
+/// the bookmark with no passage at all.
 private struct TranscriptSelectionTextView: UIViewRepresentable {
     let transcript: TranscriptModel
 
@@ -80,8 +76,7 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
     let textColor: UIColor
     let selectionColor: UIColor
 
-    /// Where the passage sits vertically once scrolled to, leaving room to drag the
-    /// selection in either direction
+    /// Where the passage sits vertically once scrolled to
     private let verticalAnchor: CGFloat = 0.3
 
     func makeUIView(context: Context) -> SelectableTextView {
@@ -94,11 +89,10 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
         textView.textContainer.lineFragmentPadding = 0
         textView.tintColor = selectionColor
         textView.showsVerticalScrollIndicator = false
-        // The text runs under the home indicator, so it needs room to scroll clear of it
+        // Leaves room to scroll the text clear of the home indicator it runs under
         textView.contentInsetAdjustmentBehavior = .always
 
-        // The passage can only be scrolled to once the text has a width to be laid out
-        // in, so the transcript is kept hidden until it's in position
+        // The passage can only be scrolled to once the text has a width to be laid out in
         textView.alpha = 0
         textView.onFirstLayout = { [weak textView] in
             guard let textView else { return }
@@ -111,9 +105,8 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
                 textView.alpha = 1
             }
 
-            // Listen only from here on: the passage above would report itself back
-            // as a change, and the empty selection the text view starts out with
-            // would be snapped to a sentence and overwrite the passage
+            // Listen only from here on: the passage above would report itself back as a
+            // change, and the empty selection it starts out with would overwrite it
             textView.delegate = context.coordinator
         }
 
@@ -156,8 +149,7 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
         return text
     }
 
-    /// A text view that reports the first layout pass its text is laid out in, and that
-    /// it has a window to become the first responder in
+    /// A text view that reports the first layout pass it can scroll and select in
     class SelectableTextView: UITextView {
         var onFirstLayout: (() -> Void)?
 
@@ -195,8 +187,7 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
             selection = range
         }
 
-        /// The passage is what's being picked here, so the copy and share actions the
-        /// selection would otherwise offer are just in the way
+        /// The copy and share actions a selection normally offers are just in the way here
         func textView(_ textView: UITextView, editMenuForTextIn range: NSRange, suggestedActions: [UIMenuElement]) -> UIMenu? {
             nil
         }

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
@@ -1,0 +1,238 @@
+import PocketCastsUtils
+import SwiftUI
+
+/// The full episode transcript with the bookmark's passage selected, so the user can
+/// pick a different one.
+struct BookmarkTranscriptEditView: View {
+    let transcript: TranscriptModel
+
+    @Binding var selection: NSRange
+
+    @ObservedObject var theme: BookmarkEditTheme
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 18) {
+            subtitle
+
+            TranscriptSelectionTextView(transcript: transcript,
+                                        selection: $selection,
+                                        textColor: UIColor(theme.title),
+                                        selectionColor: UIColor(theme.transcriptSelection))
+        }
+        .frame(maxWidth: .infinity)
+        .padding([.horizontal, .top])
+        .background(theme.background.ignoresSafeArea())
+        // The transcript runs off the bottom of the screen rather than stopping short of it
+        .ignoresSafeArea(edges: .bottom)
+        .navigationTitle(L10n.bookmarkEditTranscriptTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                backButton
+            }
+
+            // The screen is painted in the player's colors, which the bar's own title
+            // knows nothing about
+            ToolbarItem(placement: .principal) {
+                Text(L10n.bookmarkEditTranscriptTitle)
+                    .font(style: .headline, weight: .semibold)
+                    .foregroundStyle(theme.title)
+            }
+        }
+    }
+
+    // MARK: - Views
+
+    private var subtitle: some View {
+        Text(L10n.bookmarkEditTranscriptSubtitle)
+            .foregroundStyle(theme.subTitle)
+            .font(style: .callout)
+            .multilineTextAlignment(.center)
+    }
+
+    private var backButton: some View {
+        Button {
+            dismiss()
+        } label: {
+            Image("nav-back")
+                .renderingMode(.template)
+                .foregroundStyle(theme.title)
+        }
+        .accessibilityLabel(L10n.back)
+    }
+}
+
+// MARK: - TranscriptSelectionTextView
+
+/// The transcript as selectable text, scrolled to the bookmark's passage.
+///
+/// The passage is UIKit's own text selection, so it's adjusted with the standard grab
+/// handles. A tap selects the sentence it lands in rather than collapsing the selection
+/// to a caret, which would leave the bookmark with no passage at all.
+private struct TranscriptSelectionTextView: UIViewRepresentable {
+    let transcript: TranscriptModel
+
+    @Binding var selection: NSRange
+
+    let textColor: UIColor
+    let selectionColor: UIColor
+
+    /// Where the passage sits vertically once scrolled to, leaving room to drag the
+    /// selection in either direction
+    private let verticalAnchor: CGFloat = 0.3
+
+    func makeUIView(context: Context) -> SelectableTextView {
+        // TextKit 1: `scrollToRange` and the character index lookups work off `layoutManager`
+        let textView = SelectableTextView(usingTextLayoutManager: false)
+        textView.attributedText = styledText()
+        textView.isEditable = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.tintColor = selectionColor
+        textView.showsVerticalScrollIndicator = false
+        // The text runs under the home indicator, so it needs room to scroll clear of it
+        textView.contentInsetAdjustmentBehavior = .always
+
+        // The passage can only be scrolled to once the text has a width to be laid out
+        // in, so the transcript is kept hidden until it's in position
+        textView.alpha = 0
+        textView.onFirstLayout = { [weak textView] in
+            guard let textView else { return }
+
+            UIView.performWithoutAnimation {
+                // A selection is only drawn while the text view is the first responder
+                textView.becomeFirstResponder()
+                textView.selectedRange = selection
+                textView.scrollToRange(selection, verticalAnchor: verticalAnchor, animated: false)
+                textView.alpha = 1
+            }
+
+            // Listen only from here on: the passage above would report itself back
+            // as a change, and the empty selection the text view starts out with
+            // would be snapped to a sentence and overwrite the passage
+            textView.delegate = context.coordinator
+        }
+
+        return textView
+    }
+
+    func updateUIView(_ textView: SelectableTextView, context: Context) {
+        guard textView.selectedRange != selection else { return }
+
+        textView.selectedRange = selection
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selection: $selection)
+    }
+
+    private func styledText() -> NSAttributedString {
+        let text = NSMutableAttributedString(attributedString: transcript.attributedText)
+        let fullRange = NSRange(location: 0, length: text.length)
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.minimumLineHeight = BookmarkTranscriptStyle.lineHeight
+        paragraphStyle.maximumLineHeight = BookmarkTranscriptStyle.lineHeight
+        paragraphStyle.paragraphSpacing = 10
+        paragraphStyle.lineBreakMode = .byWordWrapping
+        paragraphStyle.alignment = .natural
+
+        text.addAttributes([.paragraphStyle: paragraphStyle,
+                            .font: BookmarkTranscriptStyle.font,
+                            .baselineOffset: BookmarkTranscriptStyle.baselineOffset,
+                            .foregroundColor: textColor],
+                           range: fullRange)
+
+        text.enumerateAttribute(.transcriptSpeaker, in: fullRange, options: [.longestEffectiveRangeNotRequired]) { value, range, _ in
+            guard value != nil else { return }
+
+            text.addAttribute(.font, value: BookmarkTranscriptStyle.speakerFont, range: range)
+        }
+
+        return text
+    }
+
+    /// A text view that reports the first layout pass its text is laid out in, and that
+    /// it has a window to become the first responder in
+    class SelectableTextView: UITextView {
+        var onFirstLayout: (() -> Void)?
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+
+            guard window != nil, bounds.width > 0, let onFirstLayout else { return }
+
+            // Cleared first: the callback lays the text out again as it scrolls
+            self.onFirstLayout = nil
+            onFirstLayout()
+        }
+    }
+
+    class Coordinator: NSObject, UITextViewDelegate {
+        @Binding private var selection: NSRange
+
+        init(selection: Binding<NSRange>) {
+            _selection = selection
+        }
+
+        func textViewDidChangeSelection(_ textView: UITextView) {
+            let range = textView.selectedRange
+
+            if range.length == 0 {
+                let sentence = BookmarkTranscriptSnippetExtractor.sentenceRange(containing: range.location,
+                                                                               in: textView.text)
+                if sentence != range {
+                    // Re-enters this method with the expanded selection
+                    textView.selectedRange = sentence
+                    return
+                }
+            }
+
+            selection = range
+        }
+
+        /// The passage is what's being picked here, so the copy and share actions the
+        /// selection would otherwise offer are just in the way
+        func textView(_ textView: UITextView, editMenuForTextIn range: NSRange, suggestedActions: [UIMenuElement]) -> UIMenu? {
+            nil
+        }
+    }
+}
+
+// MARK: - Theme
+
+private extension BookmarkEditTheme {
+    var transcriptSelection: Color { textFieldAccent }
+}
+
+// MARK: - Preview
+
+struct BookmarkTranscriptEditView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            BookmarkTranscriptEditView(transcript: previewTranscript,
+                                       selection: .constant(NSRange(location: 0, length: 42)),
+                                       theme: .init(episode: nil))
+        }
+        .setupDefaultEnvironment()
+    }
+
+    private static var previewTranscript: TranscriptModel {
+        TranscriptModel.makeModel(from: """
+        WEBVTT
+
+        00:00:00.000 --> 00:00:05.000
+        that's the thing about selective admissions — the difference between the kid who gets in
+
+        00:00:05.000 --> 00:00:10.000
+        and the kid who doesn't is often basically noise. Right, and that's why some researchers
+
+        00:00:10.000 --> 00:00:15.000
+        have floated the lottery idea. You set a bar for who's qualified, and past that, you just draw names.
+        """, format: .vtt) ?? TranscriptModel(attributedText: NSAttributedString(string: ""), cues: [], type: "", hasJavascript: false)
+    }
+}

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
@@ -10,8 +10,6 @@ struct BookmarkTranscriptEditView: View {
 
     @ObservedObject var theme: BookmarkEditTheme
 
-    @Environment(\.dismiss) private var dismiss
-
     var body: some View {
         VStack(spacing: 18) {
             subtitle
@@ -25,14 +23,11 @@ struct BookmarkTranscriptEditView: View {
         .padding([.horizontal, .top])
         .background(theme.background.ignoresSafeArea())
         .ignoresSafeArea(edges: .bottom)
+        // Colors the back button the bar gives us for free
+        .tint(theme.title)
         .navigationTitle(L10n.bookmarkEditTranscriptTitle)
         .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden()
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                backButton
-            }
-
             // The bar's own title knows nothing about the player's colors
             ToolbarItem(placement: .principal) {
                 Text(L10n.bookmarkEditTranscriptTitle)
@@ -49,17 +44,6 @@ struct BookmarkTranscriptEditView: View {
             .foregroundStyle(theme.subTitle)
             .font(style: .callout)
             .multilineTextAlignment(.center)
-    }
-
-    private var backButton: some View {
-        Button {
-            dismiss()
-        } label: {
-            Image("nav-back")
-                .renderingMode(.template)
-                .foregroundStyle(theme.title)
-        }
-        .accessibilityLabel(L10n.back)
     }
 }
 
@@ -88,7 +72,6 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
         textView.tintColor = selectionColor
-        textView.showsVerticalScrollIndicator = false
         // Leaves room to scroll the text clear of the home indicator it runs under
         textView.contentInsetAdjustmentBehavior = .always
 

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptStyle.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptStyle.swift
@@ -1,0 +1,46 @@
+import UIKit
+
+/// How transcript text reads, both as the captured passage on the edit form and as the
+/// full transcript in the editor.
+enum BookmarkTranscriptStyle {
+    static let fontSize: Double = 16
+
+    /// The line height, as a proportion of the font size
+    static let lineHeightMultiple: Double = 1.5
+
+    /// New York, scaling with the body text style
+    static var font: UIFont {
+        serifFont(ofSize: CGFloat(fontSize), scalingWith: .body)
+    }
+
+    /// The speaker names that introduce a passage, set smaller but in the same family
+    static var speakerFont: UIFont {
+        serifFont(ofSize: 12, scalingWith: .footnote)
+    }
+
+    private static func serifFont(ofSize size: CGFloat, scalingWith style: UIFont.TextStyle) -> UIFont {
+        let font = UIFont.font(ofSize: size, scalingWith: style)
+        guard let serif = font.fontDescriptor.withDesign(.serif) else {
+            return font
+        }
+
+        return UIFont(descriptor: serif, size: font.pointSize)
+    }
+
+    static var lineHeight: CGFloat {
+        font.pointSize * CGFloat(lineHeightMultiple)
+    }
+
+    /// What SwiftUI has to add between lines to reach `lineHeight`, which it measures
+    /// from the bottom of one line to the top of the next
+    static var lineSpacing: CGFloat {
+        max(0, lineHeight - font.lineHeight)
+    }
+
+    /// TextKit puts the room a taller line height buys entirely above the glyphs, which
+    /// leaves them sitting at the bottom of their line, and of any selection drawn over
+    /// it. Raising the baseline by half splits that room evenly.
+    static var baselineOffset: CGFloat {
+        lineSpacing / 2
+    }
+}

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptStyle.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptStyle.swift
@@ -4,8 +4,6 @@ import UIKit
 /// full transcript in the editor.
 enum BookmarkTranscriptStyle {
     static let fontSize: Double = 16
-
-    /// The line height, as a proportion of the font size
     static let lineHeightMultiple: Double = 1.5
 
     /// New York, scaling with the body text style
@@ -37,9 +35,9 @@ enum BookmarkTranscriptStyle {
         max(0, lineHeight - font.lineHeight)
     }
 
-    /// TextKit puts the room a taller line height buys entirely above the glyphs, which
-    /// leaves them sitting at the bottom of their line, and of any selection drawn over
-    /// it. Raising the baseline by half splits that room evenly.
+    /// TextKit puts the room a taller line height buys entirely above the glyphs, leaving
+    /// them at the bottom of their line, and of any selection drawn over it. Raising the
+    /// baseline by half splits that room evenly.
     static var baselineOffset: CGFloat {
         lineSpacing / 2
     }

--- a/podcasts/Bookmarks/List/BookmarkListRouter.swift
+++ b/podcasts/Bookmarks/List/BookmarkListRouter.swift
@@ -6,6 +6,9 @@ protocol BookmarkListRouter: AnyObject {
     func bookmarkEdit(_ bookmark: Bookmark)
     func bookmarkShare(_ bookmark: Bookmark)
 
+    /// Opens the bookmark in full, with the transcript passage it captured
+    func bookmarkDetails(_ bookmark: Bookmark, source: BookmarkAnalyticsSource)
+
     /// Optional: Dismisses the presented bookmark list, if applicable.
     func dismissBookmarksList()
 
@@ -22,5 +25,17 @@ extension BookmarkListRouter {
 extension BookmarkListRouter where Self: UIViewController {
     func presentBookmarkController(_ controller: UIViewController) {
         present(controller, animated: true)
+    }
+
+    /// Pushed where the list already sits in a navigation stack, presented where it doesn't,
+    /// such as the player's bookmarks tab
+    func bookmarkDetails(_ bookmark: Bookmark, source: BookmarkAnalyticsSource) {
+        let controller = BookmarkDetailsViewController(bookmark: bookmark, source: source)
+
+        if let navigationController {
+            navigationController.pushViewController(controller, animated: true)
+        } else {
+            present(SJUIUtils.navController(for: controller), animated: true)
+        }
     }
 }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import SwiftUI
 
 class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
@@ -51,6 +52,18 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
 
     func reload() { }
 
+    /// Outside of the multi selection, a tap opens the bookmark's details
+    override func tapped(item: Bookmark) {
+        guard !isMultiSelecting else {
+            super.tapped(item: item)
+            return
+        }
+
+        guard FeatureFlag.smartBookmarks.enabled else { return }
+
+        router?.bookmarkDetails(item, source: analyticsSource)
+    }
+
     func dismiss() {
         router?.dismissBookmarksList()
     }
@@ -63,6 +76,14 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
     }
 
     func addListeners() {
+        // Bookmarks can also be deleted from outside the list, such as from their details
+        bookmarkManager.onBookmarksDeleted
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reload()
+            }
+            .store(in: &cancellables)
+
         bookmarkManager.onBookmarkChanged
             .filter { [weak self] event in
                 self?.items.contains(where: { $0.uuid == event.uuid }) ?? false

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4510,6 +4510,9 @@
 /* Label above the text field where the user edits the bookmark title */
 "bookmark_title_label" = "Title";
 
+/* The title of a view showing a single bookmark and the transcript passage it captured */
+"bookmark_details_title" = "Bookmark";
+
 /* The title of a view where the user can edit their bookmark title */
 "change_bookmark_title" = "Change title";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4501,6 +4501,12 @@
 /* Label above the section showing the transcript text captured around the bookmarked moment */
 "bookmark_transcript_captured" = "Transcript captured";
 
+/* The title of a view where the user picks which part of the transcript the bookmark captured */
+"bookmark_edit_transcript_title" = "Edit transcript";
+
+/* The subtitle of a view where the user picks which part of the transcript the bookmark captured */
+"bookmark_edit_transcript_subtitle" = "Select a transcript passage for this bookmark";
+
 /* Label above the text field where the user edits the bookmark title */
 "bookmark_title_label" = "Title";
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-759

Stacked on #4806.

Adds an Edit button to the "Transcript captured" section that opens the full transcript with the captured passage selected and scrolled into view, so a different passage can be picked — by dragging the selection handles or tapping a sentence. Changing it deliberately leaves the suggested title alone: the suggestion belongs to the moment that was bookmarked. Storing the picked passage comes with the rest of smart bookmark storage.

I also made a couple of minor changes to the "Edit Bookmark" view to get it closer to the target design. It'll might need one more pass.

<img width="320"  alt="Screenshot 2026-07-22 at 2 34 25 PM" src="https://github.com/user-attachments/assets/92f44264-abb2-4f9c-8bb6-080ea6bf77e0" />


## To test

1. Enable `smartBookmarks` in Settings → Developer → Feature Flags.
2. Play an episode with a transcript for a minute, then create a bookmark from the player shelf.
3. Tap **Edit** next to "Transcript captured" — the transcript opens with the captured passage already selected, no scroll animation.
4. Drag the handles, or tap another sentence to select it, then go back: the new passage is shown under the field and the title is unchanged.

https://github.com/user-attachments/assets/0a83c677-5313-4e33-8ed0-8d4b644c236a


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.