### PR TITLE
Edit saved bookmarks with the smart bookmark sheet

### DIFF
--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -5,6 +5,21 @@ import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 
+/// The fields changed when saving a bookmark.
+struct BookmarkUpdateParameters {
+    var title: String
+
+    /// The captured transcript passage to store, or `nil` to leave the existing one unchanged.
+    var passage: Passage?
+
+    /// A transcript passage together with where it starts, kept so a re-selection can be
+    /// matched back to the same spot.
+    struct Passage {
+        var text: String
+        var location: Int?
+    }
+}
+
 class BookmarkManager {
     private let dataManager: BookmarkDataManager
     private let generalManager: DataManager
@@ -105,11 +120,16 @@ class BookmarkManager {
         }
     }
 
-    /// Updates the bookmark with the given title, emits `onBookmarkChanged` on success
+    /// Updates the bookmark with the given parameters, emits `onBookmarkChanged` on success
     @discardableResult
-    func update(title: String, for bookmark: Bookmark) async -> Bool {
-        await dataManager.update(bookmark: bookmark, title: title).when(true) {
-            onBookmarkChanged.send(.init(uuid: bookmark.uuid, change: .title(title)))
+    func update(_ parameters: BookmarkUpdateParameters, for bookmark: Bookmark) async -> Bool {
+        if let passage = parameters.passage {
+            bookmark.passage = passage.text
+            bookmark.passageLocation = passage.location
+        }
+
+        return await dataManager.update(bookmark: bookmark, title: parameters.title).when(true) {
+            onBookmarkChanged.send(.init(uuid: bookmark.uuid, change: .title(parameters.title)))
         }
     }
 

--- a/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
+++ b/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
@@ -22,6 +22,14 @@ extension BookmarkManager {
         return await BookmarkTranscriptSnippetExtractor().snippet(forTime: bookmark.time, episode: episode)
     }
 
+    func capturedSnippet(for bookmark: Bookmark, episode: BaseEpisode) async -> BookmarkTranscriptSnippet? {
+        guard Self.isTitleSuggestionEnabled, let passage = bookmark.passage, !passage.isEmpty else {
+            return nil
+        }
+
+        return await BookmarkTranscriptSnippetExtractor().snippet(forPassage: passage, at: bookmark.passageLocation, episode: episode)
+    }
+
     /// Returns nil when generation fails.
     func suggestTitle(from snippet: String, for bookmark: Bookmark, episode: BaseEpisode) async -> String? {
         let podcastTitle = bookmark.podcastUuid.flatMap { DataManager.sharedManager.findPodcast(uuid: $0)?.title }

--- a/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
+++ b/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
@@ -47,6 +47,16 @@ struct BookmarkTranscriptSnippetExtractor {
         return Self.extractSnippet(from: model, at: center)
     }
 
+    func snippet(forPassage passage: String, at location: Int?, episode: BaseEpisode) async -> BookmarkTranscriptSnippet? {
+        let transcriptManager = TranscriptManager(episodeUUID: episode.uuid, podcastUUID: episode.parentIdentifier())
+        guard let model = try? await transcriptManager.loadTranscript(),
+              let range = Self.passageRange(for: passage, at: location, in: model.attributedText) else {
+            return nil
+        }
+
+        return BookmarkTranscriptSnippet(transcript: model, range: range)
+    }
+
     static func extractSnippet(from model: TranscriptModel, at time: TimeInterval) -> BookmarkTranscriptSnippet? {
         let windowStart = max(0, time - backwardWindowSeconds)
         let windowEnd = time + forwardWindowSeconds

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewController.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewController.swift
@@ -88,7 +88,8 @@ private extension BookmarkDetailsViewController {
     func edit() {
         let controller = BookmarkEditTitleViewController(manager: bookmarkManager,
                                                          bookmark: bookmark,
-                                                         state: .updating) { [weak self] _, _ in
+                                                         state: .updating,
+                                                         style: .themed) { [weak self] _, _ in
             self?.viewModel.refresh()
         }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleView.swift
@@ -179,34 +179,94 @@ private extension View {
 // MARK: - Theme
 
 class BookmarkEditTheme: ThemeObserver {
-    let episode: BaseEpisode?
+    enum Style {
+        case player
+        case themed
+    }
 
-    init(episode: BaseEpisode?) {
+    let episode: BaseEpisode?
+    let style: Style
+
+    init(episode: BaseEpisode?, style: Style = .player) {
         self.episode = episode
+        self.style = style
     }
 
     var background: Color {
-        PlayerColorHelper.playerBackgroundColor01(for: theme.activeTheme, episode: episode).color
+        switch style {
+        case .player: PlayerColorHelper.playerBackgroundColor01(for: theme.activeTheme, episode: episode).color
+        case .themed: theme.primaryUi01
+        }
     }
 
-    var title: Color { theme.playerContrast01 }
-    var subTitle: Color { theme.playerContrast02 }
-    var closeButton: Color { theme.playerContrast01 }
-    var textField: Color { theme.playerContrast01 }
+    var title: Color {
+        switch style {
+        case .player: theme.playerContrast01
+        case .themed: theme.primaryText01
+        }
+    }
+
+    var subTitle: Color {
+        switch style {
+        case .player: theme.playerContrast02
+        case .themed: theme.primaryText02
+        }
+    }
+
+    var closeButton: Color {
+        switch style {
+        case .player: theme.playerContrast01
+        case .themed: theme.primaryText01
+        }
+    }
+
+    var textField: Color {
+        switch style {
+        case .player: theme.playerContrast01
+        case .themed: theme.primaryText01
+        }
+    }
 
     var textFieldAccent: Color {
-        PlayerColorHelper.playerHighlightColor01(for: .dark, episode: episode).color
+        switch style {
+        case .player: PlayerColorHelper.playerHighlightColor01(for: .dark, episode: episode).color
+        case .themed: theme.primaryInteractive01
+        }
     }
 
-    var textFieldPlaceholder: Color { theme.playerContrast05 }
-    var textFieldUnderline: Color { theme.playerContrast05 }
+    var textFieldPlaceholder: Color {
+        switch style {
+        case .player: theme.playerContrast05
+        case .themed: theme.primaryText02
+        }
+    }
+
+    var textFieldUnderline: Color {
+        switch style {
+        case .player: theme.playerContrast05
+        case .themed: theme.primaryUi05
+        }
+    }
+
+    var transcriptBackground: Color {
+        switch style {
+        case .player: theme.playerContrast06
+        case .themed: theme.primaryField01
+        }
+    }
 
     var saveButton: Color {
-        saveButtonBackground.luminance() < 0.5 ? .white : .black
+        switch style {
+        case .player: saveButtonBackground.luminance() < 0.5 ? .white : .black
+        case .themed: theme.primaryInteractive02
+        }
     }
 
     var saveButtonBackground: Color {
-        PlayerColorHelper.playerHighlightColor01(for: .dark, episode: episode).color
+        switch style {
+        case .player: PlayerColorHelper.playerHighlightColor01(for: .dark, episode: episode).color
+        case .themed: theme.primaryInteractive01
+        }
     }
 }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -17,17 +17,20 @@ class BookmarkEditTitleViewController: ThemedHostingController<AnyView> {
     init(manager: BookmarkManager,
          bookmark: Bookmark,
          state: BookmarkEditViewModel.EditState,
+         style: BookmarkEditTheme.Style = .player,
          onDismiss: ((String, Bool) -> Void)? = nil) {
-        let theme = BookmarkEditTheme(episode: manager.episode(for: bookmark))
+        let episode = manager.episode(for: bookmark)
 
         let viewModel: any BookmarkEditing
         let rootView: AnyView
 
         if FeatureFlag.smartBookmarks.enabled {
+            let theme = BookmarkEditTheme(episode: episode, style: style)
             let smartViewModel = BookmarkEditViewModel(manager: manager, bookmark: bookmark, state: state)
             viewModel = smartViewModel
             rootView = AnyView(BookmarkEditView(viewModel: smartViewModel, theme: theme))
         } else {
+            let theme = BookmarkEditTheme(episode: episode)
             let titleViewModel = BookmarkEditTitleViewModel(manager: manager, bookmark: bookmark, state: .init(state))
             viewModel = titleViewModel
             rootView = AnyView(BookmarkEditTitleView(viewModel: titleViewModel, theme: theme))

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewModel.swift
@@ -58,7 +58,7 @@ class BookmarkEditTitleViewModel: ObservableObject {
         Task {
             let title = String(title.trim().prefix(maxTitleLength))
 
-            await bookmarkManager.update(title: title.isEmpty ? placeholder : title, for: bookmark)
+            await bookmarkManager.update(.init(title: title.isEmpty ? placeholder : title), for: bookmark)
 
             if editState == .updating {
                 Analytics.track(.bookmarkUpdateTitle, source: analyticsSource)

--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -36,7 +36,7 @@ struct BookmarkEditView: View {
 
             saveButton
         }
-        .animation(.easeInOut(duration: 0.2), value: viewModel.snippet?.text)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.passage)
         .animation(.easeInOut(duration: 0.2), value: viewModel.isCapturingTranscript)
         .frame(maxWidth: .infinity)
         .padding()
@@ -139,7 +139,7 @@ struct BookmarkEditView: View {
 
     @ViewBuilder
     private var transcriptSection: some View {
-        if viewModel.snippet != nil || viewModel.isCapturingTranscript {
+        if viewModel.passage != nil || viewModel.isCapturingTranscript {
             section {
                 HStack {
                     Text(L10n.bookmarkTranscriptCaptured)
@@ -152,8 +152,8 @@ struct BookmarkEditView: View {
                 }
                 .padding(.horizontal, 8)
             } content: {
-                if let snippet = viewModel.snippet {
-                    transcript(snippet.text)
+                if let passage = viewModel.passage {
+                    transcript(passage)
                 } else {
                     transcript(Self.transcriptPlaceholder)
                         .redacted(reason: .placeholder)
@@ -231,7 +231,6 @@ struct BookmarkEditView: View {
 // MARK: - Theme
 
 private extension BookmarkEditTheme {
-    var transcriptBackground: Color { theme.playerContrast06 }
     var editButton: Color { textFieldAccent }
 }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PocketCastsDataModel
 
+@MainActor
 class BookmarkEditViewModel: ObservableObject {
     weak var router: BookmarkEditRouter?
 
@@ -52,6 +53,10 @@ class BookmarkEditViewModel: ObservableObject {
     /// placeholder rather than appearing out of nowhere
     @Published private(set) var isCapturingTranscript = false
 
+    var passage: String? {
+        snippet?.text ?? bookmark.passage
+    }
+
     /// The captured passage, which the transcript editor changes as the user picks a
     /// different one. It deliberately doesn't regenerate the title, which belongs to the
     /// moment that was bookmarked.
@@ -79,15 +84,35 @@ class BookmarkEditViewModel: ObservableObject {
             headerTitle = L10n.addBookmark
             saveButtonTitle = L10n.saveBookmark
         case .updating:
-            headerTitle = L10n.changeBookmarkTitle
-            saveButtonTitle = L10n.changeBookmarkTitle
+            headerTitle = L10n.editBookmark
+            saveButtonTitle = L10n.saveBookmark
         }
 
-        generateTitleSuggestion()
+        switch editState {
+        case .adding:
+            generateTitleSuggestion()
+        case .updating:
+            loadCapturedPassage()
+        }
     }
 
     deinit {
         suggestionTask?.cancel()
+    }
+
+    private func loadCapturedPassage() {
+        guard BookmarkManager.isTitleSuggestionEnabled,
+              bookmark.passage?.isEmpty == false,
+              let episode = bookmarkManager.episode(for: bookmark) else { return }
+
+        suggestionTask = Task { [weak self, bookmarkManager, bookmark] in
+            let snippet = await bookmarkManager.capturedSnippet(for: bookmark, episode: episode)
+            guard !Task.isCancelled, let snippet else { return }
+
+            await MainActor.run {
+                self?.snippet = snippet
+            }
+        }
     }
 
     // MARK: - Title Suggestion

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -38,16 +38,9 @@ class BookmarkEditViewModel: ObservableObject {
     /// A title suggestion generated from the transcript around the bookmark's position
     @Published private(set) var titleSuggestion: TitleSuggestion = .none
 
-    /// Storing the passage as it's captured, and again on every change, keeps it around
-    /// even when the sheet is dismissed without saving the title
-    @Published private(set) var snippet: BookmarkTranscriptSnippet? {
-        didSet {
-            guard let snippet, snippet.range != oldValue?.range else { return }
-
-            bookmark.passage = snippet.text
-            bookmark.passageLocation = snippet.range.location
-        }
-    }
+    /// The captured transcript passage, re-selectable while editing. It's persisted to the
+    /// bookmark only on save, so dismissing without saving leaves the stored passage intact.
+    @Published private(set) var snippet: BookmarkTranscriptSnippet?
 
     /// Whether the transcript is still being fetched, so the passage can be shown as a
     /// placeholder rather than appearing out of nowhere
@@ -83,15 +76,10 @@ class BookmarkEditViewModel: ObservableObject {
         case .adding:
             headerTitle = L10n.addBookmark
             saveButtonTitle = L10n.saveBookmark
+            generateTitleSuggestion()
         case .updating:
             headerTitle = L10n.editBookmark
             saveButtonTitle = L10n.saveBookmark
-        }
-
-        switch editState {
-        case .adding:
-            generateTitleSuggestion()
-        case .updating:
             loadCapturedPassage()
         }
     }
@@ -109,9 +97,7 @@ class BookmarkEditViewModel: ObservableObject {
             let snippet = await bookmarkManager.capturedSnippet(for: bookmark, episode: episode)
             guard !Task.isCancelled, let snippet else { return }
 
-            await MainActor.run {
-                self?.snippet = snippet
-            }
+            self?.snippet = snippet
         }
     }
 
@@ -127,33 +113,28 @@ class BookmarkEditViewModel: ObservableObject {
             let snippet = await bookmarkManager.transcriptSnippet(for: bookmark, episode: episode)
             guard !Task.isCancelled else { return }
 
-            await MainActor.run {
-                self?.snippet = snippet
-                self?.isCapturingTranscript = false
-            }
+            self?.snippet = snippet
+            self?.isCapturingTranscript = false
 
             guard let snippet else {
-                await MainActor.run { self?.titleSuggestion = .none }
+                self?.titleSuggestion = .none
                 return
             }
 
             let suggestion = await bookmarkManager.suggestTitle(from: snippet.text, for: bookmark, episode: episode)
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled, let self else { return }
 
             let trimmed = suggestion.map { String($0.trim().prefix(maxTitleLength)) }
-            await MainActor.run {
-                guard let self else { return }
-                guard let trimmed, !trimmed.isEmpty else {
-                    self.titleSuggestion = .none
-                    return
-                }
+            guard let trimmed, !trimmed.isEmpty else {
+                self.titleSuggestion = .none
+                return
+            }
 
-                if self.isTitleUnchanged {
-                    self.applySuggestion(trimmed)
-                } else {
-                    // Never replace the user's own words — offer the suggestion instead
-                    self.titleSuggestion = .available(trimmed)
-                }
+            if self.isTitleUnchanged {
+                self.applySuggestion(trimmed)
+            } else {
+                // Never replace the user's own words — offer the suggestion instead
+                self.titleSuggestion = .available(trimmed)
             }
         }
     }
@@ -184,8 +165,9 @@ class BookmarkEditViewModel: ObservableObject {
         suggestionTask?.cancel()
         Task {
             let title = String(title.trim().prefix(maxTitleLength))
+            let passage = snippet.map { BookmarkUpdateParameters.Passage(text: $0.text, location: $0.range.location) }
 
-            await bookmarkManager.update(title: title.isEmpty ? placeholder : title, for: bookmark)
+            await bookmarkManager.update(.init(title: title.isEmpty ? placeholder : title, passage: passage), for: bookmark)
 
             if editState == .updating {
                 Analytics.track(.bookmarkUpdateTitle, source: analyticsSource)

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -47,7 +47,8 @@ extension BookmarkEpisodeListController: BookmarkListRouter {
     func bookmarkEdit(_ bookmark: Bookmark) {
         let controller = BookmarkEditTitleViewController(manager: bookmarkManager,
                                                          bookmark: bookmark,
-                                                         state: .updating)
+                                                         state: .updating,
+                                                         style: .themed)
 
         controller.source = viewModel.analyticsSource
 

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
@@ -39,7 +39,7 @@ extension BookmarksPodcastListController: BookmarkListRouter {
     }
 
     func bookmarkEdit(_ bookmark: Bookmark) {
-        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating)
+        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating, style: .themed)
         controller.source = viewModel.analyticsSource
 
         present(controller, animated: true)

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
@@ -42,7 +42,7 @@ extension BookmarksProfileListController: BookmarkListRouter {
     }
 
     func bookmarkEdit(_ bookmark: Bookmark) {
-        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating)
+        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating, style: .themed)
         controller.source = viewModel.analyticsSource
 
         present(controller, animated: true)

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -982,7 +982,7 @@ private extension MainTabBarController {
         let message = title == L10n.bookmarkDefaultTitle ? L10n.bookmarkAdded : L10n.bookmarkAddedNotification(title)
 
         let action = Toast.Action(title: L10n.changeBookmarkTitle) { [weak self] in
-            let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating, onDismiss: { [weak self] updatedTitle, _ in
+            let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating, style: .themed, onDismiss: { [weak self] updatedTitle, _ in
                 guard title != updatedTitle else { return }
 
                 self?.handleBookmarkTitleUpdated(updatedTitle: updatedTitle)

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -1758,7 +1758,7 @@ extension PodcastViewController: BookmarkListRouter {
     }
 
     func bookmarkEdit(_ bookmark: Bookmark) {
-        let controller = BookmarkEditTitleViewController(manager: PlaybackManager.shared.bookmarkManager, bookmark: bookmark, state: .updating)
+        let controller = BookmarkEditTitleViewController(manager: PlaybackManager.shared.bookmarkManager, bookmark: bookmark, state: .updating, style: .themed)
         controller.source = .podcasts
 
         present(controller, animated: true)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4516,6 +4516,9 @@
 /* The title of a view where the user can edit their bookmark title */
 "change_bookmark_title" = "Change title";
 
+/* The title of the sheet where the user edits a saved bookmark */
+"edit_bookmark" = "Edit Bookmark";
+
 /* The subtitle of a view where the user can edit their bookmark title */
 "change_bookmark_subtitle" = "Change the title that identifies this bookmark";
 


### PR DESCRIPTION
| 📘 Part of: Smart Bookmarks |
|:---:|

Closes PCIOS-856.

> [!NOTE]
> Stacked on `kean/smart-bookmark-editing` — review/merge that first.

Editing a saved bookmark now opens the smart bookmark sheet (behind `FeatureFlag.smartBookmarks`), showing its captured passage and letting you re-select it. The sheet uses the app theme outside the player and the player theme over it. Legacy title editor unchanged.

<img width="320" alt="Screenshot 2026-07-24 at 12 49 16 PM" src="https://github.com/user-attachments/assets/715fbf14-4682-4530-8c9b-b576f93568d5" /> <img width="320" alt="Screenshot 2026-07-24 at 12 49 22 PM" src="https://github.com/user-attachments/assets/58da1bee-2059-4572-bd5b-a2ec5ff78bd5" />

## To test

Debug build (flag on):

1. Add a bookmark on an episode with a transcript.
2. From a bookmarks list outside the player, tap ⋯ → **Edit**.
3. Confirm the sheet is titled **Edit Bookmark**, shows the passage themed to the screen, and the **Edit** button lets you re-select it.
4. Change the title, tap **Save Bookmark**, confirm it persists.
5. Editing from the player's Bookmarks tab still uses the player colors.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
