### PR TITLE
Cosmetic: Turn PlaybackManager.currentEpisode/playing/buffering into properties

### DIFF
--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
@@ -95,7 +95,7 @@ class RetrieveCustomFilesTask: ApiBaseTask, @unchecked Sendable {
                 }
 
                 // if the episode is loaded into the player, and is currently paused record the up to time so we can seek there
-                if let playbackDelegate = ServerConfig.shared.playbackDelegate, playbackDelegate.isNowPlayingEpisode(episodeUuid: episode.uuid), !playbackDelegate.playing() {
+                if let playbackDelegate = ServerConfig.shared.playbackDelegate, playbackDelegate.isNowPlayingEpisode(episodeUuid: episode.uuid), !playbackDelegate.isPlaying {
                     updatedNowPlayingTime = episode.playedUpTo
                 }
             } else {

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -224,7 +224,7 @@ extension SyncTask {
             DataManager.sharedManager.saveEpisode(playedUpTo: playedUpTo, episode: episode, updateSyncFlag: false)
 
             // if the episode is loaded into the player, and is currently paused seek to the new up to time
-            if let delegate = ServerConfig.shared.playbackDelegate, delegate.isNowPlayingEpisode(episodeUuid: episode.uuid), !delegate.playing() {
+            if let delegate = ServerConfig.shared.playbackDelegate, delegate.isNowPlayingEpisode(episodeUuid: episode.uuid), !delegate.isPlaying {
                 if playedUpTo < 1 {
                     FileLog.shared.addMessage("Saving a time of \(playedUpTo) for episode \(episode.displayableTitle()) because that's what the server sent us during a sync")
                 }

--- a/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -385,7 +385,7 @@ class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
     }
 
     private func addPlayingEpisode(list: [Api_UpNextResponse.EpisodeResponse]) -> [Api_UpNextResponse.EpisodeResponse] {
-        guard let isPlaying = ServerConfig.shared.playbackDelegate?.playing(), isPlaying == true else { return list }
+        guard let isPlaying = ServerConfig.shared.playbackDelegate?.isPlaying, isPlaying == true else { return list }
 
         guard let playingEpisode = ServerConfig.shared.playbackDelegate?.currentEpisode else { return list }
 

--- a/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -385,7 +385,7 @@ class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
     }
 
     private func addPlayingEpisode(list: [Api_UpNextResponse.EpisodeResponse]) -> [Api_UpNextResponse.EpisodeResponse] {
-        guard let isPlaying = ServerConfig.shared.playbackDelegate?.isPlaying, isPlaying == true else { return list }
+        guard ServerConfig.shared.playbackDelegate?.isPlaying == true else { return list }
 
         guard let playingEpisode = ServerConfig.shared.playbackDelegate?.currentEpisode else { return list }
 

--- a/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -185,7 +185,7 @@ class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
         // To ensure that the device's local copy of the queue is maintained, we ignore the incoming remote data and instead
         // save our local copy and then send it back to the server.
         let reason = SyncManager.syncReason
-        if reason == .accountCreated, ServerConfig.shared.playbackDelegate?.currentEpisode() != nil {
+        if reason == .accountCreated, ServerConfig.shared.playbackDelegate?.currentEpisode != nil {
             // if this is our first sync (eg: no server modified stored), treat our local copy as the one that should be used. This avoids issues with users getting their Up Next list wiped by the server copy
             FileLog.shared.addMessage("UpNextSyncTask: We have a local Up Next list during first sync of a new account, saving that as the most current version and overwriting server copy")
 
@@ -219,7 +219,7 @@ class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
         let modifiedList = addPlayingEpisode(list: episodes)
         FileLog.shared.addMessage("UpNextSyncTask: server sent \(episodes.count) episodes, we have \(modifiedList.count), making changes")
 
-        let episodePlayingBeforeChanges = ServerConfig.shared.playbackDelegate?.currentEpisode()
+        let episodePlayingBeforeChanges = ServerConfig.shared.playbackDelegate?.currentEpisode
         var uuids = [String]()
         if !modifiedList.isEmpty {
             for (index, episodeInfo) in modifiedList.enumerated() {
@@ -387,7 +387,7 @@ class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
     private func addPlayingEpisode(list: [Api_UpNextResponse.EpisodeResponse]) -> [Api_UpNextResponse.EpisodeResponse] {
         guard let isPlaying = ServerConfig.shared.playbackDelegate?.playing(), isPlaying == true else { return list }
 
-        guard let playingEpisode = ServerConfig.shared.playbackDelegate?.currentEpisode() else { return list }
+        guard let playingEpisode = ServerConfig.shared.playbackDelegate?.currentEpisode else { return list }
 
         // check it isn't already the top episode
         if let firstEpisode = list.first, firstEpisode.uuid == playingEpisode.uuid { return list }

--- a/Modules/Sources/PocketCastsServer/Public/Upload/ServerPlaybackDelegateProtocol.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Upload/ServerPlaybackDelegateProtocol.swift
@@ -2,7 +2,7 @@ import Foundation
 import PocketCastsDataModel
 
 public protocol ServerPlaybackDelegate {
-    func playing() -> Bool
+    var isPlaying: Bool { get }
     func inUpNext(episode: BaseEpisode?) -> Bool
     func addToUpNext(episode: BaseEpisode, ignoringQueueLimit: Bool, toTop: Bool)
     func removeLastEpisodeFromUpNext()

--- a/Modules/Sources/PocketCastsServer/Public/Upload/ServerPlaybackDelegateProtocol.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Upload/ServerPlaybackDelegateProtocol.swift
@@ -7,7 +7,7 @@ public protocol ServerPlaybackDelegate {
     func addToUpNext(episode: BaseEpisode, ignoringQueueLimit: Bool, toTop: Bool)
     func removeLastEpisodeFromUpNext()
 
-    func currentEpisode() -> BaseEpisode?
+    var currentEpisode: BaseEpisode? { get }
     func isNowPlayingEpisode(episodeUuid: String?) -> Bool
     func isActivelyPlaying(episodeUuid: String?) -> Bool
 

--- a/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverFeaturedPodcastCell.swift
@@ -138,7 +138,7 @@ struct DiscoverFeaturedPodcastCell: View {
     }
 
     private func trackEpisodeTapped() {
-        guard let episodeUuid = PlaybackManager.shared.currentEpisode()?.uuid,
+        guard let episodeUuid = PlaybackManager.shared.currentEpisode?.uuid,
               let podcastUuid = podcast.uuid,
               let listId else {
             return

--- a/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
+++ b/Pocket Casts TV App/UI/Discover/DiscoverVideoEpisodeModel.swift
@@ -138,7 +138,7 @@ class DiscoverVideoEpisodeModel {
             return
         }
 
-        player.volume = playbackManager.playing() ? 0 : 0.5
+        player.volume = playbackManager.isPlaying ? 0 : 0.5
         player.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
         player.play()
         isPlaying = true

--- a/Pocket Casts TV App/UI/MainTabViewModel.swift
+++ b/Pocket Casts TV App/UI/MainTabViewModel.swift
@@ -28,7 +28,7 @@ final class MainTabViewModel {
     var discoverHomeSignedOutViewModel = DiscoverAllViewModel(type: .signedOut)
 
     init() {
-        currentPlayingEpisode = PlaybackManager.shared.currentEpisode()
+        currentPlayingEpisode = PlaybackManager.shared.currentEpisode
         observeUpNextChanges()
     }
 
@@ -58,7 +58,7 @@ final class MainTabViewModel {
                 guard let self else {
                     return
                 }
-                currentPlayingEpisode = PlaybackManager.shared.currentEpisode()
+                currentPlayingEpisode = PlaybackManager.shared.currentEpisode
                 if currentPlayingEpisode == nil, selectedTab == .nowPlaying {
                      selectedTab = .home
                      isShowingDetail = false

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -56,7 +56,7 @@ class NowPlayingViewModel: Identifiable {
     private var seekAfterLoad = false
 
     func load() {
-        let newEpisode = playbackManager.currentEpisode()
+        let newEpisode = playbackManager.currentEpisode
         guard newEpisode?.uuid != episode?.uuid else {
             return
         }

--- a/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
+++ b/Pocket Casts TV App/UI/Player/NowPlayingViewModel.swift
@@ -64,7 +64,7 @@ class NowPlayingViewModel: Identifiable {
         isFirstLoad = true
         podcast = playbackManager.currentPodcast
         player = playbackManager.avPlayer
-        if !playbackManager.playing(), !playbackManager.isReadyToPlay {
+        if !playbackManager.isPlaying, !playbackManager.isReadyToPlay {
             playbackManager.loadCurrentEpisode()
             seekAfterLoad = true
         }

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -180,7 +180,7 @@ class EpisodeRowViewModel: Identifiable {
     }
 
     private func updateProgress() {
-        guard let currentEpisode = playbackManager.currentEpisode(), episode.uuid == currentEpisode.uuid else {
+        guard let currentEpisode = playbackManager.currentEpisode, episode.uuid == currentEpisode.uuid else {
             return
         }
         episode.playedUpTo = currentEpisode.playedUpTo

--- a/Pocket Casts Watch App/Data & Communication/SessionManager.swift
+++ b/Pocket Casts Watch App/Data & Communication/SessionManager.swift
@@ -141,7 +141,7 @@ class SessionManager: NSObject, WCSessionDelegate {
         guard FeatureFlag.watchPlaybackProgressLocalSync.enabled,
               !WatchDataManager.isPlaying(),
               let phoneEpisode = WatchDataManager.playingEpisode(),
-              let localCurrent = PlaybackManager.shared.currentEpisode() else { return }
+              let localCurrent = PlaybackManager.shared.currentEpisode else { return }
 
         guard localCurrent.uuid == phoneEpisode.uuid else {
             FileLog.shared.addMessage("SessionManager: skipping phone progress - episode mismatch (local \(localCurrent.uuid), phone \(phoneEpisode.uuid))")

--- a/Pocket Casts Watch App/UI/Main Page/SourceInterfaceModel.swift
+++ b/Pocket Casts Watch App/UI/Main Page/SourceInterfaceModel.swift
@@ -127,7 +127,7 @@ class SourceInterfaceModel: ObservableObject {
     }
 
     private func nowPlayingEpisodesMatchOnBothSources() -> Bool {
-        let watchCurrentEpisode = PlaybackManager.shared.currentEpisode()
+        let watchCurrentEpisode = PlaybackManager.shared.currentEpisode
         let phoneCurrentEpisode = WatchDataManager.playingEpisode()
         if watchCurrentEpisode?.uuid == phoneCurrentEpisode?.uuid {
             if watchCurrentEpisode?.playedUpTo == phoneCurrentEpisode?.playedUpTo {

--- a/Pocket Casts Watch App/UI/Main Page/SourceInterfaceNavigationView.swift
+++ b/Pocket Casts Watch App/UI/Main Page/SourceInterfaceNavigationView.swift
@@ -154,7 +154,7 @@ struct SourceInterfaceNavigationView: View {
     }
 
     private func nowPlayingEpisodesMatchOnBothSources() -> Bool {
-        let watchCurrentEpisode = PlaybackManager.shared.currentEpisode()
+        let watchCurrentEpisode = PlaybackManager.shared.currentEpisode
         let phoneCurrentEpisode = WatchDataManager.playingEpisode()
         if watchCurrentEpisode?.uuid == phoneCurrentEpisode?.uuid {
             if watchCurrentEpisode?.playedUpTo == phoneCurrentEpisode?.playedUpTo {

--- a/Pocket Casts Watch App/UI/Play Source/WatchSourceViewModel.swift
+++ b/Pocket Casts Watch App/UI/Play Source/WatchSourceViewModel.swift
@@ -6,7 +6,7 @@ import SwiftUI
 
 class WatchSourceViewModel: PlaySourceViewModel {
     var isPlaying: Bool {
-        PlaybackManager.shared.playing()
+        PlaybackManager.shared.isPlaying
     }
 
     // MARK: Episodes
@@ -270,7 +270,7 @@ class WatchSourceViewModel: PlaySourceViewModel {
     }
 
     func nowPlayingSubTitle(forEpisode episode: BaseEpisode) -> String? {
-        guard !PlaybackManager.shared.buffering() else { return L10n.watchBuffering }
+        guard !PlaybackManager.shared.isBuffering else { return L10n.watchBuffering }
         return episode.subTitle()
     }
 

--- a/Pocket Casts Watch App/UI/Play Source/WatchSourceViewModel.swift
+++ b/Pocket Casts Watch App/UI/Play Source/WatchSourceViewModel.swift
@@ -33,7 +33,7 @@ class WatchSourceViewModel: PlaySourceViewModel {
     }
 
     func isCurrentlyPlaying(episode: BaseEpisode) -> Bool {
-        PlaybackManager.shared.currentEpisode()?.uuid == episode.uuid
+        PlaybackManager.shared.currentEpisode?.uuid == episode.uuid
     }
 
     func supportsPodcastNavigation(forEpisode episode: BaseEpisode) -> Bool {
@@ -233,7 +233,7 @@ class WatchSourceViewModel: PlaySourceViewModel {
     // MARK: Now Playing
 
     var nowPlayingEpisode: BaseEpisode? {
-        PlaybackManager.shared.currentEpisode()
+        PlaybackManager.shared.currentEpisode
     }
 
     var playbackProgress: CGFloat {

--- a/Pocket Casts Watch App/UI/WatchSyncManager.swift
+++ b/Pocket Casts Watch App/UI/WatchSyncManager.swift
@@ -300,7 +300,7 @@ class WatchSyncManager {
     @objc private func playbackPaused() {
         guard FeatureFlag.watchPlaybackProgressLocalSync.enabled,
               SyncManager.isUserLoggedIn(),
-              let episode = PlaybackManager.shared.currentEpisode() else { return }
+              let episode = PlaybackManager.shared.currentEpisode else { return }
 
         FileLog.shared.addMessage("WatchSync: pushing playback progress \(episode.playedUpTo) to phone for \(episode.uuid)")
         SessionManager.shared.sendPlaybackProgress(episodeUuid: episode.uuid,

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -78,7 +78,7 @@ class AnalyticsCoordinator {
         // in the episode's MIME type and is only detected once frames render — so assume video rather
         // than mislabel it as audio. `willPlayViaHLS` is gated behind the HLS flag and only true when the
         // current source is actually HLS, so this only affects analytics for real HLS playback.
-        if let episode = PlaybackManager.shared.currentEpisode(), EpisodeManager.willPlayViaHLS(episode) {
+        if let episode = PlaybackManager.shared.currentEpisode, EpisodeManager.willPlayViaHLS(episode) {
             return true
         }
         return PlaybackManager.shared.isCurrentEpisodeVideo()

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -14,7 +14,7 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     var timestampOfLastRemoteAction: Date?
 
     func play() {
-        track(.playbackPlay, properties: Self.hlsLifecycleProperties(for: PlaybackManager.shared.currentEpisode()))
+        track(.playbackPlay, properties: Self.hlsLifecycleProperties(for: PlaybackManager.shared.currentEpisode))
     }
 
     func pause() {

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -83,7 +83,7 @@ extension AppDelegate {
                 strongSelf.openPlayerWhenReadyFromExternalEvent()
                 AnalyticsHelper.forceTouchPlay()
             } else if shortcut == "markAsPlayed" {
-                if let episode = PlaybackManager.shared.currentEpisode() {
+                if let episode = PlaybackManager.shared.currentEpisode {
                     AnalyticsEpisodeHelper.shared.currentSource = .appIconMenu
                     EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
                     AnalyticsHelper.forceTouchMarkPlayed()

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -223,7 +223,7 @@ extension AppDelegate {
             strongSelf.openPlayerWhenReadyFromExternalEvent()
 
             if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
-                if !PlaybackManager.shared.playing() {
+                if !PlaybackManager.shared.isPlaying {
                     PlaybackManager.shared.play()
                 }
             } else {

--- a/podcasts/AppPlayEpisodeIntentExtension.swift
+++ b/podcasts/AppPlayEpisodeIntentExtension.swift
@@ -14,7 +14,7 @@ extension PlayEpisodeIntent {
         let current = PlaybackManager.shared.currentEpisode
 
         if current?.uuid == podcastEpisode.uuid {
-            Analytics.track(.widgetInteraction, properties: ["action": PlaybackManager.shared.playing() ? "pause" : "play"])
+            Analytics.track(.widgetInteraction, properties: ["action": PlaybackManager.shared.isPlaying ? "pause" : "play"])
             PlaybackActionHelper.playPause()
         } else {
             // Ideally we should use PlaybackActionHelper here

--- a/podcasts/AppPlayEpisodeIntentExtension.swift
+++ b/podcasts/AppPlayEpisodeIntentExtension.swift
@@ -11,7 +11,7 @@ extension PlayEpisodeIntent {
         }
 
         AnalyticsPlaybackHelper.shared.currentSource = .interactiveWidget
-        let current = PlaybackManager.shared.currentEpisode()
+        let current = PlaybackManager.shared.currentEpisode
 
         if current?.uuid == podcastEpisode.uuid {
             Analytics.track(.widgetInteraction, properties: ["action": PlaybackManager.shared.playing() ? "pause" : "play"])

--- a/podcasts/ArchiveHelper.swift
+++ b/podcasts/ArchiveHelper.swift
@@ -53,7 +53,7 @@ class ArchiveHelper {
         }
 
         if episodeLimit > 0 {
-            let currentlyPlayingUuid = PlaybackManager.shared.playing() ? PlaybackManager.shared.currentEpisode?.uuid : nil
+            let currentlyPlayingUuid = PlaybackManager.shared.isPlaying ? PlaybackManager.shared.currentEpisode?.uuid : nil
             let episodes = DataManager.sharedManager.findEpisodesWhere(customWhere: "podcast_id = ? ORDER BY publishedDate DESC, addedDate DESC", arguments: [podcast.id])
             for (index, episode) in episodes.enumerated() {
                 if index < episodeLimit { continue }

--- a/podcasts/ArchiveHelper.swift
+++ b/podcasts/ArchiveHelper.swift
@@ -53,7 +53,7 @@ class ArchiveHelper {
         }
 
         if episodeLimit > 0 {
-            let currentlyPlayingUuid = PlaybackManager.shared.playing() ? PlaybackManager.shared.currentEpisode()?.uuid : nil
+            let currentlyPlayingUuid = PlaybackManager.shared.playing() ? PlaybackManager.shared.currentEpisode?.uuid : nil
             let episodes = DataManager.sharedManager.findEpisodesWhere(customWhere: "podcast_id = ? ORDER BY publishedDate DESC, addedDate DESC", arguments: [podcast.id])
             for (index, episode) in episodes.enumerated() {
                 if index < episodeLimit { continue }

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -72,7 +72,7 @@ class BookmarksPlayerTabController: PlayerItemViewController {
     // MARK: - Notification Handlers
 
     private func updateCurrentEpisode() {
-        viewModel.episode = playbackManager.currentEpisode()
+        viewModel.episode = playbackManager.currentEpisode
     }
 
     private func handleBookmarkCreated(bookmark: Bookmark, isDuplicate: Bool) {

--- a/podcasts/CarPlay/CarPlaySceneDelegate.swift
+++ b/podcasts/CarPlay/CarPlaySceneDelegate.swift
@@ -129,7 +129,7 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
 
         if let image = UIImage(named: "car_markasplayed") {
             let markPlayedBtn = CPNowPlayingImageButton(image: image) { _ in
-                guard let episode = PlaybackManager.shared.currentEpisode() else { return }
+                guard let episode = PlaybackManager.shared.currentEpisode else { return }
                 AnalyticsEpisodeHelper.shared.currentSource = .carPlay
 
                 EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
@@ -160,7 +160,7 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     }
 
     private func starButton() -> CPNowPlayingImageButton? {
-        let episode = PlaybackManager.shared.currentEpisode() as? Episode
+        let episode = PlaybackManager.shared.currentEpisode as? Episode
 
         let starImageName = episode?.keepEpisode == true ? "star_filled" : "star_empty"
 
@@ -188,7 +188,7 @@ class CarPlaySceneDelegate: CustomObserver, CPTemplateApplicationSceneDelegate, 
     }
 
     func nowPlayingTemplateAlbumArtistButtonTapped(_ nowPlayingTemplate: CPNowPlayingTemplate) {
-        guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let playingEpisode = PlaybackManager.shared.currentEpisode else { return }
 
         if let episode = playingEpisode as? Episode, let podcast = episode.parentPodcast() {
             podcastTapped(podcast)

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -113,7 +113,7 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
             "origin": PlaybackManager.shared.chaptersOriginAnalyticsValue,
             "source": "fullscreen_player",
             "content_type": AnalyticsPlaybackHelper.shared.currentEpisodeIsVideo ? "video" : "audio",
-            "episode_uuid": PlaybackManager.shared.currentEpisode()?.uuid ?? "unknown",
+            "episode_uuid": PlaybackManager.shared.currentEpisode?.uuid ?? "unknown",
             "podcast_uuid": PlaybackManager.shared.currentPodcast?.uuid ?? "unknown"
         ])
     }
@@ -135,7 +135,7 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
     }
 
     var shouldShowDeselectChaptersHeader: Bool {
-        PlaybackManager.shared.currentEpisode()?.isUserEpisode == false
+        PlaybackManager.shared.currentEpisode?.isUserEpisode == false
     }
 }
 

--- a/podcasts/ChaptersViewController+Table.swift
+++ b/podcasts/ChaptersViewController+Table.swift
@@ -25,7 +25,7 @@ extension ChaptersViewController: UITableViewDataSource, UITableViewDelegate, UI
             let currentChapters = PlaybackManager.shared.currentChapters()
 
             if chapter.index == currentChapters.index {
-                state = PlaybackManager.shared.playing() ? .currentlyPlaying : .currentlyPaused
+                state = PlaybackManager.shared.isPlaying ? .currentlyPlaying : .currentlyPaused
             } else if chapter.index > currentChapters.index {
                 state = .future
             }

--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -138,7 +138,7 @@ class MainEpisodeActionView: UIView {
     // MARK: - Update Events
 
     @objc private func playbackDidProgress() {
-        guard let playingEpisode = PlaybackManager.shared.currentEpisode(), let uuid = episodeUuid, uuid == playingEpisode.uuid else { return }
+        guard let playingEpisode = PlaybackManager.shared.currentEpisode, let uuid = episodeUuid, uuid == playingEpisode.uuid else { return }
 
         // don't update the progress of episodes that are downloading
         if playingEpisode.downloading() { return }

--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -113,7 +113,7 @@ class MainEpisodeActionView: UIView {
         }
 
         // update button state
-        let isPlaying = (isCurrent && PlaybackManager.shared.playing())
+        let isPlaying = (isCurrent && PlaybackManager.shared.isPlaying)
         let googleCastConnected = GoogleCastManager.sharedManager.connected()
         let primaryRowActionIsDownload = Settings.primaryRowAction() == .download
         if googleCastConnected {

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -142,7 +142,7 @@ class EffectsViewController: SimpleNotificationsViewController {
 
     @IBOutlet weak var playbackSettingsSegmentedControl: UISegmentedControl! {
         didSet {
-            let isUserEpisode = PlaybackManager.shared.currentEpisode()?.isUserEpisode == true
+            let isUserEpisode = PlaybackManager.shared.currentEpisode?.isUserEpisode == true
             let shouldDisplaySegmentedControl = isCustomPlaybackSettingsEnabled && !isUserEpisode
             playbackSettingsSegmentedControl.isHidden = !shouldDisplaySegmentedControl
 
@@ -158,7 +158,7 @@ class EffectsViewController: SimpleNotificationsViewController {
 
     @IBOutlet weak var speedControlTopConstraint: NSLayoutConstraint! {
         didSet {
-            let isUserEpisode = PlaybackManager.shared.currentEpisode()?.isUserEpisode == true
+            let isUserEpisode = PlaybackManager.shared.currentEpisode?.isUserEpisode == true
             speedControlTopConstraint.isActive = isCustomPlaybackSettingsEnabled && !isUserEpisode
         }
     }
@@ -208,7 +208,7 @@ class EffectsViewController: SimpleNotificationsViewController {
         if isCustomPlaybackSettingsEnabled {
             playbackSettingsSegmentedControl.selectedSegmentIndex = PlaybackManager.shared.isCurrentEffectGlobal() ? 0 : 1
         }
-        if let episode = PlaybackManager.shared.currentEpisode() as? Episode, let podcast = episode.parentPodcast() {
+        if let episode = PlaybackManager.shared.currentEpisode as? Episode, let podcast = episode.parentPodcast() {
             clearForPodcastImage.setPodcast(uuid: podcast.uuid, size: .list)
         }
 
@@ -344,7 +344,7 @@ class EffectsViewController: SimpleNotificationsViewController {
     }
 
     @IBAction func clearForPodcastTapped(_ sender: Any) {
-        guard let episode = PlaybackManager.shared.currentEpisode() as? Episode, let podcast = episode.parentPodcast() else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode as? Episode, let podcast = episode.parentPodcast() else { return }
 
         podcast.overrideGlobalEffects = false
         DataManager.sharedManager.save(podcast: podcast)
@@ -379,7 +379,7 @@ class EffectsViewController: SimpleNotificationsViewController {
         if isCustomPlaybackSettingsEnabled {
             return
         }
-        guard let episode = PlaybackManager.shared.currentEpisode() as? Episode, let podcast = episode.parentPodcast() else {
+        guard let episode = PlaybackManager.shared.currentEpisode as? Episode, let podcast = episode.parentPodcast() else {
             clearForPodcastView.isHidden = true
             customEffectsToVolumeBoostConstraint.isActive = false
 
@@ -440,7 +440,7 @@ class EffectsViewController: SimpleNotificationsViewController {
         // is higher. The applied rate is already capped in DefaultPlayer; this keeps the display honest
         // without persisting a change to the user's non-HLS preference.
         var displaySpeed = effects.playbackSpeed
-        if let episode = PlaybackManager.shared.currentEpisode(), EpisodeManager.willPlayViaHLS(episode) {
+        if let episode = PlaybackManager.shared.currentEpisode, EpisodeManager.willPlayViaHLS(episode) {
             displaySpeed = min(displaySpeed, 2)
         }
         speedBtn.fillColor = ThemeColor.playerContrast01()

--- a/podcasts/Episode/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+Actions.swift
@@ -64,7 +64,7 @@ extension EpisodeDetailViewController {
         let isNowPlaying = PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid)
         if isNowPlaying {
             // dismiss the dialog if the user hit play
-            if !PlaybackManager.shared.playing() {
+            if !PlaybackManager.shared.isPlaying {
                 dismiss(animated: true, completion: nil)
             }
         } else {

--- a/podcasts/EpisodeFilter+Formatting.swift
+++ b/podcasts/EpisodeFilter+Formatting.swift
@@ -116,7 +116,7 @@ extension EpisodeFilter {
     }
 
     func episodeUuidToAddToQueries() -> String? {
-        if let playingEpisode = PlaybackManager.shared.currentEpisode(), PlaybackManager.shared.uuidOfPlayingList == uuid {
+        if let playingEpisode = PlaybackManager.shared.currentEpisode, PlaybackManager.shared.uuidOfPlayingList == uuid {
             return playingEpisode.uuid
         }
 

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -49,7 +49,7 @@ class EpisodeManager: NSObject {
         var episodesMinusCurrent = episodes
         var currentEpisodeToMarkAsPlayed: BaseEpisode?
 
-        if let currentEpisode = PlaybackManager.shared.currentEpisode(), let index = episodes.firstIndex(where: { $0.uuid == currentEpisode.uuid }) {
+        if let currentEpisode = PlaybackManager.shared.currentEpisode, let index = episodes.firstIndex(where: { $0.uuid == currentEpisode.uuid }) {
             episodesMinusCurrent.remove(at: index)
             currentEpisodeToMarkAsPlayed = currentEpisode
         }
@@ -289,7 +289,7 @@ class EpisodeManager: NSObject {
 
     class func bulkSetStarred(_ starred: Bool, episodes: [Episode], updateSyncStatus: Bool) {
         DataManager.sharedManager.bulkSetStarred(starred: starred, episodes: episodes, updateSyncStatus: updateSyncStatus)
-        if let currentEpisode = PlaybackManager.shared.currentEpisode() as? Episode, episodes.contains(currentEpisode) {
+        if let currentEpisode = PlaybackManager.shared.currentEpisode as? Episode, episodes.contains(currentEpisode) {
             PlaybackManager.shared.nowPlayingStarredChanged()
         }
         if updateSyncStatus {
@@ -570,7 +570,7 @@ class EpisodeManager: NSObject {
 
     class func removeDownloadForEpisodes(_ episodes: [BaseEpisode]) {
         var episodesToRemoveFromQueue = episodes
-        if let currentEpisode = PlaybackManager.shared.currentEpisode(), let index = episodes.firstIndex(where: { $0.uuid == currentEpisode.uuid }) {
+        if let currentEpisode = PlaybackManager.shared.currentEpisode, let index = episodes.firstIndex(where: { $0.uuid == currentEpisode.uuid }) {
             PlaybackManager.shared.removeIfPlayingOrQueued(episode: currentEpisode, fireNotification: true, saveCurrentEpisode: true)
             episodesToRemoveFromQueue.remove(at: index)
         }

--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -158,7 +158,7 @@ final class FingerprintTimingManager: NSObject {
     // MARK: - Public API
 
     func prepareForCurrentEpisode() {
-        let episode = PlaybackManager.shared.currentEpisode()
+        let episode = PlaybackManager.shared.currentEpisode
 
         queue.async { [weak self] in
             guard let self else { return }
@@ -185,7 +185,7 @@ final class FingerprintTimingManager: NSObject {
     /// processing a partial streaming buffer, we now have a complete file to fingerprint.
     @objc private func handleEpisodeDownloaded(_ notification: Notification) {
         guard let downloadedUuid = notification.object as? String,
-              let currentUuid = PlaybackManager.shared.currentEpisode()?.uuid,
+              let currentUuid = PlaybackManager.shared.currentEpisode?.uuid,
               currentUuid == downloadedUuid else { return }
 
         DispatchQueue.main.async { [weak self] in
@@ -205,7 +205,7 @@ final class FingerprintTimingManager: NSObject {
         let playbackTime = PlaybackManager.shared.currentTime()
         guard playbackTime >= 0 else { return }
 
-        let episodeUuid = PlaybackManager.shared.currentEpisode()?.uuid
+        let episodeUuid = PlaybackManager.shared.currentEpisode?.uuid
         queue.async { [weak self] in
             self?.processProgress(playbackTime: playbackTime, episodeUuid: episodeUuid)
         }

--- a/podcasts/Fingerprint/GeneratedChapterSeeker.swift
+++ b/podcasts/Fingerprint/GeneratedChapterSeeker.swift
@@ -18,7 +18,7 @@ enum GeneratedChapterSeeker {
         FeatureFlag.generatedChapters.enabled
             && FeatureFlag.syncedTranscripts.enabled
             && PlaybackManager.shared.chaptersAreGenerated
-            && PlaybackManager.shared.currentEpisode() != nil
+            && PlaybackManager.shared.currentEpisode != nil
     }
 
     /// Resolve `chapter` to its real playback position and seek there.
@@ -41,7 +41,7 @@ enum GeneratedChapterSeeker {
         // resolve complete afterwards and yank playback back to its chapter.
         FingerprintTimingManager.shared.cancelPendingChapterResolve()
 
-        guard let episode = PlaybackManager.shared.currentEpisode() else {
+        guard let episode = PlaybackManager.shared.currentEpisode else {
             PlaybackManager.shared.skipToChapter(chapter, startPlaybackAfterSkip: startPlayback)
             return
         }
@@ -62,7 +62,7 @@ enum GeneratedChapterSeeker {
 
             // The listener switched episodes while we were resolving — the resolved
             // position is meaningless now, so don't seek.
-            guard PlaybackManager.shared.currentEpisode()?.uuid == episodeUuid else {
+            guard PlaybackManager.shared.currentEpisode?.uuid == episodeUuid else {
                 return
             }
 

--- a/podcasts/Google Cast/GoogleCastManager.swift
+++ b/podcasts/Google Cast/GoogleCastManager.swift
@@ -286,7 +286,7 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
             return mediaInfo.streamDuration
         }
 
-        if let playerEpisode = PlaybackManager.shared.currentEpisode() {
+        if let playerEpisode = PlaybackManager.shared.currentEpisode {
             return playerEpisode.duration
         }
 

--- a/podcasts/Google Cast/UI/CastToViewController.swift
+++ b/podcasts/Google Cast/UI/CastToViewController.swift
@@ -112,7 +112,7 @@ class CastToViewController: PCViewController {
     }
 
     private func updatePlayingDetails() {
-        guard GoogleCastManager.sharedManager.connected(), let playingEpisode = PlaybackManager.shared.currentEpisode() else {
+        guard GoogleCastManager.sharedManager.connected(), let playingEpisode = PlaybackManager.shared.currentEpisode else {
             episodeName.text = L10n.chromecastConnectedToDevice
             podcastName.text = L10n.chromecastNothingPlaying
             playPauseBtn.isHidden = true

--- a/podcasts/Google Cast/UI/CastToViewController.swift
+++ b/podcasts/Google Cast/UI/CastToViewController.swift
@@ -124,7 +124,7 @@ class CastToViewController: PCViewController {
         episodeName.text = playingEpisode.displayableTitle()
         podcastName.text = playingEpisode.subTitle()
 
-        let imageName = PlaybackManager.shared.playing() ? "icon-pause" : "icon-play"
+        let imageName = PlaybackManager.shared.isPlaying ? "icon-pause" : "icon-play"
         playPauseBtn.setImage(UIImage(named: imageName), for: .normal)
         playPauseBtn.isHidden = false
 

--- a/podcasts/LiquidGlass.swift
+++ b/podcasts/LiquidGlass.swift
@@ -36,7 +36,7 @@ extension Constants {
             // added to bottom safe area.
             return 0
         }
-        return PlaybackManager.shared.currentEpisode() == nil ? 0 : Constants.Values.miniPlayerOffset
+        return PlaybackManager.shared.currentEpisode == nil ? 0 : Constants.Values.miniPlayerOffset
     }
 
     static var effectiveFooterViewPadding: CGFloat {

--- a/podcasts/MiniPlayerViewController+Gestures.swift
+++ b/podcasts/MiniPlayerViewController+Gestures.swift
@@ -84,7 +84,7 @@ extension MiniPlayerViewController: UIGestureRecognizerDelegate {
         let markAsPlayed = OptionAction(label: L10n.markPlayedShort, icon: "episode-markasplayed") { [weak self] in
             guard let self else { return }
             Analytics.track(.miniPlayerLongPressMenuOptionTapped, properties: ["option": "mark_played"])
-            if let episode = PlaybackManager.shared.currentEpisode() {
+            if let episode = PlaybackManager.shared.currentEpisode {
                 AnalyticsEpisodeHelper.shared.currentSource = self.analyticsSource
                 EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
             }
@@ -114,7 +114,7 @@ extension MiniPlayerViewController: UIContextMenuInteractionDelegate {
         return UIContextMenuConfiguration(
             identifier: nil,
             previewProvider: {
-                guard let episode = PlaybackManager.shared.currentEpisode() else { return nil }
+                guard let episode = PlaybackManager.shared.currentEpisode else { return nil }
                 return MiniPlayerLongPressPreviewViewController(episode: episode)
             },
             actionProvider: { [weak self] _ in

--- a/podcasts/MiniPlayerViewController+Positioning.swift
+++ b/podcasts/MiniPlayerViewController+Positioning.swift
@@ -34,7 +34,7 @@ extension MiniPlayerViewController {
 
     func showMiniPlayer() {
         // only show if something is playing
-        if PlaybackManager.shared.currentEpisode() == nil { return }
+        if PlaybackManager.shared.currentEpisode == nil { return }
 
         if LiquidGlass.isEnabled, #available(iOS 26.0, *) {
             guard let tabBarController = parent as? UITabBarController, tabBarController.bottomAccessory == nil else { return }
@@ -60,7 +60,7 @@ extension MiniPlayerViewController {
     }
 
     func openFullScreenPlayer(completion: (() -> Void)? = nil) {
-        guard PlaybackManager.shared.currentEpisode() != nil else { return }
+        guard PlaybackManager.shared.currentEpisode != nil else { return }
 
         if fullScreenPlayer?.presentingViewController != nil || fullScreenPlayer?.isBeingPresented == true { return }
 

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -608,7 +608,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             progress = min(1, CGFloat(currentTime / duration))
         }
 
-        let isIndeterminate = PlaybackManager.shared.buffering() && PlaybackManager.shared.playing()
+        let isIndeterminate = PlaybackManager.shared.isBuffering && PlaybackManager.shared.isPlaying
 
         playbackProgressView.progress = progress
         playbackProgressView.indeterminant = isIndeterminate
@@ -654,7 +654,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
             updateColorsLegacy()
         }
 
-        playPauseBtn.isPlaying = PlaybackManager.shared.playing()
+        playPauseBtn.isPlaying = PlaybackManager.shared.isPlaying
     }
 
     private func updateColorsLegacy() {

--- a/podcasts/MiniPlayerViewController.swift
+++ b/podcasts/MiniPlayerViewController.swift
@@ -504,7 +504,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
     /// Shows the current chapter title when the episode has chapters, falling
     /// back to the episode title otherwise — matching the full screen player.
-    private func updateTitle(for episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) {
+    private func updateTitle(for episode: BaseEpisode? = PlaybackManager.shared.currentEpisode) {
         guard let episodeTitleLabel, let episode else { return }
 
         let chapters = PlaybackManager.shared.currentChapters()
@@ -522,13 +522,13 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
 
     @objc private func chapterDidChange() {
         updateTitle()
-        if let episode = PlaybackManager.shared.currentEpisode() {
+        if let episode = PlaybackManager.shared.currentEpisode {
             updateArtwork(for: episode)
         }
     }
 
     @objc private func playbackStarted() {
-        if let episode = PlaybackManager.shared.currentEpisode() {
+        if let episode = PlaybackManager.shared.currentEpisode {
             // Forget the auto open marker once a different episode plays, otherwise coming back to a
             // previously auto opened episode never opens the player again. Keeping it for the same
             // episode still stops a reload (e.g. switching to the downloaded file) from re-opening it.
@@ -562,7 +562,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     @objc private func videoPlaybackEngineSwitched() {
         // Video can be detected after playback starts (e.g. an HLS stream), so give it the same
         // automatic full screen treatment a video podcast gets.
-        guard let episode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode else { return }
         autoOpenFullScreenPlayerIfNeeded(for: episode)
     }
 
@@ -582,7 +582,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     }
 
     @objc private func playbackStateDidChange() {
-        guard let episodePlaying = PlaybackManager.shared.currentEpisode() else {
+        guard let episodePlaying = PlaybackManager.shared.currentEpisode else {
             hideMiniPlayer(true)
 
             return
@@ -695,9 +695,9 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     }
 
     private func currentPodcastTintColor() -> UIColor {
-        if let podcast = podcastForEpisode(PlaybackManager.shared.currentEpisode()) {
+        if let podcast = podcastForEpisode(PlaybackManager.shared.currentEpisode) {
             return Theme.isDarkTheme() ? ColorManager.darkThemeTintForPodcast(podcast) : ColorManager.lightThemeTintForPodcast(podcast)
-        } else if let episode = PlaybackManager.shared.currentEpisode() as? UserEpisode, episode.imageColor > 0 {
+        } else if let episode = PlaybackManager.shared.currentEpisode as? UserEpisode, episode.imageColor > 0 {
             return AppTheme.userEpisodeColor(number: Int(episode.imageColor))
         } else {
             return AppTheme.userEpisodeColor(number: 1)
@@ -705,7 +705,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     }
 
     private func podcastForEpisode(_ episode: BaseEpisode?) -> Podcast? {
-        if let episode = PlaybackManager.shared.currentEpisode() as? Episode {
+        if let episode = PlaybackManager.shared.currentEpisode as? Episode {
             return episode.parentPodcast()
         }
 
@@ -713,7 +713,7 @@ class MiniPlayerViewController: SimpleNotificationsViewController {
     }
 
     @objc private func updateRequired() {
-        guard let episode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode else { return }
 
         updateColors()
         updateArtwork(for: episode, forceReload: true)

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -84,7 +84,7 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
         NotificationCenter.default.publisher(for: Constants.Notifications.playbackProgress)
             .receive(on: OperationQueue.main)
             .sink(receiveValue: { [unowned self] notification in
-                guard let episodeUUID = notification.object as? String ?? PlaybackManager.shared.currentEpisode()?.uuid,
+                guard let episodeUUID = notification.object as? String ?? PlaybackManager.shared.currentEpisode?.uuid,
                       episodeUUID == episode.uuid
                 else {
                     return

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -25,7 +25,7 @@ protocol NowPlayingActionsDelegate: AnyObject {
 extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
     @objc func reloadShelfActions() {
-        guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let playingEpisode = PlaybackManager.shared.currentEpisode else { return }
 
         #if APPCLIP
         let actions: [PlayerAction] = [.effects, .sleepTimer, .routePicker]
@@ -242,9 +242,9 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
     func goToTapped() {
         #if !APPCLIP
-        if PlaybackManager.shared.currentEpisode() is Episode {
+        if PlaybackManager.shared.currentEpisode is Episode {
             goToPodcast()
-        } else if PlaybackManager.shared.currentEpisode() is UserEpisode {
+        } else if PlaybackManager.shared.currentEpisode is UserEpisode {
             goToFiles()
         }
         #endif
@@ -264,7 +264,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
     func archiveTapped() {
         #if !APPCLIP
-        if PlaybackManager.shared.currentEpisode() is UserEpisode {
+        if PlaybackManager.shared.currentEpisode is UserEpisode {
             delete()
         } else {
             archive()
@@ -303,7 +303,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
     func downloadTapped() {
         #if !APPCLIP
-        guard let episode = PlaybackManager.shared.currentEpisode() as? Episode else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode as? Episode else { return }
 
         AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
 
@@ -328,7 +328,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     private func deleteDownloadedFile() {
-        guard let episode = PlaybackManager.shared.currentEpisode() as? Episode else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode as? Episode else { return }
 
         EpisodeManager.analyticsHelper.currentSource = analyticsSource
 
@@ -458,7 +458,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
     @objc func presentManualPlaylistsChooser() {
 #if !APPCLIP
-        guard let episode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode else { return }
 
         NavigationManager.sharedManager.navigateTo(
             NavigationManager.manualPlaylistsChooserKey,
@@ -478,13 +478,13 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     private func goToPodcast() {
-        guard let episode = PlaybackManager.shared.currentEpisode() as? Episode else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode as? Episode else { return }
 
         NavigationManager.sharedManager.navigateTo(NavigationManager.podcastPageKey, data: [NavigationManager.podcastKey: episode.podcastUuid])
     }
 
     private func markPlayed() {
-        guard let episode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode else { return }
 
         let alert = UIAlertController(title: L10n.playerMarkAsPlayedConfirmation, message: L10n.playerMarkAsPlayedConfirmationMessage, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
@@ -496,14 +496,14 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     private func delete() {
-        guard let episode = PlaybackManager.shared.currentEpisode() as? UserEpisode else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode as? UserEpisode else { return }
         AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
 
         UserEpisodeManager.presentDeleteOptions(episode: episode, from: self)
     }
 
     private func archive() {
-        guard let episode = PlaybackManager.shared.currentEpisode() as? Episode else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode as? Episode else { return }
 
         AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
 
@@ -529,7 +529,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
     }
 
     private func performStarAction(starBtn: UIButton? = nil) {
-        guard let episode = PlaybackManager.shared.currentEpisode() as? Episode else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode as? Episode else { return }
 
         AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
 
@@ -547,7 +547,7 @@ extension NowPlayingPlayerItemViewController: NowPlayingActionsDelegate {
 
     #if !APPCLIP
     private func shareEpisode(sender: UIView) {
-        guard let episode = PlaybackManager.shared.currentEpisode() as? Episode else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode as? Episode else { return }
 
         SharingModal.showModal(episode: episode, from: analyticsSource, in: self)
     }
@@ -597,7 +597,7 @@ extension NowPlayingPlayerItemViewController {
             SmartBookmarksPromo.shouldShowPlayerTip,
             smartBookmarksTip == nil,
             let anchor = smartBookmarksTipAnchor,
-            let episode = PlaybackManager.shared.currentEpisode(),
+            let episode = PlaybackManager.shared.currentEpisode,
             PlayerAction.addBookmark.canBePerformedOn(episode: episode)
         else {
             return

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -77,7 +77,7 @@ extension NowPlayingPlayerItemViewController {
         let skipFwdAmount = Settings.skipForwardTime
         skipFwdBtn.skipAmount = skipFwdAmount
 
-        updatePlayPauseButton(isPlaying: PlaybackManager.shared.playing())
+        updatePlayPauseButton(isPlaying: PlaybackManager.shared.isPlaying)
         updateUpTo(upTo: PlaybackManager.shared.currentTime(), duration: PlaybackManager.shared.duration(), moveSlider: true)
         reloadShelfActions()
         updateChaptersControls()
@@ -195,7 +195,7 @@ extension NowPlayingPlayerItemViewController {
             timeSlider.currentTime = upTo
         }
 
-        timeSlider.indeterminant = PlaybackManager.shared.buffering() && PlaybackManager.shared.playing()
+        timeSlider.indeterminant = PlaybackManager.shared.isBuffering && PlaybackManager.shared.isPlaying
     }
 
     var isErrorVisible: Bool {

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -45,7 +45,7 @@ extension NowPlayingPlayerItemViewController {
     }
 
     @objc func update(notification: NSNotification?) {
-        guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let playingEpisode = PlaybackManager.shared.currentEpisode else { return }
 
         if PlaybackManager.shared.shouldRenderVideo() {
             if floatingVideoView.isHidden {
@@ -129,7 +129,7 @@ extension NowPlayingPlayerItemViewController {
     }
 
     private func updateChapterInfoWithChapters(_ chapters: Chapters) {
-        guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let playingEpisode = PlaybackManager.shared.currentEpisode else { return }
         if let visibleChapter = chapters.visibleChapter, PlaybackManager.shared.chapterCount() != 0 {
             episodeInfoView.isHidden = true
             chapterInfoView.isHidden = false
@@ -207,7 +207,7 @@ extension NowPlayingPlayerItemViewController {
             hideError()
             return
         }
-        guard PlaybackManager.shared.currentEpisode() != nil,
+        guard PlaybackManager.shared.currentEpisode != nil,
               let error = PlaybackManager.shared.activeError else {
             hideError()
             return
@@ -266,7 +266,7 @@ extension NowPlayingPlayerItemViewController {
     }
 
     func updateProvisionalChapterInfoForTime(time: TimeInterval) {
-        guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let playingEpisode = PlaybackManager.shared.currentEpisode else { return }
 
         if PlaybackManager.shared.chapterCount() == 0 {
             return

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -604,7 +604,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     }
 
     @objc private func videoTapped() {
-        guard PlaybackManager.shared.currentEpisode() != nil else { return }
+        guard PlaybackManager.shared.currentEpisode != nil else { return }
 
         if PlaybackManager.shared.shouldRenderVideo() {
             let videoController = VideoViewController()
@@ -632,7 +632,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
     }
 
     private func skipForwardLongPressed() {
-        guard let episode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode else { return }
 
         let options = OptionsPicker(title: nil, themeOverride: .dark)
 
@@ -644,7 +644,7 @@ class NowPlayingPlayerItemViewController: PlayerItemViewController {
 
         if PlaybackManager.shared.queue.upNextCount() > 0 {
             let skipToNextAction = OptionAction(label: L10n.nextEpisode, icon: nil) {
-                let currentlyPlayingEpisode = PlaybackManager.shared.currentEpisode()
+                let currentlyPlayingEpisode = PlaybackManager.shared.currentEpisode
                 PlaybackManager.shared.removeIfPlayingOrQueued(episode: currentlyPlayingEpisode, fireNotification: true, userInitiated: true)
             }
             options.addAction(action: skipToNextAction)

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -136,7 +136,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     // MARK: - API
 
     func isNowPlayingEpisode(episodeUuid: String?) -> Bool {
-        if let episodeUuid, let playingEpisode = currentEpisode() {
+        if let episodeUuid, let playingEpisode = currentEpisode {
             return playingEpisode.uuid == episodeUuid
         }
 
@@ -147,12 +147,12 @@ class PlaybackManager: ServerPlaybackDelegate {
         isNowPlayingEpisode(episodeUuid: episodeUuid) && playing()
     }
 
-    func currentEpisode() -> BaseEpisode? {
+    var currentEpisode: BaseEpisode? {
         queue.currentEpisode()
     }
 
     var currentPodcast: Podcast? {
-        if let episode = currentEpisode() as? Episode {
+        if let episode = currentEpisode as? Episode {
             return episode.parentPodcast()
         }
 
@@ -184,7 +184,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     func load(episode: BaseEpisode, autoPlay: Bool, overrideUpNext: Bool, saveCurrentEpisode: Bool = true, completion: (() -> Void)? = nil) {
         FileLog.shared.addMessage("Loading \(episode.displayableTitle()) with UUID \(episode.uuid) autoPlay \(autoPlay) overrideUpNext: \(overrideUpNext)")
 
-        let episodeIsChanging = episode.uuid != currentEpisode()?.uuid
+        let episodeIsChanging = episode.uuid != currentEpisode?.uuid
 
         // A new episode shouldn't inherit the previous one's "watch downloaded video" choice.
         if episodeIsChanging {
@@ -193,18 +193,18 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         // if the user has built an Up Next list, preserve that but make this the currently playing episode
         if !overrideUpNext && !switchingToDifferentUpNextEpisode && queue.upNextCount() > 0 {
-            if let currEpisode = currentEpisode(), currEpisode.uuid != episode.uuid {
+            if let currEpisode = currentEpisode, currEpisode.uuid != episode.uuid {
                 switchTo(episodeToPlay: episode, moveExistingToUpNext: true, autoPlay: autoPlay, completion: completion)
 
                 return
             }
         }
 
-        if let uuid = currentEpisode()?.uuid, uuid != episode.uuid {
+        if let uuid = currentEpisode?.uuid, uuid != episode.uuid {
             chapterManager.clearChapterInfo()
         }
 
-        if saveCurrentEpisode && currentEpisode() != nil && !switchingToDifferentUpNextEpisode {
+        if saveCurrentEpisode && currentEpisode != nil && !switchingToDifferentUpNextEpisode {
             recordPlaybackPosition(sendToServerImmediately: false, fireNotifications: false)
         }
 
@@ -249,7 +249,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func loadCurrentEpisode() {
-        guard let currEpisode = currentEpisode() else { return }
+        guard let currEpisode = currentEpisode else { return }
         if playerSwitchRequired() {
             load(episode: currEpisode, autoPlay: false, overrideUpNext: false)
         }
@@ -269,7 +269,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func ensureBackgroundMediaSessionConfiguration() {
-        guard let currEpisode = currentEpisode() else { return }
+        guard let currEpisode = currentEpisode else { return }
         refreshNowPlayingInfo(forceFullRebuild: true)
         activateAudioSession(completion: { _ in
             self.updateCommandCenterSkipTimes(addTarget: false)
@@ -281,9 +281,9 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func play(completion: (() -> Void)? = nil, userInitiated: Bool = true) {
-        guard let currEpisode = currentEpisode() else { return }
+        guard let currEpisode = currentEpisode else { return }
 
-        FileLog.shared.addMessage("PlaybackManager Play \(currentEpisode()?.title ?? "unknown episode") userInitiated: \(userInitiated)")
+        FileLog.shared.addMessage("PlaybackManager Play \(currentEpisode?.title ?? "unknown episode") userInitiated: \(userInitiated)")
 
         if userInitiated {
             analyticsPlaybackHelper.play()
@@ -331,7 +331,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             // player (resumes/seeks reuse the same player and don't re-report). Only report if the
             // current episode still matches the one we started: activation can run async, and if the
             // user has since switched episodes the new play cycle reports its own resolved source.
-            if shouldReportSourceResolved, self.currentEpisode()?.uuid == currEpisode.uuid {
+            if shouldReportSourceResolved, self.currentEpisode?.uuid == currEpisode.uuid {
                 self.analyticsPlaybackHelper.playbackSourceResolved(for: currEpisode)
             }
 
@@ -346,7 +346,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func pause(userInitiated: Bool = true) {
-        guard let episode = currentEpisode() else { return }
+        guard let episode = currentEpisode else { return }
 
         // Only trigger the event if we are already playing
         if playing(), userInitiated == true {
@@ -356,7 +356,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         // one kind of interruption would be to launch siri and ask it to pause, handle this here
         wasPlayingBeforeInterruption = false
 
-        FileLog.shared.addMessage("PlaybackManager pausing playback \(currentEpisode()?.title ?? "unknown episode")")
+        FileLog.shared.addMessage("PlaybackManager pausing playback \(currentEpisode?.title ?? "unknown episode")")
 
         recordPlaybackPosition(sendToServerImmediately: playing(), fireNotifications: true)
 
@@ -513,7 +513,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private func checkForChapterChange() {
-        guard let episodeUuid = currentEpisode()?.uuid else { return }
+        guard let episodeUuid = currentEpisode?.uuid else { return }
 
         if chapterManager.haveTriedToParseChaptersFor(episodeUuid: episodeUuid), chapterManager.updateCurrentChapter(time: currentTime()) {
             if currentChapters().visibleChapter?.isPlayable() == false {
@@ -545,7 +545,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func seekTo(time: TimeInterval, syncChanges: Bool, startPlaybackAfterSeek: Bool = false, seekHint: SeekHint? = nil) {
-        guard let playingEpisode = currentEpisode() else { return } // nothing to actually seek
+        guard let playingEpisode = currentEpisode else { return } // nothing to actually seek
 
         if seekHint == .back, !isValidSeek(time: time) {
             FileLog.shared.addMessage("aborting seek because it's moving forward from \(previousSeekTime ?? 0) to \(time)")
@@ -621,7 +621,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func currentTime() -> TimeInterval {
-        guard let episode = currentEpisode() else { return -1 }
+        guard let episode = currentEpisode else { return -1 }
 
         if seekingTo >= 0, seekingTo <= duration(), !playing() { return seekingTo }
 
@@ -636,7 +636,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func duration() -> TimeInterval {
-        guard let currentEpisode = currentEpisode() else { return 0 }
+        guard let currentEpisode else { return 0 }
 
         if let player, !aboutToPlay.value, !buffering() {
             let episodeDuration = currentEpisode.duration
@@ -671,12 +671,12 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         // If we don't have a current episode, reload the persisted queue to updated our cache just in case
         // We're getting reports from users about Up Next being cleared where this line is indicated by the logs
-        if currentEpisode() == nil {
+        if currentEpisode == nil {
             FileLog.shared.addMessage("PlaybackManager: Missing current episode, reloading queue")
             queue.loadPersistedQueue()
         }
 
-        guard let playingEpisode = currentEpisode() else {
+        guard let playingEpisode = currentEpisode else {
             // if there's nothing playing, just play this
             load(episode: episode, autoPlay: false, overrideUpNext: true)
 
@@ -781,7 +781,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     private func switchTo(episodeToPlay: BaseEpisode, moveExistingToUpNext: Bool, autoPlay: Bool, completion: (() -> Void)? = nil) {
         cancelUpdateTimer()
 
-        if let previousEpisode = currentEpisode(), !moveExistingToUpNext {
+        if let previousEpisode = currentEpisode, !moveExistingToUpNext {
             queue.remove(episode: previousEpisode, fireNotification: false)
         }
 
@@ -835,7 +835,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             return false
         }
 
-        guard let currentID = currentEpisode()?.uuid else {
+        guard let currentID = currentEpisode?.uuid else {
             return true
         }
 
@@ -854,7 +854,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// (`videoPodcast()`), any video tracks detected at runtime in the stream, and actual HLS playback
     /// (`willPlayViaHLS`), which we assume is video.
     func isCurrentEpisodeVideo() -> Bool {
-        guard let episode = currentEpisode() else { return false }
+        guard let episode = currentEpisode else { return false }
         // Assume HLS episodes are video so the player can go full screen immediately, without waiting to
         // detect video tracks at runtime. Use willPlayViaHLS so this only applies when the current source
         // is actually HLS (a downloaded episode plays its local file, which may not be video).
@@ -890,7 +890,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// episode has been downloaded (its downloaded file is audio-only, so the toggle streams the HLS video).
     /// When the global "Audio only" setting forces audio for every episode, the per-episode toggle is hidden.
     func canToggleVideoRendering() -> Bool {
-        guard FeatureFlag.hls.enabled, !isAudioOnlyForced, let episode = currentEpisode(), episode is Episode else { return false }
+        guard FeatureFlag.hls.enabled, !isAudioOnlyForced, let episode = currentEpisode, episode is Episode else { return false }
         return EpisodeManager.hasHLSStream(episode)
     }
 
@@ -899,7 +899,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// `urlForEpisode` when resolving the playback source.
     func shouldStreamVideoDespiteDownload(_ episode: BaseEpisode) -> Bool {
         streamingVideoForDownloadedEpisode.value
-            && episode.uuid == currentEpisode()?.uuid
+            && episode.uuid == currentEpisode?.uuid
             && EpisodeManager.hasHLSStream(episode)
     }
 
@@ -908,7 +908,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// its local file is audio-only, so we flip the streaming preference and reload playback in place to
     /// switch between the downloaded audio file and the streamed HLS video.
     func toggleVideoRendering() {
-        guard canToggleVideoRendering(), let episode = currentEpisode() else { return }
+        guard canToggleVideoRendering(), let episode = currentEpisode else { return }
 
         let switchedToVideo: Bool
         if hasDownloadedFile(episode) {
@@ -932,7 +932,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// playback position and whether it was playing. Used to switch a downloaded episode between its local
     /// audio file and the streamed HLS video.
     private func reloadCurrentEpisodeSource() {
-        guard let episode = currentEpisode() else { return }
+        guard let episode = currentEpisode else { return }
         let wasPlaying = playing()
         recordPlaybackPosition(sendToServerImmediately: false, fireNotifications: false)
         load(episode: episode, autoPlay: wasPlaying, overrideUpNext: false, saveCurrentEpisode: false)
@@ -941,7 +941,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// Called by the player when it detects video tracks in the stream it is playing.
     /// Used for HLS streams whose video content isn't reflected in the episode's file type.
     func handleVideoTracksDetected(forEpisode episodeUuid: String) {
-        guard currentEpisode()?.uuid == episodeUuid, !currentStreamContainsVideo.value else { return }
+        guard currentEpisode?.uuid == episodeUuid, !currentStreamContainsVideo.value else { return }
         currentStreamContainsVideo.value = true
         setAudioSessionVideoProperties()
         // Force a full now playing rebuild so the lock screen / Control Center switch to the video media type
@@ -950,7 +950,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func internalPlayerForVideoPlayback() -> AVPlayer? {
-        if let episode = currentEpisode(), player == nil {
+        if let episode = currentEpisode, player == nil {
             load(episode: episode, autoPlay: false, overrideUpNext: false)
             player?.loadEpisode(episode)
             haveCalledPlayerLoad = true
@@ -1022,7 +1022,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         // if the episode is downloaded, parse it for chapters so the UI is up to date. If it's not, don't, because this will use data
         // we only do this on iOS, since on watchOS the chapters aren't as prominent and we need to conserve battery life
         #if !os(watchOS)
-            if let episode = currentEpisode(), episode.downloaded(pathFinder: DownloadManager.shared) {
+            if let episode = currentEpisode, episode.downloaded(pathFinder: DownloadManager.shared) {
                 updateChapterInfo()
             }
         #endif
@@ -1060,7 +1060,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func changeEffects(_ effects: PlaybackEffects) {
-        guard let episode = currentEpisode() else { return }
+        guard let episode = currentEpisode else { return }
 
         // round it to the nearest 0.1, so we end up with 1.5 not 1.53667346262
         effects.playbackSpeed = round(effects.playbackSpeed * 10.0) / 10.0
@@ -1103,7 +1103,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         if playbackEffects.playbackSpeed > 4.9 { return }
 
         // HLS streams can't sustain playback above 2x, so don't let the speed be raised past it.
-        if let episode = currentEpisode(), EpisodeManager.willPlayViaHLS(episode), playbackEffects.playbackSpeed >= SharedConstants.PlaybackEffects.maximumHlsPlaybackSpeed { return }
+        if let episode = currentEpisode, EpisodeManager.willPlayViaHLS(episode), playbackEffects.playbackSpeed >= SharedConstants.PlaybackEffects.maximumHlsPlaybackSpeed { return }
 
         playbackEffects.playbackSpeed = playbackEffects.playbackSpeed + 0.1
         changeEffects(playbackEffects)
@@ -1116,7 +1116,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func overrideEffectsToggled(applyLocalSettings: Bool) {
-        guard let episode = currentEpisode() as? Episode,
+        guard let episode = currentEpisode as? Episode,
               let podcast = episode.parentPodcast() else {
             return
         }
@@ -1137,7 +1137,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private func handlePlaybackEffectsChanged(effects: PlaybackEffects) {
-        guard let episode = currentEpisode() else { return }
+        guard let episode = currentEpisode else { return }
 
         if playerSwitchRequired() {
             load(episode: episode, autoPlay: playing(), overrideUpNext: false)
@@ -1155,11 +1155,11 @@ class PlaybackManager: ServerPlaybackDelegate {
     func silenceRemovalAvailable() -> Bool {
         // Trim silence relies on the EffectsPlayer audio engine; HLS plays through AVPlayer, which can't do it.
         #if APPCLIP
-        if let episode = currentEpisode() {
+        if let episode = currentEpisode {
             return !episode.videoPodcast() && !EpisodeManager.willPlayViaHLS(episode)
         }
         #elseif !os(watchOS) && !os(tvOS)
-            if let episode = currentEpisode() {
+            if let episode = currentEpisode {
                 return !episode.videoPodcast() && !EpisodeManager.willPlayViaHLS(episode) && !GoogleCastManager.sharedManager.connectedOrConnectingToDevice()
             }
         #endif
@@ -1171,7 +1171,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         // Volume boost uses an audio processing tap, which needs a concrete audio track that HLS streams don't
         // expose. The tap logic in DefaultPlayer is compiled on tvOS too, so exclude HLS there as well.
         #if !os(watchOS)
-        if let episode = currentEpisode(), EpisodeManager.willPlayViaHLS(episode) {
+        if let episode = currentEpisode, EpisodeManager.willPlayViaHLS(episode) {
             return false
         }
         #endif
@@ -1188,7 +1188,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     // MARK: - Player Callbacks
 
     @objc func requiredStartingPosition() -> TimeInterval {
-        guard let episode = currentEpisode() else { return 0 }
+        guard let episode = currentEpisode else { return 0 }
 
         if seekingTo >= 0, seekingTo <= duration() {
             let timeToReturn = seekingTo
@@ -1334,10 +1334,10 @@ class PlaybackManager: ServerPlaybackDelegate {
     func playbackDidFail(error: PlaybackError, fallbackToDefaultPlayer: Bool = false) {
         FileLog.shared.addMessage("[PlaybackManager] Playback did fail with error: \(error.logMessage ?? "No error detail provided")")
 
-        AnalyticsPlaybackHelper.shared.playbackFailed(episode: currentEpisode(), error: error.logMessage ?? "Unknown", hlsErrorDetail: error.analyticsDetail, player: player)
+        AnalyticsPlaybackHelper.shared.playbackFailed(episode: currentEpisode, error: error.logMessage ?? "Unknown", hlsErrorDetail: error.analyticsDetail, player: player)
 
         #if !os(watchOS)
-        if fallbackToDefaultPlayer, let episode = currentEpisode() {
+        if fallbackToDefaultPlayer, let episode = currentEpisode {
             FileLog.shared.addMessage("[PlaybackManager] Playback failed, attempting to fallback to: DefaultPlayer")
 
             fallbackToPlayer = DefaultPlayer.self
@@ -1349,7 +1349,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
         #endif
 
-        guard let episode = currentEpisode() else {
+        guard let episode = currentEpisode else {
             FileLog.shared.addMessage("[PlaybackManager] Failed to fetch current episode. Queue will be cleared.")
             endPlayback()
 
@@ -1385,7 +1385,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func playerDidCalculateDuration() {
-        guard let episode = currentEpisode(), let playerDuration = player?.duration(), !episode.downloading() else { return }
+        guard let episode = currentEpisode, let playerDuration = player?.duration(), !episode.downloading() else { return }
 
         let currentDuration = episode.duration
 
@@ -1420,7 +1420,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         chapterManager.clearChapterInfo()
 
         // handle the episode that just finished, marking it as played, etc
-        if let episode = currentEpisode() {
+        if let episode = currentEpisode {
             autoplayIfNeeded()
 
             FileLog.shared.addMessage("Finished playing \(episode.displayableTitle())")
@@ -1471,7 +1471,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         // check to see if there's another episode we should be moving onto
         if queue.upNextCount() == 0 {
-            if let episode = currentEpisode() {
+            if let episode = currentEpisode {
                 queue.remove(episode: episode, fireNotification: false)
             }
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackEnded)
@@ -1490,7 +1490,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func playerDidRequestTermination() {
-        guard let currEpisode = currentEpisode() else { return }
+        guard let currEpisode = currentEpisode else { return }
 
         let upTo = currentTime()
         DataManager.sharedManager.saveEpisode(playedUpTo: upTo, episode: currEpisode, updateSyncFlag: SyncManager.isUserLoggedIn())
@@ -1503,7 +1503,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func bulkAdd(_ episodes: [BaseEpisode], toTop: Bool = false) {
         var episodesToAdd = episodes
-        if let currentEpisodeIndex = episodes.firstIndex(where: { $0.uuid == PlaybackManager.shared.currentEpisode()?.uuid }) {
+        if let currentEpisodeIndex = episodes.firstIndex(where: { $0.uuid == PlaybackManager.shared.currentEpisode?.uuid }) {
             episodesToAdd.remove(at: currentEpisodeIndex)
         }
 
@@ -1559,7 +1559,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private func setupPlayer() {
-        guard let currEpisode = currentEpisode() else { return }
+        guard let currEpisode = currentEpisode else { return }
 
         // check for rogue settings
         if currEpisode.videoPodcast() {
@@ -1596,7 +1596,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     private func supportedPlayers() -> [PlaybackProtocol.Type] {
         var possiblePlayers = [PlaybackProtocol.Type]()
 
-        guard let currEpisode = currentEpisode() else { return possiblePlayers }
+        guard let currEpisode = currentEpisode else { return possiblePlayers }
 
         #if !os(watchOS) && !APPCLIP && !os(tvOS)
             if let fallbackToPlayer {
@@ -1761,7 +1761,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     // MARK: - Playback Position
 
     private func recordPlaybackPosition(sendToServerImmediately: Bool, fireNotifications: Bool) {
-        guard let currEpisode = currentEpisode() else { return }
+        guard let currEpisode = currentEpisode else { return }
 
         let upTo = currentTime()
         if upTo <= 0 { return }
@@ -1801,7 +1801,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     @objc private func progressTimerFired() {
-        guard let player, let episode = currentEpisode() else { return }
+        guard let player, let episode = currentEpisode else { return }
 
         StatsManager.shared.addTotalListeningTime(updateTimerInterval)
         if player.playbackRate() > 1 {
@@ -1919,7 +1919,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         #endif
 
         // When Google Casting in the background, control over the casting device is not available, so remove the controls
-        guard let episode = currentEpisode(), !connectedToExternalDevice else {
+        guard let episode = currentEpisode, !connectedToExternalDevice else {
             #if os(watchOS)
                 WatchNowPlayingHelper.clearNowPlayingInfo()
             #else
@@ -1946,19 +1946,19 @@ class PlaybackManager: ServerPlaybackDelegate {
     func forceUpdateChapterInfo() {
         queue.nowPlayingEpisodeChanged()
 
-        guard let episode = currentEpisode(), episode.mayContainChapters() else { return }
+        guard let episode = currentEpisode, episode.mayContainChapters() else { return }
 
         chapterManager.parseChapters(episode: episode, duration: duration())
     }
 
     private func updateChapterInfo() {
-        guard let episode = currentEpisode(), episode.mayContainChapters(), !chapterManager.haveTriedToParseChaptersFor(episodeUuid: episode.uuid) else { return }
+        guard let episode = currentEpisode, episode.mayContainChapters(), !chapterManager.haveTriedToParseChaptersFor(episodeUuid: episode.uuid) else { return }
 
         chapterManager.parseChapters(episode: episode, duration: duration())
     }
 
     @objc private func updateAllNowPlayingData() {
-        guard let episode = currentEpisode() else {
+        guard let episode = currentEpisode else {
             #if os(watchOS)
                 WatchNowPlayingHelper.clearNowPlayingInfo()
             #else
@@ -2008,7 +2008,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     // MARK: - Remote Control support
     func remotePlayPauseToggle() {
-        guard self.currentEpisode() != nil else {
+        guard self.currentEpisode != nil else {
             return
         }
         analyticsPlaybackHelper.currentSource = self.commandCenterSource
@@ -2021,13 +2021,13 @@ class PlaybackManager: ServerPlaybackDelegate {
         let commandCenter = MPRemoteCommandCenter.shared()
 
         commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
-            guard let self, let _ = self.currentEpisode() else { return .noActionableNowPlayingItem }
+            guard let self, let _ = self.currentEpisode else { return .noActionableNowPlayingItem }
             remotePlayPauseToggle()
             return .success
         }
 
         commandCenter.pauseCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
-            guard let strongSelf = self, let _ = strongSelf.currentEpisode() else { return .noActionableNowPlayingItem }
+            guard let strongSelf = self, let _ = strongSelf.currentEpisode else { return .noActionableNowPlayingItem }
 
             strongSelf.analyticsPlaybackHelper.currentSource = strongSelf.commandCenterSource
 
@@ -2038,7 +2038,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
 
         commandCenter.playCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
-            guard let strongSelf = self, let _ = strongSelf.currentEpisode() else { return .noActionableNowPlayingItem }
+            guard let strongSelf = self, let _ = strongSelf.currentEpisode else { return .noActionableNowPlayingItem }
 
             strongSelf.analyticsPlaybackHelper.currentSource = strongSelf.commandCenterSource
 
@@ -2073,7 +2073,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
 
         commandCenter.stopCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
-            guard let strongSelf = self, let _ = strongSelf.currentEpisode() else { return .noActionableNowPlayingItem }
+            guard let strongSelf = self, let _ = strongSelf.currentEpisode else { return .noActionableNowPlayingItem }
 
             FileLog.shared.addMessage("Remote control: stopCommand")
             strongSelf.pause()
@@ -2082,7 +2082,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
 
         commandCenter.previousTrackCommand.addTarget { [weak self] event -> MPRemoteCommandHandlerStatus in
-            guard let strongSelf = self, let _ = strongSelf.currentEpisode() else { return .noActionableNowPlayingItem }
+            guard let strongSelf = self, let _ = strongSelf.currentEpisode else { return .noActionableNowPlayingItem }
 
             FileLog.shared.addMessage("Remote control: previousTrackCommand")
 
@@ -2097,7 +2097,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
 
         commandCenter.nextTrackCommand.addTarget { [weak self] event -> MPRemoteCommandHandlerStatus in
-            guard let strongSelf = self, let _ = strongSelf.currentEpisode() else { return .noActionableNowPlayingItem }
+            guard let strongSelf = self, let _ = strongSelf.currentEpisode else { return .noActionableNowPlayingItem }
 
             FileLog.shared.addMessage("Remote control: nextTrackCommand")
 
@@ -2113,7 +2113,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         commandCenter.changePlaybackRateCommand.supportedPlaybackRates = [0.5, 1.0, 1.5, 2.0, 2.5, 3.0]
         commandCenter.changePlaybackRateCommand.addTarget { [weak self] event -> MPRemoteCommandHandlerStatus in
-            guard let strongSelf = self, let _ = strongSelf.currentEpisode() else { return .noActionableNowPlayingItem }
+            guard let strongSelf = self, let _ = strongSelf.currentEpisode else { return .noActionableNowPlayingItem }
 
             if let rateEvent = event as? MPChangePlaybackRateCommandEvent {
                 FileLog.shared.addMessage("Remote control: changePlaybackRateCommand")
@@ -2142,7 +2142,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         if !Settings.isLockScreenScrubbingDisabled { // Only perform the seek if lock screen scrubbing is enabled
             commandCenter.changePlaybackPositionCommand.addTarget { [weak self] event -> MPRemoteCommandHandlerStatus in
 
-                guard let self, let _ = currentEpisode() else { return .noActionableNowPlayingItem }
+                guard let self, let _ = currentEpisode else { return .noActionableNowPlayingItem }
 
                 analyticsPlaybackHelper.currentSource = commandCenterSource
 
@@ -2186,7 +2186,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             #endif
             markPlayedCommand.removeTarget(nil)
             markPlayedCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
-                guard let strongSelf = self, let episode = strongSelf.currentEpisode() else { return .noActionableNowPlayingItem }
+                guard let strongSelf = self, let episode = strongSelf.currentEpisode else { return .noActionableNowPlayingItem }
 
                 AnalyticsEpisodeHelper.shared.currentSource = strongSelf.commandCenterSource
                 EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
@@ -2199,16 +2199,16 @@ class PlaybackManager: ServerPlaybackDelegate {
             #endif
             starCommand.removeTarget(nil)
             starCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
-                guard let strongSelf = self, let episode = strongSelf.currentEpisode() as? Episode else { return .noActionableNowPlayingItem }
+                guard let strongSelf = self, let episode = strongSelf.currentEpisode as? Episode else { return .noActionableNowPlayingItem }
                 EpisodeManager.setStarred(!episode.keepEpisode, episode: episode, updateSyncStatus: SyncManager.isUserLoggedIn())
                 return .success
             }
-            if let episode = self.currentEpisode() {
+            if let episode = self.currentEpisode {
                 starCommand.isActive = episode.keepEpisode
             } else {
                 starCommand.isActive = false
             }
-            if self.currentEpisode() is UserEpisode {
+            if self.currentEpisode is UserEpisode {
                 starCommand.isEnabled = false
             }
             else {
@@ -2316,7 +2316,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         logRouteChange(userInfo: userInfo)
 
         let reason = changeReason.uintValue
-        if let currEpisode = currentEpisode(), playingOverAirplay() && playerSwitchRequired() {
+        if let currEpisode = currentEpisode, playingOverAirplay() && playerSwitchRequired() {
             let wasPlaying = player?.shouldBePlaying() ?? false
             let autoPlay: Bool
             if FeatureFlag.dontAutoplayOnRouteChange.enabled {
@@ -2399,7 +2399,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 player.interruptionDidStart()
             }
 
-            if let episode = currentEpisode() {
+            if let episode = currentEpisode {
                 catchUpHelper.playbackDidPause(of: episode)
             }
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackPaused)
@@ -2411,14 +2411,14 @@ class PlaybackManager: ServerPlaybackDelegate {
             if GoogleCastManager.sharedManager.connected() { return } // while google casting we don't care about system audio events
         #endif
 
-        if currentEpisode() != nil {
+        if currentEpisode != nil {
             cleanupCurrentPlayer(permanent: false)
         }
     }
 
     func remoteDeviceConnected() {
         AnalyticsHelper.didConnectToChromecast()
-        if let episode = currentEpisode() {
+        if let episode = currentEpisode {
             if playerSwitchRequired() {
                 AnalyticsPlaybackHelper.shared.currentSource = .chromecast
                 pause()
@@ -2434,7 +2434,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func remoteDeviceDisconnected() {
-        guard let episode = currentEpisode() else { return }
+        guard let episode = currentEpisode else { return }
 
         if playerSwitchRequired() {
             load(episode: episode, autoPlay: false, overrideUpNext: false)
@@ -2448,7 +2448,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 return // we already have a Google Cast player, probably just a background resume rather than a restart
             }
 
-            if let playingEpisode = currentEpisode(), playingEpisode.uuid != episodeUuid {
+            if let playingEpisode = currentEpisode, playingEpisode.uuid != episodeUuid {
                 return // if we connected back up and a different episode is playing to what we are playing, don't switch
             }
 
@@ -2487,14 +2487,14 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func nowPlayingStarredChanged() {
         queue.nowPlayingEpisodeChanged()
-        guard let episode = currentEpisode() else { return }
+        guard let episode = currentEpisode else { return }
         MPRemoteCommandCenter.shared().likeCommand.isActive = episode.keepEpisode
     }
 
     // MARK: - Downloading a streamed episode check
 
     @objc private func handleEpisodeDidDownload(_ notification: Notification) {
-        guard let playingEpisode = currentEpisode(), let uuid = notification.object as? String else { return }
+        guard let playingEpisode = currentEpisode, let uuid = notification.object as? String else { return }
 
         if uuid != playingEpisode.uuid { return } // download isn't the episode we're playing
 
@@ -2516,7 +2516,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func needsToReloadPlayingEpisode(_ refreshedEpisode: BaseEpisode) -> Bool {
-        let episodeIsChanging = refreshedEpisode.uuid != currentEpisode()?.uuid
+        let episodeIsChanging = refreshedEpisode.uuid != currentEpisode?.uuid
 
         if FeatureFlag.doNotSwitchToDownloadedFile.enabled,
            FeatureFlag.streamAndCachePlayingEpisode.enabled,
@@ -2536,7 +2536,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     @objc private func handleEpisodeDidUpdate(_ notification: Notification) {
-        guard let playingEpisode = currentEpisode(), let uuid = notification.object as? String, uuid == playingEpisode.uuid else { return }
+        guard let playingEpisode = currentEpisode, let uuid = notification.object as? String, uuid == playingEpisode.uuid else { return }
 
         // update the cached copy of the now playing episode so we have the latest version of it
         queue.nowPlayingEpisodeChanged()
@@ -2566,13 +2566,13 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private func startFromTimeForCurrentEpisode() -> TimeInterval {
-        guard let episode = currentEpisode() as? Episode, let parentPodcast = episode.parentPodcast() else { return 0 }
+        guard let episode = currentEpisode as? Episode, let parentPodcast = episode.parentPodcast() else { return 0 }
 
         return TimeInterval(parentPodcast.startFrom)
     }
 
     private func skipLastTimeForCurrentEpisode() -> TimeInterval {
-        guard let episode = currentEpisode() as? Episode, let parentPodcast = episode.parentPodcast() else { return 0 }
+        guard let episode = currentEpisode as? Episode, let parentPodcast = episode.parentPodcast() else { return 0 }
 
         return TimeInterval(parentPodcast.skipLast)
     }
@@ -2600,7 +2600,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         // If Autoplay is enabled we check if there's another episode to play
         if Settings.autoplay,
            queue.upNextCount() == 0,
-           let episode = currentEpisode() {
+           let episode = currentEpisode {
 
             if let nextEpisode = AutoplayHelper.shared.nextEpisode(currentEpisodeUuid: episode.uuid) {
                 FileLog.shared.addMessage("Autoplaying next episode: \(nextEpisode.displayableTitle())")
@@ -2739,7 +2739,7 @@ extension PlaybackManager {
     }
 
     func bookmark(source: BookmarkAnalyticsSource) {
-        guard bookmarksEnabled, let episode = currentEpisode() else {
+        guard bookmarksEnabled, let episode = currentEpisode else {
             return
         }
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -144,7 +144,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func isActivelyPlaying(episodeUuid: String?) -> Bool {
-        isNowPlayingEpisode(episodeUuid: episodeUuid) && playing()
+        isNowPlayingEpisode(episodeUuid: episodeUuid) && isPlaying
     }
 
     var currentEpisode: BaseEpisode? {
@@ -159,7 +159,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         return nil
     }
 
-    func playing() -> Bool {
+    var isPlaying: Bool {
         if aboutToPlay.value { return true }
 
         guard let player else { return false }
@@ -167,7 +167,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         return player.playing()
     }
 
-    func buffering() -> Bool {
+    var isBuffering: Bool {
         guard let player else { return false }
 
         return player.buffering()
@@ -349,7 +349,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard let episode = currentEpisode else { return }
 
         // Only trigger the event if we are already playing
-        if playing(), userInitiated == true {
+        if isPlaying, userInitiated == true {
             analyticsPlaybackHelper.pause()
         }
 
@@ -358,7 +358,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         FileLog.shared.addMessage("PlaybackManager pausing playback \(currentEpisode?.title ?? "unknown episode")")
 
-        recordPlaybackPosition(sendToServerImmediately: playing(), fireNotifications: true)
+        recordPlaybackPosition(sendToServerImmediately: isPlaying, fireNotifications: true)
 
         if let player {
             player.pause()
@@ -374,7 +374,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func playPause() {
-        if playing() {
+        if isPlaying {
             pause()
         } else {
             play()
@@ -573,7 +573,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 strongSelf.fireProgressNotification()
                 strongSelf.updateNowPlayingInfo()
 
-                if startPlaybackAfterSeek, !strongSelf.playing() {
+                if startPlaybackAfterSeek, !strongSelf.isPlaying {
                     strongSelf.play()
                 }
             })
@@ -591,7 +591,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 seekingTo = PlaybackManager.notSeeking
             }
 
-            if startPlaybackAfterSeek, !playing() {
+            if startPlaybackAfterSeek, !isPlaying {
                 play(userInitiated: false)
             }
         }
@@ -623,7 +623,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     func currentTime() -> TimeInterval {
         guard let episode = currentEpisode else { return -1 }
 
-        if seekingTo >= 0, seekingTo <= duration(), !playing() { return seekingTo }
+        if seekingTo >= 0, seekingTo <= duration(), !isPlaying { return seekingTo }
 
         let playerTime = !aboutToPlay.value ? player?.currentTime() ?? 0 : 0
 
@@ -638,7 +638,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     func duration() -> TimeInterval {
         guard let currentEpisode else { return 0 }
 
-        if let player, !aboutToPlay.value, !buffering() {
+        if let player, !aboutToPlay.value, !isBuffering {
             let episodeDuration = currentEpisode.duration
             let playerDuration = player.duration()
             return (playerDuration > 0) ? playerDuration : episodeDuration
@@ -714,7 +714,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         if isNowPlayingEpisode(episodeUuid: episode?.uuid) {
             autoplayIfNeeded()
             if queue.upNextCount() > 0 {
-                playNextEpisode(autoPlay: playing())
+                playNextEpisode(autoPlay: isPlaying)
             } else {
                 endPlayback(saveCurrentEpisode: saveCurrentEpisode)
             }
@@ -845,7 +845,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// Resumes playback when it's currently paused. Used by the playlist "Play All" flow when the
     /// Up Next queue already matches the playlist being played.
     private func resumeIfPaused() {
-        guard !playing() else { return }
+        guard !isPlaying else { return }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackStarting)
         play()
     }
@@ -933,7 +933,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// audio file and the streamed HLS video.
     private func reloadCurrentEpisodeSource() {
         guard let episode = currentEpisode else { return }
-        let wasPlaying = playing()
+        let wasPlaying = isPlaying
         recordPlaybackPosition(sendToServerImmediately: false, fireNotifications: false)
         load(episode: episode, autoPlay: wasPlaying, overrideUpNext: false, saveCurrentEpisode: false)
     }
@@ -1140,7 +1140,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard let episode = currentEpisode else { return }
 
         if playerSwitchRequired() {
-            load(episode: episode, autoPlay: playing(), overrideUpNext: false)
+            load(episode: episode, autoPlay: isPlaying, overrideUpNext: false)
         }
 
         if let player {
@@ -1654,7 +1654,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                     self.playersToCleanUp.remove(at: index)
                 }
 
-                if !self.playing() {
+                if !self.isPlaying {
                     self.deactiveAudioSession(waitBeforeDeactivating: false)
                 }
             }
@@ -1830,7 +1830,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         fireProgressNotification()
 
         if updateCount > updatesPerSave {
-            recordPlaybackPosition(sendToServerImmediately: playing(), fireNotifications: true)
+            recordPlaybackPosition(sendToServerImmediately: isPlaying, fireNotifications: true)
             updateCount = 0
         } else {
             let upTo = currentTime()
@@ -1901,7 +1901,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// is stopped. Reporting `nil` here is interpreted as a rate of `0`, which holds the
     /// timeline in place while paused. See PCIOS-274.
     private var nowPlayingPlaybackRate: Double? {
-        playing() ? player?.playbackRate() : nil
+        isPlaying ? player?.playbackRate() : nil
     }
 
     @objc private func updateNowPlayingInfo() {
@@ -2044,16 +2044,16 @@ class PlaybackManager: ServerPlaybackDelegate {
 
             if Settings.legacyBluetoothModeEnabled() {
                 FileLog.shared.addMessage("Remote control: playCommand, treating as play (Legacy BT Mode is on)")
-                if !strongSelf.playing() { strongSelf.play() }
+                if !strongSelf.isPlaying { strongSelf.play() }
             } else if let lastPlayTime = UserDefaults.standard.object(forKey: Constants.UserDefaults.lastPlayEvent) as? Date, fabs(lastPlayTime.timeIntervalSinceNow) < 10.seconds {
                 // iOS will sometimes issue two remotePlay commands, so if it's been less than 10 seconds since the last one, just play don't try to playPause
                 FileLog.shared.addMessage("Remote control: playCommand, treating as play")
-                if !strongSelf.playing() { strongSelf.play() }
+                if !strongSelf.isPlaying { strongSelf.play() }
             } else {
                 if strongSelf.playingOverAirplay() {
                     // during handoff iOS will call us to play even if we already are, so honour that here
                     FileLog.shared.addMessage("Remote control: playCommand, treating as play because playing over AirPlay")
-                    if !strongSelf.playing() { strongSelf.play() }
+                    if !strongSelf.isPlaying { strongSelf.play() }
                 } else {
                     if FeatureFlag.ignorePlayWithOtherAudio.enabled {
                         let audioSession = AVAudioSession.sharedInstance()
@@ -2501,7 +2501,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         // the episode we have won't be marked as downloaded, so grab a fresh copy from the database
         if let refreshedEpisode = DataManager.sharedManager.findBaseEpisode(uuid: uuid) {
             // the current episode we were playing has downloaded, switch to playing the downloaded version
-            let currentlyPlaying = playing()
+            let currentlyPlaying = isPlaying
             recordPlaybackPosition(sendToServerImmediately: false, fireNotifications: true)
 
             if !needsToReloadPlayingEpisode(refreshedEpisode) {
@@ -2582,7 +2582,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     func updateIdleTimer() {
         #if !os(watchOS)
             DispatchQueue.main.async {
-                if self.playing() {
+                if self.isPlaying {
                     let keepScreenOn = UserDefaults.standard.bool(forKey: Constants.UserDefaults.keepScreenOnWhilePlaying)
                     UIApplication.shared.isIdleTimerDisabled = keepScreenOn
                 } else {
@@ -2857,7 +2857,7 @@ extension PlaybackManager {
         )
 
         // The listener took over while we were resolving; leave things where they put them.
-        guard isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid), !playing(),
+        guard isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid), !isPlaying,
               abs(currentTime() - bookmark.time) < 1 else {
             FileLog.shared.addMessage(
                 "[Bookmarks] Playback moved while resolving bookmark \(bookmark.uuid) — not starting playback"

--- a/podcasts/PlayerChapterCell.swift
+++ b/podcasts/PlayerChapterCell.swift
@@ -159,7 +159,7 @@ class PlayerChapterCell: UITableViewCell {
         guard let chapter, let link = chapter.url, let url = URL(string: link), let linkTapped = onLinkTapped else { return }
         PlaybackManager.shared.trackChapterEvent(.chapterLinkClicked, properties: [
             "podcast_uuid": PlaybackManager.shared.currentPodcast?.uuid ?? "unknown",
-            "episode_uuid": PlaybackManager.shared.currentEpisode()?.uuid ?? "unknown",
+            "episode_uuid": PlaybackManager.shared.currentEpisode?.uuid ?? "unknown",
             "chapter_title": chapter.title
         ])
         linkTapped(url)
@@ -172,7 +172,7 @@ class PlayerChapterCell: UITableViewCell {
 
         setColors(dim: chapter?.isPlayable() == false)
 
-        if let currentEpisode = PlaybackManager.shared.currentEpisode(), let index = chapter?.index {
+        if let currentEpisode = PlaybackManager.shared.currentEpisode, let index = chapter?.index {
             if chapter?.shouldPlay == true {
                 currentEpisode.select(chapterIndex: index)
                 track(.deselectChaptersChapterSelected)
@@ -219,6 +219,6 @@ class PlayerChapterCell: UITableViewCell {
     }
 
     private func track(_ event: AnalyticsEvent) {
-        PlaybackManager.shared.trackChapterEvent(event, properties: ["podcast_uuid": PlaybackManager.shared.currentPodcast?.uuid ?? "unknown", "episode_uuid": PlaybackManager.shared.currentEpisode()?.uuid ?? "unknown"])
+        PlaybackManager.shared.trackChapterEvent(event, properties: ["podcast_uuid": PlaybackManager.shared.currentPodcast?.uuid ?? "unknown", "episode_uuid": PlaybackManager.shared.currentEpisode?.uuid ?? "unknown"])
     }
 }

--- a/podcasts/PlayerColorHelper.swift
+++ b/podcasts/PlayerColorHelper.swift
@@ -4,63 +4,63 @@ import UIKit
 
 struct PlayerColorHelper {
     static func playerBackgroundColor01(for theme: Theme.ThemeType = Theme.sharedTheme.activeTheme,
-                                        episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+                                        episode: BaseEpisode? = PlaybackManager.shared.currentEpisode) -> UIColor {
         guard let podcastBackgroundColor = backgroundColor(for: episode) else { return UIColor.black }
 
         return ThemeColor.playerBackground01(podcastColor: podcastBackgroundColor, for: theme)
     }
 
     static func playerBackgroundColor02(for theme: Theme.ThemeType = Theme.sharedTheme.activeTheme,
-                                        episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+                                        episode: BaseEpisode? = PlaybackManager.shared.currentEpisode) -> UIColor {
         guard let podcastBackgroundColor = backgroundColor(for: episode) else { return UIColor.black }
 
         return ThemeColor.playerBackground02(podcastColor: podcastBackgroundColor, for: theme)
     }
 
     static func playerHighlightColor01(for theme: Theme.ThemeType = Theme.sharedTheme.activeTheme,
-                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode) -> UIColor {
         guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.playerHighlight01(podcastColor: podcastColor)
     }
 
     static func playerHighlightColor02(for theme: Theme.ThemeType = Theme.sharedTheme.activeTheme,
-                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode) -> UIColor {
         guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.playerHighlight02(podcastColor: podcastColor)
     }
 
     static func playerHighlightColor06(for theme: Theme.ThemeType,
-                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode) -> UIColor {
         guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.playerHighlight06(podcastColor: podcastColor)
     }
 
     static func playerHighlightColor07(for theme: Theme.ThemeType,
-                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+                                       episode: BaseEpisode? = PlaybackManager.shared.currentEpisode) -> UIColor {
         guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.playerHighlight07(podcastColor: podcastColor)
     }
 
     static func podcastInteractive03(for theme: Theme.ThemeType,
-                                     episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+                                     episode: BaseEpisode? = PlaybackManager.shared.currentEpisode) -> UIColor {
         guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.podcastInteractive03(podcastColor: podcastColor)
     }
 
     static func podcastInteractive04(for theme: Theme.ThemeType,
-                                     episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+                                     episode: BaseEpisode? = PlaybackManager.shared.currentEpisode) -> UIColor {
         guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.podcastInteractive04(podcastColor: podcastColor)
     }
 
     static func podcastInteractive05(for theme: Theme.ThemeType,
-                                     episode: BaseEpisode? = PlaybackManager.shared.currentEpisode()) -> UIColor {
+                                     episode: BaseEpisode? = PlaybackManager.shared.currentEpisode) -> UIColor {
         guard let podcastColor = tint(for: episode, with: theme) else { return UIColor.white }
 
         return ThemeColor.podcastInteractive05(podcastColor: podcastColor)

--- a/podcasts/PlayerContainerViewController+Update.swift
+++ b/podcasts/PlayerContainerViewController+Update.swift
@@ -9,7 +9,7 @@ extension PlayerContainerViewController {
     }
 
     @objc func update() {
-        guard PlaybackManager.shared.currentEpisode() != nil else {
+        guard PlaybackManager.shared.currentEpisode != nil else {
             closeNowPlaying()
 
             return
@@ -21,7 +21,7 @@ extension PlayerContainerViewController {
 
     private func updateAvailableTabs() {
         #if !APPCLIP
-        guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let playingEpisode = PlaybackManager.shared.currentEpisode else { return }
 
         // Update the colors when the episode changes
         tabsView.themeDidChange()

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -275,7 +275,7 @@ class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTa
     }
 
     @objc private func playbackFinished() {
-        if PlaybackManager.shared.currentEpisode() == nil {
+        if PlaybackManager.shared.currentEpisode == nil {
             closeNowPlaying()
         }
     }

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -275,7 +275,7 @@ private extension PlayerTabsView {
         guard PlaybackManager.shared.chapterCount() > 0 else { return }
 
         Analytics.track(.chaptersShown, properties: [
-            "episode_uuid": PlaybackManager.shared.currentEpisode()?.uuid ?? "unknown",
+            "episode_uuid": PlaybackManager.shared.currentEpisode?.uuid ?? "unknown",
             "podcast_uuid": PlaybackManager.shared.currentPodcast?.uuid ?? "unknown",
             "origin": PlaybackManager.shared.chaptersOriginAnalyticsValue,
             "source": "fullscreen_player"

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController+Table.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController+Table.swift
@@ -210,7 +210,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.podcastUpdated, object: podcast.uuid)
 
         // if we're actively playing this episode, let the player know
-        if let episode = PlaybackManager.shared.currentEpisode() as? Episode, podcast.uuid == episode.parentIdentifier() {
+        if let episode = PlaybackManager.shared.currentEpisode as? Episode, podcast.uuid == episode.parentIdentifier() {
             PlaybackManager.shared.effectsChangedExternally()
         }
     }

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -87,7 +87,7 @@ enum SharingModal {
         let optionPicker = OptionsPicker(title: L10n.share.uppercased(), themeOverride: .dark, colors: colors)
 
         let timeInterval: Double
-        if PlaybackManager.shared.currentEpisode()?.uuid == episode?.uuid {
+        if PlaybackManager.shared.currentEpisode?.uuid == episode?.uuid {
             timeInterval = PlaybackManager.shared.currentTime()
         } else {
             timeInterval = episode?.playedUpTo ?? 0

--- a/podcasts/ShelfActionsViewController+Table.swift
+++ b/podcasts/ShelfActionsViewController+Table.swift
@@ -30,7 +30,7 @@ extension ShelfActionsViewController: UITableViewDelegate, UITableViewDataSource
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: ShelfActionsViewController.shelfCellId, for: indexPath) as! ShelfCell
 
-        guard let playingEpisode = PlaybackManager.shared.currentEpisode() else { return cell }
+        guard let playingEpisode = PlaybackManager.shared.currentEpisode else { return cell }
 
         let action = actionAt(indexPath: indexPath, isEditing: tableView.isEditing)
         cell.actionIcon.tintColor = ThemeColor.playerContrast01()

--- a/podcasts/ShelfActionsViewController.swift
+++ b/podcasts/ShelfActionsViewController.swift
@@ -169,13 +169,13 @@ class ShelfActionsViewController: UIViewController, CheckTranscriptAvailability 
     @objc private func episodeTranscriptAvailabilityChanged(notification: NSNotification) {
         guard let episodeUuid = notification.userInfo?["episodeUuid"] as? String,
               notification.userInfo?["isAvailable"] as? Bool != nil,
-              episodeUuid == PlaybackManager.shared.currentEpisode()?.uuid else {
+              episodeUuid == PlaybackManager.shared.currentEpisode?.uuid else {
             return
         }
     }
 
     func updateAvailableActions() {
-        guard let episode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode else { return }
 
         let availableActions = allActions.filter { $0.canBePerformedOn(episode: episode) }
         let slice = availableActions[Constants.Limits.maxShelfActions ..< availableActions.count]

--- a/podcasts/ShortcutManager.swift
+++ b/podcasts/ShortcutManager.swift
@@ -66,7 +66,7 @@ class ShortcutManager: CustomObserver {
 
         if let currentEpisode = PlaybackManager.shared.currentEpisode {
             // add a play/pause shortcut
-            if PlaybackManager.shared.playing() {
+            if PlaybackManager.shared.isPlaying {
                 shortcutItems.append(
                     UIMutableApplicationShortcutItem(
                         type: "au.com.shiftyjelly.podcasts",

--- a/podcasts/ShortcutManager.swift
+++ b/podcasts/ShortcutManager.swift
@@ -64,7 +64,7 @@ class ShortcutManager: CustomObserver {
             )
         }
 
-        if let currentEpisode = PlaybackManager.shared.currentEpisode() {
+        if let currentEpisode = PlaybackManager.shared.currentEpisode {
             // add a play/pause shortcut
             if PlaybackManager.shared.playing() {
                 shortcutItems.append(

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -120,7 +120,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
     }
 
     @objc private func updateShowNotes() {
-        guard let episode = PlaybackManager.shared.currentEpisode() as? Episode else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode as? Episode else { return }
         self.episode = episode
         let pubDate = DateFormatHelper.sharedHelper.longLocalizedFormat(episode.publishedDate)
         publishedDate.text = pubDate

--- a/podcasts/SiriShortcutsManager.swift
+++ b/podcasts/SiriShortcutsManager.swift
@@ -351,7 +351,7 @@ class SiriShortcutsManager: CustomObserver {
 
     func resumePlayback() -> INPlayMediaIntentResponseCode {
         AnalyticsHelper.siriResume()
-        if PlaybackManager.shared.currentEpisode() != nil {
+        if PlaybackManager.shared.currentEpisode != nil {
             AnalyticsPlaybackHelper.shared.currentSource = analyticsSource
             PlaybackManager.shared.play()
             return INPlayMediaIntentResponseCode.success
@@ -368,7 +368,7 @@ class SiriShortcutsManager: CustomObserver {
 
     func markAsPlayed() -> INPlayMediaIntentResponseCode {
         AnalyticsHelper.siriMarkAsPlayed()
-        guard let currentEpisode = PlaybackManager.shared.currentEpisode() else {
+        guard let currentEpisode = PlaybackManager.shared.currentEpisode else {
             return INPlayMediaIntentResponseCode.failureNoUnplayedContent
         }
         AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
@@ -379,7 +379,7 @@ class SiriShortcutsManager: CustomObserver {
     func playUpNext() -> INPlayMediaIntentResponseCode {
         AnalyticsHelper.siriUpNext()
         // unlike when the user taps an episode in Up Next, their intention here is probably to remove the currently playing episode, and go to the next one if it exists
-        guard let currentEpisode = PlaybackManager.shared.currentEpisode(), PlaybackManager.shared.queue.upNextCount() > 0 else {
+        guard let currentEpisode = PlaybackManager.shared.currentEpisode, PlaybackManager.shared.queue.upNextCount() > 0 else {
             return INPlayMediaIntentResponseCode.failureNoUnplayedContent
         }
         PlaybackManager.shared.removeIfPlayingOrQueued(episode: currentEpisode, fireNotification: true, userInitiated: true)

--- a/podcasts/TranscriptPlaybackManaging.swift
+++ b/podcasts/TranscriptPlaybackManaging.swift
@@ -11,11 +11,11 @@ protocol TranscriptPlaybackManaging {
 
 extension PlaybackManager: TranscriptPlaybackManaging {
     var episodeUUID: String? {
-        currentEpisode()?.uuid
+        currentEpisode?.uuid
     }
 
     var parentIdentifier: String? {
-        currentEpisode()?.parentIdentifier()
+        currentEpisode?.parentIdentifier()
     }
 
     var podcastUUID: String? {

--- a/podcasts/TranscriptShelfButton.swift
+++ b/podcasts/TranscriptShelfButton.swift
@@ -39,7 +39,7 @@ extension CheckTranscriptAvailability {
             guard let episodeUuid = notification.userInfo?["episodeUuid"] as? String,
                   let isAvailable = notification.userInfo?["isAvailable"] as? Bool,
                   let hasGeneratedTranscripts = notification.userInfo?["hasGeneratedTranscripts"] as? Bool,
-                  episodeUuid == PlaybackManager.shared.currentEpisode()?.uuid else {
+                  episodeUuid == PlaybackManager.shared.currentEpisode?.uuid else {
                 return
             }
 
@@ -55,7 +55,7 @@ extension CheckTranscriptAvailability {
     func checkTranscriptAvailability() {
         isTranscriptEnabled = false
         hasGeneratedTranscripts = false
-        let currentEpisode = PlaybackManager.shared.currentEpisode() as? Episode
+        let currentEpisode = PlaybackManager.shared.currentEpisode as? Episode
         currentEpisode?.checkTranscriptAvailability()
     }
 }

--- a/podcasts/UpNextNowPlayingCell.swift
+++ b/podcasts/UpNextNowPlayingCell.swift
@@ -122,7 +122,7 @@ class UpNextNowPlayingCell: ThemeableCell {
         let percentageLapsed = CGFloat(currentTime / duration)
         progressViewWidthConstraint.constant = percentageLapsed * roundedBackgroundView.frame.width
 
-        playingAnimationView.animating = PlaybackManager.shared.playing()
+        playingAnimationView.animating = PlaybackManager.shared.isPlaying
 
         updateDownloadStatus()
 
@@ -134,7 +134,7 @@ class UpNextNowPlayingCell: ThemeableCell {
     }
 
     @objc func updatePlayingAnimation() {
-        playingAnimationView.animating = PlaybackManager.shared.playing()
+        playingAnimationView.animating = PlaybackManager.shared.isPlaying
     }
 
     override func prepareForReuse() {

--- a/podcasts/UpNextViewController+Table.swift
+++ b/podcasts/UpNextViewController+Table.swift
@@ -61,7 +61,7 @@ extension UpNextViewController: UITableViewDelegate, UITableViewDataSource {
         if section == .nowPlayingSection {
             let nowPlayingCell = tableView.dequeueReusableCell(withIdentifier: UpNextViewController.nowPlayingCell, for: indexPath) as! UpNextNowPlayingCell
             nowPlayingCell.themeOverride = themeOverride
-            if let episode = PlaybackManager.shared.currentEpisode() {
+            if let episode = PlaybackManager.shared.currentEpisode {
                 nowPlayingCell.populateFrom(episode: episode)
             }
             return nowPlayingCell
@@ -256,7 +256,7 @@ extension UpNextViewController: UITableViewDelegate, UITableViewDataSource {
     func refreshSections() {
         var sections: [sections] = [.upNextSection]
 
-        if let _ = PlaybackManager.shared.currentEpisode() {
+        if let _ = PlaybackManager.shared.currentEpisode {
             sections.insert(.nowPlayingSection, at: 0)
             upNextTable.themeStyle = .primaryUi04
         } else {
@@ -275,7 +275,7 @@ extension UpNextViewController: UITableViewDelegate, UITableViewDataSource {
             let upNextUuids = Set(DataManager.sharedManager.allUpNextPlaylistEpisodes().map(\.episodeUuid))
             selectedPlayListEpisodes.removeAll { !upNextUuids.contains($0.episodeUuid) }
 
-            if let currentUuid = PlaybackManager.shared.currentEpisode()?.uuid {
+            if let currentUuid = PlaybackManager.shared.currentEpisode?.uuid {
                 selectedEpisodesRemove(uuid: currentUuid)
             }
             if upNextUuids.isEmpty {

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -435,7 +435,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
 
     @objc func updateTimeRemainingLabel() {
         var totalDuration = PlaybackManager.shared.queue.upNextTotalDuration(includePlayingEpisode: false)
-        if let episode = PlaybackManager.shared.currentEpisode() {
+        if let episode = PlaybackManager.shared.currentEpisode {
             totalDuration += episode.duration.seconds - PlaybackManager.shared.currentTime()
         }
         let time = TimeFormatter.shared.multipleUnitFormattedShortTime(time: totalDuration)

--- a/podcasts/UserEpisodeDetailViewController+Table.swift
+++ b/podcasts/UserEpisodeDetailViewController+Table.swift
@@ -188,7 +188,7 @@ extension UserEpisodeDetailViewController: UITableViewDelegate, UITableViewDataS
 
         if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
             // dismiss the dialog if the user hit play
-            if !PlaybackManager.shared.playing() {
+            if !PlaybackManager.shared.isPlaying {
                 close()
             }
 

--- a/podcasts/Utilities/SwiftUI/MiniPlayerPaddingModifier.swift
+++ b/podcasts/Utilities/SwiftUI/MiniPlayerPaddingModifier.swift
@@ -20,7 +20,7 @@ public struct MiniPlayerSafeAreaInset: ViewModifier {
                         .frame(height: (isMiniPlayerVisible ? Constants.Values.miniPlayerOffset : 0) * multipler)
                 }
                 .onAppear {
-                    isMiniPlayerVisible = (PlaybackManager.shared.currentEpisode() != nil)
+                    isMiniPlayerVisible = (PlaybackManager.shared.currentEpisode != nil)
                 }
                 .ignoresSafeArea(.keyboard)
                 .onReceive(NotificationCenter.default.publisher(for: Constants.Notifications.miniPlayerDidAppear), perform: { _ in

--- a/podcasts/VideoViewController+Controls.swift
+++ b/podcasts/VideoViewController+Controls.swift
@@ -47,7 +47,7 @@ extension VideoViewController {
             hideVideoControls()
         } else {
             showVideoControls()
-            if PlaybackManager.shared.playing() { startHideControlsTimer() }
+            if PlaybackManager.shared.isPlaying { startHideControlsTimer() }
         }
     }
 

--- a/podcasts/VideoViewController+Seek.swift
+++ b/podcasts/VideoViewController+Seek.swift
@@ -4,7 +4,7 @@ extension VideoViewController: TimeSliderDelegate {
     func sliderDidEndSliding() {}
 
     func sliderDidProvisionallySlide(to time: TimeInterval) {
-        if PlaybackManager.shared.playing() { startHideControlsTimer() }
+        if PlaybackManager.shared.isPlaying { startHideControlsTimer() }
 
         updateUpTo(upTo: time, duration: PlaybackManager.shared.duration(), moveSlider: false)
     }

--- a/podcasts/VideoViewController.swift
+++ b/podcasts/VideoViewController.swift
@@ -141,7 +141,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
         super.viewDidAppear(animated)
 
         addUiNotificationObservers()
-        if PlaybackManager.shared.playing() {
+        if PlaybackManager.shared.isPlaying {
             startHideControlsTimer()
         }
     }
@@ -170,13 +170,13 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     }
 
     @IBAction func skipBackTapped(_ sender: Any) {
-        if PlaybackManager.shared.playing() { startHideControlsTimer() }
+        if PlaybackManager.shared.isPlaying { startHideControlsTimer() }
 
         PlaybackManager.shared.skipBack()
     }
 
     @IBAction func playPauseTapped(_ sender: Any) {
-        let currentlyPlaying = PlaybackManager.shared.playing()
+        let currentlyPlaying = PlaybackManager.shared.isPlaying
         HapticsHelper.triggerPlayPauseHaptic()
         if currentlyPlaying {
             PlaybackManager.shared.pause()
@@ -188,7 +188,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     }
 
     @IBAction func skipForwardTapped(_ sender: Any) {
-        if PlaybackManager.shared.playing() { startHideControlsTimer() }
+        if PlaybackManager.shared.isPlaying { startHideControlsTimer() }
         PlaybackManager.shared.skipForward()
     }
 
@@ -315,7 +315,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     }
 
     private func updatePlayPauseButton() {
-        playPauseBtn.isPlaying = PlaybackManager.shared.playing()
+        playPauseBtn.isPlaying = PlaybackManager.shared.isPlaying
     }
 
     func updateUpTo(upTo: TimeInterval, duration: TimeInterval, moveSlider: Bool) {

--- a/podcasts/VideoViewController.swift
+++ b/podcasts/VideoViewController.swift
@@ -193,7 +193,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     }
 
     private func skipForwardLongPressed() {
-        guard let episode = PlaybackManager.shared.currentEpisode() else { return }
+        guard let episode = PlaybackManager.shared.currentEpisode else { return }
 
         let options = OptionsPicker(title: nil, themeOverride: .dark)
 
@@ -205,7 +205,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
 
         if PlaybackManager.shared.queue.upNextCount() > 0 {
             let skipToNextAction = OptionAction(label: L10n.nextEpisode, icon: nil) {
-                let currentlyPlayingEpisode = PlaybackManager.shared.currentEpisode()
+                let currentlyPlayingEpisode = PlaybackManager.shared.currentEpisode
                 PlaybackManager.shared.removeIfPlayingOrQueued(episode: currentlyPlayingEpisode, fireNotification: true, userInitiated: true)
             }
             options.addAction(action: skipToNextAction)
@@ -285,7 +285,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     }
 
     @objc private func trackChanged() {
-        guard PlaybackManager.shared.currentEpisode() != nil, PlaybackManager.shared.isCurrentEpisodeVideo() else {
+        guard PlaybackManager.shared.currentEpisode != nil, PlaybackManager.shared.isCurrentEpisodeVideo() else {
             dismiss(animated: true, completion: nil)
             return
         }

--- a/podcasts/Watch Communication/WatchManager.swift
+++ b/podcasts/Watch Communication/WatchManager.swift
@@ -675,7 +675,7 @@ class WatchManager: NSObject, WCSessionDelegate {
     private func serializeNowPlaying() -> [String: Any] {
         var nowPlayingInfo = [String: Any]()
         let playbackManager = PlaybackManager.shared
-        if let playingEpisode = playbackManager.currentEpisode() {
+        if let playingEpisode = playbackManager.currentEpisode {
             nowPlayingInfo[WatchConstants.Keys.nowPlayingEpisode] = convertForWatch(episode: playingEpisode)
             nowPlayingInfo[WatchConstants.Keys.nowPlayingSubtitle] = playingEpisode.subTitle()
             nowPlayingInfo[WatchConstants.Keys.nowPlayingStatus] = playbackManager.playing() ? WatchConstants.PlayingStatus.playing : WatchConstants.PlayingStatus.paused

--- a/podcasts/Watch Communication/WatchManager.swift
+++ b/podcasts/Watch Communication/WatchManager.swift
@@ -144,7 +144,7 @@ class WatchManager: NSObject, WCSessionDelegate {
             }
         } else if WatchConstants.Messages.PlayPauseRequest.type == messageType {
             AnalyticsPlaybackHelper.shared.currentSource = .watch
-            if PlaybackManager.shared.playing() {
+            if PlaybackManager.shared.isPlaying {
                 PlaybackManager.shared.pause()
             } else {
                 PlaybackManager.shared.play()
@@ -390,7 +390,7 @@ class WatchManager: NSObject, WCSessionDelegate {
         // mini player / now playing updates immediately rather than only after a relaunch. This mirrors
         // how the server sync applies a remote position (see SyncTask+ServerChanges). Otherwise just
         // refresh any visible episode cell via the notification.
-        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: uuid), !PlaybackManager.shared.playing() {
+        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: uuid), !PlaybackManager.shared.isPlaying {
             DispatchQueue.main.async {
                 PlaybackManager.shared.seekToFromSync(time: playedUpTo, syncChanges: false, startPlaybackAfterSeek: false)
             }
@@ -678,7 +678,7 @@ class WatchManager: NSObject, WCSessionDelegate {
         if let playingEpisode = playbackManager.currentEpisode {
             nowPlayingInfo[WatchConstants.Keys.nowPlayingEpisode] = convertForWatch(episode: playingEpisode)
             nowPlayingInfo[WatchConstants.Keys.nowPlayingSubtitle] = playingEpisode.subTitle()
-            nowPlayingInfo[WatchConstants.Keys.nowPlayingStatus] = playbackManager.playing() ? WatchConstants.PlayingStatus.playing : WatchConstants.PlayingStatus.paused
+            nowPlayingInfo[WatchConstants.Keys.nowPlayingStatus] = playbackManager.isPlaying ? WatchConstants.PlayingStatus.playing : WatchConstants.PlayingStatus.paused
             if let playingEpisode = playingEpisode as? Episode, let podcast = playingEpisode.parentPodcast() {
                 let color = ColorManager.darkThemeTintForPodcast(podcast)
                 nowPlayingInfo[WatchConstants.Keys.nowPlayingColor] = color.hexString()

--- a/podcasts/Whats New/BookmarksAnnouncement.swift
+++ b/podcasts/Whats New/BookmarksAnnouncement.swift
@@ -54,7 +54,7 @@ class BookmarkAnnouncementViewModel {
 
     // If there is an currently playing episode we show the try it now button, if not we show enable it now
     var enableButtonTitle: String {
-        if PlaybackManager.shared.currentEpisode() != nil {
+        if PlaybackManager.shared.currentEpisode != nil {
             return L10n.tryItNow
         }
 
@@ -76,7 +76,7 @@ class BookmarkAnnouncementViewModel {
         }
 
         // Show the player
-        if PlaybackManager.shared.currentEpisode() != nil {
+        if PlaybackManager.shared.currentEpisode != nil {
             AnnouncementFlow.current = .bookmarksPlayer
             NavigationManager.sharedManager.miniPlayer?.openFullScreenPlayer()
             return

--- a/podcasts/WidgetHelper.swift
+++ b/podcasts/WidgetHelper.swift
@@ -32,7 +32,7 @@ class WidgetHelper {
             if widgets.contains(where: { $0.kind == "Now_Playing_Widget" }) {
                 self.publishAppIcon()
             }
-            if widgets.contains(where: { $0.kind == "Up_Next_Widget" }), PlaybackManager.shared.currentEpisode() == nil, PlaybackManager.shared.queue.upNextCount() == 0 {
+            if widgets.contains(where: { $0.kind == "Up_Next_Widget" }), PlaybackManager.shared.currentEpisode == nil, PlaybackManager.shared.queue.upNextCount() == 0 {
                 self.publishTopFilterInfo()
             }
             WidgetCenter.shared.reloadAllTimelines()
@@ -68,7 +68,7 @@ class WidgetHelper {
     }
 
     @objc func handleFilterChanged() {
-        guard PlaybackManager.shared.currentEpisode() == nil else {
+        guard PlaybackManager.shared.currentEpisode == nil else {
             return
         }
         updateSharedUpNext()
@@ -140,7 +140,7 @@ class WidgetHelper {
         var isPlaying = false
         let currentTime = PlaybackManager.shared.currentTime()
 
-        if episode.uuid == PlaybackManager.shared.currentEpisode()?.uuid, currentTime.isFinite {
+        if episode.uuid == PlaybackManager.shared.currentEpisode?.uuid, currentTime.isFinite {
             duration = duration - currentTime
             isPlaying = PlaybackManager.shared.playing()
         }

--- a/podcasts/WidgetHelper.swift
+++ b/podcasts/WidgetHelper.swift
@@ -95,7 +95,7 @@ class WidgetHelper {
             sharedDefaults.set(max(allUpNextPlaylistEpisodes.count - 1, 0), forKey: SharedConstants.GroupUserDefaults.upNextItemsCount)
             sharedDefaults.removeObject(forKey: SharedConstants.GroupUserDefaults.topFilterItems)
             sharedDefaults.removeObject(forKey: SharedConstants.GroupUserDefaults.topFilterName)
-            let playingStatus = PlaybackManager.shared.playing()
+            let playingStatus = PlaybackManager.shared.isPlaying
             sharedDefaults.set(playingStatus, forKey: SharedConstants.GroupUserDefaults.isPlaying)
 
             sharedDefaults.synchronize()
@@ -142,7 +142,7 @@ class WidgetHelper {
 
         if episode.uuid == PlaybackManager.shared.currentEpisode?.uuid, currentTime.isFinite {
             duration = duration - currentTime
-            isPlaying = PlaybackManager.shared.playing()
+            isPlaying = PlaybackManager.shared.isPlaying
         }
         let podcastColor: UIColor = ColorManager.backgroundColorForPodcastUuid(episode.parentIdentifier())
         var imageUrl = ""


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-

`PlaybackManager.currentEpisode()`, `.playing()`, and `.buffering()` are pure accessors with no side effects, so they read better as computed properties — matching `currentPodcast`, which is already one. Converted all three and updated every call site (including the `ServerPlaybackDelegate` protocol requirements) across the main app, TV app, Watch app, and the `PocketCastsServer` module.

No behavior change.

## To test

1. Build and run on iOS, tvOS, and watchOS targets — should build and run identically to trunk.
2. Play/pause/seek an episode and confirm playback state UI (mini player, now playing, widgets, Watch, CarPlay) still updates correctly.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.