### PR TITLE
Fix missing bottom spacing on the podcast grid when the tab bar expands

### DIFF
--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController.swift
@@ -67,6 +67,10 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
     /// Whether the Liquid Glass bottom fade / spacing is active.
     private var isBottomFadeEnabled = false
 
+    /// Padding kept below the grid's last row under Liquid Glass, on top of the bottom safe
+    /// area, so the row still clears the floating tab bar after it expands back out.
+    private static let bottomContentPadding: CGFloat = 16
+
     private var homeGridDataHelper = HomeGridDataHelper()
 
     private lazy var refreshQueue: OperationQueue = {
@@ -107,7 +111,12 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
         updateCustomBottomFade()
 
         adjustSettingsForGridType()
-        insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: podcastsCollectionView)
+        if !LiquidGlass.isEnabled {
+            // Under Liquid Glass the mini player is a tab accessory covered by the safe area,
+            // so the adjuster only ever zeroes the bottom inset back out from under
+            // `updateInsets`.
+            insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: podcastsCollectionView)
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -310,7 +319,8 @@ class PodcastListViewController: PCViewController, ShareListDelegate {
 
     private func updateInsets() {
         let currentInsets = podcastsCollectionView.contentInset
-        podcastsCollectionView.contentInset = UIEdgeInsets(top: currentInsets.top, left: horizontalMargin, bottom: currentInsets.bottom, right: horizontalMargin)
+        let bottom = LiquidGlass.isEnabled ? Self.bottomContentPadding : currentInsets.bottom
+        podcastsCollectionView.contentInset = UIEdgeInsets(top: currentInsets.top, left: horizontalMargin, bottom: bottom, right: horizontalMargin)
     }
 
     private func adjustSettingsForGridType() {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Collapsing the Liquid Glass tab bar shrinks the bottom safe area and UIKit pulls the grid down with it, but expanding it back out grows the safe area without moving the content, leaving the last row tucked under the tab bar. The grid now always reserves 16pt of bottom content inset under Liquid Glass so the last row keeps some breathing room.

`InsetAdjuster` would wipe that padding whenever the mini player appears or disappears, and is otherwise a no-op here, so it's now skipped under Liquid Glass.

## To test

1. On iOS 26, open the **Podcasts** tab with enough podcasts to scroll, and make sure **Appearance → Minimize tab bar on scroll** is on.
2. Scroll to the bottom of the grid — the tab bar collapses into its pill.
3. Let it bounce back / scroll up slightly so the tab bar expands again.
4. The last row should still sit clear of the tab bar instead of being tucked underneath it.
5. Repeat for all three layouts (large grid, small grid, list), with and without the mini player.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
