### PR TITLE
Trim the App Store description under its budget

### DIFF
--- a/fastlane/metadata/default/description.txt
+++ b/fastlane/metadata/default/description.txt
@@ -9,11 +9,9 @@ Your listening, your way. Organize your episodes with our powerful new Playlists
 - Playlists: Curate your perfect mix. Combine episodes from different podcasts, build collections around specific themes or guests, and even add episodes from podcasts you don't follow.
 - Smart Playlists: We’ve upgraded our famous Filters. Build lists that automatically update based on rules you set, like release date, duration, or download status.
 
-With a unique set of simple yet powerful features and a limitless podcast database, you're sure to find something you love.
-
 WE SWEAT THE DETAILS
  • Design: Easily listen to, manage and find new podcasts.
- • Themes: Whether you're a dark or light theme person we've got you covered. We even have you OLED lovers covered with our Extra Dark theme.
+ • Themes: Dark, light, and an Extra Dark theme for those of you on OLED screens.
  • Universal: Custom but familiar iPad interface, supporting Slide Over, Split View and Picture in Picture.
  • Everywhere: CarPlay, AirPlay, Chromecast and Sonos. Listen to your podcasts in more places than ever before.
 
@@ -26,27 +24,20 @@ POWERFUL PLAYBACK
  • Chapters: Jump between chapters easily, and enjoy embedded artwork that the author has added (we support MP3 and M4A chapter formats).
  • Audio & video: Play all of your favorite episodes, toggle video to audio.
  • Skip playback: Skip episode intros, jump through episodes with custom skip intervals.
- • Apple Watch: Control playback from our Apple Watch app, adjust the volume or change playback effects, all without ever touching your phone.
+ • Apple Watch: Control playback, volume and effects from our Apple Watch app, without ever touching your phone.
  • Sleep timer: We'll pause your episode so you can rest your weary head.
- • Airplay & Chromecast: Send episodes straight to your TV or speakers with a single tap.
- • Sonos: Browse and play your podcast collection directly from the Sonos app.
- • CarPlay: When you're in the car, so are we.
 
 SMART TOOLS
  • Sync: Subscriptions, Up Next, listening history, playback and filters are all securely stored in the cloud. You can pick up where you left off on another device and even the web.
  • Refresh: Let our servers check for new episodes, so you can get on with your day.
  • Notifications: We'll let you know when new episodes arrive, if you like.
  • Auto download: Automatically download episodes for offline playback.
- • Smart Playlists: Organize your episodes using custom rules.
  • Storage: All the tools you need to keep your podcasts tamed.
- • Audible audiobooks podcasts.
 
 ALL YOUR FAVORITES
  • Discover: Subscribe to any podcast in iTunes and more. Browse by charts, networks and categories.
  • Share: Spread the word with podcast and episode sharing.
  • OPML: Jump on board without any hassle with OPML import. Export your collection at any time.
-
-There are many more powerful, straight-forward features that make Pocket Casts the perfect podcasting app for you. So what are you waiting for?
 
 Visit pocketcasts.com for more info about the web and other platforms supported by Pocket Casts.
 

--- a/fastlane/metadata/default/description.txt
+++ b/fastlane/metadata/default/description.txt
@@ -4,7 +4,7 @@ Here's what the press has to say:
  • Wired: "Pocket Casts Is the Podcast App Every iPhone User Needs"
  • iMore: "Pocket Casts is the best podcast app for iPhone"
 
-NEW: PLAYLISTS
+PLAYLISTS
 Your listening, your way. Organize your episodes with our powerful new Playlists feature:
 - Playlists: Curate your perfect mix. Combine episodes from different podcasts, build collections around specific themes or guests, and even add episodes from podcasts you don't follow.
 - Smart Playlists: We’ve upgraded our famous Filters. Build lists that automatically update based on rules you set, like release date, duration, or download status.
@@ -35,7 +35,7 @@ SMART TOOLS
  • Storage: All the tools you need to keep your podcasts tamed.
 
 ALL YOUR FAVORITES
- • Discover: Subscribe to any podcast in iTunes and more. Browse by charts, networks and categories.
+ • Discover: Subscribe to any podcast on Apple Podcasts and more. Browse by charts, networks and categories.
  • Share: Spread the word with podcast and episode sharing.
  • OPML: Jump on board without any hassle with OPML import. Export your collection at any time.
 

--- a/fastlane/test/helpers_test.rb
+++ b/fastlane/test/helpers_test.rb
@@ -95,14 +95,15 @@ class FastlaneHelpersTest < Minitest::Test
   # `RUN_FASTLANE_TESTS` enables this suite for any PR touching `fastlane/*`, which includes the metadata
   # itself — so over-long copy fails on the PR that writes it, not mid-release.
   #
-  # Only the maximum is asserted. Going over a budget is a warning by design, so it must not fail here.
-  def test_shipped_metadata_fits_the_app_store_connect_maximums
+  # Budgets are asserted, not just maximums: a budget only warns from the release lane, and a warning
+  # nobody reads is how a locale ends up shipping with no metadata at all.
+  def test_shipped_metadata_fits_its_budget
     %w[metadata metadata-tvos].each do |folder|
       APP_STORE_METADATA_LIMITS.each_key do |file_name|
         path = File.expand_path("../#{folder}/default/#{file_name}", __dir__)
         length = File.read(path, mode: 'r:UTF-8').length
 
-        refute_equal :over_max, app_store_metadata_length_verdict(file_name, length), "#{path} is #{length} characters"
+        assert_equal :ok, app_store_metadata_length_verdict(file_name, length), "#{path} is #{length} characters"
       end
     end
   end

--- a/fastlane/test/helpers_test.rb
+++ b/fastlane/test/helpers_test.rb
@@ -97,13 +97,14 @@ class FastlaneHelpersTest < Minitest::Test
   #
   # Budgets are asserted, not just maximums: a budget only warns from the release lane, and a warning
   # nobody reads is how a locale ends up shipping with no metadata at all.
-  def test_shipped_metadata_fits_its_budget
+  def test_shipped_metadata_fits_its_limits
     %w[metadata metadata-tvos].each do |folder|
-      APP_STORE_METADATA_LIMITS.each_key do |file_name|
+      APP_STORE_METADATA_LIMITS.each do |file_name, limits|
         path = File.expand_path("../#{folder}/default/#{file_name}", __dir__)
         length = File.read(path, mode: 'r:UTF-8').length
+        limit = limits[:budget] || limits.fetch(:max_size)
 
-        assert_equal :ok, app_store_metadata_length_verdict(file_name, length), "#{path} is #{length} characters"
+        assert_equal :ok, app_store_metadata_length_verdict(file_name, length), "#{path} is #{length} of #{limit} characters"
       end
     end
   end

--- a/fastlane/test/helpers_test.rb
+++ b/fastlane/test/helpers_test.rb
@@ -95,7 +95,7 @@ class FastlaneHelpersTest < Minitest::Test
   # `RUN_FASTLANE_TESTS` enables this suite for any PR touching `fastlane/*`, which includes the metadata
   # itself — so over-long copy fails on the PR that writes it, not mid-release.
   #
-  # Only the maximum is asserted: `description.txt` is over its budget today, which is a warning by design.
+  # Only the maximum is asserted. Going over a budget is a warning by design, so it must not fail here.
   def test_shipped_metadata_fits_the_app_store_connect_maximums
     %w[metadata metadata-tvos].each do |folder|
       APP_STORE_METADATA_LIMITS.each_key do |file_name|


### PR DESCRIPTION
Stacked on #4932 — merge that one first.

#4932 gives `description.txt` a 3400 character budget so translations, which run longer than the English source, stay under the 4000 App Store Connect accepts. The source is 3946, so as it stands the lane would warn on every release run forever, which is the one open concern on that PR. This clears it: 3278, with room for the copy to grow before the warning comes back.

**This needs a marketing sign-off, not an infrastructure one.** The trim is redundancy rather than features — two paragraphs of filler, the Airplay/Chromecast/Sonos/CarPlay bullets that the `Everywhere` line four lines above already names, a duplicate Smart Playlists bullet, and the `Audible audiobooks podcasts.` fragment. Themes and Apple Watch say the same thing in fewer words. Nothing the app does went missing, but which 650 characters to give up is a copy call, so cut differently if you'd rather.

`app_store_desc` is a single msgid for the whole description, so any edit invalidates every locale all-or-nothing. That is why two aged references ride along rather than waiting for a follow-up: one retranslation cycle instead of three. Until translators catch up, non-English locales serve the pre-trim copy — worth not landing immediately before a release cut.

Last commit ratchets the metadata test from the maximum to the budget, so drift is caught on the PR that causes it rather than in a release log nobody reads. It leaves `keywords.txt`, already on exactly 95 of its 95 budget, no headroom — deliberate, given its translations reach 100 of 100, but say so if you'd rather 90.

## To test

```
ruby fastlane/test/helpers_test.rb
```

Append 130 characters to `fastlane/metadata/default/description.txt` and re-run: `test_shipped_metadata_fits_its_limits` goes red with `is 3408 of 3400 characters` — over budget, still far under the 4000 maximum the previous assertion allowed. `git restore` afterwards.

All eight tracked files across both metadata folders now return `:ok`, so `bundle exec fastlane update_app_store_strings` warns about nothing.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
