### PR TITLE
Fix an issue with audio session completion delivered on background queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
 - [tvOS] Add a Top Results tab to Search, now the default, showing a Featured row of matching video episodes followed by Episodes and Podcasts rows. The Episodes tab leads with the same Featured row whenever a search turns up video episodes [#4926](https://github.com/Automattic/pocket-casts-ios/pull/4926)
+- [tvOS] Fix playback controls stalling the app when another app is holding audio, by activating the audio session off the main thread [#4938](https://github.com/Automattic/pocket-casts-ios/pull/4938)
 
 8.18
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 - Fix the bookmark multi-select long press options: Select all above/below now flip to Deselect all above/below once that range is selected, and are left out for the first and last bookmark [#4915](https://github.com/Automattic/pocket-casts-ios/pull/4915)
 - Fix the podcast screen tabs being clipped when scrolled [#4918](https://github.com/Automattic/pocket-casts-ios/pull/4918)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
+- Improve playback reliability when starting audio [#4938](https://github.com/Automattic/pocket-casts-ios/pull/4938)
 - [tvOS] Show Episode artworks on player, episode show notes and podcast episode list [#4893](https://github.com/Automattic/pocket-casts-ios/pull/4893)
 - [tvOS] Add a Top Results tab to Search, now the default, showing a Featured row of matching video episodes followed by Episodes and Podcasts rows. The Episodes tab leads with the same Featured row whenever a search turns up video episodes [#4926](https://github.com/Automattic/pocket-casts-ios/pull/4926)
-- [tvOS] Fix playback controls stalling the app when another app is holding audio, by activating the audio session off the main thread [#4938](https://github.com/Automattic/pocket-casts-ios/pull/4938)
 
 8.18
 -----

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -215,11 +215,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Ignores play remote commands when another app is playing non-mixable audio
     case ignorePlayWithOtherAudio
 
-    /// activates the audio session in the background to avoid locks in the main thread
-    case activateAudioSessionInBackground
-
     /// Use cellular-specific network APIs instead of expensive network APIs
     case useCellularNetworkApis
+
     /// Optimizes manual playlist queries with improved deduplication
     case optimizeManualPlaylistQueries
 
@@ -460,12 +458,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .ignorePlayWithOtherAudio:
             true
-        case .activateAudioSessionInBackground:
-#if os(tvOS)
-            false
-#else
-            true
-#endif
         case .useCellularNetworkApis:
             true
         case .optimizeManualPlaylistQueries:

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1663,10 +1663,15 @@ class PlaybackManager: ServerPlaybackDelegate {
         player = nil
     }
 
-    func activateAudioSession(completion: ((Bool) -> Void)?) {
+    /// Activates the audio session, calling `completion` on the main queue once it has.
+    func activateAudioSession(completion: (@MainActor (Bool) -> Void)?) {
+        let completeOnMain: (Bool) -> Void = { activated in
+            DispatchQueue.main.async { completion?(activated) }
+        }
+
         #if !os(watchOS) && !APPCLIP && !os(tvOS)
             if GoogleCastManager.sharedManager.connectedOrConnectingToDevice() {
-                completion?(true)
+                completeOnMain(true)
                 return
             }
         #endif
@@ -1677,24 +1682,24 @@ class PlaybackManager: ServerPlaybackDelegate {
             do {
                 try setAudioSessionProperties()
                 AVAudioSession.sharedInstance().activate(options: []) { activated, _ in
-                    completion?(activated)
+                    completeOnMain(activated)
                 }
             } catch {
                 FileLog.shared.addMessage("activating audio session failed \(error.localizedDescription)")
-                completion?(false)
+                completeOnMain(false)
             }
         #else
         if FeatureFlag.activateAudioSessionInBackground.enabled {
             // Perform audio session activation on a background queue to avoid blocking the main thread
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let self else {
-                    completion?(false)
+                    completeOnMain(false)
                     return
                 }
-                self.activateSession(completion: completion)
+                self.activateSession(completion: completeOnMain)
             }
         } else {
-            self.activateSession(completion: completion)
+            self.activateSession(completion: completeOnMain)
         }
         #endif
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1690,11 +1690,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             }
         #else
             // Perform audio session activation on a background queue to avoid blocking the main thread
-            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-                guard let self else {
-                    completeOnMain(false)
-                    return
-                }
+            DispatchQueue.global(qos: .userInitiated).async {
                 self.activateSession(completion: completeOnMain)
             }
         #endif

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1689,7 +1689,6 @@ class PlaybackManager: ServerPlaybackDelegate {
                 completeOnMain(false)
             }
         #else
-        if FeatureFlag.activateAudioSessionInBackground.enabled {
             // Perform audio session activation on a background queue to avoid blocking the main thread
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 guard let self else {
@@ -1698,9 +1697,6 @@ class PlaybackManager: ServerPlaybackDelegate {
                 }
                 self.activateSession(completion: completeOnMain)
             }
-        } else {
-            self.activateSession(completion: completeOnMain)
-        }
         #endif
     }
 

--- a/podcasts/Sharing/Clip/ClipPlaybackManager.swift
+++ b/podcasts/Sharing/Clip/ClipPlaybackManager.swift
@@ -42,13 +42,7 @@ class ClipPlaybackManager: ObservableObject {
         let playbackCMTime = CMTime(seconds: playbackTime, preferredTimescale: .audio)
 
         normalPlaybackManager.activateAudioSession(completion: { [weak self] _ in
-            if Thread.current.isMainThread {
-                self?.startPlayer(at: playbackCMTime)
-            } else {
-                DispatchQueue.main.async { [weak self] in
-                    self?.startPlayer(at: playbackCMTime)
-                }
-            }
+            self?.startPlayer(at: playbackCMTime)
         })
 
         isPlaying = true


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-778

`activateAudioSession` now always calls its completion on the main queue, and always activates on a background queue. Extracted from #4934, which also serializes every `AVAudioSession` call on a dedicated queue — that part is not here.

### How we got here

- [#3826](https://github.com/Automattic/pocket-casts-ios/pull/3826) moved activation to `DispatchQueue.global(qos: .userInitiated)` behind the `activateAudioSessionInBackground` flag, because activation blocking the main thread was breaking playback started from the widget. Unintended side effect: the completion started firing on an arbitrary background thread.
- [#4695](https://github.com/Automattic/pocket-casts-ios/pull/4695) had to make `hasReportedSourceResolved` atomic as fallout, and `ClipPlaybackManager` still branches on `Thread.current.isMainThread` for the same reason.
- [#4651](https://github.com/Automattic/pocket-casts-ios/pull/4651) turned the flag off on tvOS, putting activation back on the main thread there — trading the hang back for correctness.

The thread the completion arrived on was a function of platform *and* runtime state: main when Cast was connected (synchronously, from the early return) or on tvOS, a global queue on iOS, and whatever thread `activate(options:)` used on watchOS. Same API, four behaviors, so every caller had to defend for itself.

### Potential negative effects this fixes

Everything below is reachable from the two completion bodies in `PlaybackManager` (`ensureBackgroundMediaSessionConfiguration`, `play`) once the completion runs off the main thread:

- **`MPRemoteCommandCenter` mutated off main.** `updateExtraActions` and `updateCommandCenterSkipTimes` do `removeTarget(nil)` → `addTarget` → `isEnabled` on shared command objects. MediaPlayer isn't documented as thread-safe, and `DispatchQueue.global()` is *concurrent*, so two rapid play cycles can interleave that remove/add pair — leaving a lock-screen or CarPlay button with no target (dead) or two targets (one press skips twice).
- **No ordering between activations.** Completion N+1 can land before N, so `aboutToPlay` and the command-center targets settle on whichever completion finished last rather than the last thing the user pressed.
- **Timers that silently never fire.** A global-queue thread has no run loop. `startUpdateTimer` and `TimedActionHelper` each defend with their own hop to main, and `TimedActionHelper` hops with `DispatchQueue.main.sync` — which blocks the background thread on main, and deadlocks if main is waiting on that work.
- **Unsynchronized `PlaybackManager` state.** The completion reads and writes `player`, `haveCalledPlayerLoad` and `analyticsPlaybackHelper.currentSource` while `play()`/`pause()` touch the same fields from main. The two `AtomicBool`s added in #4695 cover two flags; the rest is unguarded.
- **Notification delivery.** `NotificationCenter` delivers on the posting thread, so a plain `.post` on that path reaches UI observers on a background thread.
- **UIKit.** `updateIdleTimer` touches `UIApplication.shared.isIdleTimerDisabled`, guarded by yet another main hop.

The pattern: this worked because roughly six separate places each remembered to hop to main. Guaranteeing delivery at the source collapses that to one hop, and `@MainActor` on the closure lets the compiler enforce it instead of a comment.

### This PR

- `activateAudioSession` wraps every path — including the Cast early return, the watchOS callback and its `catch` — so the completion is always delivered on the main queue.
- The completion is typed `@MainActor (Bool) -> Void`, so the contract is enforced at the call site.
- `activateAudioSessionInBackground` and its tvOS carve-out are removed; activation is always off the main thread. The carve-out existed because the completion fired on an arbitrary thread on tvOS, which is no longer true.

Follow-ups this unblocks, deliberately left out: the `Thread.current.isMainThread` branch in `ClipPlaybackManager`, and the two `AtomicBool`s that only exist because the completion could run off main.

## To test

tvOS is the platform whose behavior actually changes — it had activation back on the main thread and now gets the same background activation as everything else.

1. Play an episode; pause, resume, skip forward/back, change episodes. Playback behaves as before.
2. Start audio in another app (or a game), then start playback in Pocket Casts from the widget or lock screen. Audio takes over without a stall.
3. Tap play/pause rapidly from the lock screen or CarPlay, then check the skip buttons still work and skip once per press.
4. [tvOS] Play, pause, resume and switch episodes.
5. [watchOS] Play an episode with no output connected; the route picker still appears and playback starts after choosing an output.
6. [Chromecast] Connect to a device and start playback; it still starts (this path returns early and now completes asynchronously).
7. Share a clip and play it back — `ClipPlaybackManager` starts its player from this completion.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
