### PR TITLE
Fix episode cell day label scaling out of proportion at large text sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.18
 -----
+- Fix the day label in episode cells growing out of proportion at large text sizes [#4818](https://github.com/Automattic/pocket-casts-ios/pull/4818)
 
 
 8.17

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -70,7 +70,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     @IBOutlet var dayName: ThemeableLabel! {
         didSet {
             dayName.style = .primaryText02
-            dayName.font = UIFont.font(ofSize: 11, weight: .semibold, scalingWith: .caption2)
+            dayName.font = UIFont.font(ofSize: 11, weight: .semibold, scalingWith: .footnote)
         }
     }
 


### PR DESCRIPTION
Fixes PCIOS-

The day label in episode cells (e.g. "Today", "Yesterday", weekday names in episode lists) scaled against the `.caption2` Dynamic Type text style. At larger accessibility text sizes `.caption2` grows faster than the surrounding labels, so the day label ended up oversized and out of proportion with the rest of the cell. It now scales with `.footnote`, keeping it in proportion as text size increases.

## To test

1. Go to Settings → Accessibility → Display & Text Size → Larger Text and enable Larger Accessibility Sizes.
2. Drag the slider up to a large accessibility size.
3. Open an episode list that shows the day/date label on cells (e.g. a filter, Up Next, or a podcast's episode list).
4. Confirm the day label ("Today", weekday, etc.) grows in proportion with the other text in the cell and is no longer disproportionately large.

Before / After

<img width="320" alt="Screenshot 2026-07-23 at 3 22 36 PM" src="https://github.com/user-attachments/assets/38a1ba53-a518-42c0-a9a3-9f1f5cd20a96" /> <img width="320" alt="Screenshot 2026-07-23 at 3 23 02 PM" src="https://github.com/user-attachments/assets/d0db1493-dd7f-4e60-aafb-a40f1d60ae5e" />


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
