### PR TITLE
Capture a bookmark passage only from a fingerprinted transcript

### DIFF
--- a/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
+++ b/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
@@ -17,10 +17,12 @@ struct BookmarkTranscriptSnippet {
 /// Extracts the transcript text surrounding a bookmark's position, used as the
 /// input for generating a bookmark title.
 ///
-/// Generated transcripts are timed against a reference copy of the episode audio
-/// that dynamic ads shift away from, so the bookmark's playback time is first
-/// resolved to the reference timeline (see `docs/transcripts.md`), falling back
-/// to the raw playback time when a confident mapping isn't available.
+/// Limited to fingerprinted transcripts. Generated transcripts are timed against a
+/// reference copy of the episode audio that dynamic ads shift away from, so the
+/// bookmark's playback time has to be resolved to the reference timeline (see
+/// `docs/transcripts.md`) before it points at the right words. Anything else — an
+/// externally supplied transcript, or a fingerprint that doesn't confidently match —
+/// yields no snippet rather than one taken from the raw playback time.
 struct BookmarkTranscriptSnippetExtractor {
 
     /// The window reaches further back than forward: by the time a user bookmarks
@@ -37,14 +39,16 @@ struct BookmarkTranscriptSnippetExtractor {
             return nil
         }
 
-        // Only generated transcripts have a reference fingerprint to re-anchor against.
-        var center = time
-        if transcriptManager.isDisplayingGeneratedTranscript, FeatureFlag.syncedTranscripts.enabled,
-           let referenceTime = await FingerprintTimingManager.shared.resolveReferenceTime(forPlaybackTime: time, episode: episode) {
-            center = referenceTime
+        // Only generated transcripts have a reference fingerprint to re-anchor against, and
+        // without a confident match there's no telling how far dynamic ads have pushed the
+        // playback time from the timeline the transcript is cued against. Either way, capture
+        // nothing rather than a passage from somewhere else in the episode.
+        guard transcriptManager.isDisplayingGeneratedTranscript, FeatureFlag.syncedTranscripts.enabled,
+              let referenceTime = await FingerprintTimingManager.shared.resolveReferenceTime(forPlaybackTime: time, episode: episode) else {
+            return nil
         }
 
-        return Self.extractSnippet(from: model, at: center)
+        return Self.extractSnippet(from: model, at: referenceTime)
     }
 
     func snippet(forPassage passage: String, at location: Int?, episode: BaseEpisode) async -> BookmarkTranscriptSnippet? {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-864

Limits the bookmark transcript passage and suggested title to episodes with a fingerprinted transcript.

Only generated transcripts are fingerprinted, so only they can re-anchor the bookmark's playback time once dynamic ads have shifted it. `BookmarkTranscriptSnippetExtractor` fell back to the raw playback time otherwise, which could capture a passage minutes from the bookmarked moment. That `if` is now a `guard`.

## To test

Requires the `smartBookmarks` feature flag and a Plus account.

1. Subscribe to **Podnews Daily**, play an episode, and add a bookmark. Expect the default title with no spinner and **no Transcript section** on the edit sheet. Repeat with any podcast from the table below.
2. Subscribe to **Syntax** (`fe30f8e0-3da9-0135-9028-63f4b61a9224`), play an episode, add a bookmark. Expect the passage to appear and the title to be suggested, as before. Same for **Search Engine** (`cb2108e0-8619-013a-d7f7-0acc26574db2`) and **ATP** (`e7abe050-6cc7-0130-f8c5-723c91aeae46`).
3. On a Syntax episode, add a bookmark within the first few seconds of streaming, before the audio buffers. The fingerprint can't resolve yet, so expect no passage — this is the intended trade, and the main behaviour change to watch for.
4. Subscribe to **Darknet Diaries** (`170a7610-948e-0135-9d21-5bb073f92b78`) and bookmark *NSL* (`522d6ca2-8a0b-4574-8d38-c55004b40511`) or *Tarjeteros* (`fd8c0aff-650a-4688-a4e3-2b5a59ea1da3`). These have **both** an external and a fingerprinted generated transcript; the external one wins, so expect no passage. This is the case `hasGeneratedTranscript` would have wrongly allowed.
5. Open an existing bookmark created before this change. Expect its stored passage to still display and the transcript editor to still open.

### External transcript only, nothing generated

| Podcast | Podcast UUID | Episodes |
|---|---|---|
| Podnews Daily | `afc41610-c22f-0135-9e60-5bb073f92b78` | 150 / 151 (VTT) |
| Podcasting 2.0 | `fddf2140-d311-0138-e773-0acc26574db2` | 198 / 199 (SRT) |
| Buzzcast | `a96a50f0-e1e8-0136-3249-08b04944ede4` | 240 / 253 |

Podnews Daily is the cleanest — short daily episodes, not one generated transcript in the feed.

<details>
<summary>How the tables were derived</summary>

`transcripts` is the RSS/external list, `pocket_casts_transcripts` the generated one:

```
curl -sL --compressed https://cache.pocketcasts.com/mobile/show_notes/full/<podcastUuid>
```

Fingerprint availability confirmed per episode with a **GET** (not HEAD — S3 returns 403 for HEAD regardless):

```
https://shownotes.pocketcasts.com/generated_transcripts/<podcastUuid>/<episodeUuid>-fingerprints.json.gz
```

200 for the generated-only and "both" episodes, 403 (absent) for the external-only ones.

</details>

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
