### PR TITLE
Start bookmark playback from the reference time

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
@@ -77,12 +77,36 @@ extension Bookmark {
         }
     }
 
+    /// The bookmark's position on the transcript's canonical (reference) timeline, when the
+    /// episode has a generated transcript and a confident mapping was available when captured.
+    ///
+    /// Preferred over `time` wherever possible: dynamic ads shift the playback timeline per
+    /// device and download, so `time` can point at the wrong content elsewhere, whereas the
+    /// reference time is stable. Falls back to `time` when nil.
+    ///
+    /// Temporarily backed by `UserDefaults`, until it's stored with the bookmark itself.
+    public var referenceTime: TimeInterval? {
+        get { UserDefaults.standard.object(forKey: Self.referenceTimeKey(for: uuid)) as? TimeInterval }
+        nonmutating set {
+            let key = Self.referenceTimeKey(for: uuid)
+            if let newValue {
+                UserDefaults.standard.set(newValue, forKey: key)
+            } else {
+                UserDefaults.standard.removeObject(forKey: key)
+            }
+        }
+    }
+
     private static func passageKey(for uuid: String) -> String {
         "bookmark.passage.\(uuid)"
     }
 
     private static func passageLocationKey(for uuid: String) -> String {
         "bookmark.passageLocation.\(uuid)"
+    }
+
+    private static func referenceTimeKey(for uuid: String) -> String {
+        "bookmark.referenceTime.\(uuid)"
     }
 }
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -902,6 +902,7 @@ enum AnalyticsEvent: String {
     case bookmarksGetBookmarksButtonTapped
     case bookmarksEmptyGoToHeadphoneSettings
     case bookmarkPlayTapped
+    case bookmarkFingerprintCalculated
     case bookmarksSortByChanged
     case bookmarkDeleted
     case bookmarkShareTapped

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -902,7 +902,6 @@ enum AnalyticsEvent: String {
     case bookmarksGetBookmarksButtonTapped
     case bookmarksEmptyGoToHeadphoneSettings
     case bookmarkPlayTapped
-    case bookmarkFingerprintCalculated
     case bookmarksSortByChanged
     case bookmarkDeleted
     case bookmarkShareTapped

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -12,6 +12,10 @@ struct BookmarkUpdateParameters {
     /// The captured transcript passage to store, or `nil` to leave the existing one unchanged.
     var passage: Passage?
 
+    /// The bookmark's position on the transcript's reference timeline, or `nil` to leave the
+    /// existing one unchanged — re-selecting a passage doesn't move the bookmark itself.
+    var referenceTime: TimeInterval?
+
     /// A transcript passage together with where it starts, kept so a re-selection can be
     /// matched back to the same spot.
     struct Passage {
@@ -112,6 +116,7 @@ class BookmarkManager {
             bookmarks.forEach {
                 $0.passage = nil
                 $0.passageLocation = nil
+                $0.referenceTime = nil
             }
 
             onBookmarksDeleted.send(.init(items: bookmarks.map {
@@ -126,6 +131,10 @@ class BookmarkManager {
         if let passage = parameters.passage {
             bookmark.passage = passage.text
             bookmark.passageLocation = passage.location
+        }
+
+        if let referenceTime = parameters.referenceTime {
+            bookmark.referenceTime = referenceTime
         }
 
         return await dataManager.update(bookmark: bookmark, title: parameters.title).when(true) {

--- a/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
+++ b/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
@@ -19,7 +19,7 @@ extension BookmarkManager {
         // Let the on-device model load while the transcript is fetched.
         prewarmTitleGeneration()
 
-        return await BookmarkTranscriptSnippetExtractor().snippet(forTime: bookmark.time, episode: episode)
+        return await BookmarkTranscriptSnippetExtractor().snippet(forTime: bookmark.time, referenceTime: bookmark.referenceTime, episode: episode)
     }
 
     func capturedSnippet(for bookmark: Bookmark, episode: BaseEpisode) async -> BookmarkTranscriptSnippet? {
@@ -45,13 +45,14 @@ extension BookmarkManager {
             // Nothing to rename to, but the passage is still worth keeping for the edit sheet
             bookmark.passage = snippet.text
             bookmark.passageLocation = snippet.range.location
+            bookmark.referenceTime = snippet.referenceTime
             return
         }
 
         FileLog.shared.addMessage("[Bookmarks] Generated a title for bookmark \(bookmark.uuid)")
 
         let passage = BookmarkUpdateParameters.Passage(text: snippet.text, location: snippet.range.location)
-        await update(.init(title: title, passage: passage), for: bookmark)
+        await update(.init(title: title, passage: passage, referenceTime: snippet.referenceTime), for: bookmark)
     }
 
     /// Returns nil when generation fails.

--- a/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
+++ b/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
@@ -9,6 +9,10 @@ struct BookmarkTranscriptSnippet {
     let transcript: TranscriptModel
     var range: NSRange
 
+    /// The reference-timeline position the snippet was centered on; nil for a snippet
+    /// re-located from a stored passage, which isn't resolved against a time.
+    var referenceTime: TimeInterval?
+
     var text: String {
         BookmarkTranscriptSnippetExtractor.text(in: range, of: transcript.attributedText)
     }
@@ -33,7 +37,10 @@ struct BookmarkTranscriptSnippetExtractor {
     /// Snippets with fewer words than this carry too little signal to generate a meaningful title from
     static let minimumWordCount = 10
 
-    func snippet(forTime time: TimeInterval, episode: BaseEpisode) async -> BookmarkTranscriptSnippet? {
+    /// - Parameter referenceTime: The bookmark's already-resolved reference time, if any.
+    ///   It's preferred over resolving again, both to save the work and because the
+    ///   original capture had the warmest mapping.
+    func snippet(forTime time: TimeInterval, referenceTime: TimeInterval?, episode: BaseEpisode) async -> BookmarkTranscriptSnippet? {
         let transcriptManager = TranscriptManager(episodeUUID: episode.uuid, podcastUUID: episode.parentIdentifier())
         guard let model = try? await transcriptManager.loadTranscript() else {
             return nil
@@ -43,12 +50,21 @@ struct BookmarkTranscriptSnippetExtractor {
         // without a confident match there's no telling how far dynamic ads have pushed the
         // playback time from the timeline the transcript is cued against. Either way, capture
         // nothing rather than a passage from somewhere else in the episode.
-        guard transcriptManager.isDisplayingGeneratedTranscript, FeatureFlag.syncedTranscripts.enabled,
-              let referenceTime = await FingerprintTimingManager.shared.resolveReferenceTime(forPlaybackTime: time, episode: episode) else {
+        guard transcriptManager.isDisplayingGeneratedTranscript, FeatureFlag.syncedTranscripts.enabled else {
             return nil
         }
 
-        return Self.extractSnippet(from: model, at: referenceTime)
+        var resolved = referenceTime
+        if resolved == nil {
+            resolved = await FingerprintTimingManager.shared.resolveReferenceTime(forPlaybackTime: time, episode: episode)
+        }
+        guard let resolved else {
+            return nil
+        }
+
+        var snippet = Self.extractSnippet(from: model, at: resolved)
+        snippet?.referenceTime = resolved
+        return snippet
     }
 
     func snippet(forPassage passage: String, at location: Int?, episode: BaseEpisode) async -> BookmarkTranscriptSnippet? {

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -171,8 +171,9 @@ class BookmarkEditViewModel: ObservableObject {
         Task {
             let title = String(title.trim().prefix(maxTitleLength))
             let passage = snippet.map { BookmarkUpdateParameters.Passage(text: $0.text, location: $0.range.location) }
+            let parameters = BookmarkUpdateParameters(title: title.isEmpty ? placeholder : title, passage: passage, referenceTime: snippet?.referenceTime)
 
-            await bookmarkManager.update(.init(title: title.isEmpty ? placeholder : title, passage: passage), for: bookmark)
+            await bookmarkManager.update(parameters, for: bookmark)
 
             if editState == .updating {
                 Analytics.track(.bookmarkUpdateTitle, source: analyticsSource)

--- a/podcasts/Fingerprint/FingerprintConstants.swift
+++ b/podcasts/Fingerprint/FingerprintConstants.swift
@@ -156,4 +156,25 @@ enum FingerprintConstants {
     /// Hard timeout for a one-shot bookmark position resolve. On expiry the
     /// caller falls back to the raw playback time.
     static let bookmarkResolveTimeoutSeconds: TimeInterval = 5
+
+    // MARK: - Bookmark playback resolve
+
+    /// Hard timeout for resolving a bookmark's reference time back to a playback
+    /// position. Far longer than `onDemandSeekTimeoutSeconds` because a chapter's
+    /// audio is already local by definition while a bookmark's often isn't: playing
+    /// it starts a stream-and-cache download and the region being matched only
+    /// arrives once that prefix reaches it. This also bounds how long a played
+    /// bookmark keeps the player paused (and its row's spinner up) before falling
+    /// back to the stored time.
+    static let bookmarkSeekTimeoutSeconds: TimeInterval = 25
+
+    /// How much of that budget may be spent waiting for a still-downloading buffer
+    /// to cover the search window. The remainder is left for the decode, which has
+    /// to fit inside the timeout above to deliver anything at all.
+    static let bookmarkSeekBufferWaitSeconds: TimeInterval = 15
+
+    /// Stop waiting early once the buffer stops growing for this long — no network,
+    /// a stalled download, or an episode that never caches to disk at all (HLS,
+    /// video, user uploads).
+    static let bookmarkSeekBufferStallSeconds: TimeInterval = 8
 }

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -89,12 +89,18 @@ final class FingerprintTimingManager: NSObject {
         label: "au.com.pocketcasts.FingerprintTimingManager.generation",
         qos: .utility
     )
-    /// Decode queue reserved for the one-shot chapter resolve. Kept separate from
-    /// `generationQueue` — which the continuous transcript stream occupies as one
-    /// long-running block that only yields via `Thread.sleep` — so a chapter tap's
+    /// Decode queue reserved for the one-shot resolves, chapter and bookmark alike.
+    /// Kept separate from `generationQueue` — which the continuous transcript stream
+    /// occupies as one long-running block that only yields via `Thread.sleep` — so a
     /// bounded decode can't be starved behind it (which would hang the resolve past
     /// its timeout, since a queued-but-never-started block can't observe
     /// cancellation). Higher QoS because a spinner is blocked on it.
+    ///
+    /// The two one-shots share it because both are bounded, which is the distinction
+    /// that matters here. A bookmark resolve's long budget is spent waiting for its
+    /// buffer, not on this queue, so its decode is no longer than a chapter's; and
+    /// running them concurrently would only make them contend for CPU and for `queue`
+    /// during matching.
     private let onDemandQueue = DispatchQueue(
         label: "au.com.pocketcasts.FingerprintTimingManager.onDemand",
         qos: .userInitiated
@@ -356,13 +362,9 @@ final class FingerprintTimingManager: NSObject {
     ///
     /// Must be called on the main queue. `completion` is delivered on the main
     /// queue; a superseded resolve never calls back.
-    /// - Parameter analyticsEvent: The resolve-duration event to emit on a successful
-    ///   match, or nil to skip it. Defaults to the chapter event; bookmark seeks pass a
-    ///   different one so the chapter metric stays comparable across platforms.
     func resolvePlaybackTime(
         forReferenceTime referenceTime: Double,
         episode: BaseEpisode,
-        analyticsEvent: AnalyticsEvent? = .playerChapterFingerprintCalculated,
         completion: @escaping (ChapterSeekResult) -> Void
     ) {
         dispatchPrecondition(condition: .onQueue(.main))
@@ -389,7 +391,7 @@ final class FingerprintTimingManager: NSObject {
             let result = await self.performResolve(
                 forReferenceTime: referenceTime,
                 episode: episode,
-                analyticsEvent: analyticsEvent,
+                kind: .chapter,
                 flag: flag
             )
 
@@ -398,6 +400,43 @@ final class FingerprintTimingManager: NSObject {
                 guard self.onDemandFlag === flag else { return }
                 completion(result)
             }
+        }
+    }
+
+    /// Resolve a bookmark's reference-timeline position to where that content
+    /// actually sits in this listener's audio, so playback can start there.
+    ///
+    /// The same one-shot resolve as `resolvePlaybackTime`, differing only in what a
+    /// bookmark's audio is likely to be doing — see `ResolveKind.bookmark`. It keeps
+    /// no state of its own, so it neither supersedes nor is superseded by a chapter
+    /// resolve; the caller owns the lifetime, and cancelling its task stops the
+    /// decode via the cancellation handler below.
+    func resolveBookmarkPlaybackTime(
+        forReferenceTime referenceTime: Double,
+        episode: BaseEpisode
+    ) async -> ChapterSeekResult {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+        let flag = CancellationFlag()
+
+        // Hard timeout, so a decode that drags or a buffer that never arrives can't
+        // leave the correction pending forever. Both loops observe the flag.
+        let timeoutTask = Task {
+            try? await Task.sleep(
+                nanoseconds: UInt64(FingerprintConstants.bookmarkSeekTimeoutSeconds * 1_000_000_000)
+            )
+            flag.cancel()
+        }
+        defer { timeoutTask.cancel() }
+
+        return await withTaskCancellationHandler {
+            await performResolve(
+                forReferenceTime: referenceTime,
+                episode: episode,
+                kind: .bookmark,
+                flag: flag
+            )
+        } onCancel: {
+            flag.cancel()
         }
     }
 
@@ -415,10 +454,28 @@ final class FingerprintTimingManager: NSObject {
         onDemandTask = nil
     }
 
+    /// What the two one-shot resolves want differently, which all follows from what
+    /// their audio is likely to be doing: a chapter's episode is playing, so its
+    /// audio is already local, while a bookmark's is often still downloading.
+    private enum ResolveKind {
+        case chapter
+        case bookmark
+
+        var analyticsEvent: AnalyticsEvent {
+            switch self {
+            case .chapter: .playerChapterFingerprintCalculated
+            case .bookmark: .bookmarkFingerprintCalculated
+            }
+        }
+
+        /// Only a bookmark waits for the streaming buffer to reach the search window.
+        var waitsForBufferedRegion: Bool { self == .bookmark }
+    }
+
     private func performResolve(
         forReferenceTime referenceTime: Double,
         episode: BaseEpisode,
-        analyticsEvent: AnalyticsEvent?,
+        kind: ResolveKind,
         flag: CancellationFlag
     ) async -> ChapterSeekResult {
         let startDate = Date()
@@ -477,6 +534,18 @@ final class FingerprintTimingManager: NSObject {
         case .streaming(let url): audioURL = url; isStreaming = true
         }
 
+        // A bookmark's episode is often still arriving: playing it starts a
+        // stream-and-cache download that fills the buffer sequentially from byte 0,
+        // so the window we want only becomes readable once that prefix reaches it.
+        if kind.waitsForBufferedRegion, isStreaming {
+            await waitForBufferedRegion(
+                audioFileURL: audioURL,
+                coveringSeconds: searchEnd,
+                deadline: startDate.addingTimeInterval(FingerprintConstants.bookmarkSeekBufferWaitSeconds),
+                flag: flag
+            )
+        }
+
         if flag.isCancelled { return .unresolved(reason: "timeout", isStreaming: isStreaming) }
 
         // Fingerprint + match the bounded region into a local scratch accumulator
@@ -525,20 +594,74 @@ final class FingerprintTimingManager: NSObject {
             // Comparable across platforms: Android fingerprints eagerly and iOS
             // reactively on tap, but both report the calculation time here, decoupled
             // from `playerChapterSelected` (the tap) which stays untouched.
-            if let analyticsEvent {
-                Analytics.track(analyticsEvent, properties: [
-                    "duration_ms": resolveDurationMs,
-                    "is_streaming": isStreaming,
-                    "episode_uuid": episodeUuid,
-                    "podcast_uuid": episode.parentIdentifier()
-                ])
-            }
+            Analytics.track(kind.analyticsEvent, properties: [
+                "duration_ms": resolveDurationMs,
+                "is_streaming": isStreaming,
+                "episode_uuid": episodeUuid,
+                "podcast_uuid": episode.parentIdentifier()
+            ])
             return .resolved(
                 playbackTime: max(referenceTime, playback),
                 usedPrior: usedPrior,
                 isStreaming: isStreaming,
                 resolveDurationMs: resolveDurationMs
             )
+        }
+    }
+
+    /// Wait for a still-downloading streaming buffer to cover `coveringSeconds` of
+    /// audio, polling as it grows.
+    ///
+    /// `MediaExporterResourceLoaderDelegate` caches with a single un-ranged request
+    /// appended to disk, so the buffer is always a prefix of the episode and
+    /// `AVAudioFile.length` tracks exactly how much of it is local — the same
+    /// property the grow-loop anchors on.
+    ///
+    /// Returns once covered, or early when the file stops growing, the deadline
+    /// passes, or the resolve is cancelled. There's deliberately no failure signal:
+    /// the bounded fingerprint clamps to whatever is readable, so matching a short
+    /// prefix of the window still beats returning nothing.
+    private func waitForBufferedRegion(
+        audioFileURL: URL,
+        coveringSeconds: Double,
+        deadline: Date,
+        flag: CancellationFlag
+    ) async {
+        let pollCadence = FingerprintConstants.bufferGrowPollCadenceSeconds
+        var stallSeconds: Double = 0
+        var lastLength: AVAudioFramePosition = -1
+
+        while !flag.isCancelled, Date() < deadline {
+            // The buffer may not exist yet, and a partial frame at the tail can make
+            // `AVAudioFile` refuse to open momentarily — both read as "no growth".
+            if let audioFile = try? AVAudioFile(
+                forReading: audioFileURL,
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            ) {
+                let bufferedSeconds = Double(audioFile.length) / audioFile.processingFormat.sampleRate
+                if bufferedSeconds >= coveringSeconds {
+                    FileLog.shared.addMessage(
+                        "FingerprintTimingManager: streaming buffer covers the search window "
+                            + "(\(String(format: "%.1f", bufferedSeconds))s buffered)"
+                    )
+                    return
+                }
+                if audioFile.length > lastLength {
+                    lastLength = audioFile.length
+                    stallSeconds = 0
+                }
+            }
+
+            stallSeconds += pollCadence
+            if stallSeconds >= FingerprintConstants.bookmarkSeekBufferStallSeconds {
+                FileLog.shared.addMessage(
+                    "FingerprintTimingManager: streaming buffer stopped growing short of the "
+                        + "search window — fingerprinting the \(max(0, lastLength)) frames that arrived"
+                )
+                return
+            }
+            try? await Task.sleep(nanoseconds: UInt64(pollCadence * 1_000_000_000))
         }
     }
 

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Accelerate
 import Foundation
 import Fingerprint
 import PocketCastsDataModel
@@ -1216,6 +1217,7 @@ final class FingerprintTimingManager: NSObject {
             throw StreamError.bufferAllocationFailed
         }
 
+        var interleaved: [Float] = []
         while true {
             if ctx.isCancelled() { throw StreamError.cancelled }
             let nextChunkStartSeconds = Double(audioFile.framePosition) / format.sampleRate
@@ -1223,7 +1225,7 @@ final class FingerprintTimingManager: NSObject {
             try audioFile.read(into: buffer, frameCount: chunkFrames)
             if buffer.frameLength == 0 { break }
 
-            let interleaved = Self.interleavedSamples(from: buffer)
+            Self.interleave(buffer, into: &interleaved)
             let windows = streamer.pushSamplesF32(samples: interleaved, channels: channels)
             if !windows.isEmpty {
                 dispatchProcessMatches(windows: windows, startOffset: startSeconds, context: ctx)
@@ -1282,6 +1284,7 @@ final class FingerprintTimingManager: NSObject {
             throw StreamError.bufferAllocationFailed
         }
 
+        var interleaved: [Float] = []
         while audioFile.framePosition < endFrame {
             if flag.isCancelled { throw StreamError.cancelled }
             let framesRemaining = AVAudioFrameCount(endFrame - audioFile.framePosition)
@@ -1289,7 +1292,7 @@ final class FingerprintTimingManager: NSObject {
             try audioFile.read(into: buffer, frameCount: framesToRead)
             if buffer.frameLength == 0 { break }
 
-            let interleaved = Self.interleavedSamples(from: buffer)
+            Self.interleave(buffer, into: &interleaved)
             let windows = streamer.pushSamplesF32(samples: interleaved, channels: channels)
             if !windows.isEmpty {
                 queue.sync {
@@ -1328,6 +1331,7 @@ final class FingerprintTimingManager: NSObject {
         var announcedFileAppeared = false
         var totalFramesRead: AVAudioFramePosition = 0
         var windowsEmitted = 0
+        var interleaved: [Float] = []
 
         FileLog.shared.addMessage(
             "FingerprintTimingManager: streaming grow-loop starting at \(String(format: "%.1f", startSeconds))s "
@@ -1444,7 +1448,7 @@ final class FingerprintTimingManager: NSObject {
             lastProcessedFrame = audioFile.framePosition
             totalFramesRead += framesJustRead
 
-            let interleaved = Self.interleavedSamples(from: buf)
+            Self.interleave(buf, into: &interleaved)
             let windows = str.pushSamplesF32(samples: interleaved, channels: UInt16(fmt.channelCount))
             if !windows.isEmpty {
                 windowsEmitted += windows.count
@@ -1543,20 +1547,36 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
-    private static func interleavedSamples(from buffer: AVAudioPCMBuffer) -> [Float] {
+    /// Interleaves the buffer's planar Float32 channels into `scratch`, reusing
+    /// its storage across chunks. `scratch` is resized only when the sample
+    /// count changes (in practice once, plus once more for a short final
+    /// chunk), so a decode loop allocates O(1) arrays instead of one per chunk.
+    private static func interleave(_ buffer: AVAudioPCMBuffer, into scratch: inout [Float]) {
         let frameCount = Int(buffer.frameLength)
         let channelCount = Int(buffer.format.channelCount)
         guard frameCount > 0, channelCount > 0,
-              let channelData = buffer.floatChannelData else { return [] }
+              let channelData = buffer.floatChannelData else {
+            scratch.removeAll(keepingCapacity: true)
+            return
+        }
 
-        var result = [Float](repeating: 0, count: frameCount * channelCount)
-        for ch in 0..<channelCount {
-            let src = channelData[ch]
-            for frame in 0..<frameCount {
-                result[frame * channelCount + ch] = src[frame]
+        let sampleCount = frameCount * channelCount
+        if scratch.count != sampleCount {
+            scratch = [Float](repeating: 0, count: sampleCount)
+        }
+        scratch.withUnsafeMutableBufferPointer { dst in
+            guard let base = dst.baseAddress else { return }
+            if channelCount == 1 {
+                base.update(from: channelData[0], count: frameCount)
+                return
+            }
+            // Strided vector copy (add-zero) — one vDSP pass per channel
+            // instead of a scalar store per sample.
+            var zero: Float = 0
+            for ch in 0..<channelCount {
+                vDSP_vsadd(channelData[ch], 1, &zero, base + ch, vDSP_Stride(channelCount), vDSP_Length(frameCount))
             }
         }
-        return result
     }
 
     private enum StreamError: Error {

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -461,13 +461,6 @@ final class FingerprintTimingManager: NSObject {
         case chapter
         case bookmark
 
-        var analyticsEvent: AnalyticsEvent {
-            switch self {
-            case .chapter: .playerChapterFingerprintCalculated
-            case .bookmark: .bookmarkFingerprintCalculated
-            }
-        }
-
         /// Only a bookmark waits for the streaming buffer to reach the search window.
         var waitsForBufferedRegion: Bool { self == .bookmark }
     }
@@ -594,7 +587,7 @@ final class FingerprintTimingManager: NSObject {
             // Comparable across platforms: Android fingerprints eagerly and iOS
             // reactively on tap, but both report the calculation time here, decoupled
             // from `playerChapterSelected` (the tap) which stays untouched.
-            Analytics.track(kind.analyticsEvent, properties: [
+            Analytics.track(.playerChapterFingerprintCalculated, properties: [
                 "duration_ms": resolveDurationMs,
                 "is_streaming": isStreaming,
                 "episode_uuid": episodeUuid,

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -557,6 +557,7 @@ final class FingerprintTimingManager: NSObject {
     func resolveReferenceTime(forPlaybackTime playbackTime: Double, episode: BaseEpisode) async -> Double? {
         dispatchPrecondition(condition: .notOnQueue(queue))
         let episodeUuid = episode.uuid
+        let startDate = Date()
 
         // Warm fast path: interpolate off the continuous transcript mapping when
         // it already confidently covers this position.
@@ -572,7 +573,14 @@ final class FingerprintTimingManager: NSObject {
                 valuePath: \.referenceTime
             )
         }
-        if let warm { return warm }
+        if let warm {
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: bookmark resolve matched off the live mapping for \(episodeUuid) — "
+                    + "local file time \(String(format: "%.1f", playbackTime))s → "
+                    + "reference time \(String(format: "%.1f", warm))s"
+            )
+            return warm
+        }
 
         // Hard timeout, observed once per decoded chunk
         let flag = CancellationFlag()
@@ -601,12 +609,18 @@ final class FingerprintTimingManager: NSObject {
         guard !flag.isCancelled,
               let referenceData,
               let reference = ReferenceFingerprint.decode(from: referenceData) else {
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: bookmark resolve gave up for \(episodeUuid) — no usable reference"
+            )
             return nil
         }
 
         let duration = episode.duration
         guard duration > 0,
               let (matcher, _) = buildMatcher(from: reference, episodeUuid: episodeUuid, audioDuration: duration) else {
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: bookmark resolve gave up for \(episodeUuid) — no usable checkpoints"
+            )
             return nil
         }
 
@@ -652,11 +666,23 @@ final class FingerprintTimingManager: NSObject {
               ) else {
             FileLog.shared.addMessage(
                 "FingerprintTimingManager: bookmark resolve found no confident match "
-                    + "at playback \(String(format: "%.1f", playbackTime))s for \(episodeUuid)"
+                    + "at local file time \(String(format: "%.1f", playbackTime))s for \(episodeUuid) "
+                    + "(\(scratch?.playbackToReference.count ?? 0) anchors, took \(Self.elapsedMs(since: startDate))ms)"
             )
             return nil
         }
+
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: bookmark resolve matched for \(episodeUuid) — "
+                + "local file time \(String(format: "%.1f", playbackTime))s → "
+                + "reference time \(String(format: "%.1f", referenceTime))s "
+                + "(\(scratch.playbackToReference.count) anchors, took \(Self.elapsedMs(since: startDate))ms)"
+        )
         return referenceTime
+    }
+
+    private static func elapsedMs(since date: Date) -> Int {
+        Int(Date().timeIntervalSince(date) * 1000)
     }
 
     #if DEBUG

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -356,9 +356,13 @@ final class FingerprintTimingManager: NSObject {
     ///
     /// Must be called on the main queue. `completion` is delivered on the main
     /// queue; a superseded resolve never calls back.
+    /// - Parameter analyticsEvent: The resolve-duration event to emit on a successful
+    ///   match, or nil to skip it. Defaults to the chapter event; bookmark seeks pass a
+    ///   different one so the chapter metric stays comparable across platforms.
     func resolvePlaybackTime(
         forReferenceTime referenceTime: Double,
         episode: BaseEpisode,
+        analyticsEvent: AnalyticsEvent? = .playerChapterFingerprintCalculated,
         completion: @escaping (ChapterSeekResult) -> Void
     ) {
         dispatchPrecondition(condition: .onQueue(.main))
@@ -385,6 +389,7 @@ final class FingerprintTimingManager: NSObject {
             let result = await self.performResolve(
                 forReferenceTime: referenceTime,
                 episode: episode,
+                analyticsEvent: analyticsEvent,
                 flag: flag
             )
 
@@ -413,6 +418,7 @@ final class FingerprintTimingManager: NSObject {
     private func performResolve(
         forReferenceTime referenceTime: Double,
         episode: BaseEpisode,
+        analyticsEvent: AnalyticsEvent?,
         flag: CancellationFlag
     ) async -> ChapterSeekResult {
         let startDate = Date()
@@ -519,12 +525,14 @@ final class FingerprintTimingManager: NSObject {
             // Comparable across platforms: Android fingerprints eagerly and iOS
             // reactively on tap, but both report the calculation time here, decoupled
             // from `playerChapterSelected` (the tap) which stays untouched.
-            Analytics.track(.playerChapterFingerprintCalculated, properties: [
-                "duration_ms": resolveDurationMs,
-                "is_streaming": isStreaming,
-                "episode_uuid": episodeUuid,
-                "podcast_uuid": episode.parentIdentifier()
-            ])
+            if let analyticsEvent {
+                Analytics.track(analyticsEvent, properties: [
+                    "duration_ms": resolveDurationMs,
+                    "is_streaming": isStreaming,
+                    "episode_uuid": episodeUuid,
+                    "podcast_uuid": episode.parentIdentifier()
+                ])
+            }
             return .resolved(
                 playbackTime: max(referenceTime, playback),
                 usedPrior: usedPrior,

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -194,7 +194,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         // if the user has built an Up Next list, preserve that but make this the currently playing episode
         if !overrideUpNext && !switchingToDifferentUpNextEpisode && queue.upNextCount() > 0 {
             if let currEpisode = currentEpisode(), currEpisode.uuid != episode.uuid {
-                switchTo(episodeToPlay: episode, moveExistingToUpNext: true, autoPlay: true, completion: completion)
+                switchTo(episodeToPlay: episode, moveExistingToUpNext: true, autoPlay: autoPlay, completion: completion)
 
                 return
             }
@@ -2787,58 +2787,95 @@ extension PlaybackManager {
 
         analyticsPlaybackHelper.currentSource = .bookmark
 
-        #if os(watchOS)
-        startBookmarkPlayback(bookmark, episode: episode, atTime: bookmark.time)
-        #else
+        #if !os(watchOS) && !os(tvOS)
         // A bookmark's `referenceTime` sits on the transcript's canonical timeline, which
-        // dynamic ads have shifted in this device's audio, so resolve it to the real
-        // playback position first. Only worth it when the audio is local; otherwise, and
-        // whenever no confident match is found, fall back to the raw playback time.
-        guard let referenceTime = bookmark.referenceTime, FeatureFlag.syncedTranscripts.enabled,
-              isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid) || episode.downloaded(pathFinder: DownloadManager.shared) else {
-            startBookmarkPlayback(bookmark, episode: episode, atTime: bookmark.time)
+        // dynamic ads have shifted in this device's audio, so the stored time may point at
+        // the wrong content. Keep the player paused while fingerprinting resolves the true
+        // position, then start there.
+        if FeatureFlag.syncedTranscripts.enabled, let referenceTime = bookmark.referenceTime {
+            await playBookmarkAfterResolving(bookmark, referenceTime: referenceTime, episode: episode)
             return
         }
-
-        FingerprintTimingManager.shared.resolvePlaybackTime(forReferenceTime: referenceTime, episode: episode, analyticsEvent: nil) { [weak self] result in
-            let time: TimeInterval
-            switch result {
-            case let .resolved(playbackTime, _, _, resolveDurationMs):
-                time = playbackTime
-                FileLog.shared.addMessage(
-                    "[Bookmarks] Resolved bookmark \(bookmark.uuid) — local file time "
-                        + "\(String(format: "%.1f", bookmark.time))s, reference time \(String(format: "%.1f", referenceTime))s, "
-                        + "time at resolution \(String(format: "%.1f", playbackTime))s (took \(resolveDurationMs)ms)"
-                )
-            case let .unresolved(reason, _):
-                time = bookmark.time
-                FileLog.shared.addMessage(
-                    "[Bookmarks] No confident match for bookmark \(bookmark.uuid) (\(reason)) — local file time "
-                        + "\(String(format: "%.1f", bookmark.time))s, reference time \(String(format: "%.1f", referenceTime))s; "
-                        + "starting from the local file time"
-                )
-            }
-            self?.startBookmarkPlayback(bookmark, episode: episode, atTime: time)
-        }
         #endif
-    }
 
-    @MainActor
-    private func startBookmarkPlayback(_ bookmark: Bookmark, episode: BaseEpisode, atTime time: TimeInterval) {
         // If we're already the now playing episode, then just seek to the bookmark time
         if isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid) {
-            seekTo(time: time, startPlaybackAfterSeek: true)
+            seekTo(time: bookmark.time, startPlaybackAfterSeek: true)
             return
         }
 
         #if !os(watchOS)
         // Save the playback time before we start playing so the player will jump to the correct starting time when it does load
-        DataManager.sharedManager.saveEpisode(playedUpTo: time, episode: episode, updateSyncFlag: false)
-        DataManager.sharedManager.saveEpisode(playingStatus: .inProgress, episode: episode, updateSyncFlag: false)
+        dataManager.saveEpisode(playedUpTo: bookmark.time, episode: episode, updateSyncFlag: false)
+        dataManager.saveEpisode(playingStatus: .inProgress, episode: episode, updateSyncFlag: false)
         // Start the play process
         PlaybackActionHelper.play(episode: episode, podcastUuid: bookmark.podcastUuid)
         #endif
     }
+
+    #if !os(watchOS) && !os(tvOS)
+    /// Puts the bookmark's episode in the player, paused at the stored time, while
+    /// fingerprinting resolves where the bookmark's content actually sits in this
+    /// device's audio, then starts playback there (or at the stored time when no
+    /// confident match is found).
+    ///
+    /// The wait is bounded by the resolve's own timeout, and the bookmark row's spinner
+    /// covers it — `playBookmark`'s callers keep it up until this returns. Loading the
+    /// episode first isn't just for the UI: it kicks off the stream-and-cache download
+    /// whose audio the resolve fingerprints, so a not-yet-local episode can still match.
+    ///
+    /// If the listener takes over while we're resolving — seeks away, starts playback,
+    /// or loads another episode — the result is discarded and the player is left alone.
+    @MainActor
+    private func playBookmarkAfterResolving(_ bookmark: Bookmark, referenceTime: TimeInterval, episode: BaseEpisode) async {
+        // Position the player at the stored time — the best estimate until the resolve
+        // lands, and where playback falls back to. Pause before seeking so no audio from
+        // the wrong position slips out.
+        if isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid) {
+            pause(userInitiated: false)
+            seekTo(time: bookmark.time)
+        } else {
+            DataManager.sharedManager.saveEpisode(playedUpTo: bookmark.time, episode: episode, updateSyncFlag: false)
+            DataManager.sharedManager.saveEpisode(playingStatus: .inProgress, episode: episode, updateSyncFlag: false)
+            load(episode: episode, autoPlay: false, overrideUpNext: false)
+            // Create the player item now (playing would, but we aren't yet) — this is
+            // what starts the stream-and-cache download.
+            loadCurrentEpisode()
+        }
+
+        let result = await FingerprintTimingManager.shared.resolveBookmarkPlaybackTime(
+            forReferenceTime: referenceTime,
+            episode: episode
+        )
+
+        // The listener took over while we were resolving; leave things where they put them.
+        guard isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid), !playing(),
+              abs(currentTime() - bookmark.time) < 1 else {
+            FileLog.shared.addMessage(
+                "[Bookmarks] Playback moved while resolving bookmark \(bookmark.uuid) — not starting playback"
+            )
+            return
+        }
+
+        let time: TimeInterval
+        switch result {
+        case let .resolved(playbackTime, _, _, resolveDurationMs):
+            time = playbackTime
+            FileLog.shared.addMessage(
+                "[Bookmarks] Resolved bookmark \(bookmark.uuid) — stored time "
+                    + "\(String(format: "%.1f", bookmark.time))s, reference time \(String(format: "%.1f", referenceTime))s, "
+                    + "starting playback at \(String(format: "%.1f", playbackTime))s (took \(resolveDurationMs)ms)"
+            )
+        case let .unresolved(reason, _):
+            time = bookmark.time
+            FileLog.shared.addMessage(
+                "[Bookmarks] No confident match for bookmark \(bookmark.uuid) (\(reason)) — starting "
+                    + "playback at the stored time \(String(format: "%.1f", bookmark.time))s"
+            )
+        }
+        seekTo(time: time, startPlaybackAfterSeek: true)
+    }
+    #endif
 }
 
 // MARK: - SearchResults

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2803,10 +2803,20 @@ extension PlaybackManager {
         FingerprintTimingManager.shared.resolvePlaybackTime(forReferenceTime: referenceTime, episode: episode, analyticsEvent: nil) { [weak self] result in
             let time: TimeInterval
             switch result {
-            case let .resolved(playbackTime, _, _, _):
+            case let .resolved(playbackTime, _, _, resolveDurationMs):
                 time = playbackTime
-            case .unresolved:
+                FileLog.shared.addMessage(
+                    "[Bookmarks] Resolved bookmark \(bookmark.uuid) — local file time "
+                        + "\(String(format: "%.1f", bookmark.time))s, reference time \(String(format: "%.1f", referenceTime))s, "
+                        + "time at resolution \(String(format: "%.1f", playbackTime))s (took \(resolveDurationMs)ms)"
+                )
+            case let .unresolved(reason, _):
                 time = bookmark.time
+                FileLog.shared.addMessage(
+                    "[Bookmarks] No confident match for bookmark \(bookmark.uuid) (\(reason)) — local file time "
+                        + "\(String(format: "%.1f", bookmark.time))s, reference time \(String(format: "%.1f", referenceTime))s; "
+                        + "starting from the local file time"
+                )
             }
             self?.startBookmarkPlayback(bookmark, episode: episode, atTime: time)
         }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2787,16 +2787,44 @@ extension PlaybackManager {
 
         analyticsPlaybackHelper.currentSource = .bookmark
 
+        #if os(watchOS)
+        startBookmarkPlayback(bookmark, episode: episode, atTime: bookmark.time)
+        #else
+        // A bookmark's `referenceTime` sits on the transcript's canonical timeline, which
+        // dynamic ads have shifted in this device's audio, so resolve it to the real
+        // playback position first. Only worth it when the audio is local; otherwise, and
+        // whenever no confident match is found, fall back to the raw playback time.
+        guard let referenceTime = bookmark.referenceTime, FeatureFlag.syncedTranscripts.enabled,
+              isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid) || episode.downloaded(pathFinder: DownloadManager.shared) else {
+            startBookmarkPlayback(bookmark, episode: episode, atTime: bookmark.time)
+            return
+        }
+
+        FingerprintTimingManager.shared.resolvePlaybackTime(forReferenceTime: referenceTime, episode: episode, analyticsEvent: nil) { [weak self] result in
+            let time: TimeInterval
+            switch result {
+            case let .resolved(playbackTime, _, _, _):
+                time = playbackTime
+            case .unresolved:
+                time = bookmark.time
+            }
+            self?.startBookmarkPlayback(bookmark, episode: episode, atTime: time)
+        }
+        #endif
+    }
+
+    @MainActor
+    private func startBookmarkPlayback(_ bookmark: Bookmark, episode: BaseEpisode, atTime time: TimeInterval) {
         // If we're already the now playing episode, then just seek to the bookmark time
         if isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid) {
-            seekTo(time: bookmark.time, startPlaybackAfterSeek: true)
+            seekTo(time: time, startPlaybackAfterSeek: true)
             return
         }
 
         #if !os(watchOS)
         // Save the playback time before we start playing so the player will jump to the correct starting time when it does load
-        dataManager.saveEpisode(playedUpTo: bookmark.time, episode: episode, updateSyncFlag: false)
-        dataManager.saveEpisode(playingStatus: .inProgress, episode: episode, updateSyncFlag: false)
+        DataManager.sharedManager.saveEpisode(playedUpTo: time, episode: episode, updateSyncFlag: false)
+        DataManager.sharedManager.saveEpisode(playingStatus: .inProgress, episode: episode, updateSyncFlag: false)
         // Start the play process
         PlaybackActionHelper.play(episode: episode, podcastUuid: bookmark.podcastUuid)
         #endif


### PR DESCRIPTION
Fixes PCIOS-858.

**Note**: this is an initial PR. I'm also working on some performance optimizations and confirming if the UX could be improved in parallel.

A bookmark's stored time sits on this device's playback timeline, which dynamic ads shift per download — after a re-download or on another device it can point at the wrong content. This PR records the bookmark's position on the transcript's reference timeline when a passage is captured, and resolves it back to the local audio (via fingerprinting) when the bookmark is played, so playback starts on the bookmarked content.

**UI:** tapping play on a bookmark shows a spinner in place of the row's play icon while the episode loads into the player paused at the bookmark; once resolved, playback starts at the right spot and the spinner clears. Usually this is a few seconds at most; on a cold stream it can take longer (capped at 25s) since the resolver waits for the buffer to reach the bookmark — loading the episode is what starts that download, so non-local episodes work too. Seeking, pausing, or playing something else during the wait discards the pending start and leaves the player alone. Bookmarks without a reference time play immediately, as today.

Notes:

- `PlaybackManager.load`'s Up Next branch now passes the caller's `autoPlay` through to `switchTo` instead of hard-coding `true` — behavior-neutral for existing callers, needed to load the episode without autoplaying.
- New `bookmarkFingerprintCalculated` analytics event (same properties as the chapter one) so the timeouts can be tuned from field data.
- The reference time lives in `UserDefaults` alongside the captured passage for now, until it's persisted with the bookmark and synced.

## To test

Prerequisites: Smart Bookmarks feature flag; an episode with a generated transcript; bookmarks created on this device after capture (look for `[Bookmarks] Resolved bookmark …` in the logs).

1. While the episode is playing, tap play on one of its bookmarks — playback jumps to the bookmarked content near-instantly, no spinner.
2. With something else (or nothing) playing, play a bookmark of a **downloaded** episode — spinner replaces the play icon, episode appears paused in the player, then plays at the bookmarked content.
3. Repeat for a **non-downloaded** episode — same flow, longer spinner on slow networks, falling back to the stored time on timeout.
4. While the spinner is up, scrub, pause, or start another episode — playback stays where you put it and never jumps on its own afterwards.
5. With a non-empty Up Next queue, play a bookmark from a different episode — the current episode moves into Up Next; a normal episode tap with a queue still autoplays.
6. Generated-chapter taps and chapter skips still resolve and seek correctly.
7. Bookmarks without a reference time (older ones, or flag off) play immediately at the stored time.


https://github.com/user-attachments/assets/2c6e6248-ca98-4a55-84b7-f9e7a8c39e44



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
