### PR TITLE
Show bookmark indicator on transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Fix the Bookmarks multi-select layout: rows keep their text width instead of shrinking, the selection bar sits just above the mini player instead of floating too high, and on iOS 26 it hides the tab bar and mini player correctly [#4819](https://github.com/Automattic/pocket-casts-ios/pull/4819)
 - Fix the day label in episode cells growing out of proportion at large text sizes [#4818](https://github.com/Automattic/pocket-casts-ios/pull/4818)
+- Show a bookmark marker beside the matching line when editing a bookmark's transcript passage [#4826](https://github.com/Automattic/pocket-casts-ios/pull/4826)
 
 
 8.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 -----
 - Fix the Bookmarks multi-select layout: rows keep their text width instead of shrinking, the selection bar sits just above the mini player instead of floating too high, and on iOS 26 it hides the tab bar and mini player correctly [#4819](https://github.com/Automattic/pocket-casts-ios/pull/4819)
 - Fix the day label in episode cells growing out of proportion at large text sizes [#4818](https://github.com/Automattic/pocket-casts-ios/pull/4818)
-- Show a bookmark marker beside the matching line when editing a bookmark's transcript passage [#4826](https://github.com/Automattic/pocket-casts-ios/pull/4826)
 
 
 8.17

--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -66,7 +66,10 @@ struct BookmarkEditView: View {
     @ViewBuilder
     private var transcriptEditor: some View {
         if let transcript = viewModel.snippet?.transcript {
-            BookmarkTranscriptEditView(transcript: transcript, selection: $viewModel.transcriptRange, theme: theme)
+            BookmarkTranscriptEditView(transcript: transcript,
+                                       selection: $viewModel.transcriptRange,
+                                       bookmarkTime: viewModel.bookmarkTime,
+                                       theme: theme)
         }
     }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -59,6 +59,10 @@ class BookmarkEditViewModel: ObservableObject {
         set { snippet?.range = newValue }
     }
 
+    /// The playback moment the bookmark marks, used to place a marker beside the matching
+    /// line in the transcript editor
+    var bookmarkTime: TimeInterval { bookmark.time }
+
     private let bookmarkManager: BookmarkManager
     private let bookmark: Bookmark
 

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
@@ -8,16 +8,24 @@ struct BookmarkTranscriptEditView: View {
 
     @Binding var selection: NSRange
 
+    /// The playback moment the bookmark marks, so a marker can sit beside the line it lands on
+    let bookmarkTime: TimeInterval
+
     @ObservedObject var theme: BookmarkEditTheme
+
+    /// Where the marker's line currently sits vertically within the text view, or nil while
+    /// that line is scrolled out of view
+    @State private var markerY: CGFloat?
+
+    private let markerGutterWidth: CGFloat = 24
+    private let markerSpacing: CGFloat = 8
+    private let markerIconSize: CGFloat = 18
 
     var body: some View {
         VStack(spacing: 18) {
             subtitle
 
-            TranscriptSelectionTextView(transcript: transcript,
-                                        selection: $selection,
-                                        textColor: UIColor(theme.title),
-                                        selectionColor: UIColor(theme.transcriptSelection))
+            passagePicker
         }
         .frame(maxWidth: .infinity)
         .padding([.horizontal, .top])
@@ -45,6 +53,57 @@ struct BookmarkTranscriptEditView: View {
             .font(style: .callout)
             .multilineTextAlignment(.center)
     }
+
+    /// The transcript with a bookmark marker in the leading gutter, when the moment can be
+    /// placed against a line
+    private var passagePicker: some View {
+        HStack(alignment: .top, spacing: markerSpacing) {
+            if anchorLocation != nil {
+                markerGutter
+            }
+
+            TranscriptSelectionTextView(transcript: transcript,
+                                        selection: $selection,
+                                        anchorLocation: anchorLocation,
+                                        markerY: $markerY,
+                                        textColor: UIColor(theme.title),
+                                        selectionColor: UIColor(theme.transcriptSelection))
+        }
+    }
+
+    private var markerGutter: some View {
+        Color.clear
+            .frame(width: markerGutterWidth)
+            .overlay {
+                if let markerY {
+                    Image(systemName: "bookmark.fill")
+                        .font(.system(size: markerIconSize))
+                        .foregroundStyle(theme.title)
+                        .position(x: markerGutterWidth / 2, y: markerY)
+                        .allowsHitTesting(false)
+                }
+            }
+            .accessibilityHidden(true)
+    }
+
+    // MARK: - Marker position
+
+    /// The character in the transcript nearest the bookmarked moment. Nil when the transcript
+    /// carries no cue timing to place it against.
+    private var anchorLocation: Int? {
+        guard !transcript.cues.isEmpty else { return nil }
+
+        let cue = transcript.firstCue(containing: bookmarkTime)
+            ?? transcript.cues.last { $0.startTime <= bookmarkTime }
+            ?? transcript.cues.first
+        guard let cue else { return nil }
+
+        // Interpolate within the cue so the marker tracks the moment, not just the cue's start
+        let span = max(cue.endTime - cue.startTime, .leastNonzeroMagnitude)
+        let fraction = min(max((bookmarkTime - cue.startTime) / span, 0), 1)
+        let offset = Int((Double(cue.characterRange.length) * fraction).rounded())
+        return cue.characterRange.location + offset
+    }
 }
 
 // MARK: - TranscriptSelectionTextView
@@ -56,6 +115,13 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
     let transcript: TranscriptModel
 
     @Binding var selection: NSRange
+
+    /// The character the bookmark marker points at, if the moment could be placed
+    let anchorLocation: Int?
+
+    /// Reports where that character sits vertically as the text scrolls, or nil when it's
+    /// scrolled out of view
+    @Binding var markerY: CGFloat?
 
     let textColor: UIColor
     let selectionColor: UIColor
@@ -91,6 +157,11 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
             // Listen only from here on: the passage above would report itself back as a
             // change, and the empty selection it starts out with would overwrite it
             textView.delegate = context.coordinator
+
+            // Placed off the layout pass so the marker's state settles outside SwiftUI's update
+            DispatchQueue.main.async {
+                context.coordinator.updateMarker(in: textView)
+            }
         }
 
         return textView
@@ -103,7 +174,7 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(selection: $selection)
+        Coordinator(selection: $selection, markerY: $markerY, anchorLocation: anchorLocation)
     }
 
     private func styledText() -> NSAttributedString {
@@ -149,9 +220,55 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
 
     class Coordinator: NSObject, UITextViewDelegate {
         @Binding private var selection: NSRange
+        @Binding private var markerY: CGFloat?
+        private let anchorLocation: Int?
 
-        init(selection: Binding<NSRange>) {
+        init(selection: Binding<NSRange>, markerY: Binding<CGFloat?>, anchorLocation: Int?) {
             _selection = selection
+            _markerY = markerY
+            self.anchorLocation = anchorLocation
+        }
+
+        func scrollViewDidScroll(_ scrollView: UIScrollView) {
+            guard let textView = scrollView as? UITextView else { return }
+
+            updateMarker(in: textView)
+        }
+
+        /// Positions the marker beside the line holding the bookmarked moment, hiding it while
+        /// that line is scrolled out of view.
+        func updateMarker(in textView: UITextView) {
+            guard let anchorLocation else {
+                setMarkerY(nil)
+                return
+            }
+
+            let length = (textView.text as NSString).length
+            guard length > 0 else {
+                setMarkerY(nil)
+                return
+            }
+
+            let location = min(max(anchorLocation, 0), length - 1)
+            let glyphRange = textView.layoutManager.glyphRange(forCharacterRange: NSRange(location: location, length: 1), actualCharacterRange: nil)
+            var rect = textView.layoutManager.boundingRect(forGlyphRange: glyphRange, in: textView.textContainer)
+            rect.origin.y += textView.textContainerInset.top
+
+            // Content coordinate to a position within the visible bounds
+            let y = rect.midY - textView.contentOffset.y
+            setMarkerY((0...textView.bounds.height).contains(y) ? y : nil)
+        }
+
+        /// Only writes back a meaningful move, so scrolling doesn't churn SwiftUI every frame
+        private func setMarkerY(_ y: CGFloat?) {
+            switch (markerY, y) {
+            case (nil, nil):
+                return
+            case let (current?, value?) where abs(current - value) < 0.5:
+                return
+            default:
+                markerY = y
+            }
         }
 
         func textViewDidChangeSelection(_ textView: UITextView) {
@@ -190,6 +307,7 @@ struct BookmarkTranscriptEditView_Previews: PreviewProvider {
         NavigationStack {
             BookmarkTranscriptEditView(transcript: previewTranscript,
                                        selection: .constant(NSRange(location: 0, length: 42)),
+                                       bookmarkTime: 8,
                                        theme: .init(episode: nil))
         }
         .setupDefaultEnvironment()


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

Adds a bookmark marker to the transcript editor. It sits in the leading gutter next to the transcript line where the bookmark's timestamp falls, giving a quick visual anchor for the moment being bookmarked. The bookmark's playback time is mapped to the matching transcript cue (interpolated within the cue), and the marker tracks that line as the text scrolls, hiding while the line is off screen. It only appears when the transcript carries cue timing.

## To test

1. Play an episode that has a transcript.
2. Create a bookmark at a specific moment (or open an existing bookmark to edit).
3. On the Add/Change bookmark sheet, tap **Edit** next to the captured transcript passage.
4. On the **Edit transcript** screen, confirm a filled bookmark icon appears in the left margin, roughly aligned with the line matching the bookmark's timestamp.
5. Scroll the transcript and confirm the marker follows its line and disappears once that line scrolls out of view.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
