### PR TITLE
Migrate deprecated traitCollectionDidChange to registerForTraitChanges (56 warnings)

### DIFF
--- a/podcasts/AccountActionCell.swift
+++ b/podcasts/AccountActionCell.swift
@@ -74,6 +74,10 @@ class AccountActionCell: ThemeableCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         updateSize()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: AccountActionCell, _) in
+            view.updateSize()
+        }
     }
 
     override func prepareForReuse() {
@@ -82,14 +86,6 @@ class AccountActionCell: ThemeableCell {
         imageAndTextColor = nil
 
         updateSize()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 
     func updateSize() {

--- a/podcasts/ChangeEmailViewController.swift
+++ b/podcasts/ChangeEmailViewController.swift
@@ -117,6 +117,11 @@ class ChangeEmailViewController: PCViewController, UITextFieldDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = L10n.changeEmail
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: ChangeEmailViewController, _) in
+            controller.updateSize()
+        }
+
         currentEmailLabel.text = ServerSettings.syncingEmail()
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: UIImage(named: "cancel"), style: .done, target: self, action: #selector(backTapped))
         navigationController?.navigationBar.setValue(true, forKey: "hidesShadow")
@@ -315,12 +320,5 @@ class ChangeEmailViewController: PCViewController, UITextFieldDelegate {
         stackView.alignment = largeSize ? .leading : .fill
         currentEmailLabel.textAlignment = largeSize ? .natural : .right
         emailLabelSizeConstraint.isActive = largeSize ? false : true
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/ChaptersViewController.swift
+++ b/podcasts/ChaptersViewController.swift
@@ -29,6 +29,10 @@ class ChaptersViewController: PlayerItemViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         chaptersTable.sectionHeaderTopPadding = 0
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: ChaptersViewController, _) in
+            controller.updateSize()
+        }
     }
 
     override func willBeAddedToPlayer() {
@@ -89,13 +93,6 @@ class ChaptersViewController: PlayerItemViewController {
         view.backgroundColor = PlayerColorHelper.playerBackgroundColor01()
         chaptersTable.backgroundColor = PlayerColorHelper.playerBackgroundColor01()
         header.backgroundColor = PlayerColorHelper.playerBackgroundColor01()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 
     func updateSize() {

--- a/podcasts/CheckboxCell.swift
+++ b/podcasts/CheckboxCell.swift
@@ -25,6 +25,11 @@ class CheckboxCell: ThemeableCell {
     private var tickImageView: UIImageView!
     override func awakeFromNib() {
         super.awakeFromNib()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: CheckboxCell, _) in
+            view.updateSize()
+        }
+
         let tickImage = UIImage(named: "tick")
         tickImageView = UIImageView(frame: CGRect(x: 2, y: 2, width: 20, height: 20))
         tickImageView.image = tickImage
@@ -49,14 +54,6 @@ class CheckboxCell: ThemeableCell {
     }
 
     // MARK: - Dynamic Type Updates
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
-    }
 
     private func updateSize() {
         let metric = UIFontMetrics(forTextStyle: .largeTitle)

--- a/podcasts/Common Components/MultiSelect/MultiSelectActionCell.swift
+++ b/podcasts/Common Components/MultiSelect/MultiSelectActionCell.swift
@@ -33,6 +33,10 @@ class MultiSelectActionCell: ThemeableCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         updateSize()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: MultiSelectActionCell, _) in
+            view.updateSize()
+        }
     }
 
     private func updateSize() {
@@ -40,12 +44,5 @@ class MultiSelectActionCell: ThemeableCell {
         let iconSize = max(24, metric.scaledValue(for: 24))
 
         iconView.updateSizeConstraints(to: iconSize)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/Common Components/PlusLockedInfoView.swift
+++ b/podcasts/Common Components/PlusLockedInfoView.swift
@@ -67,14 +67,10 @@ class PlusLockedInfoView: ThemeableView {
         addSubview(contentView)
         contentView.anchorToAllSidesOf(view: self)
         updateSize()
-    }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateCloseButtonImage()
-            updateSize()
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: PlusLockedInfoView, _) in
+            view.updateCloseButtonImage()
+            view.updateSize()
         }
     }
 

--- a/podcasts/Common Components/Podcast Selection/PodcastChooserCell.swift
+++ b/podcasts/Common Components/Podcast Selection/PodcastChooserCell.swift
@@ -15,6 +15,10 @@ class PodcastChooserCell: ThemeableCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         updateSize()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: PodcastChooserCell, _) in
+            view.updateSize()
+        }
     }
 
     override func handleThemeDidChange() {
@@ -33,12 +37,5 @@ class PodcastChooserCell: ThemeableCell {
         podcastImage.updateSizeConstraints(to: size)
 
         podcastName.updateNumberOfLines(regular: 2, accessibility: 3)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/Common Components/RichExpandableDescriptionView.swift
+++ b/podcasts/Common Components/RichExpandableDescriptionView.swift
@@ -46,6 +46,11 @@ class RichExpandableLabel: WKWebView {
     }
 
     private func commonInit() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: RichExpandableLabel, _) in
+            view.reset()
+            view.setRichText(html: view.originalHTML)
+        }
+
         translatesAutoresizingMaskIntoConstraints = false
         let font = UIFont.preferredFont(forTextStyle: .body)
         let estimatedHeight = Self.estimateHeightFor(maxLines: maxLines, lineHeightMultiple: desiredLinedHeightMultiple, font: font)
@@ -87,16 +92,6 @@ class RichExpandableLabel: WKWebView {
         previousHTML = styledHTML
         self.loadHTMLString(styledHTML, baseURL: nil)
     }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-            super.traitCollectionDidChange(previousTraitCollection)
-
-            // Check if content size category specifically changed
-            if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-                reset()
-                setRichText(html: originalHTML)
-            }
-        }
 
     private func style(html: String) -> String {
         let  backgroundColor: UIColor = ThemeColor.primaryUi02()

--- a/podcasts/Common Components/Search/PCSearchBarController.swift
+++ b/podcasts/Common Components/Search/PCSearchBarController.swift
@@ -84,6 +84,11 @@ class PCSearchBarController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         updateColors()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: PCSearchBarController, _) in
+            controller.updateSize()
+        }
+
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(searchRequest), name: Constants.Notifications.podcastSearchRequest, object: nil)
         updateSize()
@@ -228,11 +233,5 @@ class PCSearchBarController: UIViewController {
         clearSearchBtn.updateSizeConstraints(to: clearSearchSize)
 
         view.updateSizeConstraints(to: Self.defaultHeight)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
-        updateSize()
     }
 }

--- a/podcasts/Common Components/SettingsTableHeader.swift
+++ b/podcasts/Common Components/SettingsTableHeader.swift
@@ -28,6 +28,10 @@ class SettingsTableHeader: ThemeableView {
     private var lockImage: UIView?
 
     private func setupView(title: String, showLockedImage: Bool = false, lockedSelector: Selector? = nil, lockedTarget: Any? = nil, rightBtnTitle: String? = nil, rightBtnSelector: Selector? = nil, rightBtnTarget: Any? = nil, rightBtnThemeStyle: ThemeStyle = .primaryInteractive01, themeStyle: ThemeStyle) {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: SettingsTableHeader, _) in
+            view.updateSize()
+        }
+
         style = themeStyle
 
         titleLabel.style = .primaryText02
@@ -108,14 +112,6 @@ class SettingsTableHeader: ThemeableView {
     override func handleThemeDidChange() {
         if clearBackground {
             backgroundColor = .clear
-        }
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
         }
     }
 

--- a/podcasts/DescriptiveActionView.swift
+++ b/podcasts/DescriptiveActionView.swift
@@ -24,6 +24,10 @@ class DescriptiveActionView: UIView {
         self.iconTintStyle = iconTintStyle
         self.onLinkTap = onLinkTap
         super.init(frame: frame)
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: DescriptiveActionView, _) in
+            view.updateSize()
+        }
     }
 
     @available(*, unavailable)
@@ -191,14 +195,6 @@ class DescriptiveActionView: UIView {
             action.action()
         }
         return actionButton
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 
     private func updateSize() {

--- a/podcasts/DisclosureCell.swift
+++ b/podcasts/DisclosureCell.swift
@@ -23,6 +23,11 @@ class DisclosureCell: ThemeableCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: DisclosureCell, _) in
+            view.updateSize()
+        }
+
         // Ensure label can expand vertically
         cellLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         cellLabel.setContentHuggingPriority(.defaultLow, for: .vertical)
@@ -33,14 +38,6 @@ class DisclosureCell: ThemeableCell {
     override func prepareForReuse() {
         super.prepareForReuse()
         setImage(imageName: nil)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 
     private func updateSize() {

--- a/podcasts/DiscoverFeaturedView.swift
+++ b/podcasts/DiscoverFeaturedView.swift
@@ -75,6 +75,10 @@ class DiscoverFeaturedView: ThemeableView {
     }
 
     private func commonInit() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: DiscoverFeaturedView, _) in
+            view.updateSize()
+        }
+
         Bundle.main.loadNibNamed("DiscoverFeaturedView", owner: self, options: nil)
         contentView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(contentView)
@@ -208,14 +212,6 @@ class DiscoverFeaturedView: ThemeableView {
                 titleTopConstraint,
                 titleLeadingConstraint
             ])
-        }
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            updateSize()
         }
     }
 }

--- a/podcasts/DiscoverPodcastTableCell.swift
+++ b/podcasts/DiscoverPodcastTableCell.swift
@@ -153,6 +153,10 @@ class DiscoverPodcastTableCell: ThemeableCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         updateSize()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: DiscoverPodcastTableCell, _) in
+            view.updateSize()
+        }
     }
 
     // MARK: - Dynamic Type support
@@ -170,13 +174,5 @@ class DiscoverPodcastTableCell: ThemeableCell {
 
         podcastTitle.updateNumberOfLines(regular: 1, accessibility: 3)
         podcastAuthor.updateNumberOfLines(regular: 1, accessibility: 3)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/DownloadsViewController.swift
+++ b/podcasts/DownloadsViewController.swift
@@ -80,6 +80,10 @@ class DownloadsViewController: PCViewController {
         setupNavBar()
         super.viewDidLoad()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: DownloadsViewController, _) in
+            controller.updateSize()
+        }
+
         downloadsTable.tableFooterView = UIView(frame: CGRect.zero)
         downloadsTable.sectionFooterHeight = 0.0
 
@@ -331,13 +335,6 @@ class DownloadsViewController: PCViewController {
 
     private func updateSize() {
         showManageDownloadsBanner()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }
 

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -197,6 +197,10 @@ class EffectsViewController: SimpleNotificationsViewController {
         super.viewDidLoad()
         view.translatesAutoresizingMaskIntoConstraints = false
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: EffectsViewController, _) in
+            controller.updateSize()
+        }
+
         updateColors()
         updateControls()
         setupAccessibility()
@@ -568,14 +572,6 @@ class EffectsViewController: SimpleNotificationsViewController {
         accessibilityElements.append(volumeBoostSwitch!)
 
         view.accessibilityElements = accessibilityElements
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 
     private func updateSize() {

--- a/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
+++ b/podcasts/End of Year/Stories/MDCSwiftUIWrapper.swift
@@ -34,6 +34,17 @@ class BottomSheetSwiftUIWrapper<ContentView: View>: UIViewController, UISheetPre
     }
 
     private func setup(content: ContentView, backgroundStyle: ThemeStyle? = nil, backgroundColor: UIColor? = nil) {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: BottomSheetSwiftUIWrapper<ContentView>, _) in
+            guard let sheetController = controller.sheetPresentationController else { return }
+            controller.updatePreferredContentSize()
+            //Dispatch to main to allow changes in content to reflect
+            DispatchQueue.main.async {
+                sheetController.animateChanges {
+                    sheetController.invalidateDetents()
+                }
+            }
+        }
+
         view.addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -120,22 +131,6 @@ class BottomSheetSwiftUIWrapper<ContentView: View>: UIViewController, UISheetPre
 
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         self.dismissCallback?()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            if let sheetController = sheetPresentationController {
-                updatePreferredContentSize()
-                //Dispatch to main to allow changes in content to reflect
-                DispatchQueue.main.async {
-                    sheetController.animateChanges {
-                        sheetController.invalidateDetents()
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -148,6 +148,10 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: EpisodeCell, _) in
+            view.updateSize()
+        }
+
         NotificationCenter.default.addObserver(self, selector: #selector(updateCellFromGenericEvent), name: Constants.Notifications.playbackStarted, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateCellFromGenericEvent), name: Constants.Notifications.playbackEnded, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateCellFromGenericEvent), name: Constants.Notifications.playbackPaused, object: nil)
@@ -710,11 +714,5 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
         episodeTitle.updateNumberOfLines(regular: 2, accessibility: 3)
         dayName.updateNumberOfLines(regular: 1, accessibility: 3)
         informationLabel.updateNumberOfLines(regular: 1, accessibility: 3)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
-        updateSize()
     }
 }

--- a/podcasts/Episode/EpisodeDetailViewController.swift
+++ b/podcasts/Episode/EpisodeDetailViewController.swift
@@ -222,6 +222,10 @@ class EpisodeDetailViewController: FakeNavViewController, UIDocumentInteractionC
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: EpisodeDetailViewController, _) in
+            controller.updateSize()
+        }
+
         addBookmarksTabIfNeeded()
 
         closeTapped = { [weak self] in
@@ -809,11 +813,5 @@ extension EpisodeDetailViewController {
         let iconSize = max(24, metric.scaledValue(for: 24))
         messageIcon.updateSizeConstraints(to: iconSize)
         downloadIndicator.updateSizeConstraints(to: iconSize)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
-        updateSize()
     }
 }

--- a/podcasts/EpisodePreviewCell.swift
+++ b/podcasts/EpisodePreviewCell.swift
@@ -42,11 +42,11 @@ class EpisodePreviewCell: ThemeableCell {
 
     // MARK: - Dynamic Type Updates
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
+    override func awakeFromNib() {
+        super.awakeFromNib()
 
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: EpisodePreviewCell, _) in
+            view.updateSize()
         }
     }
 

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -63,6 +63,10 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
         super.viewDidLoad()
         (view as? ThemeableView)?.style = .primaryUi02
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: ExpandedCollectionViewController, _) in
+            controller.updateSize()
+        }
+
         if let collectionSubtitle = podcastCollection?.subtitle?.localized.localizedCapitalized {
             title = collectionSubtitle
         } else {
@@ -138,13 +142,5 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
 
     func updateSize() {
         updateFlowLayoutSize()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -41,6 +41,10 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: FeaturedSummaryViewController, _) in
+            controller.updateSize()
+        }
+
         (view as? ThemeableView)?.style = .primaryUi02
 
         featuredCollectionView.register(UINib(nibName: "FeaturedCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: FeaturedSummaryViewController.cellId)
@@ -270,13 +274,5 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
     func updateSize() {
         lastLayedOutWidth = 0
         featuredCollectionViewHeight.constant = cellHeight
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/LargeListCell.swift
+++ b/podcasts/LargeListCell.swift
@@ -62,6 +62,10 @@ class LargeListCell: ThemeableCollectionCell {
         super.awakeFromNib()
         setupExplicitBadge()
         updateSize()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: LargeListCell, _) in
+            view.updateSize()
+        }
     }
 
     private func setupExplicitBadge() {
@@ -142,13 +146,5 @@ class LargeListCell: ThemeableCollectionCell {
     func updateSize() {
         podcastTitle.updateNumberOfLines(regular: 1, accessibility: 2)
         podcastAuthor.updateNumberOfLines(regular: 1, accessibility: 2)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/LargeListSummaryCellHeaderView.swift
+++ b/podcasts/LargeListSummaryCellHeaderView.swift
@@ -76,6 +76,10 @@ class LargeListSummaryCellHeaderView: UIView {
     }
 
     private func setup() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: LargeListSummaryCellHeaderView, _) in
+            view.updateSize()
+        }
+
         addSubview(horizontalStack)
         horizontalStack.translatesAutoresizingMaskIntoConstraints = false
 
@@ -110,13 +114,5 @@ class LargeListSummaryCellHeaderView: UIView {
     func updateSize() {
         topLabel.updateNumberOfLines(regular: 1, accessibility: 2)
         bottomLabel.updateNumberOfLines(regular: 1, accessibility: 2)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -45,6 +45,10 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: LargeListSummaryViewController, _) in
+            controller.updateSize()
+        }
+
         (view as? ThemeableView)?.style = .primaryUi02
 
         collectionView.register(UINib(nibName: "LargeListCell", bundle: nil), forCellWithReuseIdentifier: LargeListSummaryViewController.cellId)
@@ -262,13 +266,5 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         lastLayedOutWidth = 0
         largeListCollectionViewHeight.constant = cellWidth + cellExtraHeight
         view.setNeedsLayout()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -93,6 +93,14 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        registerForTraitChanges([UITraitUserInterfaceStyle.self, UITraitHorizontalSizeClass.self]) { (controller: MainTabBarController, _) in
+            if let scene = controller.view.window?.windowScene {
+                Theme.systemIsDark = (scene.traitCollection.userInterfaceStyle == .dark)
+            }
+            controller.fixTarBarTraitCollectionOnIpadForiOS18()
+            controller.fireSystemThemeMayHaveChanged()
+        }
+
         fixTarBarTraitCollectionOnIpadForiOS18()
 
         pcTabs = [.podcasts, .filter, .discover, .upNext, .profile]
@@ -261,15 +269,6 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
                 }
             }
         }
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if let scene = view.window?.windowScene {
-            Theme.systemIsDark = (scene.traitCollection.userInterfaceStyle == .dark)
-        }
-        fixTarBarTraitCollectionOnIpadForiOS18()
-        fireSystemThemeMayHaveChanged()
     }
 
     @objc func themeDidChange() {

--- a/podcasts/MultipleActionView.swift
+++ b/podcasts/MultipleActionView.swift
@@ -16,6 +16,10 @@ class MultipleActionView: UIView {
         self.themeOverride = themeOverride
 
         super.init(frame: frame)
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: MultipleActionView, _) in
+            view.updateSize()
+        }
     }
 
     @available(*, unavailable)
@@ -96,11 +100,5 @@ class MultipleActionView: UIView {
             let imageSize = max(24, metric.scaledValue(for: 24))
             imageView.updateSizeConstraints(to: imageSize)
         }
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
-        updateSize()
     }
 }

--- a/podcasts/NewsletterCell.swift
+++ b/podcasts/NewsletterCell.swift
@@ -38,20 +38,16 @@ class NewsletterCell: ThemeableCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         updateSize()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: NewsletterCell, _) in
+            view.updateSize()
+        }
     }
 
     override func prepareForReuse() {
         super.prepareForReuse()
 
         updateSize()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 
     func updateSize() {

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -245,6 +245,15 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: NowPlayingPlayerItemViewController, _) in
+            #if !APPCLIP
+            if FeatureFlag.bannerAdPlayer.enabled {
+                controller.updateBannerAdHeight()
+            }
+            #endif
+            controller.updateSize()
+        }
+
         setUpArtworkImageView()
 
         #if !APPCLIP
@@ -429,23 +438,6 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     override func themeDidChange() {
         lastShelfLoadState = ShelfLoadState()
         update(notification: nil)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        #if !APPCLIP
-        if FeatureFlag.bannerAdPlayer.enabled {
-            // Update banner height when text size category changes
-            if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-                updateBannerAdHeight()
-            }
-        }
-        #endif
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 
     var shelfIconSize: CGFloat {

--- a/podcasts/PlayerCell.swift
+++ b/podcasts/PlayerCell.swift
@@ -100,6 +100,10 @@ class PlayerCell: ThemeableSwipeCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: PlayerCell, _) in
+            view.updateSize()
+        }
+
         NotificationCenter.default.addObserver(self, selector: #selector(updateCellForDownloadProgressChange), name: Constants.Notifications.downloadProgress, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateCellForDownloadStatusChange(_:)), name: Constants.Notifications.episodeDownloaded, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updateCellForDownloadStatusChange(_:)), name: Constants.Notifications.episodeDownloadStatusChanged, object: nil)
@@ -311,12 +315,6 @@ class PlayerCell: ThemeableSwipeCell {
 
         episodeTitle.updateNumberOfLines(regular: 2, accessibility: 3)
         dayName.updateNumberOfLines(regular: 1, accessibility: 2)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
-        updateSize()
     }
 }
 

--- a/podcasts/PodcastFilterSelectionCell.swift
+++ b/podcasts/PodcastFilterSelectionCell.swift
@@ -41,6 +41,11 @@ class PodcastFilterSelectionCell: ThemeableCell {
     @IBOutlet var selectedImageView: UIImageView!
     override func awakeFromNib() {
         super.awakeFromNib()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: PodcastFilterSelectionCell, _) in
+            view.updateSize()
+        }
+
         let tickImage = UIImage(named: "tick")
         tickImageView.image = tickImage
         tickImageView.tintColor = ThemeColor.primaryInteractive02()
@@ -81,14 +86,6 @@ class PodcastFilterSelectionCell: ThemeableCell {
     }
 
     // MARK: - Dynamic Type Updates
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
-    }
 
     private func updateSize() {
         let metric = UIFontMetrics(forTextStyle: .largeTitle)

--- a/podcasts/PodcastHeaderListViewController.swift
+++ b/podcasts/PodcastHeaderListViewController.swift
@@ -34,6 +34,10 @@ class PodcastHeaderListViewController: PCViewController, UITableViewDataSource, 
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: PodcastHeaderListViewController, _) in
+            controller.chartsTable.reloadData()
+        }
+
         chartsTable.themeStyle = .primaryUi02
 
         chartsTable.register(UINib(nibName: "DiscoverPodcastTableCell", bundle: nil), forCellReuseIdentifier: PodcastHeaderListViewController.cellId)
@@ -52,14 +56,6 @@ class PodcastHeaderListViewController: PCViewController, UITableViewDataSource, 
         super.viewWillAppear(animated)
 
         chartsTable.reloadData()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            chartsTable.reloadData()
-        }
     }
 
     @objc private func handleShare() {

--- a/podcasts/Podcasts/All Podcasts/Cells/FolderListCell.swift
+++ b/podcasts/Podcasts/All Podcasts/Cells/FolderListCell.swift
@@ -32,6 +32,10 @@ class FolderListCell: ThemeableCollectionCell {
         super.awakeFromNib()
         isAccessibilityElement = true
         updateSize()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: FolderListCell, _) in
+            view.updateSize()
+        }
     }
 
     func populateFrom(folder: Folder, badgeType: BadgeType) {
@@ -82,11 +86,5 @@ class FolderListCell: ThemeableCollectionCell {
                 break
         }
         unplayedBadge.layoutIfNeeded()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
-        updateSize()
     }
 }

--- a/podcasts/Podcasts/All Podcasts/Cells/GridBadgeView.swift
+++ b/podcasts/Podcasts/All Podcasts/Cells/GridBadgeView.swift
@@ -55,6 +55,10 @@ class GridBadgeView: UIView {
     }
 
     private func setup() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: GridBadgeView, _) in
+            view.updateSize()
+        }
+
         badgeLabel.font = UIFont.font(ofSize: 13, weight: .bold, scalingWith: .largeTitle)
         badgeLabel.adjustsFontForContentSizeCategory = true
         badgeLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -100,14 +104,6 @@ class GridBadgeView: UIView {
         simpleBadge.borderColor = ThemeColor.primaryUi02()
         simpleBadge.centerColor = ThemeColor.primaryInteractive01()
         simpleBadge.backgroundColor = .clear
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 
     private func updateSize() {

--- a/podcasts/Podcasts/All Podcasts/Cells/PodcastListCell.swift
+++ b/podcasts/Podcasts/All Podcasts/Cells/PodcastListCell.swift
@@ -29,6 +29,10 @@ class PodcastListCell: ThemeableCollectionCell {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         isAccessibilityElement = true
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: PodcastListCell, _) in
+            view.updateSize()
+        }
     }
 
     func populateFrom(_ podcast: Podcast, badgeType: BadgeType) {
@@ -97,11 +101,5 @@ class PodcastListCell: ThemeableCollectionCell {
         }
 
         podcastTitle.updateNumberOfLines(regular: 1, accessibility: 3)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
-        updateSize()
     }
 }

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -91,6 +91,10 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         customRightBtn?.accessibilityLabel = L10n.accessibilityMoreActions
         super.viewDidLoad()
 
+        registerForTraitChanges([UITraitUserInterfaceIdiom.self]) { (controller: PodcastListViewController, _) in
+            controller.updateCustomBottomFade()
+        }
+
         updateNavigationButtons()
         title = L10n.podcastsPlural
         setupSearchBar()
@@ -406,11 +410,6 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         updateBottomSpacing()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        updateCustomBottomFade()
     }
 
     /// Fades the grid into its own background color, so the artwork dissolves cleanly

--- a/podcasts/ProfileViewController.swift
+++ b/podcasts/ProfileViewController.swift
@@ -133,6 +133,11 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
         customRightBtn?.accessibilityIdentifier = "Settings"
 
         super.viewDidLoad()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: ProfileViewController, _) in
+            controller.updateFooterFrame()
+        }
+
         navigationItem.title = L10n.profile
 
         profileTable.tableFooterView = footerView
@@ -517,14 +522,6 @@ class ProfileViewController: PCViewController, UITableViewDataSource, UITableVie
 
         footerView.frame = CGRect(x: footerView.frame.minX, y: footerView.frame.minY, width: footerView.frame.width, height: height)
         profileTable.tableFooterView = footerView
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateFooterFrame()
-        }
     }
 
     // MARK: - What's New Autoplay flow

--- a/podcasts/RadioButtonCell.swift
+++ b/podcasts/RadioButtonCell.swift
@@ -32,11 +32,11 @@ class RadioButtonCell: ThemeableCell {
         roundView.backgroundColor = color
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
+    override func awakeFromNib() {
+        super.awakeFromNib()
 
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: RadioButtonCell, _) in
+            view.updateSize()
         }
     }
 

--- a/podcasts/ShelfCell.swift
+++ b/podcasts/ShelfCell.swift
@@ -24,6 +24,10 @@ class ShelfCell: UITableViewCell {
         setHighlightedState(false)
         overrideUserInterfaceStyle = .dark
         updateSize()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: ShelfCell, _) in
+            view.updateSize()
+        }
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -55,14 +59,6 @@ class ShelfCell: UITableViewCell {
         super.prepareForReuse()
 
         customViewContainer.removeAllSubviews()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 
     private func updateSize() {

--- a/podcasts/ShiftyRoundButton.swift
+++ b/podcasts/ShiftyRoundButton.swift
@@ -103,6 +103,12 @@ class ShiftyRoundButton: UIView {
     }
 
     func setup() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: ShiftyRoundButton, _) in
+            view.lastCGRectRendered = .zero
+            view.updateTextLayerFont()
+            view.setNeedsLayout()
+        }
+
         clipsToBounds = true
         isUserInteractionEnabled = true
 
@@ -157,13 +163,5 @@ class ShiftyRoundButton: UIView {
         if !enabled { return }
 
         shapeLayer.transform = CATransform3DIdentity
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
-        lastCGRectRendered = .zero
-        updateTextLayerFont()
-        setNeedsLayout()
     }
 }

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -60,6 +60,10 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: ShowNotesPlayerItemViewController, _) in
+            controller.updateSize()
+        }
+
         setupWebView()
         updateColors()
         updateSize()
@@ -270,12 +274,5 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
         let size = max(metric.scaledValue(for: 24), 24)
         durationImageView.updateSizeConstraints(to: size)
         dateImageView.updateSizeConstraints(to: size)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/SimpleActionView.swift
+++ b/podcasts/SimpleActionView.swift
@@ -21,6 +21,10 @@ class SimpleActionView: UIView {
         self.themeOverride = themeOverride
         self.iconTintStyle = iconTintStyle
         super.init(frame: frame)
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: SimpleActionView, _) in
+            view.updateSize()
+        }
     }
 
     @available(*, unavailable)
@@ -220,12 +224,5 @@ class SimpleActionView: UIView {
         if let selectedView {
             selectedView.updateSizeConstraints(to: imageSize)
         }
-    }
-
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
-        updateSize()
     }
 }

--- a/podcasts/SingleEpisodeViewController.swift
+++ b/podcasts/SingleEpisodeViewController.swift
@@ -46,6 +46,10 @@ class SingleEpisodeViewController: UIViewController {
         (view as? ThemeableView)?.style = .primaryUi02
         view.translatesAutoresizingMaskIntoConstraints = false
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: SingleEpisodeViewController, _) in
+            controller.updateSize()
+        }
+
         observeEpisodeChanges()
 
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didSelectEpisode))
@@ -126,13 +130,6 @@ class SingleEpisodeViewController: UIViewController {
         podcastTitle.sizeToFit()
         playButton.sizeToFit()
         view.sizeToFit()
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }
 

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -52,6 +52,10 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
         super.viewDidLoad()
         (view as? ThemeableView)?.style = .primaryUi02
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: SinglePodcastViewController, _) in
+            controller.updateSize()
+        }
+
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(showPodcast))
         view.addGestureRecognizer(tapGesture)
         NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
@@ -192,13 +196,5 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
     func updateSize() {
         podcastTitle.updateNumberOfLines(regular: 2, accessibility: 3)
         podcastDescription.updateNumberOfLines(regular: 4, accessibility: 6)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/SiriShortcutAddCell.swift
+++ b/podcasts/SiriShortcutAddCell.swift
@@ -36,11 +36,11 @@ class SiriShortcutAddCell: ThemeableCell {
         updateSize()
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
+    override func awakeFromNib() {
+        super.awakeFromNib()
 
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: SiriShortcutAddCell, _) in
+            view.updateSize()
         }
     }
 

--- a/podcasts/SiriShortcutSuggestedCell.swift
+++ b/podcasts/SiriShortcutSuggestedCell.swift
@@ -10,11 +10,11 @@ class SiriShortcutSuggestedCell: ThemeableCell {
 
     @IBOutlet var titleLabel: UILabel!
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
+    override func awakeFromNib() {
+        super.awakeFromNib()
 
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: SiriShortcutSuggestedCell, _) in
+            view.updateSize()
         }
     }
 

--- a/podcasts/SmallListCell.swift
+++ b/podcasts/SmallListCell.swift
@@ -49,6 +49,10 @@ class SmallListCell: ThemeableCollectionCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         updateSize()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: SmallListCell, _) in
+            view.updateSize()
+        }
     }
 
     func setSelectedState(_ selected: Bool) {
@@ -143,13 +147,5 @@ class SmallListCell: ThemeableCollectionCell {
         podcastImage.updateSizeConstraints(to: max(48, metric.scaledValue(for: 48)))
 
         subscribeButton.updateSizeConstraints(to: max(44, metric.scaledValue(for: 44)))
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/SmallPagedListSummaryViewController.swift
+++ b/podcasts/SmallPagedListSummaryViewController.swift
@@ -58,6 +58,10 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: SmallPagedListSummaryViewController, _) in
+            controller.updateSize()
+        }
+
         (view as? ThemeableView)?.style = .primaryUi02
 
         maxCellWidth = view.bounds.width
@@ -253,13 +257,5 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
     func updateSize() {
         lastLayedOutWidth = 0
         smallPagedCollectionViewHeight.constant = (cellHeight + cellSpacing) * CGFloat(numberOfRows)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/StatsCell.swift
+++ b/podcasts/StatsCell.swift
@@ -13,6 +13,10 @@ class StatsCell: ThemeableCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         updateSize()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: StatsCell, _) in
+            view.updateSize()
+        }
     }
 
     @IBOutlet var leadingSpaceToIcon: NSLayoutConstraint!
@@ -41,12 +45,5 @@ class StatsCell: ThemeableCell {
         let metric = UIFontMetrics(forTextStyle: .largeTitle)
         let size = max(metric.scaledValue(for: 24), 24)
         statsIcon.updateSizeConstraints(to: size)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/SwitchCell.swift
+++ b/podcasts/SwitchCell.swift
@@ -33,6 +33,10 @@ class SwitchCell: ThemeableCell {
         super.awakeFromNib()
         accessoryView = cellSwitch
         setNoImage()
+
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: SwitchCell, _) in
+            view.updateSize()
+        }
     }
 
     override func handleThemeDidChange() {
@@ -65,12 +69,5 @@ class SwitchCell: ThemeableCell {
 
         let settingsSize = max(24, metric.scaledValue(for: 24))
         cellImage.updateSizeConstraints(to: settingsSize)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/TimeStepperCell.swift
+++ b/podcasts/TimeStepperCell.swift
@@ -27,6 +27,10 @@ class TimeStepperCell: ThemeableCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: TimeStepperCell, _) in
+            view.updateSize()
+        }
+
         cellTextToImageConstraint.isActive = false
         cellTextToMarginConstraint.isActive = true
 
@@ -69,12 +73,5 @@ class TimeStepperCell: ThemeableCell {
 
         let settingsSize = max(24, metric.scaledValue(for: 24))
         cellImage.updateSizeConstraints(to: settingsSize)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }

--- a/podcasts/TopLevelSettingsCell.swift
+++ b/podcasts/TopLevelSettingsCell.swift
@@ -29,6 +29,10 @@ class TopLevelSettingsCell: ThemeableCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: TopLevelSettingsCell, _) in
+            view.updateSize()
+        }
+
         setupDisclosureImageView()
         settingsLabel.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
         updateColor()
@@ -44,14 +48,6 @@ class TopLevelSettingsCell: ThemeableCell {
         imageView.frame = CGRect(x: 0, y: 0, width: size, height: size)
 
         accessoryView = imageView
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 
     private func updateSize() {

--- a/podcasts/TranscriptSearchAccessoryView.swift
+++ b/podcasts/TranscriptSearchAccessoryView.swift
@@ -91,6 +91,10 @@ class TranscriptSearchAccessoryView: UIInputView {
     }
 
     private func setupView() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: TranscriptSearchAccessoryView, _) in
+            view.updateSize()
+        }
+
         overrideUserInterfaceStyle = .dark
 
         addSubview(mainStackView)
@@ -161,13 +165,6 @@ class TranscriptSearchAccessoryView: UIInputView {
         let config = UIImage.SymbolConfiguration(pointSize: UIFont.font(with: .callout, maxSizeCategory: maxContentSizeCategory).pointSize)
         upButton.setImage(UIImage(systemName: "chevron.up")?.withConfiguration(config), for: .normal)
         downButton.setImage(UIImage(systemName: "chevron.down")?.withConfiguration(config), for: .normal)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            updateSize()
-        }
     }
 }
 

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -196,6 +196,15 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     }
 
     private func setupViews() {
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self, UITraitHorizontalSizeClass.self]) { (controller: TranscriptViewController, previousTraitCollection: UITraitCollection) in
+            if controller.traitCollection.preferredContentSizeCategory != previousTraitCollection.preferredContentSizeCategory {
+                controller.refreshText()
+                controller.refreshError()
+                controller.refreshActionButtons()
+            }
+            controller.updateTextMargins()
+        }
+
         view.addSubview(transcriptView)
         let transcriptViewTopConstraint = transcriptView.topAnchor.constraint(equalTo: view.topAnchor)
         self.transcriptViewTopConstraint = transcriptViewTopConstraint
@@ -706,15 +715,6 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
     private func resetKmp() {
         kmpSearch = nil
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        if traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory {
-            refreshText()
-            refreshError()
-            refreshActionButtons()
-        }
-        updateTextMargins()
     }
 
     private func refreshActionButtons() {

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -61,6 +61,10 @@ class UpNextNowPlayingCell: ThemeableCell {
         super.awakeFromNib()
         style = .primaryUi04
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: UpNextNowPlayingCell, _) in
+            view.updateSize()
+        }
+
         NotificationCenter.default.addObserver(self, selector: #selector(progressUpdated), name: Constants.Notifications.playbackProgress, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updatePlayingAnimation), name: Constants.Notifications.playbackPaused, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(updatePlayingAnimation), name: Constants.Notifications.playbackStarted, object: nil)
@@ -254,11 +258,5 @@ class UpNextNowPlayingCell: ThemeableCell {
 
         episodeTitle.updateNumberOfLines(regular: 1, accessibility: 3)
         dateLabel.updateNumberOfLines(regular: 1, accessibility: 2)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
-        updateSize()
     }
 }

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -187,6 +187,10 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (controller: UpNextViewController, _) in
+            controller.updateSize()
+        }
+
         title = L10n.upNext
 
         (view as? ThemeableView)?.style = .primaryUi04
@@ -676,12 +680,6 @@ extension UpNextViewController {
         if FeatureFlag.upNextSort.enabled {
             sortButton.updateSizeConstraints(to: buttonSize)
         }
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        guard traitCollection.preferredContentSizeCategory != previousTraitCollection?.preferredContentSizeCategory else { return }
-        updateSize()
     }
 }
 


### PR DESCRIPTION
Migrates every `traitCollectionDidChange(_:)` override — deprecated in iOS 17 — to the modern `registerForTraitChanges(_:handler:)` API, clearing the associated build warnings.

Each type registers for the specific trait it actually reacted to (almost always `UITraitPreferredContentSizeCategory` for Dynamic Type) in its existing setup method (`awakeFromNib` / `viewDidLoad` / `init` / `commonInit` / `setup`). Handlers use the passed-in instance rather than capturing `self`, following the codebase's existing pattern and avoiding a retain cycle. Since registration is trait-scoped, the redundant `preferredContentSizeCategory` guards inside the old overrides were dropped.

A few non-trivial cases:
- **MainTabBarController** reacts to theme + iPad size-class fixes → registers for `[UITraitUserInterfaceStyle, UITraitHorizontalSizeClass]`.
- **PodcastListViewController** → `UITraitUserInterfaceIdiom` (its bottom-fade reads `userInterfaceIdiom`).
- **NowPlayingPlayerItemViewController** preserves the `#if !APPCLIP` banner-ad branch.
- **TranscriptViewController** → `[UITraitPreferredContentSizeCategory, UITraitHorizontalSizeClass]` since its text margins derive from `readableContentGuide`.

Covers the 52 files reported by the compiler (App Clip re-reports 6 of them) plus 4 additional files with the identical deprecation.

Deployment target is iOS 17.0, so no availability guards are needed.

## To test

1. Build the app — confirm there are no `'traitCollectionDidChange' was deprecated in iOS 17.0` warnings.
2. Enable a large Dynamic Type size in Settings → Accessibility → Display & Text Size while the app is open; verify cells/labels across Podcasts, Discover, Up Next, Downloads, Player, Chapters, Profile, etc. resize live.
3. Toggle system Light/Dark appearance and rotate / resize (Split View on iPad); verify the tab bar theme and layout still update correctly.
4. Open the Transcript screen and change the text size; verify text, error state, action buttons, and margins update.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
