### PR TITLE
Fix full screen player not re-opening for a previously played video episode

### DIFF
--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -529,6 +529,13 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
     @objc private func playbackStarted() {
         if let episode = PlaybackManager.shared.currentEpisode() {
+            // Forget the auto open marker once a different episode plays, otherwise coming back to a
+            // previously auto opened episode never opens the player again. Keeping it for the same
+            // episode still stops a reload (e.g. switching to the downloaded file) from re-opening it.
+            if lastEpisodeUuidAutoOpened != episode.uuid {
+                lastEpisodeUuidAutoOpened = ""
+            }
+
             setupForEpisode(episode)
             showMiniPlayer()
             autoOpenFullScreenPlayerIfNeeded(for: episode)


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

- Clear `lastEpisodeUuidAutoOpened` in `playbackStarted` when a different episode starts, so the full screen player auto opens again for an episode that was already auto opened once. The marker still survives a reload of the same episode (e.g. switching to the downloaded file), so that doesn't re-open the player.

## To test

1. Add two HLS video episodes (you can use "The Resilient Recruiter") and one audio episode ("The Daily"), none downloaded, added to Up Next;
2. Tap play on video episode A → the full screen player opens.
3. Tap play on the audio episode.
4. Tap play on video episode A again → the full screen player opens (before this fix it didn't).
5. Tap play on the audio episode, then on video episode B → the full screen player opens.
6. With Settings > General > "Open player automatically" off, play an audio episode → the player does not open.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
