### PR TITLE
Add swipe actions for bookmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.19
 -----
+- Add swipe actions to bookmark rows (Share and Delete) in the Player, standalone Podcast bookmarks, Episode, and Profile bookmark lists [#4900](https://github.com/Automattic/pocket-casts-ios/pull/4900)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 
 

--- a/podcasts/Bookmarks/BookmarksTheme.swift
+++ b/podcasts/Bookmarks/BookmarksTheme.swift
@@ -18,6 +18,8 @@ protocol BookmarksStyle: ObservableObject {
     var playButtonText: Color { get }
     var playButtonBackground: Color? { get }
     var playButtonStroke: Color? { get }
+    var shareSwipeTint: Color { get }
+    var deleteSwipeTint: Color { get }
     var actionBarStyle: ActionStyle { get }
     var emptyStyle: EmptyStyle { get }
 }
@@ -55,6 +57,8 @@ class BookmarksPlayerTabStyle: ThemeObserver, BookmarksStyle {
     var playButtonText: Color { theme.playerBackground01 }
     var playButtonBackground: Color? { theme.playerContrast01 }
     var playButtonStroke: Color? = nil
+    var shareSwipeTint: Color { theme.support03 }
+    var deleteSwipeTint: Color { theme.support05 }
     var actionBarStyle = PlayerActionBarStyle()
     var emptyStyle = PlayerEmptyStateStyle()
 }
@@ -76,6 +80,8 @@ class ThemedBookmarksStyle: ThemeObserver, BookmarksStyle {
     var playButtonText: Color { theme.primaryText01 }
     var playButtonBackground: Color? { theme.primaryUi01 }
     var playButtonStroke: Color? { theme.primaryText01 }
+    var shareSwipeTint: Color { theme.support03 }
+    var deleteSwipeTint: Color { theme.support05 }
     var actionBarStyle = ThemedActionBarStyle()
     var emptyStyle = DefaultEmptyStateStyle()
 }
@@ -106,6 +112,8 @@ class OverrideThemedBookmarksStyle: ThemedBookmarksStyle {
         set { }
         get { Color(ThemeColor.primaryText01(for: overrideTheme)) }
     }
+    override var shareSwipeTint: Color { Color(ThemeColor.support03(for: overrideTheme)) }
+    override var deleteSwipeTint: Color { Color(ThemeColor.support05(for: overrideTheme)) }
     override var emptyStyle: DefaultEmptyStateStyle {
         set { }
         get { overrideEmptyStyle }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -150,6 +150,21 @@ extension BookmarkListViewModel {
         toggleMultiSelection()
     }
 
+    /// Whether the share swipe action should be shown for this bookmark
+    func canShare(_ bookmark: Bookmark) -> Bool {
+        bookmark.episode is Episode
+    }
+
+    func shareTapped(_ bookmark: Bookmark) {
+        router?.bookmarkShare(bookmark)
+    }
+
+    func deleteTapped(_ bookmark: Bookmark) {
+        confirmDeletion { [weak self] in
+            self?.actuallyDelete([bookmark])
+        }
+    }
+
     func sorted(by option: BookmarkSortOption) {
         sortOption = option
         reload()

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -202,23 +202,54 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
 
     @ViewBuilder
     private var scrollView: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                bookmarksRows
-            }
+        List {
+            bookmarksRows
         }
+        .animation(.default, value: viewModel.bookmarks)
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .environment(\.defaultMinListRowHeight, 0)
     }
 
     @ViewBuilder
     private var bookmarksRows: some View {
         ForEach(viewModel.bookmarks) { bookmark in
             BookmarkRow(bookmark: bookmark, style: style)
+                .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                    if !viewModel.isMultiSelecting && viewModel.canShare(bookmark) {
+                        Button {
+                            viewModel.shareTapped(bookmark)
+                        } label: {
+                            Image("podcast-share")
+                        }
+                        .tint(style.shareSwipeTint)
+                    }
+                }
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    if !viewModel.isMultiSelecting {
+                        Button {
+                            viewModel.deleteTapped(bookmark)
+                        } label: {
+                            Image("delete")
+                        }
+                        .tint(style.deleteSwipeTint)
+                    }
+                }
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
             if !viewModel.isLast(item: bookmark) {
                 divider
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
             }
         }
         if !LiquidGlass.isEnabled && actionBarVisible && !useExternalActionBar {
             Spacer(minLength: BookmarkListConstants.multiSelectionBottomPadding)
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
         }
     }
 

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -214,6 +214,28 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
     @ViewBuilder
     private var bookmarksRows: some View {
         ForEach(viewModel.bookmarks) { bookmark in
+            bookmarkRow(bookmark)
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+            if !viewModel.isLast(item: bookmark) {
+                divider
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+            }
+        }
+        if !LiquidGlass.isEnabled && actionBarVisible && !useExternalActionBar {
+            Spacer(minLength: BookmarkListConstants.multiSelectionBottomPadding)
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+        }
+    }
+
+    @ViewBuilder
+    private func bookmarkRow(_ bookmark: Bookmark) -> some View {
+        if allowInternalScrolling {
             BookmarkRow(bookmark: bookmark, style: style)
                 .swipeActions(edge: .leading, allowsFullSwipe: false) {
                     if !viewModel.isMultiSelecting && viewModel.canShare(bookmark) {
@@ -235,21 +257,8 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
                         .tint(style.deleteSwipeTint)
                     }
                 }
-                .listRowInsets(EdgeInsets())
-                .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
-            if !viewModel.isLast(item: bookmark) {
-                divider
-                    .listRowInsets(EdgeInsets())
-                    .listRowSeparator(.hidden)
-                    .listRowBackground(Color.clear)
-            }
-        }
-        if !LiquidGlass.isEnabled && actionBarVisible && !useExternalActionBar {
-            Spacer(minLength: BookmarkListConstants.multiSelectionBottomPadding)
-                .listRowInsets(EdgeInsets())
-                .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
+        } else {
+            BookmarkRow(bookmark: bookmark, style: style)
         }
     }
 

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -245,16 +245,18 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
                             Image("podcast-share")
                         }
                         .tint(style.shareSwipeTint)
+                        .accessibilityLabel(L10n.share)
                     }
                 }
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                     if !viewModel.isMultiSelecting {
-                        Button {
+                        Button(role: .destructive) {
                             viewModel.deleteTapped(bookmark)
                         } label: {
                             Image("delete")
                         }
                         .tint(style.deleteSwipeTint)
+                        .accessibilityLabel(L10n.delete)
                     }
                 }
         } else {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

Adds native SwiftUI `.swipeActions` to bookmark rows: leading edge "Share" (blue), trailing edge "Delete" (red, with the existing delete confirmation alert), using the app's custom icons.

`.swipeActions` only works inside a `List`, so this required converting the full-screen bookmark lists (Player tab, standalone Podcast bookmarks list, Episode bookmark list, Profile bookmarks list) from `ScrollView`/`LazyVStack` to `List`, styled to match the previous look.

**Known limitation:** the Podcast tab's embedded Bookmarks section (`PodcastViewController` → `BookmarksHostingCell`) stays on the non-scrolling `LazyVStack` path and does **not** get swipe actions in this PR — it's hosted non-scrolling inside a `UITableViewCell`, and a `List` doesn't reliably self-size in that configuration, so it was left out of scope rather than risk layout bugs there.

## To test

1. Open a podcast with bookmarks, go to the Player tab's Bookmarks section — swipe a row left for Delete (red), right for Share (blue).
2. Confirm swiping Delete shows a confirmation alert before the row disappears, and canceling leaves the row in place.
3. Repeat on the standalone Podcast bookmarks list, an episode's bookmark list, and the Profile bookmarks list.
4. Open the Podcast tab (not the Player tab) and view its embedded Bookmarks section — confirm rows behave as before (no swipe actions here, this is expected).


https://github.com/user-attachments/assets/9b4f62ca-8e82-4ca4-b34c-35d724653b30



## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.