### PR TITLE
Stop expiring builds waiting for beta review

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -730,7 +730,9 @@ platform :ios do
 
     upload_to_testflight(
       ipa: ipa_path,
-      reject_build_waiting_for_review: true,
+      # Deliberately no `reject_build_waiting_for_review`: `pilot` picks the build to expire by version alone, and the
+      # tvOS app shares this App Store Connect record and version number, so it would expire the tvOS build.
+      # https://github.com/fastlane/fastlane/blob/2.237.0/pilot/lib/pilot/build_manager.rb#L379-L385
       distribute_external: true,
       groups: EXTERNAL_BETA_TESTER_GROUPS,
       notify_external_testers: true,
@@ -771,7 +773,7 @@ platform :ios do
 
     if distribute_external
       testflight_options.merge!(
-        reject_build_waiting_for_review: true,
+        # See the iOS lane for why this doesn't set `reject_build_waiting_for_review`.
         groups: EXTERNAL_BETA_TESTER_GROUPS,
         notify_external_testers: true
       )


### PR DESCRIPTION
Follow-up to #4895, which made tvOS release builds reach Beta App Review.

`pilot` picks the build to expire by version alone, [ignoring the platform](https://github.com/fastlane/fastlane/blob/2.237.0/pilot/lib/pilot/build_manager.rb#L379-L385), and the tvOS app shares both the App Store Connect record and the version number with iOS. That was harmless while tvOS builds never reached review; now either platform's upload could expire the other's build, so neither lane asks for the rejection.

The tradeoff we're accepting: a stale iOS build stuck in review no longer gets expired automatically. The real fix is a `preReleaseVersion.platform` filter upstream in `pilot`.

Side note: This PR might look a bit random. Originally, as you might guess from the branch name, this was going to address https://linear.app/a8c/issue/AINFRA-2800. Alas, @iangmaia beat me to it.

## To test

No CI job exercises these lanes — `release-upload.sh` only runs from `release-builds.yml`. Locally, `bundle exec fastlane upload_app_store_connect_build_to_testflight_tvos ipa_path:/tmp/nope.ipa distribute_external:true` with dummy `APP_STORE_CONNECT_API_KEY_*` values drives through to the API-key step, confirming the options hash builds. End-to-end validation comes with the next release cycle.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
