### PR TITLE
DRY the CI secrets install into a dedicated script

### DIFF
--- a/.buildkite/commands/build-tvos-app-store.sh
+++ b/.buildkite/commands/build-tvos-app-store.sh
@@ -8,9 +8,6 @@ fi
 
 "$(dirname "${BASH_SOURCE[0]}")/shared_setup.sh"
 
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
-
 echo "--- :hammer_and_wrench: Building"
 # CI-driven tvOS uploads use a low 0.x build number. App Store Connect may
 # reject these after a release build already exists for the same version.

--- a/.buildkite/commands/install-secrets.sh
+++ b/.buildkite/commands/install-secrets.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -9,8 +9,5 @@ brew upgrade sentry-cli
 
 "$(dirname "${BASH_SOURCE[0]}")/shared_setup.sh"
 
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
-
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_enterprise

--- a/.buildkite/commands/prototype-upload.sh
+++ b/.buildkite/commands/prototype-upload.sh
@@ -14,7 +14,5 @@ buildkite-agent artifact download "artifacts/*.app.dSYM.zip" . --step build_prot
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-"$(dirname "${BASH_SOURCE[0]}")/install-secrets.sh"
-
 echo "--- :hammer_and_wrench: Uploading"
 bundle exec fastlane upload_enterprise

--- a/.buildkite/commands/prototype-upload.sh
+++ b/.buildkite/commands/prototype-upload.sh
@@ -14,8 +14,7 @@ buildkite-agent artifact download "artifacts/*.app.dSYM.zip" . --step build_prot
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
+"$(dirname "${BASH_SOURCE[0]}")/install-secrets.sh"
 
 echo "--- :hammer_and_wrench: Uploading"
 bundle exec fastlane upload_enterprise

--- a/.buildkite/commands/release-build.sh
+++ b/.buildkite/commands/release-build.sh
@@ -13,9 +13,6 @@ fi
 
 "$(dirname "${BASH_SOURCE[0]}")/shared_setup.sh"
 
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
-
 case "$RELEASE_PLATFORM" in
   ios)
     echo "--- :hammer_and_wrench: Building iOS"

--- a/.buildkite/commands/release-upload.sh
+++ b/.buildkite/commands/release-upload.sh
@@ -65,8 +65,7 @@ buildkite-agent artifact download "$ARCHIVE_ZIP_PATH" . --step "$STEP"
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
+"$(dirname "${BASH_SOURCE[0]}")/install-secrets.sh"
 
 echo "--- :github: Updating GitHub Release"
 bundle exec fastlane create_release_on_github beta_release:"$BETA_RELEASE" archive_zip_path:"$ARCHIVE_ZIP_PATH" notify_slack:false create_release:"$CREATE_GITHUB_RELEASE"

--- a/.buildkite/commands/release-upload.sh
+++ b/.buildkite/commands/release-upload.sh
@@ -65,8 +65,6 @@ buildkite-agent artifact download "$ARCHIVE_ZIP_PATH" . --step "$STEP"
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-"$(dirname "${BASH_SOURCE[0]}")/install-secrets.sh"
-
 echo "--- :github: Updating GitHub Release"
 bundle exec fastlane create_release_on_github beta_release:"$BETA_RELEASE" archive_zip_path:"$ARCHIVE_ZIP_PATH" notify_slack:false create_release:"$CREATE_GITHUB_RELEASE"
 

--- a/.buildkite/commands/shared_setup.sh
+++ b/.buildkite/commands/shared_setup.sh
@@ -3,6 +3,8 @@
 echo "--- :ruby: Setting up Ruby tools"
 install_gems
 
+"$(dirname "${BASH_SOURCE[0]}")/install-secrets.sh"
+
 # The push/pop is a workaround for tooling not supporting a Package.swift path.
 # Note that neither ours nor Apple's tooling does.
 pushd "$(dirname "${BASH_SOURCE[0]}")/../../Modules"

--- a/.buildkite/commands/upload-tvos-app-store.sh
+++ b/.buildkite/commands/upload-tvos-app-store.sh
@@ -12,8 +12,5 @@ echo "--- :arrow_down: Downloading tvOS App Store Build"
 buildkite-agent artifact download "artifacts/*.ipa" . --step build_tvos_app_store
 buildkite-agent artifact download "artifacts/*.app.dSYM.zip" . --step build_tvos_app_store
 
-echo "--- :closed_lock_with_key: Installing Secrets"
-bundle exec fastlane run configure_apply
-
 echo "--- :rocket: Uploading to TestFlight"
 bundle exec fastlane upload_app_store_connect_build_to_testflight_tvos

--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -15,8 +15,7 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- 🔐 Access Secrets'
-      bundle exec fastlane run configure_apply
+      .buildkite/commands/install-secrets.sh
 
       echo '--- ❄️ Code Freeze'
       bundle exec fastlane code_freeze version:"${RELEASE_VERSION}" skip_confirm:true

--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -15,8 +15,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      .buildkite/commands/install-secrets.sh
-
       echo '--- ❄️ Code Freeze'
       bundle exec fastlane code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -17,8 +17,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      .buildkite/commands/install-secrets.sh
-
       echo '--- 🚀 Finalize Hotfix Release'
       bundle exec fastlane finalize_hotfix_release skip_confirm:true
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -17,8 +17,7 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- 🔐 Access Secrets'
-      bundle exec fastlane run configure_apply
+      .buildkite/commands/install-secrets.sh
 
       echo '--- 🚀 Finalize Hotfix Release'
       bundle exec fastlane finalize_hotfix_release skip_confirm:true

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -17,8 +17,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      .buildkite/commands/install-secrets.sh
-
       echo '--- 🚀 Finalize Release'
       bundle exec fastlane finalize_release skip_confirm:true
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -17,8 +17,7 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- 🔐 Access Secrets'
-      bundle exec fastlane run configure_apply
+      .buildkite/commands/install-secrets.sh
 
       echo '--- 🚀 Finalize Release'
       bundle exec fastlane finalize_release skip_confirm:true

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -17,8 +17,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      .buildkite/commands/install-secrets.sh
-
       echo '--- 🚀 New Beta Release'
       bundle exec fastlane new_beta_release skip_confirm:true
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -17,8 +17,7 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- 🔐 Access Secrets'
-      bundle exec fastlane run configure_apply
+      .buildkite/commands/install-secrets.sh
 
       echo '--- 🚀 New Beta Release'
       bundle exec fastlane new_beta_release skip_confirm:true

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -15,8 +15,7 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- 🔐 Access Secrets'
-      bundle exec fastlane run configure_apply
+      .buildkite/commands/install-secrets.sh
 
       echo '--- 🚀 New Hotfix Release'
       bundle exec fastlane new_hotfix_release version:"$RELEASE_VERSION" skip_confirm:true

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -15,8 +15,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      .buildkite/commands/install-secrets.sh
-
       echo '--- 🚀 New Hotfix Release'
       bundle exec fastlane new_hotfix_release version:"$RELEASE_VERSION" skip_confirm:true
     plugins: [$CI_TOOLKIT]

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -17,8 +17,7 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      echo '--- 🔐 Access Secrets'
-      bundle exec fastlane run configure_apply
+      .buildkite/commands/install-secrets.sh
 
       echo '--- :github: Publish Release'
       bundle exec fastlane publish_release skip_confirm:true

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -17,8 +17,6 @@ steps:
       echo '--- :ruby: Setup Ruby Tools'
       install_gems
 
-      .buildkite/commands/install-secrets.sh
-
       echo '--- :github: Publish Release'
       bundle exec fastlane publish_release skip_confirm:true
     plugins: [$CI_TOOLKIT]


### PR DESCRIPTION
Part of [AINFRA-2774](https://linear.app/a8c/issue/AINFRA-2774), under [AINFRA-1541](https://linear.app/a8c/issue/AINFRA-1541).

I was looking at #4731 to get it ready for a new round of review and grew overwhelmed by the various changes and the open question of how it should flow in CI vs local (when and how to call the decrypt?) and for internal vs external contributors.

As such, I've decided to extract the parts that are already good in dedicated PRs, and to rework the remainder in isolation.

This PR DRYs how CI decrypts secrets.

<details>
<summary>AI-generated Details</summary>

Twelve CI call sites each spelled out their own `bundle exec fastlane run configure_apply` step, so changing how secrets are decrypted means touching all twelve.
This collapses them onto `.buildkite/commands/install-secrets.sh`.

The mechanism is unchanged — it still calls `configure_apply`.
The point is that [#4731](https://github.com/Automattic/pocket-casts-ios/pull/4731), which swaps `.configure` for [`a8c-secrets`](https://github.com/Automattic/a8c-secrets), shrinks to the parts that still need discussion once this lands.

One behaviour change: `build.sh` had no explicit secrets step and leaned on `configure_apply` in fastlane's `before_all`.
It now decrypts through `shared_setup.sh` like the other build scripts — same net effect, one extra visible Buildkite step.

## To test

This PR's own build exercises the new shared path (`build.sh` → `shared_setup.sh` → `install-secrets.sh`).

The six release pipelines under `.buildkite/release-pipelines/` and the prototype/tvOS upload scripts only run on demand, so CI here does not cover them.
Their edit is the same two-line-for-one-line substitution in every file — worth an eyeball, not a manual trigger.

</details>

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
