### PR TITLE
Add `fastlane/Frozen.strings` as an exception to `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@ Gemfile*              @Automattic/apps-infra-tooling
 .bundle/              @Automattic/apps-infra-tooling
 .rubocop*.yml         @Automattic/apps-infra-tooling
 fastlane/             @Automattic/apps-infra-tooling
-# Store-listing localization is content, not infra.
+# Store-listing localization and frozen strings are content, not infra.
 fastlane/metadata/
 fastlane/Frozen.strings
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@ Gemfile*              @Automattic/apps-infra-tooling
 fastlane/             @Automattic/apps-infra-tooling
 # Store-listing localization is content, not infra.
 fastlane/metadata/
+fastlane/Frozen.strings
 
 # CI and automation
 .buildkite/           @Automattic/apps-infra-tooling


### PR DESCRIPTION
The @apps-infra-tooling team gets ping'd on every code freeze backmerge PR because those update the `fastlane/Frozen.strings` as part of the code freeze procedure and our team is a CODEOWNER of `fastlane/` (recent example: https://github.com/Automattic/pocket-casts-ios/pull/4890)

But in practice our team don't really need to chime in on those backmerge PRs, and we only are as an artifact of the fact that `Frozen.strings` is stored inside `fastlane/*` dir. So adding this as an exception to the CODEOWNERS

An alternative would have been to store the `Frozen.strings` file elsewhere (e.g. maybe in `fastlane/metadata/` which is already set as an exception), but I figured the simpler approach was enough.

## To test

Can't really test this properly pre-merge, so I guess we'll just have to check that our team is not ping'd again during the next code freeze's backmerge PR next sprint 🙃 
