### PR TITLE
PCIOS-868: iOS/Bluetooth: .routeConfigurationChange on an unchanged route tears down the player and never resumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Fix the Bookmarks multi-select layout: rows keep their text width instead of shrinking, the selection bar sits just above the mini player instead of floating too high, and on iOS 26 it hides the tab bar and mini player correctly [#4819](https://github.com/Automattic/pocket-casts-ios/pull/4819)
 - Fix the day label in episode cells growing out of proportion at large text sizes [#4818](https://github.com/Automattic/pocket-casts-ios/pull/4818)
+- Fix playback becoming silent and failing to resume when some Bluetooth devices reconfigure their audio connection [#4834](https://github.com/Automattic/pocket-casts-ios/pull/4834)
 
 
 8.17

--- a/PocketCastsTests/Tests/Playback/PlaybackRouteChangePolicyTests.swift
+++ b/PocketCastsTests/Tests/Playback/PlaybackRouteChangePolicyTests.swift
@@ -1,0 +1,47 @@
+import AVFoundation
+import XCTest
+
+@testable import podcasts
+
+final class PlaybackRouteChangePolicyTests: XCTestCase {
+    func testOldDeviceUnavailablePausesPlayback() {
+        XCTAssertEqual(
+            PlaybackManager.routeChangeDecision(for: .oldDeviceUnavailable),
+            .pause
+        )
+    }
+
+    func testConnectingOrReconfiguringADeviceRestartsPlaybackAndNowPlayingData() {
+        let reasons: [AVAudioSession.RouteChangeReason] = [
+            .newDeviceAvailable,
+            .override,
+            .categoryChange
+        ]
+
+        for reason in reasons {
+            XCTAssertEqual(
+                PlaybackManager.routeChangeDecision(for: reason),
+                .restart(updateNowPlaying: true)
+            )
+        }
+    }
+
+    func testRouteConfigurationChangeRestartsPlaybackWithoutRebuildingNowPlayingData() {
+        XCTAssertEqual(
+            PlaybackManager.routeChangeDecision(for: .routeConfigurationChange),
+            .restart(updateNowPlaying: false)
+        )
+    }
+
+    func testUnrelatedRouteChangesDoNotAffectPlayback() {
+        let reasons: [AVAudioSession.RouteChangeReason] = [
+            .unknown,
+            .wakeFromSleep,
+            .noSuitableRouteForCategory
+        ]
+
+        for reason in reasons {
+            XCTAssertNil(PlaybackManager.routeChangeDecision(for: reason))
+        }
+    }
+}

--- a/PocketCastsTests/Tests/Playback/PlaybackRouteChangePolicyTests.swift
+++ b/PocketCastsTests/Tests/Playback/PlaybackRouteChangePolicyTests.swift
@@ -21,7 +21,8 @@ final class PlaybackRouteChangePolicyTests: XCTestCase {
         for reason in reasons {
             XCTAssertEqual(
                 PlaybackManager.routeChangeDecision(for: reason),
-                .restart(updateNowPlaying: true)
+                .restart(updateNowPlaying: true),
+                "Unexpected decision for route reason \(reason.rawValue)"
             )
         }
     }
@@ -41,7 +42,10 @@ final class PlaybackRouteChangePolicyTests: XCTestCase {
         ]
 
         for reason in reasons {
-            XCTAssertNil(PlaybackManager.routeChangeDecision(for: reason))
+            XCTAssertNil(
+                PlaybackManager.routeChangeDecision(for: reason),
+                "Expected no decision for route reason \(reason.rawValue)"
+            )
         }
     }
 }

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -82,6 +82,12 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
             guard let strongSelf = self, let episode = strongSelf.episode else { return }
 
             strongSelf.playerLock.lock()
+            // A pause can tear down this player before its queued setup acquires the lock.
+            // Recheck playback intent so that stale work cannot start an orphaned engine.
+            guard strongSelf.shouldKeepPlaying.value else {
+                strongSelf.playerLock.unlock()
+                return
+            }
 
             strongSelf.engine = AVAudioEngine()
             strongSelf.player = AVAudioPlayerNode()

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -351,16 +351,20 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
     }
 
     func routeDidChange(shouldPause: Bool) {
-        shouldKeepPlaying.value = shouldKeepPlaying.value && !shouldPause
-
-        // when this is called, the engine has detected an interruption like a route change. Because this happens on things like bluetooth connect, and not just disconnect, we deal with it here.
-        // The audio engine has shut down at this point, so we call pause to destroy all our current state and play to restore it all if we should still be playing
-        if shouldKeepPlaying.value, !PlaybackManager.shared.interruptionInProgress() {
+        if shouldPause {
+            shouldKeepPlaying.value = false
             PlaybackManager.shared.pause(userInitiated: false)
-            PlaybackManager.shared.play(userInitiated: false)
-        } else if !shouldKeepPlaying.value {
-            PlaybackManager.shared.pause(userInitiated: false)
+            return
         }
+
+        // A restart-only route change can arrive while PlaybackManager is still asynchronously
+        // activating a replacement player. Do not turn that pending start into a permanent pause.
+        guard shouldKeepPlaying.value, !PlaybackManager.shared.interruptionInProgress() else { return }
+
+        // Route and engine configuration notifications are delivered independently, so checking
+        // engine.isRunning here can race the engine shutdown. Rebuild while playback is intended.
+        PlaybackManager.shared.pause(userInitiated: false)
+        PlaybackManager.shared.play(userInitiated: false)
     }
 
     // MARK: - Helper methods

--- a/podcasts/EffectsPlayer.swift
+++ b/podcasts/EffectsPlayer.swift
@@ -84,6 +84,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
             strongSelf.playerLock.lock()
             // A pause can tear down this player before its queued setup acquires the lock.
             // Recheck playback intent so that stale work cannot start an orphaned engine.
+            // The completion reports a successful start, so cancelled setup must not invoke it.
             guard strongSelf.shouldKeepPlaying.value else {
                 strongSelf.playerLock.unlock()
                 return
@@ -369,6 +370,7 @@ class EffectsPlayer: PlaybackProtocol, Hashable {
 
         // Route and engine configuration notifications are delivered independently, so checking
         // engine.isRunning here can race the engine shutdown. Rebuild while playback is intended.
+        FileLog.shared.addMessage("EffectsPlayer: route changed while playing, rebuilding audio engine")
         PlaybackManager.shared.pause(userInitiated: false)
         PlaybackManager.shared.play(userInitiated: false)
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2327,6 +2327,15 @@ class PlaybackManager: ServerPlaybackDelegate {
         } else if reason == AVAudioSession.RouteChangeReason.newDeviceAvailable.rawValue || reason == AVAudioSession.RouteChangeReason.override.rawValue || reason == AVAudioSession.RouteChangeReason.categoryChange.rawValue {
             player?.routeDidChange(shouldPause: false)
             updateAllNowPlayingData()
+        } else if reason == AVAudioSession.RouteChangeReason.routeConfigurationChange.rawValue {
+            if let previousRoute = userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription {
+                let currentOutputUIDs = Set(AVAudioSession.sharedInstance().currentRoute.outputs.map(\.uid))
+                let previousOutputUIDs = Set(previousRoute.outputs.map(\.uid))
+                if previousOutputUIDs == currentOutputUIDs {
+                    FileLog.shared.addMessage("PlaybackManager: routeConfigurationChange with unchanged outputs, letting player handle restart")
+                    player?.routeDidChange(shouldPause: false)
+                }
+            }
         }
     }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2318,11 +2318,18 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     @objc private func handleRouteChanged(_ notification: Notification) {
+        // Snapshot the route before the main-thread hop so rapid route churn does not change
+        // the outputs recorded for this notification.
+        let currentOutputDescriptions = AVAudioSession.sharedInstance().currentRoute.outputs.map(\.portName).joined(separator: ", ")
+        processRouteChange(notification, currentOutputDescriptions: currentOutputDescriptions)
+    }
+
+    private func processRouteChange(_ notification: Notification, currentOutputDescriptions: String) {
         // AVAudioSession posts route changes on a secondary thread. Keep player replacement and
         // route recovery serialized with user-initiated playback changes on the main thread.
         guard Thread.isMainThread else {
             DispatchQueue.main.async { [weak self] in
-                self?.handleRouteChanged(notification)
+                self?.processRouteChange(notification, currentOutputDescriptions: currentOutputDescriptions)
             }
             return
         }
@@ -2337,7 +2344,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             return
         }
 
-        logRouteChange(userInfo: userInfo)
+        logRouteChange(userInfo: userInfo, currentOutputDescriptions: currentOutputDescriptions)
 
         if let currEpisode = currentEpisode(), playingOverAirplay() && playerSwitchRequired() {
             let wasPlaying = player?.shouldBePlaying() ?? false
@@ -2358,9 +2365,6 @@ class PlaybackManager: ServerPlaybackDelegate {
             case .pause:
                 player?.routeDidChange(shouldPause: true)
             case .restart(let updateNowPlaying):
-                if reason == .routeConfigurationChange {
-                    FileLog.shared.addMessage("PlaybackManager: routeConfigurationChange, letting the active player rebuild")
-                }
                 player?.routeDidChange(shouldPause: false)
                 if updateNowPlaying {
                     updateAllNowPlayingData()
@@ -2369,15 +2373,13 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
     }
 
-    private func logRouteChange(userInfo: [AnyHashable: Any]) {
+    private func logRouteChange(userInfo: [AnyHashable: Any], currentOutputDescriptions: String) {
         guard let changeReason = userInfo[AVAudioSessionRouteChangeReasonKey] as? NSNumber,
-              let previousRoute = userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription,
-              let currentRoute = AVAudioSession.sharedInstance().currentRoute as AVAudioSessionRouteDescription? else {
+              let previousRoute = userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription else {
             return
         }
 
         let previousOutputDescriptions = previousRoute.outputs.map { $0.portName }.joined(separator: ", ")
-        let currentOutputDescriptions = currentRoute.outputs.map { $0.portName }.joined(separator: ", ")
         if let reason = AVAudioSession.RouteChangeReason(rawValue: UInt(changeReason.intValue)) {
             FileLog.shared.addMessage("PlaybackManager: Handle route change \(reason) | Previous Outputs: [\(previousOutputDescriptions)] | Current Outputs: [\(currentOutputDescriptions)]")
         }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2298,16 +2298,47 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     // MARK: - AVAudioSession Notifications
 
+    enum RouteChangeDecision: Equatable {
+        case pause
+        case restart(updateNowPlaying: Bool)
+    }
+
+    static func routeChangeDecision(for reason: AVAudioSession.RouteChangeReason) -> RouteChangeDecision? {
+        switch reason {
+        case .oldDeviceUnavailable:
+            .pause
+        case .newDeviceAvailable, .override, .categoryChange:
+            .restart(updateNowPlaying: true)
+        case .routeConfigurationChange:
+            // The set of ports is unchanged by definition; only their configuration changed.
+            .restart(updateNowPlaying: false)
+        default:
+            nil
+        }
+    }
+
     @objc private func handleRouteChanged(_ notification: Notification) {
+        // AVAudioSession posts route changes on a secondary thread. Keep player replacement and
+        // route recovery serialized with user-initiated playback changes on the main thread.
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.handleRouteChanged(notification)
+            }
+            return
+        }
+
         #if !os(watchOS) && !APPCLIP && !os(tvOS)
             if GoogleCastManager.sharedManager.connectedOrConnectingToDevice() { return } // while google casting we don't care about interruptions
         #endif
 
-        guard let userInfo = notification.userInfo, let changeReason = userInfo[AVAudioSessionRouteChangeReasonKey] as? NSNumber else { return }
+        guard let userInfo = notification.userInfo,
+              let changeReason = userInfo[AVAudioSessionRouteChangeReasonKey] as? NSNumber,
+              let reason = AVAudioSession.RouteChangeReason(rawValue: changeReason.uintValue) else {
+            return
+        }
 
         logRouteChange(userInfo: userInfo)
 
-        let reason = changeReason.uintValue
         if let currEpisode = currentEpisode(), playingOverAirplay() && playerSwitchRequired() {
             let wasPlaying = player?.shouldBePlaying() ?? false
             let autoPlay: Bool
@@ -2322,18 +2353,17 @@ class PlaybackManager: ServerPlaybackDelegate {
                 autoPlay = true
             }
             load(episode: currEpisode, autoPlay: autoPlay, overrideUpNext: false)
-        } else if reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue {
-            player?.routeDidChange(shouldPause: true)
-        } else if reason == AVAudioSession.RouteChangeReason.newDeviceAvailable.rawValue || reason == AVAudioSession.RouteChangeReason.override.rawValue || reason == AVAudioSession.RouteChangeReason.categoryChange.rawValue {
-            player?.routeDidChange(shouldPause: false)
-            updateAllNowPlayingData()
-        } else if reason == AVAudioSession.RouteChangeReason.routeConfigurationChange.rawValue {
-            if let previousRoute = userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription {
-                let currentOutputUIDs = Set(AVAudioSession.sharedInstance().currentRoute.outputs.map(\.uid))
-                let previousOutputUIDs = Set(previousRoute.outputs.map(\.uid))
-                if previousOutputUIDs == currentOutputUIDs {
-                    FileLog.shared.addMessage("PlaybackManager: routeConfigurationChange with unchanged outputs, letting player handle restart")
-                    player?.routeDidChange(shouldPause: false)
+        } else if let decision = Self.routeChangeDecision(for: reason) {
+            switch decision {
+            case .pause:
+                player?.routeDidChange(shouldPause: true)
+            case .restart(let updateNowPlaying):
+                if reason == .routeConfigurationChange {
+                    FileLog.shared.addMessage("PlaybackManager: routeConfigurationChange, letting the active player rebuild")
+                }
+                player?.routeDidChange(shouldPause: false)
+                if updateNowPlaying {
+                    updateAllNowPlayingData()
                 }
             }
         }


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-868/iosbluetooth-routeconfigurationchange-on-an-unchanged-route-tears-down

## Summary

When a Bluetooth head unit renegotiates its A2DP link, iOS can emit `.routeConfigurationChange` while the set of audio ports remains unchanged. The `EffectsPlayer` audio engine may stop during that reconfiguration and needs to be rebuilt.

Deep review also found a lifecycle race because the affected hardware emits reason-8 events in pairs. A duplicate event could arrive while `PlaybackManager` was asynchronously activating a replacement `EffectsPlayer`; the old route handler would then permanently pause and tear down that not-yet-started replacement.

## Changes

- Handle `.routeConfigurationChange` directly from its API contract, without requiring previous-route metadata, and restart an actively intended `EffectsPlayer` without rebuilding Now Playing data.
- Serialize audio-route recovery onto the main thread before mutating playback state.
- Replace raw reason comparisons with a typed, testable route-change policy.
- Make restart-only route events a no-op while playback is paused, interrupted, or a replacement player has not started yet.
- Cancel queued `EffectsPlayer` setup if teardown wins the player lock, preventing an orphaned audio engine.
- Remove the non-atomic read/modify/write of `shouldKeepPlaying`.
- Log the rebuild only when `EffectsPlayer` actually performs it, and snapshot route outputs before the main-thread hop for accurate diagnostics.
- Add unit coverage for the route-policy mappings: pause, restart, configuration change, and ignored reasons.

## Accepted trade-offs

- Recovery deliberately does not use `engine.isRunning` as a gate. Route and engine-configuration notifications have no documented ordering, so a stale `true` result could skip recovery and recreate the silent-playback failure.
- Route state changes remain serialized on the main thread. Audio-session activation is already dispatched to a background queue by default, while deactivation is delayed and cancelled by the immediate restart. This can be profiled separately if hardware testing shows a UI hitch.
- Cancelled engine setup does not invoke the `play` completion because that callback represents a successful start; firing it could run stale seek or pause work against a replacement player.

## Verification

- `make format`: PASS
- `make lint`: PASS
- `git diff --check`: PASS
- Focused test/build execution is blocked locally before source compilation because the required watchOS 26.5 simulator runtime is not installed.

## Manual verification

The original issue is hardware-specific. Playback should still be verified with the affected Bluetooth/A2DP head unit, including paired reason-8 notifications and active Trim Silence playback. The pass should also check for an unacceptable audio gap or UI hitch during route reconfiguration.

## Confidence

**MEDIUM-HIGH** for the state-management, route-policy, and diagnostic changes. Hardware verification remains necessary to confirm audible recovery behavior.
