### PR TITLE
Optimize fingerprinting hot path (~1.6x speedup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix the podcast screen tabs being clipped when scrolled [#4918](https://github.com/Automattic/pocket-casts-ios/pull/4918)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - Improve playback reliability when starting audio [#4938](https://github.com/Automattic/pocket-casts-ios/pull/4938)
+- Optimize fingerprinting and features that depend on it, including synced transcripts and more [#4846](https://github.com/Automattic/pocket-casts-ios/pull/4846), [#4847](https://github.com/Automattic/pocket-casts-ios/pull/4847)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
 - [tvOS] Add a Top Results tab to Search, now the default, showing a Featured row of matching video episodes followed by Episodes and Podcasts rows. The Episodes tab leads with the same Featured row whenever a search turns up video episodes [#4926](https://github.com/Automattic/pocket-casts-ios/pull/4926)
 

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2981f43f0683d1d38ce5837633fdba7ac14ed536a966f62359f8c3db9f9e91fb",
+  "originHash" : "7772afb3d35af053a0a051f3c283ca6769d72cd737802755c9d567b6d50ad9d9",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -223,7 +223,7 @@
       "location" : "https://github.com/Automattic/pocket-casts-ios-fingerprint",
       "state" : {
         "branch" : "trunk",
-        "revision" : "b696bd9a4a495604532b1b7a484ab140c144eccc"
+        "revision" : "4ca89cc127a444b918784839331b6044c1624ba2"
       }
     },
     {


### PR DESCRIPTION
Integrates the changes from PR #15 in the fingerprinting repo for testing purposes.

## To test

Smoke test fingerprinting (for transcripts, chapters, bookmarks)

```
// Before
FingerprintTimingManager: bookmark resolve breakdown for 1002fc70-2338-46b2-956d-a712a814474c
total 750ms: fingerprint 528ms (70%), audio decode 167ms (22%), match 34ms (5%), 
interleave 6ms (1%), matcher build 4ms (1%), other 10ms (1%)

// After
FingerprintTimingManager: bookmark resolve breakdown for 1002fc70-2338-46b2-956d-a712a814474c
total 575ms: fingerprint 347ms (60%), audio decode 167ms (29%), match 32ms (6%), 
matcher build 6ms (1%), interleave 6ms (1%), other 15ms (3%)
```

I'm using the following git patch for quick benchmarks (`git apply`):

[fingerprint-performresolve-benchmark-logs.patch](https://github.com/user-attachments/files/30504923/fingerprint-performresolve-benchmark-logs.patch)


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
