### PR TITLE
Delete the new bookmark when its edit sheet is swiped away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 -----
 - Fix the Bookmarks multi-select layout: rows keep their text width instead of shrinking, the selection bar sits just above the mini player instead of floating too high, and on iOS 26 it hides the tab bar and mini player correctly [#4819](https://github.com/Automattic/pocket-casts-ios/pull/4819)
 - Fix the day label in episode cells growing out of proportion at large text sizes [#4818](https://github.com/Automattic/pocket-casts-ios/pull/4818)
+- Fix swiping away the bookmark edit sheet keeping the new bookmark with its default title instead of discarding it, like the close button does [#4864](https://github.com/Automattic/pocket-casts-ios/pull/4864)
 
 8.17
 -----

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewController.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewController.swift
@@ -89,7 +89,7 @@ private extension BookmarkDetailsViewController {
         let controller = BookmarkEditTitleViewController(manager: bookmarkManager,
                                                          bookmark: bookmark,
                                                          state: .updating,
-                                                         style: .themed) { [weak self] _, _ in
+                                                         style: .themed) { [weak self] _ in
             self?.viewModel.refresh()
         }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -8,6 +8,8 @@ class BookmarkEditTitleViewController: ThemedHostingController<AnyView> {
     let onDismiss: ((String, Bool) -> Void)?
     var editSaved: Bool = false
 
+    private var didReportDismiss = false
+
     var source: BookmarkAnalyticsSource = .unknown {
         didSet {
             viewModel.analyticsSource = source
@@ -44,6 +46,12 @@ class BookmarkEditTitleViewController: ThemedHostingController<AnyView> {
         viewModel.router = self
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        presentationController?.delegate = self
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -66,13 +74,26 @@ class BookmarkEditTitleViewController: ThemedHostingController<AnyView> {
 extension BookmarkEditTitleViewController: BookmarkEditRouter {
     func dismiss() {
         dismiss(animated: true)
-        onDismiss?(viewModel.originalTitle, true)
+        reportDismiss(title: viewModel.originalTitle, canceled: true)
     }
 
     func titleUpdated(title: String) {
         editSaved = true
         Analytics.track(.bookmarkEditFormSubmitted, properties: ["source": source.rawValue])
         dismiss(animated: true)
-        onDismiss?(title, false)
+        reportDismiss(title: title, canceled: false)
+    }
+
+    private func reportDismiss(title: String, canceled: Bool) {
+        guard !didReportDismiss else { return }
+
+        didReportDismiss = true
+        onDismiss?(title, canceled)
+    }
+}
+
+extension BookmarkEditTitleViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        viewModel.cancel()
     }
 }

--- a/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditTitleViewController.swift
@@ -3,9 +3,15 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import SwiftUI
 
+/// How an edit sheet ended, so callers can tell a submitted edit from a discarded one
+enum BookmarkEditOutcome {
+    case saved(title: String)
+    case cancelled
+}
+
 class BookmarkEditTitleViewController: ThemedHostingController<AnyView> {
     private let viewModel: any BookmarkEditing
-    let onDismiss: ((String, Bool) -> Void)?
+    let onDismiss: ((BookmarkEditOutcome) -> Void)?
     var editSaved: Bool = false
 
     private var didReportDismiss = false
@@ -20,7 +26,7 @@ class BookmarkEditTitleViewController: ThemedHostingController<AnyView> {
          bookmark: Bookmark,
          state: BookmarkEditViewModel.EditState,
          style: BookmarkEditTheme.Style = .player,
-         onDismiss: ((String, Bool) -> Void)? = nil) {
+         onDismiss: ((BookmarkEditOutcome) -> Void)? = nil) {
         let episode = manager.episode(for: bookmark)
 
         let viewModel: any BookmarkEditing
@@ -74,21 +80,21 @@ class BookmarkEditTitleViewController: ThemedHostingController<AnyView> {
 extension BookmarkEditTitleViewController: BookmarkEditRouter {
     func dismiss() {
         dismiss(animated: true)
-        reportDismiss(title: viewModel.originalTitle, canceled: true)
+        reportDismiss(.cancelled)
     }
 
     func titleUpdated(title: String) {
         editSaved = true
         Analytics.track(.bookmarkEditFormSubmitted, properties: ["source": source.rawValue])
         dismiss(animated: true)
-        reportDismiss(title: title, canceled: false)
+        reportDismiss(.saved(title: title))
     }
 
-    private func reportDismiss(title: String, canceled: Bool) {
+    private func reportDismiss(_ outcome: BookmarkEditOutcome) {
         guard !didReportDismiss else { return }
 
         didReportDismiss = true
-        onDismiss?(title, canceled)
+        onDismiss?(outcome)
     }
 }
 

--- a/podcasts/Bookmarks/Editing/BookmarkEditing.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditing.swift
@@ -5,7 +5,6 @@ import Foundation
 protocol BookmarkEditing: AnyObject {
     var router: BookmarkEditRouter? { get set }
     var analyticsSource: BookmarkAnalyticsSource { get set }
-    var originalTitle: String { get }
 
     func viewDidAppear()
     func cancel()

--- a/podcasts/Bookmarks/Editing/BookmarkEditing.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkEditing.swift
@@ -8,6 +8,7 @@ protocol BookmarkEditing: AnyObject {
     var originalTitle: String { get }
 
     func viewDidAppear()
+    func cancel()
 }
 
 extension BookmarkEditing {

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -87,8 +87,8 @@ class BookmarksPlayerTabController: PlayerItemViewController {
     }
 
     private func showBookmarkEdit(isNew: Bool, bookmark: Bookmark) {
-        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: isNew ? .adding : .updating, onDismiss: { [weak self] title, canceled in
-            self?.handleEditDismissed(bookmark: bookmark, isNew: isNew, title: title, canceled: canceled)
+        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: isNew ? .adding : .updating, onDismiss: { [weak self] outcome in
+            self?.handleEditDismissed(bookmark: bookmark, isNew: isNew, outcome: outcome)
         })
 
         controller.source = viewModel.analyticsSource
@@ -96,24 +96,25 @@ class BookmarksPlayerTabController: PlayerItemViewController {
         present(controller, animated: true)
     }
 
-    func handleEditDismissed(bookmark: Bookmark, isNew: Bool, title: String, canceled: Bool) {
+    func handleEditDismissed(bookmark: Bookmark, isNew: Bool, outcome: BookmarkEditOutcome) {
         guard isNew else { return }
 
-        if canceled {
+        switch outcome {
+        case .cancelled:
             Task {
                 let _ = await bookmarkManager.remove([bookmark])
                 viewModel.reload()
             }
-            return
-        }
-        // If the title is still the default, we'll just show a 'Bookmark Added' message instead of displaying 'Bookmark "Bookmark" Added'.
-        let message = title == L10n.bookmarkDefaultTitle ? L10n.bookmarkAdded : L10n.bookmarkAddedNotification(title)
 
-        let action = Toast.Action(title: L10n.bookmarkAddedButtonTitle) { [weak self] in
-            self?.showBookmarksTab()
-        }
+        case .saved(let title):
+            let message = title == L10n.bookmarkDefaultTitle ? L10n.bookmarkAdded : L10n.bookmarkAddedNotification(title)
 
-        Toast.show(message, actions: [action], theme: .playerTheme)
+            let action = Toast.Action(title: L10n.bookmarkAddedButtonTitle) { [weak self] in
+                self?.showBookmarksTab()
+            }
+
+            Toast.show(message, actions: [action], theme: .playerTheme)
+        }
     }
 
     private func showBookmarksTab() {

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -1011,8 +1011,8 @@ private extension MainTabBarController {
             let bookmark = bookmarkManager.bookmark(for: bookmark.uuid) ?? bookmark
             let title = bookmark.title
 
-            let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating, style: .themed, onDismiss: { [weak self] updatedTitle, _ in
-                guard title != updatedTitle else { return }
+            let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: .updating, style: .themed, onDismiss: { [weak self] outcome in
+                guard case .saved(let updatedTitle) = outcome, title != updatedTitle else { return }
 
                 self?.handleBookmarkTitleUpdated(updatedTitle: updatedTitle)
             })


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-870

The bookmark edit sheet only ran its `onDismiss` callback from the close button, so swiping the sheet away kept the new bookmark with its default title instead of discarding it. The controller is now its own `UIAdaptivePresentationControllerDelegate` and routes `presentationControllerDidDismiss` through `viewModel.cancel()`, the same path the close button uses.

The second commit replaces the `((String, Bool) -> Void)?` callback with a `BookmarkEditOutcome` enum (`.saved(title:)` / `.cancelled`).

## To test

1. Play an episode, open the player, and create a bookmark.
2. Swipe the edit sheet down.
3. The bookmark should not appear in the player's Bookmarks tab. Before this change it was kept, titled "Bookmark".
4. Repeat, tapping X instead — same result. Repeat once more, saving a title — the bookmark is kept and the toast appears.
5. Edit an existing bookmark and swipe the sheet down — its title is left untouched.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
