### PR TITLE
Stop posting a top-level Claude review comment on every push

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -58,6 +58,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
+          # Update the previous review comment on each new push instead of posting a new one.
+          use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -57,8 +57,6 @@ jobs:
         uses: anthropics/claude-code-action@b76a0776ae74036e77cd11018083743453d7ad35 # v1.0.179
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          track_progress: true
-          # Update the previous review comment on each new push instead of posting a new one.
           use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
Enable `use_sticky_comment` so Claude updates the existing review comment instead of posting new ones.

## To test

1. Open a PR (or use an existing one) and wait for the Claude review to run.
2. Verify no top-level Claude comment is posted — only inline comments on specific issues.
3. Push another commit and verify the re-review again adds no top-level comment.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XiExGc7WwWyLVCkBAJNkMK