### PR TITLE
Add CODEOWNERS entry for fastlane/metadata-tvos/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@ Gemfile*              @Automattic/apps-infra-tooling
 fastlane/             @Automattic/apps-infra-tooling
 # Store-listing localization and frozen strings are content, not infra.
 fastlane/metadata/
+fastlane/metadata-tvos/
 fastlane/Frozen.strings
 
 # CI and automation


### PR DESCRIPTION
Turns out that https://github.com/Automattic/pocket-casts-ios/pull/4892 was not enough to stop our team getting ping'd on backmerge PRs we don't need to chime in on 😅  as I forgot that `fastlane/metadata-tvos` was a new thing after the recent introduction of tvOS in the repo.

## To test

Can't really test until the next backmerge PR happens
