### PR TITLE
Rename SECRETS_PATH to CREDENTIALS_JSON_PATH

### DIFF
--- a/config/PocketCasts.base.xcconfig
+++ b/config/PocketCasts.base.xcconfig
@@ -14,5 +14,5 @@ DEVELOPMENT_TEAM = PZYM8XX95Q // Automattic, Inc. (Company)
 
 SECRETS_DIR = $(HOME)/.configure/pocketcasts-ios/secrets
 FIREBASE_SECRETS_PATH = $(SECRETS_DIR)/GoogleService-Info.plist
-SECRETS_PATH = $(SECRETS_DIR)/pocket_casts_credentials.json
+CREDENTIALS_JSON_PATH = $(SECRETS_DIR)/pocket_casts_credentials.json
 GOOGLE_SIGN_IN_SECRETS_PATH = $(SECRETS_DIR)/GoogleSignIn.txt

--- a/scripts/build-phases/generate-credentials.sh
+++ b/scripts/build-phases/generate-credentials.sh
@@ -24,11 +24,11 @@ fi
 
 ## Validate Secrets!
 ##
-if [ ! -f $SECRETS_PATH ]; then
-    echo "error: $SECRETS_PATH not found! Please run \`bundle exec fastlane run configure_apply\`."
+if [ ! -f $CREDENTIALS_JSON_PATH ]; then
+    echo "error: $CREDENTIALS_JSON_PATH not found! Please run \`bundle exec fastlane run configure_apply\`."
     exit 1
 else
-    echo ">> Loading Secrets from ${SECRETS_PATH}"
+    echo ">> Loading Secrets from ${CREDENTIALS_JSON_PATH}"
 
     ## Generate the Derived Sources folder, if needed
     ##
@@ -37,7 +37,7 @@ else
     ## Generate ApiCredentials.swift
     ##
     echo ">> Generating Credentials ${CREDS_OUTPUT_PATH}"
-    ruby ${SCRIPT_PATH} -i ${CREDS_INPUT_PATH} -s ${SECRETS_PATH} > "${CREDS_OUTPUT_PATH}"
+    ruby ${SCRIPT_PATH} -i ${CREDS_INPUT_PATH} -s ${CREDENTIALS_JSON_PATH} > "${CREDS_OUTPUT_PATH}"
 
     ## Copy private GoogleService-Info.plist
     ##


### PR DESCRIPTION
Follow-up to [a review comment on #4858](https://github.com/Automattic/pocket-casts-ios/pull/4858#discussion_r3682987398).

`SECRETS_PATH` reads as "the path to the secrets folder" — which is what `SECRETS_DIR` is — or as the path to any one of the secret files (`GoogleService-Info.plist`, `GoogleSignIn.txt`, ...).
It points at `pocket_casts_credentials.json` specifically, so it's now named after that.

No `PC_` prefix: the build settings here are Pocket Casts-only, so it would be redundant.

## To test

The variable is only read by the `generate-credentials.sh` build phase, so a build exercises it:

```sh
make build_staging
```

Watch for `>> Loading Secrets from …/pocket_casts_credentials.json` in the build log — an empty path there means the setting didn't propagate.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
