### PR TITLE
Add the Smart Bookmarks promo

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -314,6 +314,11 @@ public enum FeatureFlag: String, CaseIterable {
     /// Show the Categories and Curated rows on the tvOS Home screen
     case tvHomeCategoriesAndCurated
 
+    /// Introduce Smart Bookmarks with a tip in the player and a "New" badge on the Add Bookmark row.
+    ///
+    /// The promo runs for 8.19, 8.20 and 8.21 only. Remove this flag and `SmartBookmarksPromo` when 8.22 is cut.
+    case smartBookmarksPromo
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -530,6 +535,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .tvHomeCategoriesAndCurated:
             false
+        case .smartBookmarksPromo:
+            true
         }
     }
 

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Staging.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/Pocket Casts Staging.xcscheme
@@ -68,6 +68,12 @@
             ReferencedContainer = "container:podcasts.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-PCSmartBookmarksPromo"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "StagingDebug"

--- a/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
+++ b/podcasts.xcodeproj/xcshareddata/xcschemes/pocketcasts.xcscheme
@@ -82,6 +82,10 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-PCSmartBookmarksPromo"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-PCSQLTracing"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/podcasts/Bookmarks/SmartBookmarksPromo.swift
+++ b/podcasts/Bookmarks/SmartBookmarksPromo.swift
@@ -3,18 +3,20 @@ import PocketCastsUtils
 
 /// The discoverability affordances that introduce Smart Bookmarks: a tip in the player and a "New" badge
 /// on the Add Bookmark row of the player's More Actions menu.
+///
+/// Remove this type, `FeatureFlag.smartBookmarksPromo` and their call sites when 8.22 is cut.
 enum SmartBookmarksPromo {
-    /// The only app version that shows the promo.
-    static let version = "8.19"
+    /// The only app versions that show the promo.
+    static let versions = ["8.19", "8.20", "8.21"]
 
     /// Launch with `-PCSmartBookmarksPromo` (Edit Scheme ▸ Run ▸ Arguments, off by default) to show the promo in
-    /// builds that aren't `version`, and to show the player tip on every launch.
+    /// builds that aren't one of `versions`, and to show the player tip on every launch.
     static let forceLaunchArgument = "-PCSmartBookmarksPromo"
 
     static var isActive: Bool {
-        guard FeatureFlag.smartBookmarks.enabled else { return false }
+        guard FeatureFlag.smartBookmarks.enabled, FeatureFlag.smartBookmarksPromo.enabled else { return false }
 
-        return isForced || runningVersion == version
+        return isForced || versions.contains(runningVersion)
     }
 
     static var shouldShowPlayerTip: Bool {
@@ -26,6 +28,8 @@ enum SmartBookmarksPromo {
     }
 
     /// The running app version as MAJOR.MINOR, so patch releases such as 8.19.1 still count as 8.19.
+    ///
+    /// Listing the versions rather than comparing bounds keeps the check away from string ordering, where "8.9" sorts after "8.19".
     private static var runningVersion: String {
         Settings.appVersion().split(separator: ".").prefix(2).joined(separator: ".")
     }

--- a/podcasts/Bookmarks/SmartBookmarksPromo.swift
+++ b/podcasts/Bookmarks/SmartBookmarksPromo.swift
@@ -1,0 +1,32 @@
+import Foundation
+import PocketCastsUtils
+
+/// The discoverability affordances that introduce Smart Bookmarks: a tip in the player and a "New" badge
+/// on the Add Bookmark row of the player's More Actions menu.
+enum SmartBookmarksPromo {
+    /// The only app version that shows the promo.
+    static let version = "8.19"
+
+    /// Launch with `-PCSmartBookmarksPromo` (Edit Scheme ▸ Run ▸ Arguments, off by default) to show the promo in
+    /// builds that aren't `version`, and to show the player tip on every launch.
+    static let forceLaunchArgument = "-PCSmartBookmarksPromo"
+
+    static var isActive: Bool {
+        guard FeatureFlag.smartBookmarks.enabled else { return false }
+
+        return isForced || runningVersion == version
+    }
+
+    static var shouldShowPlayerTip: Bool {
+        isActive && (Settings.shouldShowBookmarksPlayerTip || isForced)
+    }
+
+    static var isForced: Bool {
+        ProcessInfo.processInfo.arguments.contains(forceLaunchArgument)
+    }
+
+    /// The running app version as MAJOR.MINOR, so patch releases such as 8.19.1 still count as 8.19.
+    private static var runningVersion: String {
+        Settings.appVersion().split(separator: ".").prefix(2).joined(separator: ".")
+    }
+}

--- a/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
+++ b/podcasts/Common SwiftUI/BookmarksLockedStateView.swift
@@ -6,7 +6,7 @@ struct BookmarksLockedStateView<Style: EmptyStateViewStyle>: View {
     @ObservedObject var style: Style
     @StateObject private var upgradeModel: BookmarksUpgradeViewModel
 
-    private var title: String = L10n.noBookmarksTitle
+    private var title: String = L10n.noBookmarksLockedTitle
     private var message: String = L10n.noBookmarksLockedMessage
     private var actionTitle: String = L10n.noBookmarksLockedButtonTitle
 

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -210,6 +210,8 @@ struct Constants {
             static let podcastSort = SettingValue("bookmarks.podcastSort", defaultValue: BookmarkSortOption.newestToOldest)
             static let episodeSort = SettingValue("bookmarks.episodeSort", defaultValue: BookmarkSortOption.newestToOldest)
             static let profileSort = SettingValue("bookmarks.profileSort", defaultValue: BookmarkSortOption.newestToOldest)
+
+            static let showPlayerTip = "bookmarks.showPlayerTip"
         }
 
         enum appearance {

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -38,6 +38,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
         // load the first 4 actions into the player, followed by an overflow icon
         playerControlsStackView.removeAllSubviews()
+        smartBookmarksTipAnchor = nil
         for action in actions {
             if !action.canBePerformedOn(episode: playingEpisode) { continue }
 
@@ -57,6 +58,10 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
             overflowButton.addTarget(self, action: #selector(overflowTapped), for: .touchUpInside)
             overflowButton.accessibilityLabel = L10n.accessibilityMoreActions
             addToShelf(on: overflowButton)
+
+            if smartBookmarksTipAnchor == nil {
+                smartBookmarksTipAnchor = overflowButton
+            }
 
             return false
         }
@@ -151,6 +156,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
             button.accessibilityLabel = L10n.addBookmark
 
             addToShelf(on: button)
+            smartBookmarksTipAnchor = button
 
         case .transcript:
             #if !APPCLIP
@@ -580,6 +586,51 @@ extension NowPlayingPlayerItemViewController {
         Analytics.track(.playerShelfActionTapped, properties: ["action": button.analyticsDescription, "from": "shelf"])
     }
 }
+
+// MARK: - Smart Bookmarks tip
+
+#if !APPCLIP
+extension NowPlayingPlayerItemViewController {
+    /// Shows the one-time tip that points at the action used to add a bookmark, for the release that introduces Smart Bookmarks.
+    func showSmartBookmarksTipIfNeeded() {
+        guard
+            SmartBookmarksPromo.shouldShowPlayerTip,
+            smartBookmarksTip == nil,
+            let anchor = smartBookmarksTipAnchor,
+            let episode = PlaybackManager.shared.currentEpisode(),
+            PlayerAction.addBookmark.canBePerformedOn(episode: episode)
+        else {
+            return
+        }
+
+        smartBookmarksTip = presentTip(
+            title: L10n.bookmarksPlayerTipTitle,
+            message: L10n.bookmarksPlayerTipMessage,
+            anchor: .item(anchor),
+            arrow: .down,
+            idealSize: CGSize(width: 240, height: 64),
+            onTap: { [weak self] in
+                self?.dismissSmartBookmarksTip()
+            },
+            onDismiss: { [weak self] in
+                self?.dismissSmartBookmarksTip()
+            },
+            onShow: {
+                Settings.shouldShowBookmarksPlayerTip = false
+            }
+        )
+    }
+
+    func dismissSmartBookmarksTip() {
+        guard smartBookmarksTip != nil else { return }
+
+        Settings.shouldShowBookmarksPlayerTip = false
+        smartBookmarksTip?.dismiss(animated: true) { [weak self] in
+            self?.smartBookmarksTip = nil
+        }
+    }
+}
+#endif
 
 extension NowPlayingPlayerItemViewController: AVRoutePickerViewDelegate {
     func routePickerViewWillBeginPresentingRoutes(_ routePickerView: AVRoutePickerView) {

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -237,6 +237,10 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
     var lastShelfLoadState = ShelfLoadState()
 
+    /// The shelf button the Smart Bookmarks tip points at: the bookmark button when it's on the shelf, the overflow button otherwise.
+    weak var smartBookmarksTipAnchor: UIView?
+    var smartBookmarksTip: UIViewController?
+
     private var bannerAdHostingController: PCHostingController<AnyView>?
     private var bannerAdHeightConstraint: NSLayoutConstraint?
 
@@ -277,6 +281,8 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
         // Show the overflow menu
         if AnnouncementFlow.current == .bookmarksPlayer {
             overflowTapped()
+        } else {
+            showSmartBookmarksTipIfNeeded()
         }
         #endif
     }
@@ -289,6 +295,9 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         bannerTask?.cancel()
+        #if !APPCLIP
+        dismissSmartBookmarksTip()
+        #endif
     }
 
     private var lastBoundsAdjustedFor = CGRect.zero

--- a/podcasts/Onboarding/Plus/NewUpgrade/Animations/BookmarksAnimationView.swift
+++ b/podcasts/Onboarding/Plus/NewUpgrade/Animations/BookmarksAnimationView.swift
@@ -1,103 +1,115 @@
 import Foundation
 import SwiftUI
 
-fileprivate struct BookmarkUpgradeAnimation {
-    let image: String
-    let title: String
-    let time: String
-    let rotationStart: Double
-    let rotationEnd: Double
+private struct BookmarkUpgradeCardStyle {
     let gradientStart: Color
     let gradientEnd: Color
+
+    static let front = BookmarkUpgradeCardStyle(gradientStart: Color(hex: "#0202FE"), gradientEnd: Color(hex: "#27D9E9"))
+    static let middle = BookmarkUpgradeCardStyle(gradientStart: Color(hex: "#EC4034"), gradientEnd: Color(hex: "#FF9D00"))
+    static let back = BookmarkUpgradeCardStyle(gradientStart: Color(hex: "#E8A92C"), gradientEnd: Color(hex: "#E4D820"))
 }
 
-fileprivate struct BookmarkUpgradeRow: View {
+private extension BookmarkUpgradeCardStyle {
+    var gradient: LinearGradient {
+        LinearGradient(
+            stops: [
+                Gradient.Stop(color: gradientStart, location: 0.00),
+                Gradient.Stop(color: gradientEnd, location: 1.00),
+            ],
+            startPoint: UnitPoint(x: 0.0, y: 1.0),
+            endPoint: UnitPoint(x: 1.0, y: 0.0)
+        )
+    }
+}
 
-    let bookmark: BookmarkUpgradeAnimation
-    let index: Int
-
-    @EnvironmentObject var theme: Theme
-
-    @State private var rotation = Angle(degrees: 0.0)
-    @State private var opacity = 0.0
-    @State private var selected = true
-    @State private var scale: CGFloat = 2.0
+/// The bookmark a listener ends up with: a generated title, the words from the transcript, and the timestamp.
+private struct BookmarkUpgradeCard: View {
+    @ScaledMetric(relativeTo: .subheadline) private var artworkSize = 44
 
     var body: some View {
-        VStack(alignment: .center, spacing: 18) {
-            Image(bookmark.image)
+        HStack(spacing: 12) {
+            Image("login-cover-2")
                 .resizable()
-                .frame(width: 78, height: 78)
-                .cornerRadius(8)
-            Text(bookmark.title)
-                .font(size: 16, style: .body, weight: .medium)
-                .kerning(0.36)
-                .foregroundStyle(.white)
-            HStack {
-                Text(bookmark.time)
-                    .font(size: 16, style: .body, weight: .medium)
-                    .foregroundStyle(.black)
-                Image("bookmarks-icon-play")
-                    .renderingMode(.template)
-                    .foregroundStyle(.black)
+                .frame(width: artworkSize, height: artworkSize)
+                .cornerRadius(6)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L10n.bookmarksUpgradeExampleTitle)
+                    .font(size: 15, style: .subheadline, weight: .semibold)
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                Text(L10n.bookmarksUpgradeExamplePassage)
+                    .font(size: 12, style: .caption, weight: .regular)
+                    .foregroundStyle(.white.opacity(0.8))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
-            .background {
-                Capsule(style: .continuous)
-                    .fill(Color.white)
-            }
+
+            Spacer(minLength: 8)
+
+            timestamp
         }
-        .padding(.vertical, 24)
-        .frame(width: 180, height: 180)
-        .background(
-            LinearGradient(
-                stops: [
-                    Gradient.Stop(color: bookmark.gradientStart, location: 0.00),
-                    Gradient.Stop(color: bookmark.gradientEnd, location: 1.00),
-                ],
-                startPoint: UnitPoint(x: 0.85, y: 0.94),
-                endPoint: UnitPoint(x: 0.18, y: 0.06)
-            )
-        )
+        .padding(12)
+        .background(BookmarkUpgradeCardStyle.front.gradient)
         .cornerRadius(12)
-        .shadow(color: .black.opacity(0.2), radius: 16, x: 0, y: 2)
-        .rotationEffect(rotation)
-        .opacity(opacity)
-        .scaleEffect(scale)
-        .onAppear {
-            animate(Double(index))
+    }
+
+    private var timestamp: some View {
+        HStack(spacing: 4) {
+            Text(Constants.timestamp)
+                .font(size: 13, style: .caption, weight: .medium)
+                .foregroundStyle(.black)
+            Image("bookmarks-icon-play")
+                .renderingMode(.template)
+                .foregroundStyle(.black)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background {
+            Capsule(style: .continuous)
+                .fill(Color.white)
         }
     }
 
-    private func animate(_ index: Double) {
-        rotation = Angle(degrees: bookmark.rotationStart)
-        opacity = 0
-        withAnimation(.easeInOut(duration: 0.8).delay(0.1 + (0.9 * index))) {
-            rotation = Angle(degrees: bookmark.rotationEnd)
-            opacity = 1
-            scale = 1
-        }
+    private enum Constants {
+        static let timestamp = "6:45"
     }
 }
 
 struct BookmarksAnimationView: View {
-
-    fileprivate let bookmarks: [BookmarkUpgradeAnimation] = [
-        .init(image: "login-cover-9", title: "Amazing quote!", time: "19:05", rotationStart: 9.5, rotationEnd: -2.5, gradientStart: Color(hex: "#E4D820"), gradientEnd: Color(hex: "#E8A92C")),
-        .init(image: "login-cover-10", title: "This bit cracks me up", time: "23:10", rotationStart: 12, rotationEnd: 7, gradientStart: Color(hex: "#EC4034"), gradientEnd: Color(hex: "#FF9D00")),
-        .init(image: "login-cover-2", title: "Love this part!", time: "6:45", rotationStart: 5, rotationEnd: -5, gradientStart: Color(hex: "#0202FE"), gradientEnd: Color(hex: "#27D9E9")),
-    ]
-
-    @EnvironmentObject var theme: Theme
+    @State private var revealed = false
 
     var body: some View {
-        ZStack {
-            ForEach(Array(zip(bookmarks.indices, bookmarks)), id: \.0) { index, bookmark in
-                BookmarkUpgradeRow(bookmark: bookmark, index: index).zIndex(Double(index) * 0.1)
+        BookmarkUpgradeCard()
+            .shadow(color: .black.opacity(0.2), radius: 16, x: 0, y: 2)
+            .opacity(revealed ? 1 : 0)
+            .offset(y: revealed ? 0 : 24)
+            .animation(.easeOut(duration: 0.5).delay(0.5), value: revealed)
+            .background(alignment: .top) {
+                stackedCards
             }
+            .padding(.horizontal, 16)
+            .onAppear {
+                revealed = true
+            }
+    }
+
+    private var stackedCards: some View {
+        ZStack(alignment: .top) {
+            card(style: .back, inset: 34, offset: -22)
+                .animation(.easeOut(duration: 0.5).delay(0.1), value: revealed)
+            card(style: .middle, inset: 17, offset: -11)
+                .animation(.easeOut(duration: 0.5).delay(0.3), value: revealed)
         }
-        .padding(.horizontal, 16)
+    }
+
+    private func card(style: BookmarkUpgradeCardStyle, inset: CGFloat, offset: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(style.gradient)
+            .padding(.horizontal, inset)
+            .offset(y: revealed ? offset : 0)
+            .opacity(revealed ? 1 : 0)
     }
 }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -1258,6 +1258,17 @@ class Settings: NSObject {
         }
     }
 
+    // MARK: - Smart Bookmarks Promo
+
+    static var shouldShowBookmarksPlayerTip: Bool {
+        get {
+            UserDefaults.standard.value(forKey: Constants.UserDefaults.bookmarks.showPlayerTip) as? Bool ?? true
+        }
+        set {
+            UserDefaults.standard.setValue(newValue, forKey: Constants.UserDefaults.bookmarks.showPlayerTip)
+        }
+    }
+
     // MARK: - Playlists
 
     static var shouldShowNewFilterTip: Bool {

--- a/podcasts/ShelfActionsViewController+Table.swift
+++ b/podcasts/ShelfActionsViewController+Table.swift
@@ -72,6 +72,8 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
         cell.actionSubtitle.text = (tableView.isEditing && playingEpisode is UserEpisode) ? action.subtitle() : nil
         cell.actionSubtitle.isHidden = (cell.actionSubtitle.text == nil)
 
+        cell.showsNewBadge = !tableView.isEditing && action == .addBookmark && SmartBookmarksPromo.isActive
+
         return cell
     }
 

--- a/podcasts/ShelfCell.swift
+++ b/podcasts/ShelfCell.swift
@@ -18,16 +18,48 @@ class ShelfCell: UITableViewCell {
     @IBOutlet var actionIcon: UIImageView!
     @IBOutlet var customViewContainer: UIView!
 
+    private let newBadge = NewBadgeLabel()
+
+    /// Shows a "New" pill next to the action name.
+    var showsNewBadge: Bool {
+        get { !newBadge.isHidden }
+        set {
+            newBadge.isHidden = !newValue
+            if newValue {
+                newBadge.updateColors()
+            }
+        }
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
         setHighlightedState(false)
         overrideUserInterfaceStyle = .dark
+        setupNewBadge()
         updateSize()
 
         registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (view: ShelfCell, _) in
             view.updateSize()
         }
+    }
+
+    /// Moves the action name into a row of its own so the badge can sit beside it rather than below it.
+    private func setupNewBadge() {
+        guard let titleStack = actionName.superview as? UIStackView,
+              let index = titleStack.arrangedSubviews.firstIndex(of: actionName) else { return }
+
+        newBadge.isHidden = true
+
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.init(1), for: .horizontal)
+        spacer.setContentCompressionResistancePriority(.init(1), for: .horizontal)
+
+        let titleRow = UIStackView(arrangedSubviews: [actionName, newBadge, spacer])
+        titleRow.axis = .horizontal
+        titleRow.alignment = .center
+        titleRow.spacing = 8
+        titleStack.insertArrangedSubview(titleRow, at: index)
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -59,6 +91,7 @@ class ShelfCell: UITableViewCell {
         super.prepareForReuse()
 
         customViewContainer.removeAllSubviews()
+        showsNewBadge = false
     }
 
     private func updateSize() {
@@ -67,5 +100,48 @@ class ShelfCell: UITableViewCell {
         actionIcon.updateSizeConstraints(to: iconSize)
 
         customViewContainer.updateSizeConstraints(to: iconSize)
+    }
+}
+
+/// A pill that marks a row as a feature introduced in the current release.
+private final class NewBadgeLabel: UILabel {
+    private let insets = UIEdgeInsets(top: 3, left: 8, bottom: 3, right: 8)
+
+    init() {
+        super.init(frame: .zero)
+
+        text = L10n.badgeNew
+        font = .font(ofSize: 13, weight: .medium, scalingWith: .footnote)
+        adjustsFontForContentSizeCategory = true
+        textAlignment = .center
+        layer.masksToBounds = true
+        setContentHuggingPriority(.required, for: .horizontal)
+        setContentCompressionResistancePriority(.required, for: .horizontal)
+        updateColors()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func updateColors() {
+        textColor = ThemeColor.playerContrast01()
+        backgroundColor = ThemeColor.playerContrast05()
+    }
+
+    override var intrinsicContentSize: CGSize {
+        let size = super.intrinsicContentSize
+
+        return CGSize(width: size.width + insets.left + insets.right, height: size.height + insets.top + insets.bottom)
+    }
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: insets))
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        layer.cornerRadius = bounds.height / 2
     }
 }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4562,10 +4562,28 @@
 "no_bookmarks_button_title" = "Headphone settings";
 
 /* Title shown when the bookmarks feature is locked due to account upgrade status */
-"no_bookmarks_locked_message" = "You can save timestamps of important moments in an episode.";
+"no_bookmarks_locked_title" = "Save the parts worth keeping";
+
+/* Subtitle shown when the bookmarks feature is locked due to account upgrade status. It describes that a bookmark is created with a single tap and is saved with a generated title and the words spoken at that moment. */
+"no_bookmarks_locked_message" = "One tap. It’s named, and the words come with it.";
 
 /* Button title shown when the bookmarks feature is locked due to account upgrade status. This will take the user to the upgrade screen. */
 "no_bookmarks_locked_button_title" = "Get Bookmarks";
+
+/* Badge marking a menu item as a feature introduced in the current release */
+"badge_new" = "New";
+
+/* Title of the tip shown in the player that points at the action used to add a bookmark */
+"bookmarks_player_tip_title" = "Add bookmark";
+
+/* Body of the tip shown in the player that points at the action used to add a bookmark */
+"bookmarks_player_tip_message" = "Keep the part you wanted";
+
+/* Title of the example bookmark shown on the bookmarks upgrade screen. It is a sample of a title generated for the user. */
+"bookmarks_upgrade_example_title" = "The audition room";
+
+/* Transcript excerpt of the example bookmark shown on the bookmarks upgrade screen. It is a sample of the words captured with a bookmark. */
+"bookmarks_upgrade_example_passage" = "You’re casting the person, not the résumé.";
 
 /* Title of a message when no search results appear */
 "bookmark_search_no_results_title" = "No bookmarks found";


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Adds the two discoverability affordances for Smart Bookmarks — a one-time tip in the player and a "New" badge on Add Bookmark — and refreshes the bookmarks upsell copy and the upgrade screen card.

`SmartBookmarksPromo` gates both affordances: the running version, reduced to `MAJOR.MINOR`, must be one of `["8.19", "8.20", "8.21"]`, and both `FeatureFlag.smartBookmarks` and the new `FeatureFlag.smartBookmarksPromo` kill switch must be on. The versions are listed rather than compared as bounds, since string ordering puts "8.9" after "8.19". **Delete `SmartBookmarksPromo`, the flag and their call sites when 8.22 is cut** — noted on both declarations.

What's New isn't used for this: its range is open-ended forward, it skips fresh installs, and it's one-shot — the opposite of what a release-scoped badge needs.

Trunk is 8.18, so the promo is off in current builds. `-PCSmartBookmarksPromo` (in the Debug and Staging schemes, unchecked) turns it on and re-shows the tip on every launch.

## To test

1. Tick `-PCSmartBookmarksPromo` in Edit Scheme ▸ Run ▸ Arguments, and confirm **Smart Bookmarks** and **Smart Bookmarks Promo** are both on in Beta Features.
2. Open the full player: the tip points at the bookmark shelf button, or at ••• when the action sits in the overflow menu. Tap it or tap outside to dismiss.
3. Open ••• — **Add Bookmark** has a "New" pill. Reopen the sheet to check it doesn't leak onto other rows, tap Edit to confirm it hides while rearranging, and switch themes to confirm it recolors.
4. Turn **Smart Bookmarks Promo** off, then untick the launch argument and relaunch: no tip, no pill. That's what 8.18 and 8.22 users get.
5. On a free account, the player's Bookmarks tab reads "Save the parts worth keeping", and **Get Bookmarks** shows the new horizontal card with the generated title, transcript passage and timestamp.
6. Repeat steps 3 and 5 at an accessibility text size.

<img width="320" alt="Screenshot 2026-08-11 at 3 24 09 PM" src="https://github.com/user-attachments/assets/d9190b0b-9782-437e-98b5-3f27f8ce7f5c" /> <img width="320" alt="Screenshot 2026-08-11 at 3 24 12 PM" src="https://github.com/user-attachments/assets/7e9b7ee0-5c31-4672-92a4-8bdee6d51e22" />
<img width="320"alt="Screenshot 2026-08-11 at 3 24 15 PM" src="https://github.com/user-attachments/assets/cc39dc7b-0253-4cc4-807d-3de68a7bc5ad" /> <img width="320" alt="Screenshot 2026-08-11 at 3 24 19 PM" src="https://github.com/user-attachments/assets/2df8d7eb-de47-4f36-bccc-2999267d5993" />
<img width="320" alt="Screenshot 2026-08-11 at 3 26 02 PM" src="https://github.com/user-attachments/assets/316a911e-224c-45c7-b987-c869e42c5115" />

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
