### PR TITLE
Fix crash when the onboarding flow is triggered mid-transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [tvOS] Add audio-reactive waveform to TV now playing screen. [#4853](https://github.com/Automattic/pocket-casts-ios/pull/4853)
 - Make the Up Next navigation bar consistent between the tab and player presentations: Select and a new "…" menu with Clear Up Next on the trailing edge, and a standard close button when opened from the player [#4875](https://github.com/Automattic/pocket-casts-ios/pull/4875)
 - [tvOS] Add support for regular episode lists. [#4852](https://github.com/Automattic/pocket-casts-ios/pull/4852)
+- Fix a crash when the sign in prompt was shown while another screen was still being dismissed [#4903](https://github.com/Automattic/pocket-casts-ios/pull/4903)
 
 8.17
 -----

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -739,14 +739,18 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
     }
 
     func showOnboardingFlow(flow: OnboardingFlow.Flow?) {
-        let controller = OnboardingFlow.shared.begin(flow: flow ?? .initialOnboarding, source: .onboarding)
-        guard let presentedViewController else {
-            present(controller, animated: true)
-            return
-        }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
 
-        presentedViewController.dismiss(animated: true) {
-            self.present(controller, animated: true)
+            let controller = OnboardingFlow.shared.begin(flow: flow ?? .initialOnboarding, source: .onboarding)
+            guard let presentedViewController = self.presentedViewController else {
+                self.present(controller, animated: true)
+                return
+            }
+
+            presentedViewController.dismiss(animated: true) {
+                self.present(controller, animated: true)
+            }
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes an `EXC_BREAKPOINT` crash inside UIKit's `_pinInputViewsForKeyboardSceneDelegate`.

`showOnboardingFlow` could be invoked from inside a modal transition's completion window. When a full-screen onboarding modal is dismissed, `MainTabBarController.viewDidAppear` fires during `-[UIPresentationController transitionDidFinish:]`'s deferred-commit flush (`_runAfterCACommitDeferredBlocks`), and `showInitialOnboardingIfNeeded()` — which runs on every appearance, not just the first — navigates straight back into the onboarding flow. Dismissing `presentedViewController` from there made UIKit start the new transition synchronously inside that flush and trap while pinning the keyboard's input views.

Hopping a runloop turn with `DispatchQueue.main.async` starts the new transition from a clean runloop pass instead. The hop lives in `showOnboardingFlow` itself, so it covers all five entry points, not just the crashing one. The whole method body is deferred rather than only the dismiss: that keeps `OnboardingFlow.shared.begin(...)` adjacent to the presentation so the shared flow state isn't mutated a turn before the controller appears, and it re-reads `presentedViewController` at the moment it's used instead of capturing it while the modal stack is still settling. All callers are fire-and-forget, and every synchronous reader of `OnboardingFlow.shared.currentFlow`/`source` lives inside the presented flow's own controllers, so the one-turn delay is safe.

## To test

Repro is timing-dependent, so the most reliable check is that onboarding still behaves normally:

1. Delete the app and install a fresh build, then launch it. The onboarding/login flow should appear as usual.
2. Dismiss it, then background and foreground the app a few times — no crash, and onboarding should not re-appear unexpectedly.
3. Log out from Profile → Settings. The forced-logout onboarding flow should present correctly.
4. From the Profile header, tap the sign-in prompt. The login flow should present.
5. Tap a locked feature to reach the Plus upsell, then dismiss it. No crash on dismissal.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
