### PR TITLE
Improve video thumbnail frame capture algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix a crash when swiping down with VoiceOver on the first style in the share sheet; it now wraps to the last style [#4783](https://github.com/Automattic/pocket-casts-ios/pull/4783)
 - Fix an issue where the now playing episode was not being auto-downloaded when setting was active for UpNext [#4792](https://github.com/Automattic/pocket-casts-ios/pull/4792)
 - Fix the Playlists tab showing a blank screen instead of the empty state when there are no playlists [#4794](https://github.com/Automattic/pocket-casts-ios/pull/4794)
+- [tvOS] Improve thumbnail algorithm for videos [#4861](https://github.com/Automattic/pocket-casts-ios/pull/4861)
 
 8.16
 -----

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -311,6 +311,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable Smart Bookmarks
     case smartBookmarks
 
+    /// Use best frame when capturing a thumbnail for video cells
+    case captureBestFrame
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -525,6 +528,9 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .smartBookmarks:
             BuildEnvironment.current == .debug
+
+        case .captureBestFrame:
+            true
         }
     }
 

--- a/Pocket Casts TV App/UI/Discover/BestFrameSelector.swift
+++ b/Pocket Casts TV App/UI/Discover/BestFrameSelector.swift
@@ -1,0 +1,163 @@
+import AVFoundation
+import UIKit
+
+struct FrameCandidate {
+    let time: CMTime
+    let image: UIImage
+    let score: Double
+}
+
+class BestFrameSelector {
+
+    enum SelectorError: Error {
+        case invalidDuration
+        case noCandidatesGenerated
+    }
+
+    /// Samples several timestamps across the asset and returns the best-scoring frame.
+    static func bestFrame(
+        from asset: AVAsset,
+        candidateCount: Int = 3,
+        startPercentage: Double = 0.05,
+        endPercentage: Double = 0.95
+    ) async throws -> UIImage {
+
+        let duration = try await asset.load(.duration)
+        let durationSeconds = CMTimeGetSeconds(duration)
+        guard durationSeconds > 0 else {
+            throw SelectorError.invalidDuration
+        }
+
+        // Skip the very start/end (often black, fading, or logos)
+        let start = durationSeconds * startPercentage
+        let end = durationSeconds * endPercentage
+        let step = (end - start) / Double(max(candidateCount - 1, 1))
+
+        let times: [CMTime] = (0..<candidateCount).map {
+            CMTime(seconds: start + Double($0) * step, preferredTimescale: 600)
+        }
+
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.requestedTimeToleranceBefore = .zero
+        generator.requestedTimeToleranceAfter = .zero
+
+        // Generate + score candidates concurrently.
+        let candidates = await withTaskGroup(of: FrameCandidate?.self) { group in
+            for time in times {
+                group.addTask {
+                    await Self.candidate(for: time, using: generator)
+                }
+            }
+
+            var results: [FrameCandidate] = []
+            for await candidate in group {
+                if let candidate {
+                    results.append(candidate)
+                }
+            }
+            return results
+        }
+
+        guard let best = candidates.max(by: { $0.score < $1.score }) else {
+            throw SelectorError.noCandidatesGenerated
+        }
+
+        return best.image
+    }
+
+    /// Generates a single frame at `time` and scores it. Runs off-actor since
+    /// AVAssetImageGenerator's async image(at:) is itself concurrency-safe.
+    private static func candidate(
+        for time: CMTime,
+        using generator: AVAssetImageGenerator
+    ) async -> FrameCandidate? {
+        do {
+            let result = try await generator.image(at: time)
+            let image = UIImage(cgImage: result.image)
+            let score = score(image: image)
+            return FrameCandidate(time: time, image: image, score: score)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Higher score = more "interesting"/usable frame.
+    /// Combines: not-blank check, brightness in a good range, and contrast/detail.
+    private static func score(image: UIImage) -> Double {
+        guard let stats = pixelStats(of: image) else { return -1 }
+
+        // Penalize blank/near-solid-color frames heavily
+        if stats.isNearSolidColor {
+            return -1
+        }
+
+        // Prefer frames that aren't too dark or too blown out
+        let brightnessScore = 1.0 - abs(stats.meanBrightness - 0.5) * 2 // peak at 0.5
+
+        // Prefer higher variance (more detail/contrast = less likely blurry or flat)
+        let contrastScore = min(stats.stdDevBrightness * 4, 1.0)
+
+        return brightnessScore * 0.4 + contrastScore * 0.6
+    }
+
+    private struct PixelStats {
+        let meanBrightness: Double     // 0...1
+        let stdDevBrightness: Double   // 0...1-ish
+        let isNearSolidColor: Bool
+    }
+
+    private static func pixelStats(of image: UIImage, sampleSize: Int = 50) -> PixelStats? {
+        guard let cgImage = image.cgImage else { return nil }
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        var pixelData = [UInt8](repeating: 0, count: sampleSize * sampleSize * 4)
+
+        guard let context = CGContext(
+            data: &pixelData,
+            width: sampleSize,
+            height: sampleSize,
+            bitsPerComponent: 8,
+            bytesPerRow: sampleSize * 4,
+            space: colorSpace,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return nil
+        }
+
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize))
+
+        var brightnesses: [Double] = []
+        brightnesses.reserveCapacity(sampleSize * sampleSize)
+
+        var firstPixel: (UInt8, UInt8, UInt8)?
+        var isSolid = true
+        let tolerance: Int = 10
+
+        for i in 0..<(sampleSize * sampleSize) {
+            let offset = i * 4
+            let r = pixelData[offset]
+            let g = pixelData[offset + 1]
+            let b = pixelData[offset + 2]
+
+            let brightness = (0.299 * Double(r) + 0.587 * Double(g) + 0.114 * Double(b)) / 255.0
+            brightnesses.append(brightness)
+
+            if let first = firstPixel {
+                if abs(Int(r) - Int(first.0)) > tolerance ||
+                   abs(Int(g) - Int(first.1)) > tolerance ||
+                   abs(Int(b) - Int(first.2)) > tolerance {
+                    isSolid = false
+                }
+            } else {
+                firstPixel = (r, g, b)
+            }
+        }
+
+        let mean = brightnesses.reduce(0, +) / Double(brightnesses.count)
+        let variance = brightnesses.reduce(0) { $0 + pow($1 - mean, 2) } / Double(brightnesses.count)
+        let stdDev = sqrt(variance)
+
+        return PixelStats(meanBrightness: mean, stdDevBrightness: stdDev, isNearSolidColor: isSolid)
+    }
+}

--- a/Pocket Casts TV App/UI/Discover/BestFrameSelector.swift
+++ b/Pocket Casts TV App/UI/Discover/BestFrameSelector.swift
@@ -2,12 +2,11 @@ import AVFoundation
 import UIKit
 
 struct FrameCandidate {
-    let time: CMTime
     let image: UIImage
     let score: Double
 }
 
-class BestFrameSelector {
+enum BestFrameSelector {
 
     enum SelectorError: Error {
         case invalidDuration
@@ -76,7 +75,7 @@ class BestFrameSelector {
             let result = try await generator.image(at: time)
             let image = UIImage(cgImage: result.image)
             let score = score(image: image)
-            return FrameCandidate(time: time, image: image, score: score)
+            return FrameCandidate(image: image, score: score)
         } catch {
             return nil
         }
@@ -127,21 +126,23 @@ class BestFrameSelector {
 
         context.draw(cgImage, in: CGRect(x: 0, y: 0, width: sampleSize, height: sampleSize))
 
-        var brightnesses: [Double] = []
-        brightnesses.reserveCapacity(sampleSize * sampleSize)
+        let pixelCount = sampleSize * sampleSize
+        var sum = 0.0
+        var sumOfSquares = 0.0
 
         var firstPixel: (UInt8, UInt8, UInt8)?
         var isSolid = true
         let tolerance: Int = 10
 
-        for i in 0..<(sampleSize * sampleSize) {
+        for i in 0..<pixelCount {
             let offset = i * 4
             let r = pixelData[offset]
             let g = pixelData[offset + 1]
             let b = pixelData[offset + 2]
 
             let brightness = (0.299 * Double(r) + 0.587 * Double(g) + 0.114 * Double(b)) / 255.0
-            brightnesses.append(brightness)
+            sum += brightness
+            sumOfSquares += brightness * brightness
 
             if let first = firstPixel {
                 if abs(Int(r) - Int(first.0)) > tolerance ||
@@ -154,8 +155,8 @@ class BestFrameSelector {
             }
         }
 
-        let mean = brightnesses.reduce(0, +) / Double(brightnesses.count)
-        let variance = brightnesses.reduce(0) { $0 + pow($1 - mean, 2) } / Double(brightnesses.count)
+        let mean = sum / Double(pixelCount)
+        let variance = max(sumOfSquares / Double(pixelCount) - mean * mean, 0)
         let stdDev = sqrt(variance)
 
         return PixelStats(meanBrightness: mean, stdDevBrightness: stdDev, isNearSolidColor: isSolid)

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -63,7 +63,12 @@ class DiscoverVideoEpisodeModel {
             if cachedVideoFrame != nil {
                 videoFrame = cachedVideoFrame
             } else {
-                let image = try await thumbnail(url: videoUrl, at: CMTime(seconds: 1, preferredTimescale: 600))
+                let image: UIImage
+                if FeatureFlag.captureBestFrame.enabled {
+                    image = try await thumbnailFromBestFrame(url: videoUrl)
+                } else {
+                   image = try await thumbnail(url: videoUrl, at: CMTime(seconds: 1, preferredTimescale: 600))
+                }
                 let _ = await ImageManager.sharedManager.storeDiscoverVideoThumbnail(for: urlString, image: image)
                 videoFrame = image
             }
@@ -77,6 +82,7 @@ class DiscoverVideoEpisodeModel {
 
     private func thumbnail(url: URL, at time: CMTime = .zero) async throws -> UIImage {
         let asset = AVURLAsset(url: url)
+
         let generator = AVAssetImageGenerator(asset: asset)
         generator.appliesPreferredTrackTransform = true
         generator.requestedTimeToleranceBefore = CMTime(seconds: 1, preferredTimescale: 600)
@@ -84,6 +90,12 @@ class DiscoverVideoEpisodeModel {
 
         let (image, _) = try await generator.image(at: time)
         return UIImage(cgImage: image)
+    }
+
+    private func thumbnailFromBestFrame(url: URL) async throws -> UIImage {
+        let asset = AVURLAsset(url: url)
+        let image = try await BestFrameSelector.bestFrame(from: asset, candidateCount: 3, endPercentage: 0.1)
+        return image
     }
 
     var podcast: DiscoverPodcast? {

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -58,18 +58,17 @@ class DiscoverVideoEpisodeModel {
         setupPlayer()
 
         do {
-            var videoFrame: UIImage?
-            let cachedVideoFrame = await ImageManager.sharedManager.retrieveDiscoverVideoThumbnail(imageUrl: urlString)
-            if cachedVideoFrame != nil {
+            let videoFrame: UIImage
+            if let cachedVideoFrame = await ImageManager.sharedManager.retrieveDiscoverVideoThumbnail(imageUrl: urlString) {
                 videoFrame = cachedVideoFrame
             } else {
                 let image: UIImage
                 if FeatureFlag.captureBestFrame.enabled {
                     image = try await thumbnailFromBestFrame(url: videoUrl)
                 } else {
-                   image = try await thumbnail(url: videoUrl, at: CMTime(seconds: 1, preferredTimescale: 600))
+                    image = try await thumbnail(url: videoUrl, at: CMTime(seconds: 1, preferredTimescale: 600))
                 }
-                let _ = await ImageManager.sharedManager.storeDiscoverVideoThumbnail(for: urlString, image: image)
+                _ = await ImageManager.sharedManager.storeDiscoverVideoThumbnail(for: urlString, image: image)
                 videoFrame = image
             }
             await MainActor.run { [videoFrame] in
@@ -82,7 +81,6 @@ class DiscoverVideoEpisodeModel {
 
     private func thumbnail(url: URL, at time: CMTime = .zero) async throws -> UIImage {
         let asset = AVURLAsset(url: url)
-
         let generator = AVAssetImageGenerator(asset: asset)
         generator.appliesPreferredTrackTransform = true
         generator.requestedTimeToleranceBefore = CMTime(seconds: 1, preferredTimescale: 600)
@@ -93,9 +91,7 @@ class DiscoverVideoEpisodeModel {
     }
 
     private func thumbnailFromBestFrame(url: URL) async throws -> UIImage {
-        let asset = AVURLAsset(url: url)
-        let image = try await BestFrameSelector.bestFrame(from: asset, candidateCount: 3, endPercentage: 0.1)
-        return image
+        try await BestFrameSelector.bestFrame(from: AVURLAsset(url: url), endPercentage: 0.1)
     }
 
     var podcast: DiscoverPodcast? {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Improves how the Apple TV Discover video cells choose their thumbnail. Instead of always grabbing the frame at 1 second — which is often a black frame, a fade-in, or a channel logo — this samples several frames near the start of the video and picks the most "usable" one.

A new `BestFrameSelector` samples candidate timestamps across a window of the asset, generates and scores each frame concurrently, and returns the highest-scoring image. Scoring penalizes near-solid-color/blank frames and favors frames with balanced brightness and higher contrast/detail. `DiscoverVideoEpisodeModel` calls the selector when the new `captureBestFrame` feature flag is enabled (on by default), and falls back to the previous single-frame behavior otherwise. Selected thumbnails continue to be cached via `ImageManager` as before.

## To test

1. Delete the app if you have it installed before ( in order to clean up the thumbnail cache)
2. Select the debugStaging scheme
3. On an Apple TV build, open the Search **Discover** tab and scroll to a row of video episodes.
4. Confirm each video cell shows a representative thumbnail (not a black/blank frame or a plain logo/title card).
5. Check the Rick Steve row ( with the previous algorithm a lot of episodes where showing black thumbnails)
6. Scroll away and back to confirm thumbnails are cached and load instantly the second time.
7. Toggle the `captureBestFrame` feature flag off and confirm the cells still load a thumbnail (the previous 1-second-frame behavior).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
