### PR TITLE
Fix Bookmarks multi-selection presentation on iOS 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 8.18
 -----
-- Fix the Bookmarks multi-select layout on iOS 26: rows keep their text width instead of shrinking, and the selection bar hides the tab bar and mini player correctly [#4819](https://github.com/Automattic/pocket-casts-ios/pull/4819)
+- Fix the Bookmarks multi-select layout: rows keep their text width instead of shrinking, the selection bar sits just above the mini player instead of floating too high, and on iOS 26 it hides the tab bar and mini player correctly [#4819](https://github.com/Automattic/pocket-casts-ios/pull/4819)
 
 
 8.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.18
 -----
+- Fix the Bookmarks multi-select layout on iOS 26: rows keep their text width instead of shrinking, and the selection bar hides the tab bar and mini player correctly [#4819](https://github.com/Automattic/pocket-casts-ios/pull/4819)
 
 
 8.17

--- a/podcasts/Bookmarks/List/BookmarkRow.swift
+++ b/podcasts/Bookmarks/List/BookmarkRow.swift
@@ -102,22 +102,23 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
     /// Displays the play button view, and adds the action to it
     private var playButtonView: some View {
         let isLoading = viewModel.loadingBookmarkUuid == bookmark.uuid
+        let isMultiSelecting = viewModel.isMultiSelecting
 
-        return PlayButton(title: TimeFormatter.shared.playTimeFormat(time: bookmark.time), isLoading: isLoading, style: style).buttonize {
+        return PlayButton(title: TimeFormatter.shared.playTimeFormat(time: bookmark.time), isLoading: isLoading, isCollapsed: isMultiSelecting, style: style).buttonize {
             viewModel.bookmarkPlayTapped(bookmark)
         } customize: { config in
             config.label
                 .opacity(config.isPressed ? 0.9 : 1)
                 .applyButtonEffect(isPressed: config.isPressed)
         }
-        .opacity(viewModel.isMultiSelecting ? 0.3 : 1)
-        .disabled(viewModel.isMultiSelecting || isLoading)
+        .disabled(isMultiSelecting || isLoading)
     }
 
     // MARK: - Play Button View
     private struct PlayButton<ButtonStyle: BookmarksStyle>: View {
         let title: String
         let isLoading: Bool
+        let isCollapsed: Bool
         @ObservedObject var style: ButtonStyle
 
         var body: some View {
@@ -128,7 +129,7 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
 
                 Image("bookmarks-icon-play")
                     .renderingMode(.template)
-                    .opacity(isLoading ? 0 : 1)
+                    .opacity(isCollapsed || isLoading ? 0 : 1)
                     .overlay {
                         if isLoading {
                             ProgressView()
@@ -137,13 +138,13 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
                         }
                     }
             }
-            .foregroundStyle(style.playButtonText)
+            .foregroundStyle(isCollapsed ? style.secondaryText : style.playButtonText)
             .padding(.horizontal, RowConstants.horizontalPadding)
             .padding(.vertical, RowConstants.playButtonVerticalPadding)
-            .background(style.playButtonBackground)
+            .background(isCollapsed ? nil : style.playButtonBackground)
             .cornerRadius(.infinity) // Always rounded
             .overlay(
-                style.playButtonStroke.map {
+                isCollapsed ? nil : style.playButtonStroke.map {
                     RoundedRectangle(cornerRadius: .infinity, style: .continuous)
                         .inset(by: 1)
                         .stroke($0, lineWidth: 2)

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -90,7 +90,7 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
             if !feature.isUnlocked || viewModel.bookmarks.isEmpty {
                 emptyView
             } else {
-                listView
+                contentView
             }
         }
         .environmentObject(viewModel)
@@ -122,9 +122,8 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
         }
     }
 
-    /// The main content view that displays a list of bookmarks
     @ViewBuilder
-    private var listView: some View {
+    private var contentView: some View {
         if showHeader {
             if showSearchField {
                 divider
@@ -134,13 +133,32 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
             divider
         }
 
-        actionBarView {
-            Group {
-                if allowInternalScrolling {
-                    scrollView
-                } else {
-                    stableContainer
+        if LiquidGlass.isEnabled && !useExternalActionBar {
+            scrollableContent
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    if actionBarVisible {
+                        ActionBarView(
+                            title: L10n.selectedCountFormat(viewModel.numberOfSelectedItems),
+                            style: style.actionBarStyle,
+                            actions: bookmarkActions
+                        )
+                        .transition(.opacity)
+                    }
                 }
+                .animation(.linear(duration: 0.1), value: actionBarVisible)
+                .enclosingTabBarHidden(viewModel.isMultiSelecting)
+        } else {
+            actionBarView { scrollableContent }
+        }
+    }
+
+    @ViewBuilder
+    private var scrollableContent: some View {
+        if allowInternalScrolling {
+            scrollView
+        } else {
+            LazyVStack(spacing: 0) {
+                bookmarksRows
             }
         }
     }
@@ -180,45 +198,40 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
     private var scrollView: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                ForEach(viewModel.bookmarks) { bookmark in
-                    BookmarkRow(bookmark: bookmark, style: style)
-
-                    if !viewModel.isLast(item: bookmark) {
-                        divider
-                    }
-                }
-
-                // Add padding to the bottom of the list when the action bar is visible so it's not blocking the view
-                if actionBarVisible && !useExternalActionBar {
-                    Spacer(minLength: BookmarkListConstants.multiSelectionBottomPadding)
-                }
+                bookmarksRows
             }
         }
-    }
-
-    private var stableContainer: some View {
-        LazyVStack(spacing: 0) { bookmarksRows }
-    }
-
-    @ViewBuilder
-    private var listContent: some View {
-        LazyVStack(spacing: 0) { bookmarksRows }
     }
 
     @ViewBuilder
     private var bookmarksRows: some View {
         ForEach(viewModel.bookmarks) { bookmark in
             BookmarkRow(bookmark: bookmark, style: style)
-            if !viewModel.isLast(item: bookmark) { divider }
+            if !viewModel.isLast(item: bookmark) {
+                divider
+            }
         }
-        if actionBarVisible && !useExternalActionBar { Spacer(minLength: BookmarkListConstants.multiSelectionBottomPadding) }
+        if !LiquidGlass.isEnabled && actionBarVisible && !useExternalActionBar {
+            Spacer(minLength: BookmarkListConstants.multiSelectionBottomPadding)
+        }
     }
 
-    @ViewBuilder
-    private func actionBarView<Content: View>(_ content: @escaping () -> Content) -> some View {
-        let title = L10n.selectedCountFormat(viewModel.numberOfSelectedItems)
+    private var bookmarkActions: [ActionBarView<ListStyle.ActionStyle>.Action] {
         let editVisible = viewModel.numberOfSelectedItems == 1
         let shareVisible = viewModel.selectedItems.first?.episode is Episode
+        return makeBookmarkActions(BookmarkActionConfig(
+            showShare: editVisible && shareVisible,
+            showEdit: editVisible,
+            onShare: { viewModel.shareSelectedBookmarks() },
+            onEdit: { viewModel.editSelectedBookmarks() },
+            onDelete: { viewModel.deleteSelectedBookmarks() }
+        ))
+    }
+
+    /// Legacy action bar handling for the previous (non-Liquid Glass) behavior.
+    /// Under Liquid Glass, `listView` adds `ActionBarView` directly via `.safeAreaInset`.
+    @ViewBuilder
+    private func actionBarView<Content: View>(_ content: @escaping () -> Content) -> some View {
         Group {
             if useExternalActionBar {
                 content()
@@ -229,15 +242,12 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
                         externalActionBarHandler?(ExternalActionBarState(visible: false, title: nil, showEdit: false, showShare: false, isMultiSelecting: false))
                     }
             } else {
-                ActionBarOverlayView(actionBarVisible: actionBarVisible, title: title, style: style.actionBarStyle, content: {
-                    content()
-                }, actions: makeBookmarkActions(BookmarkActionConfig(
-                    showShare: editVisible && shareVisible,
-                    showEdit: editVisible,
-                    onShare: { viewModel.shareSelectedBookmarks() },
-                    onEdit: { viewModel.editSelectedBookmarks() },
-                    onDelete: { viewModel.deleteSelectedBookmarks() }
-                )))
+                // `ActionBarOverlayView` is used on iOS 18 and earlier only.
+                ActionBarOverlayView(actionBarVisible: actionBarVisible,
+                                     title: L10n.selectedCountFormat(viewModel.numberOfSelectedItems),
+                                     style: style.actionBarStyle,
+                                     content: { content() },
+                                     actions: bookmarkActions)
             }
         }
     }

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -39,6 +39,10 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
     // Callback to inform an external presenter of the desired action bar state
     var externalActionBarHandler: ((ExternalActionBarState) -> Void)? = nil
 
+    // When false, the action bar won't reserve space for the mini player below it.
+    // Set this for hosts where the mini player never appears, like the full screen player.
+    var reservesMiniPlayerSpace: Bool = true
+
     init(viewModel: BookmarkListViewModel,
          style: ListStyle,
          showHeader: Bool = true,
@@ -47,6 +51,7 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
          allowInternalScrolling: Bool = true,
          showSearchField: Bool = false,
          useExternalActionBar: Bool = false,
+         reservesMiniPlayerSpace: Bool = true,
          externalActionBarHandler: ((ExternalActionBarState) -> Void)? = nil) {
         self.viewModel = viewModel
         self.feature = viewModel.feature
@@ -57,6 +62,7 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
         self.allowInternalScrolling = allowInternalScrolling
         self.showSearchField = showSearchField
         self.useExternalActionBar = useExternalActionBar
+        self.reservesMiniPlayerSpace = reservesMiniPlayerSpace
         self.externalActionBarHandler = externalActionBarHandler
     }
 
@@ -247,7 +253,8 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
                                      title: L10n.selectedCountFormat(viewModel.numberOfSelectedItems),
                                      style: style.actionBarStyle,
                                      content: { content() },
-                                     actions: bookmarkActions)
+                                     actions: bookmarkActions,
+                                     reservesMiniPlayerSpace: reservesMiniPlayerSpace)
             }
         }
     }

--- a/podcasts/Bookmarks/Player/ActionBarStyles.swift
+++ b/podcasts/Bookmarks/Player/ActionBarStyles.swift
@@ -40,7 +40,7 @@ struct ThemedActionBarStyle: ActionBarStyle {
     }
 
     var buttonColor: Color {
-        theme.primaryText01
+        theme.primaryInteractive01
     }
 
     var titleColor: Color {
@@ -48,7 +48,7 @@ struct ThemedActionBarStyle: ActionBarStyle {
     }
 
     var iconColor: Color {
-        theme.primaryUi01
+        theme.primaryInteractive02
     }
 }
 

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTab.swift
@@ -6,7 +6,7 @@ struct BookmarksPlayerTab: View {
     @ObservedObject var viewModel: BookmarkEpisodeListViewModel
 
     var body: some View {
-        BookmarksListView(viewModel: viewModel, style: BookmarksPlayerTabStyle())
+        BookmarksListView(viewModel: viewModel, style: BookmarksPlayerTabStyle(), reservesMiniPlayerSpace: false)
     }
 }
 

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
@@ -73,12 +73,5 @@ struct BookmarksProfileListView: View {
 
     private var bookmarkListView: some View {
         BookmarksListView(viewModel: viewModel, style: style, showHeader: false, showMultiSelectInHeader: false, showMoreInHeader: false)
-            .padding(.bottom, bottomInset(multiSelectEnabled: viewModel.isMultiSelecting))
-    }
-
-    func bottomInset(multiSelectEnabled: Bool) -> CGFloat {
-        guard !LiquidGlass.isEnabled else { return 0 }
-        let multiSelectFooterOffset: CGFloat = multiSelectEnabled ? 80 : 0
-        return min(Constants.effectiveMiniPlayerOffset + multiSelectFooterOffset, 40)
     }
 }

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
@@ -73,6 +73,7 @@ struct BookmarksProfileListView: View {
     }
 
     func bottomInset(multiSelectEnabled: Bool) -> CGFloat {
+        guard !LiquidGlass.isEnabled else { return 0 }
         let multiSelectFooterOffset: CGFloat = multiSelectEnabled ? 80 : 0
         return min(Constants.effectiveMiniPlayerOffset + multiSelectFooterOffset, 40)
     }

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
@@ -20,6 +20,10 @@ struct BookmarksProfileListView: View {
         .background(style.background.ignoresSafeArea())
     }
 
+    private var navBarTint: Color? {
+        ThemeColor.navBarTint(ThemeColor.secondaryIcon01(for: style.theme.activeTheme))
+    }
+
     @ToolbarContentBuilder
     private var toolbar: some ToolbarContent {
         ToolbarItem(placement: .topBarLeading) {
@@ -33,7 +37,7 @@ struct BookmarksProfileListView: View {
                         Text(L10n.selectAll)
                     }
                 }
-                .tint(style.theme.secondaryIcon01)
+                .tint(navBarTint)
             }
         }
 
@@ -54,7 +58,7 @@ struct BookmarksProfileListView: View {
                 }
                 .disabled(!viewModel.feature.isUnlocked)
                 .opacity(viewModel.feature.isUnlocked ? 1 : 0)
-                .tint(style.theme.secondaryIcon01)
+                .tint(navBarTint)
             }
         }
     }

--- a/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
+++ b/podcasts/Common SwiftUI/List View/MultiSelectRow.swift
@@ -19,21 +19,23 @@ struct MultiSelectRow<Content: View>: View {
     @ScaledMetricWithMaxSize(relativeTo: .body, maxSize: .xxLarge) private var multiSelectButtonSize = 24
     @ScaledMetricWithMaxSize(relativeTo: .body, maxSize: .xxLarge) private var checkSize = 20
 
+    private let selectButtonSpacing = 15.0
+
     private let style = Style()
 
     var body: some View {
-        HStack(spacing: 15) {
-            if showSelectButton {
-                buttonView.buttonize {
-                    onSelectionToggled()
-                } customize: { config in
-                    config.label.applyButtonEffect(isPressed: config.isPressed)
+        content()
+            .offset(x: showSelectButton ? multiSelectButtonSize + selectButtonSpacing : 0)
+            .overlay(alignment: .leading) {
+                if showSelectButton {
+                    buttonView.buttonize {
+                        onSelectionToggled()
+                    } customize: { config in
+                        config.label.applyButtonEffect(isPressed: config.isPressed)
+                    }
+                    .accessibilityTransition(.move(edge: .leading).combined(with: .opacity))
                 }
-                .accessibilityTransition(.move(edge: .leading).combined(with: .opacity))
             }
-
-            content()
-        }
     }
 
     /// Customizes the selection button colors

--- a/podcasts/Utilities/SwiftUI/ActionBarOverlayView.swift
+++ b/podcasts/Utilities/SwiftUI/ActionBarOverlayView.swift
@@ -20,7 +20,9 @@ struct ActionBarOverlayView<Content: View, Style: ActionBarStyle>: View {
     /// The actions to display in the action bar
     var actions: [ActionBarView<Style>.Action] = []
 
-    // No manual padding; rely on miniPlayerSafeAreaInset()
+    /// Whether to reserve space for the mini player below the bar. Set to false when
+    /// hosted somewhere the mini player never appears, such as the full screen player.
+    var reservesMiniPlayerSpace: Bool = true
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -32,7 +34,7 @@ struct ActionBarOverlayView<Content: View, Style: ActionBarStyle>: View {
             }
         }
         // Reserve space for the mini player so the bar floats just above it
-        .miniPlayerSafeAreaInset()
+        .miniPlayerSafeAreaInset(multiplier: reservesMiniPlayerSpace ? 1 : 0)
         .accessibilityTransition(.opacity)
         .animation(.linear(duration: 0.1), value: actionBarVisible)
     }

--- a/podcasts/Utilities/SwiftUI/ActionBarOverlayView.swift
+++ b/podcasts/Utilities/SwiftUI/ActionBarOverlayView.swift
@@ -1,7 +1,9 @@
 import SwiftUI
 
-/// Displays an overlay view that displays the ActionBarView at the bottom
+/// Displays an overlay view that displays the ActionBarView at the bottom.
 ///
+/// Used on iOS 18 and earlier only. On iOS 26+ (Liquid Glass) the bar is added
+/// directly via `.safeAreaInset` instead of overlaying it here.
 struct ActionBarOverlayView<Content: View, Style: ActionBarStyle>: View {
     /// Whether the action bar should appear in the view or not
     var actionBarVisible: Bool
@@ -62,7 +64,7 @@ struct ActionBarView<Style: ActionBarStyle>: View {
     @ScaledMetricWithMaxSize(relativeTo: .body, maxSize: .xxLarge) private var imageSize = 24
 
     var body: some View {
-        HStack {
+        HStack(spacing: ActionBarConstants.buttonSpacing) {
             // Show the title if needed
             title.map {
                 Text($0)
@@ -83,8 +85,7 @@ struct ActionBarView<Style: ActionBarStyle>: View {
         // Inner Padding
         .padding(.vertical, ActionBarConstants.barPaddingVertical)
         .padding(.horizontal, ActionBarConstants.barPaddingHorizontal)
-        .applyMaterial(tint: style.backgroundTint)
-        .cornerRadius(ActionBarConstants.radius)
+        .actionBarBackground(tint: style.backgroundTint)
         // Outer Padding
         .padding(.horizontal, ActionBarConstants.barPaddingHorizontal)
     }
@@ -130,18 +131,29 @@ struct ActionBarView<Style: ActionBarStyle>: View {
 
 private enum ActionBarConstants {
     static let radius = 12.0
+    static let glassRadius = 28.0
     static let barPaddingVertical = 12.0
     static let barPaddingHorizontal = 16.0
-    static let buttonPaddingHorizontal = 12.0
-    static let buttonPaddingVertical = 4.0
+    static let buttonPaddingHorizontal = 16.0
+    static let buttonPaddingVertical = 6.0
+    static let buttonSpacing = 12.0
 }
 
 private extension View {
-    func applyMaterial(tint: Color) -> some View {
-        self
-            .background(.ultraThinMaterial)
-            .background(tint)
-            .environment(\.colorScheme, .dark)
+    /// Applies the action bar's background. Under Liquid Glass this mirrors
+    /// `MultiSelectFooterView`'s glass footer; otherwise it falls back to the
+    /// translucent material used on iOS 18 and earlier.
+    @ViewBuilder
+    func actionBarBackground(tint: Color) -> some View {
+        if LiquidGlass.isEnabled, #available(iOS 26.0, *) {
+            self.glassEffect(.regular.interactive(), in: .rect(cornerRadius: ActionBarConstants.glassRadius))
+        } else {
+            self
+                .background(.ultraThinMaterial)
+                .background(tint)
+                .environment(\.colorScheme, .dark)
+                .cornerRadius(ActionBarConstants.radius)
+        }
     }
 }
 

--- a/podcasts/Utilities/SwiftUI/ActionBarOverlayView.swift
+++ b/podcasts/Utilities/SwiftUI/ActionBarOverlayView.swift
@@ -31,8 +31,8 @@ struct ActionBarOverlayView<Content: View, Style: ActionBarStyle>: View {
                     .padding(.bottom)
             }
         }
-        // Automatically add space when the mini player is visible
-        .miniPlayerSafeAreaInset(multiplier: 1.7)
+        // Reserve space for the mini player so the bar floats just above it
+        .miniPlayerSafeAreaInset()
         .accessibilityTransition(.opacity)
         .animation(.linear(duration: 0.1), value: actionBarVisible)
     }

--- a/podcasts/Utilities/SwiftUI/EnclosingTabBarHiddenModifier.swift
+++ b/podcasts/Utilities/SwiftUI/EnclosingTabBarHiddenModifier.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import UIKit
+
+extension View {
+    /// Hides the enclosing tab bar and mini player while `hidden` is true, matching the
+    /// screens that present a `MultiSelectFooterView`. It resolves the SwiftUI view's host
+    /// controller and forwards to `setEnclosingTabBarHidden`, which is a no-op on iOS 18
+    /// and earlier, or when the view isn't inside a tab bar controller (e.g. the player).
+    func enclosingTabBarHidden(_ hidden: Bool) -> some View {
+        modifier(EnclosingTabBarHiddenModifier(hidden: hidden))
+    }
+}
+
+private struct EnclosingTabBarHiddenModifier: ViewModifier {
+    let hidden: Bool
+    @State private var host: UIViewController?
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                HostControllerResolver { resolved in
+                    host = resolved
+                    if hidden {
+                        resolved.setEnclosingTabBarHidden(true, animated: false)
+                    }
+                }
+                .frame(width: 0, height: 0)
+                .accessibilityHidden(true)
+            )
+            .onChange(of: hidden) {
+                host?.setEnclosingTabBarHidden(hidden, animated: true)
+            }
+            .onAppear {
+                if hidden {
+                    host?.setEnclosingTabBarHidden(true, animated: false)
+                }
+            }
+            .onDisappear {
+                host?.setEnclosingTabBarHidden(false, animated: true)
+            }
+    }
+}

--- a/podcasts/Utilities/SwiftUI/HostControllerResolver.swift
+++ b/podcasts/Utilities/SwiftUI/HostControllerResolver.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import UIKit
+
+/// Resolves the `UIViewController` that hosts this SwiftUI view once it's added to the
+/// controller hierarchy.
+struct HostControllerResolver: UIViewControllerRepresentable {
+    let onResolve: (UIViewController) -> Void
+
+    func makeUIViewController(context: Context) -> ResolverViewController {
+        ResolverViewController(onResolve: onResolve)
+    }
+
+    func updateUIViewController(_ uiViewController: ResolverViewController, context: Context) {}
+
+    final class ResolverViewController: UIViewController {
+        private let onResolve: (UIViewController) -> Void
+
+        init(onResolve: @escaping (UIViewController) -> Void) {
+            self.onResolve = onResolve
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func didMove(toParent parent: UIViewController?) {
+            super.didMove(toParent: parent)
+            if let parent {
+                onResolve(parent)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes PCIOS-860 – the Bookmarks multi-selection UI on iOS 26 (Liquid Glass) 

- Present the selection action bar via `safeAreaInset` under Liquid Glass, and hide the enclosing tab bar + mini player while multi-selecting (new `EnclosingTabBarHiddenModifier` / `HostControllerResolver`).
- Fix the navigation bar button colors in the profile Bookmarks list.
- Offset the row content when entering multi-select instead of shrinking it, so the title/subtitle keep the same available width and are not re-laid out. The play button collapses to just its time label (background, border, and play icon hidden) to make room.

Before / After

https://github.com/user-attachments/assets/42abc68a-9dc6-4f0f-946b-fd455ae537e1


https://github.com/user-attachments/assets/5e0b2b6f-113d-4f08-86d8-83b06a79d021




## To test

1. Open a podcast (or the profile Bookmarks screen, or the player's Bookmarks tab) that has several bookmarks.
2. Long-press a bookmark (or use the "..." > Select) to enter multi-selection.
3. Verify the row title/subtitle do **not** re-truncate or shift width — the content simply slides right to reveal the select circle, and each row's time button collapses to a plain time label (no pill background, border, or play icon).
4. Verify the selection action bar appears at the bottom and the tab bar + mini player are hidden while selecting; exit selection and confirm they return.
5. Repeat on iOS 18 and iOS 26 to confirm both the legacy overlay bar and the Liquid Glass presentation look correct.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
