### PR TITLE
Fix podcast page tabs being clipped when scrolled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add swipe actions to bookmark rows (Share and Delete) in the Player, the podcast screen's Bookmarks tab, standalone Podcast bookmarks, Episode, and Profile bookmark lists [#4900](https://github.com/Automattic/pocket-casts-ios/pull/4900) [#4912](https://github.com/Automattic/pocket-casts-ios/pull/4912)
 - Fix animations on the podcast screen's Bookmarks tab: rows now animate as they are added, removed and filtered, and highlight when tapped [#4904](https://github.com/Automattic/pocket-casts-ios/pull/4904)
 - Fix bookmark multi-select losing track of a selected bookmark when it was edited or updated by a sync, leaving a wrong selection count and a row that could not be deselected [#4913](https://github.com/Automattic/pocket-casts-ios/pull/4913)
+- Fix the podcast screen tabs truncating their labels and clipping the press effect [#4918](https://github.com/Automattic/pocket-casts-ios/pull/4918)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Add swipe actions to bookmark rows (Share and Delete) in the Player, the podcast screen's Bookmarks tab, standalone Podcast bookmarks, Episode, and Profile bookmark lists [#4900](https://github.com/Automattic/pocket-casts-ios/pull/4900) [#4912](https://github.com/Automattic/pocket-casts-ios/pull/4912)
 - Fix animations on the podcast screen's Bookmarks tab: rows now animate as they are added, removed and filtered, and highlight when tapped [#4904](https://github.com/Automattic/pocket-casts-ios/pull/4904)
 - Fix bookmark multi-select losing track of a selected bookmark when it was edited or updated by a sync, leaving a wrong selection count and a row that could not be deselected [#4913](https://github.com/Automattic/pocket-casts-ios/pull/4913)
-- Fix the podcast screen tabs truncating their labels and clipping the press effect [#4918](https://github.com/Automattic/pocket-casts-ios/pull/4918)
+- Fix the podcast screen tabs being clipped when scrolled [#4918](https://github.com/Automattic/pocket-casts-ios/pull/4918)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
 

--- a/podcasts/Podcasts/Podcast Page/PodcastDetailsTabView.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastDetailsTabView.swift
@@ -30,6 +30,7 @@ struct PodcastDetailsTabView: View {
         Group {
             if FeatureFlag.recommendations.enabled {
                 ScrollView(.horizontal, showsIndicators: false) { tabs }
+                    .scrollClipDisabled()
             } else {
                 tabs
             }
@@ -71,7 +72,7 @@ struct PodcastDetailsTabView: View {
                         .applyButtonEffect(isPressed: config.isPressed)
                 }
 
-            Spacer()
+            Spacer(minLength: 0)
         }
         .font(.subheadline.weight(.medium))
     }
@@ -82,6 +83,7 @@ struct PodcastDetailsTabView: View {
 private extension View {
     func applyStyle(theme: Theme, highlighted: Bool = false) -> some View {
         self
+            .fixedSize()
             .contentShape(Rectangle())
             .padding(.vertical, 8)
             .padding(.horizontal, 12)

--- a/podcasts/Podcasts/Podcast Page/PodcastDetailsTabView.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastDetailsTabView.swift
@@ -41,7 +41,7 @@ struct PodcastDetailsTabView: View {
     }
 
     @ViewBuilder var tabs: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 9) {
             Text(L10n.episodes)
                 .buttonize {
                     selectedTab = .episodes
@@ -72,7 +72,7 @@ struct PodcastDetailsTabView: View {
                         .applyButtonEffect(isPressed: config.isPressed)
                 }
 
-            Spacer(minLength: 0)
+            Spacer()
         }
         .font(.subheadline.weight(.medium))
     }
@@ -83,7 +83,6 @@ struct PodcastDetailsTabView: View {
 private extension View {
     func applyStyle(theme: Theme, highlighted: Bool = false) -> some View {
         self
-            .fixedSize()
             .contentShape(Rectangle())
             .padding(.vertical, 8)
             .padding(.horizontal, 12)


### PR DESCRIPTION
The podcast page tabs sit in a horizontal `ScrollView`, which clipped them at its bounds when scrolled. Disables scroll clipping and lets the tabs size to their content.

## To test

1. Enable the Recommendations feature flag.
2. Open a podcast page.
3. Scroll the tabs row horizontally and verify the tabs are not clipped at the edges.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
