### PR TITLE
Load the podcast title for bookmarks from podcasts not in the local database

### DIFF
--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -31,13 +31,7 @@ struct BookmarkDetailsView: View {
             artwork
 
             VStack(alignment: .leading, spacing: 2) {
-                viewModel.podcastTitle.map {
-                    Text($0)
-                        .font(size: 11, style: .caption2, weight: .semibold)
-                        .kerning(-0.4)
-                        .foregroundStyle(theme.primaryText02)
-                        .lineLimit(1)
-                }
+                podcastTitle
 
                 viewModel.episode.map {
                     Text($0.displayableTitle())
@@ -52,6 +46,29 @@ struct BookmarkDetailsView: View {
             playButton
         }
     }
+
+    @ViewBuilder
+    private var podcastTitle: some View {
+        if let title = viewModel.podcastTitle {
+            podcastTitleText(title)
+        } else if viewModel.isLoadingPodcastTitle {
+            podcastTitleText(Self.podcastTitlePlaceholder)
+                .redacted(reason: .placeholder)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private func podcastTitleText(_ title: String) -> some View {
+        Text(title)
+            .font(size: 11, style: .caption2, weight: .semibold)
+            .kerning(-0.4)
+            .foregroundStyle(theme.primaryText02)
+            .lineLimit(1)
+    }
+
+    /// Stands in for the podcast title while it loads. The redaction blocks it out,
+    /// so it's never read, it only gives the placeholder the shape of a title.
+    private static let podcastTitlePlaceholder = "The Podcast Title"
 
     @ViewBuilder
     private var artwork: some View {

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import PocketCastsDataModel
+import PocketCastsServer
 
 /// What the bookmark details show, kept in one place so the hosting controller can
 /// refresh it after the bookmark is edited.
@@ -10,8 +11,13 @@ class BookmarkDetailsViewModel: ObservableObject {
     /// The captured transcript passage, absent for bookmarks made before it was captured
     @Published private(set) var passage: String?
 
+    /// Fetched from the server when the podcast isn't in the local database, e.g. a
+    /// bookmark synced from a podcast this device isn't subscribed to
+    @Published private(set) var podcastTitle: String?
+
+    @Published private(set) var isLoadingPodcastTitle = false
+
     let episode: BaseEpisode?
-    let podcastTitle: String?
 
     /// Assigned by the hosting controller, which owns playback
     var onPlay: () -> Void = {}
@@ -36,8 +42,12 @@ class BookmarkDetailsViewModel: ObservableObject {
         self.init(bookmark: bookmark,
                   passage: bookmark.passage,
                   episode: episode,
-                  podcastTitle: Self.podcastTitle(for: bookmark, episode: episode),
+                  podcastTitle: Self.localPodcastTitle(for: bookmark, episode: episode),
                   bookmarkManager: bookmarkManager)
+
+        if podcastTitle == nil {
+            loadPodcastTitle()
+        }
     }
 
     func refresh() {
@@ -47,8 +57,27 @@ class BookmarkDetailsViewModel: ObservableObject {
         self.passage = bookmark.passage
     }
 
-    private static func podcastTitle(for bookmark: Bookmark, episode: BaseEpisode?) -> String? {
-        let uuid = bookmark.podcastUuid ?? (episode as? Episode)?.podcastUuid
-        return uuid.flatMap { DataManager.sharedManager.findPodcast(uuid: $0)?.title }
+    private func loadPodcastTitle() {
+        guard let podcastUuid = Self.podcastUuid(for: bookmark, episode: episode) else { return }
+
+        isLoadingPodcastTitle = true
+
+        CacheServerHandler.shared.loadPodcastInfo(podcastUuid: podcastUuid) { podcastInfo, _ in
+            let title = (podcastInfo?["podcast"] as? [String: Any])?["title"] as? String
+
+            Task { @MainActor [weak self] in
+                self?.podcastTitle = title
+                self?.isLoadingPodcastTitle = false
+            }
+        }
+    }
+
+    private static func localPodcastTitle(for bookmark: Bookmark, episode: BaseEpisode?) -> String? {
+        podcastUuid(for: bookmark, episode: episode)
+            .flatMap { DataManager.sharedManager.findPodcast(uuid: $0, includeUnsubscribed: true)?.title }
+    }
+
+    private static func podcastUuid(for bookmark: Bookmark, episode: BaseEpisode?) -> String? {
+        bookmark.podcastUuid ?? (episode as? Episode)?.podcastUuid
     }
 }


### PR DESCRIPTION
Fixes PCIOS-862.

Bookmark details resolved the podcast title only from the local database, so bookmarks synced from podcasts this device isn't subscribed to showed no podcast title at all. The header now shows a redacted placeholder while the title is fetched from the cache server, and the local lookup includes unsubscribed podcasts, which resolve without a network call.

## To test

1. Enable the Smart Bookmarks feature flag and sign in to an account that has a bookmark for a podcast this device isn't subscribed to (e.g. create one on another device or simulator, then sync).
2. Open Profile → Bookmarks and tap that bookmark.
3. Confirm the header shows a redacted placeholder where the podcast title goes, then the actual title once it loads.
4. Open a bookmark for a subscribed podcast and confirm its title still appears immediately.

Here I tested it with a podcast I'm not subscribed to:

<img width="320" alt="Screenshot 2026-07-29 at 12 40 43 PM" src="https://github.com/user-attachments/assets/40b36c98-4856-4edd-9398-a4009a95001a" />


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.