### PR TITLE
Move video row up on Apple TV Home

### DIFF
--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -68,8 +68,8 @@ struct HomeView: View {
                     if coordinator.userState.isLoggedIn {
                         nowPlayingRow
                         upNextRow
-                        youMightLikeRow
                         videoRow
+                        youMightLikeRow
                         newReleasesRow
                         lovedByListenersOfRow
                         trendingRow


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

This reorders the rows on the Apple TV Home screen so the **video row** appears above the **You Might Like** row, giving video content higher prominence in the layout.

<img width="3840" height="2160" alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-07-28 at 08 45 26" src="https://github.com/user-attachments/assets/b171df6e-f3f1-4a1b-a7fd-ca3864cb319d" />


## To test

1. Sign in on the Apple TV app.
2. Open the Home screen.
3. Confirm the video row now appears above the "You Might Like" row (previously it was below).
4. Confirm all other rows (Now Playing, Up Next, New Releases, Loved by Listeners, Trending) remain in their expected order.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
