### PR TITLE
Add a bookmark details screen

### DIFF
--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -10,6 +10,7 @@ class BookmarkManager {
     private let generalManager: DataManager
     private let playbackManager: PlaybackManager
     private let cacheServerHandler: CacheServerHandler
+    private let userDefaults: UserDefaults
 
     /// Called when a bookmark is created
     let onBookmarkCreated = PassthroughSubject<Event.Created, Never>()
@@ -23,11 +24,13 @@ class BookmarkManager {
     init(dataManager: BookmarkDataManager = DataManager.sharedManager.bookmarks,
          generalManager: DataManager = .sharedManager,
          playbackManager: PlaybackManager = .shared,
-         cacheServerHandler: CacheServerHandler = .shared) {
+         cacheServerHandler: CacheServerHandler = .shared,
+         userDefaults: UserDefaults = .standard) {
         self.dataManager = dataManager
         self.generalManager = generalManager
         self.playbackManager = playbackManager
         self.cacheServerHandler = cacheServerHandler
+        self.userDefaults = userDefaults
     }
 
     /// Plays the "bookmark created" tone
@@ -94,6 +97,8 @@ class BookmarkManager {
     /// Removes an array of bookmarks
     func remove(_ bookmarks: [Bookmark]) async -> Bool {
         await dataManager.remove(bookmarks: bookmarks).when(true) {
+            bookmarks.forEach { setPassage(nil, for: $0) }
+
             onBookmarksDeleted.send(.init(items: bookmarks.map {
                 .init(uuid: $0.uuid, episode: $0.episodeUuid, podcast: $0.podcastUuid)
             }))
@@ -111,6 +116,29 @@ class BookmarkManager {
     /// Gets the `BaseEpisode` for the given bookmark
     func episode(for bookmark: Bookmark) -> BaseEpisode? {
         generalManager.findBaseEpisode(uuid: bookmark.episodeUuid)
+    }
+
+    // MARK: - Passage
+
+    /// The transcript passage the bookmark captures.
+    ///
+    /// Temporarily kept in `UserDefaults`, until the passage is stored with the bookmark itself.
+    func passage(for bookmark: Bookmark) -> String? {
+        userDefaults.string(forKey: Self.passageKey(for: bookmark))
+    }
+
+    /// Passing `nil` removes the stored passage
+    func setPassage(_ passage: String?, for bookmark: Bookmark) {
+        let key = Self.passageKey(for: bookmark)
+        if let passage {
+            userDefaults.set(passage, forKey: key)
+        } else {
+            userDefaults.removeObject(forKey: key)
+        }
+    }
+
+    private static func passageKey(for bookmark: Bookmark) -> String {
+        "bookmark.passage.\(bookmark.uuid)"
     }
 
     // MARK: - Title Generation

--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -33,14 +33,16 @@ struct BookmarkDetailsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 viewModel.podcastTitle.map {
                     Text($0)
-                        .font(style: .footnote, weight: .medium)
+                        .font(size: 11, style: .caption2, weight: .semibold)
+                        .kerning(-0.4)
                         .foregroundStyle(theme.primaryText02)
                         .lineLimit(1)
                 }
 
                 viewModel.episode.map {
                     Text($0.displayableTitle())
-                        .font(style: .subheadline, weight: .semibold)
+                        .font(size: 15, style: .subheadline, weight: .semibold)
+                        .kerning(-0.4)
                         .foregroundStyle(theme.primaryText01)
                         .lineLimit(2)
                 }

--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -1,0 +1,154 @@
+import PocketCastsDataModel
+import PocketCastsUtils
+import SwiftUI
+
+/// A single bookmark in full: the episode it was taken from, and the transcript passage
+/// it captured.
+struct BookmarkDetailsView: View {
+    @ObservedObject var viewModel: BookmarkDetailsViewModel
+
+    @EnvironmentObject private var theme: Theme
+
+    @ScaledMetricWithMaxSize(relativeTo: .body, maxSize: .xxLarge) private var imageSize = 56
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+                content
+            }
+            .padding(16)
+        }
+        .frame(maxWidth: .infinity)
+        .background(theme.primaryUi01.ignoresSafeArea())
+        .miniPlayerSafeAreaInset()
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            artwork
+
+            VStack(alignment: .leading, spacing: 2) {
+                viewModel.podcastTitle.map {
+                    Text($0)
+                        .font(style: .footnote, weight: .medium)
+                        .foregroundStyle(theme.primaryText02)
+                        .lineLimit(1)
+                }
+
+                viewModel.episode.map {
+                    Text($0.displayableTitle())
+                        .font(style: .subheadline, weight: .semibold)
+                        .foregroundStyle(theme.primaryText01)
+                        .lineLimit(2)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            playButton
+        }
+    }
+
+    @ViewBuilder
+    private var artwork: some View {
+        if let episode = viewModel.episode {
+            EpisodeImage(episode: episode)
+                .aspectRatio(contentMode: .fill)
+                .frame(width: imageSize, height: imageSize)
+                .cornerRadius(8)
+        } else {
+            RoundedRectangle(cornerRadius: 8)
+                .foregroundStyle(theme.primaryUi05)
+                .frame(width: imageSize, height: imageSize)
+        }
+    }
+
+    private var playButton: some View {
+        HStack(spacing: 8) {
+            Text(timestamp)
+                .font(style: .subheadline, weight: .medium)
+                .fixedSize()
+
+            Image("bookmarks-icon-play")
+                .renderingMode(.template)
+        }
+        .foregroundStyle(theme.primaryInteractive02)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(theme.primaryInteractive01)
+        .clipShape(Capsule())
+        .buttonize {
+            viewModel.onPlay()
+        }
+        .accessibilityLabel(L10n.play)
+    }
+
+    // MARK: - Content
+
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(created)
+                .font(style: .footnote, weight: .medium)
+                .foregroundStyle(theme.primaryText02)
+
+            Text(viewModel.bookmark.title)
+                .font(size: 22, style: .title3, weight: .bold)
+                .foregroundStyle(theme.primaryText01)
+                .padding(.bottom, 4)
+
+            Text(timestamp)
+                .font(style: .footnote, weight: .medium)
+                .foregroundStyle(theme.primaryText02)
+
+            viewModel.passage.map {
+                Text($0)
+                    .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
+                    .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
+                    .foregroundStyle(theme.primaryText02)
+                    .padding(.top, 4)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var timestamp: String {
+        TimeFormatter.shared.playTimeFormat(time: viewModel.bookmark.time)
+    }
+
+    private var created: String {
+        DateFormatter.localizedString(from: viewModel.bookmark.created, dateStyle: .medium, timeStyle: .short)
+    }
+}
+
+// MARK: - Preview
+
+struct BookmarkDetailsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationStack {
+            BookmarkDetailsView(viewModel: .init(bookmark: Self.previewBookmark(title: "Why admissions feel like a lottery",
+                                                                                time: 1390,
+                                                                                created: .now),
+                                                 passage: previewPassage,
+                                                 episode: previewEpisode,
+                                                 podcastTitle: "Radio Atlantic",
+                                                 bookmarkManager: .init()))
+        }
+        .setupDefaultEnvironment()
+    }
+
+    private static var previewEpisode: Episode {
+        let episode = Episode()
+        episode.title = "Higher Educations Identify Crisis"
+        return episode
+    }
+
+    private static let previewPassage = """
+    that's the thing about selective admissions — the difference between the kid who gets in \
+    and the kid who doesn't is often basically noise. Right, and that's why some researchers \
+    have floated the lottery idea. You set a bar for who's qualified, and past that, you just \
+    draw names. It sounds radical, but it's arguably more honest than pretending there's a \
+    meaningful distinction between applicant 1,800 and applicant 2,100.
+    """
+}

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewController.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewController.swift
@@ -1,0 +1,145 @@
+import PocketCastsDataModel
+import SwiftUI
+
+/// Hosts `BookmarkDetailsView` and performs the actions its navigation bar offers.
+class BookmarkDetailsViewController: ThemedHostingController<BookmarkDetailsView> {
+    private let bookmarkManager: BookmarkManager
+    private let playbackManager: PlaybackManager
+    private let analyticsSource: BookmarkAnalyticsSource
+    private let viewModel: BookmarkDetailsViewModel
+
+    init(bookmark: Bookmark,
+         bookmarkManager: BookmarkManager = PlaybackManager.shared.bookmarkManager,
+         playbackManager: PlaybackManager = .shared,
+         source: BookmarkAnalyticsSource = .unknown) {
+        self.bookmarkManager = bookmarkManager
+        self.playbackManager = playbackManager
+        self.analyticsSource = source
+
+        let viewModel = BookmarkDetailsViewModel(bookmark: bookmark, bookmarkManager: bookmarkManager)
+        self.viewModel = viewModel
+
+        super.init(rootView: .init(viewModel: viewModel))
+
+        viewModel.onPlay = { [weak self] in
+            self?.play()
+        }
+    }
+
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = L10n.bookmarkDetailsTitle
+        navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(named: "more"),
+                                                            style: .plain,
+                                                            target: self,
+                                                            action: #selector(moreTapped))
+        navigationItem.rightBarButtonItem?.accessibilityLabel = L10n.accessibilityMoreActions
+    }
+}
+
+// MARK: - Actions
+
+private extension BookmarkDetailsViewController {
+    var bookmark: Bookmark {
+        viewModel.bookmark
+    }
+
+    func play() {
+        Task {
+            do {
+                try await playbackManager.playBookmark(bookmark, source: analyticsSource)
+            } catch {
+                HapticsHelper.triggerErrorHaptic()
+                Toast.show(L10n.discoverEpisodeFailToLoad)
+            }
+        }
+    }
+
+    @objc func moreTapped() {
+        let optionPicker = OptionsPicker(title: nil)
+
+        var actions: [OptionAction] = [
+            .init(label: L10n.edit, icon: "folder-edit") { [weak self] in
+                self?.edit()
+            }
+        ]
+
+        if viewModel.episode is Episode {
+            actions.append(.init(label: L10n.share, icon: "podcast-share") { [weak self] in
+                self?.share()
+            })
+        }
+
+        let delete = OptionAction(label: L10n.delete, icon: "delete") { [weak self] in
+            self?.confirmDeletion()
+        }
+        delete.destructive = true
+        actions.append(delete)
+
+        optionPicker.addActions(actions)
+        optionPicker.present()
+    }
+
+    func edit() {
+        let controller = BookmarkEditTitleViewController(manager: bookmarkManager,
+                                                         bookmark: bookmark,
+                                                         state: .updating) { [weak self] _, _ in
+            self?.viewModel.refresh()
+        }
+
+        controller.source = analyticsSource
+
+        present(controller, animated: true)
+    }
+
+    func share() {
+        guard let episode = viewModel.episode as? Episode else { return }
+
+        Analytics.track(.bookmarkShareTapped, source: analyticsSource, properties: ["podcast_uuid": episode.podcastUuid, "episode_uuid": bookmark.episodeUuid])
+
+        SharingModal.show(option: .bookmark(episode, bookmark.time), from: .bookmark, in: self)
+    }
+
+    func confirmDeletion() {
+        let alert = UIAlertController(title: L10n.bookmarkDeleteWarningTitle,
+                                      message: L10n.bookmarkDeleteWarningBody,
+                                      preferredStyle: .alert)
+
+        alert.addAction(.init(title: L10n.cancel, style: .cancel, handler: { [analyticsSource] _ in
+            Analytics.track(.bookmarkDeleteFormDismissed, source: analyticsSource)
+        }))
+
+        alert.addAction(.init(title: L10n.delete, style: .destructive, handler: { [weak self, analyticsSource] _ in
+            Analytics.track(.bookmarkDeleteFormSubmitted, source: analyticsSource)
+            self?.delete()
+        }))
+
+        Analytics.track(.bookmarkDeleteFormShown, source: analyticsSource)
+
+        present(alert, animated: true)
+    }
+
+    func delete() {
+        Task {
+            guard await bookmarkManager.remove([bookmark]) else { return }
+
+            Analytics.track(.bookmarkDeleted, source: analyticsSource)
+
+            close()
+        }
+    }
+
+    /// Pushed onto a list's navigation stack, or presented over the player
+    func close() {
+        if let navigationController, navigationController.viewControllers.first != self {
+            navigationController.popViewController(animated: true)
+        } else {
+            dismiss(animated: true)
+        }
+    }
+}

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
@@ -1,0 +1,54 @@
+import Foundation
+import PocketCastsDataModel
+
+/// What the bookmark details show, kept in one place so the hosting controller can
+/// refresh it after the bookmark is edited.
+@MainActor
+class BookmarkDetailsViewModel: ObservableObject {
+    @Published private(set) var bookmark: Bookmark
+
+    /// The captured transcript passage, absent for bookmarks made before it was captured
+    @Published private(set) var passage: String?
+
+    let episode: BaseEpisode?
+    let podcastTitle: String?
+
+    /// Assigned by the hosting controller, which owns playback
+    var onPlay: () -> Void = {}
+
+    private let bookmarkManager: BookmarkManager
+
+    init(bookmark: Bookmark,
+         passage: String?,
+         episode: BaseEpisode?,
+         podcastTitle: String?,
+         bookmarkManager: BookmarkManager = PlaybackManager.shared.bookmarkManager) {
+        self.bookmark = bookmark
+        self.passage = passage
+        self.episode = episode
+        self.podcastTitle = podcastTitle
+        self.bookmarkManager = bookmarkManager
+    }
+
+    convenience init(bookmark: Bookmark, bookmarkManager: BookmarkManager) {
+        let episode = bookmark.episode ?? bookmarkManager.episode(for: bookmark)
+
+        self.init(bookmark: bookmark,
+                  passage: bookmarkManager.passage(for: bookmark),
+                  episode: episode,
+                  podcastTitle: Self.podcastTitle(for: bookmark, episode: episode),
+                  bookmarkManager: bookmarkManager)
+    }
+
+    func refresh() {
+        guard let bookmark = bookmarkManager.bookmark(for: bookmark.uuid) else { return }
+
+        self.bookmark = bookmark
+        self.passage = bookmarkManager.passage(for: bookmark)
+    }
+
+    private static func podcastTitle(for bookmark: Bookmark, episode: BaseEpisode?) -> String? {
+        let uuid = bookmark.podcastUuid ?? (episode as? Episode)?.podcastUuid
+        return uuid.flatMap { DataManager.sharedManager.findPodcast(uuid: $0)?.title }
+    }
+}

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -37,7 +37,15 @@ class BookmarkEditViewModel: ObservableObject {
     /// A title suggestion generated from the transcript around the bookmark's position
     @Published private(set) var titleSuggestion: TitleSuggestion = .none
 
-    @Published private(set) var snippet: BookmarkTranscriptSnippet?
+    /// Storing the passage as it's captured, and again on every change, keeps it around
+    /// even when the sheet is dismissed without saving the title
+    @Published private(set) var snippet: BookmarkTranscriptSnippet? {
+        didSet {
+            guard let snippet, snippet.range != oldValue?.range else { return }
+
+            bookmarkManager.setPassage(snippet.text, for: bookmark)
+        }
+    }
 
     /// Whether the transcript is still being fetched, so the passage can be shown as a
     /// placeholder rather than appearing out of nowhere

--- a/podcasts/Bookmarks/List/BookmarkListRouter.swift
+++ b/podcasts/Bookmarks/List/BookmarkListRouter.swift
@@ -6,6 +6,9 @@ protocol BookmarkListRouter: AnyObject {
     func bookmarkEdit(_ bookmark: Bookmark)
     func bookmarkShare(_ bookmark: Bookmark)
 
+    /// Opens the bookmark in full, with the transcript passage it captured
+    func bookmarkDetails(_ bookmark: Bookmark, source: BookmarkAnalyticsSource)
+
     /// Optional: Dismisses the presented bookmark list, if applicable.
     func dismissBookmarksList()
 
@@ -22,5 +25,17 @@ extension BookmarkListRouter {
 extension BookmarkListRouter where Self: UIViewController {
     func presentBookmarkController(_ controller: UIViewController) {
         present(controller, animated: true)
+    }
+
+    /// Pushed where the list already sits in a navigation stack, presented where it doesn't,
+    /// such as the player's bookmarks tab
+    func bookmarkDetails(_ bookmark: Bookmark, source: BookmarkAnalyticsSource) {
+        let controller = BookmarkDetailsViewController(bookmark: bookmark, source: source)
+
+        if let navigationController {
+            navigationController.pushViewController(controller, animated: true)
+        } else {
+            present(SJUIUtils.navController(for: controller), animated: true)
+        }
     }
 }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 import SwiftUI
 
 class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
@@ -51,6 +52,18 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
 
     func reload() { }
 
+    /// Outside of the multi selection, a tap opens the bookmark's details
+    override func tapped(item: Bookmark) {
+        guard !isMultiSelecting else {
+            super.tapped(item: item)
+            return
+        }
+
+        guard FeatureFlag.smartBookmarks.enabled else { return }
+
+        router?.bookmarkDetails(item, source: analyticsSource)
+    }
+
     func dismiss() {
         router?.dismissBookmarksList()
     }
@@ -63,6 +76,14 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
     }
 
     func addListeners() {
+        // Bookmarks can also be deleted from outside the list, such as from their details
+        bookmarkManager.onBookmarksDeleted
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.reload()
+            }
+            .store(in: &cancellables)
+
         bookmarkManager.onBookmarkChanged
             .filter { [weak self] event in
                 self?.items.contains(where: { $0.uuid == event.uuid }) ?? false

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4510,6 +4510,9 @@
 /* Label above the text field where the user edits the bookmark title */
 "bookmark_title_label" = "Title";
 
+/* The title of a view showing a single bookmark and the transcript passage it captured */
+"bookmark_details_title" = "Bookmark";
+
 /* The title of a view where the user can edit their bookmark title */
 "change_bookmark_title" = "Change title";
 


### PR DESCRIPTION
| 📘 Part of: #759 |
|:---:|

Fixes PCIOS-759

Stacked on #4809.

Adds a bookmark details screen. Tapping a bookmark in any of the lists now opens it in full: the episode it belongs to with a play button for its timestamp, and below that the date it was made, its title, and the transcript passage it captured. The nav bar's more menu carries the same edit, share, and delete actions the multi-select bar offers.

The captured passage is kept in `UserDefaults` keyed by the bookmark UUID for now — a temporary store until the passage is persisted with the bookmark itself as part of smart bookmark storage. The `BookmarkEditView` writes it as it's captured and on every re-selection, so a bookmark keeps its passage even when the sheet is closed without saving.

Only reachable while `smartBookmarks` is on; without it, tapping a row does nothing, as before.

## To test

1. Enable `smartBookmarks` in Settings → Developer → Feature Flags.
2. Play an episode with a transcript for a minute, then create a bookmark from the player shelf.
3. Open the bookmarks list (player shelf, episode, podcast, or Profile) and tap a bookmark.
4. The details screen shows the podcast/episode header, the timestamp play button, and the captured passage. Tap the play button to jump to the bookmark.
5. Tap **•••** → **Edit** to change the title, **Share**, or **Delete**. Deleting returns to the list, which no longer shows the removed bookmark.

<img width="320" alt="Screenshot 2026-07-22 at 7 04 26 PM" src="https://github.com/user-attachments/assets/3196c896-971b-4379-9010-97afea65324c" /> <img width="320" alt="Screenshot 2026-07-22 at 7 04 33 PM" src="https://github.com/user-attachments/assets/1827a8f3-1de9-48d0-98e6-711200a7dc88" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
