### PR TITLE
Use a multi-line text view for the bookmark title

### DIFF
--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -14,7 +14,7 @@ struct BookmarkEditView: View {
 
     @State private var isEditingTranscript = false
 
-    @State private var titleTextView: UITextView?
+    @State private var titleTextView: BookmarkTitleTextView.TextView?
 
     var body: some View {
         NavigationStack {
@@ -152,11 +152,14 @@ struct BookmarkEditView: View {
         }
     }
 
-    /// Selects the whole title after a short delay, so the selection reliably appears
-    /// once the field has settled — whether focus just arrived or a suggestion was applied
-    private func selectAll(in textView: UITextView) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-            textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.endOfDocument)
+    /// Selects the whole title once the field has laid the text out, so the selection is
+    /// drawn — whether focus just arrived or a suggestion replaced the title
+    private func selectAll(in textView: BookmarkTitleTextView.TextView) {
+        textView.onNextLayout { [weak textView] in
+            guard let textView else { return }
+
+            textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument,
+                                                            to: textView.endOfDocument)
         }
     }
 
@@ -264,16 +267,23 @@ private struct BookmarkTitleTextView: UIViewRepresentable {
     let accentColor: UIColor
 
     /// Handed the text view as editing begins, so the title can be selected in it
-    let onBeginEditing: (UITextView) -> Void
+    let onBeginEditing: (TextView) -> Void
     let onSubmit: () -> Void
 
     @ScaledMetricWithMaxSize(relativeTo: .title2, maxSize: BookmarkTitleStyle.maxTypeSize)
     private var fontSize: CGFloat = BookmarkTitleStyle.fontSize
 
-    func makeUIView(context: Context) -> UITextView {
-        let textView = UITextView()
+    private var font: UIFont {
+        .systemFont(ofSize: fontSize, weight: BookmarkTitleStyle.fontWeight)
+    }
+
+    func makeUIView(context: Context) -> TextView {
+        let textView = TextView()
         textView.delegate = context.coordinator
         textView.text = text
+        // Set here as well as on update, so the first height the field is measured for
+        // is the one the title is actually drawn at
+        textView.font = font
         textView.backgroundColor = .clear
         // Lines the text up with the label above it and the underline below it
         textView.textContainerInset = .zero
@@ -285,14 +295,14 @@ private struct BookmarkTitleTextView: UIViewRepresentable {
         return textView
     }
 
-    func updateUIView(_ textView: UITextView, context: Context) {
+    func updateUIView(_ textView: TextView, context: Context) {
         context.coordinator.view = self
 
         if textView.text != text {
             textView.text = text
         }
 
-        textView.font = .systemFont(ofSize: fontSize, weight: BookmarkTitleStyle.fontWeight)
+        textView.font = font
         textView.textColor = textColor
         textView.tintColor = accentColor
 
@@ -311,7 +321,7 @@ private struct BookmarkTitleTextView: UIViewRepresentable {
     }
 
     /// Asks the text view how tall it needs to be for the width it's offered
-    func sizeThatFits(_ proposal: ProposedViewSize, uiView textView: UITextView, context: Context) -> CGSize? {
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView textView: TextView, context: Context) -> CGSize? {
         guard let width = proposal.width, width.isFinite else { return nil }
 
         let size = textView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
@@ -320,6 +330,29 @@ private struct BookmarkTitleTextView: UIViewRepresentable {
 
     func makeCoordinator() -> Coordinator {
         Coordinator(view: self)
+    }
+
+    /// A text view that can be asked to run work once its text has been laid out
+    class TextView: UITextView {
+        private var afterLayout: (() -> Void)?
+
+        /// Runs `work` after the next layout pass, so a selection made against the text
+        /// is drawn rather than dropped by the layout that follows it. Only the latest
+        /// piece of work is kept, so repeated calls can't stack up.
+        func onNextLayout(_ work: @escaping () -> Void) {
+            afterLayout = work
+            setNeedsLayout()
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+
+            guard window != nil, bounds.width > 0, let afterLayout else { return }
+
+            self.afterLayout = nil
+            // Out of the layout pass the work would otherwise be changing the text view in
+            DispatchQueue.main.async(execute: afterLayout)
+        }
     }
 
     class Coordinator: NSObject, UITextViewDelegate {
@@ -335,6 +368,9 @@ private struct BookmarkTitleTextView: UIViewRepresentable {
 
         func textViewDidBeginEditing(_ textView: UITextView) {
             view.isFocused = true
+
+            guard let textView = textView as? TextView else { return }
+
             view.onBeginEditing(textView)
         }
 
@@ -342,12 +378,20 @@ private struct BookmarkTitleTextView: UIViewRepresentable {
             view.isFocused = false
         }
 
-        /// Return saves the bookmark, as it did when this was a single line field, rather
-        /// than putting a line break in the title
+        /// Return saves the bookmark, as it did when this was a single line field. Line
+        /// breaks arriving any other way — pasted or dictated — are folded into spaces,
+        /// since the title is drawn on one line everywhere it's listed.
         func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-            guard text == "\n" else { return true }
+            if text == "\n" {
+                view.onSubmit()
+                return false
+            }
 
-            view.onSubmit()
+            guard text.rangeOfCharacter(from: .newlines) != nil,
+                  let replacedRange = textView.textRange(for: range) else { return true }
+
+            textView.replace(replacedRange, withText: text.singleLine)
+            view.text = textView.text
             return false
         }
     }
@@ -371,6 +415,25 @@ private enum BookmarkTitleStyle {
 private extension View {
     func titleFont() -> some View {
         font(size: BookmarkTitleStyle.fontSize, style: .title2, weight: .bold)
+    }
+}
+
+private extension UITextView {
+    /// The range of text a delegate's `NSRange` points at
+    func textRange(for range: NSRange) -> UITextRange? {
+        guard let start = position(from: beginningOfDocument, offset: range.location),
+              let end = position(from: start, offset: range.length) else { return nil }
+
+        return textRange(from: start, to: end)
+    }
+}
+
+private extension String {
+    /// The text on a single line, with each run of line breaks standing in as one space
+    var singleLine: String {
+        components(separatedBy: .newlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
     }
 }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -27,25 +27,34 @@ struct BookmarkEditView: View {
 
     // MARK: - Views
 
+    /// The fields scroll so they stay reachable at large text sizes, while the save
+    /// button stays pinned to the bottom, above the keyboard
     private var form: some View {
-        VStack(spacing: 0) {
+        ScrollView {
             VStack(spacing: 32) {
                 titleSection
                 transcriptSection
             }
-
-            Spacer(minLength: 32)
-
-            saveButton
+            .frame(maxWidth: .infinity)
+            .padding()
         }
+        .scrollBounceBehavior(.basedOnSize)
         .animation(.easeInOut(duration: 0.2), value: viewModel.passage)
         .animation(.easeInOut(duration: 0.2), value: viewModel.isCapturingTranscript)
-        .frame(maxWidth: .infinity)
+        .safeAreaInset(edge: .bottom) {
+            saveButton
+                .padding()
+                .background(theme.background)
+        }
         .dynamicTypeSize(...DynamicTypeSize.accessibility2)
-        .padding()
         .background(theme.background.ignoresSafeArea())
         .navigationTitle(viewModel.headerTitle)
         .navigationBarTitleDisplayMode(.inline)
+
+        // Keep the themed background under the bar, so scrolled content doesn't
+        // surface the system material behind the title
+        .toolbarBackground(theme.background, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 closeButton

--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -6,7 +6,7 @@ struct BookmarkEditView: View {
     @ObservedObject var viewModel: BookmarkEditViewModel
     @ObservedObject var theme: BookmarkEditTheme
 
-    @FocusState private var isTitleFocused: Bool
+    @State private var isTitleFocused = false
 
     /// The title is only focused the first time the form appears, so coming back from
     /// the transcript editor doesn't pop the keyboard and select the title again
@@ -14,7 +14,7 @@ struct BookmarkEditView: View {
 
     @State private var isEditingTranscript = false
 
-    @State private var titleTextField: UITextField?
+    @State private var titleTextView: UITextView?
 
     var body: some View {
         NavigationStack {
@@ -111,15 +111,28 @@ struct BookmarkEditView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    /// An empty line of the same font pins the field to a single line height, so it
-    /// doesn't jump around as the text scales down to fit
     private var titleField: some View {
-        ZStack {
-            Text(" ")
-                .titleFont()
-                .frame(maxWidth: .infinity)
-                .hidden()
-            textField
+        BookmarkTitleTextView(
+            text: $viewModel.title,
+            isFocused: $isTitleFocused,
+            textColor: UIColor(theme.textField),
+            accentColor: UIColor(theme.textFieldAccent),
+            onBeginEditing: { textView in
+                titleTextView = textView
+                selectAll(in: textView)
+            },
+            onSubmit: {
+                viewModel.save()
+            }
+        )
+        .overlay(alignment: .topLeading) {
+            if viewModel.title.isEmpty {
+                Text(viewModel.placeholder)
+                    .titleFont()
+                    .foregroundStyle(theme.textFieldPlaceholder)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+            }
         }
         .overlay(alignment: .bottom) {
             Divider()
@@ -132,37 +145,18 @@ struct BookmarkEditView: View {
                     .tint(theme.subTitle)
             }
         }
-    }
+        .onReceive(viewModel.didApplySuggestion) { _ in
+            guard let titleTextView else { return }
 
-    private var textField: some View {
-        let prompt = Text(viewModel.placeholder).foregroundColor(theme.textFieldPlaceholder)
-
-        return TextField(viewModel.placeholder, text: $viewModel.title, prompt: prompt)
-            .textFieldStyle(.plain)
-            .titleFont()
-            .foregroundStyle(theme.textField)
-            .accentColor(theme.textFieldAccent)
-            .focused($isTitleFocused)
-            .onReceive(UITextField.textDidBeginEditingNotification.publisher()) { notification in
-                guard let textField = notification.object as? UITextField else { return }
-                titleTextField = textField
-                selectAllTitle()
-            }
-            .onReceive(viewModel.didApplySuggestion) { _ in
-                selectAllTitle()
-            }
-            .onSubmit {
-                viewModel.save()
-            }
+            selectAll(in: titleTextView)
+        }
     }
 
     /// Selects the whole title after a short delay, so the selection reliably appears
     /// once the field has settled — whether focus just arrived or a suggestion was applied
-    private func selectAllTitle() {
-        guard let titleTextField else { return }
-
+    private func selectAll(in textView: UITextView) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-            titleTextField.selectedTextRange = titleTextField.textRange(from: titleTextField.beginningOfDocument, to: titleTextField.endOfDocument)
+            textView.selectedTextRange = textView.textRange(from: textView.beginningOfDocument, to: textView.endOfDocument)
         }
     }
 
@@ -255,6 +249,110 @@ struct BookmarkEditView: View {
     }
 }
 
+// MARK: - BookmarkTitleTextView
+
+/// The title field, as a text view that wraps onto as many lines as the title needs and
+/// grows to fit them.
+private struct BookmarkTitleTextView: UIViewRepresentable {
+    @Binding var text: String
+
+    /// Two-way, so the form can move focus away from the title, and the field can report
+    /// the keyboard being dismissed
+    @Binding var isFocused: Bool
+
+    let textColor: UIColor
+    let accentColor: UIColor
+
+    /// Handed the text view as editing begins, so the title can be selected in it
+    let onBeginEditing: (UITextView) -> Void
+    let onSubmit: () -> Void
+
+    @ScaledMetricWithMaxSize(relativeTo: .title2, maxSize: BookmarkTitleStyle.maxTypeSize)
+    private var fontSize: CGFloat = BookmarkTitleStyle.fontSize
+
+    func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView()
+        textView.delegate = context.coordinator
+        textView.text = text
+        textView.backgroundColor = .clear
+        // Lines the text up with the label above it and the underline below it
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        // The text view grows with its content instead, so the form scrolls as a whole
+        textView.isScrollEnabled = false
+        textView.returnKeyType = .done
+        textView.accessibilityLabel = L10n.bookmarkTitleLabel
+        return textView
+    }
+
+    func updateUIView(_ textView: UITextView, context: Context) {
+        context.coordinator.view = self
+
+        if textView.text != text {
+            textView.text = text
+        }
+
+        textView.font = .systemFont(ofSize: fontSize, weight: BookmarkTitleStyle.fontWeight)
+        textView.textColor = textColor
+        textView.tintColor = accentColor
+
+        guard isFocused != textView.isFirstResponder else { return }
+
+        // Deferred: editing begins the moment the text view takes focus, and reporting
+        // that back while SwiftUI is still updating the view would be a state change
+        // in the middle of one
+        DispatchQueue.main.async {
+            if isFocused {
+                textView.becomeFirstResponder()
+            } else {
+                textView.resignFirstResponder()
+            }
+        }
+    }
+
+    /// Asks the text view how tall it needs to be for the width it's offered
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView textView: UITextView, context: Context) -> CGSize? {
+        guard let width = proposal.width, width.isFinite else { return nil }
+
+        let size = textView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+        return CGSize(width: width, height: size.height)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(view: self)
+    }
+
+    class Coordinator: NSObject, UITextViewDelegate {
+        var view: BookmarkTitleTextView
+
+        init(view: BookmarkTitleTextView) {
+            self.view = view
+        }
+
+        func textViewDidChange(_ textView: UITextView) {
+            view.text = textView.text
+        }
+
+        func textViewDidBeginEditing(_ textView: UITextView) {
+            view.isFocused = true
+            view.onBeginEditing(textView)
+        }
+
+        func textViewDidEndEditing(_ textView: UITextView) {
+            view.isFocused = false
+        }
+
+        /// Return saves the bookmark, as it did when this was a single line field, rather
+        /// than putting a line break in the title
+        func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+            guard text == "\n" else { return true }
+
+            view.onSubmit()
+            return false
+        }
+    }
+}
+
 // MARK: - Theme
 
 private extension BookmarkEditTheme {
@@ -263,12 +361,16 @@ private extension BookmarkEditTheme {
 
 // MARK: - Private Extensions
 
+/// How the title reads, both in the field and in the placeholder standing in for it
+private enum BookmarkTitleStyle {
+    static let fontSize: CGFloat = 24
+    static let fontWeight: UIFont.Weight = .bold
+    static let maxTypeSize: DynamicTypeSize = .accessibility2
+}
+
 private extension View {
     func titleFont() -> some View {
-        self
-            .lineLimit(1)
-            .minimumScaleFactor(0.7)
-            .font(size: 24, style: .title2, weight: .bold)
+        font(size: BookmarkTitleStyle.fontSize, style: .title2, weight: .bold)
     }
 }
 


### PR DESCRIPTION
This PR addressed the second part of the change suggested [here](https://github.com/Automattic/pocket-casts-ios/pull/4835#issuecomment-5107319877).

The bookmark title was a single-line `TextField` that scaled its font down to fit, so a long title ended up small and hard to read. It is now a self-sizing `UITextView` that wraps onto as many lines as the title needs, with the font size fixed at 24pt (still scaling with Dynamic Type, capped at AX2 as before). Focus on appear, select-all when editing starts or a suggestion is applied, and saving on Return all carry over — Return still saves rather than inserting a line break.

Also included: the editor form now scrolls, with the Save button pinned to the bottom via `safeAreaInset`, so the fields stay reachable at large text sizes.

<img width="456" height="972" alt="Screenshot 2026-07-29 at 9 56 55 AM" src="https://github.com/user-attachments/assets/a44f19bc-7873-4288-9818-3df8bb3f424c" />


## To test

1. Play an episode and add a bookmark.
2. Type a long title — it wraps onto more lines instead of shrinking, and the field grows to fit.
3. Press Return — the bookmark saves.
4. Clear the title — the placeholder shows in its place.
5. Tap **Edit** on the transcript section — the keyboard dismisses; come back and the title isn't re-selected.
6. Add a bookmark on an episode with a transcript and tap the suggested title — it's applied and selected.
7. Raise the text size to the largest accessibility size — the title stays at its (scaled) size, and the form scrolls with the Save button pinned.

https://github.com/user-attachments/assets/352f5bd4-0212-467c-9fe7-7a25c798a68f


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014spkvY4zB1ecL4zsaHVq4V
