### PR TITLE
Fix episode count on smart playlists (TV)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [tvOS] Add audio-reactive waveform to TV now playing screen. [#4853](https://github.com/Automattic/pocket-casts-ios/pull/4853)
 - Make the Up Next navigation bar consistent between the tab and player presentations: Select and a new "…" menu with Clear Up Next on the trailing edge, and a standard close button when opened from the player [#4875](https://github.com/Automattic/pocket-casts-ios/pull/4875)
 - [tvOS] Add support for regular episode lists. [#4852](https://github.com/Automattic/pocket-casts-ios/pull/4852)
+- [tvOS] Fix episode count on smart playlists [#4905](https://github.com/Automattic/pocket-casts-ios/pull/#4905)
 
 8.17
 -----

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -83,7 +83,7 @@ class PlaylistDetailsViewModel {
     func load() {
         Task {
             // `DataManager.playlistEpisodes(for:)` always filters archived out, so query directly
-            // with `shouldShowArchived: true` and let the local toggle decide what to display.
+            // with `shouldShowArchived` depending of the list type and let the local toggle decide what to display.
             let query = PlaylistQueryBuilder.query(
                 clause: .episode,
                 for: playlist.playlist,

--- a/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
+++ b/Pocket Casts TV App/UI/Playlists/PlaylistDetailsViewModel.swift
@@ -88,10 +88,10 @@ class PlaylistDetailsViewModel {
                 clause: .episode,
                 for: playlist.playlist,
                 limit: Self.playlistEpisodeLimit,
-                shouldShowArchived: true
+                shouldShowArchived: playlist.playlist.manual
             )
             let playlistEpisodes = dataManager.findPlaylistEpisodesWhere(query: query, arguments: nil)
-            let count = dataManager.allPlaylistEpisodeCount(for: playlist.playlist, episodeUuidToAdd: nil, includingArchivedEpisodes: true)
+            let count = dataManager.allPlaylistEpisodeCount(for: playlist.playlist, episodeUuidToAdd: nil, includingArchivedEpisodes: playlist.playlist.manual)
             await MainActor.run {
                 allEpisodes = playlistEpisodes
                 episodesCount = count


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

On the TV app, the playlist details screen was always fetching episodes and counting them with archived episodes included (`shouldShowArchived: true` / `includingArchivedEpisodes: true`). This inflated the episode count on smart playlists, which should honor the smart playlist's own filtering and not include archived episodes.

This change makes the archived episodes only be considered for **manual** playlists by passing `playlist.playlist.manual` instead of a hardcoded `true` for both the episode query and the count. Smart playlists now show a count consistent with the episodes they actually display.

## To test

1. On the TV app, open a smart playlist that contains archived episodes.
2. Verify the episode count shown matches the number of (non-archived) episodes actually listed.
3. Open a manual playlist that contains archived episodes.
4. Verify archived episodes are still included in its list and count, as before.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
