### PR TITLE
Fix onChange(of:perform:) deprecation warning in PlayPauseAnimatableModifier

### DIFF
--- a/Modules/Sources/EndOfYear/Animations/PlayPauseAnimatableModifier.swift
+++ b/Modules/Sources/EndOfYear/Animations/PlayPauseAnimatableModifier.swift
@@ -76,7 +76,7 @@ public struct PlayPauseAnimatableModifier: AnimatableModifier {
 
     public func body(content: Content) -> some View {
         content
-            .onChange(of: viewModel.paused) { _ in
+            .onChange(of: viewModel.paused) {
                 playOrPause()
             }
     }


### PR DESCRIPTION
Replaces the deprecated `onChange(of:perform:)` in `PlayPauseAnimatableModifier` with the iOS 17 zero-parameter variant. The closure already ignored the new value, so behavior is unchanged — both variants fire only on change, not on appear. The module targets iOS 17, so the new API is available unconditionally.

## To test

1. Build the app — the deprecation warning for `PlayPauseAnimatableModifier.swift:79` is gone.
2. Open End of Year stories and confirm the story animations still play, pause, and resume as before.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
