### PR TITLE
Store a bookmark's captured passage and its transcript location

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
@@ -43,6 +43,29 @@ extension Bookmark: Identifiable {
     public var id: String { uuid }
 }
 
+// MARK: - Passage
+
+extension Bookmark {
+    /// The transcript passage the bookmark captures.
+    ///
+    /// Temporarily backed by `UserDefaults`, until the passage is stored with the bookmark itself.
+    public var passage: String? {
+        get { UserDefaults.standard.string(forKey: Self.passageKey(for: uuid)) }
+        nonmutating set {
+            let key = Self.passageKey(for: uuid)
+            if let newValue {
+                UserDefaults.standard.set(newValue, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+    }
+
+    private static func passageKey(for uuid: String) -> String {
+        "bookmark.passage.\(uuid)"
+    }
+}
+
 // MARK: - Preview Data
 
 extension PreviewProvider {

--- a/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
@@ -61,8 +61,28 @@ extension Bookmark {
         }
     }
 
+    /// Where `passage` begins in the episode transcript, kept only to disambiguate a
+    /// passage that appears more than once — the passage text itself is what's matched.
+    ///
+    /// Temporarily backed by `UserDefaults`, until it's stored with the bookmark itself.
+    public var passageLocation: Int? {
+        get { UserDefaults.standard.object(forKey: Self.passageLocationKey(for: uuid)) as? Int }
+        nonmutating set {
+            let key = Self.passageLocationKey(for: uuid)
+            if let newValue {
+                UserDefaults.standard.set(newValue, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+    }
+
     private static func passageKey(for uuid: String) -> String {
         "bookmark.passage.\(uuid)"
+    }
+
+    private static func passageLocationKey(for uuid: String) -> String {
+        "bookmark.passageLocation.\(uuid)"
     }
 }
 

--- a/PocketCastsTests/Tests/Bookmarks/BookmarkTranscriptSnippetExtractorTests.swift
+++ b/PocketCastsTests/Tests/Bookmarks/BookmarkTranscriptSnippetExtractorTests.swift
@@ -68,4 +68,74 @@ final class BookmarkTranscriptSnippetExtractorTests: XCTestCase {
         XCTAssertEqual(BookmarkTranscriptSnippetExtractor.sentenceRange(containing: 0, in: ""),
                        NSRange(location: 0, length: 0))
     }
+
+    // MARK: - passageRange
+
+    func testPassageRangeRoundTripsACapturedPassageAcrossSpeakerChanges() throws {
+        let model = try makeModel()
+        let snippet = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.extractSnippet(from: model, at: 12))
+
+        let range = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.passageRange(for: snippet.text,
+                                                                                  at: snippet.range.location,
+                                                                                  in: model.attributedText))
+
+        XCTAssertEqual(BookmarkTranscriptSnippetExtractor.text(in: range, of: model.attributedText), snippet.text)
+    }
+
+    func testPassageRangeSearchesForTheTextWhenTheLocationDoesNotLineUp() throws {
+        let model = try makeModel()
+        let passage = "Right, and that's why some researchers have floated the lottery idea."
+
+        // A location pointing at the start of the transcript, where this passage isn't
+        let range = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.passageRange(for: passage, at: 0, in: model.attributedText))
+
+        XCTAssertEqual(BookmarkTranscriptSnippetExtractor.text(in: range, of: model.attributedText), passage)
+    }
+
+    func testPassageRangeSearchesForTheTextWithoutALocation() throws {
+        let model = try makeModel()
+        let passage = "Right, and that's why some researchers have floated the lottery idea."
+
+        let range = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.passageRange(for: passage, at: nil, in: model.attributedText))
+
+        XCTAssertEqual(BookmarkTranscriptSnippetExtractor.text(in: range, of: model.attributedText), passage)
+    }
+
+    func testPassageRangeUsesTheLocationToDisambiguateARepeatedPassage() throws {
+        let duplicated = """
+        WEBVTT
+
+        0:00:00.000 --> 0:00:05.000
+        The lottery idea comes up again and again.
+
+        0:00:05.000 --> 0:00:10.000
+        Some filler in between to keep the two mentions apart.
+
+        0:00:10.000 --> 0:00:15.000
+        The lottery idea comes up again and again.
+        """
+        let model = try XCTUnwrap(TranscriptModel.makeModel(from: duplicated, format: .vtt))
+        let passage = "The lottery idea comes up again and again."
+
+        let string = model.attributedText.string as NSString
+        let first = string.range(of: passage).location
+        let second = string.range(of: passage, options: .backwards).location
+        XCTAssertNotEqual(first, second)
+
+        // The captured location points at the second mention, so that's what's highlighted
+        let located = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.passageRange(for: passage, at: second, in: model.attributedText))
+        XCTAssertEqual(located.location, second)
+
+        // Without a matching location, the search takes the first mention
+        let searched = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.passageRange(for: passage, at: nil, in: model.attributedText))
+        XCTAssertEqual(searched.location, first)
+    }
+
+    func testPassageRangeIsNilWhenThePassageIsAbsent() throws {
+        let model = try makeModel()
+
+        XCTAssertNil(BookmarkTranscriptSnippetExtractor.passageRange(for: "a passage no transcript would ever contain",
+                                                                     at: nil,
+                                                                     in: model.attributedText))
+    }
 }

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -10,7 +10,6 @@ class BookmarkManager {
     private let generalManager: DataManager
     private let playbackManager: PlaybackManager
     private let cacheServerHandler: CacheServerHandler
-    private let userDefaults: UserDefaults
 
     /// Called when a bookmark is created
     let onBookmarkCreated = PassthroughSubject<Event.Created, Never>()
@@ -24,13 +23,11 @@ class BookmarkManager {
     init(dataManager: BookmarkDataManager = DataManager.sharedManager.bookmarks,
          generalManager: DataManager = .sharedManager,
          playbackManager: PlaybackManager = .shared,
-         cacheServerHandler: CacheServerHandler = .shared,
-         userDefaults: UserDefaults = .standard) {
+         cacheServerHandler: CacheServerHandler = .shared) {
         self.dataManager = dataManager
         self.generalManager = generalManager
         self.playbackManager = playbackManager
         self.cacheServerHandler = cacheServerHandler
-        self.userDefaults = userDefaults
     }
 
     /// Plays the "bookmark created" tone
@@ -97,7 +94,7 @@ class BookmarkManager {
     /// Removes an array of bookmarks
     func remove(_ bookmarks: [Bookmark]) async -> Bool {
         await dataManager.remove(bookmarks: bookmarks).when(true) {
-            bookmarks.forEach { setPassage(nil, for: $0) }
+            bookmarks.forEach { $0.passage = nil }
 
             onBookmarksDeleted.send(.init(items: bookmarks.map {
                 .init(uuid: $0.uuid, episode: $0.episodeUuid, podcast: $0.podcastUuid)
@@ -116,29 +113,6 @@ class BookmarkManager {
     /// Gets the `BaseEpisode` for the given bookmark
     func episode(for bookmark: Bookmark) -> BaseEpisode? {
         generalManager.findBaseEpisode(uuid: bookmark.episodeUuid)
-    }
-
-    // MARK: - Passage
-
-    /// The transcript passage the bookmark captures.
-    ///
-    /// Temporarily kept in `UserDefaults`, until the passage is stored with the bookmark itself.
-    func passage(for bookmark: Bookmark) -> String? {
-        userDefaults.string(forKey: Self.passageKey(for: bookmark))
-    }
-
-    /// Passing `nil` removes the stored passage
-    func setPassage(_ passage: String?, for bookmark: Bookmark) {
-        let key = Self.passageKey(for: bookmark)
-        if let passage {
-            userDefaults.set(passage, forKey: key)
-        } else {
-            userDefaults.removeObject(forKey: key)
-        }
-    }
-
-    private static func passageKey(for bookmark: Bookmark) -> String {
-        "bookmark.passage.\(bookmark.uuid)"
     }
 
     // MARK: - Title Generation

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -94,7 +94,10 @@ class BookmarkManager {
     /// Removes an array of bookmarks
     func remove(_ bookmarks: [Bookmark]) async -> Bool {
         await dataManager.remove(bookmarks: bookmarks).when(true) {
-            bookmarks.forEach { $0.passage = nil }
+            bookmarks.forEach {
+                $0.passage = nil
+                $0.passageLocation = nil
+            }
 
             onBookmarksDeleted.send(.init(items: bookmarks.map {
                 .init(uuid: $0.uuid, episode: $0.episodeUuid, podcast: $0.podcastUuid)

--- a/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
+++ b/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
@@ -93,6 +93,106 @@ struct BookmarkTranscriptSnippetExtractor {
         return NSRange(lowerBound..<upperBound, in: text)
     }
 
+    // MARK: - Locating a passage
+
+    /// Finds the range to highlight for a bookmark's captured passage within a transcript.
+    ///
+    /// The passage text is the source of truth; `location` only disambiguates when the same
+    /// passage appears more than once. So the captured location is tried first, and only when
+    /// the text there no longer lines up does it fall back to the first match of the passage
+    /// text anywhere in the transcript.
+    ///
+    /// - Parameter location: The passage's captured start within `attributedText`, or `nil`
+    ///   for bookmarks made before the location was recorded.
+    static func passageRange(for passage: String, at location: Int?, in attributedText: NSAttributedString) -> NSRange? {
+        guard !passage.isEmpty else { return nil }
+
+        // Location first: is the passage still exactly where it was captured?
+        if let location {
+            let suffix = cleaned(attributedText, from: location)
+            if suffix.text.hasPrefix(passage),
+               let end = suffix.text.index(suffix.text.startIndex, offsetBy: passage.count, limitedBy: suffix.text.endIndex) {
+                return suffix.transcriptRange(for: suffix.text.startIndex..<end)
+            }
+        }
+
+        // Otherwise search the whole transcript, taking the first occurrence
+        let full = cleaned(attributedText, from: 0)
+        guard let match = full.text.range(of: passage) else { return nil }
+        return full.transcriptRange(for: match)
+    }
+
+    /// The transcript's text collapsed the same way a passage is, paired with a map back to
+    /// the character positions each piece came from
+    private struct CleanedText {
+        let text: String
+        /// Start position in the transcript of each character in `text`
+        let starts: [Int]
+        /// Position in the transcript just past each character in `text`
+        let ends: [Int]
+
+        /// Maps a range found within `text` back to the transcript's character positions
+        func transcriptRange(for cleanedRange: Range<String.Index>) -> NSRange? {
+            let lower = text.distance(from: text.startIndex, to: cleanedRange.lowerBound)
+            let upper = text.distance(from: text.startIndex, to: cleanedRange.upperBound)
+            guard lower >= 0, upper > lower, upper <= starts.count else { return nil }
+            return NSRange(location: starts[lower], length: ends[upper - 1] - starts[lower])
+        }
+    }
+
+    /// Cleans the transcript from `startLocation` onward the same way `text(in:)` cleans a
+    /// passage — skipping speaker runs, collapsing whitespace — while recording where each
+    /// surviving character came from, so a match can be mapped back to the transcript.
+    private static func cleaned(_ attributedText: NSAttributedString, from startLocation: Int) -> CleanedText {
+        let string = attributedText.string as NSString
+        let total = string.length
+        let start = min(max(startLocation, 0), total)
+        guard start < total else { return CleanedText(text: "", starts: [], ends: []) }
+
+        let scanRange = NSRange(location: start, length: total - start)
+
+        var text = ""
+        var starts = [Int]()
+        var ends = [Int]()
+        // A run of whitespace (real or the boundary between two cue parts) collapses to a
+        // single space, dropped entirely at the start or end
+        var pendingSpace: (start: Int, end: Int)?
+        var isFirstPart = true
+
+        attributedText.enumerateAttribute(.transcriptSpeaker, in: scanRange, options: []) { value, subrange, _ in
+            guard value == nil else { return }
+
+            if !isFirstPart {
+                pendingSpace = pendingSpace ?? (subrange.location, subrange.location)
+            }
+            isFirstPart = false
+
+            string.enumerateSubstrings(in: subrange, options: .byComposedCharacterSequences) { substring, characterRange, _, _ in
+                guard let substring else { return }
+
+                if substring.allSatisfy(\.isWhitespace) {
+                    if !text.isEmpty {
+                        pendingSpace = pendingSpace ?? (characterRange.location, characterRange.location + characterRange.length)
+                    }
+                    return
+                }
+
+                if let space = pendingSpace {
+                    text.append(" ")
+                    starts.append(space.start)
+                    ends.append(space.end)
+                    pendingSpace = nil
+                }
+
+                text.append(substring)
+                starts.append(characterRange.location)
+                ends.append(characterRange.location + characterRange.length)
+            }
+        }
+
+        return CleanedText(text: text, starts: starts, ends: ends)
+    }
+
     /// The plain text within `range`, skipping the speaker-name runs interleaved between
     /// cues and collapsing the line breaks between them
     static func text(in range: NSRange, of attributedText: NSAttributedString) -> String {

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
@@ -34,7 +34,7 @@ class BookmarkDetailsViewModel: ObservableObject {
         let episode = bookmark.episode ?? bookmarkManager.episode(for: bookmark)
 
         self.init(bookmark: bookmark,
-                  passage: bookmarkManager.passage(for: bookmark),
+                  passage: bookmark.passage,
                   episode: episode,
                   podcastTitle: Self.podcastTitle(for: bookmark, episode: episode),
                   bookmarkManager: bookmarkManager)
@@ -44,7 +44,7 @@ class BookmarkDetailsViewModel: ObservableObject {
         guard let bookmark = bookmarkManager.bookmark(for: bookmark.uuid) else { return }
 
         self.bookmark = bookmark
-        self.passage = bookmarkManager.passage(for: bookmark)
+        self.passage = bookmark.passage
     }
 
     private static func podcastTitle(for bookmark: Bookmark, episode: BaseEpisode?) -> String? {

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -43,7 +43,7 @@ class BookmarkEditViewModel: ObservableObject {
         didSet {
             guard let snippet, snippet.range != oldValue?.range else { return }
 
-            bookmarkManager.setPassage(snippet.text, for: bookmark)
+            bookmark.passage = snippet.text
         }
     }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -44,6 +44,7 @@ class BookmarkEditViewModel: ObservableObject {
             guard let snippet, snippet.range != oldValue?.range else { return }
 
             bookmark.passage = snippet.text
+            bookmark.passageLocation = snippet.range.location
         }
     }
 


### PR DESCRIPTION
Part of the Smart Bookmarks data layer (behind the `smartBookmarks` feature flag), built field by field. This adds the transcript passage a bookmark captures — and where that passage sits in the episode transcript — to the `Bookmark` model.

- **`Bookmark.passage`** — the captured transcript passage, moved off `BookmarkManager` and onto the model itself as a dynamic property. Still backed by `UserDefaults` for now; it moves into the database in a later step.
- **`Bookmark.passageLocation`** — the passage's start position in the transcript, kept only to disambiguate a passage that appears more than once. The passage text stays the source of truth.
- **`BookmarkTranscriptSnippetExtractor.passageRange(for:at:in:)`** — resolves the range to highlight for a stored passage: it tries the captured location first, then falls back to searching the whole transcript for the passage text.

No user-facing behavior changes on its own — this is plumbing for the feature, which stays behind the flag.

## To test

1. Enable the `smartBookmarks` feature flag.
2. Play an episode that has a generated transcript and add a bookmark.
3. Open the bookmark's edit sheet and confirm the captured passage is shown, and that re-picking a different passage updates it.
4. Close and reopen the bookmark; confirm the passage persists.
5. `passageLocation` and the `passageRange` resolver are covered by unit tests in `BookmarkTranscriptSnippetExtractorTests` (round-trip, duplicate disambiguation, text-search fallback, absent passage).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
