### PR TITLE
Consolidate Smart Bookmarks CHANGELOG entries for 8.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 -----
 - Fix the Bookmarks multi-select layout: rows keep their text width instead of shrinking, the selection bar sits just above the mini player instead of floating too high, and on iOS 26 it hides the tab bar and mini player correctly [#4819](https://github.com/Automattic/pocket-casts-ios/pull/4819)
 - Fix the day label in episode cells growing out of proportion at large text sizes [#4818](https://github.com/Automattic/pocket-casts-ios/pull/4818)
-- Fix swiping away the bookmark edit sheet keeping the new bookmark with its default title instead of discarding it, like the close button does [#4864](https://github.com/Automattic/pocket-casts-ios/pull/4864)
+- Add Smart Bookmarks: bookmarks now suggest a title and capture the surrounding passage from the episode transcript, mark their spot in the transcript, and anchor their timestamp to the transcript's reference timeline so it stays accurate even when dynamic ads shift the audio [#4761](https://github.com/Automattic/pocket-casts-ios/pull/4761)
 - [tvOS] Add audio-reactive waveform to TV now playing screen. [#4853](https://github.com/Automattic/pocket-casts-ios/pull/4853)
 
 8.17


### PR DESCRIPTION
Smart Bookmarks (title suggestion, transcript passage capture, transcript marker, and reference-time anchoring) is a single new feature spread across many PRs. Replaces the individual per-PR CHANGELOG lines added for it in 8.18 with one consolidated entry, and drops the standalone swipe-to-dismiss fix line since it's polish on the same not-yet-released editor.

## To test

1. Open `CHANGELOG.md` and confirm the 8.18 section reads correctly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.