### PR TITLE
Add TWiT network to Apple TV home page

### DIFF
--- a/Pocket Casts TV App/Data/DiscoverManager.swift
+++ b/Pocket Casts TV App/Data/DiscoverManager.swift
@@ -10,6 +10,8 @@ enum DiscoverType: String, CaseIterable {
     case popularRegion = "popular_region" // Popular in region ...
     case curatedList
     case categories
+    // special lists
+    case twit = "twit-2026"
     case other
 
     func match(item: DiscoverItem) -> Bool {
@@ -37,6 +39,7 @@ enum DiscoverType: String, CaseIterable {
         case .curatedList: L10n.discoverFreshPick
         case .categories: L10n.tvHomeBrowseCategoriesSectionTitle
         case .other: L10n.discover
+        default: L10n.discover
         }
     }
 }

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -69,6 +69,7 @@ struct HomeView: View {
                         nowPlayingRow
                         upNextRow
                         videoRow
+                        twitNetworkRow
                         youMightLikeRow
                         newReleasesRow
                         lovedByListenersOfRow
@@ -81,6 +82,7 @@ struct HomeView: View {
                         nowPlayingRow
                         featuredRow
                         videoRow
+                        twitNetworkRow
                         BannerRow(type: .createAccount, focusSection: Section.homeBanner.rawValue) {
                             Analytics.track(.bannerRowTapped, properties: ["type": "create_account"])
                             tabRouter.pendingAuthFlow = .createAccount
@@ -152,6 +154,10 @@ struct HomeView: View {
 
     var curatedRow: some View {
         DiscoverPodcastRow(type: .curatedList, source: DiscoverAnalytics.homeSource)
+    }
+
+    var twitNetworkRow: some View {
+        DiscoverPodcastRow(type: .twit, source: DiscoverAnalytics.homeSource)
     }
 
     var categoriesRow: some View {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<img width="3840" height="2160" alt="Simulator Screenshot - Apple TV 4K (3rd generation) - 2026-07-30 at 14 59 14" src="https://github.com/user-attachments/assets/d36ed238-6bf0-4e66-b6f8-08b3f4f8ff4e" />


Adds a dedicated TWiT network row to the Apple TV Home screen. This introduces a new `twit` discover type (mapped to the `twit-2026` list) and surfaces it as a `DiscoverPodcastRow` on both the logged-in and logged-out home layouts, placed right below the video row.

## To test

1. Build and run the **Pocket Casts TV App** target on the Apple TV simulator.
2. On the Home screen while **logged in**, confirm a TWiT network row appears directly below the video row.
3. Log out and confirm the TWiT network row also appears below the video row on the logged-out home layout.
4. Confirm the row loads podcasts from the `twit-2026` list and that selecting an item behaves like other discover rows.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.