### PR TITLE
Init `a8c-secrets` (identities only)

### DIFF
--- a/.a8c-secrets/keys.pub
+++ b/.a8c-secrets/keys.pub
@@ -1,0 +1,4 @@
+# dev
+age1xhg8d9y3x5surnx7kxfsxuplxk28cpalzn4kpnt0tn9ug92u2utqkvsj8h
+# ci
+age1jl8q0kes68j5h70pzar799za8c5rscpw3uresyjuuea48nd063rsw84y2q

--- a/.a8c-secrets/repo-id
+++ b/.a8c-secrets/repo-id
@@ -1,0 +1,1 @@
+pocket-casts-ios@github.com@automattic

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@ CHANGELOG.md merge=union
 
 podcasts/Strings+Generated.swift linguist-generated
 
-.a8c-secrets/**/*.age binary
+.a8c-secrets/*.age binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@ CHANGELOG.md merge=union
 *.pbxproj merge=union
 
 podcasts/Strings+Generated.swift linguist-generated
+
+.a8c-secrets/**/*.age binary


### PR DESCRIPTION
See [AINFRA-2776](https://linear.app/a8c/issue/AINFRA-2776), under [AINFRA-1541](https://linear.app/a8c/issue/AINFRA-1541).

I was looking at #4731 to get it ready for a new round of review and grew overwhelmed by the various changes and the open question of how it should flow in CI vs local (when and how to call the decrypt?) and for internal vs external contributors.

As such, I've decided to extract the parts that are already good in dedicated PRs, and to rework the remainder in isolation.

This PR sets up the `a8c-secrets` identities and `.gitattributes`. I may have gone a bit overboard with extracting this, too. But, I thought it'd be interesting to see how GitHub would render the upcoming `.age` files in the diff once this lands with the instruction to treat them as binaries.