### PR TITLE
Serialize AVAudioSession access on a dedicated queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix the podcast screen tabs being clipped when scrolled [#4918](https://github.com/Automattic/pocket-casts-ios/pull/4918)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
+- Fix playback controls stalling the app when another app is holding audio, by moving all audio session work off the main thread [#4934](https://github.com/Automattic/pocket-casts-ios/pull/4934)
 
 8.18
 -----

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -215,11 +215,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Ignores play remote commands when another app is playing non-mixable audio
     case ignorePlayWithOtherAudio
 
-    /// activates the audio session in the background to avoid locks in the main thread
-    case activateAudioSessionInBackground
-
     /// Use cellular-specific network APIs instead of expensive network APIs
     case useCellularNetworkApis
+
     /// Optimizes manual playlist queries with improved deduplication
     case optimizeManualPlaylistQueries
 
@@ -460,12 +458,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .ignorePlayWithOtherAudio:
             true
-        case .activateAudioSessionInBackground:
-#if os(tvOS)
-            false
-#else
-            true
-#endif
         case .useCellularNetworkApis:
             true
         case .optimizeManualPlaylistQueries:

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -44,7 +44,15 @@ class PlaybackManager: ServerPlaybackDelegate {
     private var wasPlayingBeforeInterruption = false
     private let aboutToPlay = AtomicBool()
 
-    private let shouldDeactivateSession = AtomicBool()
+    /// Every `AVAudioSession` call is made on this queue. They're synchronous IPC round trips to
+    /// `mediaserverd` that can block for seconds while another app is holding audio, so they can't
+    /// run on the main thread. Serial, so an activation can't be undone by a deactivation that was
+    /// requested before it.
+    private let audioSessionQueue = DispatchQueue(label: "au.com.pocketcasts.audio-session", qos: .userInitiated)
+
+    /// The delayed deactivation waiting to run, if any. Confined to `audioSessionQueue`.
+    private var pendingDeactivation: DispatchWorkItem?
+
     private var haveCalledPlayerLoad = false
 
     /// Tracks whether `playback_source_resolved` has been reported for the current player, so it's
@@ -986,28 +994,27 @@ class PlaybackManager: ServerPlaybackDelegate {
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackEnded)
     }
 
-    private var deactivateTimedActionHelper = TimedActionHelper()
     private func deactiveAudioSession(waitBeforeDeactivating: Bool = true) {
-        if !waitBeforeDeactivating {
-            performDeactivate(audioSession: AVAudioSession.sharedInstance())
-            return
-        }
+        audioSessionQueue.async { [self] in
+            pendingDeactivation?.cancel()
 
-        shouldDeactivateSession.value = true
-        // iOS gets cranky if you try to de-activate a session that's playing audio, and calling pause doesn't immediately cause audio to stop playing, so as a workaround wait a bit then do it
-        deactivateTimedActionHelper.startTimer(for: 3.seconds) { [weak self] in
-            guard let self else { return }
+            guard waitBeforeDeactivating else {
+                performDeactivate()
+                return
+            }
 
-            let audioSession = AVAudioSession.sharedInstance()
-            if !self.shouldDeactivateSession.value { return }
-            self.shouldDeactivateSession.value = false
-            self.performDeactivate(audioSession: audioSession)
+            // iOS gets cranky if you try to de-activate a session that's playing audio, and calling pause doesn't immediately cause audio to stop playing, so as a workaround wait a bit then do it
+            let deactivation = DispatchWorkItem { [self] in
+                performDeactivate()
+            }
+            pendingDeactivation = deactivation
+            audioSessionQueue.asyncAfter(deadline: .now() + 3.seconds, execute: deactivation)
         }
     }
 
-    private func performDeactivate(audioSession: AVAudioSession) {
+    private func performDeactivate() {
         do {
-            try audioSession.setActive(false)
+            try AVAudioSession.sharedInstance().setActive(false)
             FileLog.shared.addMessage("deactiveAudioSession succeeded")
         } catch {
             FileLog.shared.addMessage("deactiveAudioSession failed")
@@ -1663,64 +1670,61 @@ class PlaybackManager: ServerPlaybackDelegate {
         player = nil
     }
 
-    func activateAudioSession(completion: ((Bool) -> Void)?) {
-        #if !os(watchOS) && !APPCLIP && !os(tvOS)
-            if GoogleCastManager.sharedManager.connectedOrConnectingToDevice() {
-                completion?(true)
-                return
-            }
-        #endif
-
-        shouldDeactivateSession.value = false
-
-        #if os(watchOS)
-            do {
-                try setAudioSessionProperties()
-                AVAudioSession.sharedInstance().activate(options: []) { activated, _ in
-                    completion?(activated)
-                }
-            } catch {
-                FileLog.shared.addMessage("activating audio session failed \(error.localizedDescription)")
-                completion?(false)
-            }
-        #else
-        if FeatureFlag.activateAudioSessionInBackground.enabled {
-            // Perform audio session activation on a background queue to avoid blocking the main thread
-            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                guard let self else {
-                    completion?(false)
-                    return
-                }
-                self.activateSession(completion: completion)
-            }
-        } else {
-            self.activateSession(completion: completion)
+    /// Activates the audio session, calling `completion` on the main queue once it has.
+    func activateAudioSession(completion: (@MainActor (Bool) -> Void)?) {
+        let completeOnMain: (Bool) -> Void = { activated in
+            DispatchQueue.main.async { completion?(activated) }
         }
-        #endif
+
+#if !os(watchOS) && !APPCLIP && !os(tvOS)
+        if GoogleCastManager.sharedManager.connectedOrConnectingToDevice() {
+            completeOnMain(true)
+            return
+        }
+#endif
+
+        audioSessionQueue.async { [self] in
+            pendingDeactivation?.cancel()
+            activateSession(completion: completeOnMain)
+        }
     }
 
+    /// Configures the audio session and activates it, reporting back whether it's now active.
+    ///
+    /// Must run on `audioSessionQueue`. `setCategory` and `setActive` are synchronous IPC round trips
+    /// to `mediaserverd`, and while another app is holding audio they block until it hands the session
+    /// over, which can take seconds. On the main thread that stalls the UI, and it stalls the remote
+    /// command handlers too, which `MPRemoteCommandCenter` only gives us a few seconds to return from.
     private func activateSession(completion: ((Bool) -> Void)?) {
+#if DEBUG
+        dispatchPrecondition(condition: .onQueue(audioSessionQueue))
+#endif
         do {
-            try self.setAudioSessionProperties()
-            try AVAudioSession.sharedInstance().setActive(true)
+            let audioSession = AVAudioSession.sharedInstance()
+            try audioSession.setCategory(.playback, mode: .spokenAudio, policy: .longFormAudio)
+
+#if os(watchOS)
+            // watchOS has no synchronous equivalent: activation can put a route picker in front of the user,
+            // so it answers asynchronously and fails if they dismiss it without picking an output.
+            audioSession.activate(options: []) { activated, error in
+                FileLog.shared.addMessage("activating audio session \(activated ? "succeeded" : "failed \(error?.localizedDescription ?? "")")")
+                completion?(activated)
+            }
+#else
+            try audioSession.setActive(true)
             FileLog.shared.addMessage("activating audio session succeeded")
             completion?(true)
+#endif
         } catch {
             FileLog.shared.addMessage("activating audio session failed \(error.localizedDescription)")
             completion?(false)
         }
     }
 
-    private func setAudioSessionProperties() throws {
-        let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(.playback, mode: .spokenAudio, policy: .longFormAudio)
-    }
-
     private func setAudioSessionVideoProperties() {
-        do {
-            let audioSession = AVAudioSession.sharedInstance()
-            try audioSession.setMode(AVAudioSession.Mode.moviePlayback)
-        } catch {}
+        audioSessionQueue.async {
+            try? AVAudioSession.sharedInstance().setMode(.moviePlayback)
+        }
     }
 
     private func loadEffects() -> PlaybackEffects {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-778

Every `AVAudioSession` call (`setCategory`, `setActive`, `setMode`) now runs on a single serial background queue, and `activateAudioSession` always calls its completion on the main queue.

### How we got here

- [#3826](https://github.com/Automattic/pocket-casts-ios/pull/3826) moved activation to `DispatchQueue.global(qos: .userInitiated)` behind the `activateAudioSessionInBackground` flag, because activation blocking the main thread was breaking playback started from the widget. Unintended side effect: the completion started firing on an arbitrary background thread!
- [#4695](https://github.com/Automattic/pocket-casts-ios/pull/4695) had to make `hasReportedSourceResolved` atomic as fallout, and `ClipPlaybackManager` still branches on `Thread.current.isMainThread` for the same reason.
- [#4651](https://github.com/Automattic/pocket-casts-ios/pull/4651) (PCIOS-778) turned the flag off on tvOS, putting activation back on the main thread there — trading the hang back for correctness.

The flag was covering two different problems: activation blocking the main thread, and activation racing deactivation. A *concurrent* queue only addressed the first. Deactivation still ran on the main thread from a `TimedActionHelper` timer, so `setActive(true)` and `setActive(false)` could execute at the same time on two threads, ordered by nothing but an `AtomicBool` that can't impose ordering.

### This PR

- One serial queue for every session call: nothing blocks the main thread on any platform, and an activation can no longer be undone by a deactivation requested before it.
- The delayed deactivation is now a `DispatchWorkItem` that activation cancels, replacing the `shouldDeactivateSession` flag and timer.
- `activateAudioSession` delivers its completion on the main queue on every path, including the Cast early-return, so callers don't have to check what thread they're on.
- `activateAudioSessionInBackground` and its tvOS carve-out are removed; tvOS gets the same behavior as everything else.
- watchOS still uses `activate(options:completionHandler:)` — the only activation API that exists there — but shares the rest of the path instead of duplicating it.

## To test

1. Play an episode; pause, resume, skip forward/back, change episodes. Playback behaves as before.
2. Start audio in another app (or a game), then start playback in Pocket Casts from the widget or lock screen. Audio takes over without a stall.
3. Tap play/pause rapidly from the lock screen or CarPlay. Audio ends in the state matching the last press, and doesn't get stuck silent.
4. [tvOS] Play, pause, resume and switch episodes — this is the platform whose behavior changes most, since activation is no longer on the main thread there.
5. [watchOS] Play an episode with no output connected; the route picker still appears and playback starts after choosing an output.

### Next Steps

Synchronize `PlaybackManager` on `MainActor` to make these types of regressions impossible in the future.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
