### PR TITLE
Log analytics events to the log file only

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -2,6 +2,23 @@ import Combine
 import Foundation
 import os
 
+/// The destinations a log message can be written to.
+public struct LogDestination: OptionSet, Sendable {
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    /// The rotating log file, which is what gets uploaded with support requests.
+    public static let file = LogDestination(rawValue: 1 << 0)
+
+    /// The unified logging system, visible in Console and Xcode.
+    public static let console = LogDestination(rawValue: 1 << 1)
+
+    public static let all: LogDestination = [.file, .console]
+}
+
 actor LogBuffer {
     private let bufferThreshold: UInt
 
@@ -33,11 +50,14 @@ actor LogBuffer {
         private let maxFileSize = 1.megabytes
     #endif
 
-    func append(_ message: String, date: Date) {
-        // if it's important enough to log to file, write it to the debug console as well
-        logger?.log("\(message, privacy: .public)")
+    func append(_ message: String, date: Date, to destinations: LogDestination = .all) {
+        if destinations.contains(.console) {
+            logger?.log("\(message, privacy: .public)")
+        }
 
-        logBuffer.append(LogEntry(message, timestamp: date))
+        if destinations.contains(.file) {
+            logBuffer.append(LogEntry(message, timestamp: date))
+        }
     }
 
     func console(_ message: String) {
@@ -125,9 +145,14 @@ public final class FileLog {
         self.logBuffer = LogBuffer(logPersistence: logPersistence, logRotator: logRotator, bufferThreshold: bufferThreshold, loggingTo: logger)
     }
 
-    public func addMessage(_ message: String, date: Date = Date()) {
+    /// Writes the message to the given destinations.
+    ///
+    /// By default a message is written everywhere: if it's important enough to log to file,
+    /// it's worth having in the debug console as well. Pass `.file` to opt out of the console
+    /// copy when the caller already logs to the unified logging system itself.
+    public func addMessage(_ message: String, date: Date = Date(), to destinations: LogDestination = .all) {
         Task {
-            await logBuffer.append(message, date: date)
+            await logBuffer.append(message, date: date, to: destinations)
             publisher.send(message)
         }
     }

--- a/podcasts/Analytics/Adapters/AnalyticsLoggingAdapter.swift
+++ b/podcasts/Analytics/Adapters/AnalyticsLoggingAdapter.swift
@@ -1,7 +1,10 @@
 import Foundation
 import PocketCastsUtils
 
-/// Simple tracking adapter that just logs the event
+/// Simple tracking adapter that writes the event to the log file.
+///
+/// The unified logging system is covered by ``AnalyticsOSLogAdapter``, so events
+/// are never echoed to the console from here.
 struct AnalyticsLoggingAdapter: AnalyticsAdapter {
     func track(name: String, properties: [String: Sendable]) async {
         guard FeatureFlag.tracksLogging.enabled else { return }
@@ -14,6 +17,6 @@ struct AnalyticsLoggingAdapter: AnalyticsAdapter {
     }
 
     private func log(_ message: String) {
-        FileLog.shared.addMessage(message)
+        FileLog.shared.addMessage(message, to: .file)
     }
 }


### PR DESCRIPTION
`AnalyticsLoggingAdapter` wrote to both the log file and the console, duplicating `AnalyticsOSLogAdapter`. It now writes to the file only, via a new `LogDestination` OptionSet on `FileLog.addMessage` (defaults to `.all`, so existing call sites are unchanged).

**Note**: this is based on the recent thread in dev-ios.

## To test

1. Run a debug build and enable the `tracksLogging` feature flag.
2. In Console, filter on `subsystem:au.com.shiftyjelly.podcasts category:Analytics` and navigate the app — each `🔵 Tracked:` event should appear once, not twice.
3. Export the logs from Settings → Help & Feedback and confirm the `🔵 Tracked:` lines are still there.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
