### PR TITLE
Polish bookmark editor: suggested title, Dynamic Type, transcript loading label

### DIFF
--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -211,18 +211,19 @@ struct BookmarkEditView: View {
 
     /// A generated title suggestion the user can tap to use
     private func suggestionButton(_ suggestion: String) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: "sparkles")
-            Text(suggestion)
-                .lineLimit(2)
-        }
-        .font(style: .callout)
-        .foregroundStyle(theme.subTitle)
-        .buttonize {
-            viewModel.applySuggestion(suggestion)
-        }
-        .accessibilityLabel(L10n.bookmarkSuggestedTitle(suggestion))
-        .transition(.opacity.combined(with: .move(edge: .top)))
+        (Text(L10n.bookmarkSuggestionPrefix)
+            .foregroundColor(theme.subTitle)
+            + Text(suggestion)
+            .foregroundColor(theme.editButton))
+            .font(size: 13, style: .footnote, weight: .medium)
+            .kerning(-0.4)
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .buttonize {
+                viewModel.applySuggestion(suggestion)
+            }
+            .accessibilityLabel(L10n.bookmarkSuggestedTitle(suggestion))
+            .transition(.opacity.combined(with: .move(edge: .top)))
     }
 
     private var saveButton: some View {

--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -162,7 +162,7 @@ struct BookmarkEditView: View {
         if viewModel.passage != nil || viewModel.isCapturingTranscript {
             section {
                 HStack {
-                    Text(L10n.transcript)
+                    Text(viewModel.passage == nil ? L10n.bookmarkTranscriptAdding : L10n.transcript)
 
                     Spacer()
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -41,6 +41,7 @@ struct BookmarkEditView: View {
         .animation(.easeInOut(duration: 0.2), value: viewModel.passage)
         .animation(.easeInOut(duration: 0.2), value: viewModel.isCapturingTranscript)
         .frame(maxWidth: .infinity)
+        .dynamicTypeSize(...DynamicTypeSize.accessibility2)
         .padding()
         .background(theme.background.ignoresSafeArea())
         .navigationTitle(viewModel.headerTitle)

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4501,6 +4501,9 @@
 /* Prefix label shown before a generated, tappable bookmark title suggestion. Includes a trailing space so it reads inline with the suggested title that follows. */
 "bookmark_suggestion_prefix" = "Suggestion: ";
 
+/* Section title shown while the transcript passage for a bookmark is still being fetched */
+"bookmark_transcript_adding" = "Adding transcript...";
+
 /* Label above the section showing the transcript text captured around the bookmarked moment */
 "bookmark_transcript_captured" = "Transcript captured";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4498,6 +4498,9 @@
 /* Accessibility label for a tappable bookmark title suggestion generated from the episode transcript. '%1$@' is the suggested title. */
 "bookmark_suggested_title" = "Suggested title: %1$@";
 
+/* Prefix label shown before a generated, tappable bookmark title suggestion. Includes a trailing space so it reads inline with the suggested title that follows. */
+"bookmark_suggestion_prefix" = "Suggestion: ";
+
 /* Label above the section showing the transcript text captured around the bookmarked moment */
 "bookmark_transcript_captured" = "Transcript captured";
 


### PR DESCRIPTION
Polishes the bookmark editor: highlights the suggested title, caps Dynamic Type at AX2 so the non-scrolling sheet stays intact, and shows an "Adding transcript..." label while the passage loads.


<img width="568" height="1084" alt="Screenshot 2026-07-27 at 2 43 44 PM" src="https://github.com/user-attachments/assets/0ac0d90a-f95b-4c73-9b74-09165c924cfe" />

## To test

1. Add a bookmark on an episode with a transcript.
2. Note the title suggestion is highlighted and the section reads "Adding transcript..." until the passage loads, then "Transcript".
3. Set text size to the largest accessibility size — the layout stays intact and the Save button stays reachable.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
