### PR TITLE
tvOS: Add Subscription info to Settings

### DIFF
--- a/Pocket Casts TV App/UI/MainTabView.swift
+++ b/Pocket Casts TV App/UI/MainTabView.swift
@@ -97,6 +97,9 @@ struct MainTabView: View {
         }
         .defaultFocus($focusedArea, .tabBar)
         .focusScope(mainTabFocusNS)
+        .onAppear {
+            focusedArea = .tabBar
+        }
         .ignoresSafeArea()
         .background(Color.pcBackgroundSurface)
         .requireAccountSupport()

--- a/Pocket Casts TV App/UI/Profile/SettingsMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/SettingsMenuView.swift
@@ -14,7 +14,7 @@ struct SettingsMenuView: View {
                 Button {
                     isShowingSubscription = true
                 } label: {
-                    Text("Subscription")
+                    Text(L10n.tvSettingsSubscriptionTitle)
                         .frame(minWidth: 400)
                 }
             }

--- a/Pocket Casts TV App/UI/Profile/SettingsMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/SettingsMenuView.swift
@@ -40,7 +40,7 @@ struct SettingsMenuView: View {
         .sheet(isPresented: $isShowingSubscription) {
             SubscriptionInfoView()
                 .onAppear {
-                    Analytics.track(.accountDetailsShowPrivacyPolicy)
+                    Analytics.track(.accountDetailSubscription)
                 }
         }
         .sheet(isPresented: $isShowingPrivacyPolicy) {

--- a/Pocket Casts TV App/UI/Profile/SettingsMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/SettingsMenuView.swift
@@ -40,7 +40,7 @@ struct SettingsMenuView: View {
         .sheet(isPresented: $isShowingSubscription) {
             SubscriptionInfoView()
                 .onAppear {
-                    Analytics.track(.accountDetailSubscription)
+                    Analytics.track(.accountDetailsSubscription)
                 }
         }
         .sheet(isPresented: $isShowingPrivacyPolicy) {

--- a/Pocket Casts TV App/UI/Profile/SettingsMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/SettingsMenuView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import PocketCastsServer
 
 struct SettingsMenuView: View {
-    @Environment(\.dismiss) private var dismiss
+    @Environment(AppCoordinator.self) private var coordinator
 
     @State private var isShowingSubscription = false
     @State private var isShowingPrivacyPolicy = false
@@ -10,11 +10,13 @@ struct SettingsMenuView: View {
 
     var body: some View {
         VStack {
-            Button {
-                isShowingSubscription = true
-            } label: {
-                Text("Subscription")
-                    .frame(minWidth: 400)
+            if coordinator.userState.isLoggedIn {
+                Button {
+                    isShowingSubscription = true
+                } label: {
+                    Text("Subscription")
+                        .frame(minWidth: 400)
+                }
             }
             Button {
                 isShowingPrivacyPolicy = true

--- a/Pocket Casts TV App/UI/Profile/SettingsMenuView.swift
+++ b/Pocket Casts TV App/UI/Profile/SettingsMenuView.swift
@@ -4,12 +4,18 @@ import PocketCastsServer
 struct SettingsMenuView: View {
     @Environment(\.dismiss) private var dismiss
 
+    @State private var isShowingSubscription = false
     @State private var isShowingPrivacyPolicy = false
     @State private var isShowingTermsOfUse = false
 
-
     var body: some View {
         VStack {
+            Button {
+                isShowingSubscription = true
+            } label: {
+                Text("Subscription")
+                    .frame(minWidth: 400)
+            }
             Button {
                 isShowingPrivacyPolicy = true
             } label: {
@@ -28,6 +34,12 @@ struct SettingsMenuView: View {
         .fixedSize(horizontal: true, vertical: false)
         .onAppear {
             Analytics.track(.settingsGeneralShown)
+        }
+        .sheet(isPresented: $isShowingSubscription) {
+            SubscriptionInfoView()
+                .onAppear {
+                    Analytics.track(.accountDetailsShowPrivacyPolicy)
+                }
         }
         .sheet(isPresented: $isShowingPrivacyPolicy) {
             ShowQRLinkView(title: L10n.accountPrivacyPolicy, message: L10n.tvSettingsPrivacyPolicyQrMessage, urlString: ServerConstants.Urls.privacyPolicy)

--- a/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
+++ b/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
@@ -18,16 +18,21 @@ class SubscriptionInfoViewModel {
     }
 
     func resolveProductID(tier: SubscriptionTier, frequency: SubscriptionFrequency) -> IAPProductID? {
-        switch(tier, frequency) {
-        case (.plus, .monthly):
-            return .monthly
-        case (.plus, .yearly):
-            return .yearly
-        case (.patron, .yearly):
-            return .patronYearly
-        case (.patron, .monthly):
-            return .patronMonthly
-        default:
+        let plan: Plan
+        switch tier {
+        case .plus:
+            plan = .plus
+        case .patron:
+            plan = .patron
+        case .none:
+            return nil
+        }
+        switch frequency {
+        case .yearly:
+            return plan.yearly
+        case .monthly:
+            return plan.monthly
+        case .none:
             return nil
         }
     }
@@ -49,25 +54,14 @@ struct SubscriptionInfoView: View {
     @State var model = SubscriptionInfoViewModel()
 
     var plan: String {
-        var result = ""
-        result = coordinator.userState.subscriptionTier.localizedDescription
-        result += " "
-        result += coordinator.userState.frequency.localizedDescription
-        return result
+        "\(coordinator.userState.subscriptionTier.localizedDescription) \(coordinator.userState.frequency.localizedDescription)"
     }
 
     var length: String {
-        var result = ""
-        if case SubscriptionStatus.lifetime = coordinator.userState.subscriptionStatus {
-            result = "Lifetime"
-            return result
+        if case .lifetime = coordinator.userState.subscriptionStatus {
+            return "Lifetime"
         }
-        result = DateFormatHelper.sharedHelper.longLocalizedFormat(coordinator.userState.expirationDate)
-        return result
-    }
-
-    var price: String? {
-        model.price
+        return DateFormatHelper.sharedHelper.longLocalizedFormat(coordinator.userState.expirationDate)
     }
 
     var body: some View {
@@ -76,12 +70,10 @@ struct SubscriptionInfoView: View {
                 .font(.headline)
                 .foregroundStyle(Color.pcTextPrimary)
             if case .freeAccount = coordinator.userState.subscriptionStatus {
-                Text("Free Account")
+                Text(L10n.accountDetailsFreeAccount)
                     .font(.caption)
                     .foregroundStyle(Color.pcTextSecondary)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(nil)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .wrappingMultiline()
             } else {
                 InfoRow(label: "Plan", value: self.plan)
                 InfoRow(label: "Next renewal", value: self.length)
@@ -94,9 +86,7 @@ struct SubscriptionInfoView: View {
                         Text("This subscription was made on another platform. Please use that platform to manage the subscription.")
                             .font(.caption)
                             .foregroundStyle(Color.pcTextSecondary)
-                            .multilineTextAlignment(.center)
-                            .lineLimit(nil)
-                            .fixedSize(horizontal: false, vertical: true)
+                            .wrappingMultiline()
                     }
                 }
             }
@@ -123,11 +113,24 @@ struct InfoRow: View {
             Text(value)
                 .font(.body)
                 .foregroundStyle(Color.pcTextPrimary)
-                .multilineTextAlignment(.center)
-                .lineLimit(nil)
-                .fixedSize(horizontal: false, vertical: true)
+                .wrappingMultiline()
         }
         .frame(minWidth: 400, maxWidth: 500)
+    }
+}
+
+private struct WrappingMultiline: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .multilineTextAlignment(.center)
+            .lineLimit(nil)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+private extension View {
+    func wrappingMultiline() -> some View {
+        modifier(WrappingMultiline())
     }
 }
 

--- a/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
+++ b/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
@@ -1,24 +1,164 @@
 import SwiftUI
+import PocketCastsServer
+import PocketCastsUtils
+import StoreKit
+
+@MainActor
+@Observable
+class SubscriptionInfoViewModel {
+
+    var isLoading: Bool = true
+    var price: String?
+
+    func refresh(isiOS: Bool, tier: SubscriptionTier, frequency: SubscriptionFrequency) async {
+        if isiOS, let productID = resolveProductID(tier: tier, frequency: frequency) {
+            price = await getSubscriptionPrice(productID: productID.rawValue)
+        }
+        isLoading = false
+    }
+
+    func resolveProductID(tier: SubscriptionTier, frequency: SubscriptionFrequency) -> IAPProductID? {
+        switch(tier, frequency) {
+        case (.plus, .monthly):
+            return .monthly
+        case (.plus, .yearly):
+            return .yearly
+        case (.patron, .yearly):
+            return .patronYearly
+        case (.patron, .monthly):
+            return .patronMonthly
+        default:
+            return nil
+        }
+    }
+
+    func getSubscriptionPrice(productID: String) async -> String? {
+        guard
+            let products = try? await Product.products(for: [productID]),
+            let product = products.first
+        else {
+            return nil
+        }
+        return product.displayPrice
+    }
+}
 
 struct SubscriptionInfoView: View {
-    @Environment(\.dismiss) private var dismiss
+    @Environment(AppCoordinator.self) private var coordinator
+
+    @State var model = SubscriptionInfoViewModel()
+
+    var plan: String {
+        var result = ""
+        result = coordinator.userState.subscriptionTier.localizedDescription
+        result += " "
+        result += coordinator.userState.frequency.localizedDescription
+        return result
+    }
+
+    var length: String {
+        var result = ""
+        if case SubscriptionStatus.lifetime = coordinator.userState.subscriptionStatus {
+            result = "Lifetime"
+            return result
+        }
+        result = DateFormatHelper.sharedHelper.longLocalizedFormat(coordinator.userState.expirationDate)
+        return result
+    }
+
+    var price: String? {
+        model.price
+    }
 
     var body: some View {
         VStack(spacing: 48) {
-            HStack(spacing: 16) {
-                Text("")
-                    .font(.title2)
-                    .foregroundStyle(Color.pcTextPrimary)
-                Spacer()
-                Text("")
-                    .font(.body)
+            Text("Subscription")
+                .font(.headline)
+                .foregroundStyle(Color.pcTextPrimary)
+            if case .freeAccount = coordinator.userState.subscriptionStatus {
+                Text("Free Account")
+                    .font(.caption)
                     .foregroundStyle(Color.pcTextSecondary)
                     .multilineTextAlignment(.center)
                     .lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true)
+            } else {
+                InfoRow(label: "Plan", value: self.plan)
+                InfoRow(label: "Next renewal", value: self.length)
+                if model.isLoading {
+                    ProgressView()
+                } else {
+                    if let price = model.price {
+                        InfoRow(label: "Price", value: price)
+                    } else {
+                        Text("This subscription was made on another platform. Please use that platform to manage the subscription.")
+                            .font(.caption)
+                            .foregroundStyle(Color.pcTextSecondary)
+                            .multilineTextAlignment(.center)
+                            .lineLimit(nil)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
             }
         }
         .frame(maxWidth: 800)
         .padding(80)
+        .task {
+            await model.refresh(isiOS: coordinator.userState.platform == .iOS, tier: coordinator.userState.subscriptionTier, frequency: coordinator.userState.frequency)
+        }
     }
+}
+
+struct InfoRow: View {
+
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Text(label)
+                .font(.body)
+                .foregroundStyle(Color.pcTextSecondary)
+            Spacer()
+            Text(value)
+                .font(.body)
+                .foregroundStyle(Color.pcTextPrimary)
+                .multilineTextAlignment(.center)
+                .lineLimit(nil)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(minWidth: 400, maxWidth: 500)
+    }
+}
+
+private extension SubscriptionTier {
+    var localizedDescription: String {
+        switch self {
+        case .none:
+            return "None"
+        case .plus:
+            return L10n.pocketCastsPlusShort
+        case .patron:
+            return L10n.patron
+        }
+    }
+}
+
+private extension SubscriptionFrequency {
+
+    var localizedDescription: String {
+        switch self {
+        case .none:
+            return ""
+        case .monthly:
+            return L10n.monthly
+        case .yearly:
+            return L10n.yearly
+        }
+    }
+}
+
+#Preview {
+    SubscriptionInfoView()
+        .environment(AppCoordinator())
 }

--- a/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
+++ b/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
@@ -54,7 +54,12 @@ struct SubscriptionInfoView: View {
     @State var model = SubscriptionInfoViewModel()
 
     var plan: String {
-        "\(coordinator.userState.subscriptionTier.localizedDescription) \(coordinator.userState.frequency.localizedDescription)"
+        [
+            coordinator.userState.subscriptionTier.localizedDescription,
+            coordinator.userState.frequency.localizedDescription
+        ]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
     }
 
     var length: String {

--- a/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
+++ b/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
@@ -13,6 +13,9 @@ class SubscriptionInfoViewModel {
     func refresh(isiOS: Bool, tier: SubscriptionTier, frequency: SubscriptionFrequency) async {
         if isiOS, let productID = resolveProductID(tier: tier, frequency: frequency) {
             price = await getSubscriptionPrice(productID: productID.rawValue)
+            if price == nil {
+                price = L10n.tvSettingsSubscriptionPriceUnavailable
+            }
         }
         isLoading = false
     }

--- a/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
+++ b/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
@@ -59,14 +59,14 @@ struct SubscriptionInfoView: View {
 
     var length: String {
         if case .lifetime = coordinator.userState.subscriptionStatus {
-            return "Lifetime"
+            return L10n.tvSettingsSubscriptionLifetime
         }
         return DateFormatHelper.sharedHelper.longLocalizedFormat(coordinator.userState.expirationDate)
     }
 
     var body: some View {
         VStack(spacing: 48) {
-            Text("Subscription")
+            Text(L10n.tvSettingsSubscriptionTitle)
                 .font(.headline)
                 .foregroundStyle(Color.pcTextPrimary)
             if case .freeAccount = coordinator.userState.subscriptionStatus {
@@ -75,15 +75,15 @@ struct SubscriptionInfoView: View {
                     .foregroundStyle(Color.pcTextSecondary)
                     .wrappingMultiline()
             } else {
-                InfoRow(label: "Plan", value: self.plan)
-                InfoRow(label: "Next renewal", value: self.length)
+                InfoRow(label: L10n.tvSettingsSubscriptionPlan, value: self.plan)
+                InfoRow(label: L10n.tvSettingsSubscriptionNextRenewal, value: self.length)
                 if model.isLoading {
                     ProgressView()
                 } else {
                     if let price = model.price {
-                        InfoRow(label: "Price", value: price)
+                        InfoRow(label: L10n.tvSettingsSubscriptionPrice, value: price)
                     } else {
-                        Text("This subscription was made on another platform. Please use that platform to manage the subscription.")
+                        Text(L10n.tvSettingsSubscriptionOtherPlatform)
                             .font(.caption)
                             .foregroundStyle(Color.pcTextSecondary)
                             .wrappingMultiline()
@@ -138,7 +138,7 @@ private extension SubscriptionTier {
     var localizedDescription: String {
         switch self {
         case .none:
-            return "None"
+            return L10n.none
         case .plus:
             return L10n.pocketCastsPlusShort
         case .patron:

--- a/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
+++ b/Pocket Casts TV App/UI/Profile/SubscriptionInfoView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct SubscriptionInfoView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 48) {
+            HStack(spacing: 16) {
+                Text("")
+                    .font(.title2)
+                    .foregroundStyle(Color.pcTextPrimary)
+                Spacer()
+                Text("")
+                    .font(.body)
+                    .foregroundStyle(Color.pcTextSecondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: 800)
+        .padding(80)
+    }
+}

--- a/Pocket Casts TV App/UI/UserStateModel.swift
+++ b/Pocket Casts TV App/UI/UserStateModel.swift
@@ -1,4 +1,5 @@
 import PocketCastsServer
+import PocketCastsUtils
 import Combine
 
 @Observable
@@ -6,9 +7,17 @@ class UserStateModel {
 
     private var cancellables: Set<AnyCancellable> = []
 
-    var isPlusUser: Bool
-    var isLoggedIn: Bool
+    var isPlusUser: Bool = false
+    var isLoggedIn: Bool = false
     var usernameEmail: String?
+    var expirationDate: Date?
+    var frequency: SubscriptionFrequency = .none
+    var subscriptionTier: SubscriptionTier = .none
+    var giftDays: Int = 0
+    var hasLifeTime: Bool = false
+    var hasRenewing: Bool = false
+    var platform: SubscriptionPlatform = .iOS
+    var subscriptionStatus: SubscriptionStatus = .freeAccount
 
     var usernameLabel: String {
         let usernameLabel = isLoggedIn ? (usernameEmail ?? "") : L10n.signedOut
@@ -16,9 +25,7 @@ class UserStateModel {
     }
 
     init() {
-        isPlusUser = SubscriptionHelper.hasActiveSubscription()
-        isLoggedIn = SyncManager.isUserLoggedIn()
-        usernameEmail = ServerSettings.syncingEmail()
+        refresh()
         setupObservers()
     }
 
@@ -26,6 +33,14 @@ class UserStateModel {
         isPlusUser = SubscriptionHelper.hasActiveSubscription()
         isLoggedIn = SyncManager.isUserLoggedIn()
         usernameEmail = ServerSettings.syncingEmail()
+        expirationDate = SubscriptionHelper.subscriptionRenewalDate()
+        frequency = SubscriptionHelper.subscriptionFrequencyValue()
+        subscriptionTier = SubscriptionHelper.subscriptionTier
+        giftDays = SubscriptionHelper.subscriptionGiftDays()
+        hasLifeTime = SubscriptionHelper.hasLifetimeGift()
+        hasRenewing = SubscriptionHelper.hasRenewingSubscription()
+        platform = SubscriptionHelper.subscriptionPlatform()
+        subscriptionStatus = SubscriptionStatus.make(hasActiveSubscription: SubscriptionHelper.hasActiveSubscription(), type: subscriptionTier, hasRenewing: hasRenewing, platform: platform, hasLifeTime: hasLifeTime, frequency: frequency, expirationDate: expirationDate, giftDays: giftDays)
     }
 
     private func setupObservers() {
@@ -41,5 +56,31 @@ class UserStateModel {
             refresh()
         }
         .store(in: &cancellables)
+    }
+}
+
+
+enum SubscriptionStatus {
+    case freeAccount
+    case lifetime
+    case activeSubscription(SubscriptionTier, SubscriptionFrequency, Date?)
+    case freeTrial(TimeInterval)
+    case paymentCancelled(SubscriptionTier, SubscriptionFrequency)
+
+    static func make(hasActiveSubscription: Bool, type: SubscriptionTier, hasRenewing: Bool, platform: SubscriptionPlatform, hasLifeTime: Bool, frequency: SubscriptionFrequency, expirationDate: Date?, giftDays: Int) -> SubscriptionStatus {
+        guard SubscriptionHelper.hasActiveSubscription() else {
+            return .freeAccount
+        }
+
+        switch(hasRenewing, platform, hasLifeTime) {
+        case (true, _, _): // Has a renewing subscription
+            return .activeSubscription(type, frequency, expirationDate)
+        case (false, .gift, true): // Lifetime plus subscription
+            return .lifetime
+        case (false, .gift, false): // Gift days (free trial)
+            return .freeTrial(Double(giftDays).days)
+        default: // Anything else should be a cancelled but not expired sub
+            return .paymentCancelled(type, frequency)
+        }
     }
 }

--- a/Pocket Casts TV App/UI/UserStateModel.swift
+++ b/Pocket Casts TV App/UI/UserStateModel.swift
@@ -32,7 +32,7 @@ class UserStateModel {
         usernameEmail = ServerSettings.syncingEmail()
         expirationDate = SubscriptionHelper.subscriptionRenewalDate()
         frequency = SubscriptionHelper.subscriptionFrequencyValue()
-        subscriptionTier = SubscriptionHelper.subscriptionTier
+        subscriptionTier = SubscriptionHelper.activeTier
         platform = SubscriptionHelper.subscriptionPlatform()
 
         let giftDays = SubscriptionHelper.subscriptionGiftDays()

--- a/Pocket Casts TV App/UI/UserStateModel.swift
+++ b/Pocket Casts TV App/UI/UserStateModel.swift
@@ -13,9 +13,6 @@ class UserStateModel {
     var expirationDate: Date?
     var frequency: SubscriptionFrequency = .none
     var subscriptionTier: SubscriptionTier = .none
-    var giftDays: Int = 0
-    var hasLifeTime: Bool = false
-    var hasRenewing: Bool = false
     var platform: SubscriptionPlatform = .iOS
     var subscriptionStatus: SubscriptionStatus = .freeAccount
 
@@ -36,11 +33,12 @@ class UserStateModel {
         expirationDate = SubscriptionHelper.subscriptionRenewalDate()
         frequency = SubscriptionHelper.subscriptionFrequencyValue()
         subscriptionTier = SubscriptionHelper.subscriptionTier
-        giftDays = SubscriptionHelper.subscriptionGiftDays()
-        hasLifeTime = SubscriptionHelper.hasLifetimeGift()
-        hasRenewing = SubscriptionHelper.hasRenewingSubscription()
         platform = SubscriptionHelper.subscriptionPlatform()
-        subscriptionStatus = SubscriptionStatus.make(hasActiveSubscription: SubscriptionHelper.hasActiveSubscription(), type: subscriptionTier, hasRenewing: hasRenewing, platform: platform, hasLifeTime: hasLifeTime, frequency: frequency, expirationDate: expirationDate, giftDays: giftDays)
+
+        let giftDays = SubscriptionHelper.subscriptionGiftDays()
+        let hasLifeTime = SubscriptionHelper.hasLifetimeGift()
+        let hasRenewing = SubscriptionHelper.hasRenewingSubscription()
+        subscriptionStatus = SubscriptionStatus.make(hasActiveSubscription: isPlusUser, type: subscriptionTier, hasRenewing: hasRenewing, platform: platform, hasLifeTime: hasLifeTime, frequency: frequency, expirationDate: expirationDate, giftDays: giftDays)
     }
 
     private func setupObservers() {
@@ -68,7 +66,7 @@ enum SubscriptionStatus {
     case paymentCancelled(SubscriptionTier, SubscriptionFrequency)
 
     static func make(hasActiveSubscription: Bool, type: SubscriptionTier, hasRenewing: Bool, platform: SubscriptionPlatform, hasLifeTime: Bool, frequency: SubscriptionFrequency, expirationDate: Date?, giftDays: Int) -> SubscriptionStatus {
-        guard SubscriptionHelper.hasActiveSubscription() else {
+        guard hasActiveSubscription else {
             return .freeAccount
         }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -3004,6 +3004,13 @@
 			);
 			target = FF4B83AD2F981D8E001B8C56 /* Pocket Casts TV App */;
 		};
+		FF94119530125CD2001837B8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				IAPTypes.swift,
+			);
+			target = FF4B83AD2F981D8E001B8C56 /* Pocket Casts TV App */;
+		};
 		FFE437E72FBCB03800716EAA /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -3020,7 +3027,7 @@
 		3F26BC112F4FC3C90007119B /* PodcastsIntents */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3F26BC1B2F4FC3CA0007119B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = PodcastsIntents; sourceTree = "<group>"; };
 		3F26BF082F4FC7C40007119B /* Pocket Casts Watch App */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3F26BF582F4FC7C40007119B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = "Pocket Casts Watch App"; sourceTree = "<group>"; };
 		3F584D1D2F567E4A005A3593 /* Episode Info Coordinator */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (FF8FFE672FAA8E650086A867 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = "Episode Info Coordinator"; sourceTree = "<group>"; };
-		3F584D242F567E73005A3593 /* InAppPurchases */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = InAppPurchases; sourceTree = "<group>"; };
+		3F584D242F567E73005A3593 /* InAppPurchases */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (FF94119530125CD2001837B8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = InAppPurchases; sourceTree = "<group>"; };
 		3F584D252F567EA6005A3593 /* Watch Communication */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Watch Communication"; sourceTree = "<group>"; };
 		3F584D262F567EE1005A3593 /* Lists */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (FF603BAA2FAB4F7100EB3AD5 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Lists; sourceTree = "<group>"; };
 		3F584DED2F56811B005A3593 /* End of Year */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "End of Year"; sourceTree = "<group>"; };

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
@@ -86,9 +86,6 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
-      <StoreKitConfigurationFileReference
-         identifier = "../../Pocket Casts Configuration.storekit">
-      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -136,6 +136,7 @@ enum AnalyticsEvent: String {
     case accountDetailsShowTOS
     case accountDetailsShowPrivacyPolicy
     case accountDetailsChangeAvatar
+    case accountDetailsSubscription
 
     // MARK: - Upgrade banner
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6558,6 +6558,9 @@
 /* tv settings - label for the row showing the subscription price */
 "tv_settings_subscription_price" = "Price";
 
+/* tv settings - value shown for the subscription price when it could not be retrieved */
+"tv_settings_subscription_price_unavailable" = "Unavailable";
+
 /* tv settings - value shown for the renewal date when the user has a lifetime subscription */
 "tv_settings_subscription_lifetime" = "Lifetime";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6546,6 +6546,24 @@
 /* tv settings - instruction to scan the QR code or open the URL on a phone to read the Terms of Use */
 "tv_settings_terms_of_use_qr_message" = "Scan the QR code below, or open the URL on your phone to access the Terms of Use.";
 
+/* tv settings - title of the subscription details screen */
+"tv_settings_subscription_title" = "Subscription";
+
+/* tv settings - label for the row showing the user's subscription plan (tier and frequency) */
+"tv_settings_subscription_plan" = "Plan";
+
+/* tv settings - label for the row showing when the subscription will next renew */
+"tv_settings_subscription_next_renewal" = "Next renewal";
+
+/* tv settings - label for the row showing the subscription price */
+"tv_settings_subscription_price" = "Price";
+
+/* tv settings - value shown for the renewal date when the user has a lifetime subscription */
+"tv_settings_subscription_lifetime" = "Lifetime";
+
+/* tv settings - message shown when the subscription was purchased on a different platform and must be managed there */
+"tv_settings_subscription_other_platform" = "This subscription was made on another platform. Please use that platform to manage the subscription.";
+
 
 /* tv create account step - scan the QR code */
 "tv_create_account_step_scan" = "Scan the QR code or go to %1$@";


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

Adds a **Subscription** section to the Pocket Casts tvOS app Settings menu. When the user is logged in, a new "Subscription" entry opens a screen showing the current subscription details:

- **Plan** — subscription tier (Plus / Patron) and frequency (monthly / yearly).
- **Next renewal** — the renewal/expiration date, or "Lifetime" for lifetime subscriptions.
- **Price** — fetched from StoreKit for subscriptions purchased on iOS. Subscriptions made on another platform show an explanatory message instead of a price.
- Free accounts show a "Free Account" label.

Subscription status is derived in `UserStateModel` via a new `SubscriptionStatus` enum (built from `SubscriptionHelper`), and a new `accountDetailsSubscription` analytics event tracks when the screen is shown.

| 1 | 2 | 3 |
| - | - | - |
| <img width="3840" height="2160" alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-07-23 at 14 45 35" src="https://github.com/user-attachments/assets/b94b9ae6-c4e7-4106-97aa-ff5a2207cd67" /> | <img width="3840" height="2160" alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-07-23 at 15 45 24" src="https://github.com/user-attachments/assets/aa084fd6-153e-459f-9a75-127ae8a04de9" /> | <img width="3840" height="2160" alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-07-23 at 14 45 38" src="https://github.com/user-attachments/assets/c7aa8253-eb17-48ca-b514-7bb1477c94ef" /> |

## To test

**In order to test this with a valid iOS subscription you need to create an account use staging on a mobile phone, and using a real device.
Then on that device, create a test account in staging and do a subscription purchase using a Testflight Sandbox AppStore account.
After the subscription is done on mobile you will be able to login on the TV simulator in staging and see the subscription status.**

1. Build & run the **Pocket Casts Staging** scheme on a tvOS simulator.
2. While **signed out**: open Settings and confirm there is **no** "Subscription" entry.
3. Sign in with a **free** account: open Settings → **Subscription** → confirm it shows "Free Account".
4. Sign in with an account holding an **active iOS subscription** (Plus or Patron): open Settings → **Subscription** → confirm Plan, Next renewal date, and a localized Price are shown.
5. Sign in with a subscription purchased on **another platform** (e.g. Android/Web): confirm the "made on another platform" message appears instead of a price.
6. If available, verify a **lifetime** subscription shows "Lifetime" as the renewal value.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have [updated](https://github.com/Automattic/EventHorizonSchemas/pull/113) (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
