### PR TITLE
[tvOS] Add a Top Results section to search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix the podcast screen tabs being clipped when scrolled [#4918](https://github.com/Automattic/pocket-casts-ios/pull/4918)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
+- [tvOS] Add a Top Results tab to Search, now the default, showing a Featured row of matching video episodes followed by Episodes and Podcasts rows. The Episodes tab leads with the same Featured row whenever a search turns up video episodes
 
 8.18
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fix the podcast screen tabs being clipped when scrolled [#4918](https://github.com/Automattic/pocket-casts-ios/pull/4918)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
-- [tvOS] Add a Top Results tab to Search, now the default, showing a Featured row of matching video episodes followed by Episodes and Podcasts rows. The Episodes tab leads with the same Featured row whenever a search turns up video episodes
+- [tvOS] Add a Top Results tab to Search, now the default, showing a Featured row of matching video episodes followed by Episodes and Podcasts rows. The Episodes tab leads with the same Featured row whenever a search turns up video episodes [#4926](https://github.com/Automattic/pocket-casts-ios/pull/4926)
 
 8.18
 -----

--- a/Modules/Sources/PocketCastsServer/Public/Search/CombinedSearchTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Search/CombinedSearchTask.swift
@@ -19,19 +19,24 @@ public struct CombinedSearchResult: Decodable, Hashable {
     public let podcastTitle: String?
     public let author: String?
     public let explicit: Bool?
+    public let isVideo: Bool?
+    public let hasVideo: Bool?
+    public let videoUrl: String?
 
     public var resolvedResultType: CombinedSearchResultType? {
         switch type {
-            case "podcast":
-                guard let podcast = PodcastFolderSearchResult(from: self) else {
-                    return nil
-                }
-                return .podcast(podcast)
-            case "episode":
-            let episode = EpisodeSearchResult(uuid: self.uuid, title: self.title, publishedDate: self.publishedDate ?? Date.now, state: .normal, duration: duration, podcastUuid: self.podcastUuid ?? "", podcastTitle: self.podcastTitle ?? "")
-                return .episode(episode)
-            default:
+        case "podcast":
+            guard let podcast = PodcastFolderSearchResult(from: self) else {
                 return nil
+            }
+            return .podcast(podcast)
+        case "episode":
+            guard let episode = EpisodeSearchResult(from: self) else {
+                return nil
+            }
+            return .episode(episode)
+        default:
+            return nil
         }
     }
 }

--- a/Modules/Sources/PocketCastsServer/Public/Search/EpisodeSearchResult.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Search/EpisodeSearchResult.swift
@@ -8,8 +8,14 @@ public struct EpisodeSearchResult: Codable, Hashable {
     public let podcastUuid: String
     public let podcastTitle: String
     public let state: State?
+    public let hasVideo: Bool
+    public let videoURL: URL?
 
-    public init(uuid: String, title: String, publishedDate: Date, state: State? = nil, duration: Double? = nil, podcastUuid: String, podcastTitle: String) {
+    enum CodingKeys: String, CodingKey {
+        case uuid, title, publishedDate, duration, podcastUuid, podcastTitle, state, hasVideo, videoURL
+    }
+
+    public init(uuid: String, title: String, publishedDate: Date, state: State? = nil, duration: Double? = nil, podcastUuid: String, podcastTitle: String, hasVideo: Bool = false, videoURL: URL? = nil) {
         self.uuid = uuid
         self.title = title
         self.publishedDate = publishedDate
@@ -17,6 +23,36 @@ public struct EpisodeSearchResult: Codable, Hashable {
         self.duration = duration
         self.podcastUuid = podcastUuid
         self.podcastTitle = podcastTitle
+        self.hasVideo = hasVideo
+        self.videoURL = videoURL
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.uuid = try container.decode(String.self, forKey: .uuid)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.publishedDate = try container.decode(Date.self, forKey: .publishedDate)
+        self.duration = try? container.decodeIfPresent(Double.self, forKey: .duration)
+        self.podcastUuid = try container.decode(String.self, forKey: .podcastUuid)
+        self.podcastTitle = try container.decode(String.self, forKey: .podcastTitle)
+        self.state = try? container.decodeIfPresent(State.self, forKey: .state)
+        self.hasVideo = (try? container.decodeIfPresent(Bool.self, forKey: .hasVideo)) ?? false
+        self.videoURL = try? container.decodeIfPresent(URL.self, forKey: .videoURL)
+    }
+
+    public init?(from combinedResult: CombinedSearchResult) {
+        guard combinedResult.type == "episode" else {
+            return nil
+        }
+        self.uuid = combinedResult.uuid
+        self.title = combinedResult.title
+        self.publishedDate = combinedResult.publishedDate ?? Date()
+        self.state = .normal
+        self.duration = combinedResult.duration
+        self.podcastUuid = combinedResult.podcastUuid ?? ""
+        self.podcastTitle = combinedResult.podcastTitle ?? ""
+        self.hasVideo = combinedResult.hasVideo ?? false
+        self.videoURL = combinedResult.videoUrl.flatMap { URL(string: $0) }
     }
 
     public enum State: Codable {

--- a/Modules/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Search/PodcastSearchTask.swift
@@ -25,9 +25,10 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
     public let kind: Kind
     public var isLocal: Bool?
     public var explicit: Bool?
+    public var isVideo: Bool?
 
     enum CodingKeys: String, CodingKey {
-        case uuid, title, author, kind, isLocal, explicit
+        case uuid, title, author, kind, isLocal, explicit, isVideo
     }
 
     public init(from decoder: Decoder) throws {
@@ -38,6 +39,7 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
         self.kind = (try? container.decodeIfPresent(Kind.self, forKey: .kind)) ?? .podcast
         self.isLocal = (try? container.decode(Bool.self, forKey: .isLocal)) ?? false
         self.explicit = try? container.decodeIfPresent(Bool.self, forKey: .explicit)
+        self.isVideo = try? container.decodeIfPresent(Bool.self, forKey: .isVideo)
     }
 
     public init?(from podcast: Podcast) {
@@ -47,6 +49,7 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
         self.isLocal = true
         self.kind = .podcast
         self.explicit = podcast.isExplicit
+        self.isVideo = nil
     }
 
     public init?(from folder: Folder) {
@@ -56,6 +59,7 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
         self.isLocal = true
         self.kind = .folder
         self.explicit = false
+        self.isVideo = false
     }
 
     public init?(from predictiveResult: PredictiveSearchResult) {
@@ -67,6 +71,7 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
                 self.kind = .podcast
                 self.isLocal = false
                 self.explicit = podcast.isExplicit
+                self.isVideo = nil
             default:
                 return nil
         }
@@ -82,6 +87,7 @@ public struct PodcastFolderSearchResult: Codable, Hashable {
         self.kind = .podcast
         self.isLocal = false
         self.explicit = combinedResult.explicit
+        self.isVideo = combinedResult.isVideo
     }
 
     public enum Kind: Codable {

--- a/Pocket Casts TV App/Analytics/SearchAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/SearchAnalytics.swift
@@ -1,0 +1,26 @@
+import PocketCastsServer
+
+/// Centralizes the tvOS `search_result_tapped` event so every surface that renders a
+/// search result — the grids, the `Top Results` rows and the `Featured` row — reports
+/// the same `result_type` for the same kind of result.
+enum SearchAnalytics {
+
+    static let source = "search"
+
+    static func episodeTapped(_ episode: EpisodeSearchResult) {
+        AnalyticsPlaybackHelper.shared.currentSource = .search
+        Analytics.track(.searchResultTapped, properties: [
+            "source": source,
+            "uuid": episode.uuid,
+            "result_type": "episode"
+        ])
+    }
+
+    static func podcastTapped(_ podcast: PodcastFolderSearchResult) {
+        Analytics.track(.searchResultTapped, properties: [
+            "source": source,
+            "uuid": podcast.uuid,
+            "result_type": podcast.isLocal == true ? "podcast_local_result" : "podcast_remote_result"
+        ])
+    }
+}

--- a/Pocket Casts TV App/UI/Common/PodcastCoverCard.swift
+++ b/Pocket Casts TV App/UI/Common/PodcastCoverCard.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+/// The square podcast cover used by the horizontal rows on Home, Discover and Search.
+/// Reads focus from the environment, so it can be dropped straight into a
+/// `NavigationLink` / `Button` label without the call site tracking focus itself.
+struct PodcastCoverCard: View {
+
+    enum Layout {
+        static let size = CGFloat(250)
+        static let cornerRadius = CGFloat(12)
+    }
+
+    let uuid: String
+    var size: CGFloat = Layout.size
+
+    var body: some View {
+        PodcastImage(uuid: uuid, size: .page)
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous))
+            .focusedCardDepth(cornerRadius: Layout.cornerRadius, style: .surface)
+    }
+}

--- a/Pocket Casts TV App/UI/Discover/DiscoverEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverEpisodeCell.swift
@@ -9,6 +9,10 @@ struct DiscoverEpisodeCell: View {
     private let listId: String?
     private let source: String
 
+    /// Fires just before playback starts, for screens that reuse the cell outside
+    /// Discover and need to record their own tap (search results, for instance).
+    private let onTap: (() -> Void)?
+
     @State private var showNotesEpisode: DiscoveryLoadedEpisode?
     @State private var showNowPlayingPlayer: Bool = false
 
@@ -18,10 +22,11 @@ struct DiscoverEpisodeCell: View {
         static let imageSize = CGFloat(124)
     }
 
-    init(episode: DiscoverEpisode, listId: String? = nil, source: String = "") {
+    init(episode: DiscoverEpisode, listId: String? = nil, source: String = "", onTap: (() -> Void)? = nil) {
         self.episode = episode
         self.listId = listId
         self.source = source
+        self.onTap = onTap
     }
 
     @ViewBuilder
@@ -36,6 +41,7 @@ struct DiscoverEpisodeCell: View {
     var body: some View {
         Button {
             trackEpisodeTapped()
+            onTap?()
             Task {
                 let successPlay = await TVDataManager.shared.playEpisode(episode)
                 await MainActor.run {

--- a/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverPodcastRow.swift
@@ -3,10 +3,6 @@ import PocketCastsServer
 
 struct DiscoverPodcastRow: View {
 
-    fileprivate enum Layout {
-        static let gridSize = CGFloat(250)
-    }
-
     @State private var model: DiscoverSectionModel
 
     private let callback: ((String?)->())?
@@ -53,10 +49,7 @@ struct DiscoverPodcastRow: View {
                 ForEach(model.podcasts, id: \.uuid) { podcast in
                     if let uuid = podcast.uuid {
                         NavigationLink(value: podcast) {
-                            PodcastImage(uuid: uuid, size: .page)
-                                .frame(width: Layout.gridSize, height: Layout.gridSize)
-                                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                                .focusedCardDepth(cornerRadius: 12, style: .surface)
+                            PodcastCoverCard(uuid: uuid)
                         }
                         .buttonStyle(.card)
                         .accessibilityLabel(podcast.title ?? "")

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeCell.swift
@@ -15,6 +15,10 @@ struct DiscoverVideoEpisodeCell: View {
     private let listId: String?
     private let source: String
 
+    /// Fires just before playback starts, for screens that reuse the cell outside
+    /// Discover and need to record their own tap (search results, for instance).
+    private let onTap: (() -> Void)?
+
     @FocusState private var isFocused: Bool
 
     @State var showNowPlayingPlayer: Bool = false
@@ -27,15 +31,17 @@ struct DiscoverVideoEpisodeCell: View {
         static let playDelay: TimeInterval = 2
     }
 
-    init(episode: DiscoverEpisode, listId: String? = nil, source: String = "") {
+    init(episode: DiscoverEpisode, listId: String? = nil, source: String = "", onTap: (() -> Void)? = nil) {
         _model = State(wrappedValue: DiscoverVideoEpisodeModel(episode: episode, fadeDuration: Layout.fadeDuration, playDelay: Layout.playDelay))
         self.listId = listId
         self.source = source
+        self.onTap = onTap
     }
 
     var body: some View {
         Button {
             trackEpisodeTapped()
+            onTap?()
             Task {
                 AnalyticsPlaybackHelper.shared.currentSource = AnalyticsSource(rawValue: source)
                 let successPlay = await TVDataManager.shared.playEpisode(model.episode)

--- a/Pocket Casts TV App/UI/Search/SearchFeaturedEpisodesRow.swift
+++ b/Pocket Casts TV App/UI/Search/SearchFeaturedEpisodesRow.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import PocketCastsServer
+
+/// The `Featured` row of video episode results, shared by the `Top Results` and
+/// `Episodes` search scopes. Reuses the Discover video cell, so the cards keep their
+/// on-focus preview playback.
+struct SearchFeaturedEpisodesRow: View {
+
+    let episodes: [EpisodeSearchResult]
+
+    private enum Layout {
+        static let spacing = CGFloat(56)
+    }
+
+    var body: some View {
+        RowSection(title: L10n.tvSearchFeaturedSectionTitle, focusSection: SearchFocusSection.featured) {
+            ScrollView(.horizontal) {
+                LazyHStack(spacing: Layout.spacing) {
+                    ForEach(episodes, id: \.uuid) { episode in
+                        DiscoverVideoEpisodeCell(episode: episode.discoverEpisode, source: DiscoverAnalytics.searchSource) {
+                            SearchAnalytics.episodeTapped(episode)
+                        }
+                        // The cell scales up on focus, so leave room for it to grow.
+                        .padding(.vertical, Layout.spacing / 2)
+                        .setFocus(section: SearchFocusSection.featured)
+                    }
+                }
+                .focusSection()
+            }
+            // Otherwise the focused-card drop shadow gets clipped at the
+            // scroll-view boundary instead of pooling below the card.
+            .scrollClipDisabled()
+        }
+    }
+}
+
+extension EpisodeSearchResult {
+    /// Search results reshaped into what the Discover cells render, so the search rows
+    /// reuse `DiscoverEpisodeCell` and `DiscoverVideoEpisodeCell` as-is. `url` carries
+    /// the video stream those cells preview on focus.
+    var discoverEpisode: DiscoverEpisode {
+        DiscoverEpisode(uuid: uuid,
+                        title: title,
+                        duration: duration.map { Int($0) },
+                        url: videoURL?.absoluteString,
+                        podcastUuid: podcastUuid,
+                        podcastTitle: podcastTitle,
+                        published: publishedDate)
+    }
+}

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -6,6 +6,14 @@ fileprivate enum Layout {
     static let cellSize = CGFloat(250)
 }
 
+/// `FocusStore` identities for the search sections, so a `RowSection` title highlights
+/// while anything inside it holds focus.
+enum SearchFocusSection {
+    static let featured = "search_featured"
+    static let episodes = "search_episodes"
+    static let podcasts = "search_podcasts"
+}
+
 struct SearchResultsView<ViewModel: SearchableViewModel>: View {
 
     @Environment(MainTabViewModel.self) var mainTabModel: MainTabViewModel
@@ -32,6 +40,12 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                 ContentUnavailableView.search(text: model.searchTerm)
             case .results:
                 switch model.scope {
+                case .topResults:
+                    if model.podcastResults.isEmpty, model.episodeResults.isEmpty {
+                        ContentUnavailableView.search(text: model.searchTerm)
+                    } else {
+                        SearchTopResultsView(model: model)
+                    }
                 case .podcasts:
                     if model.podcastResults.isEmpty {
                         ContentUnavailableView.search(text: model.searchTerm)
@@ -61,6 +75,9 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
         .navigationDestination(for: DiscoverCategory.self) { discoverCategory in
             DiscoverPodcastsListView(category: discoverCategory, source: DiscoverAnalytics.searchSource)
         }
+        .navigationDestination(for: PodcastFolderSearchResult.self) { podcast in
+            PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: podcast.uuid))
+        }
         .animation(.easeInOut, value: model.state)
         .animation(.easeInOut, value: model.scope)
         .fullScreenCover(isPresented: $showNowPlayingPlayer) {
@@ -82,51 +99,61 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                         .buttonStyle(.card)
                         .accessibilityLabel(podcast.title ?? "")
                         .simultaneousGesture(TapGesture().onEnded {
-                            Analytics.track(.searchResultTapped, properties: [
-                                "source": "search",
-                                "uuid": podcast.uuid,
-                                "result_type": podcast.isLocal == true ? "podcast_local_result" : "podcast_remote_result"
-                            ])
+                            SearchAnalytics.podcastTapped(podcast)
                         })
                     case .episode:
                         EmptyView()
                     }
                 }
             })
-            .navigationDestination(for: PodcastFolderSearchResult.self) { podcast in
-                PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: podcast.uuid))
+        }
+    }
+
+    /// Without video results this is the plain grid it has always been. With them, the
+    /// video episodes lead in a `Featured` row and the grid drops below an `Episodes`
+    /// heading, holding whatever the row didn't already show.
+    @ViewBuilder
+    var episodeResults: some View {
+        if model.videoEpisodeResults.isEmpty {
+            ScrollView {
+                episodeGrid(model.episodeResults)
+            }
+        } else {
+            ScrollView {
+                VStack(alignment: .leading, spacing: RowSectionLayout.sectionSpacing) {
+                    SearchFeaturedEpisodesRow(episodes: model.videoEpisodeResults)
+                    if !model.remainingEpisodeResults.isEmpty {
+                        RowSection(title: L10n.episodes, focusSection: SearchFocusSection.episodes) {
+                            episodeGrid(model.remainingEpisodeResults)
+                        }
+                    }
+                }
             }
         }
     }
 
-    var episodeResults: some View {
-        ScrollView {
-            LazyVGrid(columns: episodeItems, spacing: 24, content: {
-                ForEach(model.episodeResults, id: \.self) { episode in
-                    Button() {
-                        Analytics.track(.searchResultTapped, properties: [
-                            "source": "search",
-                            "uuid": episode.uuid,
-                            "result_type": "episode"
-                        ])
-                        Task {
-
-                            let playSuccess = await model.playEpisode(episode)
-                            await MainActor.run {
-                                if playSuccess {
-                                    showNowPlayingPlayer = true
-                                } else {
-                                    ToastManager.shared.show(L10n.playbackFailed)
-                                }
+    private func episodeGrid(_ episodes: [EpisodeSearchResult]) -> some View {
+        LazyVGrid(columns: episodeItems, spacing: 24, content: {
+            ForEach(episodes, id: \.self) { episode in
+                Button() {
+                    SearchAnalytics.episodeTapped(episode)
+                    Task {
+                        let playSuccess = await model.playEpisode(episode)
+                        await MainActor.run {
+                            if playSuccess {
+                                showNowPlayingPlayer = true
+                            } else {
+                                ToastManager.shared.show(L10n.playbackFailed)
                             }
                         }
-                    } label: {
-                        SearchEpisodeRow(model: episode)
                     }
-                    .buttonStyle(.card)
-                    .discoveryEpisodeContextMenu(podcastUuid: episode.podcastUuid, episodeUuid: episode.uuid)
+                } label: {
+                    SearchEpisodeRow(model: episode)
                 }
-            })
-        }
+                .buttonStyle(.card)
+                .setFocus(section: SearchFocusSection.episodes)
+                .discoveryEpisodeContextMenu(podcastUuid: episode.podcastUuid, episodeUuid: episode.uuid)
+            }
+        })
     }
 }

--- a/Pocket Casts TV App/UI/Search/SearchTopResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchTopResultsView.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import PocketCastsServer
+
+fileprivate enum Layout {
+    static let maxItemsPerRow = 10
+    static let podcastSpacing = CGFloat(48)
+    static let podcastPadding = CGFloat(24)
+    static let episodeSpacing = CGFloat(56)
+    static let episodeCellWidth = CGFloat(864)
+}
+
+/// The default search scope: a Home-style stack of rows that blends the video,
+/// episode and podcast results into a single screen. Each row is a preview —
+/// the dedicated `Podcasts` and `Episodes` scopes hold the full lists.
+struct SearchTopResultsView<ViewModel: SearchableViewModel>: View {
+
+    let model: ViewModel
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: RowSectionLayout.sectionSpacing) {
+                featuredRow
+                episodesRow
+                podcastsRow
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var featuredRow: some View {
+        let episodes = Array(model.videoEpisodeResults.prefix(Layout.maxItemsPerRow))
+        if !episodes.isEmpty {
+            SearchFeaturedEpisodesRow(episodes: episodes)
+        }
+    }
+
+    @ViewBuilder
+    private var episodesRow: some View {
+        let episodes = Array(model.remainingEpisodeResults.prefix(Layout.maxItemsPerRow))
+        if !episodes.isEmpty {
+            RowSection(title: L10n.episodes, focusSection: SearchFocusSection.episodes) {
+                horizontalRow(spacing: Layout.episodeSpacing) {
+                    ForEach(episodes, id: \.uuid) { episode in
+                        DiscoverEpisodeCell(episode: episode.discoverEpisode, source: DiscoverAnalytics.searchSource) {
+                            SearchAnalytics.episodeTapped(episode)
+                        }
+                        .frame(width: Layout.episodeCellWidth)
+                        .setFocus(section: SearchFocusSection.episodes)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var podcastsRow: some View {
+        let podcasts = Array(model.podcastOnlyResults.prefix(Layout.maxItemsPerRow))
+        if !podcasts.isEmpty {
+            RowSection(title: L10n.podcastsPlural, focusSection: SearchFocusSection.podcasts) {
+                horizontalRow(spacing: Layout.podcastSpacing) {
+                    ForEach(podcasts, id: \.uuid) { podcast in
+                        NavigationLink(value: podcast) {
+                            PodcastCoverCard(uuid: podcast.uuid)
+                        }
+                        .buttonStyle(.card)
+                        .padding(.vertical, Layout.podcastPadding)
+                        .setFocus(section: SearchFocusSection.podcasts)
+                        .simultaneousGesture(TapGesture().onEnded {
+                            SearchAnalytics.podcastTapped(podcast)
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    private func horizontalRow<Content: View>(spacing: CGFloat, @ViewBuilder content: () -> Content) -> some View {
+        ScrollView(.horizontal) {
+            LazyHStack(spacing: spacing, content: content)
+                .focusSection()
+        }
+        // Otherwise the focused-card drop shadow gets clipped at the
+        // scroll-view boundary instead of pooling below the card.
+        .scrollClipDisabled()
+    }
+}

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -38,7 +38,7 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
             .searchScopes($model.scope) {
                 if model.isInSearchMode {
                     ForEach(SearchScope.allCases, id: \.self) { scope in
-                        Text(scope.localizedName)
+                        Text(" \(scope.localizedName) ")
                             .tag(scope)
                     }
                 }

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -3,11 +3,14 @@ import PocketCastsDataModel
 import PocketCastsServer
 
 enum SearchScope: CaseIterable, Equatable {
+    case topResults
     case podcasts
     case episodes
 
     var localizedName: String {
         switch self {
+        case .topResults:
+            return L10n.tvSearchScopeTopResults
         case .podcasts:
             return L10n.podcastsPlural
         case .episodes:
@@ -18,6 +21,8 @@ enum SearchScope: CaseIterable, Equatable {
     /// Matches the iOS `SearchDisplayMode` analytics values.
     var analyticsDescription: String {
         switch self {
+        case .topResults:
+            return "top_results"
         case .podcasts:
             return "podcasts"
         case .episodes:
@@ -54,6 +59,13 @@ protocol SearchableViewModel: AnyObject, Observation.Observable {
     var scope: SearchScope { get set }
     var podcastResults: [CombinedSearchResultType] { get }
     var episodeResults: [EpisodeSearchResult] { get }
+
+    /// `episodeResults` split into the episodes the `Featured` row previews and the
+    /// ones left for the `Episodes` row. Partitioned once per search rather than on
+    /// every render.
+    var videoEpisodeResults: [EpisodeSearchResult] { get }
+    var remainingEpisodeResults: [EpisodeSearchResult] { get }
+
     var searchHistory: [String] { get }
     var autoCompleteSuggestions: [String] { get }
 
@@ -64,6 +76,24 @@ protocol SearchableViewModel: AnyObject, Observation.Observable {
     func playEpisode(_ episode: EpisodeSearchResult) async -> Bool
 
     var isInSearchMode: Bool { get }
+}
+
+extension SearchableViewModel {
+    /// `podcastResults` only ever holds `.podcast` cases — this unwraps them for the
+    /// rows that take a podcast directly.
+    var podcastOnlyResults: [PodcastFolderSearchResult] {
+        podcastResults.compactMap {
+            guard case .podcast(let podcast) = $0 else { return nil }
+            return podcast
+        }
+    }
+}
+
+extension EpisodeSearchResult {
+    /// A video episode we also have a stream for — the only kind the `Featured` row can preview.
+    var isPlayableVideo: Bool {
+        hasVideo && videoURL != nil
+    }
 }
 
 @Observable
@@ -95,11 +125,22 @@ class SearchViewModel: SearchableViewModel {
 
     var state: SearchState = .query
 
-    var scope: SearchScope = .podcasts
+    var scope: SearchScope = .topResults
 
     var podcastResults: [CombinedSearchResultType] = []
 
-    var episodeResults: [EpisodeSearchResult] = []
+    // Partitioned here rather than in the view so the filtering runs once per search
+    // instead of on every render, and the two halves can't drift from `episodeResults`.
+    var episodeResults: [EpisodeSearchResult] = [] {
+        didSet {
+            videoEpisodeResults = episodeResults.filter(\.isPlayableVideo)
+            remainingEpisodeResults = episodeResults.filter { !$0.isPlayableVideo }
+        }
+    }
+
+    private(set) var videoEpisodeResults: [EpisodeSearchResult] = []
+
+    private(set) var remainingEpisodeResults: [EpisodeSearchResult] = []
 
     var searchHistory: [String] {
         searchModel.entries.compactMap(\.searchTerm)

--- a/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
+++ b/podcasts/New Search/Views/Results/LocalSearchViewModel.swift
@@ -430,7 +430,7 @@ extension EpisodeSearchResult {
         let podcastTitle = episode.parentPodcast(dataManager: dataManager)?.title ?? ""
         let state: EpisodeSearchResult.State = episode.wasDeleted ? .unavailable : episode.archived ? .archived : .normal
 
-        self.init(uuid: episode.uuid, title: episode.displayableTitle(), publishedDate: publishedDate, state: state, duration: duration, podcastUuid: episode.podcastUuid, podcastTitle: podcastTitle)
+        self.init(uuid: episode.uuid, title: episode.displayableTitle(), publishedDate: publishedDate, state: state, duration: duration, podcastUuid: episode.podcastUuid, podcastTitle: podcastTitle, hasVideo: episode.videoPodcast())
     }
 
     init(listEpisode: ListEpisode, dataManager: DataManager = DataManager.sharedManager) {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6460,6 +6460,12 @@
 /* tv search error label. '%1$@' is a placeholder for a localized error description. */
 "tv_search_failed" = "Search failed: %1$@";
 
+/* tv search scope title for the default tab that blends podcasts and episodes */
+"tv_search_scope_top_results" = "Top Results";
+
+/* tv search section title for the row of video episodes matching the query */
+"tv_search_featured_section_title" = "Featured";
+
 /* info message when authorization is pending on server */
 "server_error_login_auth_pending" = "Authorization pending";
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-888

The search endpoints now return `is_video` for podcasts and `has_video` + `video_url` for episodes, so tvOS search can surface video episodes instead of opening straight into a flat grid.

Adds a **Top Results** scope, now the default, laid out like Home — a stack of `RowSection`s, each capped at 10 items since the Podcasts and Episodes scopes still hold the full lists:

- **Featured** — video episodes, via `DiscoverVideoEpisodeCell` so the cards keep their on-focus preview playback
- **Episodes** — `DiscoverEpisodeCell`, holding what Featured didn't show
- **Podcasts** — the cover card lifted out of `DiscoverPodcastRow`

The **Episodes** scope leads with the same Featured row when a search turns up video episodes, moving the grid below an "Episodes" heading. Without video results it stays the plain grid it has always been.

No new analytics events — `search_result_tapped` just gains a `top_results` value for the scope filter.

<img width="1568" height="934" alt="Screenshot 2026-08-07 at 1 25 22 PM" src="https://github.com/user-attachments/assets/544205f6-d6a1-43e6-93de-947c818fd9f3" />


## To test

1. Search for a podcast with video episodes on tvOS (`huberman` works well).
2. **Top Results** is selected by default — confirm **Featured**, **Episodes** and **Podcasts** appear in order, titled and spaced like the Home rows.
3. Focus a Featured card and wait ~2s: the video preview fades in and plays, and fades back to the thumbnail when focus leaves. Select it to play the episode.
4. Confirm the **Episodes** row excludes what Featured already shows, and that the **Podcasts** row opens the podcast page.
5. Switch to the **Episodes** scope — Featured leads, grid below an "Episodes" heading.
6. Search something with no video episodes (e.g. `radiolab`) and confirm the Episodes scope falls back to the plain grid, no headings.
7. Check Home and Discover are unchanged — `DiscoverPodcastRow` and both episode cells were touched.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
