### PR TITLE
Add bookmark swipe actions to the podcast page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add Smart Bookmarks: bookmarks now suggest a title and capture the surrounding passage from the episode transcript, mark their spot in the transcript, and anchor their timestamp to the transcript's reference timeline so it stays accurate even when dynamic ads shift the audio [#4761](https://github.com/Automattic/pocket-casts-ios/pull/4761)
 - Add swipe actions to bookmark rows (Share and Delete) in the Player, standalone Podcast bookmarks, Episode, and Profile bookmark lists [#4900](https://github.com/Automattic/pocket-casts-ios/pull/4900)
 - Fix animations on the podcast screen's Bookmarks tab: rows now animate as they are added, removed and filtered, and highlight when tapped [#4904](https://github.com/Automattic/pocket-casts-ios/pull/4904)
+- Add swipe actions to bookmark rows (Share and Delete) on the podcast screen's Bookmarks tab [#4912](https://github.com/Automattic/pocket-casts-ios/pull/4912)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 8.19
 -----
 - Add Smart Bookmarks: bookmarks now suggest a title and capture the surrounding passage from the episode transcript, mark their spot in the transcript, and anchor their timestamp to the transcript's reference timeline so it stays accurate even when dynamic ads shift the audio [#4761](https://github.com/Automattic/pocket-casts-ios/pull/4761)
-- Add swipe actions to bookmark rows (Share and Delete) in the Player, standalone Podcast bookmarks, Episode, and Profile bookmark lists [#4900](https://github.com/Automattic/pocket-casts-ios/pull/4900)
+- Add swipe actions to bookmark rows (Share and Delete) in the Player, the podcast screen's Bookmarks tab, standalone Podcast bookmarks, Episode, and Profile bookmark lists [#4900](https://github.com/Automattic/pocket-casts-ios/pull/4900) [#4912](https://github.com/Automattic/pocket-casts-ios/pull/4912)
 - Fix animations on the podcast screen's Bookmarks tab: rows now animate as they are added, removed and filtered, and highlight when tapped [#4904](https://github.com/Automattic/pocket-casts-ios/pull/4904)
-- Add swipe actions to bookmark rows (Share and Delete) on the podcast screen's Bookmarks tab [#4912](https://github.com/Automattic/pocket-casts-ios/pull/4912)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
 

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -173,27 +173,23 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
     private func bookmarkRow(_ bookmark: Bookmark) -> some View {
         BookmarkRow(bookmark: bookmark, style: style)
             .swipeActions(edge: .leading, allowsFullSwipe: false) {
-                if !viewModel.isMultiSelecting && viewModel.canShare(bookmark) {
-                    Button {
-                        viewModel.shareTapped(bookmark)
-                    } label: {
-                        Image("podcast-share")
-                    }
-                    .tint(style.shareSwipeTint)
-                    .accessibilityLabel(L10n.share)
-                }
+                swipeActions(for: bookmark, edge: .leading)
             }
             .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                if !viewModel.isMultiSelecting {
-                    Button(role: .destructive) {
-                        viewModel.deleteTapped(bookmark)
-                    } label: {
-                        Image("delete")
-                    }
-                    .tint(style.deleteSwipeTint)
-                    .accessibilityLabel(L10n.delete)
-                }
+                swipeActions(for: bookmark, edge: .trailing)
             }
+    }
+
+    private func swipeActions(for bookmark: Bookmark, edge: HorizontalEdge) -> some View {
+        ForEach(makeBookmarkSwipeActions(for: bookmark, edge: edge, viewModel: viewModel, style: style)) { action in
+            Button(role: action.isDestructive ? .destructive : nil) {
+                action.handler()
+            } label: {
+                Image(action.imageName)
+            }
+            .tint(action.tint)
+            .accessibilityLabel(action.title)
+        }
     }
 
     private var bookmarkActions: [ActionBarView<ListStyle.ActionStyle>.Action] {

--- a/podcasts/Podcasts/Podcast Page/BookmarkListController.swift
+++ b/podcasts/Podcasts/Podcast Page/BookmarkListController.swift
@@ -182,9 +182,43 @@ final class BookmarkListController {
 
     /// The rows handle their own taps in SwiftUI, the selection is only there to highlight them
     func canSelectRow(at indexPath: IndexPath) -> Bool {
-        guard indexPath.section == Self.listSection, case .bookmark = rows[safe: indexPath.row] else { return false }
+        bookmark(at: indexPath) != nil
+    }
 
-        return true
+    private func bookmark(at indexPath: IndexPath) -> Bookmark? {
+        guard indexPath.section == Self.listSection, case .bookmark(let bookmark, _) = rows[safe: indexPath.row] else { return nil }
+
+        return bookmark
+    }
+
+    // MARK: - Swipe Actions
+
+    /// Only the bookmark rows swipe, and only outside of the multi selection
+    func canEditRow(at indexPath: IndexPath) -> Bool {
+        !viewModel.isMultiSelecting && bookmark(at: indexPath) != nil
+    }
+
+    /// The same actions the SwiftUI list swipes in, rendered by the table
+    func swipeActionsConfiguration(for edge: HorizontalEdge, at indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard let bookmark = bookmark(at: indexPath) else { return nil }
+
+        let actions = makeBookmarkSwipeActions(for: bookmark, edge: edge, viewModel: viewModel, style: style).map { action in
+            let contextualAction = UIContextualAction(style: action.isDestructive ? .destructive : .normal, title: nil) { _, _, completion in
+                action.handler()
+                // The rows are reloaded by the view model, so the table shouldn't remove them itself
+                completion(false)
+            }
+            contextualAction.image = UIImage(named: action.imageName)
+            contextualAction.backgroundColor = UIColor(action.tint)
+            contextualAction.accessibilityLabel = action.title
+            return contextualAction
+        }
+
+        guard !actions.isEmpty else { return nil }
+
+        let configuration = UISwipeActionsConfiguration(actions: actions)
+        configuration.performsFirstActionWithFullSwipe = false
+        return configuration
     }
 
     // MARK: - Cells

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController+TableData.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController+TableData.swift
@@ -482,8 +482,27 @@ extension PodcastViewController: UITableViewDataSource, UITableViewDelegate {
     // MARK: - Swipe Actions
 
     func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        guard currentViewMode == .episodes else { return false }
-        return indexPath.section == PodcastViewController.allEpisodesSection && episodeAtIndexPath(indexPath) != nil
+        switch currentViewMode {
+        case .episodes:
+            return indexPath.section == PodcastViewController.allEpisodesSection && episodeAtIndexPath(indexPath) != nil
+        case .bookmarks:
+            return bookmarkList?.canEditRow(at: indexPath) ?? false
+        case .youMightLike:
+            return false
+        }
+    }
+
+    /// The episode cells swipe with SwipeCellKit, the bookmarks use the table's own swipe actions
+    func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard currentViewMode == .bookmarks else { return nil }
+
+        return bookmarkList?.swipeActionsConfiguration(for: .leading, at: indexPath)
+    }
+
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard currentViewMode == .bookmarks else { return nil }
+
+        return bookmarkList?.swipeActionsConfiguration(for: .trailing, at: indexPath)
     }
 
     func episodeAtIndexPath(_ indexPath: IndexPath) -> Episode? {

--- a/podcasts/Shared/BookmarkActionFactory.swift
+++ b/podcasts/Shared/BookmarkActionFactory.swift
@@ -12,3 +12,40 @@ import SwiftUI
         .init(imageName: "delete", title: L10n.delete) { viewModel.deleteSelectedBookmarks() }
     ]
 }
+
+/// A swipe action of a bookmark row, rendered by SwiftUI in the bookmarks list and by UIKit in the
+/// podcast page's table
+struct BookmarkSwipeAction: Identifiable {
+    let imageName: String
+    let title: String
+    let tint: Color
+    let isDestructive: Bool
+    let handler: () -> Void
+
+    var id: String { imageName }
+}
+
+/// The swipe actions of a single bookmark row. There are none while the list is multi selecting.
+@MainActor func makeBookmarkSwipeActions<Style: BookmarksStyle>(for bookmark: Bookmark,
+                                                                edge: HorizontalEdge,
+                                                                viewModel: BookmarkListViewModel,
+                                                                style: Style) -> [BookmarkSwipeAction] {
+    guard !viewModel.isMultiSelecting else { return [] }
+
+    switch edge {
+    case .leading:
+        guard viewModel.canShare(bookmark) else { return [] }
+
+        return [
+            .init(imageName: "podcast-share", title: L10n.share, tint: style.shareSwipeTint, isDestructive: false) {
+                viewModel.shareTapped(bookmark)
+            }
+        ]
+    case .trailing:
+        return [
+            .init(imageName: "delete", title: L10n.delete, tint: style.deleteSwipeTint, isDestructive: true) {
+                viewModel.deleteTapped(bookmark)
+            }
+        ]
+    }
+}


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-886

#4900 added Share / Delete swipe actions to the bookmark lists, but the podcast screen's Bookmarks tab is a `UITableView` (#4904) and had none.

The actions moved into `makeBookmarkSwipeActions`, next to the existing action bar factory, and both call sites render them: SwiftUI's `.swipeActions` in `BookmarksListView`, and `UIContextualAction`s in the podcast page's table.

<img width="340"  alt="Screenshot 2026-08-06 at 11 49 12 AM" src="https://github.com/user-attachments/assets/c97ab381-369e-45d4-ad26-bdf7e57c14aa" />


## To test

1. Open a podcast with bookmarks and switch to the Bookmarks tab.
2. Swipe a row right — Share appears and opens the share sheet.
3. Swipe a row left — Delete appears and removes the bookmark, with the row animating out.
4. Confirm a full swipe on either edge doesn't fire the action on its own.
5. Long press a row to enter multi select and confirm rows no longer swipe.
6. Switch to the Episodes tab and confirm episode swipe actions still work.
7. Check the Player, Episode, and Profile bookmark lists still swipe as before.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
