### PR TITLE
Support HLS video in Discover episodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - [tvOS] Add support for regular episode lists. [#4852](https://github.com/Automattic/pocket-casts-ios/pull/4852)
 - [tvOS] Fix episode count on smart playlists [#4905](https://github.com/Automattic/pocket-casts-ios/pull/#4905)
 - Fix a crash when the sign in prompt was shown while another screen was still being dismissed [#4903](https://github.com/Automattic/pocket-casts-ios/pull/4903)
+- [tvOS] Add support server driven home page layout [#4854](https://github.com/Automattic/pocket-casts-ios/pull/4854)
+- [tvOS] Add support for HLS episodes previews in episodes video list [#4921](https://github.com/Automattic/pocket-casts-ios/pull/4921)
 
 8.17
 -----

--- a/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -553,20 +553,21 @@ public struct DiscoverEpisode: Decodable {
 }
 
 public struct DiscoverAlternateEnclosure: Decodable {
-    let type: String
-    let sources: [DiscoverEnclosureSource]
-}
+    public struct Source: Decodable {
+        let uri: String
+    }
 
-public struct DiscoverEnclosureSource: Decodable {
-    let uri: String
+    let type: String
+    let sources: [Source]
 }
 
 extension DiscoverEpisode {
 
-    public var videoURL: String? {
-        let videoTypes = Set(["video/mp4", "application/x-mpegURL", "application/mpegURL"])
+    static let supportedVideoTypes = Set(["video/mp4", "application/x-mpegURL", "application/mpegURL"])
 
-        if let url, let fileType, videoTypes.contains(fileType) {
+    public var videoURL: String? {
+
+        if let url, let fileType, Self.supportedVideoTypes.contains(fileType) {
             //if the default url is already a video use it
             return url
         }
@@ -576,7 +577,7 @@ extension DiscoverEpisode {
         }
 
         let videoEnclosures = alternateEnclosures.filter { enclosure in
-            videoTypes.contains(enclosure.type) && !enclosure.sources.isEmpty
+            Self.supportedVideoTypes.contains(enclosure.type.lowercased()) && !enclosure.sources.isEmpty
         }
 
         return videoEnclosures.first?.sources.first?.uri

--- a/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -569,7 +569,7 @@ public struct DiscoverAlternateEnclosure: Decodable {
 
 extension DiscoverEpisode {
 
-    static let supportedVideoTypes = Set(["video/mp4", "application/x-mpegURL", "application/mpegURL"])
+    static let supportedVideoTypes = Set(["video/mp4", "application/x-mpegURL", "application/mpegURL"].map { $0.lowercased() })
 
     public var videoURL: String? {
 

--- a/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -514,6 +514,8 @@ public struct DiscoverEpisode: Decodable {
 
         case podcastUuid = "podcast_uuid"
         case podcastTitle = "podcast_title"
+        case alternateEnclosures = "alternate_enclosures"
+        case fileType = "file_type"
     }
 
     public let title: String?
@@ -523,16 +525,18 @@ public struct DiscoverEpisode: Decodable {
     public let podcastUuid: String?
     public let podcastTitle: String?
     public let type: String?
+    public let fileType: String?
     public let published: Date?
     public let season: Int?
     public let number: Int?
+    public let alternateEnclosures: [DiscoverAlternateEnclosure]?
 
     public var isTrailer: Bool {
         guard let type else { return false }
         return type == "trailer"
     }
 
-    public init(uuid: String, title: String? = nil, duration: Int? = nil, url: String? = nil, podcastUuid: String? = nil, podcastTitle: String? = nil, type: String? = nil, published: Date? = nil, season: Int? = nil, number: Int? = nil) {
+    public init(uuid: String, title: String? = nil, duration: Int? = nil, url: String? = nil, podcastUuid: String? = nil, podcastTitle: String? = nil, type: String? = nil, published: Date? = nil, season: Int? = nil, number: Int? = nil, fileType: String? = nil, alternateEnclosures: [DiscoverAlternateEnclosure]? = nil) {
         self.uuid = uuid
         self.title = title
         self.duration = duration
@@ -543,5 +547,38 @@ public struct DiscoverEpisode: Decodable {
         self.published = published
         self.season = season
         self.number = number
+        self.fileType = fileType
+        self.alternateEnclosures = alternateEnclosures
+    }
+}
+
+public struct DiscoverAlternateEnclosure: Decodable {
+    let type: String
+    let sources: [DiscoverEnclosureSource]
+}
+
+public struct DiscoverEnclosureSource: Decodable {
+    let uri: String
+}
+
+extension DiscoverEpisode {
+
+    public var videoURL: String? {
+        let videoTypes = Set(["video/mp4", "application/x-mpegURL", "application/mpegURL"])
+
+        if let url, let fileType, videoTypes.contains(fileType) {
+            //if the default url is already a video use it
+            return url
+        }
+
+        guard let alternateEnclosures else {
+            return url
+        }
+
+        let videoEnclosures = alternateEnclosures.filter { enclosure in
+            videoTypes.contains(enclosure.type) && !enclosure.sources.isEmpty
+        }
+
+        return videoEnclosures.first?.sources.first?.uri
     }
 }

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -37,6 +37,7 @@ struct DiscoverVideoEpisodeCell: View {
         Button {
             trackEpisodeTapped()
             Task {
+                AnalyticsPlaybackHelper.shared.currentSource = AnalyticsSource(rawValue: source)
                 let successPlay = await TVDataManager.shared.playEpisode(model.episode)
                 await MainActor.run {
                     if successPlay {

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -51,7 +51,7 @@ class DiscoverVideoEpisodeModel {
     }
 
     func load() async {
-        guard let urlString = episode.url, let videoUrl = URL(string: urlString) else {
+        guard let urlString = episode.videoURL, let videoUrl = URL(string: urlString) else {
             return
         }
 
@@ -101,7 +101,7 @@ class DiscoverVideoEpisodeModel {
     private var isFadePausing: Bool { fadeTimer != nil }
 
     private func setupPlayer() {
-        guard let urlString = episode.url, let videoUrl = URL(string: urlString) else {
+        guard let urlString = episode.videoURL, let videoUrl = URL(string: urlString) else {
             return
         }
         player = AVPlayer(url: videoUrl)

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -52,10 +52,11 @@ class DiscoverVideoEpisodeModel {
 
     func load() async {
         guard let urlString = episode.videoURL, let videoUrl = URL(string: urlString) else {
+            FileLog.shared.addMessage("[DiscoverVideoEpisodeModel] Failed to get a video url for episode \(episode.uuid ?? "unknown")")
             return
         }
 
-        setupPlayer()
+        setupPlayer(for: videoUrl)
 
         do {
             let videoFrame: UIImage
@@ -100,10 +101,7 @@ class DiscoverVideoEpisodeModel {
 
     private var isFadePausing: Bool { fadeTimer != nil }
 
-    private func setupPlayer() {
-        guard let urlString = episode.videoURL, let videoUrl = URL(string: urlString) else {
-            return
-        }
+    private func setupPlayer(for videoUrl: URL) {
         player = AVPlayer(url: videoUrl)
 
         let interval = CMTime(seconds: 0.5, preferredTimescale: 600)


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes [POC-794](https://linear.app/a8c/issue/POC-794/ios-add-support-for-alternate-enclosures-in-episode-lists)<!-- issue number, if applicable -->

<img width="977" height="334" alt="Screenshot 2026-08-07 at 16 02 45" src="https://github.com/user-attachments/assets/dcfc2ddb-1a8c-40ef-8db7-48e92eaa31cc" />


Adds support for HLS (and other) video streams in the tvOS Discover video episode previews.

Previously the Discover video preview always used the episode's default `url`, which fails when the playable video lives in the feed's `alternate_enclosures` (e.g. HLS `application/x-mpegURL` streams) rather than the default enclosure. This PR:

- Extends `DiscoverEpisode` (Server module) with the `file_type` and `alternate_enclosures` fields returned by the Discover API, backed by new `DiscoverAlternateEnclosure` / nested `Source` types kept separate from the refresh models.
- Adds a `videoURL` computed property that returns the default `url` when it is already a video type, otherwise falls back to the first video enclosure found in `alternate_enclosures`.
- Updates the tvOS `DiscoverVideoEpisodeModel` to load and play `episode.videoURL` instead of the raw `episode.url`.

## To test

Use the staging enviroment to test

1. On tvOS, open the Search tab and navigate to the bottom until you see the Made for TV HLS row
2. Navigate to a featured/discover row that contains video episodes, including a podcast whose episode only exposes an HLS (`application/x-mpegURL`) stream via `alternate_enclosures`.
3. Focus the video episode cell and confirm the video preview loads and plays.
4. Confirm episodes whose default `url` is already a video still play as before.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
