### PR TITLE
Recognise more HLS content types in alternate enclosures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix a crash when the sign in prompt was shown while another screen was still being dismissed [#4903](https://github.com/Automattic/pocket-casts-ios/pull/4903)
 - [tvOS] Add support server driven home page layout [#4854](https://github.com/Automattic/pocket-casts-ios/pull/4854)
 - [tvOS] Add support for HLS episodes previews in episodes video list [#4921](https://github.com/Automattic/pocket-casts-ios/pull/4921)
+- Recognise more HLS content types in alternate enclosures [#4935](https://github.com/Automattic/pocket-casts-ios/pull/4935)
 
 8.17
 -----

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDictionary.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDictionary.swift
@@ -1,8 +1,21 @@
 import Foundation
 
 extension Episode {
-    /// MIME type advertised for HLS streams inside a feed's `alternate_enclosures`.
-    public static let hlsEnclosureType = "application/x-mpegURL"
+    /// MIME type we advertise for HLS streams we send elsewhere, e.g. to Google Cast.
+    public static let advertisedHLSMimeType = "application/x-mpegURL"
+
+    /// HLS content types we accept and play as video.
+    public static let hlsEnclosureTypes = Set([
+        "application/x-mpegurl",
+        "application/mpegurl",
+        "application/vnd.apple.mpegurl"
+    ])
+
+    /// Whether an `alternate_enclosures` type string advertises an HLS stream.
+    public static func isHLSEnclosureType(_ type: String?) -> Bool {
+        guard let type else { return false }
+        return hlsEnclosureTypes.contains(type.lowercased())
+    }
 
     /// Extracts the HLS stream URL from a feed episode's `alternate_enclosures` array, if one is present.
     ///
@@ -17,7 +30,7 @@ extension Episode {
             return nil
         }
 
-        let hlsEnclosure = alternateEnclosures.first { ($0["type"] as? String)?.caseInsensitiveCompare(hlsEnclosureType) == .orderedSame }
+        let hlsEnclosure = alternateEnclosures.first { isHLSEnclosureType($0["type"] as? String) }
         let sources = hlsEnclosure?["sources"] as? [[String: Any]]
         return sources?.first?["uri"] as? String
     }

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDictionary.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Episode+fromDictionary.swift
@@ -4,12 +4,12 @@ extension Episode {
     /// MIME type we advertise for HLS streams we send elsewhere, e.g. to Google Cast.
     public static let advertisedHLSMimeType = "application/x-mpegURL"
 
-    /// HLS content types we accept and play as video.
+    /// HLS content types we accept and play as video. Stored lowercased, so lookups must lowercase their input too.
     public static let hlsEnclosureTypes = Set([
         "application/x-mpegurl",
         "application/mpegurl",
         "application/vnd.apple.mpegurl"
-    ])
+    ].map { $0.lowercased() })
 
     /// Whether an `alternate_enclosures` type string advertises an HLS stream.
     public static func isHLSEnclosureType(_ type: String?) -> Bool {

--- a/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerStructs.swift
@@ -145,7 +145,7 @@ public struct RefreshEpisode: Decodable {
     /// Normalises an empty `uri` to `nil` so it isn't persisted as a bogus "missing-but-present" url.
     public var hlsUrl: String? {
         let uri = alternateEnclosures?
-            .first { $0.type?.caseInsensitiveCompare(Episode.hlsEnclosureType) == .orderedSame }?
+            .first { Episode.isHLSEnclosureType($0.type) }?
             .sources?.first?.uri
         return (uri?.isEmpty ?? true) ? nil : uri
     }
@@ -569,11 +569,11 @@ public struct DiscoverAlternateEnclosure: Decodable {
 
 extension DiscoverEpisode {
 
-    static let supportedVideoTypes = Set(["video/mp4", "application/x-mpegURL", "application/mpegURL", "application/vnd.apple.mpegurl"].map { $0.lowercased() })
+    static let supportedVideoTypes = Episode.hlsEnclosureTypes.union(["video/mp4"])
 
     public var videoURL: String? {
 
-        if let url, let fileType, Self.supportedVideoTypes.contains(fileType) {
+        if let url, let fileType, Self.supportedVideoTypes.contains(fileType.lowercased()) {
             //if the default url is already a video use it
             return url
         }

--- a/Modules/Sources/PocketCastsServer/Public/Sync/Api_AlternateEnclosure+HLS.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/Api_AlternateEnclosure+HLS.swift
@@ -6,7 +6,7 @@ extension Array where Element == Api_AlternateEnclosure {
     /// Mirrors `Episode.hlsUrl(fromEpisodeJson:)` for the protobuf sync path. Normalises the
     /// protobuf default of `""` to `nil` so it isn't persisted as a bogus "missing-but-present" url.
     var hlsUrl: String? {
-        let uri = first { $0.type.caseInsensitiveCompare(Episode.hlsEnclosureType) == .orderedSame }?
+        let uri = first { Episode.isHLSEnclosureType($0.type) }?
             .sources.first?.uri
         return (uri?.isEmpty ?? true) ? nil : uri
     }

--- a/Modules/Tests/PocketCastsDataModelTests/EpisodeAlternateEnclosuresTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/EpisodeAlternateEnclosuresTests.swift
@@ -39,6 +39,19 @@ final class EpisodeAlternateEnclosuresTests: XCTestCase {
         XCTAssertEqual(Episode.hlsUrl(fromEpisodeJson: json), "https://example.com/stream.m3u8")
     }
 
+    /// Feeds advertise HLS under several types.
+    func testMatchesEveryAdvertisedHlsType() {
+        for type in ["application/x-mpegURL", "application/mpegURL", "application/vnd.apple.mpegurl"] {
+            let json: [String: Any] = [
+                "alternate_enclosures": [
+                    ["type": type, "sources": [["uri": "https://example.com/stream.m3u8"]]]
+                ]
+            ]
+
+            XCTAssertEqual(Episode.hlsUrl(fromEpisodeJson: json), "https://example.com/stream.m3u8", "failed for type \(type)")
+        }
+    }
+
     func testReturnsNilWhenNoHlsType() {
         let json: [String: Any] = [
             "alternate_enclosures": [

--- a/Modules/Tests/PocketCastsServerTests/AlternateEnclosureHLSTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/AlternateEnclosureHLSTests.swift
@@ -16,7 +16,7 @@ final class AlternateEnclosureHLSTests: XCTestCase {
     }
 
     func testReturnsHLSUrlWhenPresent() {
-        let enclosures = [enclosure(type: Episode.hlsEnclosureType, uris: ["https://example.com/stream.m3u8"])]
+        let enclosures = [enclosure(type: Episode.advertisedHLSMimeType, uris: ["https://example.com/stream.m3u8"])]
         XCTAssertEqual(enclosures.hlsUrl, "https://example.com/stream.m3u8")
     }
 
@@ -25,16 +25,24 @@ final class AlternateEnclosureHLSTests: XCTestCase {
         XCTAssertEqual(enclosures.hlsUrl, "https://example.com/stream.m3u8")
     }
 
+    /// Feeds advertise HLS under several types.
+    func testMatchesEveryAdvertisedHLSType() {
+        for type in ["application/x-mpegURL", "application/mpegURL", "application/vnd.apple.mpegurl"] {
+            let enclosures = [enclosure(type: type, uris: ["https://example.com/stream.m3u8"])]
+            XCTAssertEqual(enclosures.hlsUrl, "https://example.com/stream.m3u8", "failed for type \(type)")
+        }
+    }
+
     func testPicksHLSAmongOtherEnclosures() {
         let enclosures = [
             enclosure(type: "video/mp4", uris: ["https://example.com/video.mp4"]),
-            enclosure(type: Episode.hlsEnclosureType, uris: ["https://example.com/stream.m3u8"])
+            enclosure(type: Episode.advertisedHLSMimeType, uris: ["https://example.com/stream.m3u8"])
         ]
         XCTAssertEqual(enclosures.hlsUrl, "https://example.com/stream.m3u8")
     }
 
     func testReturnsFirstSourceUri() {
-        let enclosures = [enclosure(type: Episode.hlsEnclosureType, uris: ["https://a.example.com/1.m3u8", "https://b.example.com/2.m3u8"])]
+        let enclosures = [enclosure(type: Episode.advertisedHLSMimeType, uris: ["https://a.example.com/1.m3u8", "https://b.example.com/2.m3u8"])]
         XCTAssertEqual(enclosures.hlsUrl, "https://a.example.com/1.m3u8")
     }
 
@@ -48,7 +56,7 @@ final class AlternateEnclosureHLSTests: XCTestCase {
     }
 
     func testReturnsNilWhenHLSEnclosureHasNoSources() {
-        let enclosures = [enclosure(type: Episode.hlsEnclosureType, uris: [])]
+        let enclosures = [enclosure(type: Episode.advertisedHLSMimeType, uris: [])]
         XCTAssertNil(enclosures.hlsUrl)
     }
 }

--- a/Modules/Tests/PocketCastsServerTests/RefreshEpisodeHLSTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/RefreshEpisodeHLSTests.swift
@@ -20,6 +20,19 @@ final class RefreshEpisodeHLSTests: XCTestCase {
         XCTAssertEqual(episode.hlsUrl, "https://example.com/master.m3u8")
     }
 
+    /// Feeds advertise HLS under several types.
+    func testMatchesEveryAdvertisedHlsType() throws {
+        for type in ["application/x-mpegURL", "application/mpegURL", "application/vnd.apple.mpegurl"] {
+            let episode = try decode("""
+            { "uuid": "abc",
+              "alternate_enclosures": [
+                { "type": "\(type)", "sources": [{ "uri": "https://example.com/master.m3u8" }] }
+              ] }
+            """)
+            XCTAssertEqual(episode.hlsUrl, "https://example.com/master.m3u8", "failed for type \(type)")
+        }
+    }
+
     func testPicksHlsAmongOtherEnclosures() throws {
         let episode = try decode("""
         { "uuid": "abc",

--- a/Pocket Casts TV App/UI/Discover/DiscoverRowSection.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverRowSection.swift
@@ -178,7 +178,7 @@ struct DiscoverRowSection: View {
     @ViewBuilder
     var newVideoReleasesRow: some View {
         if !tabRouter.homeModel.newVideoReleases.isEmpty {
-            VideoEpisodesHorizontalList(title: L10n.tvHomeNewReleases,
+            VideoEpisodesHorizontalList(title: L10n.newEpisodes,
                                    focusSection: HomeView.Section.homeNewVideoReleases.rawValue,
                                    episodes: tabRouter.homeModel.newVideoReleases, episodeContext: .other(showGoToPodcast: true)) {
                 tabRouter.showFullScreenPlayer = true

--- a/podcasts/Google Cast/GoogleCastManager.swift
+++ b/podcasts/Google Cast/GoogleCastManager.swift
@@ -221,7 +221,7 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
         // When streaming HLS, the content URL is an .m3u8 manifest, not the progressive file.
         // The receiver needs the HLS content type to load it — the episode's file type describes
         // the progressive enclosure and would make the receiver try to play the manifest directly.
-        let fileType = isHLS ? Episode.hlsEnclosureType : (episode.fileType ?? "")
+        let fileType = isHLS ? Episode.advertisedHLSMimeType : (episode.fileType ?? "")
         let mediaBuilder = GCKMediaInformationBuilder()
         mediaBuilder.contentURL = downloadUrl
         mediaBuilder.streamType = .buffered


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/PCIOS-889/the-app-does-not-recognize-some-hls-enclosures

Podcast feeds advertise HLS under a few different MIME types, but we only matched `application/x-mpegURL`. Episodes that used `application/mpegURL` or `application/vnd.apple.mpegurl` looked like they had no HLS stream at all.

Also renames `Episode.hlsEnclosureType` to `Episode.advertisedHLSMimeType`. That constant is the type we send out (Google Cast needs it), not the set we accept, and the old name made it easy to confuse the two.

Also changes the Discover list for new episode videos to "New episodes" to match the design.

## To test

1. Play the latest episode from Mike Dell's World https://pca.st/mikedellsworld
2. Make sure the video plays instead of audio

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
