### PR TITLE
Migrate BadgeHelper to setBadgeCount (4 warnings)

### DIFF
--- a/podcasts/Utilities/BadgeHelper.swift
+++ b/podcasts/Utilities/BadgeHelper.swift
@@ -12,18 +12,20 @@ class BadgeHelper {
     private var cancelable: Cancellable?
 
     func setup() {
-        let notifications: [NSNotification.Name] = [Constants.Notifications.playlistChanged,
-                                                    Constants.Notifications.episodePlayStatusChanged,
-                                                    Constants.Notifications.episodeArchiveStatusChanged,
-                                                    Constants.Notifications.episodeStarredChanged,
-                                                    Constants.Notifications.episodeDownloadStatusChanged,
-                                                    Constants.Notifications.manyEpisodesChanged,
-                                                    ServerNotifications.podcastsRefreshed,
-                                                    Constants.Notifications.opmlImportCompleted,
-                                                    Constants.Notifications.episodeDownloaded,
-                                                    Constants.Notifications.playbackTrackChanged,
-                                                    Constants.Notifications.playbackEnded,
-                                                    Constants.Notifications.playbackStarted]
+        let notifications: [NSNotification.Name] = [
+            Constants.Notifications.playlistChanged,
+            Constants.Notifications.episodePlayStatusChanged,
+            Constants.Notifications.episodeArchiveStatusChanged,
+            Constants.Notifications.episodeStarredChanged,
+            Constants.Notifications.episodeDownloadStatusChanged,
+            Constants.Notifications.manyEpisodesChanged,
+            ServerNotifications.podcastsRefreshed,
+            Constants.Notifications.opmlImportCompleted,
+            Constants.Notifications.episodeDownloaded,
+            Constants.Notifications.playbackTrackChanged,
+            Constants.Notifications.playbackEnded,
+            Constants.Notifications.playbackStarted
+        ]
 
         let mergedNotifications = notifications
             .map { NotificationCenter.default.publisher(for: $0) }

--- a/podcasts/Utilities/BadgeHelper.swift
+++ b/podcasts/Utilities/BadgeHelper.swift
@@ -2,6 +2,7 @@ import Foundation
 import PocketCastsDataModel
 import PocketCastsServer
 import Combine
+import UserNotifications
 
 class BadgeHelper {
     deinit {
@@ -49,13 +50,13 @@ class BadgeHelper {
         if badgeSetting == .off && !pushOn { return } // user has both the badge and push turned off, don't attempt to badge their app. Results in iOS 8 push message request popup
 
         if badgeSetting == .off || !pushOn {
-            clearBadge(clearNotificationsToo: false)
+            clearBadge()
         } else if badgeSetting == .totalUnplayed {
             let unplayedCount = DataManager.sharedManager.count(query: "SELECT COUNT(e.id) FROM SJEpisode e LEFT JOIN SJPodcast p ON p.id = e.podcast_id WHERE p.subscribed = 1 AND e.playingStatus == 1 AND e.archived = 0", values: nil)
             setBadgeTo(unplayedCount)
         } else if badgeSetting == .newSinceLastOpened {
             guard let lastClosedDate = UserDefaults.standard.object(forKey: Constants.UserDefaults.lastAppCloseDate) as? Date else {
-                clearBadge(clearNotificationsToo: false)
+                clearBadge()
 
                 return
             }
@@ -80,27 +81,11 @@ class BadgeHelper {
         }
     }
 
-    func clearNotifications() {
-        clearBadge(clearNotificationsToo: true)
-        updateBadge()
-    }
-
-    private func clearBadge(clearNotificationsToo: Bool) {
-        DispatchQueue.main.async {
-            let currentBadgeValue = UIApplication.shared.applicationIconBadgeNumber
-            if clearNotificationsToo, currentBadgeValue == 0 {
-                // if the badge is already 0, set it to 1 to clear out things like notifications, setting a badge that's 0 to 0 won't do that
-                UIApplication.shared.applicationIconBadgeNumber = 1
-            }
-            if !clearNotificationsToo, currentBadgeValue == 0 { return }
-
-            UIApplication.shared.applicationIconBadgeNumber = 0
-        }
+    private func clearBadge() {
+        UNUserNotificationCenter.current().setBadgeCount(0)
     }
 
     private func setBadgeTo(_ badgeNumber: Int) {
-        DispatchQueue.main.async {
-            UIApplication.shared.applicationIconBadgeNumber = badgeNumber
-        }
+        UNUserNotificationCenter.current().setBadgeCount(badgeNumber)
     }
 }


### PR DESCRIPTION
`UIApplication.applicationIconBadgeNumber` is deprecated in iOS 17. Migrated all uses in `BadgeHelper` to `UNUserNotificationCenter.setBadgeCount(_:)`, which clears 4 deprecation warnings. Since `setBadgeCount` is thread-safe, the `DispatchQueue.main.async` wrappers (only needed for the main-thread-only `applicationIconBadgeNumber`) are gone.

Also removed the unused `clearNotifications()` method and its "bump the badge to 1 then back to 0" hack. That trick relied on legacy iOS coupling where zeroing the badge also cleared Notification Center entries — a behavior Apple decoupled years ago (the badge API only affects the icon badge now). The method was also dead code (nothing called it), so its branch was unreachable. `clearBadge()` now simply sets the count to 0. No behavior change.

## To test

1. In Settings → General, set the app icon badge to **Total Unplayed Episodes** (or a filter count).
2. Background the app and confirm the app icon badge shows the expected count.
3. Change the badge setting to **Off** and confirm the badge clears from the app icon.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
