### PR TITLE
Refine bookmark transcript UI

### DIFF
--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -100,10 +100,6 @@ struct BookmarkDetailsView: View {
                 .foregroundStyle(theme.primaryText01)
                 .padding(.bottom, 4)
 
-            Text(timestamp)
-                .font(style: .footnote, weight: .medium)
-                .foregroundStyle(theme.primaryText02)
-
             viewModel.passage.map {
                 Text($0)
                     .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)

--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -155,7 +155,7 @@ struct BookmarkEditView: View {
                 if let passage = viewModel.passage {
                     transcript(passage)
                 } else {
-                    transcript(Self.transcriptPlaceholder)
+                    transcript(Self.transcriptPlaceholder, showsBackground: false)
                         .redacted(reason: .placeholder)
                         .accessibilityHidden(true)
                 }
@@ -163,7 +163,7 @@ struct BookmarkEditView: View {
         }
     }
 
-    private func transcript(_ text: String) -> some View {
+    private func transcript(_ text: String, showsBackground: Bool = true) -> some View {
         Text(text)
             .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
             .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
@@ -171,7 +171,7 @@ struct BookmarkEditView: View {
             .lineLimit(4)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(16)
-            .background(theme.transcriptBackground)
+            .background(showsBackground ? theme.transcriptBackground : .clear)
             .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -150,12 +150,12 @@ struct BookmarkEditView: View {
                         editTranscriptButton
                     }
                 }
-                .padding(.horizontal, 8)
+                .padding(.bottom, 4)
             } content: {
                 if let passage = viewModel.passage {
                     transcript(passage)
                 } else {
-                    transcript(Self.transcriptPlaceholder, showsBackground: false)
+                    transcript(Self.transcriptPlaceholder)
                         .redacted(reason: .placeholder)
                         .accessibilityHidden(true)
                 }
@@ -163,16 +163,13 @@ struct BookmarkEditView: View {
         }
     }
 
-    private func transcript(_ text: String, showsBackground: Bool = true) -> some View {
+    private func transcript(_ text: String) -> some View {
         Text(text)
             .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
             .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
             .foregroundStyle(theme.title)
             .lineLimit(4)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(16)
-            .background(showsBackground ? theme.transcriptBackground : .clear)
-            .clipShape(RoundedRectangle(cornerRadius: 8))
     }
 
     /// Stands in for the passage while the transcript loads. The redaction blocks it out,

--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -14,6 +14,8 @@ struct BookmarkEditView: View {
 
     @State private var isEditingTranscript = false
 
+    @State private var titleTextField: UITextField?
+
     var body: some View {
         NavigationStack {
             form
@@ -131,10 +133,27 @@ struct BookmarkEditView: View {
             .foregroundStyle(theme.textField)
             .accentColor(theme.textFieldAccent)
             .focused($isTitleFocused)
-            .selectAllOnFocus()
+            .onReceive(UITextField.textDidBeginEditingNotification.publisher()) { notification in
+                guard let textField = notification.object as? UITextField else { return }
+                titleTextField = textField
+                selectAllTitle()
+            }
+            .onReceive(viewModel.didApplySuggestion) { _ in
+                selectAllTitle()
+            }
             .onSubmit {
                 viewModel.save()
             }
+    }
+
+    /// Selects the whole title after a short delay, so the selection reliably appears
+    /// once the field has settled — whether focus just arrived or a suggestion was applied
+    private func selectAllTitle() {
+        guard let titleTextField else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            titleTextField.selectedTextRange = titleTextField.textRange(from: titleTextField.beginningOfDocument, to: titleTextField.endOfDocument)
+        }
     }
 
     @ViewBuilder
@@ -142,7 +161,7 @@ struct BookmarkEditView: View {
         if viewModel.passage != nil || viewModel.isCapturingTranscript {
             section {
                 HStack {
-                    Text(L10n.bookmarkTranscriptCaptured)
+                    Text(L10n.transcript)
 
                     Spacer()
 
@@ -239,20 +258,6 @@ private extension View {
             .lineLimit(1)
             .minimumScaleFactor(0.7)
             .font(size: 24, style: .title2, weight: .bold)
-    }
-
-    /// Selects all the text when the text field gains focus
-    func selectAllOnFocus() -> some View {
-        self.onReceive(UITextField.textDidBeginEditingNotification.publisher()) { notification in
-            guard let textField = notification.object as? UITextField else {
-                return
-            }
-
-            // Select after a delay because there's a bug where the selection won't appear if the text is too long
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                textField.selectedTextRange = textField.textRange(from: textField.beginningOfDocument, to: textField.endOfDocument)
-            }
-        }
     }
 }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -1,3 +1,4 @@
+import Combine
 import Foundation
 import PocketCastsDataModel
 
@@ -37,6 +38,9 @@ class BookmarkEditViewModel: ObservableObject {
 
     /// A title suggestion generated from the transcript around the bookmark's position
     @Published private(set) var titleSuggestion: TitleSuggestion = .none
+
+    /// Fires when the title is replaced programmatically so the field can re-select it
+    let didApplySuggestion = PassthroughSubject<Void, Never>()
 
     /// The captured transcript passage, re-selectable while editing. It's persisted to the
     /// bookmark only on save, so dismissing without saving leaves the stored passage intact.
@@ -142,6 +146,7 @@ class BookmarkEditViewModel: ObservableObject {
     func applySuggestion(_ suggestion: String) {
         title = suggestion
         titleSuggestion = .none
+        didApplySuggestion.send()
     }
 
     enum TitleSuggestion: Equatable {

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
@@ -11,30 +11,31 @@ struct BookmarkTranscriptEditView: View {
     @ObservedObject var theme: BookmarkEditTheme
 
     var body: some View {
-        VStack(spacing: 18) {
-            subtitle
-
-            TranscriptSelectionTextView(transcript: transcript,
-                                        selection: $selection,
-                                        textColor: UIColor(theme.title),
-                                        selectionColor: UIColor(theme.transcriptSelection))
-        }
-        .frame(maxWidth: .infinity)
-        .padding([.horizontal, .top])
-        .background(theme.background.ignoresSafeArea())
-        .ignoresSafeArea(edges: .bottom)
-        // Colors the back button the bar gives us for free
-        .tint(theme.title)
-        .navigationTitle(L10n.bookmarkEditTranscriptTitle)
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            // The bar's own title knows nothing about the player's colors
-            ToolbarItem(placement: .principal) {
-                Text(L10n.bookmarkEditTranscriptTitle)
-                    .font(style: .headline, weight: .semibold)
-                    .foregroundStyle(theme.title)
+        TranscriptSelectionTextView(transcript: transcript,
+                                    selection: $selection,
+                                    textColor: UIColor(theme.title),
+                                    selectionColor: UIColor(theme.transcriptSelection))
+            .mask(topFadeMask)
+            .overlay(alignment: .top) {
+                subtitle
+                    .allowsHitTesting(false)
             }
-        }
+            .frame(maxWidth: .infinity)
+            .padding([.horizontal, .top])
+            .background(theme.background.ignoresSafeArea())
+            .ignoresSafeArea(edges: .bottom)
+            // Colors the back button the bar gives us for free
+            .tint(theme.title)
+            .navigationTitle(L10n.bookmarkEditTranscriptTitle)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                // The bar's own title knows nothing about the player's colors
+                ToolbarItem(placement: .principal) {
+                    Text(L10n.bookmarkEditTranscriptTitle)
+                        .font(style: .headline, weight: .semibold)
+                        .foregroundStyle(theme.title)
+                }
+            }
     }
 
     // MARK: - Views
@@ -44,6 +45,15 @@ struct BookmarkTranscriptEditView: View {
             .foregroundStyle(theme.subTitle)
             .font(style: .callout)
             .multilineTextAlignment(.center)
+    }
+
+    /// Softens the top edge so the passage scrolls out of view instead of being clipped
+    private var topFadeMask: some View {
+        VStack(spacing: 0) {
+            LinearGradient(colors: [.clear, .black], startPoint: .top, endPoint: .bottom)
+                .frame(height: 140)
+            Color.black
+        }
     }
 }
 
@@ -61,7 +71,7 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
     let selectionColor: UIColor
 
     /// Where the passage sits vertically once scrolled to
-    private let verticalAnchor: CGFloat = 0.3
+    private let verticalAnchor: CGFloat = 0.5
 
     func makeUIView(context: Context) -> SelectableTextView {
         // TextKit 1: `scrollToRange` and the character index lookups work off `layoutManager`


### PR DESCRIPTION
Fixes PCIOS-844.

Small UI refinements to the bookmark add/edit and details screens:

- Fade out the top of the transcript editor (behind the header) instead of a hard cut, and open it centered on the selected passage with more room above.
- Remove the transcript background/padding in the edit view and tidy the "Transcript" section header spacing.
- Keep the title fully selected after an auto-suggestion is applied, so it stays overtypeable.
- Remove the redundant timestamp above the passage in the bookmark details view.

<img width="320" alt="Screenshot 2026-07-24 at 1 25 34 PM" src="https://github.com/user-attachments/assets/d5d15b7b-b961-4052-84cf-3248b84cd2c2" /> <img width="320" alt="Screenshot 2026-07-24 at 1 25 36 PM" src="https://github.com/user-attachments/assets/9405d1fb-fd00-4fa7-901c-c6b2c6a8dd94" />


## To test

1. Play an episode and add a bookmark, then open the Add Bookmark sheet.
2. Confirm the title is selected and can be overtyped, including after an AI title suggestion lands.
3. Tap Edit on the transcript — confirm the passage fades under the "Select a transcript passage…" header and opens centered on the selection.
4. Open a saved bookmark's details and confirm the layout under the title.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.