### PR TITLE
Fix bookmark multi-select breaking when a selected bookmark changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add Smart Bookmarks: bookmarks now suggest a title and capture the surrounding passage from the episode transcript, mark their spot in the transcript, and anchor their timestamp to the transcript's reference timeline so it stays accurate even when dynamic ads shift the audio [#4761](https://github.com/Automattic/pocket-casts-ios/pull/4761)
 - Add swipe actions to bookmark rows (Share and Delete) in the Player, standalone Podcast bookmarks, Episode, and Profile bookmark lists [#4900](https://github.com/Automattic/pocket-casts-ios/pull/4900)
 - Fix animations on the podcast screen's Bookmarks tab: rows now animate as they are added, removed and filtered, and highlight when tapped [#4904](https://github.com/Automattic/pocket-casts-ios/pull/4904)
+- Fix bookmark multi-select losing track of a selected bookmark when it was edited or updated by a sync, leaving a wrong selection count and a row that could not be deselected [#4913](https://github.com/Automattic/pocket-casts-ios/pull/4913)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
 

--- a/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
@@ -2,8 +2,11 @@ import Foundation
 import SwiftUI
 
 /// A bookmark that represents a position in time within an episode
-public struct Bookmark: Hashable {
+public struct Bookmark: Identifiable {
     public let uuid: String
+
+    public var id: String { uuid }
+
     public let title: String
     public let time: TimeInterval
 
@@ -36,31 +39,6 @@ public struct Bookmark: Hashable {
     public var passageModified: Date? = nil
     public var referenceTimeModified: Date? = nil
     public var deleted: Bool = false
-
-    // `BaseEpisode` and `Podcast` don't conform to Hashable, so instead we implement it manually to ignore those properties
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(uuid)
-        hasher.combine(title)
-        hasher.combine(time)
-        hasher.combine(created)
-        hasher.combine(episodeUuid)
-        hasher.combine(podcastUuid)
-        hasher.combine(passage)
-        hasher.combine(passageLocation)
-        hasher.combine(referenceTime)
-        hasher.combine(titleModified)
-        hasher.combine(deletedModified)
-    }
-
-    public static func == (lhs: Bookmark, rhs: Bookmark) -> Bool {
-        lhs.uuid == rhs.uuid
-    }
-}
-
-// MARK: - Identifiable
-
-extension Bookmark: Identifiable {
-    public var id: String { uuid }
 }
 
 // MARK: - Preview Data

--- a/PocketCastsTests/Tests/Common SwiftUI/List View Model/ListViewModelTests.swift
+++ b/PocketCastsTests/Tests/Common SwiftUI/List View Model/ListViewModelTests.swift
@@ -32,7 +32,9 @@ final class ListViewModelTests: XCTestCase {
     }
 
     // MARK: - Test Model
-    private struct TestableModel: Hashable {
+    private struct TestableModel: Identifiable, Equatable {
         let title: String
+
+        var id: String { title }
     }
 }

--- a/PocketCastsTests/Tests/Common SwiftUI/List View Model/MutliSelectListViewModel.swift
+++ b/PocketCastsTests/Tests/Common SwiftUI/List View Model/MutliSelectListViewModel.swift
@@ -188,8 +188,10 @@ final class MultiSelectListViewModelTests: XCTestCase {
     }
 
     // MARK: - Test Model
-    private struct TestableModel: Hashable {
+    private struct TestableModel: Identifiable {
         let title: String
+
+        var id: String { title }
     }
 
     private class TestingMultiSelectViewModel: MultiSelectListViewModel<TestableModel> {

--- a/PocketCastsTests/Tests/Common SwiftUI/List View Model/SearchableListViewModelTests.swift
+++ b/PocketCastsTests/Tests/Common SwiftUI/List View Model/SearchableListViewModelTests.swift
@@ -62,9 +62,10 @@ final class SearchableListViewModelTests: XCTestCase {
     }
 
     // MARK: - Test Model
-    private struct TestableModel: SearchableDataModel {
+    private struct TestableModel: SearchableDataModel, Equatable {
         let title: String
 
+        var id: String { title }
         var searchableContent: String { title }
     }
 }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -70,9 +70,9 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
 
     /// Reload a single item from the list
     func refresh(bookmark: Bookmark) {
-        guard let index = items.firstIndex(of: bookmark) else { return }
+        guard let index = items.firstIndex(where: { $0.id == bookmark.id }) else { return }
 
-        items.replaceSubrange(index...index, with: [bookmark])
+        items[index] = bookmark
     }
 
     func addListeners() {
@@ -173,7 +173,7 @@ extension BookmarkListViewModel {
     func deleteSelectedBookmarks() {
         guard numberOfSelectedItems > 0 else { return }
 
-        let items = Array(selectedItems)
+        let items = selectedItems
 
         confirmDeletion { [weak self] in
             self?.actuallyDelete(items)

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -142,7 +142,7 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
         List {
             bookmarksRows
         }
-        .animation(.default, value: viewModel.bookmarks)
+        .animation(.default, value: viewModel.bookmarks.map(\.id))
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .environment(\.defaultMinListRowHeight, 0)

--- a/podcasts/Common SwiftUI/List View/ListViewModel.swift
+++ b/podcasts/Common SwiftUI/List View/ListViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 ///     }
 ///
 @MainActor
-class ListViewModel<Model: Hashable>: ObservableObject {
+class ListViewModel<Model: Identifiable>: ObservableObject {
     @Published var items: [Model] = [] {
         didSet {
             numberOfItems = items.count
@@ -30,6 +30,6 @@ class ListViewModel<Model: Hashable>: ObservableObject {
 
     /// Whether the given item is the last in the list
     func isLast(item: Model) -> Bool {
-        items.last == item
+        items.last?.id == item.id
     }
 }

--- a/podcasts/Common SwiftUI/List View/MultiSelectListViewModel.swift
+++ b/podcasts/Common SwiftUI/List View/MultiSelectListViewModel.swift
@@ -7,7 +7,7 @@ import Foundation
 ///     class MyListViewModel: MultiSelectListViewModel<MyCustomModel> {
 ///         ...
 ///     }
-class MultiSelectListViewModel<Model: Hashable>: ListViewModel<Model> {
+class MultiSelectListViewModel<Model: Identifiable>: ListViewModel<Model> {
     /// Whether the list is currently in the multi selection mode
     @Published private(set) var isMultiSelecting = false
 
@@ -17,11 +17,16 @@ class MultiSelectListViewModel<Model: Hashable>: ListViewModel<Model> {
     /// Whether all the items in the list have been selected
     @Published private(set) var hasSelectedAll = false
 
-    /// An internal set that keeps track of the items that are currently selected
-    private(set) lazy var selectedItems: Set<Model> = [] {
+    /// An internal set that keeps track of the ids of the items that are currently selected
+    private var selectedIDs: Set<Model.ID> = [] {
         didSet {
             updateCounts()
         }
+    }
+
+    /// The currently selected items, in the order they appear in the list
+    var selectedItems: [Model] {
+        items.filter { selectedIDs.contains($0.id) }
     }
 
     /// Update the selected items whenever the parent items change
@@ -49,15 +54,15 @@ class MultiSelectListViewModel<Model: Hashable>: ListViewModel<Model> {
     // MARK: - Item Selection
 
     func isSelected(_ item: Model) -> Bool {
-        selectedItems.contains(where: { $0 == item })
+        selectedIDs.contains(item.id)
     }
 
     func select(item: Model) {
-        selectedItems.insert(item)
+        selectedIDs.insert(item.id)
     }
 
     func deselect(item: Model) {
-        selectedItems.remove(item)
+        selectedIDs.remove(item.id)
     }
 
     func toggleSelected(_ item: Model) {
@@ -71,25 +76,25 @@ class MultiSelectListViewModel<Model: Hashable>: ListViewModel<Model> {
     }
 
     func selectAll() {
-        selectedItems = Set(items)
+        selectedIDs = Set(items.map(\.id))
     }
 
     func deselectAll() {
-        selectedItems.removeAll()
+        selectedIDs.removeAll()
     }
 
     // MARK: - Select All Before/After
 
     func selectAllBefore(_ item: Model) {
-        guard let index = items.firstIndex(of: item) else { return }
+        guard let index = index(of: item) else { return }
 
-        selectedItems.formUnion(items[...index])
+        selectedIDs.formUnion(items[...index].map(\.id))
     }
 
     func selectAllAfter(_ item: Model) {
-        guard let index = items.firstIndex(of: item) else { return }
+        guard let index = index(of: item) else { return }
 
-        selectedItems.formUnion(items[index...])
+        selectedIDs.formUnion(items[index...].map(\.id))
     }
 
     // MARK: - Long Press
@@ -131,8 +136,12 @@ class MultiSelectListViewModel<Model: Hashable>: ListViewModel<Model> {
 // MARK: - Private Methods
 
 private extension MultiSelectListViewModel {
+    func index(of item: Model) -> Int? {
+        items.firstIndex { $0.id == item.id }
+    }
+
     func updateCounts() {
-        let selected = selectedItems.count
+        let selected = selectedIDs.count
         numberOfSelectedItems = selected
         hasSelectedAll = selected == items.count
     }
@@ -140,7 +149,7 @@ private extension MultiSelectListViewModel {
     func validateSelectedItems() {
         // Update the selected items to remove any items that are not present in the items array
         // IE: if they were deleted
-        selectedItems.formIntersection(items)
+        selectedIDs.formIntersection(items.map(\.id))
 
         // If we're multiselecting and there are no items left, exit the multiselection mode
         if isMultiSelecting, numberOfItems == 0 {

--- a/podcasts/Common SwiftUI/List View/SearchableListViewModel.swift
+++ b/podcasts/Common SwiftUI/List View/SearchableListViewModel.swift
@@ -2,7 +2,7 @@ import Combine
 import PocketCastsUtils
 
 ///Allows a mode to be searched by the `SearchableListViewModel`
-protocol SearchableDataModel: Hashable {
+protocol SearchableDataModel: Identifiable {
     /// Defines a field that the search text should match against
     /// This should contain all keywords for the model
     var searchableContent: String { get }
@@ -52,7 +52,7 @@ class SearchableListViewModel<Model: SearchableDataModel>: MultiSelectListViewMo
             return super.isLast(item: item)
         }
 
-        return filteredItems.last == item
+        return filteredItems.last?.id == item.id
     }
 
     /// Search the items with the given text


### PR DESCRIPTION
`Bookmark`'s `Hashable` contract was broken: `==` compared only `uuid`, but `hash(into:)` mixed in `title`, `time`, `passage` and the sync dates. Equal values hashed differently, so every `Set<Bookmark>` operation in `MultiSelectListViewModel` was unreliable — editing a selected bookmark's title (or a sync-driven refresh swapping the instance) dropped it from the set while the row still looked selected, leaving a wrong count and a row that couldn't be deselected.

`Bookmark` no longer conforms to `Hashable`/`Equatable`. The list view models are now constrained to `Identifiable` and track selection as a `Set<Model.ID>`; `selectedItems` is derived from `items`, so it always reflects the current instances.

## To test

1. Open a bookmarks list (Player tab, podcast Bookmarks tab, episode, or Profile).
2. Long press a bookmark to enter multi-select, and select a couple of bookmarks.
3. Tap Edit on a single selected bookmark, change its title, and save.
4. Verify the count stays correct and the row can still be deselected.
5. Verify Select All / Select All Above / Below, Share, and Delete still behave.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
