### PR TITLE
Cosmetic: Rename isNowPlayingEpisode to isCurrentEpisode and drop the optional uuid

### DIFF
--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
@@ -95,7 +95,7 @@ class RetrieveCustomFilesTask: ApiBaseTask, @unchecked Sendable {
                 }
 
                 // if the episode is loaded into the player, and is currently paused record the up to time so we can seek there
-                if let playbackDelegate = ServerConfig.shared.playbackDelegate, playbackDelegate.isNowPlayingEpisode(episodeUuid: episode.uuid), !playbackDelegate.isPlaying {
+                if let playbackDelegate = ServerConfig.shared.playbackDelegate, playbackDelegate.isCurrentEpisode(uuid: episode.uuid), !playbackDelegate.isPlaying {
                     updatedNowPlayingTime = episode.playedUpTo
                 }
             } else {

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -224,7 +224,7 @@ extension SyncTask {
             DataManager.sharedManager.saveEpisode(playedUpTo: playedUpTo, episode: episode, updateSyncFlag: false)
 
             // if the episode is loaded into the player, and is currently paused seek to the new up to time
-            if let delegate = ServerConfig.shared.playbackDelegate, delegate.isNowPlayingEpisode(episodeUuid: episode.uuid), !delegate.isPlaying {
+            if let delegate = ServerConfig.shared.playbackDelegate, delegate.isCurrentEpisode(uuid: episode.uuid), !delegate.isPlaying {
                 if playedUpTo < 1 {
                     FileLog.shared.addMessage("Saving a time of \(playedUpTo) for episode \(episode.displayableTitle()) because that's what the server sent us during a sync")
                 }

--- a/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -372,7 +372,7 @@ class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
         ServerConfig.shared.playbackDelegate?.queueRefreshList(checkForAutoDownload: true)
 
         ServerConfig.shared.playbackDelegate?.upNextQueueChanged()
-        if let episodePlayingBeforeChanges, let currentlyPlaying = ServerConfig.shared.playbackDelegate?.isNowPlayingEpisode(episodeUuid: episodePlayingBeforeChanges.uuid), currentlyPlaying == false {
+        if let episodePlayingBeforeChanges, let currentlyPlaying = ServerConfig.shared.playbackDelegate?.isCurrentEpisode(uuid: episodePlayingBeforeChanges.uuid), currentlyPlaying == false {
             // currently playing episode has changed
             ServerConfig.shared.playbackDelegate?.playingEpisodeChangedExternally()
         } else if episodePlayingBeforeChanges == nil, !modifiedList.isEmpty {

--- a/Modules/Sources/PocketCastsServer/Public/Upload/ServerPlaybackDelegateProtocol.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Upload/ServerPlaybackDelegateProtocol.swift
@@ -8,8 +8,8 @@ public protocol ServerPlaybackDelegate {
     func removeLastEpisodeFromUpNext()
 
     var currentEpisode: BaseEpisode? { get }
-    func isNowPlayingEpisode(episodeUuid: String?) -> Bool
-    func isActivelyPlaying(episodeUuid: String?) -> Bool
+    func isCurrentEpisode(uuid: String) -> Bool
+    func isActivelyPlaying(episodeUuid: String) -> Bool
 
     func queuePersistLocalCopyAsReplace()
     func queueRefreshList(checkForAutoDownload: Bool)

--- a/Pocket Casts Watch App/UI/Play Source/WatchSourceViewModel.swift
+++ b/Pocket Casts Watch App/UI/Play Source/WatchSourceViewModel.swift
@@ -55,7 +55,7 @@ class WatchSourceViewModel: PlaySourceViewModel {
     }
 
     func playPauseTapped(withEpisode episode: BaseEpisode, playlist: AutoplayHelper.Playlist?) {
-        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+        if PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid) {
             PlaybackManager.shared.playPause()
         } else {
             PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)

--- a/podcasts/AppDelegate+UrlHandling.swift
+++ b/podcasts/AppDelegate+UrlHandling.swift
@@ -222,7 +222,7 @@ extension AppDelegate {
 
             strongSelf.openPlayerWhenReadyFromExternalEvent()
 
-            if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+            if PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid) {
                 if !PlaybackManager.shared.isPlaying {
                     PlaybackManager.shared.play()
                 }
@@ -239,7 +239,7 @@ extension AppDelegate {
 
             guard let baseEpisode = DataManager.sharedManager.findBaseEpisode(uuid: episodeUuid) else { return true }
 
-            if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: baseEpisode.uuid) {
+            if PlaybackManager.shared.isCurrentEpisode(uuid: baseEpisode.uuid) {
                 strongSelf.openPlayerWhenReadyFromExternalEvent()
                 Analytics.track(.widgetInteraction, properties: ["action": "now_playing"])
             } else {

--- a/podcasts/CarPlay/CarPlaySceneDelegate+Convert.swift
+++ b/podcasts/CarPlay/CarPlaySceneDelegate+Convert.swift
@@ -41,7 +41,7 @@ extension CarPlaySceneDelegate {
                 item.accessoryType = .cloud
             }
 
-            item.isPlaying = PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid)
+            item.isPlaying = PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid)
 
             item.handler = { [weak self] _, completion in
                 self?.episodeTapped(episode, playlist: playlist)

--- a/podcasts/CarPlay/CarPlaySceneDelegate+Interaction.swift
+++ b/podcasts/CarPlay/CarPlaySceneDelegate+Interaction.swift
@@ -43,7 +43,7 @@ extension CarPlaySceneDelegate {
         guard !PlaybackManager.shared.isActivelyPlaying(episodeUuid: episode.uuid) else { return }
 
         // If the episode is the currently playing one but isn't actively being played, then start playing it
-        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+        if PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid) {
             PlaybackManager.shared.play()
             return
         }

--- a/podcasts/Common Components/Lottie Animation Views/PlayPauseLabeledButton.swift
+++ b/podcasts/Common Components/Lottie Animation Views/PlayPauseLabeledButton.swift
@@ -66,7 +66,7 @@ class PlayPauseLabeledButton: BasePlayPauseButton {
     }
 
     private func updatePlayingState() {
-        isPlaying = PlaybackManager.shared.isActivelyPlaying(episodeUuid: episodeUUID)
+        isPlaying = episodeUUID.map { PlaybackManager.shared.isActivelyPlaying(episodeUuid: $0) } ?? false
     }
 
     override public func layoutSubviews() {

--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -95,7 +95,7 @@ class MainEpisodeActionView: UIView {
     func populateFrom(episode: BaseEpisode) {
         episodeUuid = episode.uuid
 
-        let isCurrent = PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episodeUuid)
+        let isCurrent = PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid)
 
         // update download and play progress
         if episode.downloaded(pathFinder: DownloadManager.shared) {

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -563,7 +563,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
         guard let episode else { return }
 
         // if the user tapped play from a featured list, record that. We just want the first play, if they are unpausing it, that's not relevant (hence the last check below)
-        if let podcastUuid, let listUuid, !PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+        if let podcastUuid, let listUuid, !PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid) {
             AnalyticsHelper.podcastEpisodePlayedFromList(listId: listUuid, podcastUuid: podcastUuid)
         }
 

--- a/podcasts/Episode/EpisodeDetailViewController+Actions.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+Actions.swift
@@ -8,7 +8,7 @@ extension EpisodeDetailViewController {
     @IBAction func addTapped(_ sender: UIButton) {
         let addPicker = OptionsPicker(title: nil)
 
-        let isInUpNext = PlaybackManager.shared.inUpNext(episode: episode) || PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid)
+        let isInUpNext = PlaybackManager.shared.inUpNext(episode: episode) || PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid)
 
         if isInUpNext {
             let removeFromUpNextAction = OptionAction(label: L10n.removeFromUpNext, icon: "episode-removenext") { [weak self] in
@@ -61,7 +61,7 @@ extension EpisodeDetailViewController {
     }
 
     @IBAction func playPauseTapped(_ sender: UIButton) {
-        let isNowPlaying = PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid)
+        let isNowPlaying = PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid)
         if isNowPlaying {
             // dismiss the dialog if the user hit play
             if !PlaybackManager.shared.isPlaying {
@@ -164,7 +164,7 @@ extension EpisodeDetailViewController {
 
     func updateProgress() {
         var progress: CGFloat = 0
-        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+        if PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid) {
             let currentTime = PlaybackManager.shared.currentTime()
             let duration = PlaybackManager.shared.duration()
             if currentTime > 0, duration > 0 {

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -270,7 +270,7 @@ class EpisodeManager: NSObject {
 
         // special case if the starred status of the now playing episode is changed, tell the player to update it
         // we do this before sending notifications so that other parts of the app that grab the now playing episode get the one with the right star status
-        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+        if PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid) {
             PlaybackManager.shared.nowPlayingStarredChanged()
         }
 
@@ -367,14 +367,14 @@ class EpisodeManager: NSObject {
             }
 
             // we don't want a huge number of these so if we're over 5, blow the oldest ones away
-            if index >= 5, !PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+            if index >= 5, !PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid) {
                 deleteDownloadedFiles(episode: episode)
 
                 continue
             }
 
             // delete episodes older than a week that we're not currently playing
-            if fabs(lastPlaybackDate.timeIntervalSinceNow) > 1.week, !PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+            if fabs(lastPlaybackDate.timeIntervalSinceNow) > 1.week, !PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid) {
                 deleteDownloadedFiles(episode: episode)
             }
         }

--- a/podcasts/PlaybackActionHelper.swift
+++ b/podcasts/PlaybackActionHelper.swift
@@ -81,7 +81,7 @@ class PlaybackActionHelper {
     }
 
     private class func performPlay(episode: BaseEpisode, playlistUuid: String? = nil, podcastUuid: String? = nil) {
-        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+        if PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid) {
             PlaybackManager.shared.play()
         } else {
             if episode.archived, let episode = episode as? Episode {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -133,16 +133,14 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     // MARK: - API
 
-    func isNowPlayingEpisode(episodeUuid: String?) -> Bool {
-        if let episodeUuid, let playingEpisode = currentEpisode {
-            return playingEpisode.uuid == episodeUuid
-        }
-
-        return false
+    /// `true` if the episode is loaded in the player. It may be playing, paused or buffering.
+    func isCurrentEpisode(uuid: String) -> Bool {
+        currentEpisode?.uuid == uuid
     }
 
-    func isActivelyPlaying(episodeUuid: String?) -> Bool {
-        isNowPlayingEpisode(episodeUuid: episodeUuid) && isPlaying
+    /// `true` if the episode is loaded in the player *and* playback is running.
+    func isActivelyPlaying(episodeUuid: String) -> Bool {
+        isCurrentEpisode(uuid: episodeUuid) && isPlaying
     }
 
     var currentEpisode: BaseEpisode? {
@@ -708,7 +706,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         if userInitiated, let episode {
             AnalyticsEpisodeHelper.shared.episodeRemovedFromUpNext(episode: episode)
         }
-        if isNowPlayingEpisode(episodeUuid: episode?.uuid) {
+        if let episode, isCurrentEpisode(uuid: episode.uuid) {
             autoplayIfNeeded()
             if queue.upNextCount() > 0 {
                 playNextEpisode(autoPlay: isPlaying)
@@ -2788,7 +2786,7 @@ extension PlaybackManager {
         #endif
 
         // If we're already the now playing episode, then just seek to the bookmark time
-        if isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid) {
+        if isCurrentEpisode(uuid: bookmark.episodeUuid) {
             seekTo(time: bookmark.time, startPlaybackAfterSeek: true)
             return
         }
@@ -2820,7 +2818,7 @@ extension PlaybackManager {
         // Position the player at the stored time — the best estimate until the resolve
         // lands, and where playback falls back to. Pause before seeking so no audio from
         // the wrong position slips out.
-        if isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid) {
+        if isCurrentEpisode(uuid: bookmark.episodeUuid) {
             pause(userInitiated: false)
             seekTo(time: bookmark.time)
         } else {
@@ -2838,7 +2836,7 @@ extension PlaybackManager {
         )
 
         // The listener took over while we were resolving; leave things where they put them.
-        guard isNowPlayingEpisode(episodeUuid: bookmark.episodeUuid), !isPlaying,
+        guard isCurrentEpisode(uuid: bookmark.episodeUuid), !isPlaying,
               abs(currentTime() - bookmark.time) < 1 else {
             FileLog.shared.addMessage(
                 "[Bookmarks] Playback moved while resolving bookmark \(bookmark.uuid) — not starting playback"

--- a/podcasts/ServerSyncManager.swift
+++ b/podcasts/ServerSyncManager.swift
@@ -41,7 +41,7 @@ class ServerSyncManager: ServerSyncDelegate {
     // MARK: - Episode functions
 
     func episodeStarredChanged(episode: Episode) {
-        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+        if PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid) {
             PlaybackManager.shared.nowPlayingStarredChanged()
         }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeStarredChanged, object: episode.uuid)

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -182,7 +182,7 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
             strongSelf.loadingIndicator.stopAnimating()
             let tintColor = strongSelf.linkTintColor()
             if let showNotes {
-                let isCurrentEpisode = PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid)
+                let isCurrentEpisode = PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid)
                 let formattedNotes = ShowNotesFormatter.format(showNotes: showNotes, tintColor: tintColor, convertTimesToLinks: isCurrentEpisode, bgColor: nil, textColor: ThemeColor.playerContrast01())
                 strongSelf.showNotesWebView.loadHTMLString(formattedNotes, baseURL: URL(fileURLWithPath: Bundle.main.bundlePath))
                 // We need to ensure that the scroll view offset is back at 0,0 to cater for instances

--- a/podcasts/TranscriptPlaybackManaging.swift
+++ b/podcasts/TranscriptPlaybackManaging.swift
@@ -23,7 +23,7 @@ extension PlaybackManager: TranscriptPlaybackManaging {
     }
 
     var isPlayingEpisode: Bool {
-        isActivelyPlaying(episodeUuid: episodeUUID)
+        isPlaying
     }
 
     var canSeek: Bool { true }
@@ -34,33 +34,37 @@ extension PlaybackManager: TranscriptPlaybackManaging {
 }
 
 struct TranscriptEpisodeInfoProvider: TranscriptPlaybackManaging {
-    let episodeUUID: String?
+    private let episodeUuid: String
     let podcastUUID: String?
+
+    var episodeUUID: String? {
+        episodeUuid
+    }
 
     var parentIdentifier: String? {
         podcastUUID
     }
 
     init(episodeUUID: String, podcastUUID: String) {
-        self.episodeUUID = episodeUUID
+        self.episodeUuid = episodeUUID
         self.podcastUUID = podcastUUID
     }
 
     func currentTime() -> TimeInterval {
-        guard PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episodeUUID) else {
+        guard PlaybackManager.shared.isCurrentEpisode(uuid: episodeUuid) else {
             return 0
         }
         return PlaybackManager.shared.currentTime()
     }
 
     func seekTo(time: TimeInterval) {
-        guard PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episodeUUID) else { return }
+        guard PlaybackManager.shared.isCurrentEpisode(uuid: episodeUuid) else { return }
         PlaybackManager.shared.seekTo(time: time)
     }
 
-    var canSeek: Bool { PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episodeUUID) }
+    var canSeek: Bool { PlaybackManager.shared.isCurrentEpisode(uuid: episodeUuid) }
 
     var isPlayingEpisode: Bool {
-        PlaybackManager.shared.isActivelyPlaying(episodeUuid: episodeUUID)
+        PlaybackManager.shared.isActivelyPlaying(episodeUuid: episodeUuid)
     }
 }

--- a/podcasts/TranscriptPlaybackManaging.swift
+++ b/podcasts/TranscriptPlaybackManaging.swift
@@ -23,7 +23,8 @@ extension PlaybackManager: TranscriptPlaybackManaging {
     }
 
     var isPlayingEpisode: Bool {
-        isPlaying
+        guard let episodeUUID else { return false }
+        return isActivelyPlaying(episodeUuid: episodeUUID)
     }
 
     var canSeek: Bool { true }
@@ -34,37 +35,32 @@ extension PlaybackManager: TranscriptPlaybackManaging {
 }
 
 struct TranscriptEpisodeInfoProvider: TranscriptPlaybackManaging {
-    private let episodeUuid: String
+    private let _episodeUUID: String
+
+    var episodeUUID: String? { _episodeUUID }
     let podcastUUID: String?
-
-    var episodeUUID: String? {
-        episodeUuid
-    }
-
-    var parentIdentifier: String? {
-        podcastUUID
-    }
+    var parentIdentifier: String? { podcastUUID }
 
     init(episodeUUID: String, podcastUUID: String) {
-        self.episodeUuid = episodeUUID
+        self._episodeUUID = episodeUUID
         self.podcastUUID = podcastUUID
     }
 
     func currentTime() -> TimeInterval {
-        guard PlaybackManager.shared.isCurrentEpisode(uuid: episodeUuid) else {
+        guard PlaybackManager.shared.isCurrentEpisode(uuid: _episodeUUID) else {
             return 0
         }
         return PlaybackManager.shared.currentTime()
     }
 
     func seekTo(time: TimeInterval) {
-        guard PlaybackManager.shared.isCurrentEpisode(uuid: episodeUuid) else { return }
+        guard PlaybackManager.shared.isCurrentEpisode(uuid: _episodeUUID) else { return }
         PlaybackManager.shared.seekTo(time: time)
     }
 
-    var canSeek: Bool { PlaybackManager.shared.isCurrentEpisode(uuid: episodeUuid) }
+    var canSeek: Bool { PlaybackManager.shared.isCurrentEpisode(uuid: _episodeUUID) }
 
     var isPlayingEpisode: Bool {
-        PlaybackManager.shared.isActivelyPlaying(episodeUuid: episodeUuid)
+        PlaybackManager.shared.isActivelyPlaying(episodeUuid: _episodeUUID)
     }
 }

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -664,7 +664,8 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 await MainActor.run {
                     self.setHasGeneratedTranscripts(hasGeneratedTranscripts)
                     if isDisplayingGenerated {
-                        if FeatureFlag.syncedTranscripts.enabled, !self.showFromEpisode || PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: self.playbackManager.episodeUUID) {
+                        let isCurrentEpisode = PlaybackManager.shared.isCurrentEpisode(uuid: episodeUUID)
+                        if FeatureFlag.syncedTranscripts.enabled, !self.showFromEpisode || isCurrentEpisode {
                             FingerprintTimingManager.shared.prepareForCurrentEpisode()
                         }
                         self.startHighlightDisplayLink()

--- a/podcasts/UserEpisodeDetailViewController+Table.swift
+++ b/podcasts/UserEpisodeDetailViewController+Table.swift
@@ -186,7 +186,7 @@ extension UserEpisodeDetailViewController: UITableViewDelegate, UITableViewDataS
         let option = playPauseButton.isPlaying ? "play" : "pause"
         Analytics.track(.userFilePlayPauseButtonTapped, properties: ["option": option])
 
-        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: episode.uuid) {
+        if PlaybackManager.shared.isCurrentEpisode(uuid: episode.uuid) {
             // dismiss the dialog if the user hit play
             if !PlaybackManager.shared.isPlaying {
                 close()

--- a/podcasts/Watch Communication/WatchManager.swift
+++ b/podcasts/Watch Communication/WatchManager.swift
@@ -390,7 +390,7 @@ class WatchManager: NSObject, WCSessionDelegate {
         // mini player / now playing updates immediately rather than only after a relaunch. This mirrors
         // how the server sync applies a remote position (see SyncTask+ServerChanges). Otherwise just
         // refresh any visible episode cell via the notification.
-        if PlaybackManager.shared.isNowPlayingEpisode(episodeUuid: uuid), !PlaybackManager.shared.isPlaying {
+        if PlaybackManager.shared.isCurrentEpisode(uuid: uuid), !PlaybackManager.shared.isPlaying {
             DispatchQueue.main.async {
                 PlaybackManager.shared.seekToFromSync(time: playedUpTo, syncChanges: false, startPlaybackAfterSeek: false)
             }


### PR DESCRIPTION
`PlaybackManager` had two confusingly named neighbours:

```swift
func isNowPlayingEpisode(episodeUuid: String?) -> Bool
func isActivelyPlaying(episodeUuid: String?) -> Bool
```

The one whose name says "playing" doesn't check playback state at all — it's an identity check that's `true` for a paused episode too. This renames it to `isCurrentEpisode(uuid:)`, matching the `currentEpisode` property it's the parameterized form of, and adds doc comments so the identity-vs-state split is stated rather than inferred.

Both parameters also become non-optional. 46 of the 49 call sites already passed a non-optional `String`, and where the uuid really is optional a `nil` now has to be handled at the call site instead of silently meaning "false".

Two smaller things fell out of that:

- `PlaybackManager`'s `TranscriptPlaybackManaging.isPlayingEpisode` was `isActivelyPlaying(episodeUuid: episodeUUID)` where `episodeUUID` is `currentEpisode?.uuid` — it asked whether the current episode is the current episode, so it collapses to `isPlaying`. These are equivalent: `isPlaying` can't be `true` while `currentEpisode` is `nil`, since `aboutToPlay` is only set after the `guard let currEpisode = currentEpisode` in `play()`.
- `TranscriptEpisodeInfoProvider` now stores a non-optional `episodeUuid` behind the optional protocol getter, which its `init(episodeUUID: String, ...)` signature already implied.

No behaviour change otherwise — the rest is mechanical.

## To test

This is a refactor with no user-facing change, so it's mostly a regression check on the play/pause state of episodes that are loaded but not playing:

1. Play an episode, then pause it. In the episode list, episode details, and Up Next, confirm it still shows as the current episode (highlighted / play button in the paused state) rather than reverting to an idle row.
2. Open the transcript for the playing episode and confirm it still scrolls in sync, and that seeking from the transcript works.
3. Open the transcript from an episode that is *not* loaded in the player and confirm seeking is disabled there.
4. Tap a bookmark for the currently playing episode and confirm it seeks in place instead of reloading the episode.
5. On CarPlay, confirm the now playing episode is still marked as playing in lists.
6. With the watch app, play on the watch and confirm the phone doesn't clobber the position.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.