### PR TITLE
[tvOS] Add categories and curated rows to Home

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -531,7 +531,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .smartBookmarks:
             BuildEnvironment.current == .debug
-
         case .captureBestFrame:
             true
         case .tvHomeCategoriesAndCurated:

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -314,6 +314,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Use best frame when capturing a thumbnail for video cells
     case captureBestFrame
 
+    /// Show the Categories and Curated rows on the tvOS Home screen
+    case tvHomeCategoriesAndCurated
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -531,6 +534,8 @@ public enum FeatureFlag: String, CaseIterable {
 
         case .captureBestFrame:
             true
+        case .tvHomeCategoriesAndCurated:
+            false
         }
     }
 

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -75,6 +75,8 @@ struct HomeView: View {
                         newReleasesRow
                         lovedByListenersOfRow
                         trendingRow
+                        categoriesRow
+                        curatedRow
                         BannerRow(type: .discoverMore, focusSection: Section.homeBanner.rawValue) {
                             Analytics.track(.bannerRowTapped, properties: ["type": "discover_more"])
                             tabRouter.selectedTab = .search

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 
 struct HomeView: View {
     @Environment(AppCoordinator.self) var coordinator
@@ -75,8 +76,10 @@ struct HomeView: View {
                         newReleasesRow
                         lovedByListenersOfRow
                         trendingRow
-                        categoriesRow
-                        curatedRow
+                        if FeatureFlag.tvHomeCategoriesAndCurated.enabled {
+                            categoriesRow
+                            curatedRow
+                        }
                         BannerRow(type: .discoverMore, focusSection: Section.homeBanner.rawValue) {
                             Analytics.track(.bannerRowTapped, properties: ["type": "discover_more"])
                             tabRouter.selectedTab = .search
@@ -91,8 +94,10 @@ struct HomeView: View {
                             tabRouter.pendingAuthFlow = .createAccount
                         }
                         trendingRow
-                        categoriesRow
-                        curatedRow
+                        if FeatureFlag.tvHomeCategoriesAndCurated.enabled {
+                            categoriesRow
+                            curatedRow
+                        }
                         BannerRow(type: .discoverMore, focusSection: Section.homeBanner.rawValue) {
                             Analytics.track(.bannerRowTapped, properties: ["type": "discover_more"])
                             tabRouter.selectedTab = .search

--- a/Pocket Casts TV App/UI/Home/HomeView.swift
+++ b/Pocket Casts TV App/UI/Home/HomeView.swift
@@ -94,10 +94,8 @@ struct HomeView: View {
                             tabRouter.pendingAuthFlow = .createAccount
                         }
                         trendingRow
-                        if FeatureFlag.tvHomeCategoriesAndCurated.enabled {
-                            categoriesRow
-                            curatedRow
-                        }
+                        categoriesRow
+                        curatedRow
                         BannerRow(type: .discoverMore, focusSection: Section.homeBanner.rawValue) {
                             Analytics.track(.bannerRowTapped, properties: ["type": "discover_more"])
                             tabRouter.selectedTab = .search


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

<!-- issue number, if applicable -->

Adds the **Categories** and **Curated** rows to the tvOS Home screen so they appear alongside the existing New Releases, Loved by Listeners, and Trending rows. Both row views already existed in `HomeView`; this change surfaces them in the main content stack.

This is in case we need to add more Home content for signed In users that are new to the app.

## To test

1. Ensure the FF is active in code ( default: true)
1. Launch the Pocket Casts TV app.
3. Open the Home tab.
4. Scroll down past the Trending row.
5. Confirm the **Categories** and **Curated** rows are shown before the "Discover more" banner.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
