### PR TITLE
Hide the video icon for downloaded HLS episodes

### DIFF
--- a/PocketCastsTests/Tests/Utilities/EpisodeManagerTests.swift
+++ b/PocketCastsTests/Tests/Utilities/EpisodeManagerTests.swift
@@ -316,4 +316,37 @@ final class EpisodeManagerTests: DBTestCase {
 
         XCTAssertFalse(EpisodeManager.isVideo(episode), "A plain audio episode should not be treated as video")
     }
+
+    func testIsNotVideoForDownloadedHLSEpisode() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+
+        let episode = makeStreamingHLSEpisode()
+        episode.episodeStatus = DownloadStatus.downloaded.rawValue
+        createDownloadedFile(for: episode)
+        defer { removeDownloadedFile(for: episode) }
+
+        XCTAssertFalse(EpisodeManager.isVideo(episode), "A downloaded episode plays its local audio file, so it should not be shown as video")
+    }
+
+    func testIsVideoForDownloadedNativeVideoPodcast() throws {
+        try FeatureFlagOverrideStore().override(FeatureFlag.hls, withValue: true)
+
+        let episode = makeVideoEpisode()
+        episode.episodeStatus = DownloadStatus.downloaded.rawValue
+        createDownloadedFile(for: episode)
+        defer { removeDownloadedFile(for: episode) }
+
+        XCTAssertTrue(EpisodeManager.isVideo(episode), "A downloaded video podcast still plays video from its local file")
+    }
+
+    private func createDownloadedFile(for episode: Episode) {
+        let path = DownloadManager.shared.pathForEpisode(episode)
+        let directory = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: path, contents: Data())
+    }
+
+    private func removeDownloadedFile(for episode: Episode) {
+        try? FileManager.default.removeItem(atPath: DownloadManager.shared.pathForEpisode(episode))
+    }
 }

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -238,8 +238,8 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             setEpisodeTitle(episode: episode)
 
             starIndicator.isHidden = !episode.keepEpisode
-            // Treat episodes with a usable HLS stream (HLS feature enabled + valid HLS URL) as video, so
-            // we show the video indicator without parsing the stream.
+            // Treat episodes that will stream HLS as video, so we show the video indicator without parsing
+            // the stream. Downloaded episodes play their local audio-only file, so they get no icon.
             videoIndicator.isHidden = !EpisodeManager.isVideo(episode)
             videoIndicator.tintColor = ThemeColor.support01()
             setUpNextIndicator(visible: PlaybackManager.shared.inUpNext(episode: episode), animated: false)

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -434,9 +434,11 @@ class EpisodeManager: NSObject {
     }
 
     /// Whether the episode should be presented as video in the UI: either a native video podcast or an
-    /// episode that advertises an HLS stream (which may carry video).
+    /// episode that will actually play its HLS stream. Downloaded episodes play their local (audio-only)
+    /// file, so advertising a video icon for them would promise video the user won't get — hence
+    /// `willPlayViaHLS` rather than `hasHLSStream`.
     class func isVideo(_ episode: BaseEpisode) -> Bool {
-        episode.videoPodcast() || hasHLSStream(episode)
+        episode.videoPodcast() || willPlayViaHLS(episode)
     }
 
     /// Whether the episode will actually play via HLS right now. Downloaded copies take precedence over


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

An episode with an HLS stream showed the video icon in the row even once downloaded, but a downloaded episode plays its local audio-only file — so we were promising video the user wouldn't get.

- `EpisodeManager.isVideo` now uses `willPlayViaHLS` (what will actually play) instead of `hasHLSStream` (capability). Native video podcasts and episodes where the user toggled video-despite-download on still show the icon.
- Added unit tests for the downloaded HLS and downloaded video-podcast cases.

## To test

2. Search for the "The Resilient Recruiter" podcast → the video icon shows in the row.
3. Download it → the video icon disappears, download checkmark shows.
4. Delete the download → the video icon comes back.
6. Confirm a podcast with a video progressive file keeps its icon when downloaded. (Twit News Video)

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.