### PR TITLE
Reduce the gap under category pills on the Discover category page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Fix the Bookmarks multi-select layout: rows keep their text width instead of shrinking, the selection bar sits just above the mini player instead of floating too high, and on iOS 26 it hides the tab bar and mini player correctly [#4819](https://github.com/Automattic/pocket-casts-ios/pull/4819)
 - Fix the day label in episode cells growing out of proportion at large text sizes [#4818](https://github.com/Automattic/pocket-casts-ios/pull/4818)
+- Fix a large empty gap under the category filter on the Discover screen [#4862](https://github.com/Automattic/pocket-casts-ios/pull/4862)
 
 
 8.17

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -79,10 +79,20 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         return max(baseHeight, metric.scaledValue(for: baseHeight))
     }
 
+    /// Tighter top padding when this list is shown on a selected-category page (directly
+    /// under the category pills), so the title doesn't sit far below the pills (PCIOS-193).
+    /// Matches the 16pt bottom padding the pills have on the root Discover screen
+    /// (`CategoriesPillsView` `buttonInsets.bottom`), which drops to 0 once a category is
+    /// selected — so this reproduces the same pills-to-content gap as the featured carousel.
+    /// The larger xib default is kept for large lists elsewhere in the Discover feed.
+    private static let categoryPageTitleTopPadding: CGFloat = 16
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
-        if let padding {
+        if category != nil {
+            titleTopConstraint.constant = Self.categoryPageTitleTopPadding
+        } else if let padding {
             titleTopConstraint.constant = padding / 2
         }
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-193

On a selected-category Discover page (e.g. after tapping **Comedy**), the "Most Popular in …" list title sat 30pt below the category pills, leaving a large empty band. This reduces that title's top padding to 16pt in the selected-category context, so it matches the pills-to-content spacing on the root Discover screen — where the pills carry a 16pt bottom inset that drops to 0 once a category is selected.

The change is scoped to the selected-category context (`category != nil` in `LargeListSummaryViewController`), so large lists elsewhere in the Discover feed keep their existing spacing.

### Before
<img width="402" height="874" alt="img_6359" src="https://github.com/user-attachments/assets/a101b2eb-5a7b-4684-a323-7002e5d3a52a" />

### After
<img width="402" height="874" alt="pcios-193-after" src="https://github.com/user-attachments/assets/9f8f5ce5-38e7-48df-bdf4-cbd10b248ed1" />


## To test

1. Open the **Discover** tab.
2. Tap a category pill (e.g. **Fiction** or **Society & Culture**).
- [ ] Verify the "Most Popular in …" heading sits snugly under the pills — roughly the same gap as between the pills and the featured carousel on the root Discover screen, not a large empty band.
- [ ] Scroll the category page and confirm the list/sections below look unchanged.
- [ ] Tap ✕ to return to the root Discover screen and confirm large lists there are unchanged (still the default spacing).

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. <!-- will tick once the CHANGELOG entry referencing this PR is added -->
- [x] I have considered adding unit tests for my changes. <!-- layout-constant applied in viewDidLayoutSubviews; verified visually in the simulator, not readily unit-testable -->
- [x] I have updated (or requested that someone edit) the Event Horizon schema to reflect any new or changed analytics. <!-- n/a — no analytics changes -->
