### PR TITLE
Skip interactive confirmation of HTML preview during release notes upload on CI

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1548,6 +1548,7 @@ platform :ios do
       overwrite_screenshots: true, # won't have effect if `skip_screenshots` is true
       phased_release: true,
       precheck_include_in_app_purchases: false,
+      force: is_ci, # Skip interactive verification of HTML preview on CI
       api_key: app_store_connect_api_key
     )
   ensure


### PR DESCRIPTION
See p1785528771728499-slack-CC7L49W13

PRs https://github.com/Automattic/pocket-casts-ios/pull/4685 and https://github.com/Automattic/pocket-casts-ios/pull/4586 introduced calls to `upload_to_app_store` to upload release notes on ASC, but they were missing the `force: true` parameter that skips the interactive confirmation of the release notes HTML

This PR fixes this by passing `force: is_ci`, so it bypasses the confirmation on CI while still keeping it if we ever wanted to run the lane locally.