### PR TITLE
Show the bookmark's passage within the full transcript on the details screen

### DIFF
--- a/PocketCastsTests/Tests/Bookmarks/BookmarkTranscriptSnippetExtractorTests.swift
+++ b/PocketCastsTests/Tests/Bookmarks/BookmarkTranscriptSnippetExtractorTests.swift
@@ -40,16 +40,17 @@ final class BookmarkTranscriptSnippetExtractorTests: XCTestCase {
         XCTAssertNil(BookmarkTranscriptSnippetExtractor.extractSnippet(from: model, at: 2))
     }
 
-    func testTextSkipsSpeakerNamesAndCollapsesCueBreaks() throws {
+    func testTextSkipsSpeakerNamesAndKeepsLineBreaks() throws {
         let model = try makeModel()
         let fullRange = NSRange(location: 0, length: model.attributedText.length)
 
         let text = BookmarkTranscriptSnippetExtractor.text(in: fullRange, of: model.attributedText)
 
-        XCTAssertFalse(text.contains("Speaker 1"))
-        XCTAssertFalse(text.contains("Speaker 2"))
-        XCTAssertFalse(text.contains("\n"))
-        XCTAssertFalse(text.contains("  "))
+        XCTAssertEqual(text, """
+        that's the thing about selective admissions.
+        The difference between the kid who gets in and the kid who doesn't is often basically noise.
+        Right, and that's why some researchers have floated the lottery idea.
+        """)
     }
 
     func testSentenceRangeExpandsAnIndexToTheSentenceAroundIt() throws {
@@ -76,6 +77,20 @@ final class BookmarkTranscriptSnippetExtractorTests: XCTestCase {
         let snippet = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.extractSnippet(from: model, at: 12))
 
         let range = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.passageRange(for: snippet.text,
+                                                                                  at: snippet.range.location,
+                                                                                  in: model.attributedText))
+
+        XCTAssertEqual(BookmarkTranscriptSnippetExtractor.text(in: range, of: model.attributedText), snippet.text)
+    }
+
+    func testPassageRangeMatchesAPassageStoredWithoutItsLineBreaks() throws {
+        let model = try makeModel()
+        let snippet = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.extractSnippet(from: model, at: 12))
+
+        // Passages captured by earlier versions were flattened to a single line
+        let flattened = snippet.text.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+
+        let range = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.passageRange(for: flattened,
                                                                                   at: snippet.range.location,
                                                                                   in: model.attributedText))
 

--- a/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
+++ b/podcasts/Bookmarks/BookmarkTranscriptSnippetExtractor.swift
@@ -135,6 +135,10 @@ struct BookmarkTranscriptSnippetExtractor {
     /// - Parameter location: The passage's captured start within `attributedText`, or `nil`
     ///   for bookmarks made before the location was recorded.
     static func passageRange(for passage: String, at location: Int?, in attributedText: NSAttributedString) -> NSRange? {
+        // The transcript side of the match collapses whitespace, so the passage collapses
+        // the same way — lining up passages stored flattened by earlier versions and
+        // passages stored with their line breaks alike
+        let passage = passage.split(whereSeparator: \.isWhitespace).joined(separator: " ")
         guard !passage.isEmpty else { return nil }
 
         // Location first: is the passage still exactly where it was captured?
@@ -224,19 +228,47 @@ struct BookmarkTranscriptSnippetExtractor {
     }
 
     /// The plain text within `range`, skipping the speaker-name runs interleaved between
-    /// cues and collapsing the line breaks between them
+    /// cues while keeping the transcript's line breaks, so a stored passage reads with
+    /// the same paragraphs the transcript shows
     static func text(in range: NSRange, of attributedText: NSAttributedString) -> String {
         let clamped = NSIntersectionRange(range, NSRange(location: 0, length: attributedText.length))
         guard clamped.length > 0 else {
             return ""
         }
 
-        var parts = [String]()
         let string = attributedText.string as NSString
+        var text = ""
+        // A whitespace run collapses to a single newline when it contains one, a single
+        // space otherwise; dropped entirely at either edge
+        var pendingSeparator: String?
+
         attributedText.enumerateAttribute(.transcriptSpeaker, in: clamped, options: []) { value, subrange, _ in
-            guard value == nil else { return }
-            parts.append(string.substring(with: subrange))
+            guard value == nil else {
+                // Speaker names sit on their own line, so skipping one leaves a line break
+                if !text.isEmpty {
+                    pendingSeparator = "\n"
+                }
+                return
+            }
+
+            string.enumerateSubstrings(in: subrange, options: .byComposedCharacterSequences) { substring, _, _, _ in
+                guard let substring else { return }
+
+                if substring.allSatisfy(\.isWhitespace) {
+                    if !text.isEmpty {
+                        pendingSeparator = substring.contains(where: \.isNewline) ? "\n" : (pendingSeparator ?? " ")
+                    }
+                    return
+                }
+
+                if let separator = pendingSeparator {
+                    text.append(separator)
+                    pendingSeparator = nil
+                }
+                text.append(substring)
+            }
         }
-        return parts.joined(separator: " ").split(whereSeparator: \.isWhitespace).joined(separator: " ")
+
+        return text
     }
 }

--- a/podcasts/Bookmarks/BookmarkTranscriptTextView.swift
+++ b/podcasts/Bookmarks/BookmarkTranscriptTextView.swift
@@ -1,0 +1,86 @@
+import UIKit
+
+/// A transcript text view that reports the first layout pass it can scroll and select in,
+/// and can mark the line the bookmark sits on with a glyph in the leading gutter.
+class BookmarkTranscriptTextView: UITextView {
+    /// The gutter the text keeps on both sides, which the indicator sits inside of
+    static let gutterWidth: CGFloat = 28
+
+    var onFirstLayout: (() -> Void)?
+
+    private var bookmarkedCharacterIndex: Int?
+    private var bookmarkIndicator: UIImageView?
+
+    /// Marks the line holding `characterIndex` with a bookmark glyph in the leading gutter
+    func showBookmarkIndicator(at characterIndex: Int, color: UIColor) {
+        let configuration = UIImage.SymbolConfiguration(pointSize: BookmarkTranscriptStyle.fontSize, weight: .semibold)
+        let indicator = UIImageView(image: UIImage(systemName: "bookmark.fill", withConfiguration: configuration))
+        indicator.tintColor = color
+        indicator.sizeToFit()
+        addSubview(indicator)
+
+        bookmarkIndicator = indicator
+        bookmarkedCharacterIndex = characterIndex
+    }
+
+    /// Recolors the indicator where it stands, for theme changes
+    func setBookmarkIndicatorColor(_ color: UIColor) {
+        bookmarkIndicator?.tintColor = color
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        layoutBookmarkIndicator()
+
+        guard window != nil, bounds.width > 0, let onFirstLayout else { return }
+
+        // Cleared first: the callback lays the text out again as it scrolls
+        self.onFirstLayout = nil
+        onFirstLayout()
+    }
+
+    /// Pins the indicator to the line fragment its character is laid out on, so it stays
+    /// with its line whatever width the text wraps to
+    private func layoutBookmarkIndicator() {
+        guard let bookmarkIndicator, let bookmarkedCharacterIndex, textStorage.length > 0 else { return }
+
+        let characterIndex = min(max(bookmarkedCharacterIndex, 0), textStorage.length - 1)
+        let glyphIndex = layoutManager.glyphIndexForCharacter(at: characterIndex)
+        let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
+
+        let isRightToLeft = effectiveUserInterfaceLayoutDirection == .rightToLeft
+        let gutterCenter = Self.gutterWidth / 2
+        bookmarkIndicator.center = CGPoint(x: isRightToLeft ? bounds.width - gutterCenter : gutterCenter,
+                                           y: lineRect.midY + textContainerInset.top)
+    }
+}
+
+// MARK: - Reference time lookup
+
+extension TranscriptModel {
+    /// The character the given reference-timeline position lands on, interpolated within
+    /// its cue so a long cue that wraps over several lines still points at the right one
+    func characterIndex(at time: TimeInterval) -> Int? {
+        guard let cue = nearestCue(to: time) else { return nil }
+
+        let duration = cue.endTime - cue.startTime
+        let fraction = duration > 0 ? min(max((time - cue.startTime) / duration, 0), 1) : 0
+        let range = cue.characterRange
+        guard range.length > 0 else { return range.location }
+
+        return range.location + min(Int(fraction * Double(range.length)), range.length - 1)
+    }
+
+    /// The cue the time falls in, or the closest one when it lands in the silence between cues
+    private func nearestCue(to time: TimeInterval) -> TranscriptCue? {
+        firstCue(containing: time) ?? cues.min { $0.distance(to: time) < $1.distance(to: time) }
+    }
+}
+
+private extension TranscriptCue {
+    /// How far outside the cue's time span the given time falls; 0 within it
+    func distance(to time: TimeInterval) -> TimeInterval {
+        max(startTime - time, time - endTime, 0)
+    }
+}

--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -3,7 +3,7 @@ import PocketCastsUtils
 import SwiftUI
 
 /// A single bookmark in full: the episode it was taken from, and the transcript passage
-/// it captured.
+/// it captured, shown in place within the episode's full transcript.
 struct BookmarkDetailsView: View {
     @ObservedObject var viewModel: BookmarkDetailsViewModel
 
@@ -12,16 +12,39 @@ struct BookmarkDetailsView: View {
     @ScaledMetricWithMaxSize(relativeTo: .body, maxSize: .xxLarge) private var imageSize = 56
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
-                header
-                content
+        layout
+            .frame(maxWidth: .infinity)
+            .background(theme.primaryUi01.ignoresSafeArea())
+            .miniPlayerSafeAreaInset()
+            .task {
+                await viewModel.loadTranscript()
             }
-            .padding(16)
+    }
+
+    /// With a passage, the transcript takes the rest of the screen and scrolls by itself
+    /// under the fixed header; without one there's only the header, scrolling as a whole
+    @ViewBuilder
+    private var layout: some View {
+        if viewModel.passage != nil {
+            VStack(alignment: .leading, spacing: 24) {
+                Group {
+                    header
+                    details
+                }
+                .padding(.horizontal, 16)
+
+                transcriptSection
+            }
+            .padding(.top, 16)
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    header
+                    details
+                }
+                .padding(16)
+            }
         }
-        .frame(maxWidth: .infinity)
-        .background(theme.primaryUi01.ignoresSafeArea())
-        .miniPlayerSafeAreaInset()
     }
 
     // MARK: - Header
@@ -104,9 +127,9 @@ struct BookmarkDetailsView: View {
         .accessibilityLabel(L10n.play)
     }
 
-    // MARK: - Content
+    // MARK: - Details
 
-    private var content: some View {
+    private var details: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(created)
                 .font(style: .footnote, weight: .medium)
@@ -115,18 +138,109 @@ struct BookmarkDetailsView: View {
             Text(viewModel.bookmark.title)
                 .font(size: 22, style: .title3, weight: .bold)
                 .foregroundStyle(theme.primaryText01)
-                .padding(.bottom, 4)
-
-            viewModel.passage.map {
-                Text($0)
-                    .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
-                    .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
-                    .foregroundStyle(theme.primaryText02)
-                    .padding(.top, 4)
-            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
+
+    // MARK: - Transcript
+
+    @ViewBuilder
+    private var transcriptSection: some View {
+        Group {
+            if let snippet = viewModel.transcriptSnippet {
+                transcriptView(for: snippet)
+            } else if viewModel.isLoadingTranscript {
+                loadingPlaceholder
+            } else if let passage = viewModel.passage {
+                // No transcript to place the passage in, so it stands alone
+                ScrollView {
+                    passageText(passage)
+                        .padding(.horizontal, BookmarkTranscriptTextView.gutterWidth)
+                }
+                .scrollBounceBehavior(.basedOnSize)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.isLoadingTranscript)
+    }
+
+    private func transcriptView(for snippet: BookmarkTranscriptSnippet) -> some View {
+        BookmarkTranscriptReadView(transcript: snippet.transcript,
+                                   passageRange: snippet.range,
+                                   bookmarkCharacterIndex: bookmarkCharacterIndex(for: snippet),
+                                   passageColor: UIColor(theme.primaryText01),
+                                   surroundingColor: UIColor(theme.primaryText02),
+                                   selectionColor: UIColor(theme.primaryInteractive01))
+            .mask(edgeFade)
+            // Re-created when an edit moves the passage, so the view scrolls to it anew
+            .id(snippet.range)
+    }
+
+    /// The line the bookmark's glyph marks: where the bookmark sits on the reference
+    /// timeline when that's resolved, or the start of the passage otherwise
+    private func bookmarkCharacterIndex(for snippet: BookmarkTranscriptSnippet) -> Int {
+        viewModel.bookmark.referenceTime.flatMap { snippet.transcript.characterIndex(at: $0) } ?? snippet.range.location
+    }
+
+    /// Softens both edges so lines fade out as they scroll past, rather than being clipped
+    private var edgeFade: some View {
+        VStack(spacing: 0) {
+            LinearGradient(colors: [.clear, .black], startPoint: .top, endPoint: .bottom)
+                .frame(height: 96)
+            Color.black
+            LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
+                .frame(height: 64)
+        }
+    }
+
+    /// The passage with placeholder text standing in for the transcript around it while
+    /// the real one loads
+    private var loadingPlaceholder: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            placeholderParagraph(Self.leadingPlaceholder)
+
+            viewModel.passage.map { passageText($0) }
+
+            placeholderParagraph(Self.trailingPlaceholder)
+        }
+        .padding(.horizontal, BookmarkTranscriptTextView.gutterWidth)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .clipped()
+    }
+
+    private func placeholderParagraph(_ text: String) -> some View {
+        transcriptText(text)
+            .foregroundStyle(theme.primaryText02)
+            .redacted(reason: .placeholder)
+            .accessibilityHidden(true)
+    }
+
+    private func passageText(_ text: String) -> some View {
+        transcriptText(text)
+            .foregroundStyle(theme.primaryText01)
+    }
+
+    private func transcriptText(_ text: String) -> some View {
+        Text(text)
+            .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
+            .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Stand-ins for the transcript around the passage while it loads. The redaction
+    /// blocks them out, so they're never read; they only give the placeholders the
+    /// shape of prose.
+    private static let leadingPlaceholder = """
+    The lines of the transcript leading into the bookmarked passage land here once the \
+    episode transcript has been fetched, filling out a few lines above it.
+    """
+
+    private static let trailingPlaceholder = """
+    The rest of the transcript follows the passage the moment it arrives, running on \
+    long enough to fill the space below with the shape of the conversation as it \
+    continues past the bookmarked moment, line after line, until the fetched text \
+    takes its place.
+    """
 
     private var timestamp: String {
         TimeFormatter.shared.playTimeFormat(time: viewModel.bookmark.time)
@@ -134,6 +248,95 @@ struct BookmarkDetailsView: View {
 
     private var created: String {
         DateFormatter.localizedString(from: viewModel.bookmark.created, dateStyle: .medium, timeStyle: .short)
+    }
+}
+
+// MARK: - BookmarkTranscriptReadView
+
+/// The full transcript as selectable read-only text, scrolled so the bookmarked passage
+/// starts in view. The passage reads in the primary color with the transcript around it
+/// receding into the secondary one, and a glyph in the leading gutter marks the line
+/// the bookmark sits on.
+private struct BookmarkTranscriptReadView: UIViewRepresentable {
+    let transcript: TranscriptModel
+    let passageRange: NSRange
+    let bookmarkCharacterIndex: Int
+    let passageColor: UIColor
+    let surroundingColor: UIColor
+    let selectionColor: UIColor
+
+    /// Where the passage sits vertically once scrolled to
+    private let verticalAnchor: CGFloat = 0.4
+
+    func makeUIView(context: Context) -> BookmarkTranscriptTextView {
+        // TextKit 1: `scrollToRange` and the indicator's line lookup work off `layoutManager`
+        let textView = BookmarkTranscriptTextView(usingTextLayoutManager: false)
+        textView.attributedText = styledText()
+        textView.isEditable = false
+        // Selectable so a quote can be copied out of the transcript
+        textView.isSelectable = true
+        textView.backgroundColor = .clear
+        // The gutter on both sides is the text view's own inset rather than outside
+        // padding, so the bookmark indicator can sit in the leading one, beside the text
+        textView.textContainerInset = UIEdgeInsets(top: 0,
+                                                   left: BookmarkTranscriptTextView.gutterWidth,
+                                                   bottom: 0,
+                                                   right: BookmarkTranscriptTextView.gutterWidth)
+        textView.textContainer.lineFragmentPadding = 0
+        textView.tintColor = selectionColor
+        textView.contentInsetAdjustmentBehavior = .always
+        textView.showBookmarkIndicator(at: bookmarkCharacterIndex, color: passageColor)
+
+        // The passage can only be scrolled to once the text has a width to be laid out in
+        textView.alpha = 0
+        textView.onFirstLayout = { [weak textView] in
+            guard let textView else { return }
+
+            UIView.performWithoutAnimation {
+                textView.scrollToRange(passageRange, verticalAnchor: verticalAnchor, animated: false)
+                textView.alpha = 1
+            }
+        }
+
+        context.coordinator.colors = [passageColor, surroundingColor]
+        return textView
+    }
+
+    func updateUIView(_ textView: BookmarkTranscriptTextView, context: Context) {
+        guard context.coordinator.colors != [passageColor, surroundingColor] else { return }
+
+        // Recolored in place: only the colors changed, and the text keeps its layout
+        context.coordinator.colors = [passageColor, surroundingColor]
+        applyColors(to: textView.textStorage)
+        textView.setBookmarkIndicatorColor(passageColor)
+        textView.tintColor = selectionColor
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    class Coordinator {
+        var colors: [UIColor]?
+    }
+
+    private func styledText() -> NSAttributedString {
+        let text = NSMutableAttributedString(attributedString: BookmarkTranscriptStyle.styledTranscript(transcript.attributedText,
+                                                                                                        textColor: surroundingColor))
+        applyPassageColor(to: text)
+        return text
+    }
+
+    private func applyColors(to text: NSMutableAttributedString) {
+        text.addAttribute(.foregroundColor, value: surroundingColor, range: NSRange(location: 0, length: text.length))
+        applyPassageColor(to: text)
+    }
+
+    private func applyPassageColor(to text: NSMutableAttributedString) {
+        let clamped = NSIntersectionRange(passageRange, NSRange(location: 0, length: text.length))
+        guard clamped.length > 0 else { return }
+
+        text.addAttribute(.foregroundColor, value: passageColor, range: clamped)
     }
 }
 
@@ -148,9 +351,23 @@ struct BookmarkDetailsView_Previews: PreviewProvider {
                                                  passage: previewPassage,
                                                  episode: previewEpisode,
                                                  podcastTitle: "Radio Atlantic",
+                                                 transcriptSnippet: previewSnippet,
                                                  bookmarkManager: .init()))
         }
         .setupDefaultEnvironment()
+        .previewDisplayName("Transcript loaded")
+
+        NavigationStack {
+            BookmarkDetailsView(viewModel: .init(bookmark: Self.previewBookmark(title: "Why admissions feel like a lottery",
+                                                                                time: 1390,
+                                                                                created: .now),
+                                                 passage: previewPassage,
+                                                 episode: previewEpisode,
+                                                 podcastTitle: "Radio Atlantic",
+                                                 bookmarkManager: .init()))
+        }
+        .setupDefaultEnvironment()
+        .previewDisplayName("Loading")
     }
 
     private static var previewEpisode: Episode {
@@ -160,10 +377,34 @@ struct BookmarkDetailsView_Previews: PreviewProvider {
     }
 
     private static let previewPassage = """
-    that's the thing about selective admissions — the difference between the kid who gets in \
-    and the kid who doesn't is often basically noise. Right, and that's why some researchers \
-    have floated the lottery idea. You set a bar for who's qualified, and past that, you just \
-    draw names. It sounds radical, but it's arguably more honest than pretending there's a \
-    meaningful distinction between applicant 1,800 and applicant 2,100.
+    It sounds radical, but it's arguably more honest than pretending there's a meaningful \
+    distinction between applicant 1,800 and applicant 2,100.
     """
+
+    private static var previewSnippet: BookmarkTranscriptSnippet? {
+        let transcript = previewTranscript
+        guard let range = BookmarkTranscriptSnippetExtractor.passageRange(for: previewPassage, at: nil, in: transcript.attributedText) else {
+            return nil
+        }
+
+        return BookmarkTranscriptSnippet(transcript: transcript, range: range)
+    }
+
+    private static var previewTranscript: TranscriptModel {
+        TranscriptModel.makeModel(from: """
+        WEBVTT
+
+        00:22:40.000 --> 00:22:50.000
+        that's the thing about selective admissions — the difference between the kid who gets in and the kid who doesn't is often basically noise.
+
+        00:22:50.000 --> 00:23:00.000
+        Right, and that's why some researchers have floated the lottery idea. You set a bar for who's qualified, and past that, you just draw names.
+
+        00:23:00.000 --> 00:23:10.000
+        It sounds radical, but it's arguably more honest than pretending there's a meaningful distinction between applicant 1,800 and applicant 2,100.
+
+        00:23:10.000 --> 00:23:25.000
+        And meanwhile the debt side of this is its own crisis. Families are taking on six figures for a credential that for most of the last century, was basically a guaranteed ticket to the middle class. And that promise is getting shakier.
+        """, format: .vtt) ?? TranscriptModel(attributedText: NSAttributedString(string: ""), cues: [], type: "", hasJavascript: false)
+    }
 }

--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -154,8 +154,7 @@ struct BookmarkDetailsView: View {
             } else if let passage = viewModel.passage {
                 // No transcript to place the passage in, so it stands alone
                 ScrollView {
-                    passageText(passage)
-                        .padding(.horizontal, BookmarkTranscriptTextView.gutterWidth)
+                    passageView(passage)
                 }
                 .scrollBounceBehavior(.basedOnSize)
             }
@@ -199,32 +198,33 @@ struct BookmarkDetailsView: View {
         VStack(alignment: .leading, spacing: 20) {
             placeholderParagraph(Self.leadingPlaceholder)
 
-            viewModel.passage.map { passageText($0) }
+            // The glyph waits for the real transcript, where it can mark the right line
+            viewModel.passage.map { passageView($0, showsBookmarkIndicator: false) }
 
             placeholderParagraph(Self.trailingPlaceholder)
         }
-        .padding(.horizontal, BookmarkTranscriptTextView.gutterWidth)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .clipped()
     }
 
     private func placeholderParagraph(_ text: String) -> some View {
-        transcriptText(text)
-            .foregroundStyle(theme.primaryText02)
-            .redacted(reason: .placeholder)
-            .accessibilityHidden(true)
-    }
-
-    private func passageText(_ text: String) -> some View {
-        transcriptText(text)
-            .foregroundStyle(theme.primaryText01)
-    }
-
-    private func transcriptText(_ text: String) -> some View {
         Text(text)
             .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
             .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
             .frame(maxWidth: .infinity, alignment: .leading)
+            .foregroundStyle(theme.primaryText02)
+            .redacted(reason: .placeholder)
+            .padding(.horizontal, BookmarkTranscriptTextView.gutterWidth)
+            .accessibilityHidden(true)
+    }
+
+    /// The passage on its own, in the same text view the full transcript uses, so it
+    /// reads identically before and after the transcript arrives
+    private func passageView(_ passage: String, showsBookmarkIndicator: Bool = true) -> some View {
+        BookmarkPassageTextView(passage: passage,
+                                showsBookmarkIndicator: showsBookmarkIndicator,
+                                textColor: UIColor(theme.primaryText01),
+                                selectionColor: UIColor(theme.primaryInteractive01))
     }
 
     /// Stand-ins for the transcript around the passage while it loads. The redaction
@@ -248,6 +248,61 @@ struct BookmarkDetailsView: View {
 
     private var created: String {
         DateFormatter.localizedString(from: viewModel.bookmark.created, dateStyle: .medium, timeStyle: .short)
+    }
+}
+
+// MARK: - BookmarkPassageTextView
+
+/// The passage alone — while the transcript loads, or when there is none — rendered by
+/// the same text view the full transcript uses: the same styling and gutter, optionally
+/// the glyph marking its first line, and the text already selectable. Sized to its
+/// content, so it sits in the surrounding layout rather than scrolling.
+private struct BookmarkPassageTextView: UIViewRepresentable {
+    let passage: String
+    let showsBookmarkIndicator: Bool
+    let textColor: UIColor
+    let selectionColor: UIColor
+
+    func makeUIView(context: Context) -> BookmarkTranscriptTextView {
+        // TextKit 1: the indicator's line lookup works off `layoutManager`
+        let textView = BookmarkTranscriptTextView(usingTextLayoutManager: false)
+        textView.attributedText = styledText()
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isScrollEnabled = false
+        textView.backgroundColor = .clear
+        textView.textContainerInset = UIEdgeInsets(top: 0,
+                                                   left: BookmarkTranscriptTextView.gutterWidth,
+                                                   bottom: 0,
+                                                   right: BookmarkTranscriptTextView.gutterWidth)
+        textView.textContainer.lineFragmentPadding = 0
+        textView.tintColor = selectionColor
+        if showsBookmarkIndicator {
+            textView.showBookmarkIndicator(at: 0, color: textColor)
+        }
+        return textView
+    }
+
+    func updateUIView(_ textView: BookmarkTranscriptTextView, context: Context) {
+        let styled = styledText()
+        if !textView.attributedText.isEqual(styled) {
+            textView.attributedText = styled
+        }
+
+        textView.tintColor = selectionColor
+        textView.setBookmarkIndicatorColor(textColor)
+    }
+
+    /// Asks the text view how tall the passage runs at the width it's offered
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView textView: BookmarkTranscriptTextView, context: Context) -> CGSize? {
+        guard let width = proposal.width, width.isFinite else { return nil }
+
+        let size = textView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+        return CGSize(width: width, height: size.height)
+    }
+
+    private func styledText() -> NSAttributedString {
+        BookmarkTranscriptStyle.styledTranscript(NSAttributedString(string: passage), textColor: textColor)
     }
 }
 

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
@@ -17,6 +17,15 @@ class BookmarkDetailsViewModel: ObservableObject {
 
     @Published private(set) var isLoadingPodcastTitle = false
 
+    /// The full episode transcript with the passage located in it, so the passage can be
+    /// shown in place. Fetched by `loadTranscript`; nil while loading or when the
+    /// transcript isn't available, leaving the passage to stand alone.
+    @Published private(set) var transcriptSnippet: BookmarkTranscriptSnippet?
+
+    /// Whether the transcript is still being fetched, so placeholders can stand in for
+    /// the text around the passage until it arrives
+    @Published private(set) var isLoadingTranscript = false
+
     let episode: BaseEpisode?
 
     /// Assigned by the hosting controller, which owns playback
@@ -28,11 +37,13 @@ class BookmarkDetailsViewModel: ObservableObject {
          passage: String?,
          episode: BaseEpisode?,
          podcastTitle: String?,
+         transcriptSnippet: BookmarkTranscriptSnippet? = nil,
          bookmarkManager: BookmarkManager = PlaybackManager.shared.bookmarkManager) {
         self.bookmark = bookmark
         self.passage = passage
         self.episode = episode
         self.podcastTitle = podcastTitle
+        self.transcriptSnippet = transcriptSnippet
         self.bookmarkManager = bookmarkManager
     }
 
@@ -50,11 +61,32 @@ class BookmarkDetailsViewModel: ObservableObject {
         }
     }
 
+    /// Fetches the episode transcript and locates the passage in it
+    func loadTranscript() async {
+        guard transcriptSnippet == nil, !isLoadingTranscript,
+              passage?.isEmpty == false, let episode else { return }
+
+        isLoadingTranscript = true
+        transcriptSnippet = await bookmarkManager.capturedSnippet(for: bookmark, episode: episode)
+        isLoadingTranscript = false
+    }
+
     func refresh() {
         guard let bookmark = bookmarkManager.bookmark(for: bookmark.uuid) else { return }
 
         self.bookmark = bookmark
         self.passage = bookmark.passage
+        relocatePassage()
+    }
+
+    /// Points the already-loaded transcript at the passage as it stands after an edit
+    private func relocatePassage() {
+        guard let transcript = transcriptSnippet?.transcript else { return }
+
+        transcriptSnippet = passage.flatMap { passage in
+            BookmarkTranscriptSnippetExtractor.passageRange(for: passage, at: bookmark.passageLocation, in: transcript.attributedText)
+                .map { BookmarkTranscriptSnippet(transcript: transcript, range: $0) }
+        }
     }
 
     private func loadPodcastTitle() {

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
@@ -81,18 +81,18 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
     /// Where the passage sits vertically once scrolled to
     private let verticalAnchor: CGFloat = 0.5
 
-    func makeUIView(context: Context) -> SelectableTextView {
+    func makeUIView(context: Context) -> BookmarkTranscriptTextView {
         // TextKit 1: `scrollToRange` and the character index lookups work off `layoutManager`
-        let textView = SelectableTextView(usingTextLayoutManager: false)
-        textView.attributedText = styledText()
+        let textView = BookmarkTranscriptTextView(usingTextLayoutManager: false)
+        textView.attributedText = BookmarkTranscriptStyle.styledTranscript(transcript.attributedText, textColor: textColor)
         textView.isEditable = false
         textView.backgroundColor = .clear
         // The gutter on both sides is the text view's own inset rather than outside
         // padding, so the bookmark indicator can sit in the leading one, beside the text
         textView.textContainerInset = UIEdgeInsets(top: 0,
-                                                   left: SelectableTextView.gutterWidth,
+                                                   left: BookmarkTranscriptTextView.gutterWidth,
                                                    bottom: 0,
-                                                   right: SelectableTextView.gutterWidth)
+                                                   right: BookmarkTranscriptTextView.gutterWidth)
         textView.textContainer.lineFragmentPadding = 0
         textView.tintColor = selectionColor
         // Leaves room to scroll the text clear of the home indicator it runs under
@@ -123,7 +123,7 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
         return textView
     }
 
-    func updateUIView(_ textView: SelectableTextView, context: Context) {
+    func updateUIView(_ textView: BookmarkTranscriptTextView, context: Context) {
         guard textView.selectedRange != selection else { return }
 
         textView.selectedRange = selection
@@ -131,83 +131,6 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
 
     func makeCoordinator() -> Coordinator {
         Coordinator(selection: $selection)
-    }
-
-    private func styledText() -> NSAttributedString {
-        let text = NSMutableAttributedString(attributedString: transcript.attributedText)
-        let fullRange = NSRange(location: 0, length: text.length)
-
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.minimumLineHeight = BookmarkTranscriptStyle.lineHeight
-        paragraphStyle.maximumLineHeight = BookmarkTranscriptStyle.lineHeight
-        paragraphStyle.paragraphSpacing = 10
-        paragraphStyle.lineBreakMode = .byWordWrapping
-        paragraphStyle.alignment = .natural
-
-        text.addAttributes([.paragraphStyle: paragraphStyle,
-                            .font: BookmarkTranscriptStyle.font,
-                            .baselineOffset: BookmarkTranscriptStyle.baselineOffset,
-                            .foregroundColor: textColor],
-                           range: fullRange)
-
-        text.enumerateAttribute(.transcriptSpeaker, in: fullRange, options: [.longestEffectiveRangeNotRequired]) { value, range, _ in
-            guard value != nil else { return }
-
-            text.addAttribute(.font, value: BookmarkTranscriptStyle.speakerFont, range: range)
-        }
-
-        return text
-    }
-
-    /// A text view that reports the first layout pass it can scroll and select in, and can
-    /// mark the line the bookmark sits on with a glyph in the leading gutter
-    class SelectableTextView: UITextView {
-        /// The gutter the text keeps on both sides, which the indicator sits inside of
-        static let gutterWidth: CGFloat = 28
-
-        var onFirstLayout: (() -> Void)?
-
-        private var bookmarkedCharacterIndex: Int?
-        private var bookmarkIndicator: UIImageView?
-
-        /// Marks the line holding `characterIndex` with a bookmark glyph in the leading gutter
-        func showBookmarkIndicator(at characterIndex: Int, color: UIColor) {
-            let configuration = UIImage.SymbolConfiguration(pointSize: BookmarkTranscriptStyle.fontSize, weight: .semibold)
-            let indicator = UIImageView(image: UIImage(systemName: "bookmark.fill", withConfiguration: configuration))
-            indicator.tintColor = color
-            indicator.sizeToFit()
-            addSubview(indicator)
-
-            bookmarkIndicator = indicator
-            bookmarkedCharacterIndex = characterIndex
-        }
-
-        override func layoutSubviews() {
-            super.layoutSubviews()
-
-            layoutBookmarkIndicator()
-
-            guard window != nil, bounds.width > 0, let onFirstLayout else { return }
-
-            // Cleared first: the callback lays the text out again as it scrolls
-            self.onFirstLayout = nil
-            onFirstLayout()
-        }
-
-        /// Pins the indicator to the line fragment its character is laid out on, so it stays
-        /// with its line whatever width the text wraps to
-        private func layoutBookmarkIndicator() {
-            guard let bookmarkIndicator, let bookmarkedCharacterIndex, textStorage.length > 0 else { return }
-
-            let characterIndex = min(max(bookmarkedCharacterIndex, 0), textStorage.length - 1)
-            let glyphIndex = layoutManager.glyphIndexForCharacter(at: characterIndex)
-            let lineRect = layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
-
-            let isRightToLeft = effectiveUserInterfaceLayoutDirection == .rightToLeft
-            let gutterCenter = Self.gutterWidth / 2
-            bookmarkIndicator.center = CGPoint(x: isRightToLeft ? bounds.width - gutterCenter : gutterCenter,
-                                               y: lineRect.midY + textContainerInset.top)
-        }
     }
 
     class Coordinator: NSObject, UITextViewDelegate {
@@ -237,35 +160,6 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
         func textView(_ textView: UITextView, editMenuForTextIn range: NSRange, suggestedActions: [UIMenuElement]) -> UIMenu? {
             nil
         }
-    }
-}
-
-// MARK: - Reference time lookup
-
-private extension TranscriptModel {
-    /// The character the given reference-timeline position lands on, interpolated within
-    /// its cue so a long cue that wraps over several lines still points at the right one
-    func characterIndex(at time: TimeInterval) -> Int? {
-        guard let cue = nearestCue(to: time) else { return nil }
-
-        let duration = cue.endTime - cue.startTime
-        let fraction = duration > 0 ? min(max((time - cue.startTime) / duration, 0), 1) : 0
-        let range = cue.characterRange
-        guard range.length > 0 else { return range.location }
-
-        return range.location + min(Int(fraction * Double(range.length)), range.length - 1)
-    }
-
-    /// The cue the time falls in, or the closest one when it lands in the silence between cues
-    private func nearestCue(to time: TimeInterval) -> TranscriptCue? {
-        firstCue(containing: time) ?? cues.min { $0.distance(to: time) < $1.distance(to: time) }
-    }
-}
-
-private extension TranscriptCue {
-    /// How far outside the cue's time span the given time falls; 0 within it
-    func distance(to time: TimeInterval) -> TimeInterval {
-        max(startTime - time, time - endTime, 0)
     }
 }
 

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptStyle.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptStyle.swift
@@ -41,4 +41,32 @@ enum BookmarkTranscriptStyle {
     static var baselineOffset: CGFloat {
         lineSpacing / 2
     }
+
+    /// The transcript's text restyled for reading in a text view: the serif body font on
+    /// the style's line height, with the speaker names set smaller
+    static func styledTranscript(_ attributedText: NSAttributedString, textColor: UIColor) -> NSAttributedString {
+        let text = NSMutableAttributedString(attributedString: attributedText)
+        let fullRange = NSRange(location: 0, length: text.length)
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.minimumLineHeight = lineHeight
+        paragraphStyle.maximumLineHeight = lineHeight
+        paragraphStyle.paragraphSpacing = 10
+        paragraphStyle.lineBreakMode = .byWordWrapping
+        paragraphStyle.alignment = .natural
+
+        text.addAttributes([.paragraphStyle: paragraphStyle,
+                            .font: font,
+                            .baselineOffset: baselineOffset,
+                            .foregroundColor: textColor],
+                           range: fullRange)
+
+        text.enumerateAttribute(.transcriptSpeaker, in: fullRange, options: [.longestEffectiveRangeNotRequired]) { value, range, _ in
+            guard value != nil else { return }
+
+            text.addAttribute(.font, value: speakerFont, range: range)
+        }
+
+        return text
+    }
 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-881

The bookmark details screen now shows the captured passage in place within the full episode transcript: the transcript loads on open and scrolls to the passage, which is highlighted in the primary text color with a bookmark glyph marking its line. Redacted placeholders stand in while it loads, and the passage is shown alone if no transcript is available. The transcript rendering was extracted from `BookmarkTranscriptEditView` into shared code, with no behavior change on the edit screen.

## To test

1. Enable the Smart Bookmarks feature flag and play an episode that has a generated transcript.
2. Create a bookmark, then open it from the bookmarks list (Profile → Bookmarks or the player's Bookmarks tab).
3. Check the transcript area briefly shows redacted placeholder text around the passage, then fills in with the full transcript scrolled to the passage.
4. Check the passage is in the primary text color, the surrounding transcript is dimmed, and a bookmark glyph marks the bookmarked line.
5. Scroll the transcript and long-press to select and copy some text.
6. Edit the bookmark and pick a different passage; after saving, check the details screen highlights the new passage.
7. Open a bookmark on an episode without a transcript (or with the flag off) and check the passage alone is shown.


https://github.com/user-attachments/assets/731a10dd-690a-4225-ae7f-3e8aa4d549a4




## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
