### PR TITLE
[tvOS] Show correct number of playlist items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Fix an issue where the now playing episode was not being auto-downloaded when setting was active for UpNext [#4792](https://github.com/Automattic/pocket-casts-ios/pull/4792)
 - Fix the Playlists tab showing a blank screen instead of the empty state when there are no playlists [#4794](https://github.com/Automattic/pocket-casts-ios/pull/4794)
 - [tvOS] Improve thumbnail algorithm for videos [#4861](https://github.com/Automattic/pocket-casts-ios/pull/4861)
-- [tvOS] Show correct number of playlist items [#4869](https://github.com/Automattic/pocket-casts-ios/pull/4869)
+- [tvOS] Show correct number of playlist items, and update playlists episode status on changes [#4869](https://github.com/Automattic/pocket-casts-ios/pull/4869)
 
 8.16.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix an issue where the now playing episode was not being auto-downloaded when setting was active for UpNext [#4792](https://github.com/Automattic/pocket-casts-ios/pull/4792)
 - Fix the Playlists tab showing a blank screen instead of the empty state when there are no playlists [#4794](https://github.com/Automattic/pocket-casts-ios/pull/4794)
 - [tvOS] Improve thumbnail algorithm for videos [#4861](https://github.com/Automattic/pocket-casts-ios/pull/4861)
+- [tvOS] Show correct number of playlist items [#4869](https://github.com/Automattic/pocket-casts-ios/pull/4869)
 
 8.16.1
 ------

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -377,7 +377,9 @@ extension SyncTask {
         let didAdd = DataManager.sharedManager.add(episodes: addedEpisodes, to: playlist)
         if !didAdd {
             let playlistCount = DataManager.sharedManager.allPlaylistEpisodeCount(for: playlist, episodeUuidToAdd: nil, includingArchivedEpisodes: true)
-            FileLog.shared.addMessage("SyncTask: Tried to add too many episodes to imported playlist \(playlist.playlistName) episodeCount: \(addedEpisodes) playlistCount: \(playlistCount)")
+            if !addedEpisodes.isEmpty {
+                FileLog.shared.addMessage("SyncTask: Tried to add too many episodes to imported playlist \(playlist.playlistName) episodeCount: \(addedEpisodes) playlistCount: \(playlistCount)")
+            }
         }
 
         updateEpisodePositionsIfNeeded(for: playlistItem, playlist: playlist)

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -40,6 +40,7 @@ struct HomeView: View {
         .task {
             Analytics.track(.homeShown)
             model.load()
+            model.refresh()
         }
     }
 

--- a/Pocket Casts TV App/UI/Home/HomeViewModel.swift
+++ b/Pocket Casts TV App/UI/Home/HomeViewModel.swift
@@ -54,6 +54,10 @@ class HomeViewModel {
         }
     }
 
+    func refresh() {
+        RefreshManager.shared.refreshPodcasts()        
+    }
+
     private func fetchPodcasts() -> [Podcast] {
         return Array(dataManager.allPodcasts(includeUnsubscribed: false, reloadFromDatabase: false).prefix(20))
     }

--- a/Pocket Casts TV App/UI/Home/HomeViewModel.swift
+++ b/Pocket Casts TV App/UI/Home/HomeViewModel.swift
@@ -55,7 +55,7 @@ class HomeViewModel {
     }
 
     func refresh() {
-        RefreshManager.shared.refreshPodcasts()        
+        RefreshManager.shared.refreshPodcasts()
     }
 
     private func fetchPodcasts() -> [Podcast] {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailView.swift
@@ -220,11 +220,13 @@ struct PlaylistDetailView: View {
                     .listRowInsets(Layout.rowInsets)
                 }
             } header: {
-                HStack {
-                    Spacer()
-                    archivedFilterMenu
+                if model.isManual {
+                    HStack {
+                        Spacer()
+                        archivedFilterMenu
+                    }
+                    .padding(.bottom, 32)
                 }
-                .padding(.bottom, 32)
             }
         }
         .onChange(of: rowFocus) { _, new in

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -69,7 +69,6 @@ class PlaylistDetailsViewModel {
             let query = PlaylistQueryBuilder.query(
                 clause: .episode,
                 for: playlist.playlist,
-                limit: Self.playlistEpisodeLimit,
                 shouldShowArchived: true
             )
             let playlistEpisodes = dataManager.findPlaylistEpisodesWhere(query: query, arguments: nil)
@@ -81,9 +80,6 @@ class PlaylistDetailsViewModel {
             }
         }
     }
-
-    /// Mirrors `EpisodeDataManager.Constants.Limits.maxPlaylistItems`, which is private to the data module.
-    private static let playlistEpisodeLimit = 1000
 
     func setShowArchived(_ value: Bool) {
         guard value != showArchived else { return }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -23,6 +23,7 @@ class PlaylistDetailsViewModel {
     var episodes: [Episode] = []
     var showArchived: Bool = false
     var playlistColor: Color
+    var episodesCount: Int = 0
 
     var hasDownloadFilter: Bool { playlist.playlist.isDownloadFilterActive }
 
@@ -73,8 +74,10 @@ class PlaylistDetailsViewModel {
                 shouldShowArchived: true
             )
             let playlistEpisodes = dataManager.findPlaylistEpisodesWhere(query: query, arguments: nil)
+            let count = dataManager.allPlaylistEpisodeCount(for: playlist.playlist, episodeUuidToAdd: nil, includingArchivedEpisodes: true)
             await MainActor.run {
                 allEpisodes = playlistEpisodes
+                episodesCount = count
                 applyArchivedFilter()
                 refreshPlaylistColor()
                 state = playlistEpisodes.isEmpty ? .empty : .ready
@@ -165,11 +168,11 @@ class PlaylistDetailsViewModel {
     }
 
     var episodeCountText: String {
-        return L10n.tvPlaylistDetailEpisodeCount(allEpisodes.count)
+        return episodesCount == 1 ? L10n.podcastEpisodeCountSingular : L10n.podcastEpisodeCountPluralFormat(episodesCount.localized())
     }
 
     var allEpisodesCount: Int {
-        return allEpisodes.count
+        return episodesCount
     }
 
     var areAllEpisodesArchived: Bool {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -161,7 +161,7 @@ class PlaylistDetailsViewModel {
     }
 
     var episodeCountText: String {
-        return L10n.tvPlaylistDetailEpisodeCount(episodes.count)
+        return L10n.tvPlaylistDetailEpisodeCount(allEpisodes.count)
     }
 
     var allEpisodesCount: Int {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -69,6 +69,7 @@ class PlaylistDetailsViewModel {
             let query = PlaylistQueryBuilder.query(
                 clause: .episode,
                 for: playlist.playlist,
+                limit: Self.playlistEpisodeLimit,
                 shouldShowArchived: true
             )
             let playlistEpisodes = dataManager.findPlaylistEpisodesWhere(query: query, arguments: nil)
@@ -80,6 +81,9 @@ class PlaylistDetailsViewModel {
             }
         }
     }
+
+    /// Mirrors `EpisodeDataManager.Constants.Limits.maxPlaylistItems`, which is private to the data module.
+    private static let playlistEpisodeLimit = 1000
 
     func setShowArchived(_ value: Bool) {
         guard value != showArchived else { return }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -36,6 +36,7 @@ class PlaylistDetailsViewModel {
     }
 
     init(playlist: PlaylistItem,
+         detail: Bool = false,
          dataManager: DataManager = DataManager.sharedManager,
          playbackManager: PlaybackManager = PlaybackManager.shared) {
         self.playlist = playlist
@@ -44,6 +45,9 @@ class PlaylistDetailsViewModel {
         self.showArchived = UserDefaults.standard.bool(forKey: Self.archiveStorageKey(for: playlist.playlist))
         self.playlistColor = Self.fallbackPillColor(for: playlist.playlist.uuid)
         observePodcastColorDownloads()
+        if detail {
+            observePlaylistChanges()
+        }
     }
 
     /// Newly-subscribed podcasts return defaults until colour metadata downloads — refresh
@@ -61,6 +65,19 @@ class PlaylistDetailsViewModel {
                 self.refreshPlaylistColor()
             }
             .store(in: &cancellables)
+    }
+
+    private func observePlaylistChanges() {
+        Publishers.Merge3(
+            NotificationCenter.default.publisher(for: Constants.Notifications.playlistChanged),
+            NotificationCenter.default.publisher(for: Constants.Notifications.episodeArchiveStatusChanged),
+            NotificationCenter.default.publisher(for: Constants.Notifications.episodePlayStatusChanged),
+        )
+        .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
+        .sink { [weak self] notification in            
+            self?.load()
+        }
+        .store(in: &cancellables)
     }
 
     func load() {

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -74,7 +74,7 @@ class PlaylistDetailsViewModel {
             NotificationCenter.default.publisher(for: Constants.Notifications.episodePlayStatusChanged),
         )
         .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
-        .sink { [weak self] notification in            
+        .sink { [weak self] _ in
             self?.load()
         }
         .store(in: &cancellables)

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsView.swift
@@ -95,7 +95,7 @@ struct PlaylistsView: View {
         })
         .focusScope(listNamespace)
         .navigationDestination(for: PlaylistItem.self) { playlist in
-            PlaylistDetailView(model: PlaylistDetailsViewModel(playlist: playlist))
+            PlaylistDetailView(model: PlaylistDetailsViewModel(playlist: playlist, detail: true))
         }
     }
 }

--- a/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistsViewModel.swift
@@ -25,6 +25,9 @@ class PlaylistsViewModel {
     var playlists: [PlaylistItem] = []
 
     func load() async {
+        if state == .loading {
+            RefreshManager.shared.refreshPodcasts()
+        }
         let originalPlaylists = dataManager.allPlaylists(includeDeleted: false)
         let playlists = originalPlaylists.sorted { a, b in
             switch (a.isDownloadFilterActive, b.isDownloadFilterActive) {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [PCIOS-882](https://linear.app/a8c/issue/PCIOS-882/playlists-say-1-episodes-instead-of-1-episode) <!-- issue number, if applicable -->

Fixes [PCIOS-879](https://linear.app/a8c/issue/PCIOS-879/show-correct-playlists-counts)

On the TV app, playlists were showing an incorrect episode count and inconsistent state. This PR fixes the count and improves how playlist/home data stays fresh.

### Playlist episode count
- Show the **total** number of episodes in a playlist, ignoring archived status, via `allPlaylistEpisodeCount`. The count is now displayed using the standard episode-count strings (`podcastEpisodeCountSingular` / `podcastEpisodeCountPluralFormat`), while the list itself still displays up to 1000 episodes.
- Note: an earlier attempt to remove the 1000-item read limit entirely was reverted; instead we surface the true total count while keeping the display capped.

### Archive filter
- Only show the archived-filter menu on **manual** playlists (`model.isManual`) — it no longer appears on smart playlists where it doesn't apply.
- Keep the count consistent regardless of the archived filter state.

### Data refresh
- Refresh podcasts when the Home screen appears (`HomeViewModel.refresh()`).
- Refresh podcasts when the Playlists list loads.
- Observe `playlistChanged`, `episodeArchiveStatusChanged`, and `episodePlayStatusChanged` notifications in `PlaylistDetailsViewModel` (debounced) so the detail screen reloads when episodes are archived or played.

### Logging
- Only log "Tried to add too many episodes to imported playlist" when there are actually episodes being added (`!addedEpisodes.isEmpty`), avoiding misleading log noise.

## To test

1. On the TV app, open a playlist and confirm the displayed episode count matches the real total (including archived episodes for the count).
2. Confirm a playlist with more than 1000 episodes shows the correct total count (the list still displays up to 1000 items).
3. Open a **smart** playlist and confirm the archived-filter menu is not shown; open a **manual** playlist and confirm it is shown.
4. From the detail screen, archive or mark an episode as played and confirm the screen updates.
5. Confirm Home and Playlists screens reflect recently refreshed podcast data.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
