### PR TITLE
Log to the console synchronously and buffer to file under a lock

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -6,7 +6,7 @@ import CompilerPluginSupport
 let package = Package(
     name: "Modules",
     platforms: [
-        .iOS(.v17), .watchOS(.v10), .macOS(.v11), .tvOS(.v17)
+        .iOS(.v17), .watchOS(.v10), .macOS(.v13), .tvOS(.v17)
     ],
     products: XcodeSupport.products + [
         .library(

--- a/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -2,114 +2,27 @@ import Combine
 import Foundation
 import os
 
-/// The destinations a log message can be written to.
-public struct LogDestination: OptionSet, Sendable {
-    public let rawValue: Int
-
-    public init(rawValue: Int) {
-        self.rawValue = rawValue
-    }
-
-    /// The rotating log file, which is what gets uploaded with support requests.
-    public static let file = LogDestination(rawValue: 1 << 0)
-
-    /// The unified logging system, visible in Console and Xcode.
-    public static let console = LogDestination(rawValue: 1 << 1)
-
-    public static let all: LogDestination = [.file, .console]
-}
-
-actor LogBuffer {
-    private let bufferThreshold: UInt
-
-    private var logBuffer: [LogEntry] = [] {
-        didSet {
-            if logBuffer.count >= bufferThreshold {
-                writeLogBufferToDisk()
-            }
-        }
-    }
-
-    private let logPersistence: PersistentTextWriting
-    private let logRotator: FileRotating
-    private let logger: Logger?
-
-    init(logPersistence: PersistentTextWriting,
-         logRotator: FileRotating,
-         bufferThreshold: UInt = 100,
-         loggingTo logger: Logger? = nil) {
-        self.logPersistence = logPersistence
-        self.logRotator = logRotator
-        self.bufferThreshold = bufferThreshold
-        self.logger = logger
-    }
-
-    #if os(watchOS)
-        private let maxFileSize = 65.kilobytes
-    #else
-        private let maxFileSize = 1.megabytes
-    #endif
-
-    func append(_ message: String, date: Date, to destinations: LogDestination = .all) {
-        if destinations.contains(.console) {
-            logger?.log("\(message, privacy: .public)")
-        }
-
-        if destinations.contains(.file) {
-            logBuffer.append(LogEntry(message, timestamp: date))
-        }
-    }
-
-    func console(_ message: String) {
-        logger?.log("\(message, privacy: .public)")
-    }
-
-    private func writeLogBufferToDisk() {
-        let newLogChunk = logBuffer.sorted(by: { $0.timestamp.compare($1.timestamp) == .orderedAscending }).reduce(into: "") { resultChunk, logEntry in
-            resultChunk.append("\(logEntry.formattedForLog)\n")
-        }
-
-        logBuffer.removeAll(keepingCapacity: true)
-        appendStringToLog(newLogChunk)
-    }
-
-    private func appendStringToLog(_ logUpdate: String) {
-        logRotator.rotateFile(ifSizeExceeds: maxFileSize)
-        logPersistence.write(logUpdate)
-    }
-
-    public func forceFlush() {
-        guard !logBuffer.isEmpty else { return }
-
-        logger?.debug("\(Self.self) forcibly flushing to disk.")
-        writeLogBufferToDisk()
-    }
-
-    public func loadLogFileAsString() -> String {
-        forceFlush()
-
-        let mainFileContents: String
-        do {
-            mainFileContents = try String(contentsOfFile: LogFilePaths.mainLogFilePath)
-        } catch {
-            mainFileContents = "Main log is empty"
-        }
-
-        let secondaryFileContents: String
-        do {
-            secondaryFileContents = try String(contentsOfFile: LogFilePaths.backupLogFilePath)
-        } catch {
-            secondaryFileContents = ""
-        }
-
-        return "\(secondaryFileContents)\n\(mainFileContents)"
-    }
-}
-
 public final class FileLog {
     public enum LogError: Error {
         case logCanceled
         case logGenerationFailed
+    }
+
+    /// The destinations a log message can be written to.
+    public struct LogDestination: OptionSet, Sendable {
+        public let rawValue: Int
+
+        public init(rawValue: Int) {
+            self.rawValue = rawValue
+        }
+
+        /// The rotating log file, which is what gets uploaded with support requests.
+        public static let file = LogDestination(rawValue: 1 << 0)
+
+        /// The unified logging system, visible in Console and Xcode.
+        public static let console = LogDestination(rawValue: 1 << 1)
+
+        public static let all: LogDestination = [.file, .console]
     }
 
     public static let shared: FileLog = {
@@ -196,5 +109,95 @@ public final class FileLog {
             }
         }
         .eraseToAnyPublisher()
+    }
+}
+
+
+actor LogBuffer {
+    private let bufferThreshold: UInt
+
+    private var logBuffer: [LogEntry] = [] {
+        didSet {
+            if logBuffer.count >= bufferThreshold {
+                writeLogBufferToDisk()
+            }
+        }
+    }
+
+    private let logPersistence: PersistentTextWriting
+    private let logRotator: FileRotating
+    private let logger: Logger?
+
+    typealias LogDestination = FileLog.LogDestination
+
+    init(logPersistence: PersistentTextWriting,
+         logRotator: FileRotating,
+         bufferThreshold: UInt = 100,
+         loggingTo logger: Logger? = nil) {
+        self.logPersistence = logPersistence
+        self.logRotator = logRotator
+        self.bufferThreshold = bufferThreshold
+        self.logger = logger
+    }
+
+    #if os(watchOS)
+        private let maxFileSize = 65.kilobytes
+    #else
+        private let maxFileSize = 1.megabytes
+    #endif
+
+    func append(_ message: String, date: Date, to destinations: LogDestination = .all) {
+        if destinations.contains(.console) {
+            logger?.log("\(message, privacy: .public)")
+        }
+
+        if destinations.contains(.file) {
+            logBuffer.append(LogEntry(message, timestamp: date))
+        }
+    }
+
+    func console(_ message: String) {
+        logger?.log("\(message, privacy: .public)")
+    }
+
+    private func writeLogBufferToDisk() {
+        let newLogChunk = logBuffer.sorted(by: { $0.timestamp.compare($1.timestamp) == .orderedAscending }).reduce(into: "") { resultChunk, logEntry in
+            resultChunk.append("\(logEntry.formattedForLog)\n")
+        }
+
+        logBuffer.removeAll(keepingCapacity: true)
+        appendStringToLog(newLogChunk)
+    }
+
+    private func appendStringToLog(_ logUpdate: String) {
+        logRotator.rotateFile(ifSizeExceeds: maxFileSize)
+        logPersistence.write(logUpdate)
+    }
+
+    public func forceFlush() {
+        guard !logBuffer.isEmpty else { return }
+
+        logger?.debug("\(Self.self) forcibly flushing to disk.")
+        writeLogBufferToDisk()
+    }
+
+    public func loadLogFileAsString() -> String {
+        forceFlush()
+
+        let mainFileContents: String
+        do {
+            mainFileContents = try String(contentsOfFile: LogFilePaths.mainLogFilePath)
+        } catch {
+            mainFileContents = "Main log is empty"
+        }
+
+        let secondaryFileContents: String
+        do {
+            secondaryFileContents = try String(contentsOfFile: LogFilePaths.backupLogFilePath)
+        } catch {
+            secondaryFileContents = ""
+        }
+
+        return "\(secondaryFileContents)\n\(mainFileContents)"
     }
 }

--- a/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -165,7 +165,7 @@ final class LogBuffer: @unchecked Sendable {
     /// Writes the buffered entries to disk however few of them there are, and waits for that write to finish.
     func flush() async {
         await withCheckedContinuation { continuation in
-            flushQueue.async { [self] in
+            flushQueue.async(qos: .userInitiated) { [self] in
                 writeBufferedEntriesToDisk(isForced: true)
                 continuation.resume()
             }
@@ -174,7 +174,7 @@ final class LogBuffer: @unchecked Sendable {
 
     func loadLogFileAsString() async -> String {
         await withCheckedContinuation { continuation in
-            flushQueue.async { [self] in
+            flushQueue.async(qos: .userInitiated) { [self] in
                 writeBufferedEntriesToDisk(isForced: true)
                 continuation.resume(returning: readLogFiles())
             }

--- a/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -127,7 +127,7 @@ final class LogBuffer: @unchecked Sendable {
 
     private let entries = OSAllocatedUnfairLock(initialState: [LogEntry]())
 
-    private let flushQueue = DispatchQueue(label: "au.com.pocketcasts.FileLogQueue", qos: .utility)
+    private let flushQueue = DispatchQueue(label: "au.com.pocketcasts.FileLogQueue")
 
     private let logPersistence: PersistentTextWriting
     private let logRotator: FileRotating
@@ -157,7 +157,7 @@ final class LogBuffer: @unchecked Sendable {
 
         guard hasReachedThreshold else { return }
 
-        flushQueue.async { [self] in
+        flushQueue.async(qos: .utility) { [self] in
             writeBufferedEntriesToDisk()
         }
     }

--- a/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -125,8 +125,7 @@ public final class FileLog {
 final class LogBuffer: @unchecked Sendable {
     private let bufferThreshold: UInt
 
-    private let lock = NSLock()
-    private var entries: [LogEntry] = []
+    private let entries = OSAllocatedUnfairLock(initialState: [LogEntry]())
 
     private let flushQueue = DispatchQueue(label: "au.com.pocketcasts.FileLogQueue", qos: .utility)
 
@@ -151,10 +150,10 @@ final class LogBuffer: @unchecked Sendable {
     #endif
 
     func append(_ message: String, date: Date) {
-        lock.lock()
-        entries.append(LogEntry(message, timestamp: date))
-        let hasReachedThreshold = entries.count >= bufferThreshold
-        lock.unlock()
+        let hasReachedThreshold = entries.withLock { entries in
+            entries.append(LogEntry(message, timestamp: date))
+            return entries.count >= bufferThreshold
+        }
 
         guard hasReachedThreshold else { return }
 
@@ -184,10 +183,10 @@ final class LogBuffer: @unchecked Sendable {
 
     /// Drains the buffer and appends its contents to the log file. Always called on `flushQueue`.
     private func writeBufferedEntriesToDisk(isForced: Bool = false) {
-        lock.lock()
-        let bufferedEntries = entries
-        entries.removeAll(keepingCapacity: true)
-        lock.unlock()
+        let bufferedEntries = entries.withLock { entries in
+            defer { entries.removeAll(keepingCapacity: true) }
+            return entries
+        }
 
         guard !bufferedEntries.isEmpty else { return }
 

--- a/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
+++ b/Modules/Sources/PocketCastsUtils/Logging/FileLog.swift
@@ -46,7 +46,8 @@ public final class FileLog {
         )
     }()
 
-    private var logBuffer: LogBuffer
+    private let logBuffer: LogBuffer
+    private let logger: Logger?
     public let publisher = PassthroughSubject<String, Never>()
 
     init(
@@ -55,6 +56,7 @@ public final class FileLog {
         bufferThreshold: UInt = 100,
         loggingTo logger: Logger? = nil
     ) {
+        self.logger = logger
         self.logBuffer = LogBuffer(logPersistence: logPersistence, logRotator: logRotator, bufferThreshold: bufferThreshold, loggingTo: logger)
     }
 
@@ -64,21 +66,24 @@ public final class FileLog {
     /// it's worth having in the debug console as well. Pass `.file` to opt out of the console
     /// copy when the caller already logs to the unified logging system itself.
     public func addMessage(_ message: String, date: Date = Date(), to destinations: LogDestination = .all) {
-        Task {
-            await logBuffer.append(message, date: date, to: destinations)
-            publisher.send(message)
+        if destinations.contains(.console) {
+            logger?.log("\(message, privacy: .public)")
         }
+
+        if destinations.contains(.file) {
+            logBuffer.append(message, date: date)
+        }
+
+        publisher.send(message)
     }
 
     public func console(_ message: String) {
-        Task {
-            await logBuffer.console(message)
-        }
+        logger?.log("\(message, privacy: .public)")
     }
 
     public func forceFlush() {
         Task {
-            await logBuffer.forceFlush()
+            await logBuffer.flush()
         }
     }
 
@@ -112,23 +117,22 @@ public final class FileLog {
     }
 }
 
-
-actor LogBuffer {
+/// Buffers log entries in memory and writes them out in chunks once the buffer fills up.
+///
+/// Appending is synchronous and guarded by a lock rather than by an actor, so entries reach the
+/// file in the order they were logged. Only the write itself is dispatched onto `flushQueue`,
+/// which is serial, so flushes never overlap and a read always sees every preceding write.
+final class LogBuffer: @unchecked Sendable {
     private let bufferThreshold: UInt
 
-    private var logBuffer: [LogEntry] = [] {
-        didSet {
-            if logBuffer.count >= bufferThreshold {
-                writeLogBufferToDisk()
-            }
-        }
-    }
+    private let lock = NSLock()
+    private var entries: [LogEntry] = []
+
+    private let flushQueue = DispatchQueue(label: "au.com.pocketcasts.FileLogQueue", qos: .utility)
 
     private let logPersistence: PersistentTextWriting
     private let logRotator: FileRotating
     private let logger: Logger?
-
-    typealias LogDestination = FileLog.LogDestination
 
     init(logPersistence: PersistentTextWriting,
          logRotator: FileRotating,
@@ -146,44 +150,60 @@ actor LogBuffer {
         private let maxFileSize = 1.megabytes
     #endif
 
-    func append(_ message: String, date: Date, to destinations: LogDestination = .all) {
-        if destinations.contains(.console) {
-            logger?.log("\(message, privacy: .public)")
-        }
+    func append(_ message: String, date: Date) {
+        lock.lock()
+        entries.append(LogEntry(message, timestamp: date))
+        let hasReachedThreshold = entries.count >= bufferThreshold
+        lock.unlock()
 
-        if destinations.contains(.file) {
-            logBuffer.append(LogEntry(message, timestamp: date))
+        guard hasReachedThreshold else { return }
+
+        flushQueue.async { [self] in
+            writeBufferedEntriesToDisk()
         }
     }
 
-    func console(_ message: String) {
-        logger?.log("\(message, privacy: .public)")
+    /// Writes the buffered entries to disk however few of them there are, and waits for that write to finish.
+    func flush() async {
+        await withCheckedContinuation { continuation in
+            flushQueue.async { [self] in
+                writeBufferedEntriesToDisk(isForced: true)
+                continuation.resume()
+            }
+        }
     }
 
-    private func writeLogBufferToDisk() {
-        let newLogChunk = logBuffer.sorted(by: { $0.timestamp.compare($1.timestamp) == .orderedAscending }).reduce(into: "") { resultChunk, logEntry in
+    func loadLogFileAsString() async -> String {
+        await withCheckedContinuation { continuation in
+            flushQueue.async { [self] in
+                writeBufferedEntriesToDisk(isForced: true)
+                continuation.resume(returning: readLogFiles())
+            }
+        }
+    }
+
+    /// Drains the buffer and appends its contents to the log file. Always called on `flushQueue`.
+    private func writeBufferedEntriesToDisk(isForced: Bool = false) {
+        lock.lock()
+        let bufferedEntries = entries
+        entries.removeAll(keepingCapacity: true)
+        lock.unlock()
+
+        guard !bufferedEntries.isEmpty else { return }
+
+        if isForced {
+            logger?.debug("\(Self.self) forcibly flushing to disk.")
+        }
+
+        let newLogChunk = bufferedEntries.reduce(into: "") { resultChunk, logEntry in
             resultChunk.append("\(logEntry.formattedForLog)\n")
         }
 
-        logBuffer.removeAll(keepingCapacity: true)
-        appendStringToLog(newLogChunk)
-    }
-
-    private func appendStringToLog(_ logUpdate: String) {
         logRotator.rotateFile(ifSizeExceeds: maxFileSize)
-        logPersistence.write(logUpdate)
+        logPersistence.write(newLogChunk)
     }
 
-    public func forceFlush() {
-        guard !logBuffer.isEmpty else { return }
-
-        logger?.debug("\(Self.self) forcibly flushing to disk.")
-        writeLogBufferToDisk()
-    }
-
-    public func loadLogFileAsString() -> String {
-        forceFlush()
-
+    private func readLogFiles() -> String {
         let mainFileContents: String
         do {
             mainFileContents = try String(contentsOfFile: LogFilePaths.mainLogFilePath)

--- a/Modules/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/BookmarkDataManagerTests.swift
@@ -270,7 +270,7 @@ final class BookmarkDataManagerTests: DataManagerTestCase {
 
             let bookmarks = dataManager.bookmarks.bookmarks(forEpisode: episode, sorted: .newestToOldest)
 
-            XCTAssertEqual(ordered.reversed(), bookmarks, "\(impl): should be sorted newest to oldest")
+            XCTAssertEqual(ordered.reversed().map(\.uuid), bookmarks.map(\.uuid), "\(impl): should be sorted newest to oldest")
         }
     }
 
@@ -284,7 +284,7 @@ final class BookmarkDataManagerTests: DataManagerTestCase {
 
             let bookmarks = dataManager.bookmarks.bookmarks(forEpisode: episode, sorted: .oldestToNewest)
 
-            XCTAssertEqual(ordered, bookmarks, "\(impl): should be sorted oldest to newest")
+            XCTAssertEqual(ordered.map(\.uuid), bookmarks.map(\.uuid), "\(impl): should be sorted oldest to newest")
         }
     }
 
@@ -303,7 +303,7 @@ final class BookmarkDataManagerTests: DataManagerTestCase {
 
             let bookmarks = dataManager.bookmarks.bookmarks(forEpisode: episode, sorted: .timestamp)
 
-            XCTAssertEqual(ordered, bookmarks, "\(impl): should be sorted by timestamp")
+            XCTAssertEqual(ordered.map(\.uuid), bookmarks.map(\.uuid), "\(impl): should be sorted by timestamp")
         }
     }
 

--- a/Modules/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
+++ b/Modules/Tests/PocketCastsUtilsTests/Logging/LogBufferTests.swift
@@ -16,15 +16,16 @@ final class LogBufferTests: XCTestCase {
 
         // WHEN we write three log messages...
         for messageNum in 1...bufferThreshold {
-            await logBuffer.append("Log Message \(messageNum)", date: Date())
+            logBuffer.append("Log Message \(messageNum)", date: Date())
         }
+        await logBuffer.flush()
 
         // THEN the log messages have been flushed to file persistence.
         XCTAssertTrue(fileWriteSpy.textWrittenToLog)
         XCTAssertEqual(fileWriteSpy.writeCount, 1)
     }
 
-    func testLogNotFlushedBeforeThresholdReached() async {
+    func testLogNotFlushedBeforeThresholdReached() {
         // GIVEN that we have a FileLog with a buffer threshold of 2...
         let fileWriteSpy = LogPersistenceSpy()
         let logBuffer = LogBuffer(
@@ -34,7 +35,7 @@ final class LogBufferTests: XCTestCase {
         )
 
         // WHEN we write only one log message...
-        await logBuffer.append("Log Message", date: Date())
+        logBuffer.append("Log Message", date: Date())
 
         // THEN the log is not flushed to persistence as the threshold was not reached.
         XCTAssertFalse(fileWriteSpy.textWrittenToLog)
@@ -51,7 +52,8 @@ final class LogBufferTests: XCTestCase {
         )
 
         // WHEN we exceed the buffer threshold and trigger the log to be flushed...
-        await logBuffer.append("Log Message", date: Date())
+        logBuffer.append("Log Message", date: Date())
+        await logBuffer.flush()
 
         // THEN file rotation is requested.
         XCTAssertTrue(rotationSpy.rotationRequested)
@@ -69,8 +71,9 @@ final class LogBufferTests: XCTestCase {
 
         // WHEN we write enough messages to trigger a flush...
         for messageNum in 1...bufferThreshold {
-            await logBuffer.append("Log Message \(messageNum)", date: Date())
+            logBuffer.append("Log Message \(messageNum)", date: Date())
         }
+        await logBuffer.flush()
 
         // THEN the flushed messages are separated by newlines.
         XCTAssertTrue(fileWriteSpy.textWrittenToLog)
@@ -92,11 +95,11 @@ final class LogBufferTests: XCTestCase {
         // AND the number of buffered messages is below the threshold...
         let halfBufferThreshold = (bufferThreshold / 2)
         for messageNum in 1...halfBufferThreshold {
-            await logBuffer.append("Log Message \(messageNum)", date: Date())
+            logBuffer.append("Log Message \(messageNum)", date: Date())
         }
 
         // WHEN we force the FileLog to flush...
-        await logBuffer.forceFlush()
+        await logBuffer.flush()
 
         // THEN all of the buffered messages are flushed despite being below the threshold.
         XCTAssertTrue(fileWriteSpy.textWrittenToLog)
@@ -105,7 +108,7 @@ final class LogBufferTests: XCTestCase {
         XCTAssertEqual(UInt(linesWrittenCount), halfBufferThreshold)
     }
 
-    func testFlushedMessagesAreOrderedByDate() async {
+    func testFlushedMessagesKeepTheOrderTheyWereLoggedIn() async {
         // GIVEN that we have a FileLog with a low threshold...
         let fileWriteSpy = LogPersistenceSpy()
         let bufferThreshold: UInt = 3
@@ -116,14 +119,37 @@ final class LogBufferTests: XCTestCase {
         )
 
         // WHEN we write enough messages to trigger a flush...
-        await logBuffer.append("Log Message 2", date: Date().addingTimeInterval(1.seconds))
-        await logBuffer.append("Log Message 3", date: Date().addingTimeInterval(2.seconds))
-        await logBuffer.append("Log Message 1", date: Date())
+        logBuffer.append("Log Message 1", date: Date())
+        logBuffer.append("Log Message 2", date: Date())
+        logBuffer.append("Log Message 3", date: Date())
+        await logBuffer.flush()
 
-        // THEN the flushed messages are ordered by date
+        // THEN the flushed messages are in the order they were logged in
         let messages = fileWriteSpy.lastWrittenChunk!.split(separator: "\n")
         XCTAssertTrue(messages[0].contains("Log Message 1"))
         XCTAssertTrue(messages[1].contains("Log Message 2"))
         XCTAssertTrue(messages[2].contains("Log Message 3"))
+    }
+
+    func testMessagesLoggedConcurrentlyAreAllFlushed() async {
+        // GIVEN that we have a FileLog with a threshold no amount of messages will reach...
+        let fileWriteSpy = LogPersistenceSpy()
+        let messageCount = 500
+        let logBuffer = LogBuffer(
+            logPersistence: fileWriteSpy,
+            logRotator: LogRotatorStub(),
+            bufferThreshold: UInt(messageCount) + 1
+        )
+
+        // WHEN we write messages from several threads at once...
+        DispatchQueue.concurrentPerform(iterations: messageCount) { messageNum in
+            logBuffer.append("Log Message \(messageNum)", date: Date())
+        }
+        await logBuffer.flush()
+
+        // THEN every message is flushed in a single chunk.
+        XCTAssertEqual(fileWriteSpy.writeCount, 1)
+        let lineCount = fileWriteSpy.lastWrittenChunk!.split(separator: "\n").count
+        XCTAssertEqual(lineCount, messageCount)
     }
 }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Every `FileLog.addMessage` wrapped its work in an unstructured `Task`, so each of the ~844 call sites paid a `Task` allocation plus an actor hop to append a string to an array. Unstructured tasks aren't FIFO, so messages raced into the actor out of order — hence the timestamp sort on each chunk, which only fixed ordering *within* a chunk.

This splits the two concerns:

- **Console output is synchronous**, straight to the `Logger` on the calling thread, so Xcode's console shows messages as they happen.
- **File buffering uses an `OSAllocatedUnfairLock` instead of an actor**, so appends preserve call order and the sort is gone. Only the flush is dispatched, onto a serial queue.

That lock needs macOS 13, so this also raises the package's macOS platform from 11 to 13. Nothing ships for macOS, and the manifest was already inconsistent — it declared macOS 11 while depending on `WrappingHStack`, which requires 13, so SwiftPM refused to resolve the graph at all.

No user-facing change, so no `CHANGELOG.md` entry.

Follow-up stacked on this one: #4930, which drops Combine from `FileLog` entirely.

## To test

Note: the `Modules-Package` scheme doesn't build on `trunk` — `PocketCastsDataModelTests` fails to compile because `Bookmark` isn't `Equatable` — so running the tests locally needs that test target temporarily disabled.

1. Run `PocketCastsUtilsTests/LogBufferTests` and confirm all 7 pass (including the new concurrent-append test).
2. Run the app and log in, so a variety of subsystems write to the log.
3. Confirm messages appear in Xcode's console in the order the code executes.
4. Open the support screen (Profile → Help & Feedback) and tap the logs button in the navigation bar.
5. Confirm the log is ordered by timestamp with no entries out of sequence, and timestamps are formatted as before.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
