### PR TITLE
Move fingerprint timing to Swift Concurrency (13 warnings)

### DIFF
--- a/PocketCastsTests/Tests/Fingerprint/FingerprintFixtures.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintFixtures.swift
@@ -1,0 +1,202 @@
+import AVFoundation
+import Fingerprint
+import Foundation
+
+@testable import podcasts
+
+/// The two on-disk inputs a fingerprint run needs: an audio file, and a reference
+/// fingerprint built from that same audio the way the server builds one from the
+/// publisher's copy of the episode.
+enum FingerprintFixtures {
+
+    static let sampleRate: Double = 44100
+
+    /// The reference grid `makeReference` fingerprints on, matching the shape of a
+    /// server-generated reference: a checkpoint every 2 s, each covering 8 s.
+    static let checkpointIntervalSeconds = 2
+    static let checkpointDurationSeconds = 8
+
+    enum FixtureError: Error {
+        case bufferAllocationFailed
+        case openForWritingFailed(String)
+        case openForReadingFailed(String)
+        case readFailed(String)
+    }
+
+    // MARK: - Audio
+
+    /// Writes `seconds` of deterministic audio to `url`.
+    ///
+    /// Every 250 ms the tones change, drawn from a seeded generator, so no two
+    /// moments in the file share a spectrum — the property a fingerprint relies on
+    /// to tie a window to one point on the timeline. A little broadband noise
+    /// underneath keeps the spectrum from being three bare spikes.
+    static func writeAudio(seconds: Double, to url: URL) throws {
+        // The file is only closed (and its header finalized) when the last
+        // reference to it goes away, so it stays scoped to this pool — the
+        // caller's next move is to open the same path for reading.
+        try autoreleasepool {
+            try write(seconds: seconds, to: url)
+        }
+    }
+
+    private static func write(seconds: Double, to url: URL) throws {
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: sampleRate,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false
+        ]
+        let file: AVAudioFile
+        do {
+            file = try AVAudioFile(forWriting: url, settings: settings)
+        } catch {
+            throw FixtureError.openForWritingFailed("\(error)")
+        }
+        let format = file.processingFormat
+
+        let segmentFrames = AVAudioFrameCount(sampleRate * 0.25)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: segmentFrames) else {
+            throw FixtureError.bufferAllocationFailed
+        }
+
+        // Two octaves of semitones from A3 up, so consecutive segments are always
+        // clearly distinguishable in the spectrum.
+        let scale = (0..<24).map { 220.0 * pow(2.0, Double($0) / 12.0) }
+        var random = SeededGenerator(seed: 0xF1_9E_2B_71)
+
+        let totalFrames = Int(seconds * sampleRate)
+        var writtenFrames = 0
+        while writtenFrames < totalFrames {
+            let frames = min(Int(segmentFrames), totalFrames - writtenFrames)
+            let tones = (0..<3).map { _ in scale[random.nextIndex(upperBound: scale.count)] }
+
+            buffer.frameLength = AVAudioFrameCount(frames)
+            guard let samples = buffer.floatChannelData?[0] else { throw FixtureError.bufferAllocationFailed }
+            for frame in 0..<frames {
+                let time = Double(writtenFrames + frame) / sampleRate
+                var value = 0.0
+                for tone in tones {
+                    value += sin(2 * .pi * tone * time)
+                }
+                samples[frame] = Float(value * 0.25 + (random.nextUnit() - 0.5) * 0.04)
+            }
+
+            try file.write(from: buffer)
+            writtenFrames += frames
+        }
+    }
+
+    // MARK: - Reference fingerprint
+
+    /// Fingerprints `url` on a checkpoint grid and encodes the result as the
+    /// compact-v2 JSON the app downloads from the server, so a run against this
+    /// audio should map every window onto its own timestamp.
+    static func makeReference(
+        forAudioAt url: URL,
+        checkpointIntervalSeconds: Int = checkpointIntervalSeconds,
+        checkpointDurationSeconds: Int = checkpointDurationSeconds
+    ) throws -> Data {
+        let file: AVAudioFile
+        do {
+            file = try AVAudioFile(forReading: url, commonFormat: .pcmFormatFloat32, interleaved: false)
+        } catch {
+            throw FixtureError.openForReadingFailed("\(error)")
+        }
+        let format = file.processingFormat
+        let windowDurationMs = UInt32(checkpointDurationSeconds * 1000)
+
+        let fingerprinter = StreamingWindowedFingerprinter(
+            sampleRate: UInt32(format.sampleRate),
+            channels: UInt16(format.channelCount),
+            windowDurationMs: windowDurationMs,
+            windowIntervalMs: UInt32(checkpointIntervalSeconds * 1000)
+        )
+
+        let chunkFrames = AVAudioFrameCount(format.sampleRate * 5)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
+            throw FixtureError.bufferAllocationFailed
+        }
+
+        var windows: [WindowedFingerprint] = []
+        // Bounded by `length` rather than by a zero-length read: `read` throws at
+        // EOF instead of returning no frames.
+        while file.framePosition < file.length {
+            do {
+                try file.read(into: buffer, frameCount: chunkFrames)
+            } catch {
+                throw FixtureError.readFailed("\(error)")
+            }
+            if buffer.frameLength == 0 { break }
+            guard let channel = buffer.floatChannelData?[0] else { break }
+            let samples = Array(UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength)))
+            windows += fingerprinter.pushSamplesF32(samples: samples, channels: UInt16(format.channelCount))
+        }
+        windows += fingerprinter.flush()
+
+        // A trailing partial window covers less audio than the grid promises, so
+        // it would anchor a matching window to the wrong reference time.
+        windows = windows.filter { $0.durationMs == windowDurationMs }
+
+        var checkpoints: [[Any]] = []
+        var previousSecond = 0
+        for window in windows {
+            let second = Int(window.timestampMs) / 1000
+            guard checkpoints.isEmpty || second > previousSecond else { continue }
+            checkpoints.append([second - previousSecond, base64(hashes: window.hashes)])
+            previousSecond = second
+        }
+
+        let json: [String: Any] = [
+            "format": ReferenceFingerprint.supportedFormat,
+            "total_duration": Double(file.length) / format.sampleRate,
+            "checkpoint_interval": checkpointIntervalSeconds,
+            "checkpoint_duration": checkpointDurationSeconds,
+            "timestamp_quantum": 1,
+            "checkpoints": checkpoints
+        ]
+        return try JSONSerialization.data(withJSONObject: json)
+    }
+
+    /// Little-endian `UInt32` packing, the inverse of `ReferenceFingerprint.libraryCheckpoints()`.
+    private static func base64(hashes: [UInt32]) -> String {
+        var payload = Data(capacity: hashes.count * 4)
+        for hash in hashes {
+            payload.append(UInt8(truncatingIfNeeded: hash))
+            payload.append(UInt8(truncatingIfNeeded: hash >> 8))
+            payload.append(UInt8(truncatingIfNeeded: hash >> 16))
+            payload.append(UInt8(truncatingIfNeeded: hash >> 24))
+        }
+        return payload.base64EncodedString()
+    }
+}
+
+/// SplitMix64 — the fixtures need to be byte-identical from run to run, which
+/// rules out `SystemRandomNumberGenerator`.
+private struct SeededGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+
+    mutating func nextIndex(upperBound: Int) -> Int {
+        Int(next() % UInt64(upperBound))
+    }
+
+    /// A value in `0..<1`.
+    mutating func nextUnit() -> Double {
+        Double(next() >> 11) * (1.0 / 9_007_199_254_740_992.0)
+    }
+}

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintFixtures.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintFixtures.swift
@@ -31,16 +31,16 @@ enum FingerprintFixtures {
     /// moments in the file share a spectrum — the property a fingerprint relies on
     /// to tie a window to one point on the timeline. A little broadband noise
     /// underneath keeps the spectrum from being three bare spikes.
-    static func writeAudio(seconds: Double, to url: URL) throws {
+    static func writeAudio(seconds: Double, seed: UInt64 = 0xF1_9E_2B_71, to url: URL) throws {
         // The file is only closed (and its header finalized) when the last
         // reference to it goes away, so it stays scoped to this pool — the
         // caller's next move is to open the same path for reading.
         try autoreleasepool {
-            try write(seconds: seconds, to: url)
+            try write(seconds: seconds, seed: seed, to: url)
         }
     }
 
-    private static func write(seconds: Double, to url: URL) throws {
+    private static func write(seconds: Double, seed: UInt64, to url: URL) throws {
         let settings: [String: Any] = [
             AVFormatIDKey: kAudioFormatLinearPCM,
             AVSampleRateKey: sampleRate,
@@ -66,7 +66,7 @@ enum FingerprintFixtures {
         // Two octaves of semitones from A3 up, so consecutive segments are always
         // clearly distinguishable in the spectrum.
         let scale = (0..<24).map { 220.0 * pow(2.0, Double($0) / 12.0) }
-        var random = SeededGenerator(seed: 0xF1_9E_2B_71)
+        var random = SeededGenerator(seed: seed)
 
         let totalFrames = Int(seconds * sampleRate)
         var writtenFrames = 0

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintFixtures.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintFixtures.swift
@@ -9,7 +9,7 @@ import Foundation
 /// publisher's copy of the episode.
 enum FingerprintFixtures {
 
-    static let sampleRate: Double = 44100
+    static let defaultSampleRate: Double = 44100
 
     /// The reference grid `makeReference` fingerprints on, matching the shape of a
     /// server-generated reference: a checkpoint every 2 s, each covering 8 s.
@@ -23,24 +23,80 @@ enum FingerprintFixtures {
         case readFailed(String)
     }
 
+    static let contentSeed: UInt64 = 0xF1_9E_2B_71
+    static let adSeed: UInt64 = 0x2C_0F_FE_E1
+
     // MARK: - Audio
 
-    /// Writes `seconds` of deterministic audio to `url`.
+    /// `seconds` of deterministic mono audio.
     ///
     /// Every 250 ms the tones change, drawn from a seeded generator, so no two
-    /// moments in the file share a spectrum — the property a fingerprint relies on
-    /// to tie a window to one point on the timeline. A little broadband noise
-    /// underneath keeps the spectrum from being three bare spikes.
-    static func writeAudio(seconds: Double, seed: UInt64 = 0xF1_9E_2B_71, to url: URL) throws {
+    /// moments share a spectrum — the property a fingerprint relies on to tie a
+    /// window to one point on the timeline. A little broadband noise underneath
+    /// keeps the spectrum from being three bare spikes.
+    ///
+    /// A pure function of `(seed, frame index)`, so a slice of one episode's audio
+    /// is sample-identical to the same slice of another built from the same seed —
+    /// which is what lets a fixture splice an ad into the middle of an episode and
+    /// still expect an exact match either side of it.
+    static func samples(
+        seconds: Double,
+        seed: UInt64 = contentSeed,
+        sampleRate: Double = defaultSampleRate
+    ) -> [Float] {
+        // Two octaves of semitones from A3 up, so consecutive segments are always
+        // clearly distinguishable in the spectrum.
+        let scale = (0..<24).map { 220.0 * pow(2.0, Double($0) / 12.0) }
+        var random = SeededGenerator(seed: seed)
+
+        let totalFrames = frameCount(forSeconds: seconds, sampleRate: sampleRate)
+        let segmentFrames = frameCount(forSeconds: 0.25, sampleRate: sampleRate)
+        var samples = [Float](repeating: 0, count: totalFrames)
+
+        var index = 0
+        while index < totalFrames {
+            let tones = (0..<3).map { _ in scale[random.nextIndex(upperBound: scale.count)] }
+            for frame in index..<min(index + segmentFrames, totalFrames) {
+                let time = Double(frame) / sampleRate
+                var value = 0.0
+                for tone in tones {
+                    value += sin(2 * .pi * tone * time)
+                }
+                samples[frame] = Float(value * 0.25 + (random.nextUnit() - 0.5) * 0.04)
+            }
+            index += segmentFrames
+        }
+        return samples
+    }
+
+    static func frameCount(forSeconds seconds: Double, sampleRate: Double = defaultSampleRate) -> Int {
+        Int(seconds * sampleRate)
+    }
+
+    /// Generates and writes `seconds` of audio in one step.
+    static func writeAudio(
+        seconds: Double,
+        seed: UInt64 = contentSeed,
+        sampleRate: Double = defaultSampleRate,
+        to url: URL
+    ) throws {
+        try writeAudio(
+            samples(seconds: seconds, seed: seed, sampleRate: sampleRate),
+            sampleRate: sampleRate,
+            to: url
+        )
+    }
+
+    static func writeAudio(_ samples: [Float], sampleRate: Double = defaultSampleRate, to url: URL) throws {
         // The file is only closed (and its header finalized) when the last
         // reference to it goes away, so it stays scoped to this pool — the
         // caller's next move is to open the same path for reading.
         try autoreleasepool {
-            try write(seconds: seconds, seed: seed, to: url)
+            try write(samples, sampleRate: sampleRate, to: url)
         }
     }
 
-    private static func write(seconds: Double, seed: UInt64, to url: URL) throws {
+    private static func write(_ samples: [Float], sampleRate: Double, to url: URL) throws {
         let settings: [String: Any] = [
             AVFormatIDKey: kAudioFormatLinearPCM,
             AVSampleRateKey: sampleRate,
@@ -58,36 +114,36 @@ enum FingerprintFixtures {
         }
         let format = file.processingFormat
 
-        let segmentFrames = AVAudioFrameCount(sampleRate * 0.25)
-        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: segmentFrames) else {
+        let chunkFrames = AVAudioFrameCount(sampleRate)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
             throw FixtureError.bufferAllocationFailed
         }
 
-        // Two octaves of semitones from A3 up, so consecutive segments are always
-        // clearly distinguishable in the spectrum.
-        let scale = (0..<24).map { 220.0 * pow(2.0, Double($0) / 12.0) }
-        var random = SeededGenerator(seed: seed)
-
-        let totalFrames = Int(seconds * sampleRate)
-        var writtenFrames = 0
-        while writtenFrames < totalFrames {
-            let frames = min(Int(segmentFrames), totalFrames - writtenFrames)
-            let tones = (0..<3).map { _ in scale[random.nextIndex(upperBound: scale.count)] }
-
+        var written = 0
+        while written < samples.count {
+            let frames = min(Int(chunkFrames), samples.count - written)
             buffer.frameLength = AVAudioFrameCount(frames)
-            guard let samples = buffer.floatChannelData?[0] else { throw FixtureError.bufferAllocationFailed }
+            guard let channel = buffer.floatChannelData?[0] else { throw FixtureError.bufferAllocationFailed }
             for frame in 0..<frames {
-                let time = Double(writtenFrames + frame) / sampleRate
-                var value = 0.0
-                for tone in tones {
-                    value += sin(2 * .pi * tone * time)
-                }
-                samples[frame] = Float(value * 0.25 + (random.nextUnit() - 0.5) * 0.04)
+                channel[frame] = samples[written + frame]
             }
-
             try file.write(from: buffer)
-            writtenFrames += frames
+            written += frames
         }
+    }
+
+    /// A reference whose checkpoint list is empty — a well-formed payload the
+    /// matcher can't build anything from.
+    static func referenceWithoutCheckpoints(totalDuration: Double) throws -> Data {
+        let json: [String: Any] = [
+            "format": ReferenceFingerprint.supportedFormat,
+            "total_duration": totalDuration,
+            "checkpoint_interval": checkpointIntervalSeconds,
+            "checkpoint_duration": checkpointDurationSeconds,
+            "timestamp_quantum": 1,
+            "checkpoints": []
+        ]
+        return try JSONSerialization.data(withJSONObject: json)
     }
 
     // MARK: - Reference fingerprint

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintMappingCacheTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintMappingCacheTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class FingerprintMappingCacheTests: XCTestCase {
 
-    typealias Entry = FingerprintTimingManager.TimeMappingEntry
+    typealias Entry = TimeMappingEntry
 
     private var tempDir: URL!
     private var audioPath: String!

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintPCMTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintPCMTests.swift
@@ -1,0 +1,77 @@
+import AVFoundation
+import XCTest
+
+@testable import podcasts
+
+/// Planar → interleaved conversion. The decode loop reuses one scratch array
+/// across every chunk of an episode, so both the layout and the reuse are load
+/// bearing.
+final class FingerprintPCMTests: XCTestCase {
+
+    func testMonoBufferIsCopiedThrough() throws {
+        let buffer = try Self.buffer(channels: [[0.1, 0.2, 0.3]])
+        var scratch: [Float] = []
+
+        FingerprintPCM.interleave(buffer, into: &scratch)
+
+        XCTAssertEqual(scratch, [0.1, 0.2, 0.3])
+    }
+
+    func testStereoChannelsAreInterleaved() throws {
+        let buffer = try Self.buffer(channels: [[1, 2, 3], [-1, -2, -3]])
+        var scratch: [Float] = []
+
+        FingerprintPCM.interleave(buffer, into: &scratch)
+
+        XCTAssertEqual(scratch, [1, -1, 2, -2, 3, -3])
+    }
+
+    func testScratchIsFullyOverwrittenWhenReusedAtTheSameSize() throws {
+        var scratch: [Float] = []
+        FingerprintPCM.interleave(try Self.buffer(channels: [[1, 2, 3], [-1, -2, -3]]), into: &scratch)
+
+        FingerprintPCM.interleave(try Self.buffer(channels: [[7, 8, 9], [-7, -8, -9]]), into: &scratch)
+
+        XCTAssertEqual(scratch, [7, -7, 8, -8, 9, -9])
+    }
+
+    func testScratchIsResizedWhenTheChunkShrinks() throws {
+        var scratch: [Float] = []
+        FingerprintPCM.interleave(try Self.buffer(channels: [[1, 2, 3]]), into: &scratch)
+
+        FingerprintPCM.interleave(try Self.buffer(channels: [[4]]), into: &scratch)
+
+        XCTAssertEqual(scratch, [4])
+    }
+
+    /// A zero-length read has to leave nothing behind — feeding the previous
+    /// chunk's samples to the fingerprinter again would invent audio.
+    func testEmptyBufferClearsTheScratch() throws {
+        var scratch: [Float] = []
+        FingerprintPCM.interleave(try Self.buffer(channels: [[1, 2, 3]]), into: &scratch)
+
+        FingerprintPCM.interleave(try Self.buffer(channels: [[]]), into: &scratch)
+
+        XCTAssertTrue(scratch.isEmpty)
+    }
+
+    private static func buffer(channels: [[Float]]) throws -> AVAudioPCMBuffer {
+        let format = try XCTUnwrap(AVAudioFormat(
+            standardFormatWithSampleRate: 44100,
+            channels: AVAudioChannelCount(channels.count)
+        ))
+        let frames = channels[0].count
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(max(frames, 1))
+        ))
+        buffer.frameLength = AVAudioFrameCount(frames)
+        let data = try XCTUnwrap(buffer.floatChannelData)
+        for (channel, samples) in channels.enumerated() {
+            for (frame, sample) in samples.enumerated() {
+                data[channel][frame] = sample
+            }
+        }
+        return buffer
+    }
+}

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintPreparationTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintPreparationTests.swift
@@ -38,14 +38,7 @@ final class FingerprintPreparationTests: XCTestCase {
         try FingerprintFixtures.makeReference(forAudioAt: audioURL).write(to: referenceURL)
 
         let manager = FingerprintTimingManager()
-        await manager.testing.prepare(request: .init(
-            episodeUuid: "episode-uuid",
-            podcastUuid: "podcast-uuid",
-            duration: Self.episodeDuration,
-            audioFileURL: audioURL,
-            isStreaming: false,
-            referenceFilePath: referenceURL.path
-        ))
+        await manager.testing.prepare(request: Self.request(audio: audioURL, reference: referenceURL))
 
         // Reference decoded and the matcher built, so the stream is running. No
         // commit can have landed yet — they need the main actor, and we haven't
@@ -104,5 +97,37 @@ final class FingerprintPreparationTests: XCTestCase {
         XCTAssertTrue(manager.isWithinMatchedContent(forPlaybackTime: midpoint))
         XCTAssertEqual(try XCTUnwrap(manager.matchedReferenceTime(forPlaybackTime: midpoint)), midpoint, accuracy: 0.5)
         XCTAssertEqual(try XCTUnwrap(manager.playbackTime(forReferenceTime: midpoint)), midpoint, accuracy: 0.5)
+    }
+
+    /// A pass that reaches the end of the file having found nothing it trusts is
+    /// "we couldn't map this episode", not a decode failure — the two report
+    /// different analytics, and only the clean ending persists a mapping cache.
+    func testPreparationEndsUnavailableWhenAudioDoesNotMatchTheReference() async throws {
+        let audioURL = directory.appendingPathComponent("episode.caf")
+        try FingerprintFixtures.writeAudio(seconds: Self.episodeDuration, to: audioURL)
+
+        // A reference built from a different episode entirely.
+        let otherAudioURL = directory.appendingPathComponent("other-episode.caf")
+        try FingerprintFixtures.writeAudio(seconds: Self.episodeDuration, seed: 0x2C_0F_FE_E1, to: otherAudioURL)
+        let referenceURL = directory.appendingPathComponent("episode.ref.fp.json")
+        try FingerprintFixtures.makeReference(forAudioAt: otherAudioURL).write(to: referenceURL)
+
+        let manager = FingerprintTimingManager()
+        await manager.testing.prepare(request: Self.request(audio: audioURL, reference: referenceURL))
+        await manager.testing.waitForStream()
+
+        XCTAssertEqual(manager.state.analyticsName, "unavailable")
+        XCTAssertTrue(manager.snapshot.isEmpty)
+    }
+
+    private static func request(audio: URL, reference: URL) -> FingerprintTimingManager.EpisodeRequest {
+        FingerprintTimingManager.EpisodeRequest(
+            episodeUuid: "episode-uuid",
+            podcastUuid: "podcast-uuid",
+            duration: episodeDuration,
+            audioFileURL: audio,
+            isStreaming: false,
+            referenceFilePath: reference.path
+        )
     }
 }

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintPreparationTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintPreparationTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+
+@testable import podcasts
+
+/// End-to-end coverage of preparation: a reference fingerprint on disk, a real
+/// decode of a real audio file, the real matcher, and the real drift filter. Only
+/// the episode's audio and its reference are synthesized — and the reference is
+/// built from that same audio, so a correct run maps every anchor onto its own
+/// timestamp and any drift shows up as an assertion failure.
+@MainActor
+final class FingerprintPreparationTests: XCTestCase {
+
+    /// Long enough to commit anchors across the whole file: the first window can't
+    /// be emitted until 8 s of audio have been decoded, and the drift filter needs
+    /// three consecutive in-trend candidates before it commits anything.
+    private static let episodeDuration: Double = 45
+
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("FingerprintPreparationTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+        directory = nil
+        try super.tearDownWithError()
+    }
+
+    func testPreparationMapsDownloadedEpisodeOntoItsReference() async throws {
+        let audioURL = directory.appendingPathComponent("episode.caf")
+        try FingerprintFixtures.writeAudio(seconds: Self.episodeDuration, to: audioURL)
+
+        let referenceURL = directory.appendingPathComponent("episode.ref.fp.json")
+        try FingerprintFixtures.makeReference(forAudioAt: audioURL).write(to: referenceURL)
+
+        let manager = FingerprintTimingManager()
+        await manager.testing.prepare(request: .init(
+            episodeUuid: "episode-uuid",
+            podcastUuid: "podcast-uuid",
+            duration: Self.episodeDuration,
+            audioFileURL: audioURL,
+            isStreaming: false,
+            referenceFilePath: referenceURL.path
+        ))
+
+        // Reference decoded and the matcher built, so the stream is running. No
+        // commit can have landed yet — they need the main actor, and we haven't
+        // suspended since `prepare` returned.
+        XCTAssertEqual(manager.state.analyticsName, "preparing")
+        XCTAssertTrue(manager.snapshot.isEmpty)
+
+        await manager.testing.waitForStream()
+
+        guard case .active(let coverage) = manager.state else {
+            XCTFail("expected .active after a full pass, got \(manager.state)")
+            return
+        }
+
+        let entries = manager.snapshot.playbackToReference
+        XCTAssertEqual(coverage, entries.count)
+        // Windows are emitted every second but the reference's checkpoints sit every
+        // two, so the off-grid windows straddle a pair and are dropped by the
+        // dominance gate. What's left is one anchor per checkpoint — 19 of them in a
+        // 45 s file, allowing a few to fall out at the edges.
+        XCTAssertGreaterThanOrEqual(entries.count, 15)
+
+        // The reference was built from this exact audio, so an anchor with a
+        // checkpoint at its own timestamp should map onto itself. A window that
+        // matched a neighbouring checkpoint instead would still pass the drift
+        // filter (rate 1, just offset), and would show up here. The last window
+        // starts within a window's length of the end, where the checkpoint grid has
+        // run out — nothing exact is left for it, so it settles for the nearest.
+        let gridEnd = Self.episodeDuration - Double(FingerprintFixtures.checkpointDurationSeconds)
+        for entry in entries {
+            XCTAssertEqual(
+                entry.referenceTime,
+                entry.playbackTime,
+                accuracy: entry.playbackTime < gridEnd ? 0.001 : Double(FingerprintFixtures.checkpointIntervalSeconds),
+                "anchor at playback \(entry.playbackTime)s mapped to reference \(entry.referenceTime)s"
+            )
+            XCTAssertGreaterThanOrEqual(entry.score, FingerprintConstants.driftAnchorScoreThreshold)
+        }
+
+        // Coverage reaches both ends of the file, not just the region around the
+        // first few chunks.
+        XCTAssertLessThanOrEqual(try XCTUnwrap(entries.first).playbackTime, 4)
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(entries.last).playbackTime, gridEnd - 4)
+
+        // Both sorted views hold the same anchors, each in its own order.
+        XCTAssertEqual(manager.snapshot.referenceToPlayback.count, entries.count)
+        XCTAssertEqual(entries.map(\.playbackTime), entries.map(\.playbackTime).sorted())
+        XCTAssertEqual(
+            manager.snapshot.referenceToPlayback.map(\.referenceTime),
+            manager.snapshot.referenceToPlayback.map(\.referenceTime).sorted()
+        )
+
+        // What the transcript UI actually calls: mid-episode is matched content,
+        // and both directions agree there.
+        let midpoint = Self.episodeDuration / 2
+        XCTAssertTrue(manager.isWithinMatchedContent(forPlaybackTime: midpoint))
+        XCTAssertEqual(try XCTUnwrap(manager.matchedReferenceTime(forPlaybackTime: midpoint)), midpoint, accuracy: 0.5)
+        XCTAssertEqual(try XCTUnwrap(manager.playbackTime(forReferenceTime: midpoint)), midpoint, accuracy: 0.5)
+    }
+}

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintPreparationTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintPreparationTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 
+@testable import PocketCastsUtils
 @testable import podcasts
 
 /// End-to-end coverage of preparation: a reference fingerprint on disk, a real
@@ -15,16 +16,28 @@ final class FingerprintPreparationTests: XCTestCase {
     /// three consecutive in-trend candidates before it commits anything.
     private static let episodeDuration: Double = 45
 
+    /// The dynamic-ad fixture: a 10 s ad spliced 20 s into a 45 s episode.
+    private static let contentDuration: Double = 45
+    private static let adStart: Double = 20
+    private static let adDuration: Double = 10
+    private static var adEnd: Double { adStart + adDuration }
+
     private var directory: URL!
+    private let featureFlags = FeatureFlagMock()
 
     override func setUpWithError() throws {
         try super.setUpWithError()
+        // A pass starts wherever the listener is. Left alone, that's whatever the
+        // host app's persisted Up Next happens to hold, which would offset every
+        // anchor by that episode's position — nothing is playing in these tests.
+        PlaybackManager.shared.queue = PlaybackQueue()
         directory = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("FingerprintPreparationTests-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     }
 
     override func tearDownWithError() throws {
+        featureFlags.reset()
         try? FileManager.default.removeItem(at: directory)
         directory = nil
         try super.tearDownWithError()
@@ -99,6 +112,69 @@ final class FingerprintPreparationTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(manager.playbackTime(forReferenceTime: midpoint)), midpoint, accuracy: 0.5)
     }
 
+    /// The case the whole subsystem exists for: this listener's copy has a dynamic
+    /// ad the reference doesn't, so everything after it sits later in the audio than
+    /// the transcript says. The mapping has to absorb that shift, and highlighting
+    /// has to switch off while the ad plays.
+    func testPreparationAbsorbsADynamicAdInsertedIntoTheEpisode() async throws {
+        let content = FingerprintFixtures.samples(seconds: Self.contentDuration)
+        let ad = FingerprintFixtures.samples(seconds: Self.adDuration, seed: FingerprintFixtures.adSeed)
+        let breakpoint = FingerprintFixtures.frameCount(forSeconds: Self.adStart)
+
+        // The reference is the publisher's copy — content only, no ad.
+        let referenceAudioURL = directory.appendingPathComponent("reference-episode.caf")
+        try FingerprintFixtures.writeAudio(content, to: referenceAudioURL)
+        let referenceURL = directory.appendingPathComponent("episode.ref.fp.json")
+        try FingerprintFixtures.makeReference(forAudioAt: referenceAudioURL).write(to: referenceURL)
+
+        // This listener's copy — the same content with the ad spliced in.
+        let audioURL = directory.appendingPathComponent("episode.caf")
+        try FingerprintFixtures.writeAudio(
+            Array(content[0..<breakpoint]) + ad + Array(content[breakpoint...]),
+            to: audioURL
+        )
+
+        let manager = FingerprintTimingManager()
+        await manager.testing.prepare(request: Self.request(
+            audio: audioURL,
+            reference: referenceURL,
+            duration: Self.contentDuration + Self.adDuration
+        ))
+        await manager.testing.waitForStream()
+
+        XCTAssertEqual(manager.state.analyticsName, "active")
+        let entries = manager.snapshot.playbackToReference
+        XCTAssertFalse(entries.isEmpty)
+
+        // Every anchor sits either before the ad (no shift yet) or after it (shifted
+        // by the ad's whole length). Anything in between never anchors: those windows
+        // straddle the splice and match nothing.
+        let gridEnd = Self.contentDuration - Double(FingerprintFixtures.checkpointDurationSeconds)
+        for entry in entries {
+            let shift = entry.playbackTime < Self.adStart ? 0 : Self.adDuration
+            let expected = entry.playbackTime - shift
+            XCTAssertEqual(
+                entry.referenceTime,
+                expected,
+                accuracy: expected < gridEnd ? 0.001 : Double(FingerprintFixtures.checkpointIntervalSeconds),
+                "anchor at playback \(entry.playbackTime)s mapped to reference \(entry.referenceTime)s"
+            )
+        }
+        XCTAssertTrue(entries.contains { $0.playbackTime < Self.adStart }, "nothing anchored before the ad")
+        XCTAssertTrue(entries.contains { $0.playbackTime > Self.adEnd }, "nothing anchored after the ad")
+
+        // A transcript cue 25 s into the reference is 35 s into this listener's audio.
+        XCTAssertEqual(try XCTUnwrap(manager.playbackTime(forReferenceTime: 25)), 35, accuracy: 0.5)
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 35)), 25, accuracy: 0.5)
+
+        // Highlighting follows content either side of the ad and stops during it,
+        // with no ad detection anywhere in the pipeline.
+        XCTAssertTrue(manager.isWithinMatchedContent(forPlaybackTime: 8))
+        XCTAssertTrue(manager.isWithinMatchedContent(forPlaybackTime: 38))
+        XCTAssertFalse(manager.isWithinMatchedContent(forPlaybackTime: Self.adStart + Self.adDuration / 2))
+        XCTAssertNil(manager.matchedReferenceTime(forPlaybackTime: Self.adStart + Self.adDuration / 2))
+    }
+
     /// A pass that reaches the end of the file having found nothing it trusts is
     /// "we couldn't map this episode", not a decode failure — the two report
     /// different analytics, and only the clean ending persists a mapping cache.
@@ -120,11 +196,123 @@ final class FingerprintPreparationTests: XCTestCase {
         XCTAssertTrue(manager.snapshot.isEmpty)
     }
 
-    private static func request(audio: URL, reference: URL) -> FingerprintTimingManager.EpisodeRequest {
+    /// Re-opening a transcript for an episode already fingerprinted once should cost
+    /// nothing: the mapping is read back off disk and no audio is decoded at all.
+    func testCompletedPassPersistsAMappingCacheTheNextRunLoadsInsteadOfDecoding() async throws {
+        // The cache is all-or-nothing above `fullCoverageThreshold`, and a pass's
+        // last window starts a window's length from the end of the file — so the
+        // episode has to be long enough for that shortfall to fall under 5%.
+        let duration: Double = 170
+        let audioURL = directory.appendingPathComponent("episode.caf")
+        // Nothing here is above 1 kHz, so a lower rate costs the matcher nothing and
+        // keeps a long episode's decode from dominating the suite's runtime.
+        try FingerprintFixtures.writeAudio(seconds: duration, sampleRate: 16000, to: audioURL)
+        let referenceURL = directory.appendingPathComponent("episode.ref.fp.json")
+        try FingerprintFixtures.makeReference(forAudioAt: audioURL).write(to: referenceURL)
+        let request = Self.request(audio: audioURL, reference: referenceURL, duration: duration)
+
+        let first = FingerprintTimingManager()
+        await first.testing.prepare(request: request)
+        await first.testing.waitForStream()
+
+        XCTAssertEqual(first.state.analyticsName, "active")
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: FingerprintMappingCache.mappingPath(forAudioFilePath: audioURL.path)
+        ))
+
+        let second = FingerprintTimingManager()
+        await second.testing.prepare(request: request)
+
+        // Active the moment preparation returns. A pass that had to decode would
+        // still be `.preparing` here.
+        XCTAssertEqual(second.state.analyticsName, "active")
+        XCTAssertEqual(
+            second.snapshot.playbackToReference.map(\.playbackTime),
+            first.snapshot.playbackToReference.map(\.playbackTime)
+        )
+        XCTAssertEqual(
+            second.snapshot.playbackToReference.map(\.referenceTime),
+            first.snapshot.playbackToReference.map(\.referenceTime)
+        )
+    }
+
+    /// Closing the transcript has to leave nothing running and nothing mapped — the
+    /// next episode starts from a clean manager.
+    func testStopCancelsThePassAndClearsTheMapping() async throws {
+        let audioURL = directory.appendingPathComponent("episode.caf")
+        try FingerprintFixtures.writeAudio(seconds: Self.episodeDuration, to: audioURL)
+        let referenceURL = directory.appendingPathComponent("episode.ref.fp.json")
+        try FingerprintFixtures.makeReference(forAudioAt: audioURL).write(to: referenceURL)
+
+        let manager = FingerprintTimingManager()
+        await manager.testing.prepare(request: Self.request(audio: audioURL, reference: referenceURL))
+        XCTAssertEqual(manager.state.analyticsName, "preparing")
+
+        manager.stop()
+
+        XCTAssertEqual(manager.state.analyticsName, "idle")
+        XCTAssertTrue(manager.snapshot.isEmpty)
+        // The pass was cancelled rather than left running: nothing it commits after
+        // this point can reach the mapping.
+        await manager.testing.waitForStream()
+        XCTAssertTrue(manager.snapshot.isEmpty)
+        XCTAssertEqual(manager.state.analyticsName, "idle")
+    }
+
+    /// An episode whose duration the database doesn't know yet can't be windowed at
+    /// all, so preparation stops before it starts decoding.
+    func testPreparationIsUnavailableWhenTheEpisodeHasNoDuration() async throws {
+        let referenceURL = directory.appendingPathComponent("episode.ref.fp.json")
+        try FingerprintFixtures.referenceWithoutCheckpoints(totalDuration: Self.episodeDuration)
+            .write(to: referenceURL)
+
+        let manager = FingerprintTimingManager()
+        await manager.testing.prepare(request: Self.request(
+            audio: directory.appendingPathComponent("episode.caf"),
+            reference: referenceURL,
+            duration: 0
+        ))
+
+        XCTAssertEqual(manager.state.analyticsName, "unavailable")
+    }
+
+    /// A reference that decodes but yields nothing to match against is as good as no
+    /// reference at all.
+    func testPreparationIsUnavailableWhenTheReferenceHasNoCheckpoints() async throws {
+        let referenceURL = directory.appendingPathComponent("episode.ref.fp.json")
+        try FingerprintFixtures.referenceWithoutCheckpoints(totalDuration: Self.episodeDuration)
+            .write(to: referenceURL)
+
+        let manager = FingerprintTimingManager()
+        await manager.testing.prepare(request: Self.request(
+            audio: directory.appendingPathComponent("episode.caf"),
+            reference: referenceURL
+        ))
+
+        XCTAssertEqual(manager.state.analyticsName, "unavailable")
+    }
+
+    /// The real entry point's first guard — with the flag off nothing is read,
+    /// fetched or decoded.
+    func testPrepareForCurrentEpisodeIsUnavailableWhenTheFeatureFlagIsOff() {
+        featureFlags.set(.syncedTranscripts, value: false)
+
+        let manager = FingerprintTimingManager()
+        manager.prepareForCurrentEpisode()
+
+        XCTAssertEqual(manager.state.analyticsName, "unavailable")
+        XCTAssertTrue(manager.snapshot.isEmpty)
+    }
+
+    private static func request(
+        audio: URL,
+        reference: URL,
+        duration: Double = episodeDuration
+    ) -> FingerprintTimingManager.EpisodeRequest {
         FingerprintTimingManager.EpisodeRequest(
             episodeUuid: "episode-uuid",
             podcastUuid: "podcast-uuid",
-            duration: episodeDuration,
+            duration: duration,
             audioFileURL: audio,
             isStreaming: false,
             referenceFilePath: reference.path

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintResolveTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintResolveTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+
+@testable import podcasts
+
+/// The one-shot resolves — a tapped chapter and a played bookmark — against an
+/// episode whose audio carries a dynamic ad the reference doesn't. Both run the
+/// real bounded decode and matcher; only the audio and its reference are
+/// synthesized.
+@MainActor
+final class FingerprintResolveTests: XCTestCase {
+
+    private static let contentDuration: Double = 45
+    private static let adStart: Double = 20
+    private static let adDuration: Double = 10
+
+    /// A cue this far into the reference sits `adDuration` later in the listener's
+    /// audio, because the ad has already played by then.
+    private static let referenceCue: Double = 30
+    private static var playbackCue: Double { referenceCue + adDuration }
+
+    private var directory: URL!
+    private var audioURL: URL!
+    private var referenceURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("FingerprintResolveTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let content = FingerprintFixtures.samples(seconds: Self.contentDuration)
+        let ad = FingerprintFixtures.samples(seconds: Self.adDuration, seed: FingerprintFixtures.adSeed)
+        let breakpoint = FingerprintFixtures.frameCount(forSeconds: Self.adStart)
+
+        let referenceAudioURL = directory.appendingPathComponent("reference-episode.caf")
+        try FingerprintFixtures.writeAudio(content, to: referenceAudioURL)
+        referenceURL = directory.appendingPathComponent("episode.ref.fp.json")
+        try FingerprintFixtures.makeReference(forAudioAt: referenceAudioURL).write(to: referenceURL)
+
+        audioURL = directory.appendingPathComponent("episode.caf")
+        try FingerprintFixtures.writeAudio(
+            Array(content[0..<breakpoint]) + ad + Array(content[breakpoint...]),
+            to: audioURL
+        )
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+        directory = nil
+        audioURL = nil
+        referenceURL = nil
+        try super.tearDownWithError()
+    }
+
+    /// Tapping a generated chapter: the chapter's time is on the reference
+    /// timeline, and seeking there directly would land the listener before the
+    /// content they asked for by the length of the ad.
+    func testChapterResolveFindsTheAdShiftedPlaybackTime() async throws {
+        let manager = FingerprintTimingManager()
+
+        let result = await manager.testing.resolveChapter(request: request(), referenceTime: Self.referenceCue)
+
+        guard case .resolved(let playbackTime, let usedPrior, let isStreaming, _) = result else {
+            XCTFail("expected a resolved chapter seek, got \(result)")
+            return
+        }
+        XCTAssertEqual(playbackTime, Self.playbackCue, accuracy: 0.5)
+        // Cold path: no continuous mapping exists to warm-start from.
+        XCTAssertFalse(usedPrior)
+        XCTAssertFalse(isStreaming)
+
+        // A one-shot resolve matches into its own scratch mapping. Nothing the
+        // transcript highlighter reads may have moved.
+        XCTAssertTrue(manager.snapshot.isEmpty)
+        XCTAssertEqual(manager.state.analyticsName, "idle")
+    }
+
+    /// The bookmark variant of the same resolve. It differs only in waiting for a
+    /// streaming buffer, which a downloaded episode skips.
+    func testBookmarkSeekResolveFindsTheAdShiftedPlaybackTime() async throws {
+        let manager = FingerprintTimingManager()
+
+        let result = await manager.testing.resolveBookmark(request: request(), referenceTime: Self.referenceCue)
+
+        guard case .resolved(let playbackTime, _, _, _) = result else {
+            XCTFail("expected a resolved bookmark seek, got \(result)")
+            return
+        }
+        XCTAssertEqual(playbackTime, Self.playbackCue, accuracy: 0.5)
+    }
+
+    /// The opposite direction: a bookmark is stored at a position in this
+    /// listener's audio, and reading the transcript at that moment needs the
+    /// reference time it corresponds to.
+    func testBookmarkReferenceResolveMapsPlaybackBackOntoTheReference() async throws {
+        let manager = FingerprintTimingManager()
+
+        let referenceTime = await manager.testing.resolveReference(
+            request: request(),
+            playbackTime: Self.playbackCue
+        )
+
+        XCTAssertEqual(try XCTUnwrap(referenceTime), Self.referenceCue, accuracy: 0.5)
+        XCTAssertTrue(manager.snapshot.isEmpty)
+    }
+
+    /// A resolve against audio that isn't the reference's episode reports that it
+    /// found nothing, rather than a confident wrong answer the player would seek to.
+    func testChapterResolveReportsNoMatchForUnrelatedAudio() async throws {
+        let unrelatedURL = directory.appendingPathComponent("unrelated.caf")
+        try FingerprintFixtures.writeAudio(seconds: Self.contentDuration, seed: 0xAB_CD_EF_01, to: unrelatedURL)
+
+        let manager = FingerprintTimingManager()
+        let result = await manager.testing.resolveChapter(
+            request: request(audio: unrelatedURL),
+            referenceTime: Self.referenceCue
+        )
+
+        guard case .unresolved(let reason, _) = result else {
+            XCTFail("expected an unresolved chapter seek, got \(result)")
+            return
+        }
+        XCTAssertEqual(reason, "no_match")
+    }
+
+    private func request(audio: URL? = nil) -> FingerprintTimingManager.EpisodeRequest {
+        FingerprintTimingManager.EpisodeRequest(
+            episodeUuid: "episode-uuid",
+            podcastUuid: "podcast-uuid",
+            duration: Self.contentDuration + Self.adDuration,
+            audioFileURL: audio ?? audioURL,
+            isStreaming: false,
+            referenceFilePath: referenceURL.path
+        )
+    }
+}

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
@@ -21,7 +21,7 @@ final class FingerprintTimingManagerTests: XCTestCase {
 
     func testSingleMappingQueriesExtrapolateForwardAndBackward() throws {
         let manager = FingerprintTimingManager()
-        manager.insert(mapping: Entry(playbackTime: 10, referenceTime: 20))
+        manager.testing.insert(mapping: Entry(playbackTime: 10, referenceTime: 20))
 
         XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 10)), 20, accuracy: 0.001)
         XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 15)), 25, accuracy: 0.001)
@@ -32,8 +32,8 @@ final class FingerprintTimingManagerTests: XCTestCase {
 
     func testReferenceTimeInterpolatesBetweenTwoEntries() throws {
         let manager = FingerprintTimingManager()
-        manager.insert(mapping: Entry(playbackTime: 0, referenceTime: 100))
-        manager.insert(mapping: Entry(playbackTime: 10, referenceTime: 200))
+        manager.testing.insert(mapping: Entry(playbackTime: 0, referenceTime: 100))
+        manager.testing.insert(mapping: Entry(playbackTime: 10, referenceTime: 200))
 
         XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 5)), 150, accuracy: 0.001)
     }
@@ -42,8 +42,8 @@ final class FingerprintTimingManagerTests: XCTestCase {
 
     func testPlaybackAndReferenceQueriesRoundTrip() throws {
         let manager = FingerprintTimingManager()
-        manager.insert(mapping: Entry(playbackTime: 0, referenceTime: 0))
-        manager.insert(mapping: Entry(playbackTime: 10, referenceTime: 25))
+        manager.testing.insert(mapping: Entry(playbackTime: 0, referenceTime: 0))
+        manager.testing.insert(mapping: Entry(playbackTime: 10, referenceTime: 25))
 
         let refAtMid = try XCTUnwrap(manager.referenceTime(forPlaybackTime: 5))
         XCTAssertEqual(refAtMid, 12.5, accuracy: 0.001)
@@ -58,10 +58,10 @@ final class FingerprintTimingManagerTests: XCTestCase {
         let manager = FingerprintTimingManager()
 
         // Insert in reverse-ish order; the manager should maintain sorted state internally.
-        manager.insert(mapping: Entry(playbackTime: 30, referenceTime: 300))
-        manager.insert(mapping: Entry(playbackTime: 0, referenceTime: 0))
-        manager.insert(mapping: Entry(playbackTime: 20, referenceTime: 200))
-        manager.insert(mapping: Entry(playbackTime: 10, referenceTime: 100))
+        manager.testing.insert(mapping: Entry(playbackTime: 30, referenceTime: 300))
+        manager.testing.insert(mapping: Entry(playbackTime: 0, referenceTime: 0))
+        manager.testing.insert(mapping: Entry(playbackTime: 20, referenceTime: 200))
+        manager.testing.insert(mapping: Entry(playbackTime: 10, referenceTime: 100))
 
         XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 5)), 50, accuracy: 0.001)
         XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 15)), 150, accuracy: 0.001)
@@ -75,9 +75,9 @@ final class FingerprintTimingManagerTests: XCTestCase {
 
         // Playback ascending, reference descending — a case where a single shared
         // array sorted only by playback would give the wrong result for reverse lookup.
-        manager.insert(mapping: Entry(playbackTime: 0, referenceTime: 300))
-        manager.insert(mapping: Entry(playbackTime: 10, referenceTime: 200))
-        manager.insert(mapping: Entry(playbackTime: 20, referenceTime: 100))
+        manager.testing.insert(mapping: Entry(playbackTime: 0, referenceTime: 300))
+        manager.testing.insert(mapping: Entry(playbackTime: 10, referenceTime: 200))
+        manager.testing.insert(mapping: Entry(playbackTime: 20, referenceTime: 100))
 
         // Reference→playback sorted: [(20,100),(10,200),(0,300)]. Querying ref=150
         // sits halfway between the first two entries → playback = midpoint(20, 10) = 15.
@@ -147,7 +147,7 @@ final class FingerprintTimingManagerTests: XCTestCase {
         // Seven sequential candidates (rate 1), well under the 5 s tolerance.
         let stream = (0..<7).map { i in Entry(playbackTime: Double(i) * 2, referenceTime: Double(i) * 2) }
 
-        manager.stubMatches(stream)
+        manager.testing.stubMatches(stream)
 
         // All seven should be committed in order, queryable across the range.
         XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 0)), 0, accuracy: 0.001)
@@ -167,7 +167,7 @@ final class FingerprintTimingManagerTests: XCTestCase {
             Entry(playbackTime: 12, referenceTime: 12),
         ]
 
-        manager.stubMatches(stream)
+        manager.testing.stubMatches(stream)
 
         // The outlier at playback=6 should have been dropped, not interpolated.
         XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 4)), 4, accuracy: 0.001)
@@ -189,7 +189,7 @@ final class FingerprintTimingManagerTests: XCTestCase {
             Entry(playbackTime: 10, referenceTime: 100),
         ]
 
-        manager.stubMatches(stream)
+        manager.testing.stubMatches(stream)
 
         // Pre-jump region intact.
         XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 4)), 4, accuracy: 0.001)
@@ -212,7 +212,7 @@ final class FingerprintTimingManagerTests: XCTestCase {
             Entry(playbackTime: 12, referenceTime: 220),
         ]
 
-        manager.stubMatches(stream)
+        manager.testing.stubMatches(stream)
 
         // The three bootstrap entries are the only things in the mapping; none of
         // the noise lands. Had any of the noise been accepted, queries in that
@@ -234,7 +234,7 @@ final class FingerprintTimingManagerTests: XCTestCase {
             Entry(playbackTime: 8, referenceTime: 404),  // now (4, 400) / (6, 402) / (8, 404) form a rate-1 trio
         ]
 
-        manager.stubMatches(stream)
+        manager.testing.stubMatches(stream)
 
         // The first two candidates (0→0, 2→2) must NOT be in the mapping — if
         // they had been committed, a query at playback=4 would be 3-ish
@@ -361,7 +361,7 @@ final class FingerprintTimingManagerTests: XCTestCase {
         // mapping, cancel any pending resolve (a no-op here), and assert the
         // committed mapping is unchanged and still queryable.
         let manager = FingerprintTimingManager()
-        manager.stubMatches((0..<5).map { i in Entry(playbackTime: Double(i) * 2, referenceTime: Double(i) * 2) })
+        manager.testing.stubMatches((0..<5).map { i in Entry(playbackTime: Double(i) * 2, referenceTime: Double(i) * 2) })
 
         manager.cancelPendingChapterResolve()
 

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintTimingManagerTests.swift
@@ -2,9 +2,10 @@ import XCTest
 
 @testable import podcasts
 
+@MainActor
 final class FingerprintTimingManagerTests: XCTestCase {
 
-    typealias Entry = FingerprintTimingManager.TimeMappingEntry
+    typealias Entry = TimeMappingEntry
 
     // MARK: - Public query API: empty manager
 

--- a/PocketCastsTests/Tests/Fingerprint/ReferenceFingerprintTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/ReferenceFingerprintTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+
+@testable import podcasts
+
+/// The server payload's decoding rules. Everything downstream trusts these
+/// timestamps, so a silently mis-scaled one would shift an entire episode's
+/// mapping without any stage noticing.
+final class ReferenceFingerprintTests: XCTestCase {
+
+    // MARK: - Decoding
+
+    func testDecodesASupportedPayload() throws {
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: Self.payload()))
+
+        XCTAssertEqual(reference.format, ReferenceFingerprint.supportedFormat)
+        XCTAssertEqual(reference.totalDuration, 120, accuracy: 0.001)
+        XCTAssertEqual(reference.checkpointInterval, 2)
+        XCTAssertEqual(reference.checkpointDuration, 8)
+        XCTAssertEqual(reference.checkpointDurationSeconds, 8, accuracy: 0.001)
+        XCTAssertEqual(reference.checkpoints.count, 3)
+    }
+
+    func testRejectsAnUnknownFormat() throws {
+        let payload = try Self.payload(overrides: ["format": "fingerprint-compact-v1"])
+
+        XCTAssertNil(ReferenceFingerprint.decode(from: payload))
+    }
+
+    func testRejectsPayloadThatIsNotJSON() {
+        XCTAssertNil(ReferenceFingerprint.decode(from: Data("not json".utf8)))
+    }
+
+    // MARK: - Library checkpoints
+
+    func testTimestampsAccumulateDeltasScaledByTheQuantum() throws {
+        // Deltas 0, 2, 2 at one second per unit.
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: Self.payload()))
+
+        XCTAssertEqual(reference.libraryCheckpoints().map(\.timestampSeconds), [0, 2, 4])
+    }
+
+    func testQuantumScalesTheTimestampsRatherThanBeingMilliseconds() throws {
+        // The same deltas at two seconds per unit land twice as far apart — a
+        // /1000 conversion here would collapse them all onto zero.
+        let payload = try Self.payload(overrides: ["timestamp_quantum": 2])
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: payload))
+
+        XCTAssertEqual(reference.libraryCheckpoints().map(\.timestampSeconds), [0, 4, 8])
+    }
+
+    func testHashesAreDecodedLittleEndian() throws {
+        let payload = try Self.payload(checkpoints: [[0, Data([0x01, 0x02, 0x03, 0x04]).base64EncodedString()]])
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: payload))
+
+        XCTAssertEqual(try XCTUnwrap(reference.libraryCheckpoints().first).hashes, [0x0403_0201])
+    }
+
+    func testSkipsCheckpointsThatAreNotValidBase64() throws {
+        let payload = try Self.payload(checkpoints: [
+            [0, "!!!not base64!!!"],
+            [2, Data([0x01, 0x00, 0x00, 0x00]).base64EncodedString()]
+        ])
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: payload))
+
+        let checkpoints = reference.libraryCheckpoints()
+        XCTAssertEqual(checkpoints.count, 1)
+        // The skipped checkpoint still advances the accumulated timestamp, so the
+        // survivor keeps its own place on the timeline.
+        XCTAssertEqual(try XCTUnwrap(checkpoints.first).timestampSeconds, 2)
+    }
+
+    func testSkipsCheckpointsWhosePayloadIsNotWholeHashes() throws {
+        let payload = try Self.payload(checkpoints: [
+            [0, Data([0x01, 0x02, 0x03]).base64EncodedString()],
+            [2, Data([0x01, 0x00, 0x00, 0x00]).base64EncodedString()]
+        ])
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: payload))
+
+        XCTAssertEqual(reference.libraryCheckpoints().count, 1)
+    }
+
+    func testEmptyCheckpointListDecodesToNothingUsable() throws {
+        let payload = try Self.payload(checkpoints: [])
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: payload))
+
+        XCTAssertTrue(reference.libraryCheckpoints().isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private static func payload(
+        checkpoints: [[Any]]? = nil,
+        overrides: [String: Any] = [:]
+    ) throws -> Data {
+        let hashes = Data([0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]).base64EncodedString()
+        var json: [String: Any] = [
+            "format": ReferenceFingerprint.supportedFormat,
+            "total_duration": 120.0,
+            "checkpoint_interval": 2,
+            "checkpoint_duration": 8,
+            "timestamp_quantum": 1,
+            "checkpoints": checkpoints ?? [[0, hashes], [2, hashes], [2, hashes]]
+        ]
+        json.merge(overrides) { _, new in new }
+        return try JSONSerialization.data(withJSONObject: json)
+    }
+}

--- a/podcasts/Fingerprint/FingerprintDebugOverlay.swift
+++ b/podcasts/Fingerprint/FingerprintDebugOverlay.swift
@@ -3,8 +3,8 @@ import UIKit
 
 class FingerprintDebugOverlay: UIView {
 
-    private var entries: [FingerprintTimingManager.TimeMappingEntry] = []
-    private var rejections: [FingerprintTimingManager.TimeMappingEntry] = []
+    private var entries: [TimeMappingEntry] = []
+    private var rejections: [TimeMappingEntry] = []
     private var totalDuration: Double = 0
     private var playbackPosition: Double = 0
     private var isHighlighting = false

--- a/podcasts/Fingerprint/FingerprintMapping.swift
+++ b/podcasts/Fingerprint/FingerprintMapping.swift
@@ -1,0 +1,185 @@
+import Foundation
+import PocketCastsUtils
+
+/// A committed anchor: a position on the listener's playback timeline and the
+/// reference-timeline position the fingerprint matcher tied it to.
+struct TimeMappingEntry: Sendable {
+    let playbackTime: Double
+    let referenceTime: Double
+    let score: Float
+
+    init(playbackTime: Double, referenceTime: Double, score: Float = 0) {
+        self.playbackTime = playbackTime
+        self.referenceTime = referenceTime
+        self.score = score
+    }
+}
+
+/// The two sorted views of a committed mapping. The timing manager republishes
+/// this after every commit; interpolation and the highlight gate read it directly.
+struct MappingSnapshot: Sendable {
+    var playbackToReference: [TimeMappingEntry] = []
+    var referenceToPlayback: [TimeMappingEntry] = []
+
+    var isEmpty: Bool { playbackToReference.isEmpty }
+
+    mutating func insert(_ entry: TimeMappingEntry) {
+        let playbackIndex = playbackToReference.sortedInsertionIndex { $0.playbackTime < entry.playbackTime }
+        playbackToReference.insert(entry, at: playbackIndex)
+
+        let referenceIndex = referenceToPlayback.sortedInsertionIndex { $0.referenceTime < entry.referenceTime }
+        referenceToPlayback.insert(entry, at: referenceIndex)
+    }
+}
+
+/// The mutable state a fingerprint match run accumulates: the committed mapping
+/// plus the drift filter's rolling state. A value type so the continuous
+/// transcript path and the one-shot resolves can each run the identical matching
+/// pipeline against their own accumulator, without the one-shot ever touching the
+/// mapping the highlighter depends on.
+struct MappingAccumulator: Sendable {
+    var snapshot = MappingSnapshot()
+    var filterLastTrusted: TimeMappingEntry?
+    var filterCandidatePool: [TimeMappingEntry] = []
+
+    #if DEBUG
+    /// Candidates that reached the drift filter but were rejected. The debug
+    /// overlay uses this to distinguish "matcher never fired here" from
+    /// "matcher fired but everything was filtered out as noise".
+    private(set) var rejections: [TimeMappingEntry] = []
+    private static let rejectionCap = 500
+    #endif
+
+    /// Filter state is reset (but the mapping kept) when the stream restarts at a
+    /// new position: the new stream's first matches live in a region that has no
+    /// rate relationship to the old trusted anchor.
+    mutating func resetFilterState() {
+        filterLastTrusted = nil
+        filterCandidatePool.removeAll()
+    }
+
+    // MARK: - Drift Filter
+
+    /// Routes a score-passing candidate through the drift filter. Returns the
+    /// number of entries actually inserted into the mapping this call.
+    ///
+    /// Invariant the filter enforces:
+    /// **no anchor — bootstrap or post-jump — is admitted until we've seen
+    /// `driftBootstrapCount` consecutive rate-≈1 candidates in a row.**
+    ///
+    /// - Fast path: candidate is in-trend with `filterLastTrusted` → commit
+    ///   immediately, flush any pooled candidates as rejections (a prior jump
+    ///   attempt that didn't pan out turned out to be noise).
+    /// - Slow path: candidate goes into `filterCandidatePool`. Once the pool's
+    ///   tail is `driftBootstrapCount` consecutive consistent entries, commit
+    ///   them all and drop anything before as rejections. Otherwise evict the
+    ///   oldest and keep rolling.
+    ///
+    /// This is the same rule for the initial bootstrap (no `lastTrusted` yet)
+    /// and for post-trusted jumps, so a single lucky pair can never admit an
+    /// anchor.
+    @discardableResult
+    mutating func consider(_ candidate: TimeMappingEntry) -> Int {
+        if let trusted = filterLastTrusted, Self.isInTrend(candidate, relativeTo: trusted) {
+            // Sequential continuation. Anything that had collected in the pool
+            // was a jump attempt that never stabilized — reject it.
+            flushPoolAsRejected(reason: "returned to trend")
+            snapshot.insert(candidate)
+            filterLastTrusted = candidate
+            return 1
+        }
+
+        filterCandidatePool.append(candidate)
+        let n = FingerprintConstants.driftBootstrapCount
+
+        guard filterCandidatePool.count >= n else { return 0 }
+
+        let recent = Array(filterCandidatePool.suffix(n))
+        if Self.formsConsistentSequence(recent) {
+            // Confirmed new anchor. Anything older in the pool is noise.
+            let keepStart = filterCandidatePool.count - n
+            if keepStart > 0 {
+                for entry in filterCandidatePool.prefix(keepStart) {
+                    record(entry, reason: "pool evicted by confirmed anchor")
+                }
+            }
+            #if DEBUG
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: drift filter confirmed anchor "
+                    + "at playback \(String(format: "%.1f", recent[0].playbackTime))s → "
+                    + "\(String(format: "%.1f", recent[recent.count - 1].playbackTime))s "
+                    + "(\(n) consistent)"
+            )
+            #endif
+            for entry in recent {
+                snapshot.insert(entry)
+            }
+            filterLastTrusted = recent.last
+            filterCandidatePool.removeAll()
+            return n
+        }
+
+        // Not consistent yet — evict oldest and keep waiting for the window to
+        // roll onto a consistent stretch.
+        let evicted = filterCandidatePool.removeFirst()
+        record(evicted, reason: "pool evicted, no consistent run")
+        return 0
+    }
+
+    /// Note a candidate the pipeline dropped. DEBUG-only bookkeeping for the
+    /// overlay; a no-op in release builds.
+    mutating func record(_ entry: TimeMappingEntry, reason: String) {
+        #if DEBUG
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: drift filter dropped \(reason) "
+                + "at playback \(String(format: "%.1f", entry.playbackTime))s "
+                + "(matched reference \(String(format: "%.1f", entry.referenceTime))s)"
+        )
+        rejections.append(entry)
+        if rejections.count > Self.rejectionCap {
+            rejections.removeFirst(rejections.count - Self.rejectionCap)
+        }
+        #endif
+    }
+
+    private mutating func flushPoolAsRejected(reason: String) {
+        for entry in filterCandidatePool {
+            record(entry, reason: reason)
+        }
+        filterCandidatePool.removeAll()
+    }
+
+    /// Two entries are in-trend when `Δreference ≈ Δplayback` (rate ≈ 1),
+    /// within `driftToleranceSeconds` of residual slack.
+    private static func isInTrend(_ candidate: TimeMappingEntry, relativeTo anchor: TimeMappingEntry) -> Bool {
+        let deltaPlayback = candidate.playbackTime - anchor.playbackTime
+        let deltaReference = candidate.referenceTime - anchor.referenceTime
+        return abs(deltaReference - deltaPlayback) <= FingerprintConstants.driftToleranceSeconds
+    }
+
+    private static func formsConsistentSequence(_ entries: [TimeMappingEntry]) -> Bool {
+        guard entries.count >= 2 else { return true }
+        for i in 1..<entries.count where !isInTrend(entries[i], relativeTo: entries[i - 1]) {
+            return false
+        }
+        return true
+    }
+}
+
+// MARK: - Array Sorted Insertion
+
+private extension Array {
+    func sortedInsertionIndex(isOrderedBefore: (Element) -> Bool) -> Int {
+        var lo = 0
+        var hi = count
+        while lo < hi {
+            let mid = (lo + hi) / 2
+            if isOrderedBefore(self[mid]) {
+                lo = mid + 1
+            } else {
+                hi = mid
+            }
+        }
+        return lo
+    }
+}

--- a/podcasts/Fingerprint/FingerprintMappingCache.swift
+++ b/podcasts/Fingerprint/FingerprintMappingCache.swift
@@ -15,8 +15,8 @@ import PocketCastsUtils
 /// POC-546 attempt trapped the timing manager in `.preparing`.
 enum FingerprintMappingCache {
 
-    struct LoadResult {
-        let entries: [FingerprintTimingManager.TimeMappingEntry]
+    struct LoadResult: Sendable {
+        let entries: [TimeMappingEntry]
         let referenceDuration: Double
     }
 
@@ -98,7 +98,7 @@ enum FingerprintMappingCache {
         )
         return LoadResult(
             entries: cached.entries.map {
-                FingerprintTimingManager.TimeMappingEntry(
+                TimeMappingEntry(
                     playbackTime: $0.p,
                     referenceTime: $0.r,
                     score: $0.s
@@ -109,7 +109,7 @@ enum FingerprintMappingCache {
     }
 
     static func save(
-        _ entries: [FingerprintTimingManager.TimeMappingEntry],
+        _ entries: [TimeMappingEntry],
         audioFilePath: String,
         referenceFilePath: String,
         referenceData: Data,

--- a/podcasts/Fingerprint/FingerprintMatching.swift
+++ b/podcasts/Fingerprint/FingerprintMatching.swift
@@ -1,0 +1,184 @@
+import Accelerate
+import AVFoundation
+import Fingerprint
+import Foundation
+import PocketCastsUtils
+
+/// What one batch of fingerprint windows produced once the score and dominance
+/// gates had their say.
+struct MatchBatch: Sendable {
+
+    #if DEBUG
+    struct Rejection: Sendable {
+        let entry: TimeMappingEntry
+        let reason: String
+    }
+    #endif
+
+    /// Candidates that passed the gates, in window order, ready for the drift filter.
+    var candidates: [TimeMappingEntry] = []
+
+    #if DEBUG
+    /// Candidates the gates dropped, so the debug overlay can visualize "matcher
+    /// fired but we didn't trust it" distinctly from "matcher never fired here".
+    var rejections: [Rejection] = []
+    #endif
+}
+
+enum FingerprintStreamError: Error {
+    case bufferAllocationFailed
+    /// The requested audio region isn't present in the local file yet (a
+    /// streaming episode whose buffer hasn't reached the target region).
+    case regionUnavailable
+    /// The reference decoded but yielded no usable checkpoints.
+    case noUsableCheckpoints
+}
+
+/// The library `CheckpointMatcher` for one episode, plus the score/dominance
+/// gates every window has to clear. Each processor builds and keeps its own.
+final class FingerprintWindowMatcher {
+
+    private let matcher: CheckpointMatcher
+    let checkpointCount: Int
+
+    /// Builds a matcher populated from every usable checkpoint in `reference`.
+    /// Fails when the reference has no usable checkpoints.
+    init(reference: ReferenceFingerprint, episodeUuid: String, audioDuration: Double) throws {
+        let checkpointDuration = reference.checkpointDurationSeconds
+        let libraryCheckpoints = reference.libraryCheckpoints()
+
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: reference for \(episodeUuid) — "
+                + "totalDuration=\(reference.totalDuration)s, "
+                + "checkpointInterval=\(reference.checkpointInterval), "
+                + "checkpointDuration=\(reference.checkpointDuration)s, "
+                + "timestampQuantum=\(reference.timestampQuantum), "
+                + "raw=\(reference.checkpoints.count), decoded=\(libraryCheckpoints.count)"
+        )
+        if let first = libraryCheckpoints.first, let last = libraryCheckpoints.last {
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: checkpoint timestamps span "
+                    + "\(String(format: "%.1f", first.timestampSeconds))s..\(String(format: "%.1f", last.timestampSeconds))s "
+                    + "(audio duration \(String(format: "%.1f", audioDuration))s)"
+            )
+        }
+
+        guard !libraryCheckpoints.isEmpty else { throw FingerprintStreamError.noUsableCheckpoints }
+
+        let matcher = CheckpointMatcher()
+        for checkpoint in libraryCheckpoints {
+            matcher.add(
+                timestamp: checkpoint.timestampSeconds,
+                hashes: checkpoint.hashes,
+                duration: checkpointDuration
+            )
+        }
+        self.matcher = matcher
+        self.checkpointCount = libraryCheckpoints.count
+    }
+
+    /// Runs each window through the matcher and applies the score/dominance
+    /// gates. The expensive half of the pipeline.
+    func batch(for windows: [WindowedFingerprint], startOffset: Double) -> MatchBatch {
+        var batch = MatchBatch()
+        #if DEBUG
+        var bestScoreOverall: Float = 0
+        var nonZeroScoreCount = 0
+        var scoreSum: Float = 0
+        #endif
+
+        for window in windows {
+            // Pull top-2 so we can check how dominant the winner is — ambiguous
+            // wins (top-1 barely beats top-2) are the hallmark of correlated
+            // false positives from non-matching audio.
+            let matches = matcher.findTopMatches(queryHashes: window.hashes, maxResults: 2)
+            guard let best = matches.first else { continue }
+
+            #if DEBUG
+            if best.score > 0 {
+                nonZeroScoreCount += 1
+                scoreSum += best.score
+            }
+            if best.score > bestScoreOverall { bestScoreOverall = best.score }
+            #endif
+            guard best.score >= FingerprintConstants.matchScoreThreshold else { continue }
+
+            let absolutePlaybackTime = startOffset + Double(window.timestampMs) / 1000.0
+            let candidate = TimeMappingEntry(
+                playbackTime: absolutePlaybackTime,
+                referenceTime: Double(best.timestamp),
+                score: best.score
+            )
+
+            if best.score < FingerprintConstants.driftAnchorScoreThreshold {
+                #if DEBUG
+                batch.rejections.append(
+                    .init(entry: candidate, reason: "low score \(String(format: "%.2f", best.score))")
+                )
+                #endif
+                continue
+            }
+            let runnerUpScore = matches.dropFirst().first?.score ?? 0
+            if best.score - runnerUpScore < FingerprintConstants.driftScoreDominanceGap {
+                #if DEBUG
+                batch.rejections.append(
+                    .init(
+                        entry: candidate,
+                        reason: "ambiguous top-1 vs top-2 "
+                            + "(\(String(format: "%.2f", best.score)) vs \(String(format: "%.2f", runnerUpScore)))"
+                    )
+                )
+                #endif
+                continue
+            }
+
+            batch.candidates.append(candidate)
+        }
+
+        #if DEBUG
+        let avgNonZero = nonZeroScoreCount > 0 ? scoreSum / Float(nonZeroScoreCount) : 0
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: processed \(windows.count) windows, "
+                + "\(batch.candidates.count) passed the gates "
+                + "(bestScore: \(String(format: "%.3f", bestScoreOverall)), "
+                + "nonZero: \(nonZeroScoreCount), avgNonZero: \(String(format: "%.3f", avgNonZero)))"
+        )
+        #endif
+        return batch
+    }
+}
+
+enum FingerprintPCM {
+
+    /// Interleaves the buffer's planar Float32 channels into `scratch`, reusing
+    /// its storage across chunks. `scratch` is resized only when the sample
+    /// count changes (in practice once, plus once more for a short final
+    /// chunk), so a decode loop allocates O(1) arrays instead of one per chunk.
+    static func interleave(_ buffer: AVAudioPCMBuffer, into scratch: inout [Float]) {
+        let frameCount = Int(buffer.frameLength)
+        let channelCount = Int(buffer.format.channelCount)
+        guard frameCount > 0, channelCount > 0,
+              let channelData = buffer.floatChannelData else {
+            scratch.removeAll(keepingCapacity: true)
+            return
+        }
+
+        let sampleCount = frameCount * channelCount
+        if scratch.count != sampleCount {
+            scratch = [Float](repeating: 0, count: sampleCount)
+        }
+        scratch.withUnsafeMutableBufferPointer { dst in
+            guard let base = dst.baseAddress else { return }
+            if channelCount == 1 {
+                base.update(from: channelData[0], count: frameCount)
+                return
+            }
+            // Strided vector copy (add-zero) — one vDSP pass per channel
+            // instead of a scalar store per sample.
+            var zero: Float = 0
+            for ch in 0..<channelCount {
+                vDSP_vsadd(channelData[ch], 1, &zero, base + ch, vDSP_Stride(channelCount), vDSP_Length(frameCount))
+            }
+        }
+    }
+}

--- a/podcasts/Fingerprint/FingerprintRegionProcessor.swift
+++ b/podcasts/Fingerprint/FingerprintRegionProcessor.swift
@@ -1,0 +1,150 @@
+import AVFoundation
+import Fingerprint
+import Foundation
+import PocketCastsUtils
+
+/// Runs the bounded, one-shot resolves — chapter taps and bookmarks alike.
+///
+/// Kept separate from `FingerprintStreamProcessor` so a resolve with a spinner in
+/// front of it can't queue behind the continuous run, which lasts the length of an
+/// episode. The two one-shots share this one because both are bounded — a
+/// bookmark's long budget is spent waiting for its buffer, not decoding.
+///
+/// Every run matches into a **local** scratch accumulator, so nothing the
+/// transcript highlighter depends on is ever touched.
+actor FingerprintRegionProcessor {
+
+    /// Fingerprint `[startSeconds, endSeconds]` of `audioFileURL` and match it
+    /// against `reference` into a fresh scratch accumulator.
+    ///
+    /// Unlike the continuous run this stops at `endSeconds` (not EOF) and skips
+    /// the lookahead throttle. Throws `.regionUnavailable` when the local file
+    /// doesn't yet reach `startSeconds` (a streaming episode whose buffer hasn't
+    /// advanced to the target region).
+    func match(
+        audioFileURL: URL,
+        reference: ReferenceFingerprint,
+        episodeUuid: String,
+        audioDuration: Double,
+        startSeconds: Double,
+        endSeconds: Double
+    ) async throws -> MappingAccumulator {
+        let matcher = try FingerprintWindowMatcher(
+            reference: reference,
+            episodeUuid: episodeUuid,
+            audioDuration: audioDuration
+        )
+
+        let audioFile = try AVAudioFile(
+            forReading: audioFileURL,
+            commonFormat: .pcmFormatFloat32,
+            interleaved: false
+        )
+        let format = audioFile.processingFormat
+        let channels = UInt16(format.channelCount)
+
+        let fileDurationSeconds = Double(audioFile.length) / format.sampleRate
+        guard startSeconds < fileDurationSeconds else { throw FingerprintStreamError.regionUnavailable }
+
+        let startFrame = AVAudioFramePosition(startSeconds * format.sampleRate)
+        if startFrame > 0 { audioFile.framePosition = startFrame }
+        let endFrame = min(AVAudioFramePosition(endSeconds * format.sampleRate), audioFile.length)
+
+        let streamer = StreamingWindowedFingerprinter(
+            sampleRate: UInt32(format.sampleRate),
+            channels: channels,
+            windowDurationMs: FingerprintConstants.windowDurationMs,
+            windowIntervalMs: FingerprintConstants.windowIntervalMs
+        )
+
+        let chunkFrames = AVAudioFrameCount(format.sampleRate * FingerprintConstants.streamChunkSeconds)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
+            throw FingerprintStreamError.bufferAllocationFailed
+        }
+
+        var scratch = MappingAccumulator()
+        var interleaved: [Float] = []
+        while audioFile.framePosition < endFrame {
+            try Task.checkCancellation()
+            let framesRemaining = AVAudioFrameCount(endFrame - audioFile.framePosition)
+            try audioFile.read(into: buffer, frameCount: min(framesRemaining, chunkFrames))
+            if buffer.frameLength == 0 { break }
+
+            FingerprintPCM.interleave(buffer, into: &interleaved)
+            let windows = streamer.pushSamplesF32(samples: interleaved, channels: channels)
+            if !windows.isEmpty {
+                Self.apply(matcher.batch(for: windows, startOffset: startSeconds), to: &scratch)
+            }
+            await Task.yield()
+        }
+
+        try Task.checkCancellation()
+        let tail = streamer.flush()
+        if !tail.isEmpty {
+            Self.apply(matcher.batch(for: tail, startOffset: startSeconds), to: &scratch)
+        }
+        return scratch
+    }
+
+    /// Wait for a still-downloading streaming buffer to cover `coveringSeconds`
+    /// of audio, polling as it grows.
+    ///
+    /// `MediaExporterResourceLoaderDelegate` caches with a single un-ranged
+    /// request appended to disk, so the buffer is always a prefix of the episode
+    /// and `AVAudioFile.length` tracks exactly how much of it is local — the same
+    /// property the grow-loop anchors on.
+    ///
+    /// Returns once covered, or early when the file stops growing, the deadline
+    /// passes, or the task is cancelled. There's deliberately no failure signal:
+    /// the bounded fingerprint clamps to whatever is readable, so matching a
+    /// short prefix of the window still beats returning nothing.
+    func waitForBufferedRegion(audioFileURL: URL, coveringSeconds: Double, deadline: Date) async {
+        let pollCadence = FingerprintConstants.bufferGrowPollCadenceSeconds
+        var stallSeconds: Double = 0
+        var lastLength: AVAudioFramePosition = -1
+
+        while !Task.isCancelled, Date() < deadline {
+            // The buffer may not exist yet, and a partial frame at the tail can make
+            // `AVAudioFile` refuse to open momentarily — both read as "no growth".
+            if let audioFile = try? AVAudioFile(
+                forReading: audioFileURL,
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            ) {
+                let bufferedSeconds = Double(audioFile.length) / audioFile.processingFormat.sampleRate
+                if bufferedSeconds >= coveringSeconds {
+                    FileLog.shared.addMessage(
+                        "FingerprintTimingManager: streaming buffer covers the search window "
+                            + "(\(String(format: "%.1f", bufferedSeconds))s buffered)"
+                    )
+                    return
+                }
+                if audioFile.length > lastLength {
+                    lastLength = audioFile.length
+                    stallSeconds = 0
+                }
+            }
+
+            stallSeconds += pollCadence
+            if stallSeconds >= FingerprintConstants.bookmarkSeekBufferStallSeconds {
+                FileLog.shared.addMessage(
+                    "FingerprintTimingManager: streaming buffer stopped growing short of the "
+                        + "search window — fingerprinting the \(max(0, lastLength)) frames that arrived"
+                )
+                return
+            }
+            try? await Task.sleep(for: .seconds(pollCadence))
+        }
+    }
+
+    private static func apply(_ batch: MatchBatch, to accumulator: inout MappingAccumulator) {
+        #if DEBUG
+        for rejection in batch.rejections {
+            accumulator.record(rejection.entry, reason: rejection.reason)
+        }
+        #endif
+        for candidate in batch.candidates {
+            accumulator.consider(candidate)
+        }
+    }
+}

--- a/podcasts/Fingerprint/FingerprintStreamProcessor.swift
+++ b/podcasts/Fingerprint/FingerprintStreamProcessor.swift
@@ -101,7 +101,7 @@ actor FingerprintStreamProcessor {
         }
 
         var interleaved: [Float] = []
-        while true {
+        while audioFile.framePosition < audioFile.length {
             try Task.checkCancellation()
             let nextChunkStartSeconds = Double(audioFile.framePosition) / format.sampleRate
             try await throttleIfBeyondLookahead(

--- a/podcasts/Fingerprint/FingerprintStreamProcessor.swift
+++ b/podcasts/Fingerprint/FingerprintStreamProcessor.swift
@@ -1,0 +1,319 @@
+import AVFoundation
+import Fingerprint
+import Foundation
+import PocketCastsUtils
+
+/// Runs the continuous transcript fingerprint pass: owns the checkpoint matcher
+/// for the episode being prepared, stream-decodes the local audio chunk by chunk,
+/// and hands each batch of scored candidates back to be committed.
+///
+/// Cancel the `Task` driving `run` and the loops bail at the next chunk boundary
+/// or the next sleep.
+actor FingerprintStreamProcessor {
+
+    private var matcher: FingerprintWindowMatcher?
+
+    /// Builds the matcher for `reference` — one FFI call per checkpoint. Returns
+    /// the number of usable checkpoints, or nil when the reference has none.
+    func prepare(reference: ReferenceFingerprint, episodeUuid: String, audioDuration: Double) -> Int? {
+        guard let matcher = try? FingerprintWindowMatcher(
+            reference: reference,
+            episodeUuid: episodeUuid,
+            audioDuration: audioDuration
+        ) else {
+            return nil
+        }
+        self.matcher = matcher
+        return matcher.checkpointCount
+    }
+
+    /// Stream-decode the local file, push PCM into the streaming fingerprinter
+    /// chunk-by-chunk, and hand off each batch of windows as soon as it's
+    /// emitted. We start near the current playback position (snapped to the
+    /// window grid so window timestamps line up with the reference checkpoints),
+    /// so highlighting becomes usable for what the listener is actually hearing
+    /// without waiting for the entire file to be processed.
+    ///
+    /// - Parameters:
+    ///   - currentPlaybackTime: read once per chunk for the lookahead throttle.
+    ///   - commit: called on every non-empty batch, in decode order.
+    func run(
+        audioFileURL: URL,
+        isStreaming: Bool,
+        startingAt startSeconds: Double,
+        currentPlaybackTime: @escaping @Sendable () async -> Double,
+        commit: @escaping @Sendable (MatchBatch) async -> Void
+    ) async throws {
+        guard let matcher else { throw FingerprintStreamError.noUsableCheckpoints }
+        if isStreaming {
+            try await runGrowing(
+                audioFileURL: audioFileURL,
+                startSeconds: startSeconds,
+                matcher: matcher,
+                currentPlaybackTime: currentPlaybackTime,
+                commit: commit
+            )
+        } else {
+            try await runComplete(
+                audioFileURL: audioFileURL,
+                startSeconds: startSeconds,
+                matcher: matcher,
+                currentPlaybackTime: currentPlaybackTime,
+                commit: commit
+            )
+        }
+    }
+
+    // MARK: - Complete file
+
+    private func runComplete(
+        audioFileURL: URL,
+        startSeconds: Double,
+        matcher: FingerprintWindowMatcher,
+        currentPlaybackTime: @Sendable () async -> Double,
+        commit: @Sendable (MatchBatch) async -> Void
+    ) async throws {
+        // Force the reader to hand us non-interleaved Float32 PCM so
+        // `buffer.floatChannelData` is never nil regardless of the on-disk format.
+        let audioFile = try AVAudioFile(
+            forReading: audioFileURL,
+            commonFormat: .pcmFormatFloat32,
+            interleaved: false
+        )
+        let format = audioFile.processingFormat
+        let channels = UInt16(format.channelCount)
+
+        let startFrame = AVAudioFramePosition(startSeconds * format.sampleRate)
+        if startFrame > 0, startFrame < audioFile.length {
+            audioFile.framePosition = startFrame
+        }
+
+        let streamer = StreamingWindowedFingerprinter(
+            sampleRate: UInt32(format.sampleRate),
+            channels: channels,
+            windowDurationMs: FingerprintConstants.windowDurationMs,
+            windowIntervalMs: FingerprintConstants.windowIntervalMs
+        )
+
+        let chunkFrames = AVAudioFrameCount(format.sampleRate * FingerprintConstants.streamChunkSeconds)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
+            throw FingerprintStreamError.bufferAllocationFailed
+        }
+
+        var interleaved: [Float] = []
+        while true {
+            try Task.checkCancellation()
+            let nextChunkStartSeconds = Double(audioFile.framePosition) / format.sampleRate
+            try await throttleIfBeyondLookahead(
+                nextChunkStartSeconds: nextChunkStartSeconds,
+                currentPlaybackTime: currentPlaybackTime
+            )
+            try audioFile.read(into: buffer, frameCount: chunkFrames)
+            if buffer.frameLength == 0 { break }
+
+            FingerprintPCM.interleave(buffer, into: &interleaved)
+            let windows = streamer.pushSamplesF32(samples: interleaved, channels: channels)
+            if !windows.isEmpty {
+                await commit(matcher.batch(for: windows, startOffset: startSeconds))
+            }
+        }
+
+        try Task.checkCancellation()
+        let tail = streamer.flush()
+        if !tail.isEmpty {
+            await commit(matcher.batch(for: tail, startOffset: startSeconds))
+        }
+    }
+
+    // MARK: - Growing streaming buffer
+
+    /// Streaming-buffer variant. Same pipeline, but the file may not exist yet
+    /// when we start, and grows while we read — so we reopen `AVAudioFile` each
+    /// pass to refresh its length, seek to where we left off, and consume
+    /// whatever new frames are available. Exits when the buffer has been stalled
+    /// for `bufferGrowMaxStallSeconds` or the task is cancelled; a later
+    /// playback-progress restart picks up again if the listener keeps playing.
+    private func runGrowing(
+        audioFileURL: URL,
+        startSeconds: Double,
+        matcher: FingerprintWindowMatcher,
+        currentPlaybackTime: @Sendable () async -> Double,
+        commit: @Sendable (MatchBatch) async -> Void
+    ) async throws {
+        let pollCadence = FingerprintConstants.bufferGrowPollCadenceSeconds
+        let maxStallSeconds = FingerprintConstants.bufferGrowMaxStallSeconds
+        let trailingMarginSeconds = FingerprintConstants.bufferGrowTrailingMarginSeconds
+
+        var streamer: StreamingWindowedFingerprinter?
+        var format: AVAudioFormat?
+        var buffer: AVAudioPCMBuffer?
+        var chunkFrames: AVAudioFrameCount = 0
+        var lastProcessedFrame: AVAudioFramePosition = 0
+        var stallAccumSeconds: Double = 0
+        var announcedFileAppeared = false
+        var totalFramesRead: AVAudioFramePosition = 0
+        var windowsEmitted = 0
+        var interleaved: [Float] = []
+
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: streaming grow-loop starting at \(String(format: "%.1f", startSeconds))s "
+                + "(buffer path: \(audioFileURL.lastPathComponent))"
+        )
+
+        while true {
+            try Task.checkCancellation()
+
+            guard FileManager.default.fileExists(atPath: audioFileURL.path) else {
+                // Streaming buffer not created yet — AVPlayer will write it
+                // once it actually begins fetching bytes.
+                stallAccumSeconds += pollCadence
+                if stallAccumSeconds >= maxStallSeconds { break }
+                try await Task.sleep(for: .seconds(pollCadence))
+                continue
+            }
+
+            let audioFile: AVAudioFile
+            do {
+                audioFile = try AVAudioFile(
+                    forReading: audioFileURL,
+                    commonFormat: .pcmFormatFloat32,
+                    interleaved: false
+                )
+            } catch {
+                // Partial frame at the tail can make `AVAudioFile` refuse to
+                // open momentarily — wait and retry.
+                stallAccumSeconds += pollCadence
+                if stallAccumSeconds >= maxStallSeconds { break }
+                try await Task.sleep(for: .seconds(pollCadence))
+                continue
+            }
+
+            if !announcedFileAppeared {
+                announcedFileAppeared = true
+                FileLog.shared.addMessage(
+                    "FingerprintTimingManager: streaming buffer opened "
+                        + "(length \(audioFile.length) frames @ \(Int(audioFile.processingFormat.sampleRate))Hz, "
+                        + "\(audioFile.processingFormat.channelCount)ch)"
+                )
+            }
+
+            if streamer == nil {
+                let fmt = audioFile.processingFormat
+                let desiredStartFrame = max(0, AVAudioFramePosition(startSeconds * fmt.sampleRate))
+
+                // The streaming buffer on disk is sequential from byte 0, so the
+                // local file's frame `N` maps to audio timeline `N / sampleRate`.
+                // If the buffer hasn't grown to `startSeconds` yet, reading from
+                // the current tail and tagging those windows as `startSeconds +
+                // windowTimestamp` would attribute them to the wrong reference
+                // time — matches would fail. Wait until the file covers the
+                // target position, then anchor `lastProcessedFrame` exactly there.
+                guard audioFile.length >= desiredStartFrame else {
+                    stallAccumSeconds += pollCadence
+                    if stallAccumSeconds >= maxStallSeconds { break }
+                    try await Task.sleep(for: .seconds(pollCadence))
+                    continue
+                }
+
+                format = fmt
+                streamer = StreamingWindowedFingerprinter(
+                    sampleRate: UInt32(fmt.sampleRate),
+                    channels: UInt16(fmt.channelCount),
+                    windowDurationMs: FingerprintConstants.windowDurationMs,
+                    windowIntervalMs: FingerprintConstants.windowIntervalMs
+                )
+                chunkFrames = AVAudioFrameCount(fmt.sampleRate * FingerprintConstants.streamChunkSeconds)
+                guard let allocated = AVAudioPCMBuffer(pcmFormat: fmt, frameCapacity: chunkFrames) else {
+                    throw FingerprintStreamError.bufferAllocationFailed
+                }
+                buffer = allocated
+                lastProcessedFrame = desiredStartFrame
+            }
+
+            guard let fmt = format, let streamer, let buffer else { break }
+
+            let trailingMarginFrames = AVAudioFramePosition(trailingMarginSeconds * fmt.sampleRate)
+            let safeEnd = audioFile.length - trailingMarginFrames
+
+            guard lastProcessedFrame < safeEnd else {
+                stallAccumSeconds += pollCadence
+                if stallAccumSeconds >= maxStallSeconds { break }
+                try await Task.sleep(for: .seconds(pollCadence))
+                continue
+            }
+
+            audioFile.framePosition = lastProcessedFrame
+            let framesAvailable = AVAudioFrameCount(safeEnd - lastProcessedFrame)
+            let framesToRead = min(framesAvailable, chunkFrames)
+
+            let nextChunkStartSeconds = Double(lastProcessedFrame) / fmt.sampleRate
+            try await throttleIfBeyondLookahead(
+                nextChunkStartSeconds: nextChunkStartSeconds,
+                currentPlaybackTime: currentPlaybackTime
+            )
+
+            do {
+                try audioFile.read(into: buffer, frameCount: framesToRead)
+            } catch {
+                stallAccumSeconds += pollCadence
+                if stallAccumSeconds >= maxStallSeconds { break }
+                try await Task.sleep(for: .seconds(pollCadence))
+                continue
+            }
+
+            if buffer.frameLength == 0 {
+                stallAccumSeconds += pollCadence
+                if stallAccumSeconds >= maxStallSeconds { break }
+                try await Task.sleep(for: .seconds(pollCadence))
+                continue
+            }
+
+            stallAccumSeconds = 0
+            let framesJustRead = audioFile.framePosition - lastProcessedFrame
+            lastProcessedFrame = audioFile.framePosition
+            totalFramesRead += framesJustRead
+
+            FingerprintPCM.interleave(buffer, into: &interleaved)
+            let windows = streamer.pushSamplesF32(samples: interleaved, channels: UInt16(fmt.channelCount))
+            if !windows.isEmpty {
+                windowsEmitted += windows.count
+                await commit(matcher.batch(for: windows, startOffset: startSeconds))
+            }
+        }
+
+        try Task.checkCancellation()
+        if let streamer {
+            let tail = streamer.flush()
+            if !tail.isEmpty {
+                windowsEmitted += tail.count
+                await commit(matcher.batch(for: tail, startOffset: startSeconds))
+            }
+        }
+
+        let readSeconds = (format.map { Double(totalFramesRead) / $0.sampleRate }) ?? 0
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: streaming grow-loop ending — "
+                + "read \(String(format: "%.1f", readSeconds))s of audio, "
+                + "emitted \(windowsEmitted) windows, "
+                + "stall accum \(String(format: "%.1f", stallAccumSeconds))s"
+        )
+    }
+
+    // MARK: - Throttle
+
+    /// Yield briefly when the next chunk to fingerprint sits more than
+    /// `lookaheadSeconds` ahead of the listener's current playback time. This
+    /// keeps coverage growing to EOF — the chunk is **never** skipped — while
+    /// bounding peak CPU on long episodes the listener hasn't reached yet.
+    /// Capping the loop instead of throttling it (the prior POC-546 attempt)
+    /// dropped tail regions from the mapping and broke tap-to-seek for any cue
+    /// further than `lookaheadSeconds` ahead.
+    private func throttleIfBeyondLookahead(
+        nextChunkStartSeconds: Double,
+        currentPlaybackTime: @Sendable () async -> Double
+    ) async throws {
+        let lead = nextChunkStartSeconds - (await currentPlaybackTime())
+        guard lead > FingerprintConstants.lookaheadSeconds else { return }
+        try await Task.sleep(for: .seconds(FingerprintConstants.outsideLookaheadSleepSeconds))
+    }
+}

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -1083,16 +1083,39 @@ final class FingerprintTimingManager: NSObject {
 
     // MARK: - Test Seams
 
-    /// Inserts a mapping directly, the way a committed match would.
-    func insert(mapping: TimeMappingEntry) {
-        main.snapshot.insert(mapping)
-    }
+    var testing: Testing { Testing(manager: self) }
 
-    /// Routes a sequence of candidates through the drift filter, the way
-    /// `commit` does in production.
-    func stubMatches(_ entries: [TimeMappingEntry]) {
-        for entry in entries {
-            main.consider(entry)
+    /// Reaches past the parts of the manager a test can't drive — the current
+    /// episode, the tasks preparation owns — kept in its own namespace so none of
+    /// it reads as production API at a call site.
+    @MainActor
+    struct Testing {
+        fileprivate let manager: FingerprintTimingManager
+
+        /// Runs the preparation pipeline for an explicit request — everything
+        /// `prepareForCurrentEpisode()` does once its feature-flag and
+        /// current-episode guards pass — returning as soon as the streaming pass
+        /// has been started.
+        func prepare(request: EpisodeRequest) async {
+            await manager.prepare(request)
+        }
+
+        /// Waits for the streaming fingerprint pass to run to completion.
+        func waitForStream() async {
+            await manager.streamTask?.value
+        }
+
+        /// Inserts a mapping directly, the way a committed match would.
+        func insert(mapping: TimeMappingEntry) {
+            manager.main.snapshot.insert(mapping)
+        }
+
+        /// Routes a sequence of candidates through the drift filter, the way
+        /// `commit` does in production.
+        func stubMatches(_ entries: [TimeMappingEntry]) {
+            for entry in entries {
+                manager.main.consider(entry)
+            }
         }
     }
 }

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -1,10 +1,12 @@
-import AVFoundation
-import Accelerate
 import Foundation
-import Fingerprint
 import PocketCastsDataModel
 import PocketCastsUtils
 
+/// Owns the playback↔reference time mapping for the episode currently being
+/// fingerprinted, and drives the background work that produces it: decoding and
+/// matching run on `FingerprintStreamProcessor` (the continuous transcript pass)
+/// and `FingerprintRegionProcessor` (bounded one-shot resolves).
+@MainActor
 final class FingerprintTimingManager: NSObject {
 
     // MARK: - Public Types
@@ -27,6 +29,29 @@ final class FingerprintTimingManager: NSObject {
         }
     }
 
+    /// Outcome of a one-shot resolve. `reason` on `.unresolved` is a stable
+    /// analytics token the caller reports and can key fallback behavior on.
+    enum ChapterSeekResult: Sendable {
+        case resolved(playbackTime: Double, usedPrior: Bool, isStreaming: Bool, resolveDurationMs: Int)
+        case unresolved(reason: String, isStreaming: Bool)
+    }
+
+    /// Everything a fingerprint run needs from a `BaseEpisode`, captured as plain
+    /// values so the database model object stays with its caller.
+    struct EpisodeRequest: Sendable {
+        let episodeUuid: String
+        let podcastUuid: String
+        let duration: Double
+        let audioFileURL: URL
+        /// True when `audioFileURL` points at a streaming buffer that may still be
+        /// growing. The fingerprint loop polls for new bytes instead of quitting
+        /// at EOF.
+        let isStreaming: Bool
+        /// On-disk path of the reference fingerprint file, used to validate the
+        /// persistent mapping cache via file identity (size+mtime).
+        let referenceFilePath: String
+    }
+
     // MARK: - Singleton
 
     static let shared = FingerprintTimingManager()
@@ -35,103 +60,64 @@ final class FingerprintTimingManager: NSObject {
 
     private(set) var state: State = .idle
 
+    /// The committed mapping, republished after every commit.
+    var snapshot: MappingSnapshot { main.snapshot }
+
     // MARK: - Internal Types
 
     private struct GenerationContext {
-        let episodeUuid: String
-        let audioFileURL: URL
-        /// True when `audioFileURL` points at a streaming buffer that may still be
-        /// growing. The fingerprint loop polls for new bytes instead of quitting
-        /// at EOF.
-        let isStreaming: Bool
-        let duration: Double
-        let matcher: CheckpointMatcher
+        let request: EpisodeRequest
         /// Raw bytes of the reference fingerprint JSON, used to validate the
-        /// persistent mapping cache via SHA-256.
+        /// persistent mapping cache via SHA-256 and to warm-start a resolve.
         let referenceData: Data
-        /// On-disk path of the reference fingerprint file, used to validate
-        /// the persistent mapping cache via file identity (size+mtime).
-        let referenceFilePath: String
         /// Total duration of the reference timeline, used to gate the persistent
         /// mapping cache on full coverage.
         let referenceDuration: Double
-        let isCancelled: () -> Bool
     }
 
-    struct TimeMappingEntry {
-        let playbackTime: Double
-        let referenceTime: Double
-        let score: Float
+    /// What the two one-shot resolves want differently, which all follows from what
+    /// their audio is likely to be doing: a chapter's episode is playing, so its
+    /// audio is already local, while a bookmark's is often still downloading.
+    private enum ResolveKind: Sendable {
+        case chapter
+        case bookmark
 
-        init(playbackTime: Double, referenceTime: Double, score: Float = 0) {
-            self.playbackTime = playbackTime
-            self.referenceTime = referenceTime
-            self.score = score
-        }
+        /// Only a bookmark waits for the streaming buffer to reach the search window.
+        var waitsForBufferedRegion: Bool { self == .bookmark }
     }
 
-    /// The mutable state a fingerprint match run accumulates: the two sorted
-    /// mapping views plus the drift filter's rolling state. Extracted into a
-    /// value type so the continuous transcript path (`main`) and the one-shot
-    /// chapter resolve can each run the identical matching pipeline against
-    /// their own isolated accumulator, without the one-shot ever touching the
-    /// mapping the highlighter depends on.
-    struct MappingAccumulator {
-        var playbackToReference: [TimeMappingEntry] = []
-        var referenceToPlayback: [TimeMappingEntry] = []
-        var filterLastTrusted: TimeMappingEntry?
-        var filterCandidatePool: [TimeMappingEntry] = []
+    private struct WarmPrior: Sendable {
+        let referenceData: Data?
+        let estimatedPlayback: Double?
     }
 
     // MARK: - Private State
 
-    private let queue = DispatchQueue(label: "au.com.pocketcasts.FingerprintTimingManager")
-    private let generationQueue = DispatchQueue(
-        label: "au.com.pocketcasts.FingerprintTimingManager.generation",
-        qos: .utility
-    )
-    /// Decode queue reserved for the one-shot resolves, chapter and bookmark alike.
-    /// Kept separate from `generationQueue` — which the continuous transcript stream
-    /// occupies as one long-running block that only yields via `Thread.sleep` — so a
-    /// bounded decode can't be starved behind it (which would hang the resolve past
-    /// its timeout, since a queued-but-never-started block can't observe
-    /// cancellation). Higher QoS because a spinner is blocked on it.
-    ///
-    /// The two one-shots share it because both are bounded, which is the distinction
-    /// that matters here. A bookmark resolve's long budget is spent waiting for its
-    /// buffer, not on this queue, so its decode is no longer than a chapter's; and
-    /// running them concurrently would only make them contend for CPU and for `queue`
-    /// during matching.
-    private let onDemandQueue = DispatchQueue(
-        label: "au.com.pocketcasts.FingerprintTimingManager.onDemand",
-        qos: .userInitiated
-    )
-    private var context: GenerationContext?
-    private var cancellationFlag = CancellationFlag()
-    private var fetchTask: Task<Void, Never>?
+    private let regionProcessor = FingerprintRegionProcessor()
+    private var streamProcessor: FingerprintStreamProcessor?
 
-    /// Cancellation + task handles for the one-shot chapter resolve. Kept
-    /// separate from the continuous `cancellationFlag`/`fetchTask` so a chapter
-    /// tap never cancels (or is cancelled by) transcript preparation. Accessed
-    /// only from the main queue, where `resolvePlaybackTime` is invoked.
-    private var onDemandFlag = CancellationFlag()
-    private var onDemandTask: Task<Void, Never>?
+    private var context: GenerationContext?
 
     /// Accumulator backing the continuous transcript mapping (playback↔reference
-    /// plus drift-filter state). The one-shot chapter resolve uses its own local
-    /// accumulator and never mutates this one — see `resolvePlaybackTime`.
+    /// plus drift-filter state). The one-shot resolves use their own scratch
+    /// accumulator and never touch this one.
     private var main = MappingAccumulator()
+
+    /// Reference resolution (disk → server) and the decode/match run. Split so a
+    /// mid-episode restart can re-anchor the stream without re-fetching.
+    private var prepareTask: Task<Void, Never>?
+    private var streamTask: Task<Void, Never>?
+
+    /// The one-shot chapter resolve. Cancelling it supersedes it (last tap wins).
+    /// Bookmark resolves are owned by their caller, so they neither supersede nor
+    /// are superseded by this.
+    private var chapterResolveTask: Task<Void, Never>?
 
     private var lastProgressPosition: Double = -1
 
     private var preparationStartDate: Date?
     private var hasReachedActive = false
     private var hasEmittedPreparationStarted = false
-
-    #if DEBUG
-    private static let debugRejectionCap = 500
-    private var debugRejections: [TimeMappingEntry] = []
-    #endif
 
     // MARK: - Init
 
@@ -151,19 +137,27 @@ final class FingerprintTimingManager: NSObject {
         )
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     // MARK: - Public API
 
     func prepareForCurrentEpisode() {
-        let episode = PlaybackManager.shared.currentEpisode()
+        resetState()
+        state = .idle
 
-        queue.async { [weak self] in
-            guard let self else { return }
-            self.resetState()
-            self.prepareForEpisode(episode)
+        guard FeatureFlag.syncedTranscripts.enabled else {
+            state = .unavailable
+            track(.syncedTranscriptsUnavailable, properties: ["reason": "feature_disabled"])
+            return
+        }
+
+        guard let episode = PlaybackManager.shared.currentEpisode() else {
+            state = .unavailable
+            track(.syncedTranscriptsUnavailable, properties: ["reason": "no_episode"])
+            return
+        }
+
+        let request = Self.makeRequest(for: episode)
+        prepareTask = Task { [weak self] in
+            await self?.prepare(request)
         }
     }
 
@@ -172,13 +166,58 @@ final class FingerprintTimingManager: NSObject {
     /// transcript view is torn down so we don't keep burning CPU/memory on audio
     /// the listener is no longer looking at.
     func stop() {
-        queue.async { [weak self] in
-            guard let self else { return }
-            self.resetState()
-            self.updateState(.idle)
-            FileLog.shared.addMessage("FingerprintTimingManager: stopped")
-        }
+        resetState()
+        state = .idle
+        FileLog.shared.addMessage("FingerprintTimingManager: stopped")
     }
+
+    func referenceTime(forPlaybackTime playbackTime: Double) -> Double? {
+        Self.interpolate(
+            time: playbackTime,
+            in: main.snapshot.playbackToReference,
+            keyPath: \.playbackTime,
+            valuePath: \.referenceTime
+        )
+    }
+
+    func playbackTime(forReferenceTime referenceTime: Double) -> Double? {
+        Self.interpolate(
+            time: referenceTime,
+            in: main.snapshot.referenceToPlayback,
+            keyPath: \.referenceTime,
+            valuePath: \.playbackTime
+        )
+    }
+
+    /// Whether `playbackTime` sits on confidently-matched content — bracketed by
+    /// committed anchors no more than `highlightMaxGapSeconds` apart.
+    ///
+    /// Highlighting keys off this so it only ever runs while we're sure where we
+    /// are. Real content commits anchors every second or two, so a sparse "quick
+    /// red" gap stays under the bound and still counts as matched. A dynamic ad
+    /// (absent from the reference fingerprint, so no anchors commit across it)
+    /// opens a wide gap — or leaves no committed anchor ahead of the play-head at
+    /// all — so the instant playback crosses the last matched anchor this returns
+    /// false and highlighting stops, with no ad-detection step to lag behind.
+    func isWithinMatchedContent(forPlaybackTime playbackTime: Double) -> Bool {
+        Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: main.snapshot.playbackToReference)
+    }
+
+    /// The reference time for `playbackTime`, but only when it's on matched content
+    /// (see `isWithinMatchedContent`). Both halves read the same snapshot, so the
+    /// highlight tick can't see the gate and the interpolation disagree.
+    func matchedReferenceTime(forPlaybackTime playbackTime: Double) -> Double? {
+        let entries = main.snapshot.playbackToReference
+        guard Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: entries) else { return nil }
+        return Self.interpolate(
+            time: playbackTime,
+            in: entries,
+            keyPath: \.playbackTime,
+            valuePath: \.referenceTime
+        )
+    }
+
+    // MARK: - Notifications
 
     /// When an episode download completes while the transcript flow has already requested
     /// preparation, retry. If we previously gave up because no local file existed, or were
@@ -187,15 +226,12 @@ final class FingerprintTimingManager: NSObject {
         guard let downloadedUuid = notification.object as? String,
               let currentUuid = PlaybackManager.shared.currentEpisode()?.uuid,
               currentUuid == downloadedUuid else { return }
+        if case .active = state { return }
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            if case .active = self.state { return }
-            FileLog.shared.addMessage(
-                "FingerprintTimingManager: episode \(downloadedUuid) finished downloading — re-preparing"
-            )
-            self.prepareForCurrentEpisode()
-        }
+        FileLog.shared.addMessage(
+            "FingerprintTimingManager: episode \(downloadedUuid) finished downloading — re-preparing"
+        )
+        prepareForCurrentEpisode()
     }
 
     /// Re-anchor fingerprint generation to wherever the listener is now: if playback
@@ -203,16 +239,9 @@ final class FingerprintTimingManager: NSObject {
     /// stream from the new position so coverage stays close to what's playing.
     @objc private func handlePlaybackProgress() {
         let playbackTime = PlaybackManager.shared.currentTime()
-        guard playbackTime >= 0 else { return }
-
-        let episodeUuid = PlaybackManager.shared.currentEpisode()?.uuid
-        queue.async { [weak self] in
-            self?.processProgress(playbackTime: playbackTime, episodeUuid: episodeUuid)
-        }
-    }
-
-    private func processProgress(playbackTime: Double, episodeUuid: String?) {
-        guard let ctx = context, ctx.episodeUuid == episodeUuid else { return }
+        guard playbackTime >= 0,
+              let ctx = context,
+              ctx.request.episodeUuid == PlaybackManager.shared.currentEpisode()?.uuid else { return }
 
         if lastProgressPosition >= 0 {
             let delta = abs(playbackTime - lastProgressPosition)
@@ -237,7 +266,7 @@ final class FingerprintTimingManager: NSObject {
         // map is empty) cancels that in-flight work before it can finish. The
         // delta-based branch above still catches real seeks. Once we have
         // coverage the drift-restart resumes as before.
-        if main.playbackToReference.isEmpty { return }
+        if main.snapshot.isEmpty { return }
 
         #if DEBUG
         FileLog.shared.addMessage(
@@ -248,8 +277,8 @@ final class FingerprintTimingManager: NSObject {
     }
 
     private func isWithinMappedRange(_ playbackTime: Double) -> Bool {
-        guard let first = main.playbackToReference.first,
-              let last = main.playbackToReference.last else { return false }
+        guard let first = main.snapshot.playbackToReference.first,
+              let last = main.snapshot.playbackToReference.last else { return false }
         let margin = FingerprintConstants.playbackRangeMarginSeconds
         return playbackTime >= first.playbackTime - margin
             && playbackTime <= last.playbackTime + margin
@@ -261,94 +290,11 @@ final class FingerprintTimingManager: NSObject {
     /// reset because the new stream's first matches live in a region that has
     /// no rate relationship to the old trusted anchor.
     private func restart(from position: Double, context ctx: GenerationContext) {
-        cancellationFlag.cancel()
-        cancellationFlag = CancellationFlag()
-        let flag = cancellationFlag
-        let newContext = GenerationContext(
-            episodeUuid: ctx.episodeUuid,
-            audioFileURL: ctx.audioFileURL,
-            isStreaming: ctx.isStreaming,
-            duration: ctx.duration,
-            matcher: ctx.matcher,
-            referenceData: ctx.referenceData,
-            referenceFilePath: ctx.referenceFilePath,
-            referenceDuration: ctx.referenceDuration,
-            isCancelled: { flag.isCancelled }
-        )
-        context = newContext
-        resetFilterState()
-        startStream(context: newContext, fromPosition: position)
-    }
-
-    func referenceTime(forPlaybackTime playbackTime: Double) -> Double? {
-        dispatchPrecondition(condition: .notOnQueue(queue))
-        return queue.sync {
-            Self.interpolate(
-                time: playbackTime,
-                in: main.playbackToReference,
-                keyPath: \.playbackTime,
-                valuePath: \.referenceTime
-            )
-        }
-    }
-
-    func playbackTime(forReferenceTime referenceTime: Double) -> Double? {
-        dispatchPrecondition(condition: .notOnQueue(queue))
-        return queue.sync {
-            Self.interpolate(
-                time: referenceTime,
-                in: main.referenceToPlayback,
-                keyPath: \.referenceTime,
-                valuePath: \.playbackTime
-            )
-        }
-    }
-
-    /// Whether `playbackTime` sits on confidently-matched content — bracketed by
-    /// committed anchors no more than `highlightMaxGapSeconds` apart.
-    ///
-    /// Highlighting keys off this so it only ever runs while we're sure where we
-    /// are. Real content commits anchors every second or two, so a sparse "quick
-    /// red" gap stays under the bound and still counts as matched. A dynamic ad
-    /// (absent from the reference fingerprint, so no anchors commit across it)
-    /// opens a wide gap — or leaves no committed anchor ahead of the play-head at
-    /// all — so the instant playback crosses the last matched anchor this returns
-    /// false and highlighting stops, with no ad-detection step to lag behind.
-    func isWithinMatchedContent(forPlaybackTime playbackTime: Double) -> Bool {
-        dispatchPrecondition(condition: .notOnQueue(queue))
-        return queue.sync {
-            Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: main.playbackToReference)
-        }
-    }
-
-    /// The reference time for `playbackTime`, but only when it's on matched content
-    /// (see `isWithinMatchedContent`). Combines the gate and the interpolation into
-    /// a single `queue.sync` so the highlight tick — driven by the display link at
-    /// ~60Hz — pays one lock per frame and can't see the two disagree if the mapping
-    /// mutates between them.
-    func matchedReferenceTime(forPlaybackTime playbackTime: Double) -> Double? {
-        dispatchPrecondition(condition: .notOnQueue(queue))
-        return queue.sync {
-            guard Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: main.playbackToReference) else {
-                return nil
-            }
-            return Self.interpolate(
-                time: playbackTime,
-                in: main.playbackToReference,
-                keyPath: \.playbackTime,
-                valuePath: \.referenceTime
-            )
-        }
+        main.resetFilterState()
+        startStream(context: ctx, fromPosition: position)
     }
 
     // MARK: - On-demand chapter seek
-
-    /// Outcome of a one-shot chapter resolve. `reason` on `.unresolved` is a
-    /// stable analytics token the caller reports and can key fallback behavior on.
-    enum ChapterSeekResult {
-        case resolved(playbackTime: Double, usedPrior: Bool, isStreaming: Bool, resolveDurationMs: Int)
-        case unresolved(reason: String, isStreaming: Bool)
-    }
 
     /// Resolve a generated chapter's reference-timeline `referenceTime` to the
     /// playback-timeline position where that content actually occurs in the
@@ -357,51 +303,32 @@ final class FingerprintTimingManager: NSObject {
     /// against the reference.
     ///
     /// This is a one-shot, side-effect-free operation: it uses its own reference
-    /// data, matcher, cancellation flag, and a local scratch mapping, and never
-    /// mutates the continuous transcript mapping (`main`), `context`, or `state`.
-    /// A second call supersedes any still-running one (last tap wins).
-    ///
-    /// Must be called on the main queue. `completion` is delivered on the main
-    /// queue; a superseded resolve never calls back.
+    /// data, matcher, and scratch mapping, and never mutates the continuous
+    /// transcript mapping, `context`, or `state`. A second call supersedes any
+    /// still-running one (last tap wins), and a superseded resolve never calls back.
     func resolvePlaybackTime(
         forReferenceTime referenceTime: Double,
         episode: BaseEpisode,
-        completion: @escaping (ChapterSeekResult) -> Void
+        completion: @escaping @MainActor (ChapterSeekResult) -> Void
     ) {
-        dispatchPrecondition(condition: .onQueue(.main))
-        // Supersede any prior in-flight resolve.
-        onDemandFlag.cancel()
-        let flag = CancellationFlag()
-        onDemandFlag = flag
-        onDemandTask?.cancel()
+        chapterResolveTask?.cancel()
+        let request = Self.makeRequest(for: episode)
 
-        onDemandTask = Task { [weak self] in
+        chapterResolveTask = Task { [weak self] in
             guard let self else { return }
-
-            // Hard timeout: cancel the flag after the deadline so a slow decode
-            // can't leave the tap spinning indefinitely. The decode loop observes
-            // the flag once per chunk.
-            let timeoutTask = Task {
-                try? await Task.sleep(
-                    nanoseconds: UInt64(FingerprintConstants.onDemandSeekTimeoutSeconds * 1_000_000_000)
-                )
-                flag.cancel()
+            let result = await Self.withTimeout(FingerprintConstants.onDemandSeekTimeoutSeconds) {
+                await self.performResolve(request: request, referenceTime: referenceTime, kind: .chapter)
             }
-            defer { timeoutTask.cancel() }
-
-            let result = await self.performResolve(
-                forReferenceTime: referenceTime,
-                episode: episode,
-                kind: .chapter,
-                flag: flag
-            )
-
-            await MainActor.run {
-                // Drop the result if a newer resolve superseded us (last tap wins).
-                guard self.onDemandFlag === flag else { return }
-                completion(result)
-            }
+            guard !Task.isCancelled else { return }
+            completion(result ?? .unresolved(reason: "timeout", isStreaming: request.isStreaming))
         }
+    }
+
+    /// Cancel any in-flight one-shot chapter resolve without delivering a result.
+    /// Called on view teardown so a backgrounded chapters list can't seek later.
+    func cancelPendingChapterResolve() {
+        chapterResolveTask?.cancel()
+        chapterResolveTask = nil
     }
 
     /// Resolve a bookmark's reference-timeline position to where that content
@@ -411,251 +338,94 @@ final class FingerprintTimingManager: NSObject {
     /// bookmark's audio is likely to be doing — see `ResolveKind.bookmark`. It keeps
     /// no state of its own, so it neither supersedes nor is superseded by a chapter
     /// resolve; the caller owns the lifetime, and cancelling its task stops the
-    /// decode via the cancellation handler below.
-    func resolveBookmarkPlaybackTime(
+    /// decode at the next chunk.
+    nonisolated func resolveBookmarkPlaybackTime(
         forReferenceTime referenceTime: Double,
         episode: BaseEpisode
     ) async -> ChapterSeekResult {
-        dispatchPrecondition(condition: .notOnQueue(queue))
-        let flag = CancellationFlag()
-
-        // Hard timeout, so a decode that drags or a buffer that never arrives can't
-        // leave the correction pending forever. Both loops observe the flag.
-        let timeoutTask = Task {
-            try? await Task.sleep(
-                nanoseconds: UInt64(FingerprintConstants.bookmarkSeekTimeoutSeconds * 1_000_000_000)
-            )
-            flag.cancel()
+        let request = Self.makeRequest(for: episode)
+        let result = await Self.withTimeout(FingerprintConstants.bookmarkSeekTimeoutSeconds) {
+            await self.performResolve(request: request, referenceTime: referenceTime, kind: .bookmark)
         }
-        defer { timeoutTask.cancel() }
-
-        return await withTaskCancellationHandler {
-            await performResolve(
-                forReferenceTime: referenceTime,
-                episode: episode,
-                kind: .bookmark,
-                flag: flag
-            )
-        } onCancel: {
-            flag.cancel()
-        }
+        return result ?? .unresolved(reason: "timeout", isStreaming: request.isStreaming)
     }
 
-    /// Cancel any in-flight one-shot chapter resolve without delivering a result.
-    /// Called on view teardown so a backgrounded chapters list can't seek later.
-    ///
-    /// Swapping in a fresh `onDemandFlag` supersedes the running task the same way
-    /// a newer resolve would: even if it finishes, its `onDemandFlag === flag`
-    /// guard now fails, so its completion (and any fallback seek) is dropped.
-    func cancelPendingChapterResolve() {
-        dispatchPrecondition(condition: .onQueue(.main))
-        onDemandFlag.cancel()
-        onDemandFlag = CancellationFlag()
-        onDemandTask?.cancel()
-        onDemandTask = nil
-    }
-
-    /// What the two one-shot resolves want differently, which all follows from what
-    /// their audio is likely to be doing: a chapter's episode is playing, so its
-    /// audio is already local, while a bookmark's is often still downloading.
-    private enum ResolveKind {
-        case chapter
-        case bookmark
-
-        /// Only a bookmark waits for the streaming buffer to reach the search window.
-        var waitsForBufferedRegion: Bool { self == .bookmark }
-    }
-
-    private func performResolve(
-        forReferenceTime referenceTime: Double,
-        episode: BaseEpisode,
-        kind: ResolveKind,
-        flag: CancellationFlag
+    nonisolated private func performResolve(
+        request: EpisodeRequest,
+        referenceTime: Double,
+        kind: ResolveKind
     ) async -> ChapterSeekResult {
         let startDate = Date()
-        let episodeUuid = episode.uuid
 
         // Snapshot the warm prior (if the transcript flow already has a mapping
-        // for this episode) read-only on `queue`: its reference data lets us skip
-        // disk/network, and the existing mapping estimates the ad offset at the
-        // target so we can tighten the search window.
-        let prior: (referenceData: Data?, estimatedPlayback: Double?) = queue.sync {
-            guard let ctx = context, ctx.episodeUuid == episodeUuid else { return (nil, nil) }
-            let estimate = Self.interpolate(
-                time: referenceTime,
-                in: main.referenceToPlayback,
-                keyPath: \.referenceTime,
-                valuePath: \.playbackTime
-            )
-            return (ctx.referenceData, estimate)
-        }
+        // for this episode): its reference data lets us skip disk/network, and the
+        // existing mapping estimates the ad offset at the target so we can tighten
+        // the search window.
+        let prior = await warmPrior(forReferenceTime: referenceTime, episodeUuid: request.episodeUuid)
 
-        // Resolve reference data: warm context → disk → server.
-        var referenceData = prior.referenceData ?? loadReference(for: episode)?.data
-        if referenceData == nil {
-            referenceData = await FingerprintReferenceRetriever.shared.fetchReferenceData(
-                podcastUuid: episode.parentIdentifier(),
-                episodeUuid: episodeUuid
-            )
-            if let referenceData { saveReferenceData(referenceData, for: episode) }
-        }
-
-        if flag.isCancelled { return .unresolved(reason: "timeout", isStreaming: false) }
-        guard let referenceData,
-              let reference = ReferenceFingerprint.decode(from: referenceData) else {
+        guard let reference = await resolveReference(for: request, warm: prior.referenceData) else {
             return .unresolved(reason: "no_reference", isStreaming: false)
         }
-
-        let duration = episode.duration
-        guard duration > 0,
-              let (matcher, _) = buildMatcher(from: reference, episodeUuid: episodeUuid, audioDuration: duration) else {
-            return .unresolved(reason: "no_reference", isStreaming: false)
-        }
+        if Task.isCancelled { return .unresolved(reason: "timeout", isStreaming: false) }
+        guard request.duration > 0 else { return .unresolved(reason: "no_reference", isStreaming: false) }
 
         let usedPrior = prior.estimatedPlayback != nil
-        let window = Self.searchWindow(
-            referenceTime: referenceTime,
-            estimatedPlayback: prior.estimatedPlayback
-        )
-        let alignedStart = Self.alignToWindowGrid(window.start)
-        let searchEnd = window.end
-
-        let source = resolveAudioSource(for: episode)
-        let audioURL: URL
-        let isStreaming: Bool
-        switch source {
-        case .downloaded(let url): audioURL = url; isStreaming = false
-        case .streaming(let url): audioURL = url; isStreaming = true
-        }
+        let window = Self.searchWindow(referenceTime: referenceTime, estimatedPlayback: prior.estimatedPlayback)
 
         // A bookmark's episode is often still arriving: playing it starts a
         // stream-and-cache download that fills the buffer sequentially from byte 0,
         // so the window we want only becomes readable once that prefix reaches it.
-        if kind.waitsForBufferedRegion, isStreaming {
-            await waitForBufferedRegion(
-                audioFileURL: audioURL,
-                coveringSeconds: searchEnd,
-                deadline: startDate.addingTimeInterval(FingerprintConstants.bookmarkSeekBufferWaitSeconds),
-                flag: flag
+        if kind.waitsForBufferedRegion, request.isStreaming {
+            await regionProcessor.waitForBufferedRegion(
+                audioFileURL: request.audioFileURL,
+                coveringSeconds: window.end,
+                deadline: startDate.addingTimeInterval(FingerprintConstants.bookmarkSeekBufferWaitSeconds)
             )
         }
+        if Task.isCancelled { return .unresolved(reason: "timeout", isStreaming: request.isStreaming) }
 
-        if flag.isCancelled { return .unresolved(reason: "timeout", isStreaming: isStreaming) }
-
-        // Fingerprint + match the bounded region into a local scratch accumulator
-        // on `onDemandQueue` (heavy decode, dedicated so the continuous stream on
-        // `generationQueue` can't starve it) while matching stays serialized on
-        // `queue` — `main` is never touched.
-        let outcome: Result<MappingAccumulator, StreamError> = await withCheckedContinuation { continuation in
-            onDemandQueue.async {
-                var scratch = MappingAccumulator()
-                do {
-                    try self.streamFingerprintBounded(
-                        audioFileURL: audioURL,
-                        startSeconds: alignedStart,
-                        endSeconds: searchEnd,
-                        matcher: matcher,
-                        flag: flag,
-                        into: &scratch
-                    )
-                    continuation.resume(returning: .success(scratch))
-                } catch let error as StreamError {
-                    continuation.resume(returning: .failure(error))
-                } catch {
-                    continuation.resume(returning: .failure(.bufferAllocationFailed))
-                }
-            }
-        }
-
-        switch outcome {
-        case .failure(.cancelled):
-            return .unresolved(reason: "timeout", isStreaming: isStreaming)
-        case .failure(.regionUnavailable):
-            return .unresolved(reason: "region_not_local", isStreaming: isStreaming)
-        case .failure:
-            return .unresolved(reason: "no_match", isStreaming: isStreaming)
-        case .success(let scratch):
-            guard scratch.playbackToReference.count >= FingerprintConstants.onDemandSeekMinAnchors,
+        do {
+            let scratch = try await regionProcessor.match(
+                audioFileURL: request.audioFileURL,
+                reference: reference.fingerprint,
+                episodeUuid: request.episodeUuid,
+                audioDuration: request.duration,
+                startSeconds: Self.alignToWindowGrid(window.start),
+                endSeconds: window.end
+            )
+            guard scratch.snapshot.playbackToReference.count >= FingerprintConstants.onDemandSeekMinAnchors,
                   let playback = Self.interpolate(
                       time: referenceTime,
-                      in: scratch.referenceToPlayback,
+                      in: scratch.snapshot.referenceToPlayback,
                       keyPath: \.referenceTime,
                       valuePath: \.playbackTime
                   ) else {
-                return .unresolved(reason: "no_match", isStreaming: isStreaming)
+                return .unresolved(reason: "no_match", isStreaming: request.isStreaming)
             }
-            let resolveDurationMs = Int(Date().timeIntervalSince(startDate) * 1000)
+            let resolveDurationMs = Self.elapsedMs(since: startDate)
             // Comparable across platforms: Android fingerprints eagerly and iOS
             // reactively on tap, but both report the calculation time here, decoupled
             // from `playerChapterSelected` (the tap) which stays untouched.
             Analytics.track(.playerChapterFingerprintCalculated, properties: [
                 "duration_ms": resolveDurationMs,
-                "is_streaming": isStreaming,
-                "episode_uuid": episodeUuid,
-                "podcast_uuid": episode.parentIdentifier()
+                "is_streaming": request.isStreaming,
+                "episode_uuid": request.episodeUuid,
+                "podcast_uuid": request.podcastUuid
             ])
             return .resolved(
                 playbackTime: max(referenceTime, playback),
                 usedPrior: usedPrior,
-                isStreaming: isStreaming,
+                isStreaming: request.isStreaming,
                 resolveDurationMs: resolveDurationMs
             )
-        }
-    }
-
-    /// Wait for a still-downloading streaming buffer to cover `coveringSeconds` of
-    /// audio, polling as it grows.
-    ///
-    /// `MediaExporterResourceLoaderDelegate` caches with a single un-ranged request
-    /// appended to disk, so the buffer is always a prefix of the episode and
-    /// `AVAudioFile.length` tracks exactly how much of it is local — the same
-    /// property the grow-loop anchors on.
-    ///
-    /// Returns once covered, or early when the file stops growing, the deadline
-    /// passes, or the resolve is cancelled. There's deliberately no failure signal:
-    /// the bounded fingerprint clamps to whatever is readable, so matching a short
-    /// prefix of the window still beats returning nothing.
-    private func waitForBufferedRegion(
-        audioFileURL: URL,
-        coveringSeconds: Double,
-        deadline: Date,
-        flag: CancellationFlag
-    ) async {
-        let pollCadence = FingerprintConstants.bufferGrowPollCadenceSeconds
-        var stallSeconds: Double = 0
-        var lastLength: AVAudioFramePosition = -1
-
-        while !flag.isCancelled, Date() < deadline {
-            // The buffer may not exist yet, and a partial frame at the tail can make
-            // `AVAudioFile` refuse to open momentarily — both read as "no growth".
-            if let audioFile = try? AVAudioFile(
-                forReading: audioFileURL,
-                commonFormat: .pcmFormatFloat32,
-                interleaved: false
-            ) {
-                let bufferedSeconds = Double(audioFile.length) / audioFile.processingFormat.sampleRate
-                if bufferedSeconds >= coveringSeconds {
-                    FileLog.shared.addMessage(
-                        "FingerprintTimingManager: streaming buffer covers the search window "
-                            + "(\(String(format: "%.1f", bufferedSeconds))s buffered)"
-                    )
-                    return
-                }
-                if audioFile.length > lastLength {
-                    lastLength = audioFile.length
-                    stallSeconds = 0
-                }
-            }
-
-            stallSeconds += pollCadence
-            if stallSeconds >= FingerprintConstants.bookmarkSeekBufferStallSeconds {
-                FileLog.shared.addMessage(
-                    "FingerprintTimingManager: streaming buffer stopped growing short of the "
-                        + "search window — fingerprinting the \(max(0, lastLength)) frames that arrived"
-                )
-                return
-            }
-            try? await Task.sleep(nanoseconds: UInt64(pollCadence * 1_000_000_000))
+        } catch is CancellationError {
+            return .unresolved(reason: "timeout", isStreaming: request.isStreaming)
+        } catch FingerprintStreamError.regionUnavailable {
+            return .unresolved(reason: "region_not_local", isStreaming: request.isStreaming)
+        } catch FingerprintStreamError.noUsableCheckpoints {
+            return .unresolved(reason: "no_reference", isStreaming: request.isStreaming)
+        } catch {
+            return .unresolved(reason: "no_match", isStreaming: request.isStreaming)
         }
     }
 
@@ -665,189 +435,143 @@ final class FingerprintTimingManager: NSObject {
     /// reference timeline, so reference-timed content like a generated
     /// transcript can be read at the right spot despite dynamic-ad shifting.
     ///
-    /// Like `resolvePlaybackTime` this is one-shot and side-effect-free: it uses
-    /// its own matcher, cancellation flag, and scratch mapping, and never mutates
-    /// the continuous transcript mapping (`main`), `context`, or `state`.
+    /// Like `resolvePlaybackTime` this is one-shot and side-effect-free.
     ///
     /// Returns nil when no confident match is found (no reference, audio not
     /// local, timeout) — callers should fall back to the raw playback time.
-    func resolveReferenceTime(forPlaybackTime playbackTime: Double, episode: BaseEpisode) async -> Double? {
-        dispatchPrecondition(condition: .notOnQueue(queue))
-        let episodeUuid = episode.uuid
+    nonisolated func resolveReferenceTime(forPlaybackTime playbackTime: Double, episode: BaseEpisode) async -> Double? {
+        let request = Self.makeRequest(for: episode)
         let startDate = Date()
 
         // Warm fast path: interpolate off the continuous transcript mapping when
         // it already confidently covers this position.
-        let warm: Double? = queue.sync {
-            guard let ctx = context, ctx.episodeUuid == episodeUuid,
-                  Self.isWithinMatchedContent(forPlaybackTime: playbackTime, in: main.playbackToReference) else {
-                return nil
-            }
-            return Self.interpolate(
-                time: playbackTime,
-                in: main.playbackToReference,
-                keyPath: \.playbackTime,
-                valuePath: \.referenceTime
-            )
+        let warm: Double? = await MainActor.run {
+            guard let ctx = self.context, ctx.request.episodeUuid == request.episodeUuid else { return nil }
+            return self.matchedReferenceTime(forPlaybackTime: playbackTime)
         }
         if let warm {
             FileLog.shared.addMessage(
-                "FingerprintTimingManager: bookmark resolve matched off the live mapping for \(episodeUuid) — "
+                "FingerprintTimingManager: bookmark resolve matched off the live mapping for \(request.episodeUuid) — "
                     + "local file time \(String(format: "%.1f", playbackTime))s → "
                     + "reference time \(String(format: "%.1f", warm))s"
             )
             return warm
         }
 
-        // Hard timeout, observed once per decoded chunk
-        let flag = CancellationFlag()
-        let timeoutTask = Task {
-            try? await Task.sleep(
-                nanoseconds: UInt64(FingerprintConstants.bookmarkResolveTimeoutSeconds * 1_000_000_000)
-            )
-            flag.cancel()
+        let outcome: Double?? = await Self.withTimeout(FingerprintConstants.bookmarkResolveTimeoutSeconds) {
+            await self.performReferenceResolve(request: request, playbackTime: playbackTime, startDate: startDate)
         }
-        defer { timeoutTask.cancel() }
+        return outcome.flatMap { $0 }
+    }
 
-        // Resolve reference data: warm context → disk → server.
-        var referenceData: Data? = queue.sync {
-            guard let ctx = context, ctx.episodeUuid == episodeUuid else { return nil }
-            return ctx.referenceData
-        }
-        referenceData = referenceData ?? loadReference(for: episode)?.data
-        if referenceData == nil {
-            referenceData = await FingerprintReferenceRetriever.shared.fetchReferenceData(
-                podcastUuid: episode.parentIdentifier(),
-                episodeUuid: episodeUuid
-            )
-            if let referenceData { saveReferenceData(referenceData, for: episode) }
-        }
-
-        guard !flag.isCancelled,
-              let referenceData,
-              let reference = ReferenceFingerprint.decode(from: referenceData) else {
+    nonisolated private func performReferenceResolve(
+        request: EpisodeRequest,
+        playbackTime: Double,
+        startDate: Date
+    ) async -> Double? {
+        let warmData = await warmReferenceData(forEpisodeUuid: request.episodeUuid)
+        guard let reference = await resolveReference(for: request, warm: warmData), !Task.isCancelled else {
             FileLog.shared.addMessage(
-                "FingerprintTimingManager: bookmark resolve gave up for \(episodeUuid) — no usable reference"
+                "FingerprintTimingManager: bookmark resolve gave up for \(request.episodeUuid) — no usable reference"
             )
             return nil
         }
-
-        let duration = episode.duration
-        guard duration > 0,
-              let (matcher, _) = buildMatcher(from: reference, episodeUuid: episodeUuid, audioDuration: duration) else {
-            FileLog.shared.addMessage(
-                "FingerprintTimingManager: bookmark resolve gave up for \(episodeUuid) — no usable checkpoints"
-            )
-            return nil
-        }
+        guard request.duration > 0 else { return nil }
 
         let start = Self.alignToWindowGrid(
             max(0, playbackTime - FingerprintConstants.bookmarkResolveBackwardSeconds)
         )
         let end = playbackTime + FingerprintConstants.bookmarkResolveForwardSeconds
 
-        let audioURL: URL
-        switch resolveAudioSource(for: episode) {
-        case .downloaded(let url), .streaming(let url):
-            audioURL = url
-        }
-
-        // Fingerprint + match the bounded region into a local scratch accumulator;
-        // matching stays serialized on `queue` inside `streamFingerprintBounded`.
-        let scratch: MappingAccumulator? = await withCheckedContinuation { continuation in
-            onDemandQueue.async {
-                var acc = MappingAccumulator()
-                do {
-                    try self.streamFingerprintBounded(
-                        audioFileURL: audioURL,
-                        startSeconds: start,
-                        endSeconds: end,
-                        matcher: matcher,
-                        flag: flag,
-                        into: &acc
-                    )
-                    continuation.resume(returning: acc)
-                } catch {
-                    continuation.resume(returning: nil)
-                }
-            }
-        }
+        let scratch = try? await regionProcessor.match(
+            audioFileURL: request.audioFileURL,
+            reference: reference.fingerprint,
+            episodeUuid: request.episodeUuid,
+            audioDuration: request.duration,
+            startSeconds: start,
+            endSeconds: end
+        )
 
         guard let scratch,
-              scratch.playbackToReference.count >= FingerprintConstants.bookmarkResolveMinAnchors,
+              scratch.snapshot.playbackToReference.count >= FingerprintConstants.bookmarkResolveMinAnchors,
               let referenceTime = Self.interpolate(
                   time: playbackTime,
-                  in: scratch.playbackToReference,
+                  in: scratch.snapshot.playbackToReference,
                   keyPath: \.playbackTime,
                   valuePath: \.referenceTime
               ) else {
             FileLog.shared.addMessage(
                 "FingerprintTimingManager: bookmark resolve found no confident match "
-                    + "at local file time \(String(format: "%.1f", playbackTime))s for \(episodeUuid) "
-                    + "(\(scratch?.playbackToReference.count ?? 0) anchors, took \(Self.elapsedMs(since: startDate))ms)"
+                    + "at local file time \(String(format: "%.1f", playbackTime))s for \(request.episodeUuid) "
+                    + "(\(scratch?.snapshot.playbackToReference.count ?? 0) anchors, took \(Self.elapsedMs(since: startDate))ms)"
             )
             return nil
         }
 
         FileLog.shared.addMessage(
-            "FingerprintTimingManager: bookmark resolve matched for \(episodeUuid) — "
+            "FingerprintTimingManager: bookmark resolve matched for \(request.episodeUuid) — "
                 + "local file time \(String(format: "%.1f", playbackTime))s → "
                 + "reference time \(String(format: "%.1f", referenceTime))s "
-                + "(\(scratch.playbackToReference.count) anchors, took \(Self.elapsedMs(since: startDate))ms)"
+                + "(\(scratch.snapshot.playbackToReference.count) anchors, took \(Self.elapsedMs(since: startDate))ms)"
         )
         return referenceTime
     }
 
-    private static func elapsedMs(since date: Date) -> Int {
-        Int(Date().timeIntervalSince(date) * 1000)
+    /// Read-only peek at the continuous run's state, for a resolve that may be
+    /// able to warm-start off it.
+    nonisolated private func warmPrior(forReferenceTime referenceTime: Double, episodeUuid: String) async -> WarmPrior {
+        await MainActor.run {
+            guard let ctx = self.context, ctx.request.episodeUuid == episodeUuid else {
+                return WarmPrior(referenceData: nil, estimatedPlayback: nil)
+            }
+            return WarmPrior(
+                referenceData: ctx.referenceData,
+                estimatedPlayback: self.playbackTime(forReferenceTime: referenceTime)
+            )
+        }
     }
+
+    /// The reference bytes the continuous run already holds for this episode, if
+    /// any — enough to skip disk and network when no offset estimate is needed.
+    nonisolated private func warmReferenceData(forEpisodeUuid episodeUuid: String) async -> Data? {
+        await MainActor.run {
+            guard let ctx = self.context, ctx.request.episodeUuid == episodeUuid else { return nil }
+            return ctx.referenceData
+        }
+    }
+
+    // MARK: - Debug
 
     #if DEBUG
-    var totalDuration: Double? {
-        dispatchPrecondition(condition: .notOnQueue(queue))
-        return queue.sync { context?.duration }
-    }
+    var totalDuration: Double? { context?.request.duration }
 
-    func debugMappingSnapshot() -> [TimeMappingEntry] {
-        dispatchPrecondition(condition: .notOnQueue(queue))
-        return queue.sync { main.playbackToReference }
-    }
+    func debugMappingSnapshot() -> [TimeMappingEntry] { main.snapshot.playbackToReference }
 
     /// Candidates that reached the drift filter but were rejected. The debug
     /// overlay uses this to distinguish "matcher never fired here" from
     /// "matcher fired but everything was filtered out as noise".
-    func debugRejectionsSnapshot() -> [TimeMappingEntry] {
-        dispatchPrecondition(condition: .notOnQueue(queue))
-        return queue.sync { debugRejections }
-    }
+    func debugRejectionsSnapshot() -> [TimeMappingEntry] { main.rejections }
     #endif
 
     // MARK: - State Management
 
     private func resetState() {
-        fetchTask?.cancel()
-        fetchTask = nil
-        cancellationFlag.cancel()
-        cancellationFlag = CancellationFlag()
+        prepareTask?.cancel()
+        prepareTask = nil
+        streamTask?.cancel()
+        streamTask = nil
+        streamProcessor = nil
         context = nil
         main = MappingAccumulator()
         lastProgressPosition = -1
         preparationStartDate = nil
         hasReachedActive = false
         hasEmittedPreparationStarted = false
-        #if DEBUG
-        debugRejections.removeAll()
-        #endif
-    }
-
-    private func resetFilterState() {
-        main.filterLastTrusted = nil
-        main.filterCandidatePool.removeAll()
     }
 
     private func track(_ event: AnalyticsEvent, properties: [String: Sendable] = [:]) {
         var properties = properties
-        if let episodeUuid = context?.episodeUuid {
+        if let episodeUuid = context?.request.episodeUuid {
             properties["episode_uuid"] = episodeUuid
         }
         Analytics.track(event, properties: properties)
@@ -855,255 +579,184 @@ final class FingerprintTimingManager: NSObject {
 
     private var preparationDurationMs: Int {
         guard let start = preparationStartDate else { return 0 }
-        return Int(Date().timeIntervalSince(start) * 1000)
-    }
-
-    private func updateState(_ newState: State) {
-        DispatchQueue.main.async { [weak self] in
-            self?.state = newState
-        }
+        return Self.elapsedMs(since: start)
     }
 
     // MARK: - Track Preparation
 
-    private func prepareForEpisode(_ episode: BaseEpisode?) {
-        updateState(.idle)
+    private func prepare(_ request: EpisodeRequest) async {
+        var loaded = await Self.loadReference(atPath: request.referenceFilePath)
 
-        guard FeatureFlag.syncedTranscripts.enabled else {
-            updateState(.unavailable)
-            track(.syncedTranscriptsUnavailable, properties: ["reason": "feature_disabled"])
-            return
-        }
-
-        guard let episode else {
-            updateState(.unavailable)
-            track(.syncedTranscriptsUnavailable, properties: ["reason": "no_episode"])
-            return
-        }
-
-        let uuid = episode.uuid
-
-        if let loaded = loadReference(for: episode) {
-            configureForReference(loaded.reference, referenceData: loaded.data, episode: episode)
-            return
-        }
-
-        preparationStartDate = Date()
-        updateState(.preparing)
-        track(.syncedTranscriptsPreparationStarted, properties: [
-            "episode_uuid": uuid,
-            "episode_duration_seconds": episode.duration
-        ])
-        hasEmittedPreparationStarted = true
-        FileLog.shared.addMessage("FingerprintTimingManager: fetching reference from server for \(uuid)")
-
-        let flag = cancellationFlag
-        fetchTask = Task { [weak self] in
-            guard !flag.isCancelled else { return }
-
-            let data = await FingerprintReferenceRetriever.shared.fetchReferenceData(
-                podcastUuid: episode.parentIdentifier(),
-                episodeUuid: uuid
+        if loaded == nil {
+            preparationStartDate = Date()
+            state = .preparing
+            track(.syncedTranscriptsPreparationStarted, properties: [
+                "episode_uuid": request.episodeUuid,
+                "episode_duration_seconds": request.duration
+            ])
+            hasEmittedPreparationStarted = true
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: fetching reference from server for \(request.episodeUuid)"
             )
 
-            self?.queue.async { [weak self] in
-                guard let self, !flag.isCancelled else { return }
-
-                guard let data, let reference = ReferenceFingerprint.decode(from: data) else {
-                    self.updateState(.unavailable)
-                    self.track(.syncedTranscriptsUnavailable, properties: ["reason": "no_reference"])
-                    FileLog.shared.addMessage("FingerprintTimingManager: no reference available for \(uuid)")
-                    return
-                }
-
-                self.saveReferenceData(data, for: episode)
-                self.configureForReference(reference, referenceData: data, episode: episode)
+            let data = await FingerprintReferenceRetriever.shared.fetchReferenceData(
+                podcastUuid: request.podcastUuid,
+                episodeUuid: request.episodeUuid
+            )
+            guard !Task.isCancelled else { return }
+            if let data {
+                await Self.saveReference(data, toPath: request.referenceFilePath, episodeUuid: request.episodeUuid)
+                loaded = await Self.decodeReference(data)
             }
         }
-    }
 
-    private func configureForReference(
-        _ reference: ReferenceFingerprint,
-        referenceData: Data,
-        episode: BaseEpisode
-    ) {
-        let uuid = episode.uuid
-
-        let source = resolveAudioSource(for: episode)
-        let audioFileURL: URL
-        let isStreaming: Bool
-        switch source {
-        case .downloaded(let url):
-            audioFileURL = url
-            isStreaming = false
-        case .streaming(let url):
-            audioFileURL = url
-            isStreaming = true
+        guard let loaded else {
+            state = .unavailable
+            track(.syncedTranscriptsUnavailable, properties: ["reason": "no_reference"])
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: no reference available for \(request.episodeUuid)"
+            )
+            return
         }
 
-        let duration = episode.duration
-        guard duration > 0 else {
-            updateState(.unavailable)
+        await configure(reference: loaded, request: request)
+    }
+
+    private func configure(reference: DecodedReference, request: EpisodeRequest) async {
+        guard request.duration > 0 else {
+            state = .unavailable
             track(.syncedTranscriptsUnavailable, properties: ["reason": "invalid_duration"])
             return
         }
 
-        guard let (matcher, checkpointCount) = buildMatcher(
-            from: reference,
-            episodeUuid: uuid,
-            audioDuration: duration
-        ) else {
-            updateState(.unavailable)
+        let processor = FingerprintStreamProcessor()
+        let checkpointCount = await processor.prepare(
+            reference: reference.fingerprint,
+            episodeUuid: request.episodeUuid,
+            audioDuration: request.duration
+        )
+        guard !Task.isCancelled else { return }
+        guard let checkpointCount else {
+            state = .unavailable
             track(.syncedTranscriptsUnavailable, properties: ["reason": "no_reference"])
-            FileLog.shared.addMessage("FingerprintTimingManager: reference for \(uuid) has no usable checkpoints")
+            FileLog.shared.addMessage(
+                "FingerprintTimingManager: reference for \(request.episodeUuid) has no usable checkpoints"
+            )
             return
         }
 
-        let flag = cancellationFlag
-        let refPath = referencePath(for: episode)
-        let newContext = GenerationContext(
-            episodeUuid: uuid,
-            audioFileURL: audioFileURL,
-            isStreaming: isStreaming,
-            duration: duration,
-            matcher: matcher,
-            referenceData: referenceData,
-            referenceFilePath: refPath,
-            referenceDuration: reference.totalDuration,
-            isCancelled: { flag.isCancelled }
+        streamProcessor = processor
+        let ctx = GenerationContext(
+            request: request,
+            referenceData: reference.data,
+            referenceDuration: reference.fingerprint.totalDuration
         )
-        context = newContext
+        context = ctx
 
         if preparationStartDate == nil {
             preparationStartDate = Date()
         }
-        updateState(.preparing)
+        state = .preparing
         if !hasEmittedPreparationStarted {
             track(.syncedTranscriptsPreparationStarted, properties: [
-                "is_streaming": isStreaming,
-                "episode_duration_seconds": duration
+                "is_streaming": request.isStreaming,
+                "episode_duration_seconds": request.duration
             ])
             hasEmittedPreparationStarted = true
         }
         FileLog.shared.addMessage(
-            "FingerprintTimingManager: preparing for \(uuid) (\(checkpointCount) checkpoints)"
+            "FingerprintTimingManager: preparing for \(request.episodeUuid) (\(checkpointCount) checkpoints)"
         )
-
-        // Capture once so the range check, log, and stream start all use the same position.
-        let currentTime = PlaybackManager.shared.currentTime()
 
         // All-or-nothing cache: only short-circuit the stream if a previous
         // session persisted a mapping that covers the whole reference timeline
         // for this exact audio file + reference. Partial caches are ignored
         // (the failed branch's `inRange` short-circuit on partial coverage was
         // what trapped the manager in `.preparing`).
-        if !isStreaming,
-           let cached = FingerprintMappingCache.load(
-               audioFilePath: audioFileURL.path,
-               referenceFilePath: refPath,
-               referenceData: referenceData
-           ) {
-            // The cache is produced from `playbackToReference` (already sorted
-            // by `playbackTime`), so assign it directly and sort once for the
-            // reference-keyed view — avoids the O(n²) cost of routing every
-            // entry through `insertMapping`'s per-entry `Array.insert`.
-            main.playbackToReference = cached.entries
-            main.referenceToPlayback = cached.entries.sorted { $0.referenceTime < $1.referenceTime }
+        let cached = request.isStreaming ? nil : await Self.loadCachedSnapshot(
+            audioFilePath: request.audioFileURL.path,
+            referenceFilePath: request.referenceFilePath,
+            referenceData: reference.data
+        )
+        guard !Task.isCancelled else { return }
+
+        // Capture once so the range check, log, and stream start all use the same position.
+        let currentTime = PlaybackManager.shared.currentTime()
+
+        if let cached {
+            main.snapshot = cached
 
             if isWithinMappedRange(currentTime) {
-                main.filterLastTrusted = cached.entries.last
-                let coverage = cached.entries.count
-                updateState(.active(coverage: coverage))
+                main.filterLastTrusted = cached.playbackToReference.last
+                let coverage = cached.playbackToReference.count
+                state = .active(coverage: coverage)
                 if !hasReachedActive {
                     hasReachedActive = true
                     track(.syncedTranscriptsPreparationCompleted, properties: [
                         "duration_ms": preparationDurationMs,
-                        "is_streaming": isStreaming
+                        "is_streaming": request.isStreaming
                     ])
                 }
                 FileLog.shared.addMessage(
-                    "FingerprintTimingManager: skipping stream — full mapping loaded from cache for \(uuid)"
+                    "FingerprintTimingManager: skipping stream — full mapping loaded from cache for \(request.episodeUuid)"
                 )
                 return
             }
 
             FileLog.shared.addMessage(
-                "FingerprintTimingManager: cache loaded for \(uuid) but playback at "
+                "FingerprintTimingManager: cache loaded for \(request.episodeUuid) but playback at "
                     + "\(String(format: "%.1f", currentTime))s is outside cached range — starting stream"
             )
         }
 
-        startStream(context: newContext, fromPosition: currentTime)
-    }
-
-    /// Build a `CheckpointMatcher` populated from every usable checkpoint in
-    /// `reference`, plus the decoded checkpoint count. Returns nil when the
-    /// reference has no usable checkpoints. Shared by the continuous transcript
-    /// path (`configureForReference`) and the one-shot chapter resolve.
-    private func buildMatcher(
-        from reference: ReferenceFingerprint,
-        episodeUuid: String,
-        audioDuration: Double
-    ) -> (matcher: CheckpointMatcher, checkpointCount: Int)? {
-        let duration_s = reference.checkpointDurationSeconds
-        let rawCheckpointCount = reference.checkpoints.count
-        let libraryCheckpoints = reference.libraryCheckpoints()
-
-        FileLog.shared.addMessage(
-            "FingerprintTimingManager: reference for \(episodeUuid) — "
-                + "totalDuration=\(reference.totalDuration)s, "
-                + "checkpointInterval=\(reference.checkpointInterval), "
-                + "checkpointDuration=\(reference.checkpointDuration)s, "
-                + "timestampQuantum=\(reference.timestampQuantum), "
-                + "raw=\(rawCheckpointCount), decoded=\(libraryCheckpoints.count)"
-        )
-        if let first = libraryCheckpoints.first, let last = libraryCheckpoints.last {
-            FileLog.shared.addMessage(
-                "FingerprintTimingManager: checkpoint timestamps span "
-                    + "\(String(format: "%.1f", first.timestampSeconds))s..\(String(format: "%.1f", last.timestampSeconds))s "
-                    + "(audio duration \(String(format: "%.1f", audioDuration))s)"
-            )
-        }
-
-        guard !libraryCheckpoints.isEmpty else { return nil }
-
-        let matcher = CheckpointMatcher()
-        for checkpoint in libraryCheckpoints {
-            matcher.add(
-                timestamp: checkpoint.timestampSeconds,
-                hashes: checkpoint.hashes,
-                duration: duration_s
-            )
-        }
-        return (matcher, libraryCheckpoints.count)
+        startStream(context: ctx, fromPosition: currentTime)
     }
 
     // MARK: - Streaming Fingerprint Processing
 
-    /// Stream-decode the downloaded file with `AVAudioFile`, push PCM into the
-    /// streaming fingerprinter chunk-by-chunk, and match each batch of windows
-    /// as soon as it's emitted. We start near the current playback position
-    /// (snapped to a 2s grid so window timestamps line up with the reference
-    /// checkpoints), so highlighting becomes usable for what the listener is
-    /// actually hearing — without waiting for the entire file to be processed.
     private func startStream(context ctx: GenerationContext, fromPosition position: Double) {
+        guard let processor = streamProcessor else { return }
+        streamTask?.cancel()
+
         let aligned = Self.alignToWindowGrid(position)
-        generationQueue.async { [weak self] in
-            guard let self else { return }
+        let request = ctx.request
+        let referenceData = ctx.referenceData
+        let referenceDuration = ctx.referenceDuration
+        let currentPlaybackTime: @Sendable () async -> Double = {
+            await MainActor.run { PlaybackManager.shared.currentTime() }
+        }
+        let commit: @Sendable (MatchBatch) async -> Void = { [weak self] batch in
+            await self?.commit(batch, for: request)
+        }
+
+        streamTask = Task(priority: .utility) { [weak self] in
             do {
-                if ctx.isStreaming {
-                    try self.streamFingerprintGrowing(context: ctx, startingAt: aligned)
-                } else {
-                    try self.streamFingerprint(context: ctx, startingAt: aligned)
-                }
+                try await processor.run(
+                    audioFileURL: request.audioFileURL,
+                    isStreaming: request.isStreaming,
+                    startingAt: aligned,
+                    currentPlaybackTime: currentPlaybackTime,
+                    commit: commit
+                )
                 #if DEBUG
                 FileLog.shared.addMessage(
                     "FingerprintTimingManager: streaming fingerprint completed (started at \(String(format: "%.1f", aligned))s)"
                 )
                 #endif
-                self.persistMappingCacheIfFull(context: ctx)
+                guard let self else { return }
+                // Only persist a mapping for a complete local file, and only when
+                // it covers the whole reference timeline — `FingerprintMappingCache`
+                // enforces the same threshold the load path requires.
+                if !request.isStreaming, self.context?.request.episodeUuid == request.episodeUuid {
+                    await Self.persistMappingCache(
+                        self.main.snapshot.playbackToReference,
+                        request: request,
+                        referenceData: referenceData,
+                        referenceDuration: referenceDuration
+                    )
+                }
                 self.finishIfStillPreparing(terminalState: .unavailable, context: ctx)
-            } catch StreamError.cancelled {
+            } catch is CancellationError {
                 #if DEBUG
                 FileLog.shared.addMessage("FingerprintTimingManager: streaming fingerprint cancelled")
                 #endif
@@ -1112,8 +765,36 @@ final class FingerprintTimingManager: NSObject {
                 FileLog.shared.addMessage(
                     "FingerprintTimingManager: streaming fingerprint failed — \(error.localizedDescription)"
                 )
-                self.finishIfStillPreparing(terminalState: .failed(error), context: ctx)
+                self?.finishIfStillPreparing(terminalState: .failed(error), context: ctx)
             }
+        }
+    }
+
+    /// Fold a batch of scored candidates into the committed mapping: the drift
+    /// filter, two sorted inserts, and a coverage check.
+    private func commit(_ batch: MatchBatch, for request: EpisodeRequest) {
+        // A batch already in flight when the run was cancelled still lands here.
+        // Drop it unless it belongs to the episode we're currently mapping.
+        guard context?.request.episodeUuid == request.episodeUuid else { return }
+
+        #if DEBUG
+        for rejection in batch.rejections {
+            main.record(rejection.entry, reason: rejection.reason)
+        }
+        #endif
+        for candidate in batch.candidates {
+            main.consider(candidate)
+        }
+
+        let coverage = main.snapshot.playbackToReference.count
+        guard coverage >= FingerprintConstants.minimumCoverageForActive else { return }
+        state = .active(coverage: coverage)
+        if !hasReachedActive {
+            hasReachedActive = true
+            track(.syncedTranscriptsPreparationCompleted, properties: [
+                "duration_ms": preparationDurationMs,
+                "is_streaming": request.isStreaming
+            ])
         }
     }
 
@@ -1121,44 +802,44 @@ final class FingerprintTimingManager: NSObject {
     /// haven't already reached `.active` — otherwise a late completion for an
     /// abandoned context would clobber a healthy state.
     private func finishIfStillPreparing(terminalState: State, context ctx: GenerationContext) {
-        queue.async { [weak self] in
-            guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
-            let durationMs = self.preparationDurationMs
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                if case .active = self.state { return }
-                self.state = terminalState
-                switch terminalState {
-                case .failed(let error):
-                    let nsError = error as NSError
-                    self.track(.syncedTranscriptsPreparationFailed, properties: [
-                        "error_code": nsError.code,
-                        "error_domain": nsError.domain,
-                        "stage": "fingerprint_generation",
-                        "duration_ms": durationMs
-                    ])
-                case .unavailable:
-                    let reason = ctx.isStreaming ? "streaming_unsupported" : "no_matches"
-                    self.track(.syncedTranscriptsUnavailable, properties: [
-                        "reason": reason,
-                        "is_streaming": ctx.isStreaming
-                    ])
-                default:
-                    break
-                }
-            }
+        guard context?.request.episodeUuid == ctx.request.episodeUuid else { return }
+        if case .active = state { return }
+
+        state = terminalState
+        switch terminalState {
+        case .failed(let error):
+            let nsError = error as NSError
+            track(.syncedTranscriptsPreparationFailed, properties: [
+                "error_code": nsError.code,
+                "error_domain": nsError.domain,
+                "stage": "fingerprint_generation",
+                "duration_ms": preparationDurationMs
+            ])
+        case .unavailable:
+            track(.syncedTranscriptsUnavailable, properties: [
+                "reason": ctx.request.isStreaming ? "streaming_unsupported" : "no_matches",
+                "is_streaming": ctx.request.isStreaming
+            ])
+        default:
+            break
         }
     }
+
+    // MARK: - Static Helpers
 
     /// Snap a playback time to the window-interval grid so emitted window
     /// timestamps are deterministic (stable across restarts and cache reuse).
     /// Windows are emitted every `windowIntervalMs`, finer than the reference's
     /// 2s checkpoint grid, so a correctly-phased window exists for any dynamic-ad
     /// offset rather than relying on a single phase happening to line up.
-    private static func alignToWindowGrid(_ time: Double) -> Double {
+    nonisolated private static func alignToWindowGrid(_ time: Double) -> Double {
         let stride = Double(FingerprintConstants.windowIntervalMs) / 1000.0
         guard stride > 0 else { return max(0, time) }
         return max(0, floor(time / stride) * stride)
+    }
+
+    nonisolated private static func elapsedMs(since date: Date) -> Int {
+        Int(Date().timeIntervalSince(date) * 1000)
     }
 
     /// Bounded region of local audio to fingerprint when resolving a chapter's
@@ -1172,7 +853,7 @@ final class FingerprintTimingManager: NSObject {
     ///   intervening ads) by up to `onDemandSeekForwardBudgetSeconds`.
     /// - Cold (no mapping — the common case): search forward from the raw
     ///   reference time up to `onDemandSeekColdBudgetSeconds`.
-    static func searchWindow(referenceTime: Double, estimatedPlayback: Double?) -> (start: Double, end: Double) {
+    nonisolated static func searchWindow(referenceTime: Double, estimatedPlayback: Double?) -> (start: Double, end: Double) {
         if let estimate = estimatedPlayback {
             let start = max(referenceTime, estimate - FingerprintConstants.onDemandSeekBackwardMaxSeconds)
             let end = max(start, estimate + FingerprintConstants.onDemandSeekForwardBudgetSeconds)
@@ -1181,641 +862,7 @@ final class FingerprintTimingManager: NSObject {
         return (referenceTime, referenceTime + FingerprintConstants.onDemandSeekColdBudgetSeconds)
     }
 
-    private func streamFingerprint(context ctx: GenerationContext, startingAt startSeconds: Double) throws {
-        // Force the reader to hand us non-interleaved Float32 PCM so
-        // `buffer.floatChannelData` is never nil regardless of the on-disk format.
-        let audioFile = try AVAudioFile(
-            forReading: ctx.audioFileURL,
-            commonFormat: .pcmFormatFloat32,
-            interleaved: false
-        )
-        let format = audioFile.processingFormat
-        let sampleRate = UInt32(format.sampleRate)
-        let channels = UInt16(format.channelCount)
-
-        let startFrame = AVAudioFramePosition(startSeconds * format.sampleRate)
-        if startFrame > 0, startFrame < audioFile.length {
-            audioFile.framePosition = startFrame
-        }
-
-        let streamer = StreamingWindowedFingerprinter(
-            sampleRate: sampleRate,
-            channels: channels,
-            windowDurationMs: FingerprintConstants.windowDurationMs,
-            windowIntervalMs: FingerprintConstants.windowIntervalMs
-        )
-
-        let chunkFrames = AVAudioFrameCount(format.sampleRate * FingerprintConstants.streamChunkSeconds)
-        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
-            throw StreamError.bufferAllocationFailed
-        }
-
-        var interleaved: [Float] = []
-        while true {
-            if ctx.isCancelled() { throw StreamError.cancelled }
-            let nextChunkStartSeconds = Double(audioFile.framePosition) / format.sampleRate
-            try throttleIfBeyondLookahead(nextChunkStartSeconds: nextChunkStartSeconds, context: ctx)
-            try audioFile.read(into: buffer, frameCount: chunkFrames)
-            if buffer.frameLength == 0 { break }
-
-            Self.interleave(buffer, into: &interleaved)
-            let windows = streamer.pushSamplesF32(samples: interleaved, channels: channels)
-            if !windows.isEmpty {
-                dispatchProcessMatches(windows: windows, startOffset: startSeconds, context: ctx)
-            }
-        }
-
-        if ctx.isCancelled() { throw StreamError.cancelled }
-        let tail = streamer.flush()
-        if !tail.isEmpty {
-            dispatchProcessMatches(windows: tail, startOffset: startSeconds, context: ctx)
-        }
-    }
-
-    /// Bounded, one-shot variant of `streamFingerprint` used by the chapter
-    /// resolve. Decodes only `[startSeconds, endSeconds]` of `audioFileURL`,
-    /// matching each window against `matcher` into `acc`. Unlike the continuous
-    /// variant it stops at `endSeconds` (not EOF), skips the lookahead throttle,
-    /// and never touches shared manager state — matching runs on `queue` (so the
-    /// drift filter and DEBUG rejection log stay serialized) while decode stays
-    /// on the calling `generationQueue`. Throws `.regionUnavailable` when the
-    /// local file doesn't yet reach `startSeconds` (a streaming episode whose
-    /// buffer hasn't advanced to the target chapter).
-    private func streamFingerprintBounded(
-        audioFileURL: URL,
-        startSeconds: Double,
-        endSeconds: Double,
-        matcher: CheckpointMatcher,
-        flag: CancellationFlag,
-        into acc: inout MappingAccumulator
-    ) throws {
-        let audioFile = try AVAudioFile(
-            forReading: audioFileURL,
-            commonFormat: .pcmFormatFloat32,
-            interleaved: false
-        )
-        let format = audioFile.processingFormat
-        let sampleRate = UInt32(format.sampleRate)
-        let channels = UInt16(format.channelCount)
-
-        let fileDurationSeconds = Double(audioFile.length) / format.sampleRate
-        guard startSeconds < fileDurationSeconds else { throw StreamError.regionUnavailable }
-
-        let startFrame = AVAudioFramePosition(startSeconds * format.sampleRate)
-        if startFrame > 0 { audioFile.framePosition = startFrame }
-        let endFrame = min(AVAudioFramePosition(endSeconds * format.sampleRate), audioFile.length)
-
-        let streamer = StreamingWindowedFingerprinter(
-            sampleRate: sampleRate,
-            channels: channels,
-            windowDurationMs: FingerprintConstants.windowDurationMs,
-            windowIntervalMs: FingerprintConstants.windowIntervalMs
-        )
-
-        let chunkFrames = AVAudioFrameCount(format.sampleRate * FingerprintConstants.streamChunkSeconds)
-        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
-            throw StreamError.bufferAllocationFailed
-        }
-
-        var interleaved: [Float] = []
-        while audioFile.framePosition < endFrame {
-            if flag.isCancelled { throw StreamError.cancelled }
-            let framesRemaining = AVAudioFrameCount(endFrame - audioFile.framePosition)
-            let framesToRead = min(framesRemaining, chunkFrames)
-            try audioFile.read(into: buffer, frameCount: framesToRead)
-            if buffer.frameLength == 0 { break }
-
-            Self.interleave(buffer, into: &interleaved)
-            let windows = streamer.pushSamplesF32(samples: interleaved, channels: channels)
-            if !windows.isEmpty {
-                queue.sync {
-                    self.matchWindows(windows: windows, startOffset: startSeconds, matcher: matcher, into: &acc)
-                }
-            }
-        }
-
-        if flag.isCancelled { throw StreamError.cancelled }
-        let tail = streamer.flush()
-        if !tail.isEmpty {
-            queue.sync {
-                self.matchWindows(windows: tail, startOffset: startSeconds, matcher: matcher, into: &acc)
-            }
-        }
-    }
-
-    /// Streaming-buffer variant of `streamFingerprint`. Same pipeline, but the
-    /// file may not exist yet when we start, and grows while we read — so we
-    /// reopen `AVAudioFile` each pass to refresh its length, seek to where we
-    /// left off, and consume whatever new frames are available. Exits when the
-    /// buffer has been stalled for `bufferGrowMaxStallSeconds` or the context
-    /// is cancelled; a later `handlePlaybackProgress` restart will pick up
-    /// again if the listener keeps playing.
-    private func streamFingerprintGrowing(context ctx: GenerationContext, startingAt startSeconds: Double) throws {
-        let pollCadence = FingerprintConstants.bufferGrowPollCadenceSeconds
-        let maxStallSeconds = FingerprintConstants.bufferGrowMaxStallSeconds
-        let trailingMarginSeconds = FingerprintConstants.bufferGrowTrailingMarginSeconds
-
-        var streamer: StreamingWindowedFingerprinter?
-        var format: AVAudioFormat?
-        var buffer: AVAudioPCMBuffer?
-        var chunkFrames: AVAudioFrameCount = 0
-        var lastProcessedFrame: AVAudioFramePosition = 0
-        var stallAccumSeconds: Double = 0
-        var announcedFileAppeared = false
-        var totalFramesRead: AVAudioFramePosition = 0
-        var windowsEmitted = 0
-        var interleaved: [Float] = []
-
-        FileLog.shared.addMessage(
-            "FingerprintTimingManager: streaming grow-loop starting at \(String(format: "%.1f", startSeconds))s "
-                + "(buffer path: \(ctx.audioFileURL.lastPathComponent))"
-        )
-
-        while true {
-            if ctx.isCancelled() { throw StreamError.cancelled }
-
-            guard FileManager.default.fileExists(atPath: ctx.audioFileURL.path) else {
-                // Streaming buffer not created yet — AVPlayer will write it
-                // once it actually begins fetching bytes.
-                stallAccumSeconds += pollCadence
-                if stallAccumSeconds >= maxStallSeconds { break }
-                try sleepWithCancellation(seconds: pollCadence, context: ctx)
-                continue
-            }
-
-            let audioFile: AVAudioFile
-            do {
-                audioFile = try AVAudioFile(
-                    forReading: ctx.audioFileURL,
-                    commonFormat: .pcmFormatFloat32,
-                    interleaved: false
-                )
-            } catch {
-                // Partial frame at the tail can make `AVAudioFile` refuse to
-                // open momentarily — wait and retry.
-                stallAccumSeconds += pollCadence
-                if stallAccumSeconds >= maxStallSeconds { break }
-                try sleepWithCancellation(seconds: pollCadence, context: ctx)
-                continue
-            }
-
-            if !announcedFileAppeared {
-                announcedFileAppeared = true
-                FileLog.shared.addMessage(
-                    "FingerprintTimingManager: streaming buffer opened "
-                        + "(length \(audioFile.length) frames @ \(Int(audioFile.processingFormat.sampleRate))Hz, "
-                        + "\(audioFile.processingFormat.channelCount)ch)"
-                )
-            }
-
-            if streamer == nil {
-                let fmt = audioFile.processingFormat
-                let desiredStartFrame = max(0, AVAudioFramePosition(startSeconds * fmt.sampleRate))
-
-                // The streaming buffer on disk is sequential from byte 0, so the
-                // local file's frame `N` maps to audio timeline `N / sampleRate`.
-                // If the buffer hasn't grown to `startSeconds` yet, reading from
-                // the current tail and tagging those windows as `startSeconds +
-                // windowTimestamp` would attribute them to the wrong reference
-                // time — matches would fail. Wait until the file covers the
-                // target position, then anchor `lastProcessedFrame` exactly there.
-                guard audioFile.length >= desiredStartFrame else {
-                    stallAccumSeconds += pollCadence
-                    if stallAccumSeconds >= maxStallSeconds { break }
-                    try sleepWithCancellation(seconds: pollCadence, context: ctx)
-                    continue
-                }
-
-                format = fmt
-                streamer = StreamingWindowedFingerprinter(
-                    sampleRate: UInt32(fmt.sampleRate),
-                    channels: UInt16(fmt.channelCount),
-                    windowDurationMs: FingerprintConstants.windowDurationMs,
-                    windowIntervalMs: FingerprintConstants.windowIntervalMs
-                )
-                chunkFrames = AVAudioFrameCount(fmt.sampleRate * FingerprintConstants.streamChunkSeconds)
-                guard let b = AVAudioPCMBuffer(pcmFormat: fmt, frameCapacity: chunkFrames) else {
-                    throw StreamError.bufferAllocationFailed
-                }
-                buffer = b
-                lastProcessedFrame = desiredStartFrame
-            }
-
-            guard let fmt = format, let str = streamer, let buf = buffer else { break }
-
-            let trailingMarginFrames = AVAudioFramePosition(trailingMarginSeconds * fmt.sampleRate)
-            let safeEnd = audioFile.length - trailingMarginFrames
-
-            guard lastProcessedFrame < safeEnd else {
-                stallAccumSeconds += pollCadence
-                if stallAccumSeconds >= maxStallSeconds { break }
-                try sleepWithCancellation(seconds: pollCadence, context: ctx)
-                continue
-            }
-
-            audioFile.framePosition = lastProcessedFrame
-            let framesAvailable = AVAudioFrameCount(safeEnd - lastProcessedFrame)
-            let framesToRead = min(framesAvailable, chunkFrames)
-
-            let nextChunkStartSeconds = Double(lastProcessedFrame) / fmt.sampleRate
-            try throttleIfBeyondLookahead(nextChunkStartSeconds: nextChunkStartSeconds, context: ctx)
-
-            do {
-                try audioFile.read(into: buf, frameCount: framesToRead)
-            } catch {
-                stallAccumSeconds += pollCadence
-                if stallAccumSeconds >= maxStallSeconds { break }
-                try sleepWithCancellation(seconds: pollCadence, context: ctx)
-                continue
-            }
-
-            if buf.frameLength == 0 {
-                stallAccumSeconds += pollCadence
-                if stallAccumSeconds >= maxStallSeconds { break }
-                try sleepWithCancellation(seconds: pollCadence, context: ctx)
-                continue
-            }
-
-            stallAccumSeconds = 0
-            let framesJustRead = audioFile.framePosition - lastProcessedFrame
-            lastProcessedFrame = audioFile.framePosition
-            totalFramesRead += framesJustRead
-
-            Self.interleave(buf, into: &interleaved)
-            let windows = str.pushSamplesF32(samples: interleaved, channels: UInt16(fmt.channelCount))
-            if !windows.isEmpty {
-                windowsEmitted += windows.count
-                dispatchProcessMatches(windows: windows, startOffset: startSeconds, context: ctx)
-            }
-        }
-
-        if ctx.isCancelled() { throw StreamError.cancelled }
-        if let str = streamer {
-            let tail = str.flush()
-            if !tail.isEmpty {
-                windowsEmitted += tail.count
-                dispatchProcessMatches(windows: tail, startOffset: startSeconds, context: ctx)
-            }
-        }
-
-        let readSeconds = (format.map { Double(totalFramesRead) / $0.sampleRate }) ?? 0
-        FileLog.shared.addMessage(
-            "FingerprintTimingManager: streaming grow-loop ending — "
-                + "read \(String(format: "%.1f", readSeconds))s of audio, "
-                + "emitted \(windowsEmitted) windows, "
-                + "stall accum \(String(format: "%.1f", stallAccumSeconds))s"
-        )
-    }
-
-    /// Once the streaming loop reaches EOF, persist the committed mapping to
-    /// disk if (and only if) it covers the whole reference timeline for this
-    /// audio file. The cache is then a complete replacement on next open —
-    /// `FingerprintMappingCache.save` enforces the same coverage threshold the
-    /// load path requires, keeping the round-trip safe.
-    ///
-    /// Only the snapshot read runs on `queue`; JSON encoding + disk I/O happen
-    /// on `generationQueue` so they don't stall `queue.sync` callers (the
-    /// `referenceTime(forPlaybackTime:)` / `playbackTime(forReferenceTime:)`
-    /// queries that drive transcript highlighting and tap-to-seek).
-    private func persistMappingCacheIfFull(context ctx: GenerationContext) {
-        guard !ctx.isStreaming else { return }
-        queue.async { [weak self] in
-            guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
-            let snapshot = self.main.playbackToReference
-            self.generationQueue.async {
-                FingerprintMappingCache.save(
-                    snapshot,
-                    audioFilePath: ctx.audioFileURL.path,
-                    referenceFilePath: ctx.referenceFilePath,
-                    referenceData: ctx.referenceData,
-                    referenceDuration: ctx.referenceDuration
-                )
-            }
-        }
-    }
-
-    /// Yield CPU briefly when the next chunk to fingerprint sits more than
-    /// `lookaheadSeconds` ahead of the listener's current playback time. This
-    /// keeps coverage growing to EOF — the chunk is **never** skipped — while
-    /// bounding peak CPU on long episodes the listener hasn't reached yet.
-    /// Capping the loop instead of throttling it (the prior POC-546 attempt)
-    /// dropped tail regions from the mapping and broke tap-to-seek for any cue
-    /// further than `lookaheadSeconds` ahead.
-    private func throttleIfBeyondLookahead(
-        nextChunkStartSeconds: Double,
-        context ctx: GenerationContext
-    ) throws {
-        let currentPlayback = PlaybackManager.shared.currentTime()
-        let lead = nextChunkStartSeconds - currentPlayback
-        guard lead > FingerprintConstants.lookaheadSeconds else { return }
-        try sleepWithCancellation(
-            seconds: FingerprintConstants.outsideLookaheadSleepSeconds,
-            context: ctx
-        )
-    }
-
-    /// Sleep on the generation queue in small slices so cancellation is
-    /// observed within at most one slice. Tracks remaining time rather than
-    /// ceiling-rounding the slice count so we don't oversleep the requested
-    /// duration by up to one slice (e.g. 0.21s → 0.4s).
-    private func sleepWithCancellation(seconds: TimeInterval, context ctx: GenerationContext) throws {
-        let sliceSeconds: TimeInterval = 0.2
-        var remaining = max(0, seconds)
-        while remaining > 0 {
-            if ctx.isCancelled() { throw StreamError.cancelled }
-            let sleepDuration = min(sliceSeconds, remaining)
-            Thread.sleep(forTimeInterval: sleepDuration)
-            remaining -= sleepDuration
-        }
-    }
-
-    private func dispatchProcessMatches(
-        windows: [WindowedFingerprint],
-        startOffset: Double,
-        context ctx: GenerationContext
-    ) {
-        queue.async { [weak self] in
-            guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
-            self.processMatches(windows: windows, startOffset: startOffset, context: ctx)
-        }
-    }
-
-    /// Interleaves the buffer's planar Float32 channels into `scratch`, reusing
-    /// its storage across chunks. `scratch` is resized only when the sample
-    /// count changes (in practice once, plus once more for a short final
-    /// chunk), so a decode loop allocates O(1) arrays instead of one per chunk.
-    private static func interleave(_ buffer: AVAudioPCMBuffer, into scratch: inout [Float]) {
-        let frameCount = Int(buffer.frameLength)
-        let channelCount = Int(buffer.format.channelCount)
-        guard frameCount > 0, channelCount > 0,
-              let channelData = buffer.floatChannelData else {
-            scratch.removeAll(keepingCapacity: true)
-            return
-        }
-
-        let sampleCount = frameCount * channelCount
-        if scratch.count != sampleCount {
-            scratch = [Float](repeating: 0, count: sampleCount)
-        }
-        scratch.withUnsafeMutableBufferPointer { dst in
-            guard let base = dst.baseAddress else { return }
-            if channelCount == 1 {
-                base.update(from: channelData[0], count: frameCount)
-                return
-            }
-            // Strided vector copy (add-zero) — one vDSP pass per channel
-            // instead of a scalar store per sample.
-            var zero: Float = 0
-            for ch in 0..<channelCount {
-                vDSP_vsadd(channelData[ch], 1, &zero, base + ch, vDSP_Stride(channelCount), vDSP_Length(frameCount))
-            }
-        }
-    }
-
-    private enum StreamError: Error {
-        case cancelled
-        case bufferAllocationFailed
-        /// The requested audio region isn't present in the local file yet (a
-        /// streaming episode whose buffer hasn't reached the target chapter).
-        case regionUnavailable
-    }
-
-    private func processMatches(
-        windows: [WindowedFingerprint],
-        startOffset: Double,
-        context ctx: GenerationContext
-    ) {
-        matchWindows(windows: windows, startOffset: startOffset, matcher: ctx.matcher, into: &main)
-
-        let coverage = main.playbackToReference.count
-        if coverage >= FingerprintConstants.minimumCoverageForActive {
-            updateState(.active(coverage: coverage))
-            if !hasReachedActive {
-                hasReachedActive = true
-                track(.syncedTranscriptsPreparationCompleted, properties: [
-                    "duration_ms": preparationDurationMs,
-                    "is_streaming": context?.isStreaming ?? false
-                ])
-            }
-        }
-    }
-
-    /// The core match loop shared by the continuous transcript path and the
-    /// one-shot chapter resolve: run each window through `matcher`, apply the
-    /// score/dominance gates, and route survivors through the drift filter into
-    /// `acc`. Returns the number of mappings committed this call. Mutates only
-    /// `acc` (plus `debugRejections` in DEBUG builds), so it MUST run on `queue`.
-    @discardableResult
-    private func matchWindows(
-        windows: [WindowedFingerprint],
-        startOffset: Double,
-        matcher: CheckpointMatcher,
-        into acc: inout MappingAccumulator
-    ) -> Int {
-        var inserted = 0
-        #if DEBUG
-        var bestScoreOverall: Float = 0
-        var nonZeroScoreCount = 0
-        var scoreSum: Float = 0
-        #endif
-
-        for window in windows {
-            // Pull top-2 so we can check how dominant the winner is — ambiguous
-            // wins (top-1 barely beats top-2) are the hallmark of correlated
-            // false positives from non-matching audio.
-            let matches = matcher.findTopMatches(
-                queryHashes: window.hashes,
-                maxResults: 2
-            )
-            guard let best = matches.first else { continue }
-
-            #if DEBUG
-            if best.score > 0 {
-                nonZeroScoreCount += 1
-                scoreSum += best.score
-            }
-            if best.score > bestScoreOverall { bestScoreOverall = best.score }
-            #endif
-            guard best.score >= FingerprintConstants.matchScoreThreshold else { continue }
-
-            let absolutePlaybackTime = startOffset + Double(window.timestampMs) / 1000.0
-            let candidate = TimeMappingEntry(
-                playbackTime: absolutePlaybackTime,
-                referenceTime: Double(best.timestamp),
-                score: best.score
-            )
-
-            // Pre-filter gates. Low-score and ambiguous matches are recorded as
-            // rejections so the debug overlay can visualize "matcher fired but
-            // we didn't trust it" distinctly from "matcher never fired here".
-            if best.score < FingerprintConstants.driftAnchorScoreThreshold {
-                recordRejection(candidate, reason: "low score \(String(format: "%.2f", best.score))")
-                continue
-            }
-            let runnerUpScore = matches.dropFirst().first?.score ?? 0
-            let dominance = best.score - runnerUpScore
-            if dominance < FingerprintConstants.driftScoreDominanceGap {
-                recordRejection(
-                    candidate,
-                    reason: "ambiguous top-1 vs top-2 "
-                        + "(\(String(format: "%.2f", best.score)) vs \(String(format: "%.2f", runnerUpScore)))"
-                )
-                continue
-            }
-
-            inserted += consider(candidate: candidate, into: &acc)
-        }
-
-        #if DEBUG
-        // `inserted` is the mapping count committed during this call, not a
-        // ratio to windows processed — the drift filter holds candidates in a
-        // pool across batches and can flush several at once on confirmation, so
-        // `inserted` may exceed `windows.count` (or be zero while the pool is
-        // still accumulating). Report them as independent quantities.
-        let avgNonZero = nonZeroScoreCount > 0 ? scoreSum / Float(nonZeroScoreCount) : 0
-        FileLog.shared.addMessage(
-            "FingerprintTimingManager: processed \(windows.count) windows, "
-                + "committed \(inserted) mappings "
-                + "(coverage: \(acc.playbackToReference.count), bestScore: \(String(format: "%.3f", bestScoreOverall)), "
-                + "nonZero: \(nonZeroScoreCount), avgNonZero: \(String(format: "%.3f", avgNonZero)))"
-        )
-        #endif
-        return inserted
-    }
-
-    // MARK: - Drift Filter
-
-    /// Routes a score-passing candidate through the drift filter. Returns the
-    /// number of entries actually inserted into the mapping arrays this call.
-    ///
-    /// Invariant the filter enforces:
-    /// **no anchor — bootstrap or post-jump — is admitted until we've seen
-    /// `driftBootstrapCount` consecutive rate-≈1 candidates in a row.**
-    ///
-    /// - Fast path: candidate is in-trend with `filterLastTrusted` → commit
-    ///   immediately, flush any pooled candidates as rejections (a prior jump
-    ///   attempt that didn't pan out turned out to be noise).
-    /// - Slow path: candidate goes into `filterCandidatePool`. Once the pool's
-    ///   tail is `driftBootstrapCount` consecutive consistent entries, commit
-    ///   them all and drop anything before as rejections. Otherwise evict the
-    ///   oldest and keep rolling.
-    ///
-    /// This is the same rule for the initial bootstrap (no `lastTrusted` yet)
-    /// and for post-trusted jumps, so a single lucky pair can never admit an
-    /// anchor — what the user was seeing as "jump-arounds" in the debug UI.
-    @discardableResult
-    private func consider(candidate: TimeMappingEntry, into acc: inout MappingAccumulator) -> Int {
-        if let trusted = acc.filterLastTrusted, Self.isInTrend(candidate, relativeTo: trusted) {
-            // Sequential continuation. Anything that had collected in the pool
-            // was a jump attempt that never stabilized — reject it.
-            flushPoolAsRejected(reason: "returned to trend", into: &acc)
-            insertMapping(candidate, into: &acc)
-            acc.filterLastTrusted = candidate
-            return 1
-        }
-
-        acc.filterCandidatePool.append(candidate)
-        let n = FingerprintConstants.driftBootstrapCount
-
-        guard acc.filterCandidatePool.count >= n else { return 0 }
-
-        let recent = Array(acc.filterCandidatePool.suffix(n))
-        if Self.formsConsistentSequence(recent) {
-            // Confirmed new anchor. Anything older in the pool is noise.
-            let keepStart = acc.filterCandidatePool.count - n
-            if keepStart > 0 {
-                for entry in acc.filterCandidatePool.prefix(keepStart) {
-                    recordRejection(entry, reason: "pool evicted by confirmed anchor")
-                }
-            }
-            #if DEBUG
-            FileLog.shared.addMessage(
-                "FingerprintTimingManager: drift filter confirmed anchor "
-                    + "at playback \(String(format: "%.1f", recent.first!.playbackTime))s → "
-                    + "\(String(format: "%.1f", recent.last!.playbackTime))s "
-                    + "(\(n) consistent)"
-            )
-            #endif
-            for entry in recent {
-                insertMapping(entry, into: &acc)
-            }
-            acc.filterLastTrusted = recent.last
-            acc.filterCandidatePool.removeAll()
-            return n
-        }
-
-        // Not consistent yet — evict oldest and keep waiting for the window to
-        // roll onto a consistent stretch.
-        let evicted = acc.filterCandidatePool.removeFirst()
-        recordRejection(evicted, reason: "pool evicted, no consistent run")
-        return 0
-    }
-
-    private func flushPoolAsRejected(reason: String, into acc: inout MappingAccumulator) {
-        for entry in acc.filterCandidatePool {
-            recordRejection(entry, reason: reason)
-        }
-        acc.filterCandidatePool.removeAll()
-    }
-
-    /// Two entries are in-trend when `Δreference ≈ Δplayback` (rate ≈ 1),
-    /// within `driftToleranceSeconds` of residual slack.
-    private static func isInTrend(_ candidate: TimeMappingEntry, relativeTo anchor: TimeMappingEntry) -> Bool {
-        let deltaPlayback = candidate.playbackTime - anchor.playbackTime
-        let deltaReference = candidate.referenceTime - anchor.referenceTime
-        return abs(deltaReference - deltaPlayback) <= FingerprintConstants.driftToleranceSeconds
-    }
-
-    private static func formsConsistentSequence(_ entries: [TimeMappingEntry]) -> Bool {
-        guard entries.count >= 2 else { return true }
-        for i in 1..<entries.count where !isInTrend(entries[i], relativeTo: entries[i - 1]) {
-            return false
-        }
-        return true
-    }
-
-    private func recordRejection(_ entry: TimeMappingEntry, reason: String) {
-        #if DEBUG
-        FileLog.shared.addMessage(
-            "FingerprintTimingManager: drift filter dropped \(reason) "
-                + "at playback \(String(format: "%.1f", entry.playbackTime))s "
-                + "(matched reference \(String(format: "%.1f", entry.referenceTime))s)"
-        )
-        debugRejections.append(entry)
-        if debugRejections.count > Self.debugRejectionCap {
-            debugRejections.removeFirst(debugRejections.count - Self.debugRejectionCap)
-        }
-        #endif
-    }
-
-    // MARK: - Time Mapping
-
-    /// Test seam: inserts a mapping on the manager's serial queue so queries are
-    /// consistent with production insertions that happen from within `processMatches`.
-    func insert(mapping: TimeMappingEntry) {
-        queue.sync { insertMapping(mapping, into: &main) }
-    }
-
-    /// Test seam: routes a sequence of candidates through the drift filter
-    /// synchronously on the manager's serial queue, the way `processMatches`
-    /// does in production.
-    func stubMatches(_ entries: [TimeMappingEntry]) {
-        queue.sync {
-            for entry in entries {
-                _ = consider(candidate: entry, into: &main)
-            }
-        }
-    }
-
-    private func insertMapping(_ entry: TimeMappingEntry, into acc: inout MappingAccumulator) {
-        let pbIdx = acc.playbackToReference.sortedInsertionIndex { $0.playbackTime < entry.playbackTime }
-        acc.playbackToReference.insert(entry, at: pbIdx)
-
-        let refIdx = acc.referenceToPlayback.sortedInsertionIndex { $0.referenceTime < entry.referenceTime }
-        acc.referenceToPlayback.insert(entry, at: refIdx)
-    }
-
-    static func interpolate(
+    nonisolated static func interpolate(
         time: Double,
         in entries: [TimeMappingEntry],
         keyPath: KeyPath<TimeMappingEntry, Double>,
@@ -1857,7 +904,7 @@ final class FingerprintTimingManager: NSObject {
 
     /// Whether `playbackTime` is bracketed by two committed anchors no further
     /// apart than `highlightMaxGapSeconds`. See `isWithinMatchedContent(forPlaybackTime:)`.
-    static func isWithinMatchedContent(
+    nonisolated static func isWithinMatchedContent(
         forPlaybackTime playbackTime: Double,
         in entries: [TimeMappingEntry]
     ) -> Bool {
@@ -1882,54 +929,69 @@ final class FingerprintTimingManager: NSObject {
         return gap <= FingerprintConstants.highlightMaxGapSeconds
     }
 
-    // MARK: - Helpers
-
-    private func loadReference(for episode: BaseEpisode) -> (data: Data, reference: ReferenceFingerprint)? {
-        let path = referencePath(for: episode)
-        guard let data = FileManager.default.contents(atPath: path),
-              let reference = ReferenceFingerprint.decode(from: data) else { return nil }
-        return (data, reference)
-    }
-
-    private func referencePath(for episode: BaseEpisode) -> String {
-        let audioPath = DownloadManager.shared.pathForEpisode(episode)
-        return (audioPath as NSString).deletingPathExtension + ".ref.fp.json"
-    }
-
-    private func saveReferenceData(_ data: Data, for episode: BaseEpisode) {
-        let path = referencePath(for: episode)
-        do {
-            try data.write(to: URL(fileURLWithPath: path), options: .atomic)
-            FileLog.shared.addMessage("FingerprintTimingManager: saved reference to disk for \(episode.uuid)")
-        } catch {
-            FileLog.shared.addMessage("FingerprintTimingManager: failed to save reference — \(error.localizedDescription)")
+    /// Runs `operation`, cancelling it and returning nil if it hasn't finished
+    /// within `seconds`.
+    nonisolated private static func withTimeout<T: Sendable>(
+        _ seconds: TimeInterval,
+        _ operation: @escaping @Sendable () async -> T
+    ) async -> T? {
+        await withTaskGroup(of: T?.self) { group in
+            group.addTask { await operation() }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(seconds))
+                return nil
+            }
+            // One level of optionality is the group's "no children left", the
+            // other is the timeout child reporting that it won.
+            guard let first = await group.next() else { return nil }
+            group.cancelAll()
+            return first
         }
+    }
+
+    // MARK: - Episode / Reference Helpers
+
+    /// A decoded reference plus the bytes it came from — the cache validates
+    /// against the raw bytes, so both travel together.
+    private struct DecodedReference: Sendable {
+        let data: Data
+        let fingerprint: ReferenceFingerprint
+    }
+
+    /// Captures everything the fingerprint run needs from `episode`.
+    nonisolated static func makeRequest(for episode: BaseEpisode) -> EpisodeRequest {
+        let downloadPath = DownloadManager.shared.pathForEpisode(episode)
+        let source = audioSource(for: episode, downloadPath: downloadPath)
+        return EpisodeRequest(
+            episodeUuid: episode.uuid,
+            podcastUuid: episode.parentIdentifier(),
+            duration: episode.duration,
+            audioFileURL: source.url,
+            isStreaming: source.isStreaming,
+            referenceFilePath: (downloadPath as NSString).deletingPathExtension + ".ref.fp.json"
+        )
     }
 
     /// Which local file backs the fingerprint loop for this episode.
     ///
-    /// - `.downloaded` is a complete file — the existing read-to-EOF loop handles it.
-    /// - `.streaming` points at the AVPlayer-written buffer, which may be absent at
-    ///   call time or still growing. The grow-loop waits for it to appear and
-    ///   polls for new bytes.
-    private enum AudioSource {
-        case downloaded(URL)
-        case streaming(URL)
-    }
-
-    private func resolveAudioSource(for episode: BaseEpisode) -> AudioSource {
-        let downloadPath = DownloadManager.shared.pathForEpisode(episode)
+    /// - A complete file (downloaded, or fully stream-cached) reads to EOF.
+    /// - A streaming buffer may be absent at call time or still growing, so the
+    ///   grow-loop waits for it to appear and polls for new bytes.
+    nonisolated private static func audioSource(
+        for episode: BaseEpisode,
+        downloadPath: String
+    ) -> (url: URL, isStreaming: Bool) {
         if FileManager.default.fileExists(atPath: downloadPath) {
-            return .downloaded(URL(fileURLWithPath: downloadPath))
+            return (URL(fileURLWithPath: downloadPath), false)
         }
         // A stream-downloaded episode keeps a complete file at the streaming
         // buffer path. It isn't growing, so route it through the one-shot
-        // fingerprint path instead of the grow-loop — same path trunk took.
+        // fingerprint path instead of the grow-loop.
         if let episode = episode as? Episode,
            episode.streamDownloaded(pathFinder: DownloadManager.shared) {
             let streamingPath = DownloadManager.shared.streamingBufferPathForEpisode(episode)
             if FileManager.default.fileExists(atPath: streamingPath) {
-                return .downloaded(URL(fileURLWithPath: streamingPath))
+                return (URL(fileURLWithPath: streamingPath), false)
             }
         }
         // Active streaming: the file is either absent or still growing.
@@ -1940,45 +1002,97 @@ final class FingerprintTimingManager: NSObject {
         let tempPath = DownloadManager.shared.tempPathForEpisode(episode)
         let streamingPath = DownloadManager.shared.streamingBufferPathForEpisode(episode)
         if FileManager.default.fileExists(atPath: tempPath) {
-            return .streaming(URL(fileURLWithPath: tempPath))
+            return (URL(fileURLWithPath: tempPath), true)
         }
         if FileManager.default.fileExists(atPath: streamingPath) {
-            return .streaming(URL(fileURLWithPath: streamingPath))
+            return (URL(fileURLWithPath: streamingPath), true)
         }
         let preferred = FeatureFlag.streamAndCachePlayingEpisode.enabled ? tempPath : streamingPath
-        return .streaming(URL(fileURLWithPath: preferred))
-    }
-}
-
-// MARK: - Cancellation
-
-private final class CancellationFlag {
-    private let lock = NSLock()
-    private var cancelled = false
-
-    var isCancelled: Bool {
-        lock.withLock { cancelled }
+        return (URL(fileURLWithPath: preferred), true)
     }
 
-    func cancel() {
-        lock.withLock { cancelled = true }
+    /// Reference resolution shared by both one-shot resolves: warm context →
+    /// disk → server.
+    nonisolated private func resolveReference(for request: EpisodeRequest, warm: Data?) async -> DecodedReference? {
+        if let warm, let decoded = await Self.decodeReference(warm) { return decoded }
+        if let onDisk = await Self.loadReference(atPath: request.referenceFilePath) { return onDisk }
+
+        guard let data = await FingerprintReferenceRetriever.shared.fetchReferenceData(
+            podcastUuid: request.podcastUuid,
+            episodeUuid: request.episodeUuid
+        ) else { return nil }
+
+        await Self.saveReference(data, toPath: request.referenceFilePath, episodeUuid: request.episodeUuid)
+        return await Self.decodeReference(data)
     }
-}
 
-// MARK: - Array Sorted Insertion
+    nonisolated private static func loadReference(atPath path: String) async -> DecodedReference? {
+        guard let data = FileManager.default.contents(atPath: path),
+              let fingerprint = ReferenceFingerprint.decode(from: data) else { return nil }
+        return DecodedReference(data: data, fingerprint: fingerprint)
+    }
 
-private extension Array {
-    func sortedInsertionIndex(isOrderedBefore: (Element) -> Bool) -> Int {
-        var lo = 0
-        var hi = count
-        while lo < hi {
-            let mid = (lo + hi) / 2
-            if isOrderedBefore(self[mid]) {
-                lo = mid + 1
-            } else {
-                hi = mid
-            }
+    nonisolated private static func decodeReference(_ data: Data) async -> DecodedReference? {
+        guard let fingerprint = ReferenceFingerprint.decode(from: data) else { return nil }
+        return DecodedReference(data: data, fingerprint: fingerprint)
+    }
+
+    nonisolated private static func saveReference(_ data: Data, toPath path: String, episodeUuid: String) async {
+        do {
+            try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+            FileLog.shared.addMessage("FingerprintTimingManager: saved reference to disk for \(episodeUuid)")
+        } catch {
+            FileLog.shared.addMessage("FingerprintTimingManager: failed to save reference — \(error.localizedDescription)")
         }
-        return lo
+    }
+
+    nonisolated private static func loadCachedSnapshot(
+        audioFilePath: String,
+        referenceFilePath: String,
+        referenceData: Data
+    ) async -> MappingSnapshot? {
+        guard let cached = FingerprintMappingCache.load(
+            audioFilePath: audioFilePath,
+            referenceFilePath: referenceFilePath,
+            referenceData: referenceData
+        ) else { return nil }
+        // The cache is produced from `playbackToReference` (already sorted by
+        // `playbackTime`), so assign it directly and sort once for the
+        // reference-keyed view — avoids the O(n²) cost of routing every entry
+        // through `MappingSnapshot.insert`'s per-entry `Array.insert`.
+        return MappingSnapshot(
+            playbackToReference: cached.entries,
+            referenceToPlayback: cached.entries.sorted { $0.referenceTime < $1.referenceTime }
+        )
+    }
+
+    nonisolated private static func persistMappingCache(
+        _ entries: [TimeMappingEntry],
+        request: EpisodeRequest,
+        referenceData: Data,
+        referenceDuration: Double
+    ) async {
+        FingerprintMappingCache.save(
+            entries,
+            audioFilePath: request.audioFileURL.path,
+            referenceFilePath: request.referenceFilePath,
+            referenceData: referenceData,
+            referenceDuration: referenceDuration
+        )
+    }
+
+    // MARK: - Test Seams
+
+    /// Inserts a mapping directly, the way a committed match would.
+    func insert(mapping: TimeMappingEntry) {
+        main.snapshot.insert(mapping)
+    }
+
+    /// Routes a sequence of candidates through the drift filter, the way
+    /// `commit` does in production.
+    func stubMatches(_ entries: [TimeMappingEntry]) {
+        for entry in entries {
+            main.consider(entry)
+        }
     }
 }

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -1105,6 +1105,26 @@ final class FingerprintTimingManager: NSObject {
             await manager.streamTask?.value
         }
 
+        /// Resolves a chapter's reference time against an explicit request, the way
+        /// `resolvePlaybackTime(forReferenceTime:episode:completion:)` does past its
+        /// timeout and supersede handling.
+        func resolveChapter(request: EpisodeRequest, referenceTime: Double) async -> ChapterSeekResult {
+            await manager.performResolve(request: request, referenceTime: referenceTime, kind: .chapter)
+        }
+
+        /// The same for a bookmark, which differs only in waiting for a streaming
+        /// buffer to reach the search window.
+        func resolveBookmark(request: EpisodeRequest, referenceTime: Double) async -> ChapterSeekResult {
+            await manager.performResolve(request: request, referenceTime: referenceTime, kind: .bookmark)
+        }
+
+        /// Resolves a playback position back onto the reference timeline, the way
+        /// `resolveReferenceTime(forPlaybackTime:episode:)` does when the continuous
+        /// mapping can't already answer it.
+        func resolveReference(request: EpisodeRequest, playbackTime: Double) async -> Double? {
+            await manager.performReferenceResolve(request: request, playbackTime: playbackTime, startDate: Date())
+        }
+
         /// Inserts a mapping directly, the way a committed match would.
         func insert(mapping: TimeMappingEntry) {
             manager.main.snapshot.insert(mapping)

--- a/podcasts/Fingerprint/GeneratedChapterSeeker.swift
+++ b/podcasts/Fingerprint/GeneratedChapterSeeker.swift
@@ -14,6 +14,7 @@ enum GeneratedChapterSeeker {
 
     /// Whether generated-chapter navigation should resolve via fingerprinting
     /// rather than seeking to the raw reference start.
+    @MainActor
     static var isEnabled: Bool {
         FeatureFlag.generatedChapters.enabled
             && FeatureFlag.syncedTranscripts.enabled
@@ -30,6 +31,7 @@ enum GeneratedChapterSeeker {
     ///   list starts playback on a tap, the player's skip buttons don't.
     ///
     /// Must be called on the main queue.
+    @MainActor
     static func seek(
         to chapter: ChapterInfo,
         startPlayback: Bool,


### PR DESCRIPTION
Moves the fingerprint timing subsystem off GCD and onto Swift Concurrency, which clears the 13 concurrency warnings in `FingerprintTimingManager` and removes a main-thread stall.

`FingerprintTimingManager` becomes a `@MainActor` that owns only the mapping and the state machine. The background work moves onto two actors:

- **`FingerprintStreamProcessor`** — the continuous transcript pass. Owns the episode's `CheckpointMatcher`, stream-decodes the local file, and hands each batch of scored candidates back to the main actor to commit.
- **`FingerprintRegionProcessor`** — the bounded one-shot resolves (chapter taps and bookmarks). Matches into a local scratch accumulator, so nothing the highlighter depends on is ever touched.

Supporting value types were hoisted out of the manager into `FingerprintMapping.swift` and `FingerprintMatching.swift` so the actors can share them. The manager drops from 1984 to 1098 lines. Gone: `queue`, `generationQueue`, `onDemandQueue`, the `NSLock`-backed `CancellationFlag`, `dispatchPrecondition`, and the sliced `Thread.sleep` — cancellation is now `Task` cancellation, observed once per decoded chunk.

Two stalls fall out of it: the 60 Hz highlight tick no longer `queue.sync`s behind a whole match batch, and `PlaybackManager.currentTime()` is no longer read from the decode thread.

### Also fixes: every completed pass ended in failure

`AVAudioFile.read` throws at EOF rather than returning zero frames (reproduced on WAV and AAC), so `runComplete`'s `while true` loop always exited through the error path instead of its `break`. The tail flush was lost, the terminal state was `.failed` rather than `.unavailable`, and `persistMappingCache` never ran — so the mapping cache was never written for a downloaded episode and the "skip the stream, load from cache" path could never fire at all. Pre-existing, not a refactor regression. The loop is now bounded by the file's length; a genuine mid-file read failure still throws.

### Tests

26 new tests, 63 in the fingerprint suite. They synthesize an episode's audio and build its reference fingerprint from that same audio, then run the real pipeline — decode, matcher, score and dominance gates, drift filter — so the expected mapping is exact and drift fails an assertion rather than looking plausible. Covers the dynamic-ad case the subsystem exists for (an ad spliced into the listener's copy shifts the mapping by exactly its length, and highlighting stops while it plays), both one-shot resolves, the mapping-cache round trip, teardown, and the preparation guards. Plus unit tests for reference decoding and the PCM interleave.

### Behaviour changes

Otherwise a mechanical port, with a few deltas worth knowing about:

- A timed-out one-shot resolve now cancels the in-flight reference download. `FingerprintReferenceRetriever` dedupes by episode, so if transcript preparation is waiting on the same fetch it gets cancelled too and falls through to `.unavailable`. Narrow (needs no on-disk reference plus a concurrent chapter tap), but the old flag-based timeout never cancelled a `Task`. Happy to fix here if you'd rather not ship it.
- A chapter resolve that fails on "no usable checkpoints" now reports the real `is_streaming` instead of a hardcoded `false`.
- State transitions are synchronous instead of `DispatchQueue.main.async`, so `state` is correct immediately after `prepareForCurrentEpisode()` / `stop()`.
- DEBUG only: one-shot resolves no longer push their rejected candidates into the debug overlay.

Untouched: the drift filter, the score and dominance gates, `interpolate`, `isWithinMatchedContent`, `searchWindow`, the mapping cache format, the streaming grow-loop's stall logic, and every analytics event name.

## To test

Needs the `syncedTranscripts` feature flag on, plus `generatedChapters` for step 4.

1. Open a **downloaded** episode's transcript. It should reach the highlighted state and track playback as before. Scroll while it prepares — scrolling should stay smooth (this is the `queue.sync` that's gone).
2. Seek forward 5+ minutes mid-episode. Highlighting should drop out, then re-anchor at the new position within a few seconds.
3. Open the transcript for an episode that is **still streaming** (not downloaded). It should pick up the growing buffer and start highlighting once enough audio has arrived.
4. Open the chapters list on an episode with generated chapters and tap a chapter. It should seek to the right spot in the audio, not the raw reference time. Tap a second chapter while the first is still resolving — the second one wins and the first never seeks.
5. Tap a bookmark on an episode that isn't downloaded yet. Playback should start at the bookmarked content once the buffer reaches it.
6. Play a downloaded episode's transcript to the end, then close and reopen it — the second open should be instant (the mapping cache now actually gets written).
7. Close the transcript mid-preparation, then reopen it. No stuck spinner, no crash.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
