### PR TITLE
Sync bookmark passage and reference time fields

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -928,6 +928,20 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 76 {
+            do {
+                try db.executeUpdate("ALTER TABLE Bookmark ADD COLUMN passage TEXT;", values: nil)
+                try db.executeUpdate("ALTER TABLE Bookmark ADD COLUMN passage_location INTEGER;", values: nil)
+                try db.executeUpdate("ALTER TABLE Bookmark ADD COLUMN passage_modified_date INTEGER;", values: nil)
+                try db.executeUpdate("ALTER TABLE Bookmark ADD COLUMN reference_time real;", values: nil)
+                try db.executeUpdate("ALTER TABLE Bookmark ADD COLUMN reference_time_modified_date INTEGER;", values: nil)
+                schemaVersion = 76
+            } catch {
+                failedAt(76)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
@@ -15,9 +15,26 @@ public struct Bookmark: Hashable {
     public var episode: BaseEpisode? = nil
     public var podcast: Podcast? = nil
 
+    /// The transcript passage the bookmark captures.
+    public var passage: String? = nil
+
+    /// Where `passage` begins in the episode transcript, kept only to disambiguate a
+    /// passage that appears more than once — the passage text itself is what's matched.
+    public var passageLocation: Int? = nil
+
+    /// The bookmark's position on the transcript's canonical (reference) timeline, when the
+    /// episode has a generated transcript and a confident mapping was available when captured.
+    ///
+    /// Preferred over `time` wherever possible: dynamic ads shift the playback timeline per
+    /// device and download, so `time` can point at the wrong content elsewhere, whereas the
+    /// reference time is stable. Falls back to `time` when nil.
+    public var referenceTime: TimeInterval? = nil
+
     // For syncing
     public var titleModified: Date? = nil
     public var deletedModified: Date? = nil
+    public var passageModified: Date? = nil
+    public var referenceTimeModified: Date? = nil
     public var deleted: Bool = false
 
     // `BaseEpisode` and `Podcast` don't conform to Hashable, so instead we implement it manually to ignore those properties
@@ -28,6 +45,9 @@ public struct Bookmark: Hashable {
         hasher.combine(created)
         hasher.combine(episodeUuid)
         hasher.combine(podcastUuid)
+        hasher.combine(passage)
+        hasher.combine(passageLocation)
+        hasher.combine(referenceTime)
         hasher.combine(titleModified)
         hasher.combine(deletedModified)
     }
@@ -41,73 +61,6 @@ public struct Bookmark: Hashable {
 
 extension Bookmark: Identifiable {
     public var id: String { uuid }
-}
-
-// MARK: - Passage
-
-extension Bookmark {
-    /// The transcript passage the bookmark captures.
-    ///
-    /// Temporarily backed by `UserDefaults`, until the passage is stored with the bookmark itself.
-    public var passage: String? {
-        get { UserDefaults.standard.string(forKey: Self.passageKey(for: uuid)) }
-        nonmutating set {
-            let key = Self.passageKey(for: uuid)
-            if let newValue {
-                UserDefaults.standard.set(newValue, forKey: key)
-            } else {
-                UserDefaults.standard.removeObject(forKey: key)
-            }
-        }
-    }
-
-    /// Where `passage` begins in the episode transcript, kept only to disambiguate a
-    /// passage that appears more than once — the passage text itself is what's matched.
-    ///
-    /// Temporarily backed by `UserDefaults`, until it's stored with the bookmark itself.
-    public var passageLocation: Int? {
-        get { UserDefaults.standard.object(forKey: Self.passageLocationKey(for: uuid)) as? Int }
-        nonmutating set {
-            let key = Self.passageLocationKey(for: uuid)
-            if let newValue {
-                UserDefaults.standard.set(newValue, forKey: key)
-            } else {
-                UserDefaults.standard.removeObject(forKey: key)
-            }
-        }
-    }
-
-    /// The bookmark's position on the transcript's canonical (reference) timeline, when the
-    /// episode has a generated transcript and a confident mapping was available when captured.
-    ///
-    /// Preferred over `time` wherever possible: dynamic ads shift the playback timeline per
-    /// device and download, so `time` can point at the wrong content elsewhere, whereas the
-    /// reference time is stable. Falls back to `time` when nil.
-    ///
-    /// Temporarily backed by `UserDefaults`, until it's stored with the bookmark itself.
-    public var referenceTime: TimeInterval? {
-        get { UserDefaults.standard.object(forKey: Self.referenceTimeKey(for: uuid)) as? TimeInterval }
-        nonmutating set {
-            let key = Self.referenceTimeKey(for: uuid)
-            if let newValue {
-                UserDefaults.standard.set(newValue, forKey: key)
-            } else {
-                UserDefaults.standard.removeObject(forKey: key)
-            }
-        }
-    }
-
-    private static func passageKey(for uuid: String) -> String {
-        "bookmark.passage.\(uuid)"
-    }
-
-    private static func passageLocationKey(for uuid: String) -> String {
-        "bookmark.passageLocation.\(uuid)"
-    }
-
-    private static func referenceTimeKey(for uuid: String) -> String {
-        "bookmark.referenceTime.\(uuid)"
-    }
 }
 
 // MARK: - Preview Data

--- a/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -25,10 +25,20 @@ public struct BookmarkDataManager {
     ///   - time: The playback time for the bookmark
     ///   - transcription: A transcription of the clip if available
     @discardableResult
-    public func add(uuid: String? = nil, episodeUuid: String, podcastUuid: String?, title: String, time: TimeInterval, dateCreated: Date = Date(),
-                    passage: String? = nil, passageLocation: Int? = nil, passageModified: Date? = nil,
-                    referenceTime: TimeInterval? = nil, referenceTimeModified: Date? = nil,
-                    syncStatus: SyncStatus = .notSynced) -> String? {
+    public func add(
+        uuid: String? = nil,
+        episodeUuid: String,
+        podcastUuid: String?,
+        title: String,
+        time: TimeInterval,
+        dateCreated: Date = Date(),
+        passage: String? = nil,
+        passageLocation: Int? = nil,
+        passageModified: Date? = nil,
+        referenceTime: TimeInterval? = nil,
+        referenceTimeModified: Date? = nil,
+        syncStatus: SyncStatus = .notSynced
+    ) -> String? {
         var bookmarkUuid: String? = nil
 
         dbQueue.write { db in
@@ -65,10 +75,19 @@ public struct BookmarkDataManager {
     /// modified date, the passage and its location along with `passageModified`, and the reference
     /// time along with `referenceTimeModified`. A group whose value is nil is left untouched.
     @discardableResult
-    public func update(bookmark: Bookmark, title: String? = nil, time: TimeInterval? = nil, created: Date? = nil, modified: Date? = Date(),
-                       passage: String? = nil, passageLocation: Int? = nil, passageModified: Date? = nil,
-                       referenceTime: TimeInterval? = nil, referenceTimeModified: Date? = nil,
-                       syncStatus: SyncStatus = .notSynced) async -> Bool {
+    public func update(
+        bookmark: Bookmark,
+        title: String? = nil,
+        time: TimeInterval? = nil,
+        created: Date? = nil,
+        modified: Date? = Date(),
+        passage: String? = nil,
+        passageLocation: Int? = nil,
+        passageModified: Date? = nil,
+        referenceTime: TimeInterval? = nil,
+        referenceTimeModified: Date? = nil,
+        syncStatus: SyncStatus = .notSynced
+    ) async -> Bool {
         var updateColumns = [String]()
         var values = [Any?]()
 
@@ -89,12 +108,12 @@ public struct BookmarkDataManager {
 
         if let passageModified {
             updateColumns.append(contentsOf: ["\(Column.passage) = ?", "\(Column.passageLocation) = ?", "\(Column.passageModifiedDate) = ?"])
-            values.append(contentsOf: [passage, passageLocation, passageModified])
+            values.append(contentsOf: [passage as Any?, passageLocation as Any?, passageModified])
         }
 
         if let referenceTimeModified {
             updateColumns.append(contentsOf: ["\(Column.referenceTime) = ?", "\(Column.referenceTimeModifiedDate) = ?"])
-            values.append(contentsOf: [referenceTime, referenceTimeModified])
+            values.append(contentsOf: [referenceTime as Any?, referenceTimeModified])
         }
 
         updateColumns.append("\(Column.syncStatus) = ?")

--- a/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -25,7 +25,10 @@ public struct BookmarkDataManager {
     ///   - time: The playback time for the bookmark
     ///   - transcription: A transcription of the clip if available
     @discardableResult
-    public func add(uuid: String? = nil, episodeUuid: String, podcastUuid: String?, title: String, time: TimeInterval, dateCreated: Date = Date(), syncStatus: SyncStatus = .notSynced) -> String? {
+    public func add(uuid: String? = nil, episodeUuid: String, podcastUuid: String?, title: String, time: TimeInterval, dateCreated: Date = Date(),
+                    passage: String? = nil, passageLocation: Int? = nil, passageModified: Date? = nil,
+                    referenceTime: TimeInterval? = nil, referenceTimeModified: Date? = nil,
+                    syncStatus: SyncStatus = .notSynced) -> String? {
         var bookmarkUuid: String? = nil
 
         dbQueue.write { db in
@@ -36,10 +39,14 @@ public struct BookmarkDataManager {
                 let columns: [Column] = [
                     .uuid, .title, .time,
                     .createdDate, .titleModifiedDate,
-                    .episode, .podcast, .syncStatus
+                    .episode, .podcast, .syncStatus,
+                    .passage, .passageLocation, .passageModifiedDate,
+                    .referenceTime, .referenceTimeModifiedDate
                 ]
 
-                let values: [Any?] = [uuid, title, time, created, created, episodeUuid, podcastUuid, syncStatus.rawValue]
+                let values: [Any?] = [uuid, title, time, created, created, episodeUuid, podcastUuid, syncStatus.rawValue,
+                                      passage, passageLocation, passageModified?.timeIntervalSince1970,
+                                      referenceTime, referenceTimeModified?.timeIntervalSince1970]
 
                 try db.insert(into: Self.tableName, columns: columns.map { $0.rawValue }, values: values)
 
@@ -53,24 +60,47 @@ public struct BookmarkDataManager {
     }
 
     // MARK: - Updating
-    @discardableResult
-    public func update(bookmark: Bookmark, title: String, time: TimeInterval? = nil, created: Date? = nil, modified: Date? = Date(), syncStatus: SyncStatus = .notSynced) async -> Bool {
-        let updateColumns = [
-            "\(Column.title) = ?",
-            time.map { _ in "\(Column.time) = ?" },
-            created.map { _ in "\(Column.createdDate) = ?" },
-            "\(Column.titleModifiedDate) = ?",
-            "\(Column.syncStatus) = ?",
-        ].compactMap { $0 }
 
-        let values: [Any?] = [
-            title,
-            time,
-            created,
-            modified ?? Date(),
-            syncStatus.rawValue,
-            bookmark.uuid
-        ]
+    /// Updates a bookmark. Fields group together for syncing: the title is written along with its
+    /// modified date, the passage and its location along with `passageModified`, and the reference
+    /// time along with `referenceTimeModified`. A group whose value is nil is left untouched.
+    @discardableResult
+    public func update(bookmark: Bookmark, title: String? = nil, time: TimeInterval? = nil, created: Date? = nil, modified: Date? = Date(),
+                       passage: String? = nil, passageLocation: Int? = nil, passageModified: Date? = nil,
+                       referenceTime: TimeInterval? = nil, referenceTimeModified: Date? = nil,
+                       syncStatus: SyncStatus = .notSynced) async -> Bool {
+        var updateColumns = [String]()
+        var values = [Any?]()
+
+        if let title {
+            updateColumns.append(contentsOf: ["\(Column.title) = ?", "\(Column.titleModifiedDate) = ?"])
+            values.append(contentsOf: [title, modified ?? Date()])
+        }
+
+        if let time {
+            updateColumns.append("\(Column.time) = ?")
+            values.append(time)
+        }
+
+        if let created {
+            updateColumns.append("\(Column.createdDate) = ?")
+            values.append(created)
+        }
+
+        if let passageModified {
+            updateColumns.append(contentsOf: ["\(Column.passage) = ?", "\(Column.passageLocation) = ?", "\(Column.passageModifiedDate) = ?"])
+            values.append(contentsOf: [passage, passageLocation, passageModified])
+        }
+
+        if let referenceTimeModified {
+            updateColumns.append(contentsOf: ["\(Column.referenceTime) = ?", "\(Column.referenceTimeModifiedDate) = ?"])
+            values.append(contentsOf: [referenceTime, referenceTimeModified])
+        }
+
+        updateColumns.append("\(Column.syncStatus) = ?")
+        values.append(syncStatus.rawValue)
+
+        values.append(bookmark.uuid)
 
         let query = """
                 UPDATE \(Self.tableName)
@@ -79,7 +109,7 @@ public struct BookmarkDataManager {
                 LIMIT 1
                 """
 
-        let result = await dbQueue.executeUpdate(query, values: values.compactMap { $0 })
+        let result = await dbQueue.executeUpdate(query, values: values.databaseValues)
 
         switch result {
         case .success:
@@ -243,10 +273,15 @@ public struct BookmarkDataManager {
         case podcast = "podcast_uuid"
         case time
         case deleted
+        case passage
+        case passageLocation = "passage_location"
+        case referenceTime = "reference_time"
 
         // For Syncing
         case titleModifiedDate = "title_modified_date"
         case deletedModifiedDate = "deleted_modified_date"
+        case passageModifiedDate = "passage_modified_date"
+        case referenceTimeModifiedDate = "reference_time_modified_date"
         case syncStatus = "sync_status"
 
         var description: String { rawValue }
@@ -341,6 +376,11 @@ private extension Bookmark {
         let titleModified = resultSet.date(for: .titleModifiedDate)
         let deletedModified = resultSet.date(for: .deletedModifiedDate)
         let deleted = resultSet.bool(for: .deleted) ?? false
+        let passage = resultSet.string(for: .passage)
+        let passageLocation = resultSet.optionalInt(for: .passageLocation)
+        let referenceTime = resultSet.optionalDouble(for: .referenceTime)
+        let passageModified = resultSet.date(for: .passageModifiedDate)
+        let referenceTimeModified = resultSet.date(for: .referenceTimeModifiedDate)
 
         self.init(uuid: uuid,
                   title: title,
@@ -348,8 +388,13 @@ private extension Bookmark {
                   created: createdDate,
                   episodeUuid: episode,
                   podcastUuid: podcast,
+                  passage: passage,
+                  passageLocation: passageLocation,
+                  referenceTime: referenceTime,
                   titleModified: titleModified,
                   deletedModified: deletedModified,
+                  passageModified: passageModified,
+                  referenceTimeModified: referenceTimeModified,
                   deleted: deleted)
     }
 }
@@ -367,6 +412,16 @@ private extension PCDBResultSet {
 
     func double(for column: BookmarkDataManager.Column) -> Double? {
         double(forColumn: column.rawValue)
+    }
+
+    /// Unlike `double(for:)`, a NULL column is nil rather than 0.
+    func optionalDouble(for column: BookmarkDataManager.Column) -> Double? {
+        (object(forColumn: column.rawValue) as? NSNumber)?.doubleValue
+    }
+
+    /// A NULL column is nil rather than 0.
+    func optionalInt(for column: BookmarkDataManager.Column) -> Int? {
+        (object(forColumn: column.rawValue) as? NSNumber)?.intValue
     }
 
     func bool(for column: BookmarkDataManager.Column) -> Bool? {

--- a/Modules/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -6435,121 +6435,166 @@ nonisolated struct Api_SyncUserFolder: Sendable {
   fileprivate var _dateAdded: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
 }
 
-nonisolated struct Api_SyncUserBookmark: Sendable {
+nonisolated struct Api_SyncUserBookmark: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  var bookmarkUuid: String = String()
+  var bookmarkUuid: String {
+    get {_storage._bookmarkUuid}
+    set {_uniqueStorage()._bookmarkUuid = newValue}
+  }
 
-  var podcastUuid: String = String()
+  var podcastUuid: String {
+    get {_storage._podcastUuid}
+    set {_uniqueStorage()._podcastUuid = newValue}
+  }
 
-  var episodeUuid: String = String()
+  var episodeUuid: String {
+    get {_storage._episodeUuid}
+    set {_uniqueStorage()._episodeUuid = newValue}
+  }
 
   var createdAt: SwiftProtobuf.Google_Protobuf_Timestamp {
-    get {_createdAt ?? SwiftProtobuf.Google_Protobuf_Timestamp()}
-    set {_createdAt = newValue}
+    get {_storage._createdAt ?? SwiftProtobuf.Google_Protobuf_Timestamp()}
+    set {_uniqueStorage()._createdAt = newValue}
   }
   /// Returns true if `createdAt` has been explicitly set.
-  var hasCreatedAt: Bool {self._createdAt != nil}
+  var hasCreatedAt: Bool {_storage._createdAt != nil}
   /// Clears the value of `createdAt`. Subsequent reads from it will return its default value.
-  mutating func clearCreatedAt() {self._createdAt = nil}
+  mutating func clearCreatedAt() {_uniqueStorage()._createdAt = nil}
 
   var time: SwiftProtobuf.Google_Protobuf_Int32Value {
-    get {_time ?? SwiftProtobuf.Google_Protobuf_Int32Value()}
-    set {_time = newValue}
+    get {_storage._time ?? SwiftProtobuf.Google_Protobuf_Int32Value()}
+    set {_uniqueStorage()._time = newValue}
   }
   /// Returns true if `time` has been explicitly set.
-  var hasTime: Bool {self._time != nil}
+  var hasTime: Bool {_storage._time != nil}
   /// Clears the value of `time`. Subsequent reads from it will return its default value.
-  mutating func clearTime() {self._time = nil}
+  mutating func clearTime() {_uniqueStorage()._time = nil}
 
   var title: SwiftProtobuf.Google_Protobuf_StringValue {
-    get {_title ?? SwiftProtobuf.Google_Protobuf_StringValue()}
-    set {_title = newValue}
+    get {_storage._title ?? SwiftProtobuf.Google_Protobuf_StringValue()}
+    set {_uniqueStorage()._title = newValue}
   }
   /// Returns true if `title` has been explicitly set.
-  var hasTitle: Bool {self._title != nil}
+  var hasTitle: Bool {_storage._title != nil}
   /// Clears the value of `title`. Subsequent reads from it will return its default value.
-  mutating func clearTitle() {self._title = nil}
+  mutating func clearTitle() {_uniqueStorage()._title = nil}
 
   var titleModified: SwiftProtobuf.Google_Protobuf_Int64Value {
-    get {_titleModified ?? SwiftProtobuf.Google_Protobuf_Int64Value()}
-    set {_titleModified = newValue}
+    get {_storage._titleModified ?? SwiftProtobuf.Google_Protobuf_Int64Value()}
+    set {_uniqueStorage()._titleModified = newValue}
   }
   /// Returns true if `titleModified` has been explicitly set.
-  var hasTitleModified: Bool {self._titleModified != nil}
+  var hasTitleModified: Bool {_storage._titleModified != nil}
   /// Clears the value of `titleModified`. Subsequent reads from it will return its default value.
-  mutating func clearTitleModified() {self._titleModified = nil}
+  mutating func clearTitleModified() {_uniqueStorage()._titleModified = nil}
 
   var isDeleted: SwiftProtobuf.Google_Protobuf_BoolValue {
-    get {_isDeleted ?? SwiftProtobuf.Google_Protobuf_BoolValue()}
-    set {_isDeleted = newValue}
+    get {_storage._isDeleted ?? SwiftProtobuf.Google_Protobuf_BoolValue()}
+    set {_uniqueStorage()._isDeleted = newValue}
   }
   /// Returns true if `isDeleted` has been explicitly set.
-  var hasIsDeleted: Bool {self._isDeleted != nil}
+  var hasIsDeleted: Bool {_storage._isDeleted != nil}
   /// Clears the value of `isDeleted`. Subsequent reads from it will return its default value.
-  mutating func clearIsDeleted() {self._isDeleted = nil}
+  mutating func clearIsDeleted() {_uniqueStorage()._isDeleted = nil}
 
   var isDeletedModified: SwiftProtobuf.Google_Protobuf_Int64Value {
-    get {_isDeletedModified ?? SwiftProtobuf.Google_Protobuf_Int64Value()}
-    set {_isDeletedModified = newValue}
+    get {_storage._isDeletedModified ?? SwiftProtobuf.Google_Protobuf_Int64Value()}
+    set {_uniqueStorage()._isDeletedModified = newValue}
   }
   /// Returns true if `isDeletedModified` has been explicitly set.
-  var hasIsDeletedModified: Bool {self._isDeletedModified != nil}
+  var hasIsDeletedModified: Bool {_storage._isDeletedModified != nil}
   /// Clears the value of `isDeletedModified`. Subsequent reads from it will return its default value.
-  mutating func clearIsDeletedModified() {self._isDeletedModified = nil}
+  mutating func clearIsDeletedModified() {_uniqueStorage()._isDeletedModified = nil}
 
   var aiTitle: SwiftProtobuf.Google_Protobuf_StringValue {
-    get {_aiTitle ?? SwiftProtobuf.Google_Protobuf_StringValue()}
-    set {_aiTitle = newValue}
+    get {_storage._aiTitle ?? SwiftProtobuf.Google_Protobuf_StringValue()}
+    set {_uniqueStorage()._aiTitle = newValue}
   }
   /// Returns true if `aiTitle` has been explicitly set.
-  var hasAiTitle: Bool {self._aiTitle != nil}
+  var hasAiTitle: Bool {_storage._aiTitle != nil}
   /// Clears the value of `aiTitle`. Subsequent reads from it will return its default value.
-  mutating func clearAiTitle() {self._aiTitle = nil}
+  mutating func clearAiTitle() {_uniqueStorage()._aiTitle = nil}
 
   var aiTitleModified: SwiftProtobuf.Google_Protobuf_Int64Value {
-    get {_aiTitleModified ?? SwiftProtobuf.Google_Protobuf_Int64Value()}
-    set {_aiTitleModified = newValue}
+    get {_storage._aiTitleModified ?? SwiftProtobuf.Google_Protobuf_Int64Value()}
+    set {_uniqueStorage()._aiTitleModified = newValue}
   }
   /// Returns true if `aiTitleModified` has been explicitly set.
-  var hasAiTitleModified: Bool {self._aiTitleModified != nil}
+  var hasAiTitleModified: Bool {_storage._aiTitleModified != nil}
   /// Clears the value of `aiTitleModified`. Subsequent reads from it will return its default value.
-  mutating func clearAiTitleModified() {self._aiTitleModified = nil}
+  mutating func clearAiTitleModified() {_uniqueStorage()._aiTitleModified = nil}
 
   var aiSummary: SwiftProtobuf.Google_Protobuf_StringValue {
-    get {_aiSummary ?? SwiftProtobuf.Google_Protobuf_StringValue()}
-    set {_aiSummary = newValue}
+    get {_storage._aiSummary ?? SwiftProtobuf.Google_Protobuf_StringValue()}
+    set {_uniqueStorage()._aiSummary = newValue}
   }
   /// Returns true if `aiSummary` has been explicitly set.
-  var hasAiSummary: Bool {self._aiSummary != nil}
+  var hasAiSummary: Bool {_storage._aiSummary != nil}
   /// Clears the value of `aiSummary`. Subsequent reads from it will return its default value.
-  mutating func clearAiSummary() {self._aiSummary = nil}
+  mutating func clearAiSummary() {_uniqueStorage()._aiSummary = nil}
 
   var aiSummaryModified: SwiftProtobuf.Google_Protobuf_Int64Value {
-    get {_aiSummaryModified ?? SwiftProtobuf.Google_Protobuf_Int64Value()}
-    set {_aiSummaryModified = newValue}
+    get {_storage._aiSummaryModified ?? SwiftProtobuf.Google_Protobuf_Int64Value()}
+    set {_uniqueStorage()._aiSummaryModified = newValue}
   }
   /// Returns true if `aiSummaryModified` has been explicitly set.
-  var hasAiSummaryModified: Bool {self._aiSummaryModified != nil}
+  var hasAiSummaryModified: Bool {_storage._aiSummaryModified != nil}
   /// Clears the value of `aiSummaryModified`. Subsequent reads from it will return its default value.
-  mutating func clearAiSummaryModified() {self._aiSummaryModified = nil}
+  mutating func clearAiSummaryModified() {_uniqueStorage()._aiSummaryModified = nil}
+
+  var passage: SwiftProtobuf.Google_Protobuf_StringValue {
+    get {_storage._passage ?? SwiftProtobuf.Google_Protobuf_StringValue()}
+    set {_uniqueStorage()._passage = newValue}
+  }
+  /// Returns true if `passage` has been explicitly set.
+  var hasPassage: Bool {_storage._passage != nil}
+  /// Clears the value of `passage`. Subsequent reads from it will return its default value.
+  mutating func clearPassage() {_uniqueStorage()._passage = nil}
+
+  var passageLocation: SwiftProtobuf.Google_Protobuf_Int32Value {
+    get {_storage._passageLocation ?? SwiftProtobuf.Google_Protobuf_Int32Value()}
+    set {_uniqueStorage()._passageLocation = newValue}
+  }
+  /// Returns true if `passageLocation` has been explicitly set.
+  var hasPassageLocation: Bool {_storage._passageLocation != nil}
+  /// Clears the value of `passageLocation`. Subsequent reads from it will return its default value.
+  mutating func clearPassageLocation() {_uniqueStorage()._passageLocation = nil}
+
+  var passageModified: SwiftProtobuf.Google_Protobuf_Int64Value {
+    get {_storage._passageModified ?? SwiftProtobuf.Google_Protobuf_Int64Value()}
+    set {_uniqueStorage()._passageModified = newValue}
+  }
+  /// Returns true if `passageModified` has been explicitly set.
+  var hasPassageModified: Bool {_storage._passageModified != nil}
+  /// Clears the value of `passageModified`. Subsequent reads from it will return its default value.
+  mutating func clearPassageModified() {_uniqueStorage()._passageModified = nil}
+
+  var referenceTime: SwiftProtobuf.Google_Protobuf_Int32Value {
+    get {_storage._referenceTime ?? SwiftProtobuf.Google_Protobuf_Int32Value()}
+    set {_uniqueStorage()._referenceTime = newValue}
+  }
+  /// Returns true if `referenceTime` has been explicitly set.
+  var hasReferenceTime: Bool {_storage._referenceTime != nil}
+  /// Clears the value of `referenceTime`. Subsequent reads from it will return its default value.
+  mutating func clearReferenceTime() {_uniqueStorage()._referenceTime = nil}
+
+  var referenceTimeModified: SwiftProtobuf.Google_Protobuf_Int64Value {
+    get {_storage._referenceTimeModified ?? SwiftProtobuf.Google_Protobuf_Int64Value()}
+    set {_uniqueStorage()._referenceTimeModified = newValue}
+  }
+  /// Returns true if `referenceTimeModified` has been explicitly set.
+  var hasReferenceTimeModified: Bool {_storage._referenceTimeModified != nil}
+  /// Clears the value of `referenceTimeModified`. Subsequent reads from it will return its default value.
+  mutating func clearReferenceTimeModified() {_uniqueStorage()._referenceTimeModified = nil}
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
 
-  fileprivate var _createdAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
-  fileprivate var _time: SwiftProtobuf.Google_Protobuf_Int32Value? = nil
-  fileprivate var _title: SwiftProtobuf.Google_Protobuf_StringValue? = nil
-  fileprivate var _titleModified: SwiftProtobuf.Google_Protobuf_Int64Value? = nil
-  fileprivate var _isDeleted: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
-  fileprivate var _isDeletedModified: SwiftProtobuf.Google_Protobuf_Int64Value? = nil
-  fileprivate var _aiTitle: SwiftProtobuf.Google_Protobuf_StringValue? = nil
-  fileprivate var _aiTitleModified: SwiftProtobuf.Google_Protobuf_Int64Value? = nil
-  fileprivate var _aiSummary: SwiftProtobuf.Google_Protobuf_StringValue? = nil
-  fileprivate var _aiSummaryModified: SwiftProtobuf.Google_Protobuf_Int64Value? = nil
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 nonisolated struct Api_LegacySyncData: Sendable {
@@ -7862,9 +7907,40 @@ nonisolated struct Api_SuggestedFolder: Sendable {
 
   var podcastUuids: [String] = []
 
+  var color: SwiftProtobuf.Google_Protobuf_Int32Value {
+    get {_color ?? SwiftProtobuf.Google_Protobuf_Int32Value()}
+    set {_color = newValue}
+  }
+  /// Returns true if `color` has been explicitly set.
+  var hasColor: Bool {self._color != nil}
+  /// Clears the value of `color`. Subsequent reads from it will return its default value.
+  mutating func clearColor() {self._color = nil}
+
+  var sortPosition: SwiftProtobuf.Google_Protobuf_Int32Value {
+    get {_sortPosition ?? SwiftProtobuf.Google_Protobuf_Int32Value()}
+    set {_sortPosition = newValue}
+  }
+  /// Returns true if `sortPosition` has been explicitly set.
+  var hasSortPosition: Bool {self._sortPosition != nil}
+  /// Clears the value of `sortPosition`. Subsequent reads from it will return its default value.
+  mutating func clearSortPosition() {self._sortPosition = nil}
+
+  var podcastsSortType: SwiftProtobuf.Google_Protobuf_Int32Value {
+    get {_podcastsSortType ?? SwiftProtobuf.Google_Protobuf_Int32Value()}
+    set {_podcastsSortType = newValue}
+  }
+  /// Returns true if `podcastsSortType` has been explicitly set.
+  var hasPodcastsSortType: Bool {self._podcastsSortType != nil}
+  /// Clears the value of `podcastsSortType`. Subsequent reads from it will return its default value.
+  mutating func clearPodcastsSortType() {self._podcastsSortType = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
+
+  fileprivate var _color: SwiftProtobuf.Google_Protobuf_Int32Value? = nil
+  fileprivate var _sortPosition: SwiftProtobuf.Google_Protobuf_Int32Value? = nil
+  fileprivate var _podcastsSortType: SwiftProtobuf.Google_Protobuf_Int32Value? = nil
 }
 
 nonisolated struct Api_SuggestedFoldersRequest: Sendable {
@@ -16841,93 +16917,188 @@ nonisolated extension Api_SyncUserFolder: SwiftProtobuf.Message, SwiftProtobuf._
 
 nonisolated extension Api_SyncUserBookmark: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SyncUserBookmark"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}bookmark_uuid\0\u{3}podcast_uuid\0\u{3}episode_uuid\0\u{3}created_at\0\u{1}time\0\u{1}title\0\u{3}title_modified\0\u{3}is_deleted\0\u{3}is_deleted_modified\0\u{3}ai_title\0\u{3}ai_title_modified\0\u{3}ai_summary\0\u{3}ai_summary_modified\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}bookmark_uuid\0\u{3}podcast_uuid\0\u{3}episode_uuid\0\u{3}created_at\0\u{1}time\0\u{1}title\0\u{3}title_modified\0\u{3}is_deleted\0\u{3}is_deleted_modified\0\u{3}ai_title\0\u{3}ai_title_modified\0\u{3}ai_summary\0\u{3}ai_summary_modified\0\u{1}passage\0\u{3}passage_location\0\u{3}passage_modified\0\u{3}reference_time\0\u{3}reference_time_modified\0")
+
+  fileprivate class _StorageClass {
+    var _bookmarkUuid: String = String()
+    var _podcastUuid: String = String()
+    var _episodeUuid: String = String()
+    var _createdAt: SwiftProtobuf.Google_Protobuf_Timestamp? = nil
+    var _time: SwiftProtobuf.Google_Protobuf_Int32Value? = nil
+    var _title: SwiftProtobuf.Google_Protobuf_StringValue? = nil
+    var _titleModified: SwiftProtobuf.Google_Protobuf_Int64Value? = nil
+    var _isDeleted: SwiftProtobuf.Google_Protobuf_BoolValue? = nil
+    var _isDeletedModified: SwiftProtobuf.Google_Protobuf_Int64Value? = nil
+    var _aiTitle: SwiftProtobuf.Google_Protobuf_StringValue? = nil
+    var _aiTitleModified: SwiftProtobuf.Google_Protobuf_Int64Value? = nil
+    var _aiSummary: SwiftProtobuf.Google_Protobuf_StringValue? = nil
+    var _aiSummaryModified: SwiftProtobuf.Google_Protobuf_Int64Value? = nil
+    var _passage: SwiftProtobuf.Google_Protobuf_StringValue? = nil
+    var _passageLocation: SwiftProtobuf.Google_Protobuf_Int32Value? = nil
+    var _passageModified: SwiftProtobuf.Google_Protobuf_Int64Value? = nil
+    var _referenceTime: SwiftProtobuf.Google_Protobuf_Int32Value? = nil
+    var _referenceTimeModified: SwiftProtobuf.Google_Protobuf_Int64Value? = nil
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _bookmarkUuid = source._bookmarkUuid
+      _podcastUuid = source._podcastUuid
+      _episodeUuid = source._episodeUuid
+      _createdAt = source._createdAt
+      _time = source._time
+      _title = source._title
+      _titleModified = source._titleModified
+      _isDeleted = source._isDeleted
+      _isDeletedModified = source._isDeletedModified
+      _aiTitle = source._aiTitle
+      _aiTitleModified = source._aiTitleModified
+      _aiSummary = source._aiSummary
+      _aiSummaryModified = source._aiSummaryModified
+      _passage = source._passage
+      _passageLocation = source._passageLocation
+      _passageModified = source._passageModified
+      _referenceTime = source._referenceTime
+      _referenceTimeModified = source._referenceTimeModified
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.bookmarkUuid) }()
-      case 2: try { try decoder.decodeSingularStringField(value: &self.podcastUuid) }()
-      case 3: try { try decoder.decodeSingularStringField(value: &self.episodeUuid) }()
-      case 4: try { try decoder.decodeSingularMessageField(value: &self._createdAt) }()
-      case 5: try { try decoder.decodeSingularMessageField(value: &self._time) }()
-      case 6: try { try decoder.decodeSingularMessageField(value: &self._title) }()
-      case 7: try { try decoder.decodeSingularMessageField(value: &self._titleModified) }()
-      case 8: try { try decoder.decodeSingularMessageField(value: &self._isDeleted) }()
-      case 9: try { try decoder.decodeSingularMessageField(value: &self._isDeletedModified) }()
-      case 10: try { try decoder.decodeSingularMessageField(value: &self._aiTitle) }()
-      case 11: try { try decoder.decodeSingularMessageField(value: &self._aiTitleModified) }()
-      case 12: try { try decoder.decodeSingularMessageField(value: &self._aiSummary) }()
-      case 13: try { try decoder.decodeSingularMessageField(value: &self._aiSummaryModified) }()
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularStringField(value: &_storage._bookmarkUuid) }()
+        case 2: try { try decoder.decodeSingularStringField(value: &_storage._podcastUuid) }()
+        case 3: try { try decoder.decodeSingularStringField(value: &_storage._episodeUuid) }()
+        case 4: try { try decoder.decodeSingularMessageField(value: &_storage._createdAt) }()
+        case 5: try { try decoder.decodeSingularMessageField(value: &_storage._time) }()
+        case 6: try { try decoder.decodeSingularMessageField(value: &_storage._title) }()
+        case 7: try { try decoder.decodeSingularMessageField(value: &_storage._titleModified) }()
+        case 8: try { try decoder.decodeSingularMessageField(value: &_storage._isDeleted) }()
+        case 9: try { try decoder.decodeSingularMessageField(value: &_storage._isDeletedModified) }()
+        case 10: try { try decoder.decodeSingularMessageField(value: &_storage._aiTitle) }()
+        case 11: try { try decoder.decodeSingularMessageField(value: &_storage._aiTitleModified) }()
+        case 12: try { try decoder.decodeSingularMessageField(value: &_storage._aiSummary) }()
+        case 13: try { try decoder.decodeSingularMessageField(value: &_storage._aiSummaryModified) }()
+        case 14: try { try decoder.decodeSingularMessageField(value: &_storage._passage) }()
+        case 15: try { try decoder.decodeSingularMessageField(value: &_storage._passageLocation) }()
+        case 16: try { try decoder.decodeSingularMessageField(value: &_storage._passageModified) }()
+        case 17: try { try decoder.decodeSingularMessageField(value: &_storage._referenceTime) }()
+        case 18: try { try decoder.decodeSingularMessageField(value: &_storage._referenceTimeModified) }()
+        default: break
+        }
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every if/case branch local when no optimizations
-    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-    // https://github.com/apple/swift-protobuf/issues/1182
-    if !self.bookmarkUuid.isEmpty {
-      try visitor.visitSingularStringField(value: self.bookmarkUuid, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      if !_storage._bookmarkUuid.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._bookmarkUuid, fieldNumber: 1)
+      }
+      if !_storage._podcastUuid.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._podcastUuid, fieldNumber: 2)
+      }
+      if !_storage._episodeUuid.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._episodeUuid, fieldNumber: 3)
+      }
+      try { if let v = _storage._createdAt {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+      } }()
+      try { if let v = _storage._time {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+      } }()
+      try { if let v = _storage._title {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
+      } }()
+      try { if let v = _storage._titleModified {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+      } }()
+      try { if let v = _storage._isDeleted {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
+      } }()
+      try { if let v = _storage._isDeletedModified {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
+      } }()
+      try { if let v = _storage._aiTitle {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
+      } }()
+      try { if let v = _storage._aiTitleModified {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
+      } }()
+      try { if let v = _storage._aiSummary {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
+      } }()
+      try { if let v = _storage._aiSummaryModified {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
+      } }()
+      try { if let v = _storage._passage {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 14)
+      } }()
+      try { if let v = _storage._passageLocation {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 15)
+      } }()
+      try { if let v = _storage._passageModified {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 16)
+      } }()
+      try { if let v = _storage._referenceTime {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 17)
+      } }()
+      try { if let v = _storage._referenceTimeModified {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 18)
+      } }()
     }
-    if !self.podcastUuid.isEmpty {
-      try visitor.visitSingularStringField(value: self.podcastUuid, fieldNumber: 2)
-    }
-    if !self.episodeUuid.isEmpty {
-      try visitor.visitSingularStringField(value: self.episodeUuid, fieldNumber: 3)
-    }
-    try { if let v = self._createdAt {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
-    } }()
-    try { if let v = self._time {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
-    } }()
-    try { if let v = self._title {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 6)
-    } }()
-    try { if let v = self._titleModified {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
-    } }()
-    try { if let v = self._isDeleted {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 8)
-    } }()
-    try { if let v = self._isDeletedModified {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 9)
-    } }()
-    try { if let v = self._aiTitle {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 10)
-    } }()
-    try { if let v = self._aiTitleModified {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 11)
-    } }()
-    try { if let v = self._aiSummary {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 12)
-    } }()
-    try { if let v = self._aiSummaryModified {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 13)
-    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Api_SyncUserBookmark, rhs: Api_SyncUserBookmark) -> Bool {
-    if lhs.bookmarkUuid != rhs.bookmarkUuid {return false}
-    if lhs.podcastUuid != rhs.podcastUuid {return false}
-    if lhs.episodeUuid != rhs.episodeUuid {return false}
-    if lhs._createdAt != rhs._createdAt {return false}
-    if lhs._time != rhs._time {return false}
-    if lhs._title != rhs._title {return false}
-    if lhs._titleModified != rhs._titleModified {return false}
-    if lhs._isDeleted != rhs._isDeleted {return false}
-    if lhs._isDeletedModified != rhs._isDeletedModified {return false}
-    if lhs._aiTitle != rhs._aiTitle {return false}
-    if lhs._aiTitleModified != rhs._aiTitleModified {return false}
-    if lhs._aiSummary != rhs._aiSummary {return false}
-    if lhs._aiSummaryModified != rhs._aiSummaryModified {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._bookmarkUuid != rhs_storage._bookmarkUuid {return false}
+        if _storage._podcastUuid != rhs_storage._podcastUuid {return false}
+        if _storage._episodeUuid != rhs_storage._episodeUuid {return false}
+        if _storage._createdAt != rhs_storage._createdAt {return false}
+        if _storage._time != rhs_storage._time {return false}
+        if _storage._title != rhs_storage._title {return false}
+        if _storage._titleModified != rhs_storage._titleModified {return false}
+        if _storage._isDeleted != rhs_storage._isDeleted {return false}
+        if _storage._isDeletedModified != rhs_storage._isDeletedModified {return false}
+        if _storage._aiTitle != rhs_storage._aiTitle {return false}
+        if _storage._aiTitleModified != rhs_storage._aiTitleModified {return false}
+        if _storage._aiSummary != rhs_storage._aiSummary {return false}
+        if _storage._aiSummaryModified != rhs_storage._aiSummaryModified {return false}
+        if _storage._passage != rhs_storage._passage {return false}
+        if _storage._passageLocation != rhs_storage._passageLocation {return false}
+        if _storage._passageModified != rhs_storage._passageModified {return false}
+        if _storage._referenceTime != rhs_storage._referenceTime {return false}
+        if _storage._referenceTimeModified != rhs_storage._referenceTimeModified {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -18451,7 +18622,7 @@ nonisolated extension Api_PodcastFolderSorting: SwiftProtobuf.Message, SwiftProt
 
 nonisolated extension Api_SuggestedFolder: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".SuggestedFolder"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}podcast_uuids\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{3}podcast_uuids\0\u{1}color\0\u{3}sort_position\0\u{3}podcasts_sort_type\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -18461,24 +18632,43 @@ nonisolated extension Api_SuggestedFolder: SwiftProtobuf.Message, SwiftProtobuf.
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
       case 2: try { try decoder.decodeRepeatedStringField(value: &self.podcastUuids) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._color) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._sortPosition) }()
+      case 5: try { try decoder.decodeSingularMessageField(value: &self._podcastsSortType) }()
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
     if !self.podcastUuids.isEmpty {
       try visitor.visitRepeatedStringField(value: self.podcastUuids, fieldNumber: 2)
     }
+    try { if let v = self._color {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    } }()
+    try { if let v = self._sortPosition {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    } }()
+    try { if let v = self._podcastsSortType {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 5)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Api_SuggestedFolder, rhs: Api_SuggestedFolder) -> Bool {
     if lhs.name != rhs.name {return false}
     if lhs.podcastUuids != rhs.podcastUuids {return false}
+    if lhs._color != rhs._color {return false}
+    if lhs._sortPosition != rhs._sortPosition {return false}
+    if lhs._podcastsSortType != rhs._podcastsSortType {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -146,12 +146,18 @@ extension SyncTask {
             await bookmarkManager.markAllBookmarksAsSynced()
 
             for apiBookmark in bookmarks {
-                await bookmarkManager.remove(apiBookmark: apiBookmark).when(false) {
-                    FileLog.shared.addMessage("SyncTask: Process Server Bookmarks - Could not delete existing bookmark: \(apiBookmark.bookmarkUuid)")
+                // The response doesn't include the passage fields — they only flow through the
+                // incremental sync records — so carry them over from the replaced bookmark
+                let existingBookmark = bookmarkManager.bookmark(for: apiBookmark.bookmarkUuid, allowDeleted: true)
+
+                if let existingBookmark {
+                    await bookmarkManager.permanentlyDelete(bookmarks: [existingBookmark]).when(false) {
+                        FileLog.shared.addMessage("SyncTask: Process Server Bookmarks - Could not delete existing bookmark: \(apiBookmark.bookmarkUuid)")
+                    }
                 }
 
                 // Add the incoming bookmark to the database
-                bookmarkManager.add(from: apiBookmark).when(.none) {
+                bookmarkManager.add(from: apiBookmark, passageFieldsFrom: existingBookmark).when(.none) {
                     FileLog.shared.addMessage("SyncTask: Process Server Bookmarks - Could not add bookmark: \(String(describing: try? apiBookmark.jsonString()))")
                 }
             }
@@ -164,22 +170,19 @@ extension SyncTask {
 }
 
 private extension BookmarkDataManager {
-    func add(from apiBookmark: Api_BookmarkResponse) -> String? {
+    func add(from apiBookmark: Api_BookmarkResponse, passageFieldsFrom existingBookmark: Bookmark?) -> String? {
         add(uuid: apiBookmark.bookmarkUuid,
             episodeUuid: apiBookmark.episodeUuid,
             podcastUuid: apiBookmark.podcastUuid,
             title: apiBookmark.title,
             time: .init(apiBookmark.time),
             dateCreated: apiBookmark.createdAt.date,
+            passage: existingBookmark?.passage,
+            passageLocation: existingBookmark?.passageLocation,
+            passageModified: existingBookmark?.passageModified,
+            referenceTime: existingBookmark?.referenceTime,
+            referenceTimeModified: existingBookmark?.referenceTimeModified,
             syncStatus: .synced)
-    }
-
-    func remove(apiBookmark: Api_BookmarkResponse) async -> Bool? {
-        guard let bookmark = bookmark(for: apiBookmark.bookmarkUuid, allowDeleted: true) else {
-            return nil
-        }
-
-        return await permanentlyDelete(bookmarks: [bookmark])
     }
 }
 

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+LocalChanges.swift
@@ -249,6 +249,19 @@ private extension Api_SyncUserBookmark {
 
         self.title.value = bookmark.title
         self.titleModified = .init(date: bookmark.titleModified ?? bookmark.created)
+
+        // The passage and reference time groups only exist once their modified date is set,
+        // matching how the server only emits each group when its modified timestamp is present.
+        if let passageModified = bookmark.passageModified {
+            self.passage.value = bookmark.passage ?? ""
+            self.passageLocation.value = Int32(bookmark.passageLocation ?? 0)
+            self.passageModified = .init(date: passageModified)
+        }
+
+        if let referenceTimeModified = bookmark.referenceTimeModified {
+            self.referenceTime.value = Int32(bookmark.referenceTime ?? 0)
+            self.referenceTimeModified = .init(date: referenceTimeModified)
+        }
     }
 }
 

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -418,18 +418,20 @@ extension SyncTask {
                 // If the podcast is for a user episode then we default to nil
                 let podcastUuid = apiBookmark.podcastUuid == DataConstants.userEpisodeFakePodcastId ? nil : apiBookmark.podcastUuid
 
-                let addedUuid = bookmarkManager.add(uuid: apiBookmark.bookmarkUuid,
-                                                    episodeUuid: apiBookmark.episodeUuid,
-                                                    podcastUuid: podcastUuid,
-                                                    title: apiBookmark.title.value,
-                                                    time: Double(apiBookmark.time.value),
-                                                    dateCreated: apiBookmark.createdAt.date,
-                                                    passage: apiBookmark.bookmarkPassage,
-                                                    passageLocation: apiBookmark.bookmarkPassageLocation,
-                                                    passageModified: apiBookmark.passageModifiedDate,
-                                                    referenceTime: apiBookmark.bookmarkReferenceTime,
-                                                    referenceTimeModified: apiBookmark.referenceTimeModifiedDate,
-                                                    syncStatus: .synced)
+                let addedUuid = bookmarkManager.add(
+                    uuid: apiBookmark.bookmarkUuid,
+                    episodeUuid: apiBookmark.episodeUuid,
+                    podcastUuid: podcastUuid,
+                    title: apiBookmark.title.value,
+                    time: Double(apiBookmark.time.value),
+                    dateCreated: apiBookmark.createdAt.date,
+                    passage: apiBookmark.bookmarkPassage,
+                    passageLocation: apiBookmark.bookmarkPassageLocation,
+                    passageModified: apiBookmark.passageModifiedDate,
+                    referenceTime: apiBookmark.bookmarkReferenceTime,
+                    referenceTimeModified: apiBookmark.referenceTimeModifiedDate,
+                    syncStatus: .synced
+                )
 
                 if addedUuid == nil {
                     FileLog.shared.addMessage("SyncTask: Import Bookmark Failed: Could not add non existent bookmark. API data: \(apiBookmark.logDescription)")
@@ -457,13 +459,18 @@ extension SyncTask {
             return
         }
 
-        await bookmarkManager.update(bookmark: existingBookmark, title: title, time: time, created: created,
-                                     passage: apiBookmark.bookmarkPassage,
-                                     passageLocation: apiBookmark.bookmarkPassageLocation,
-                                     passageModified: apiBookmark.passageModifiedDate,
-                                     referenceTime: apiBookmark.bookmarkReferenceTime,
-                                     referenceTimeModified: apiBookmark.referenceTimeModifiedDate,
-                                     syncStatus: .synced).when(false) {
+        await bookmarkManager.update(
+            bookmark: existingBookmark,
+            title: title,
+            time: time,
+            created: created,
+            passage: apiBookmark.bookmarkPassage,
+            passageLocation: apiBookmark.bookmarkPassageLocation,
+            passageModified: apiBookmark.passageModifiedDate,
+            referenceTime: apiBookmark.bookmarkReferenceTime,
+            referenceTimeModified: apiBookmark.referenceTimeModifiedDate,
+            syncStatus: .synced
+        ).when(false) {
             FileLog.shared.addMessage("SyncTask: Update Bookmark Failed. API Data: \(apiBookmark.logDescription)")
         }
     }

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -424,6 +424,11 @@ extension SyncTask {
                                                     title: apiBookmark.title.value,
                                                     time: Double(apiBookmark.time.value),
                                                     dateCreated: apiBookmark.createdAt.date,
+                                                    passage: apiBookmark.bookmarkPassage,
+                                                    passageLocation: apiBookmark.bookmarkPassageLocation,
+                                                    passageModified: apiBookmark.passageModifiedDate,
+                                                    referenceTime: apiBookmark.bookmarkReferenceTime,
+                                                    referenceTimeModified: apiBookmark.referenceTimeModifiedDate,
                                                     syncStatus: .synced)
 
                 if addedUuid == nil {
@@ -452,7 +457,13 @@ extension SyncTask {
             return
         }
 
-        await bookmarkManager.update(bookmark: existingBookmark, title: title, time: time, created: created, syncStatus: .synced).when(false) {
+        await bookmarkManager.update(bookmark: existingBookmark, title: title, time: time, created: created,
+                                     passage: apiBookmark.bookmarkPassage,
+                                     passageLocation: apiBookmark.bookmarkPassageLocation,
+                                     passageModified: apiBookmark.passageModifiedDate,
+                                     referenceTime: apiBookmark.bookmarkReferenceTime,
+                                     referenceTimeModified: apiBookmark.referenceTimeModifiedDate,
+                                     syncStatus: .synced).when(false) {
             FileLog.shared.addMessage("SyncTask: Update Bookmark Failed. API Data: \(apiBookmark.logDescription)")
         }
     }
@@ -480,6 +491,33 @@ private extension Api_SyncUserBookmark {
 
     var created: Date? {
         hasCreatedAt ? createdAt.date : nil
+    }
+
+    // The server only emits the passage and reference time groups when their modified timestamp
+    // is set, using "" / 0 as placeholders for a null value within an emitted group. Each group
+    // is gated on its modified date below, so an absent group leaves the local values untouched.
+
+    var bookmarkPassage: String? {
+        guard hasPassage, !passage.value.isEmpty else { return nil }
+        return passage.value
+    }
+
+    var bookmarkPassageLocation: Int? {
+        // A location without a passage is meaningless, and 0 stands in for null on the server
+        guard bookmarkPassage != nil, hasPassageLocation else { return nil }
+        return Int(passageLocation.value)
+    }
+
+    var passageModifiedDate: Date? {
+        hasPassageModified ? Date(timeIntervalSince1970: TimeInterval(passageModified.value) / 1000) : nil
+    }
+
+    var bookmarkReferenceTime: TimeInterval? {
+        hasReferenceTime ? TimeInterval(referenceTime.value) : nil
+    }
+
+    var referenceTimeModifiedDate: Date? {
+        hasReferenceTimeModified ? Date(timeIntervalSince1970: TimeInterval(referenceTimeModified.value) / 1000) : nil
     }
 
     var logDescription: String {

--- a/Modules/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -367,6 +367,130 @@ final class BookmarkDataManagerTests: DataManagerTestCase {
         }
     }
 
+    // MARK: - Passage
+
+    func testAddingBookmarkWithPassageRoundTrips() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let passageModified = Date(timeIntervalSince1970: 100)
+            let referenceTimeModified = Date(timeIntervalSince1970: 200)
+
+            let uuid = try XCTUnwrap(dataManager.bookmarks.add(
+                episodeUuid: "episode-uuid",
+                podcastUuid: "podcast-uuid",
+                title: "Title",
+                time: 1,
+                passage: "A memorable passage",
+                passageLocation: 42,
+                passageModified: passageModified,
+                referenceTime: 118,
+                referenceTimeModified: referenceTimeModified
+            ), "\(impl): should return bookmark uuid")
+
+            let bookmark = try XCTUnwrap(dataManager.bookmarks.bookmark(for: uuid), "\(impl): bookmark should be persisted")
+            XCTAssertEqual(bookmark.passage, "A memorable passage", "\(impl): passage should round trip")
+            XCTAssertEqual(bookmark.passageLocation, 42, "\(impl): passageLocation should round trip")
+            XCTAssertEqual(bookmark.passageModified, passageModified, "\(impl): passageModified should round trip")
+            XCTAssertEqual(bookmark.referenceTime, 118, "\(impl): referenceTime should round trip")
+            XCTAssertEqual(bookmark.referenceTimeModified, referenceTimeModified, "\(impl): referenceTimeModified should round trip")
+        }
+    }
+
+    func testAddingBookmarkWithoutPassageIsNil() throws {
+        try runWithBothImplementations { dataManager, impl in
+            let bookmark = addBookmark(dataManager: dataManager)
+
+            XCTAssertNil(bookmark.passage, "\(impl): passage should be nil")
+            XCTAssertNil(bookmark.passageLocation, "\(impl): passageLocation should be nil")
+            XCTAssertNil(bookmark.passageModified, "\(impl): passageModified should be nil")
+            XCTAssertNil(bookmark.referenceTime, "\(impl): referenceTime should be nil")
+            XCTAssertNil(bookmark.referenceTimeModified, "\(impl): referenceTimeModified should be nil")
+        }
+    }
+
+    func testUpdatingPassageSaves() async throws {
+        try await runWithBothImplementations { dataManager, impl in
+            let bookmark = addBookmark(dataManager: dataManager)
+            let modified = Date(timeIntervalSince1970: 300)
+
+            await dataManager.bookmarks.update(bookmark: bookmark, passage: "New passage", passageLocation: 7, passageModified: modified)
+
+            let updated = dataManager.bookmarks.bookmark(for: bookmark.uuid)
+            XCTAssertEqual(updated?.passage, "New passage", "\(impl): passage should update")
+            XCTAssertEqual(updated?.passageLocation, 7, "\(impl): passageLocation should update")
+            XCTAssertEqual(updated?.passageModified, modified, "\(impl): passageModified should update")
+        }
+    }
+
+    func testUpdatingReferenceTimeSaves() async throws {
+        try await runWithBothImplementations { dataManager, impl in
+            let bookmark = addBookmark(dataManager: dataManager)
+            let modified = Date(timeIntervalSince1970: 300)
+
+            await dataManager.bookmarks.update(bookmark: bookmark, referenceTime: 45, referenceTimeModified: modified)
+
+            let updated = dataManager.bookmarks.bookmark(for: bookmark.uuid)
+            XCTAssertEqual(updated?.referenceTime, 45, "\(impl): referenceTime should update")
+            XCTAssertEqual(updated?.referenceTimeModified, modified, "\(impl): referenceTimeModified should update")
+        }
+    }
+
+    func testUpdatingTitleLeavesPassageUntouched() async throws {
+        try await runWithBothImplementations { dataManager, impl in
+            let uuid = try XCTUnwrap(dataManager.bookmarks.add(
+                episodeUuid: "episode-uuid",
+                podcastUuid: "podcast-uuid",
+                title: "Title",
+                time: 1,
+                passage: "A passage",
+                passageLocation: 3,
+                passageModified: Date(timeIntervalSince1970: 100)
+            ))
+            let bookmark = try XCTUnwrap(dataManager.bookmarks.bookmark(for: uuid))
+
+            await dataManager.bookmarks.update(bookmark: bookmark, title: "New Title")
+
+            let updated = dataManager.bookmarks.bookmark(for: bookmark.uuid)
+            XCTAssertEqual(updated?.title, "New Title", "\(impl): title should update")
+            XCTAssertEqual(updated?.passage, "A passage", "\(impl): passage should be untouched")
+            XCTAssertEqual(updated?.passageLocation, 3, "\(impl): passageLocation should be untouched")
+        }
+    }
+
+    func testUpdatingPassageWithoutModifiedDateIsIgnored() async throws {
+        try await runWithBothImplementations { dataManager, impl in
+            let bookmark = addBookmark(dataManager: dataManager)
+
+            await dataManager.bookmarks.update(bookmark: bookmark, passage: "New passage", passageLocation: 7)
+
+            let updated = dataManager.bookmarks.bookmark(for: bookmark.uuid)
+            XCTAssertNil(updated?.passage, "\(impl): passage without a modified date should be ignored")
+            XCTAssertNil(updated?.passageLocation, "\(impl): passageLocation without a modified date should be ignored")
+        }
+    }
+
+    func testClearingPassageSaves() async throws {
+        try await runWithBothImplementations { dataManager, impl in
+            let uuid = try XCTUnwrap(dataManager.bookmarks.add(
+                episodeUuid: "episode-uuid",
+                podcastUuid: "podcast-uuid",
+                title: "Title",
+                time: 1,
+                passage: "A passage",
+                passageLocation: 3,
+                passageModified: Date(timeIntervalSince1970: 100)
+            ))
+            let bookmark = try XCTUnwrap(dataManager.bookmarks.bookmark(for: uuid))
+            let modified = Date(timeIntervalSince1970: 300)
+
+            await dataManager.bookmarks.update(bookmark: bookmark, passageModified: modified)
+
+            let updated = dataManager.bookmarks.bookmark(for: bookmark.uuid)
+            XCTAssertNil(updated?.passage, "\(impl): passage should clear")
+            XCTAssertNil(updated?.passageLocation, "\(impl): passageLocation should clear")
+            XCTAssertEqual(updated?.passageModified, modified, "\(impl): passageModified should update")
+        }
+    }
+
     // MARK: - Helpers
 
     @discardableResult

--- a/Modules/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
+++ b/Modules/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
@@ -104,6 +104,140 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
         XCTAssertEqual(updatedTitle, dbBookmark?.title)
     }
 
+    // MARK: - Passage Fields
+
+    func testImportingNewBookmarkSavesPassageFields() async {
+        let uuid = UUID().uuidString
+        let passageModified = Date(timeIntervalSince1970: 100)
+        let referenceTimeModified = Date(timeIntervalSince1970: 200)
+
+        let apiBookmark = Api_SyncUserBookmark(uuid: uuid,
+                                               passage: "A memorable passage",
+                                               passageLocation: 4,
+                                               passageModified: passageModified,
+                                               referenceTime: 118,
+                                               referenceTimeModified: referenceTimeModified)
+
+        await syncTask.importBookmark(apiBookmark)
+
+        let bookmark = bookmarkManager.bookmark(for: uuid)
+        XCTAssertEqual(bookmark?.passage, "A memorable passage")
+        XCTAssertEqual(bookmark?.passageLocation, 4)
+        XCTAssertEqual(bookmark?.passageModified, passageModified)
+        XCTAssertEqual(bookmark?.referenceTime, 118)
+        XCTAssertEqual(bookmark?.referenceTimeModified, referenceTimeModified)
+    }
+
+    func testImportingExistingBookmarkUpdatesPassageFields() async {
+        let bookmark = addBookmark(time: 2)
+        let passageModified = Date(timeIntervalSince1970: 100)
+
+        let apiBookmark = Api_SyncUserBookmark(uuid: bookmark.uuid,
+                                               episode: bookmark.episodeUuid,
+                                               podcast: bookmark.podcastUuid,
+                                               title: bookmark.title,
+                                               time: bookmark.time,
+                                               created: bookmark.created,
+                                               passage: "Synced passage",
+                                               passageLocation: 7,
+                                               passageModified: passageModified)
+
+        await syncTask.importBookmark(apiBookmark)
+
+        let updated = bookmarkManager.bookmark(for: bookmark.uuid)
+        XCTAssertEqual(updated?.passage, "Synced passage")
+        XCTAssertEqual(updated?.passageLocation, 7)
+        XCTAssertEqual(updated?.passageModified, passageModified)
+        XCTAssertNil(updated?.referenceTime, "An absent reference time group should stay nil")
+    }
+
+    func testImportingBookmarkWithoutPassageFieldsLeavesLocalValues() async {
+        let passageModified = Date(timeIntervalSince1970: 100)
+        let uuid = bookmarkManager.add(episodeUuid: "episode-1",
+                                       podcastUuid: "podcast-uuid",
+                                       title: "Title",
+                                       time: 1,
+                                       passage: "Local passage",
+                                       passageLocation: 2,
+                                       passageModified: passageModified,
+                                       referenceTime: 30,
+                                       referenceTimeModified: passageModified)!
+
+        let apiBookmark = Api_SyncUserBookmark(uuid: uuid,
+                                               episode: "episode-1",
+                                               podcast: "podcast-uuid",
+                                               title: "New Title",
+                                               time: 1,
+                                               created: Date(timeIntervalSince1970: 456))
+
+        await syncTask.importBookmark(apiBookmark)
+
+        let updated = bookmarkManager.bookmark(for: uuid)
+        XCTAssertEqual(updated?.title, "New Title")
+        XCTAssertEqual(updated?.passage, "Local passage", "An absent passage group should leave the local passage")
+        XCTAssertEqual(updated?.passageLocation, 2)
+        XCTAssertEqual(updated?.referenceTime, 30)
+    }
+
+    func testChangedBookmarksIncludePassageFieldsWhenSet() {
+        let passageModified = Date(timeIntervalSince1970: 100)
+        let referenceTimeModified = Date(timeIntervalSince1970: 200)
+        bookmarkManager.add(episodeUuid: "episode-1",
+                            podcastUuid: "podcast-uuid",
+                            title: "Title",
+                            time: 1,
+                            passage: "Local passage",
+                            passageLocation: 2,
+                            passageModified: passageModified,
+                            referenceTime: 30,
+                            referenceTimeModified: referenceTimeModified)
+
+        let record = syncTask.changedBookmarks()?.first?.bookmark
+
+        XCTAssertNotNil(record)
+        XCTAssertEqual(record?.passage.value, "Local passage")
+        XCTAssertEqual(record?.passageLocation.value, 2)
+        XCTAssertEqual(record?.passageModified.value, 100_000, "The modified date should upload as epoch milliseconds")
+        XCTAssertEqual(record?.referenceTime.value, 30)
+        XCTAssertEqual(record?.referenceTimeModified.value, 200_000, "The modified date should upload as epoch milliseconds")
+    }
+
+    func testChangedBookmarksOmitPassageFieldsWhenNeverSet() {
+        addBookmark(time: 1)
+
+        let record = syncTask.changedBookmarks()?.first?.bookmark
+
+        XCTAssertNotNil(record)
+        XCTAssertFalse(record?.hasPassage ?? true, "The passage group should not upload when it was never set")
+        XCTAssertFalse(record?.hasPassageLocation ?? true)
+        XCTAssertFalse(record?.hasPassageModified ?? true)
+        XCTAssertFalse(record?.hasReferenceTime ?? true, "The reference time group should not upload when it was never set")
+        XCTAssertFalse(record?.hasReferenceTimeModified ?? true)
+    }
+
+    func testFullSyncKeepsLocalPassageFields() throws {
+        let passageModified = Date(timeIntervalSince1970: 100)
+        let uuid = try XCTUnwrap(bookmarkManager.add(episodeUuid: "episode-1",
+                                                     podcastUuid: "podcast-uuid",
+                                                     title: "Title",
+                                                     time: 1,
+                                                     passage: "Local passage",
+                                                     passageLocation: 2,
+                                                     passageModified: passageModified,
+                                                     referenceTime: 30,
+                                                     referenceTimeModified: passageModified))
+        let bookmark = try XCTUnwrap(bookmarkManager.bookmark(for: uuid))
+
+        syncTask.processServerBookmarks([.fromBookmark(bookmark)])
+
+        let replaced = bookmarkManager.bookmark(for: uuid)
+        XCTAssertEqual(replaced?.passage, "Local passage", "The passage fields should survive the full sync replacing the bookmark")
+        XCTAssertEqual(replaced?.passageLocation, 2)
+        XCTAssertEqual(replaced?.passageModified, passageModified)
+        XCTAssertEqual(replaced?.referenceTime, 30)
+        XCTAssertEqual(replaced?.referenceTimeModified, passageModified)
+    }
+
     // MARK: - Server Data Processed
 
     func testProcessServerDataParsesBookmarksCorrectly() {
@@ -245,7 +379,12 @@ private extension Api_SyncUserBookmark {
          title: String = "Title",
          time: TimeInterval = 1234,
          created: Date = Date(),
-         isDeleted: Bool? = nil) {
+         isDeleted: Bool? = nil,
+         passage: String? = nil,
+         passageLocation: Int? = nil,
+         passageModified: Date? = nil,
+         referenceTime: TimeInterval? = nil,
+         referenceTimeModified: Date? = nil) {
         self.init()
 
         bookmarkUuid = uuid
@@ -261,6 +400,19 @@ private extension Api_SyncUserBookmark {
 
         if let isDeleted {
             self.isDeleted.value = isDeleted
+        }
+
+        // Mirror the server: a group is only present along with its modified timestamp,
+        // with "" / 0 placeholders for null values within it
+        if let passageModified {
+            self.passage.value = passage ?? ""
+            self.passageLocation.value = Int32(passageLocation ?? 0)
+            self.passageModified = .init(date: passageModified)
+        }
+
+        if let referenceTimeModified {
+            self.referenceTime.value = Int32(referenceTime ?? 0)
+            self.referenceTimeModified = .init(date: referenceTimeModified)
         }
     }
 }

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -25,7 +25,7 @@ struct BookmarkUpdateParameters {
 }
 
 class BookmarkManager {
-    private let dataManager: BookmarkDataManager
+    let dataManager: BookmarkDataManager
     private let generalManager: DataManager
     private let playbackManager: PlaybackManager
     private let cacheServerHandler: CacheServerHandler
@@ -47,6 +47,8 @@ class BookmarkManager {
         self.generalManager = generalManager
         self.playbackManager = playbackManager
         self.cacheServerHandler = cacheServerHandler
+
+        migratePassagesFromUserDefaults()
     }
 
     /// Plays the "bookmark created" tone
@@ -113,12 +115,6 @@ class BookmarkManager {
     /// Removes an array of bookmarks
     func remove(_ bookmarks: [Bookmark]) async -> Bool {
         await dataManager.remove(bookmarks: bookmarks).when(true) {
-            bookmarks.forEach {
-                $0.passage = nil
-                $0.passageLocation = nil
-                $0.referenceTime = nil
-            }
-
             onBookmarksDeleted.send(.init(items: bookmarks.map {
                 .init(uuid: $0.uuid, episode: $0.episodeUuid, podcast: $0.podcastUuid)
             }))
@@ -128,16 +124,16 @@ class BookmarkManager {
     /// Updates the bookmark with the given parameters, emits `onBookmarkChanged` on success
     @discardableResult
     func update(_ parameters: BookmarkUpdateParameters, for bookmark: Bookmark) async -> Bool {
-        if let passage = parameters.passage {
-            bookmark.passage = passage.text
-            bookmark.passageLocation = passage.location
-        }
+        let now = Date()
 
-        if let referenceTime = parameters.referenceTime {
-            bookmark.referenceTime = referenceTime
-        }
-
-        return await dataManager.update(bookmark: bookmark, title: parameters.title).when(true) {
+        return await dataManager.update(bookmark: bookmark,
+                                        title: parameters.title,
+                                        modified: now,
+                                        passage: parameters.passage?.text,
+                                        passageLocation: parameters.passage?.location,
+                                        passageModified: parameters.passage != nil ? now : nil,
+                                        referenceTime: parameters.referenceTime,
+                                        referenceTimeModified: parameters.referenceTime != nil ? now : nil).when(true) {
             onBookmarkChanged.send(.init(uuid: bookmark.uuid, change: .title(parameters.title)))
         }
     }
@@ -236,6 +232,47 @@ class BookmarkManager {
                 /// The uuid of the podcast the bookmark was removed from, if available
                 let podcast: String?
             }
+        }
+    }
+}
+
+// MARK: - Passage UserDefaults Migration
+
+private extension BookmarkManager {
+    /// Passages were temporarily stored in `UserDefaults` before they moved into the database
+    /// and became syncable. Moves any values left behind by those builds into the database,
+    /// where a bookmark doesn't already have one.
+    func migratePassagesFromUserDefaults() {
+        let defaults = UserDefaults.standard
+        let completedKey = "bookmark.passageMigrationCompleted"
+        guard !defaults.bool(forKey: completedKey) else { return }
+
+        let dataManager = dataManager
+
+        Task.detached(priority: .background) {
+            for bookmark in dataManager.allBookmarks(includeDeleted: true) {
+                let passageKey = "bookmark.passage.\(bookmark.uuid)"
+                let locationKey = "bookmark.passageLocation.\(bookmark.uuid)"
+                let referenceTimeKey = "bookmark.referenceTime.\(bookmark.uuid)"
+
+                let passage = bookmark.passage == nil ? defaults.string(forKey: passageKey) : nil
+                let referenceTime = bookmark.referenceTime == nil ? defaults.object(forKey: referenceTimeKey) as? TimeInterval : nil
+
+                if passage != nil || referenceTime != nil {
+                    await dataManager.update(bookmark: bookmark,
+                                             passage: passage,
+                                             passageLocation: defaults.object(forKey: locationKey) as? Int,
+                                             passageModified: passage != nil ? bookmark.created : nil,
+                                             referenceTime: referenceTime,
+                                             referenceTimeModified: referenceTime != nil ? bookmark.created : nil)
+                }
+
+                defaults.removeObject(forKey: passageKey)
+                defaults.removeObject(forKey: locationKey)
+                defaults.removeObject(forKey: referenceTimeKey)
+            }
+
+            defaults.set(true, forKey: completedKey)
         }
     }
 }

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -47,8 +47,6 @@ class BookmarkManager {
         self.generalManager = generalManager
         self.playbackManager = playbackManager
         self.cacheServerHandler = cacheServerHandler
-
-        migratePassagesFromUserDefaults()
     }
 
     /// Plays the "bookmark created" tone
@@ -232,47 +230,6 @@ class BookmarkManager {
                 /// The uuid of the podcast the bookmark was removed from, if available
                 let podcast: String?
             }
-        }
-    }
-}
-
-// MARK: - Passage UserDefaults Migration
-
-private extension BookmarkManager {
-    /// Passages were temporarily stored in `UserDefaults` before they moved into the database
-    /// and became syncable. Moves any values left behind by those builds into the database,
-    /// where a bookmark doesn't already have one.
-    func migratePassagesFromUserDefaults() {
-        let defaults = UserDefaults.standard
-        let completedKey = "bookmark.passageMigrationCompleted"
-        guard !defaults.bool(forKey: completedKey) else { return }
-
-        let dataManager = dataManager
-
-        Task.detached(priority: .background) {
-            for bookmark in dataManager.allBookmarks(includeDeleted: true) {
-                let passageKey = "bookmark.passage.\(bookmark.uuid)"
-                let locationKey = "bookmark.passageLocation.\(bookmark.uuid)"
-                let referenceTimeKey = "bookmark.referenceTime.\(bookmark.uuid)"
-
-                let passage = bookmark.passage == nil ? defaults.string(forKey: passageKey) : nil
-                let referenceTime = bookmark.referenceTime == nil ? defaults.object(forKey: referenceTimeKey) as? TimeInterval : nil
-
-                if passage != nil || referenceTime != nil {
-                    await dataManager.update(bookmark: bookmark,
-                                             passage: passage,
-                                             passageLocation: defaults.object(forKey: locationKey) as? Int,
-                                             passageModified: passage != nil ? bookmark.created : nil,
-                                             referenceTime: referenceTime,
-                                             referenceTimeModified: referenceTime != nil ? bookmark.created : nil)
-                }
-
-                defaults.removeObject(forKey: passageKey)
-                defaults.removeObject(forKey: locationKey)
-                defaults.removeObject(forKey: referenceTimeKey)
-            }
-
-            defaults.set(true, forKey: completedKey)
         }
     }
 }

--- a/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
+++ b/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
@@ -43,9 +43,13 @@ extension BookmarkManager {
 
         guard let title, !title.isEmpty else {
             // Nothing to rename to, but the passage is still worth keeping for the edit sheet
-            bookmark.passage = snippet.text
-            bookmark.passageLocation = snippet.range.location
-            bookmark.referenceTime = snippet.referenceTime
+            let now = Date()
+            await dataManager.update(bookmark: bookmark,
+                                     passage: snippet.text,
+                                     passageLocation: snippet.range.location,
+                                     passageModified: now,
+                                     referenceTime: snippet.referenceTime,
+                                     referenceTimeModified: snippet.referenceTime != nil ? now : nil)
             return
         }
 


### PR DESCRIPTION
Bookmark passages now sync. The server side landed in [pocket-casts-sync-api#1448](https://github.com/Automattic/pocket-casts-sync-api/pull/1448), which added `passage`, `passage_location`, and `reference_time` to `SyncUserBookmark` (fields 14–18); this wires the app up to it:

- **Storage** — `passage`, `passageLocation`, and `referenceTime` move from the temporary UserDefaults backing into real `Bookmark` columns, each group paired with a modified date for last-write-wins merging (schema v76).
- **Protobuf** — regenerated from the updated proto. `Api_SyncUserBookmark` switched to a heap-backed storage class because it crossed 16 fields, which is most of the diff there.
- **Upload** — a group is only emitted when its modified date is set, mirroring the server's emission rules (`passage` + `passage_location` share one timestamp and merge atomically).
- **Import** — a group is only applied when its modified timestamp is present, so records without the fields leave local values untouched.
- **Full sync** — `BookmarkResponse` deliberately doesn't carry these fields (same as ai_title/ai_summary in #1355), and the full-sync path deletes and re-adds every bookmark, so it now carries the local passage fields across the re-add instead of silently wiping them.

## To test

1. Enable the `smartBookmarks` and `syncedTranscripts` feature flags on two devices signed into the same staging account.
2. On device A, play an episode with a generated transcript and create a bookmark — it captures a passage.
3. Sync both devices (background/foreground the app).
4. On device B, open the bookmark's edit sheet — the passage and transcript anchor are there, and playing the bookmark seeks using the synced reference time.
5. Sign out and back in on device A (forces a full sync) — the passage survives.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M8AZ4NDxm74z5EcR7g9b7

