### PR TITLE
Anchor bookmarks to the transcript's reference timeline

### DIFF
--- a/podcasts/Bookmarks/Editing/BookmarkEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditView.swift
@@ -69,7 +69,10 @@ struct BookmarkEditView: View {
     @ViewBuilder
     private var transcriptEditor: some View {
         if let transcript = viewModel.snippet?.transcript {
-            BookmarkTranscriptEditView(transcript: transcript, selection: $viewModel.transcriptRange, theme: theme)
+            BookmarkTranscriptEditView(transcript: transcript,
+                                       referenceTime: viewModel.referenceTime,
+                                       selection: $viewModel.transcriptRange,
+                                       theme: theme)
         }
     }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditViewModel.swift
@@ -54,6 +54,13 @@ class BookmarkEditViewModel: ObservableObject {
         snippet?.text ?? bookmark.passage
     }
 
+    /// The bookmark's position on the transcript's reference timeline. The stored value
+    /// covers bookmarks opened for editing; a snippet freshly captured for a new bookmark
+    /// carries the resolved time before it's saved.
+    var referenceTime: TimeInterval? {
+        bookmark.referenceTime ?? snippet?.referenceTime
+    }
+
     /// The captured passage, which the transcript editor changes as the user picks a
     /// different one. It deliberately doesn't regenerate the title, which belongs to the
     /// moment that was bookmarked.

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
@@ -6,12 +6,17 @@ import SwiftUI
 struct BookmarkTranscriptEditView: View {
     let transcript: TranscriptModel
 
+    /// The bookmark's position on the transcript's reference timeline, marking the line it
+    /// sits on; nil for a bookmark that was never resolved against the reference timeline.
+    let referenceTime: TimeInterval?
+
     @Binding var selection: NSRange
 
     @ObservedObject var theme: BookmarkEditTheme
 
     var body: some View {
         TranscriptSelectionTextView(transcript: transcript,
+                                    bookmarkCharacterIndex: referenceTime.flatMap { transcript.characterIndex(at: $0) },
                                     selection: $selection,
                                     textColor: UIColor(theme.title),
                                     selectionColor: UIColor(theme.transcriptSelection))
@@ -21,7 +26,7 @@ struct BookmarkTranscriptEditView: View {
                     .allowsHitTesting(false)
             }
             .frame(maxWidth: .infinity)
-            .padding([.horizontal, .top])
+            .padding(.top)
             .background(theme.background.ignoresSafeArea())
             .ignoresSafeArea(edges: .bottom)
             // Colors the back button the bar gives us for free
@@ -65,6 +70,9 @@ struct BookmarkTranscriptEditView: View {
 private struct TranscriptSelectionTextView: UIViewRepresentable {
     let transcript: TranscriptModel
 
+    /// The character whose line the bookmark indicator is drawn beside; nil shows no indicator
+    let bookmarkCharacterIndex: Int?
+
     @Binding var selection: NSRange
 
     let textColor: UIColor
@@ -79,11 +87,20 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
         textView.attributedText = styledText()
         textView.isEditable = false
         textView.backgroundColor = .clear
-        textView.textContainerInset = .zero
+        // The gutter on both sides is the text view's own inset rather than outside
+        // padding, so the bookmark indicator can sit in the leading one, beside the text
+        textView.textContainerInset = UIEdgeInsets(top: 0,
+                                                   left: SelectableTextView.gutterWidth,
+                                                   bottom: 0,
+                                                   right: SelectableTextView.gutterWidth)
         textView.textContainer.lineFragmentPadding = 0
         textView.tintColor = selectionColor
         // Leaves room to scroll the text clear of the home indicator it runs under
         textView.contentInsetAdjustmentBehavior = .always
+
+        if let bookmarkCharacterIndex {
+            textView.showBookmarkIndicator(at: bookmarkCharacterIndex, color: textColor)
+        }
 
         // The passage can only be scrolled to once the text has a width to be laid out in
         textView.alpha = 0
@@ -142,18 +159,54 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
         return text
     }
 
-    /// A text view that reports the first layout pass it can scroll and select in
+    /// A text view that reports the first layout pass it can scroll and select in, and can
+    /// mark the line the bookmark sits on with a glyph in the leading gutter
     class SelectableTextView: UITextView {
+        /// The gutter the text keeps on both sides, which the indicator sits inside of
+        static let gutterWidth: CGFloat = 28
+
         var onFirstLayout: (() -> Void)?
+
+        private var bookmarkedCharacterIndex: Int?
+        private var bookmarkIndicator: UIImageView?
+
+        /// Marks the line holding `characterIndex` with a bookmark glyph in the leading gutter
+        func showBookmarkIndicator(at characterIndex: Int, color: UIColor) {
+            let configuration = UIImage.SymbolConfiguration(pointSize: BookmarkTranscriptStyle.fontSize, weight: .semibold)
+            let indicator = UIImageView(image: UIImage(systemName: "bookmark.fill", withConfiguration: configuration))
+            indicator.tintColor = color
+            indicator.sizeToFit()
+            addSubview(indicator)
+
+            bookmarkIndicator = indicator
+            bookmarkedCharacterIndex = characterIndex
+        }
 
         override func layoutSubviews() {
             super.layoutSubviews()
+
+            layoutBookmarkIndicator()
 
             guard window != nil, bounds.width > 0, let onFirstLayout else { return }
 
             // Cleared first: the callback lays the text out again as it scrolls
             self.onFirstLayout = nil
             onFirstLayout()
+        }
+
+        /// Pins the indicator to the line fragment its character is laid out on, so it stays
+        /// with its line whatever width the text wraps to
+        private func layoutBookmarkIndicator() {
+            guard let bookmarkIndicator, let bookmarkedCharacterIndex, textStorage.length > 0 else { return }
+
+            let characterIndex = min(max(bookmarkedCharacterIndex, 0), textStorage.length - 1)
+            let glyphIndex = layoutManager.glyphIndexForCharacter(at: characterIndex)
+            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+
+            let isRightToLeft = effectiveUserInterfaceLayoutDirection == .rightToLeft
+            let gutterCenter = Self.gutterWidth / 2
+            bookmarkIndicator.center = CGPoint(x: isRightToLeft ? bounds.width - gutterCenter : gutterCenter,
+                                               y: lineRect.midY + textContainerInset.top)
         }
     }
 
@@ -187,6 +240,35 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
     }
 }
 
+// MARK: - Reference time lookup
+
+private extension TranscriptModel {
+    /// The character the given reference-timeline position lands on, interpolated within
+    /// its cue so a long cue that wraps over several lines still points at the right one
+    func characterIndex(at time: TimeInterval) -> Int? {
+        guard let cue = nearestCue(to: time) else { return nil }
+
+        let duration = cue.endTime - cue.startTime
+        let fraction = duration > 0 ? min(max((time - cue.startTime) / duration, 0), 1) : 0
+        let range = cue.characterRange
+        guard range.length > 0 else { return range.location }
+
+        return range.location + min(Int(fraction * Double(range.length)), range.length - 1)
+    }
+
+    /// The cue the time falls in, or the closest one when it lands in the silence between cues
+    private func nearestCue(to time: TimeInterval) -> TranscriptCue? {
+        firstCue(containing: time) ?? cues.min { $0.distance(to: time) < $1.distance(to: time) }
+    }
+}
+
+private extension TranscriptCue {
+    /// How far outside the cue's time span the given time falls; 0 within it
+    func distance(to time: TimeInterval) -> TimeInterval {
+        max(startTime - time, time - endTime, 0)
+    }
+}
+
 // MARK: - Theme
 
 private extension BookmarkEditTheme {
@@ -199,6 +281,7 @@ struct BookmarkTranscriptEditView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationStack {
             BookmarkTranscriptEditView(transcript: previewTranscript,
+                                       referenceTime: 8,
                                        selection: .constant(NSRange(location: 0, length: 42)),
                                        theme: .init(episode: nil))
         }


### PR DESCRIPTION
Fixes PCIOS-852.

Dynamic ads shift the playback timeline per device, so a bookmark's stored time can point at the wrong content. Bookmarks now record a `referenceTime` on the generated transcript's canonical timeline (resolved via the fingerprint mapping at capture):

- Playing a bookmark resolves the reference time back to this device's audio before seeking, falling back to the stored time when there's no confident match.
- The transcript editor marks the bookmark's line with a glyph in the leading gutter.

**Note**: it probably needs more ways to access the transcript screen – I'll work on that

<img width="320" alt="Screenshot 2026-07-29 at 11 46 23 AM" src="https://github.com/user-attachments/assets/23904b9a-7c0a-47fd-80a0-e731209174d3" />

## To test

1. Enable the `smartBookmarks` and `syncedTranscripts` feature flags.
2. Play an episode with a generated transcript and create a bookmark.
3. In the edit sheet, tap **Edit** on the transcript — the bookmark's line is marked in the gutter.
4. Play the bookmark from the episode's Bookmarks tab — playback starts on the bookmarked content.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014spkvY4zB1ecL4zsaHVq4V