### PR TITLE
Add Terms of Use and Privacy Policy links to App Store description

### DIFF
--- a/fastlane/metadata/de-DE/description.txt
+++ b/fastlane/metadata/de-DE/description.txt
@@ -40,6 +40,9 @@ ALLE DEINE FAVORITEN
 • Teilen: Teile Podcasts und einzelne Folgen mit der Welt.
 • OPML: Dank OPML-Import bist du sofort bereit einzusteigen. Exportiere deine Podcasts zu jedem beliebigen Zeitpunkt.
 
-Das sind nur einige der leistungsstarken, praktischen Funktionen, die Pocket Casts zu deiner perfekten Podcast-App machen. Worauf wartest du also noch?
+Das sind nur einige der Funktionen, die Pocket Casts zu deiner perfekten Podcast-App machen.
 
-Auf pocketcasts.com findest du weitere Informationen über die Webversion und weitere Plattformen, die Pocket Casts unterstützt.
+Weitere Infos zur Web-Version und weiteren unterstützten Plattformen findest du auf pocketcasts.com.
+
+Nutzungsbedingungen: https://support.pocketcasts.com/article/terms-of-use
+Datenschutzerklärung: https://support.pocketcasts.com/article/privacy-policy

--- a/fastlane/metadata/default/description.txt
+++ b/fastlane/metadata/default/description.txt
@@ -1,8 +1,8 @@
 Pocket Casts is the world's most powerful podcast platform, an app by listeners, for listeners. Our podcast player provides next-level listening, search and discovery tools. Find your next obsession with our hand-curated podcast recommendations for easy discovery, and seamlessly enjoy your favorite shows without the hassle of subscribing.
 
 Here's what the press has to say:
- • Wired: \"Pocket Casts Is the Podcast App Every iPhone User Needs\"
- • iMore: \"Pocket Casts is the best podcast app for iPhone\"
+ • Wired: "Pocket Casts Is the Podcast App Every iPhone User Needs"
+ • iMore: "Pocket Casts is the best podcast app for iPhone"
 
 NEW: PLAYLISTS
 Your listening, your way. Organize your episodes with our powerful new Playlists feature:
@@ -49,3 +49,6 @@ ALL YOUR FAVORITES
 There are many more powerful, straight-forward features that make Pocket Casts the perfect podcasting app for you. So what are you waiting for?
 
 Visit pocketcasts.com for more info about the web and other platforms supported by Pocket Casts.
+
+Terms of Use: https://support.pocketcasts.com/article/terms-of-use
+Privacy Policy: https://support.pocketcasts.com/article/privacy-policy

--- a/fastlane/metadata/es-ES/description.txt
+++ b/fastlane/metadata/es-ES/description.txt
@@ -1,0 +1,48 @@
+Pocket Casts es la plataforma de podcast más potente del mundo, una aplicación diseñada por y para los oyentes. Nuestro reproductor ofrece herramientas avanzadas para escuchar, buscar y descubrir podcasts. Encuentra tu próxima obsesión con nuestras recomendaciones seleccionadas y disfruta fácilmente de tus programas favoritos sin necesidad de suscribirte.
+
+Aquí puedes ver lo que dice la prensa sobre nosotros:
+• Wired: «Pocket Casts es la aplicación de podcast que todo usuario de iPhone necesita»
+• iMore: «Pocket Casts es la mejor aplicación de podcast para iPhone»
+
+Viene con un conjunto único de funciones sencillas, pero potentes, y una base de datos ilimitada para podcasts, en la que seguro que encuentras algo que te guste.
+
+CONOCE TODOS LOS DETALLES
+• Diseño: escucha, gestiona y busca fácilmente nuevos podcasts.
+• Temas: ya sea que prefieras temas oscuros o claros, tenemos lo que buscas, incluido un tema Extra oscuro para los amantes del OLED.
+• Universal: la interfaz de siempre en iPad, pero personalizada y compatible con Slide Over, Split View y Picture in Picture.
+Estés donde estés: CarPlay, AirPlay, Chromecast y Sonos. Escucha tus podcasts en muchos más lugares.
+
+POTENTE REPRODUCTOR
+• Siguiente: crea automáticamente una cola de reproducción de tus programas favoritos. Si inicias sesión la lista «A continuación» se sincronizará con todos tus dispositivos.
+• Recorta los silencios: ahorra tiempo y termina los episodios más rápido con la opción de recortar los silencios.
+• Velocidad variable: cambia la velocidad de reproducción entre 0,5 y 3x.
+• Sube el volumen: puedes aumentar el volumen de las voces y disminuir el ruido de fondo.
+• En tiempo real: reproduce los episodios sobre la marcha.
+• Capítulos: salta entre capítulos fácilmente y disfruta de las carátulas que añada el autor (compatible con MP3 y M4A).
+• Audio y vídeo: reproduce todos tus episodios favoritos, alterna vídeo y audio.
+• Salta la reproducción: sáltate las introducciones de los episodios y también los episodios enteros, con intervalos de salto personalizados.
+• Apple Watch: controla la reproducción desde nuestra app para el Apple Watch, ajusta el volumen o cambia los efectos de reproducción sin tocar el teléfono.
+• Temporizador: pondremos en pausa el episodio que estés escuchando para que puedas descansar.
+• Airplay y Chromecast: con un solo toque, puedes enviar los episodios directamente a tu televisor o altavoces.
+• Sonos: busca y reproduce tu colección de podcasts directamente desde la aplicación Sonos.
+• CarPlay: te acompañamos en tus viajes en coche.
+
+HERRAMIENTAS INTELIGENTES
+• Sincroniza: las suscripciones, «A continuación», el historial y los filtros se guardan de forma segura en la nube. Continúa donde lo dejaste en otro dispositivo e incluso en la web.
+• Actualiza: permite que nuestros servidores comprueben si hay nuevos episodios para que puedas seguir con tus asuntos.
+• Notificaciones: si quieres, te avisaremos cuando estén disponibles los nuevos episodios.
+• Descarga automática: descarga de manera automática los episodios para reproducirlos sin conexión.
+• Filtros: con los filtros personalizados, puedes organizar tus episodios.
+• Almacenamiento: todas las herramientas que necesitas para mantener tus podcasts bajo control.
+
+TODOS TUS FAVORITOS
+• Descubre: suscríbete a cualquier podcast en iTunes y mucho más. Explora por gráficos, redes y categorías.
+• Comparte: difunde el contenido con la opción de compartir podcasts y episodios.
+• OPML: únete sin ningún problema con la importación de OPML. Puedes exportar tu colección en cualquier momento.
+
+Con muchas más funciones potentes y sencillas, Pocket Casts es la aplicación de podcast perfecta para ti. ¿A qué esperas?
+
+Para obtener más información sobre la web y otras plataformas compatibles con Pocket Casts, visita pocketcasts.com.
+
+Condiciones de uso: https://support.pocketcasts.com/article/terms-of-use
+Política de privacidad: https://support.pocketcasts.com/article/privacy-policy

--- a/fastlane/metadata/fr-FR/description.txt
+++ b/fastlane/metadata/fr-FR/description.txt
@@ -13,22 +13,22 @@ CHAQUE DÉTAIL A SON IMPORTANCE
 • Partout : CarPlay, AirPlay, Chromecast et Sonos. Écoutez vos podcasts dans plus d’endroits que jamais auparavant.
 
 LECTURE PUISSANTE
-• File d’attente : créez automatiquement une file d’attente à partir de vos émissions préférées. Connectez-vous et synchronisez la sur tous vos appareils.
+• File d’attente : créez automatiquement une file d’attente à partir de vos émissions préférées et synchronisez-la sur tous vos appareils.
 • Coupure des silences : coupez les silences des épisodes pour les finir plus vite et gagner des heures.
 • Vitesse variable : modifiez la vitesse de lecture entre 0,5 et 3x.
 • Augmentation du volume : augmentez le volume des voix tout en diminuant le bruit de fond.
 • Diffusion : lisez des épisodes à la volée.
-• Chapitres : passez facilement d’un chapitre à l’autre et profitez des illustrations intégrées ajoutées par l’auteur (formats de chapitre MP3 et M4A supportés).
+• Chapitres : naviguez facilement entre les chapitres et profitez des illustrations intégrées par l’auteur (MP3 et M4A).
 • Audio et vidéo : lisez tous vos épisodes préférés et basculez la vidéo en audio.
 • Ignorer la lecture : ignorez les intros d’épisodes, parcourez les épisodes avec des intervalles de saut personnalisés.
-• Apple Watch : contrôlez la lecture à partir de votre Apple Watch, réglez le volume ou modifiez les effets de lecture, sans jamais toucher votre téléphone.
+• Apple Watch : contrôlez la lecture, le volume et les effets depuis votre Apple Watch, sans toucher votre téléphone.
 • Minuteur de mise en veille : nous mettrons votre épisode en pause pour que vous puissiez vous reposer.
 • Airplay et Chromecast : diffusez des épisodes directement sur votre téléviseur ou des enceintes en un clic.
 • Sonos : parcourez et lisez votre collection de podcasts directement à partir de l’app Sonos.
 • CarPlay : quand vous êtes dans la voiture, nous aussi.
 
 OUTILS INTELLIGENTS
-• Synchronisation : les abonnements, File d’attente, l’historique d’écoute, la lecture et les filtres sont tous stockés en toute sécurité dans le cloud. Vous pouvez reprendre là où vous vous êtes arrêté sur un autre appareil et même sur le Web.
+• Synchronisation : abonnements, File d’attente, historique d’écoute, lecture et filtres sont stockés en toute sécurité dans le cloud. Reprenez où vous vous êtes arrêté, sur un autre appareil ou sur le Web.
 • Actualisation : laissez nos serveurs rechercher de nouveaux épisodes à votre place.
 • Notifications : nous vous signalerons l’arrivée de nouveaux épisodes.
 • Téléchargement automatique : téléchargez automatiquement des épisodes pour une lecture hors ligne.
@@ -40,6 +40,9 @@ TOUS VOS PRÉFÉRÉS
 • Partager : faites-vous connaître avec le partage de podcasts et d’épisodes.
 • OPML : lancez-vous sans problème avec l’importation OPML. Exportez votre collection à tout moment.
 
-Il existe de nombreuses autres fonctionnalités simples et puissantes qui font de Pocket Casts l’application de podcasting parfaite pour vous. Mais qu’attendez-vous ?
+De nombreuses autres fonctionnalités font de Pocket Casts l’application de podcasting idéale pour vous.
 
-Visitez pocketcasts.com pour en savoir plus sur le Web et les autres plateformes prises en charge.
+Rendez-vous sur pocketcasts.com pour en savoir plus.
+
+Conditions d’utilisation : https://support.pocketcasts.com/article/terms-of-use
+Politique de confidentialité : https://support.pocketcasts.com/article/privacy-policy

--- a/fastlane/metadata/it/description.txt
+++ b/fastlane/metadata/it/description.txt
@@ -43,3 +43,6 @@ TUTTI I PREFERITI
 Esistono molte funzionalità più potenti e semplici che rendono Pocket Casts l'app per il podcasting perfetta per te. Quindi, cosa stai aspettando?
 
 Visita pocketcasts.com per maggiori informazioni sul web e sulle altre piattaforme supportate da Pocket Casts.
+
+Termini di utilizzo: https://support.pocketcasts.com/article/terms-of-use
+Informativa sulla privacy: https://support.pocketcasts.com/article/privacy-policy

--- a/fastlane/metadata/ja/description.txt
+++ b/fastlane/metadata/ja/description.txt
@@ -43,3 +43,6 @@ Pocket Casts はリスナーによる、リスナーのための世界で最も�
 Pocket Casts にはあらゆるユーザーのニーズに対応する、強力かつシンプルな機能が他にもたくさん用意されています。 今すぐお申し込みください。
 
 Pocket Casts がサポートする Web サイトとプラットフォームの詳細については pocketcasts.com をご覧ください。
+
+利用規約: https://support.pocketcasts.com/article/terms-of-use
+プライバシーポリシー: https://support.pocketcasts.com/article/privacy-policy

--- a/fastlane/metadata/nl-NL/description.txt
+++ b/fastlane/metadata/nl-NL/description.txt
@@ -43,3 +43,6 @@ AL JE FAVORIETEN
 Er zijn veel meer krachtige, eenvoudige functies die Pocket Casts voor jou de perfecte podcast-app maken. Waar wacht je op?
 
 Ga naar pocketcasts.com voor meer informatie over het web en andere platformen die worden ondersteund door Pocket Casts.
+
+Gebruiksvoorwaarden: https://support.pocketcasts.com/article/terms-of-use
+Privacybeleid: https://support.pocketcasts.com/article/privacy-policy

--- a/fastlane/metadata/pt-BR/description.txt
+++ b/fastlane/metadata/pt-BR/description.txt
@@ -40,6 +40,9 @@ TODAS AS SUAS FAVORITAS
 • Compartilhar: divulgue seus favoritos com compartilhamento de episódios e podcasts.
 • OPML: embarque nesta jornada sem dores de cabeça, com a importação de OPML. Exporte sua coleção a qualquer momento.
 
-Existem várias outras funcionalidades simples e mais avançadas que fazem do Pocket Casts o aplicativo de podcast perfeito para você. Então, o que você está esperando?
+Existem várias outras funcionalidades que fazem do Pocket Casts o aplicativo de podcast perfeito para você.
 
-Acesse pocketcasts.com para saber mais sobre o uso na Web e em outras plataformas compatíveis com o Pocket Casts.
+Acesse pocketcasts.com para saber mais sobre a Web e outras plataformas compatíveis.
+
+Termos de Uso: https://support.pocketcasts.com/article/terms-of-use
+Política de Privacidade: https://support.pocketcasts.com/article/privacy-policy

--- a/fastlane/metadata/ru/description.txt
+++ b/fastlane/metadata/ru/description.txt
@@ -43,3 +43,6 @@ Pocket Casts — одна из самых мощных в мире платфо
 Pocket Casts — это шедевр в мире подкастов, который поразит вас. Чего вы ждете?
 
 Переходите на сайт pocketcasts.com и найдите там информацию о веб-версии и других платформах, поддерживаемых Pocket Casts.
+
+Условия использования: https://support.pocketcasts.com/article/terms-of-use
+Политика конфиденциальности: https://support.pocketcasts.com/article/privacy-policy

--- a/fastlane/metadata/sv/description.txt
+++ b/fastlane/metadata/sv/description.txt
@@ -43,3 +43,6 @@ ALLA DINA FAVORITER
 Det finns många kraftfulla, enkla funktioner som gör Pocket Casts till den perfekta podcasting-appen för dig. Vad väntar du på?
 
 Besök pocketcasts.com för mer information om webben och andra plattformar som stöds av Pocket Casts.
+
+Användarvillkor: https://support.pocketcasts.com/article/terms-of-use
+Integritetspolicy: https://support.pocketcasts.com/article/privacy-policy

--- a/fastlane/metadata/zh-Hans/description.txt
+++ b/fastlane/metadata/zh-Hans/description.txt
@@ -43,3 +43,6 @@ Pocket Casts 是一个功能非常强大的播客平台，是一款因听众而�
 Pocket Casts 拥有许多更强大、更直接的功能，让它成为您的理想播客应用程序。 您还在等什么？
 
 有关 Pocket Casts 支持的网页和其他平台的详细信息，请访问 pocketcasts.com。
+
+使用条款：https://support.pocketcasts.com/article/terms-of-use
+隐私政策：https://support.pocketcasts.com/article/privacy-policy

--- a/fastlane/metadata/zh-Hant/description.txt
+++ b/fastlane/metadata/zh-Hant/description.txt
@@ -43,3 +43,6 @@ Pocket Casts 是全球最強大的 Podcast 平台，一款由聽眾打造，並�
 Pocket Casts 還有許多其他強大而簡單的功能，無疑是最適合你的 Podcast 應用程式。 還在等什麼？
 
 歡迎造訪 pocketcasts.com，深入了解 Pocket Casts 支援的網頁和其他平台。
+
+使用條款：https://support.pocketcasts.com/article/terms-of-use
+隱私政策：https://support.pocketcasts.com/article/privacy-policy


### PR DESCRIPTION
Adds Terms of Use and Privacy Policy links to the bottom of the App Store description across all supported locales (translated where applicable). Three locales (de-DE, fr-FR, pt-BR) were trimmed slightly to stay under the App Store's 4000-character limit.

## To test

1. Open `fastlane/metadata/default/description.txt` and each locale's `description.txt` under `fastlane/metadata/`
2. Confirm each ends with translated "Terms of Use" / "Privacy Policy" lines linking to `https://support.pocketcasts.com/article/terms-of-use` and `https://support.pocketcasts.com/article/privacy-policy`
3. Confirm no file exceeds 4000 characters (App Store description limit)

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.