### PR TITLE
Generate a title and passage for bookmarks created offscreen

### DIFF
--- a/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
+++ b/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
@@ -30,6 +30,30 @@ extension BookmarkManager {
         return await BookmarkTranscriptSnippetExtractor().snippet(forPassage: passage, at: bookmark.passageLocation, episode: episode)
     }
 
+    /// Generates a title and passage for a bookmark and saves them.
+    ///
+    /// Bookmarks made with a headphone button, in CarPlay, or while the app is in the background
+    /// never open the edit sheet, so this is the only thing that titles them.
+    func enrich(_ bookmark: Bookmark) async {
+        guard Self.isTitleSuggestionEnabled, let episode = episode(for: bookmark),
+              let snippet = await transcriptSnippet(for: bookmark, episode: episode) else { return }
+
+        let suggestion = await suggestTitle(from: snippet.text, for: bookmark, episode: episode)
+        let title = suggestion.map { String($0.trim().prefix(Constants.Values.bookmarkMaxTitleLength)) }
+
+        guard let title, !title.isEmpty else {
+            // Nothing to rename to, but the passage is still worth keeping for the edit sheet
+            bookmark.passage = snippet.text
+            bookmark.passageLocation = snippet.range.location
+            return
+        }
+
+        FileLog.shared.addMessage("[Bookmarks] Generated a title for bookmark \(bookmark.uuid)")
+
+        let passage = BookmarkUpdateParameters.Passage(text: snippet.text, location: snippet.range.location)
+        await update(.init(title: title, passage: passage), for: bookmark)
+    }
+
     /// Returns nil when generation fails.
     func suggestTitle(from snippet: String, for bookmark: Bookmark, episode: BaseEpisode) async -> String? {
         let podcastTitle = bookmark.podcastUuid.flatMap { DataManager.sharedManager.findPodcast(uuid: $0)?.title }

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -156,6 +156,7 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         observersForEndOfYearStats()
         addBookmarkCreatedToastHandler()
+        addBookmarkEnrichmentHandler()
         if FeatureFlag.displayErrorsOnPlayer.enabled {
             setupErrorBanner()
             setupErrorObservers()
@@ -954,6 +955,31 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 // MARK: - Bookmarks
 
 private extension MainTabBarController {
+    /// The edit sheet, where a bookmark is normally titled, only opens over the full screen player
+    /// with the app in the foreground — see `BookmarksPlayerTabController`
+    static var showsBookmarkEditSheet: Bool {
+        UIApplication.shared.applicationState == .active
+        && !CarPlayHelper.isConnectedToCarPlay
+        && NavigationManager.sharedManager.miniPlayer?.playerOpenState != .closed
+    }
+
+    /// Generates the title and passage for the bookmarks that are never shown the edit sheet:
+    /// the ones made with a headphone button, in CarPlay, or while the app is in the background
+    func addBookmarkEnrichmentHandler() {
+        let bookmarkManager = PlaybackManager.shared.bookmarkManager
+
+        bookmarkManager.onBookmarkCreated
+            .receive(on: RunLoop.main)
+            .filter { !$0.isDuplicate && !Self.showsBookmarkEditSheet }
+            .compactMap { bookmarkManager.bookmark(for: $0.uuid) }
+            .sink { bookmark in
+                Task {
+                    await bookmarkManager.enrich(bookmark)
+                }
+            }
+            .store(in: &cancellables)
+    }
+
     // Shows a toast notification when a bookmark is created and we're not in the full screen player
     func addBookmarkCreatedToastHandler() {
         let bookmarkManager = PlaybackManager.shared.bookmarkManager
@@ -981,6 +1007,10 @@ private extension MainTabBarController {
         let message = title == L10n.bookmarkDefaultTitle ? L10n.bookmarkAdded : L10n.bookmarkAddedNotification(title)
 
         let action = Toast.Action(title: L10n.changeBookmarkTitle) { [weak self] in
+            // Re-read: a generated title may have been saved since the toast was shown
+            let bookmark = bookmarkManager.bookmark(for: bookmark.uuid) ?? bookmark
+            let title = bookmark.title
+
             let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating, style: .themed, onDismiss: { [weak self] updatedTitle, _ in
                 guard title != updatedTitle else { return }
 


### PR DESCRIPTION
Fixes PCIOS-854.

Bookmarks made with a headphone button, in CarPlay, or while the app is in the background never open the edit sheet, so nothing generated a title or passage for them. They're now enriched and saved directly.

## To test

1. Enable the Smart Bookmarks feature flag and assign a headphone button to Add Bookmark (Settings → General → Headphone Controls).
2. Play an episode that has a transcript, then background the app.
3. Press the assigned headphone button.
4. Open the episode's bookmarks and confirm the new bookmark has a generated title and passage instead of "Bookmark".
5. Repeat with the app in the foreground but the full screen player closed — confirm the same, and that the toast's "Change Title" action opens the sheet showing the generated title.
6. With the full screen player open, add a bookmark and confirm the edit sheet still generates the title itself, with no duplicate generation.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
