### PR TITLE
Clean up unreachable switch case and unused var

### DIFF
--- a/Pocket Casts TV App/Data/MockData.swift
+++ b/Pocket Casts TV App/Data/MockData.swift
@@ -276,7 +276,7 @@ struct MockData {
         let urls: [String] = ["https://pscrb.fm/rss/p/mgln.ai/e/294/cdn.twit.tv/video/twit/twit1086/twit1086_h264m_1920x1080.mp4", "https://download.ted.com/products/87704.mp4?apikey=172BB350-0009", "https://dtns.muffincdn.com/DTNS20260528.mp4"]
 
         for (index, uuid) in podcastsUuids.enumerated() {
-            var episode = DiscoverEpisode(uuid: episodesUuid[index], title: episodesTitle[index], duration: 600, url: urls[index], podcastUuid: uuid, podcastTitle: podcastsNames[index], type: nil, published: Date.now, season: 0, number: 0)
+            let episode = DiscoverEpisode(uuid: episodesUuid[index], title: episodesTitle[index], duration: 600, url: urls[index], podcastUuid: uuid, podcastTitle: podcastsNames[index], type: nil, published: Date.now, season: 0, number: 0)
 
             result.append(episode)
         }

--- a/podcasts/Podcasts/Podcast Page/BookmarkListController.swift
+++ b/podcasts/Podcasts/Podcast Page/BookmarkListController.swift
@@ -256,9 +256,6 @@ final class BookmarkListController {
                     .padding(.top, showsSearch ? 0 : BookmarksTabConstants.emptyRowTopPadding)
                     .environmentObject(listViewModel)
             }
-
-        case nil:
-            return UITableViewCell()
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Two small compiler-warning cleanups, no behavior change:

- `BookmarkListController.cell(_:for:)` guards the row out of `rows[safe:]` before switching on it, so the `case nil` branch was unreachable leftover from when the switch ran on the optional subscript directly. `Row` has two cases, so the switch stays exhaustive without it.
- `MockData` declared a never-mutated `DiscoverEpisode` as `var`; now a `let`.

## To test

1. Open a podcast with bookmarks and go to the Bookmarks tab — bookmark rows render as before.
2. Open a podcast with no bookmarks — the empty row renders as before.
3. Search within the bookmarks tab and confirm the search header and filtered rows still render.
4. Build the TV app target and confirm it compiles without the "variable was never mutated" warning.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
