### PR TITLE
🍒 Fix the bookmark snippet test compile error

### DIFF
--- a/PocketCastsTests/Tests/Bookmarks/BookmarkTranscriptSnippetExtractorTests.swift
+++ b/PocketCastsTests/Tests/Bookmarks/BookmarkTranscriptSnippetExtractorTests.swift
@@ -91,7 +91,7 @@ final class BookmarkTranscriptSnippetExtractorTests: XCTestCase {
 
     func testPassageRangeMatchesAPassageStoredWithoutItsLineBreaks() throws {
         let model = try makeModel()
-        let snippet = try XCTUnwrap(BookmarkTranscriptSnippetExtractor.extractSnippet(from: model, at: 12))
+        let snippet = try BookmarkTranscriptSnippetExtractor.extractSnippet(from: model, at: 12).get()
 
         // Passages captured by earlier versions were flattened to a single line
         let flattened = snippet.text.split(whereSeparator: \.isWhitespace).joined(separator: " ")


### PR DESCRIPTION
`extractSnippet` returns a `Result`, so `XCTUnwrap` handed back the `Result` itself and the later `.text`/`.range` accesses had nothing to bind to. The other three call sites in the file already unwrap with `.get()`.

---

Generated with the help of Claude Code, https://claude.ai/code

| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

<!-- Please include a summary of what this PR is changing and why these changes are needed. -->

## To test

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Tap on the Filters tab -->
<!-- 2. Tap on a filter -->
<!-- 3. etc. -->

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
