### PR TITLE
Make the bookmark editor scrollable

### DIFF
--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -27,25 +27,34 @@ struct BookmarkEditView: View {
 
     // MARK: - Views
 
+    /// The fields scroll so they stay reachable at large text sizes, while the save
+    /// button stays pinned to the bottom, above the keyboard
     private var form: some View {
-        VStack(spacing: 0) {
+        ScrollView {
             VStack(spacing: 32) {
                 titleSection
                 transcriptSection
             }
-
-            Spacer(minLength: 32)
-
-            saveButton
+            .frame(maxWidth: .infinity)
+            .padding()
         }
+        .scrollBounceBehavior(.basedOnSize)
         .animation(.easeInOut(duration: 0.2), value: viewModel.passage)
         .animation(.easeInOut(duration: 0.2), value: viewModel.isCapturingTranscript)
-        .frame(maxWidth: .infinity)
+        .safeAreaInset(edge: .bottom) {
+            saveButton
+                .padding()
+                .background(theme.background)
+        }
         .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-        .padding()
         .background(theme.background.ignoresSafeArea())
         .navigationTitle(viewModel.headerTitle)
         .navigationBarTitleDisplayMode(.inline)
+
+        // Keep the themed background under the bar, so scrolled content doesn't
+        // surface the system material behind the title
+        .toolbarBackground(theme.background, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 closeButton


### PR DESCRIPTION
This PR addressed the first comment from https://github.com/Automattic/pocket-casts-ios/pull/4835#pullrequestreview-4799130084.

The bookmark editor was a fixed `VStack`, so at large text sizes the fields could be clipped. The sections now live in a `ScrollView` with the Save button pinned to the bottom via `safeAreaInset`, so it stays reachable above the keyboard. The toolbar keeps the themed background so scrolled content doesn't surface the system material behind the title.

## To test

1. Temporarily remove `.lineLimit(4)` from `transcript(_:)` in `BookmarkEditView.swift:200` so the passage runs past the bottom of the sheet.
2. Add a bookmark on an episode with a transcript.
3. Scroll the form — the passage scrolls, and the Save button stays pinned to the bottom above the keyboard.
4. Restore `.lineLimit(4)`, then raise the text size to the largest accessibility size and repeat: the form scrolls when the content doesn't fit, and stays static (no bounce) when it does.
5. Check both entry points, since they use different themes: the player tab (`.player` style) and the bookmarks list in Profile (`.themed` style).

https://github.com/user-attachments/assets/a288ec21-d9b8-47c6-930c-2faa353d3b22




## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
