### PR TITLE
Add animated waveform to TV now playing screen

### DIFF
--- a/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
+++ b/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
@@ -32,6 +32,13 @@ struct MediaOverlayView: View {
                                 .blurredCoverBackground(size: proxy.size.height / scale) {
                                     Image(uiImage: uiImage)
                                 }
+                                .background {
+                                    NowPlayingWaveformView(
+                                        color: .white,
+                                        isAnimating: model.isPlaying
+                                    )
+                                    .frame(width: proxy.size.width * 0.75)
+                                }
                                 .animation(.smooth, value: isTransportBarVisible)
                             Spacer()
                         }

--- a/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
+++ b/Pocket Casts TV App/UI/Player/MediaOverlayView.swift
@@ -35,7 +35,8 @@ struct MediaOverlayView: View {
                                 .background {
                                     NowPlayingWaveformView(
                                         color: .white,
-                                        isAnimating: model.isPlaying
+                                        isAnimating: model.isPlaying,
+                                        artworkSize: proxy.size.height / scale
                                     )
                                     .frame(width: proxy.size.width * 0.75)
                                 }

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -29,6 +29,7 @@ class NowPlayingViewModel: Identifiable {
     var isLoading: Bool = true
     var isFirstLoad: Bool = false
     var isFailed: Bool = false
+    var isPlaying: Bool = false
 
     @ObservationIgnored private var timeControlStatusObservation: NSKeyValueObservation?
     @ObservationIgnored private var itemStatusObservation: NSKeyValueObservation?
@@ -115,6 +116,7 @@ class NowPlayingViewModel: Identifiable {
         let itemNotReady = status == .unknown
         isLoading = waiting || itemNotReady
         isFailed = status == .failed
+        isPlaying = player.timeControlStatus == .playing
         if !isLoading {
             isFirstLoad = false
         }

--- a/Pocket Casts TV App/UI/Player/NowPlayingWaveformView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingWaveformView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct NowPlayingWaveformView: View {
+    let color: Color
+    let isAnimating: Bool
+
+    @State private var amplitude: CGFloat = 0
+
+    private let barWidth: CGFloat = 5
+    private let barSpacing: CGFloat = 7
+    private let maxBarHeight: CGFloat = 80
+
+    var body: some View {
+        // Always keep the timeline running so bars animate smoothly to zero
+        TimelineView(.animation) { timeline in
+            Canvas { context, size in
+                let centerX = size.width / 2
+                let centerY = size.height / 2
+                let artworkSize = min(size.width, size.height) * 0.85
+                let artworkHalf = artworkSize / 2
+
+                let sideWidth = (size.width - artworkSize) / 2
+                let barsPerSide = Int(sideWidth / (barWidth + barSpacing))
+
+                let time = timeline.date.timeIntervalSinceReferenceDate
+
+                for side in 0..<2 {
+                    for i in 0..<barsPerSide {
+                        let normalizedIndex = CGFloat(i) / CGFloat(max(1, barsPerSide - 1))
+                        let distanceFactor = side == 0 ? normalizedIndex : (1.0 - normalizedIndex)
+                        let wave = sin(time * 2.5 + Double(i) * 0.4) * 0.5 + 0.5
+                        let height = maxBarHeight * distanceFactor * CGFloat(wave) * amplitude
+
+                        let x: CGFloat
+                        if side == 0 {
+                            x = centerX - artworkHalf - CGFloat(barsPerSide - i) * (barWidth + barSpacing)
+                        } else {
+                            x = centerX + artworkHalf + CGFloat(i) * (barWidth + barSpacing) + barSpacing
+                        }
+
+                        var path = Path()
+                        path.addRoundedRect(
+                            in: CGRect(x: x, y: centerY - height / 2, width: barWidth, height: max(2, height)),
+                            cornerSize: CGSize(width: 2, height: 2)
+                        )
+                        context.fill(path, with: .color(color.opacity(0.8 * Double(distanceFactor) * Double(amplitude))))
+                    }
+                }
+            }
+            .allowsHitTesting(false)
+        }
+        .onChange(of: isAnimating) { _, newValue in
+            withAnimation(.easeInOut(duration: 2.0)) {
+                amplitude = newValue ? 1 : 0
+            }
+        }
+        .onAppear {
+            if isAnimating {
+                withAnimation(.easeInOut(duration: 2.0)) {
+                    amplitude = 1
+                }
+            }
+        }
+    }
+}

--- a/Pocket Casts TV App/UI/Player/NowPlayingWaveformView.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingWaveformView.swift
@@ -3,20 +3,36 @@ import SwiftUI
 struct NowPlayingWaveformView: View {
     let color: Color
     let isAnimating: Bool
+    let artworkSize: CGFloat
 
-    @State private var amplitude: CGFloat = 0
+    /// Tracks the time-based envelope fade so Canvas can lerp each frame.
+    @State private var fromAmplitude: CGFloat = 0
+    @State private var toAmplitude: CGFloat = 0
+    @State private var fadeStartTime: Date = .distantPast
+    @State private var isActive = false
 
     private let barWidth: CGFloat = 5
     private let barSpacing: CGFloat = 7
     private let maxBarHeight: CGFloat = 80
+    private let fadeDuration: TimeInterval = 2.0
+
+    /// Compute the current amplitude by lerping between fromAmplitude and
+    /// toAmplitude using an ease-in-out curve driven by wall-clock time.
+    private func amplitude(at date: Date) -> CGFloat {
+        let elapsed = date.timeIntervalSince(fadeStartTime)
+        let t = min(max(elapsed / fadeDuration, 0), 1)
+        let eased = t < 0.5 ? 2 * t * t : 1 - pow(-2 * t + 2, 2) / 2
+        return fromAmplitude + (toAmplitude - fromAmplitude) * eased
+    }
 
     var body: some View {
-        // Always keep the timeline running so bars animate smoothly to zero
-        TimelineView(.animation) { timeline in
+        TimelineView(.animation(minimumInterval: nil, paused: !isActive)) { timeline in
             Canvas { context, size in
+                let amp = amplitude(at: timeline.date)
+                guard amp > 0.001 else { return }
+
                 let centerX = size.width / 2
                 let centerY = size.height / 2
-                let artworkSize = min(size.width, size.height) * 0.85
                 let artworkHalf = artworkSize / 2
 
                 let sideWidth = (size.width - artworkSize) / 2
@@ -29,7 +45,7 @@ struct NowPlayingWaveformView: View {
                         let normalizedIndex = CGFloat(i) / CGFloat(max(1, barsPerSide - 1))
                         let distanceFactor = side == 0 ? normalizedIndex : (1.0 - normalizedIndex)
                         let wave = sin(time * 2.5 + Double(i) * 0.4) * 0.5 + 0.5
-                        let height = maxBarHeight * distanceFactor * CGFloat(wave) * amplitude
+                        let height = maxBarHeight * distanceFactor * CGFloat(wave) * amp
 
                         let x: CGFloat
                         if side == 0 {
@@ -43,21 +59,33 @@ struct NowPlayingWaveformView: View {
                             in: CGRect(x: x, y: centerY - height / 2, width: barWidth, height: max(2, height)),
                             cornerSize: CGSize(width: 2, height: 2)
                         )
-                        context.fill(path, with: .color(color.opacity(0.8 * Double(distanceFactor) * Double(amplitude))))
+                        context.fill(path, with: .color(color.opacity(0.8 * Double(distanceFactor) * Double(amp))))
                     }
                 }
             }
             .allowsHitTesting(false)
         }
         .onChange(of: isAnimating) { _, newValue in
-            withAnimation(.easeInOut(duration: 2.0)) {
-                amplitude = newValue ? 1 : 0
-            }
+            beginFade(to: newValue ? 1 : 0)
         }
         .onAppear {
             if isAnimating {
-                withAnimation(.easeInOut(duration: 2.0)) {
-                    amplitude = 1
+                beginFade(to: 1)
+            }
+        }
+    }
+
+    private func beginFade(to target: CGFloat) {
+        fromAmplitude = amplitude(at: Date())
+        toAmplitude = target
+        fadeStartTime = Date()
+        isActive = true
+        if target == 0 {
+            // Stop the timeline after the fade-out completes
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(fadeDuration + 0.1))
+                if toAmplitude == 0 {
+                    isActive = false
                 }
             }
         }


### PR DESCRIPTION
## Summary

Adds an animated waveform visualization to the tvOS now playing screen. Subtle vertical bars appear on either side of the podcast artwork, pulsing gently while audio is playing and smoothly fading in/out when playback starts/stops.

**Implementation details:**
- `NowPlayingWaveformView` — SwiftUI `Canvas` + `TimelineView` draws animated bars with sine-wave motion
- `isPlaying` state derived from `AVPlayer.timeControlStatus` via existing KVO observation, so it responds to transport bar play/pause
- Amplitude-based smooth transitions (2s ease in/out) for natural fade in/out
- Added as a `.background` modifier on the artwork image to avoid disrupting the existing blurred cover layout

## Demo

https://github.com/user-attachments/assets/c824d779-3586-47aa-bd34-5535ebd98164

<img width="1821" height="1024" alt="TV2" src="https://github.com/user-attachments/assets/07f725f3-0b33-447d-afcb-529b64048e83" />

<img width="1821" height="1024" alt="TV0" src="https://github.com/user-attachments/assets/74dca418-93b7-4786-b5fc-418560b16163" />

<img width="1821" height="1024" alt="Tv1" src="https://github.com/user-attachments/assets/b7eade0c-ee96-44ef-863a-46b9748a896b" />


## To test

1. Open the app on Apple TV (or tvOS simulator)
2. Play a podcast episode
3. Observe animated waveform bars on either side of the artwork
4. Pause playback using the transport bar — bars should smoothly fade out over ~2 seconds
5. Resume playback — bars should smoothly fade back in
6. Verify the blurred cover background behind the artwork is positioned correctly (not shifted)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.