### PR TITLE
AINFRA-2800: Automatically submit tvOS beta builds for testing

### DIFF
--- a/.buildkite/commands/release-upload.sh
+++ b/.buildkite/commands/release-upload.sh
@@ -21,7 +21,7 @@ case "$RELEASE_PLATFORM" in
     ARCHIVE_ZIP_PATH="artifacts/pocket-casts.xcarchive.zip"
     SENTRY_ANNOTATION_CONTEXT="sentry-failure-ios"
     TESTFLIGHT_LANE="upload_app_store_connect_build_to_testflight"
-    TESTFLIGHT_LANE_ARGS=()
+    TESTFLIGHT_LANE_ARGS=(ipa_path:"$IPA_PATH")
     ;;
   tvos)
     PLATFORM_NAME="tvOS"
@@ -30,7 +30,7 @@ case "$RELEASE_PLATFORM" in
     ARCHIVE_ZIP_PATH="artifacts/pocket-casts-tvos.xcarchive.zip"
     SENTRY_ANNOTATION_CONTEXT="sentry-failure-tvos"
     TESTFLIGHT_LANE="upload_app_store_connect_build_to_testflight_tvos"
-    TESTFLIGHT_LANE_ARGS=(distribute_external:"$BETA_RELEASE")
+    TESTFLIGHT_LANE_ARGS=(ipa_path:"$IPA_PATH" distribute_external:"$BETA_RELEASE")
     ;;
   *)
     echo "Unsupported RELEASE_PLATFORM: $RELEASE_PLATFORM. Expected 'ios' or 'tvos'." >&2
@@ -90,7 +90,7 @@ upload_symbols() {
 upload_symbols "$PLATFORM_NAME" "$DSYM_PATH" "$SENTRY_ANNOTATION_CONTEXT"
 
 echo "--- :testflight: Uploading $PLATFORM_NAME to TestFlight"
-bundle exec fastlane "$TESTFLIGHT_LANE" ipa_path:"$IPA_PATH" "${TESTFLIGHT_LANE_ARGS[@]}"
+bundle exec fastlane "$TESTFLIGHT_LANE" "${TESTFLIGHT_LANE_ARGS[@]}"
 
 if [[ "$NOTIFY_SLACK" == "true" ]]; then
   echo "--- :slack: Notifying Slack"

--- a/.buildkite/commands/release-upload.sh
+++ b/.buildkite/commands/release-upload.sh
@@ -21,6 +21,7 @@ case "$RELEASE_PLATFORM" in
     ARCHIVE_ZIP_PATH="artifacts/pocket-casts.xcarchive.zip"
     SENTRY_ANNOTATION_CONTEXT="sentry-failure-ios"
     TESTFLIGHT_LANE="upload_app_store_connect_build_to_testflight"
+    TESTFLIGHT_LANE_ARGS=()
     ;;
   tvos)
     PLATFORM_NAME="tvOS"
@@ -29,6 +30,7 @@ case "$RELEASE_PLATFORM" in
     ARCHIVE_ZIP_PATH="artifacts/pocket-casts-tvos.xcarchive.zip"
     SENTRY_ANNOTATION_CONTEXT="sentry-failure-tvos"
     TESTFLIGHT_LANE="upload_app_store_connect_build_to_testflight_tvos"
+    TESTFLIGHT_LANE_ARGS=(distribute_external:"$BETA_RELEASE")
     ;;
   *)
     echo "Unsupported RELEASE_PLATFORM: $RELEASE_PLATFORM. Expected 'ios' or 'tvos'." >&2
@@ -88,7 +90,7 @@ upload_symbols() {
 upload_symbols "$PLATFORM_NAME" "$DSYM_PATH" "$SENTRY_ANNOTATION_CONTEXT"
 
 echo "--- :testflight: Uploading $PLATFORM_NAME to TestFlight"
-bundle exec fastlane "$TESTFLIGHT_LANE" ipa_path:"$IPA_PATH"
+bundle exec fastlane "$TESTFLIGHT_LANE" ipa_path:"$IPA_PATH" "${TESTFLIGHT_LANE_ARGS[@]}"
 
 if [[ "$NOTIFY_SLACK" == "true" ]]; then
   echo "--- :slack: Notifying Slack"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -740,18 +740,17 @@ platform :ios do
     )
   end
 
-  # Uploads the tvOS binary to TestFlight for internal testers only.
+  # Uploads the tvOS binary to TestFlight.
   #
   # Typically called after having built the binary with `build_app_store_connect_tvos`.
   #
-  # The tvOS app is in early-days territory, so we skip external distribution and the Beta App Review submission.
-  # Revisit once the app is ready for wider testing.
-  #
   # @param ipa_path [String] Path to the `.ipa` file to upload to TestFlight
+  # @param distribute_external [Boolean] If true, distributes the build to external testers and submits it for Beta App Review.
   #
-  lane :upload_app_store_connect_build_to_testflight_tvos do |ipa_path: APP_STORE_CONNECT_TVOS_BUILD_IPA_PATH|
+  lane :upload_app_store_connect_build_to_testflight_tvos do |ipa_path: APP_STORE_CONNECT_TVOS_BUILD_IPA_PATH, distribute_external: false|
     require_env_vars!(*ASC_API_KEY_ENV_VARS)
     ipa_path = project_path(ipa_path)
+    distribute_external = boolean_option(distribute_external, default: false)
 
     # TODO: This is currently the same as the iOS changelog. We'll need a mechanism to filter tvOS-only notes (or just accept the compromise.)
     changelog = extract_release_notes_for_version(
@@ -761,14 +760,24 @@ platform :ios do
     changelog = +'Minor changes.' if changelog.empty?
     changelog.gsub!(/ ?\[#[0-9]+\]\(https:.*\)/, '') # Remove GitHub links
 
-    upload_to_testflight(
+    testflight_options = {
       ipa: ipa_path,
-      distribute_external: false,
-      skip_submission: true,
+      distribute_external: distribute_external,
+      skip_submission: !distribute_external,
       changelog: changelog,
       team_id: TEAM_ID_APP_STORE,
       api_key: app_store_connect_api_key
-    )
+    }
+
+    if distribute_external
+      testflight_options.merge!(
+        reject_build_waiting_for_review: true,
+        groups: EXTERNAL_BETA_TESTER_GROUPS,
+        notify_external_testers: true
+      )
+    end
+
+    upload_to_testflight(**testflight_options)
   end
 
   # Builds the app binary for Enterprise distribution (Prototype Build)


### PR DESCRIPTION
Fixes AINFRA-2800

Automatically distributes tvOS beta builds started by Releases V2 to the existing external TestFlight tester groups and submits them for Beta App Review, matching the iOS beta behavior.

The tvOS Fastlane lane remains upload-only by default. The Releases V2 upload path opts in using its existing `BETA_RELEASE` value, so PR/trunk uploads and final/hotfix release builds keep their current behavior.

## To test

For end-to-end validation, we'll test it in the next release cycle with a tvOS beta from Releases V2, making sure the App Store Connect distributes it to `EXTERNAL_BETA_TESTER_GROUPS` and that it submits it for Beta App Review.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
