### PR TITLE
PlaybackManager: Incremental @MainActor adoption from the UI side – Part 1

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -32,11 +32,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// When `true`, we only mark podcasts as unsynced if the user never signed in before
     case onlyMarkPodcastsUnsyncedForNewUsers
 
-    /// Only update an episode if it fails playing
-    /// If set to `false`, it will use the previous mechanism that always update
-    /// but can lead to a bigger time between tapping play and actually playing it
-    case whenPlayingOnlyUpdateEpisodeIfPlaybackFails
-
     /// Enables the Kids banner
     case kidsProfile
 
@@ -348,8 +343,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .defaultPlayerFilterCallbackFix:
             true
         case .onlyMarkPodcastsUnsyncedForNewUsers:
-            true
-        case .whenPlayingOnlyUpdateEpisodeIfPlaybackFails:
             true
         case .kidsProfile:
             false

--- a/Pocket Casts TV App/Data/TVDataManager.swift
+++ b/Pocket Casts TV App/Data/TVDataManager.swift
@@ -46,7 +46,7 @@ class TVDataManager {
         return dataManager.findEpisodesWhere(customWhere: query, arguments: arguments)
     }
 
-    func playLatestEpisode(of podcast: DiscoverPodcast) async -> Bool {
+    @concurrent func playLatestEpisode(of podcast: DiscoverPodcast) async -> Bool {
         guard let podcastUuid = podcast.uuid else {
             return false
         }
@@ -59,18 +59,18 @@ class TVDataManager {
             return false
         }
 
-        PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
+        await PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
         return true
     }
 
-    func playEpisode(_ episode: DiscoverEpisode) async -> Bool {
+    @concurrent func playEpisode(_ episode: DiscoverEpisode) async -> Bool {
         guard let podcastUuid = episode.podcastUuid, let episodeUuid = episode.uuid else {
             return false
         }
         return await playEpisode(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
     }
 
-    func loadEpisode(podcastUuid: String, episodeUuid: String) async -> (episode: Episode, podcast: Podcast?)? {
+    @concurrent func loadEpisode(podcastUuid: String, episodeUuid: String) async -> (episode: Episode, podcast: Podcast?)? {
         let podcast = await loadPodcast(podcastUuid: podcastUuid)
 
         guard let episode = dataManager.findEpisode(uuid: episodeUuid) else {
@@ -80,7 +80,7 @@ class TVDataManager {
         return (episode, podcast)
     }
 
-    func playEpisode(podcastUuid: String, episodeUuid: String) async -> Bool {
+    @concurrent func playEpisode(podcastUuid: String, episodeUuid: String) async -> Bool {
         guard let (episode, _) = await loadEpisode(podcastUuid: podcastUuid, episodeUuid: episodeUuid) else {
             return false
         }
@@ -90,11 +90,11 @@ class TVDataManager {
             return true
         }
 
-        PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
+        await PlaybackActionHelper.play(episode: episode, podcastUuid: podcastUuid)
         return true
     }
 
-    func playEpisode(_ episode: EpisodeSearchResult) async -> Bool {
+    @concurrent func playEpisode(_ episode: EpisodeSearchResult) async -> Bool {
         guard !episode.podcastUuid.isEmpty, !episode.uuid.isEmpty else {
             return false
         }

--- a/Pocket Casts TV App/Data/TVDataManager.swift
+++ b/Pocket Casts TV App/Data/TVDataManager.swift
@@ -38,7 +38,7 @@ class TVDataManager {
         }
     }
 
-    func fetchEpisodes(podcast: Podcast?, sortOrder: PodcastEpisodeSortOrder? = nil, includeArchived: Bool = false) -> [Episode] {
+    @concurrent func fetchEpisodes(podcast: Podcast?, sortOrder: PodcastEpisodeSortOrder? = nil, includeArchived: Bool = false) async -> [Episode] {
         guard let podcast else {
             return []
         }
@@ -46,13 +46,13 @@ class TVDataManager {
         return dataManager.findEpisodesWhere(customWhere: query, arguments: arguments)
     }
 
-    @concurrent func playLatestEpisode(of podcast: DiscoverPodcast) async -> Bool {
+    func playLatestEpisode(of podcast: DiscoverPodcast) async -> Bool {
         guard let podcastUuid = podcast.uuid else {
             return false
         }
         let podcast = await loadPodcast(podcastUuid: podcastUuid)
 
-        guard let episode = fetchEpisodes(podcast: podcast, sortOrder: .newestToOldest).first else {
+        guard let episode = await fetchEpisodes(podcast: podcast, sortOrder: .newestToOldest).first else {
             return false
         }
         guard !playbackManager.isActivelyPlaying(episodeUuid: episode.uuid) else {
@@ -63,7 +63,7 @@ class TVDataManager {
         return true
     }
 
-    @concurrent func playEpisode(_ episode: DiscoverEpisode) async -> Bool {
+    func playEpisode(_ episode: DiscoverEpisode) async -> Bool {
         guard let podcastUuid = episode.podcastUuid, let episodeUuid = episode.uuid else {
             return false
         }
@@ -80,7 +80,7 @@ class TVDataManager {
         return (episode, podcast)
     }
 
-    @concurrent func playEpisode(podcastUuid: String, episodeUuid: String) async -> Bool {
+    func playEpisode(podcastUuid: String, episodeUuid: String) async -> Bool {
         guard let (episode, _) = await loadEpisode(podcastUuid: podcastUuid, episodeUuid: episodeUuid) else {
             return false
         }
@@ -94,7 +94,7 @@ class TVDataManager {
         return true
     }
 
-    @concurrent func playEpisode(_ episode: EpisodeSearchResult) async -> Bool {
+    func playEpisode(_ episode: EpisodeSearchResult) async -> Bool {
         guard !episode.podcastUuid.isEmpty, !episode.uuid.isEmpty else {
             return false
         }

--- a/Pocket Casts TV App/Data/TVDataManager.swift
+++ b/Pocket Casts TV App/Data/TVDataManager.swift
@@ -18,7 +18,7 @@ class TVDataManager {
         self.playbackManager = playbackManager
     }
 
-    func loadPodcast(podcastUuid: String) async -> Podcast? {
+    @concurrent func loadPodcast(podcastUuid: String) async -> Podcast? {
         await withCheckedContinuation { continuation in
             if let podcast = dataManager.findPodcast(uuid: podcastUuid, includeUnsubscribed: true) {
                 serverPodcastManager.updatePodcastIfRequired(podcast: podcast) { _ in

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -82,6 +82,7 @@ class EpisodeRowViewModel: Identifiable {
         }
     }
 
+    @MainActor
     func play() {
         guard !playbackManager.isActivelyPlaying(episodeUuid: episode.uuid) else { return }
         AnalyticsPlaybackHelper.shared.currentSource = source

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -89,7 +89,7 @@ class PodcastDetailViewModel {
                 await MainActor.run { state = .failed }
                 return
             }
-            let allEpisodes = dataManager.fetchEpisodes(podcast: podcast, includeArchived: showArchived).map {
+            let allEpisodes = await dataManager.fetchEpisodes(podcast: podcast, includeArchived: showArchived).map {
                 EpisodeRowViewModel(episode: $0, podcast: podcast, isDiscover: isDiscover, source: .podcastScreen)
             }
             await MainActor.run {

--- a/podcasts/AppPlayEpisodeIntentExtension.swift
+++ b/podcasts/AppPlayEpisodeIntentExtension.swift
@@ -2,6 +2,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 
 extension PlayEpisodeIntent {
+    @MainActor
     func intentPlayback(_ episodeUuid: String) {
         FileLog.shared.addMessage("PlayEpisodeIntent called for episode \(episodeUuid)")
 

--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -1,6 +1,7 @@
 import PocketCastsDataModel
 import UIKit
 
+@MainActor
 protocol MainEpisodeActionViewDelegate: AnyObject {
     func downloadTapped()
     func stopDownloadTapped()

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -354,8 +354,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         let playerError: Error? = (player.currentItem?.error ?? player.error)
         let playerNSError = playerError as? NSError
 
-        if FeatureFlag.whenPlayingOnlyUpdateEpisodeIfPlaybackFails.enabled,
-           let playerNSError, playerNSError.domain == NSURLErrorDomain, playerNSError.code != NSURLErrorNotConnectedToInternet,
+        if let playerNSError, playerNSError.domain == NSURLErrorDomain, playerNSError.code != NSURLErrorNotConnectedToInternet,
            let episodeUuid {
             if PlaybackManager.shared.retryUrlLoad(for: episodeUuid) {
                 return false

--- a/podcasts/DiscoverEpisodeViewModel.swift
+++ b/podcasts/DiscoverEpisodeViewModel.swift
@@ -41,13 +41,14 @@ class DiscoverEpisodeViewModel: ObservableObject {
             .dropFirst()
             .flatMap { DiscoverServerHandler.shared.discoverItem($0?.source, authenticated: $0?.authenticated ?? false, type: PodcastCollection?.self) }
             .replaceError(with: nil)
+            .receive(on: DispatchQueue.main)
             .assign(to: &$discoverCollection)
 
         $discoverCollection
             .dropFirst()
             .map { $0?.episodes?.first }
             .replaceError(with: nil)
-            .receive(on: RunLoop.main)
+            .receive(on: DispatchQueue.main)
             .assign(to: &$discoverEpisode)
 
         $discoverEpisode
@@ -129,7 +130,7 @@ class DiscoverEpisodeViewModel: ObservableObject {
         }
 
         DiscoverEpisodeViewModel.loadPodcast(podcastUuid, episodeUuid: episodeUuid)
-            .receive(on: RunLoop.main)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] podcast in
                 guard let podcast else {
                     self?.delegate?.failedToLoadEpisode()

--- a/podcasts/DiscoverEpisodeViewModel.swift
+++ b/podcasts/DiscoverEpisodeViewModel.swift
@@ -5,6 +5,7 @@ import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 
+@MainActor
 class DiscoverEpisodeViewModel: ObservableObject {
     private enum ClientError: Swift.Error {
         case noPodcastUuid
@@ -97,6 +98,7 @@ class DiscoverEpisodeViewModel: ObservableObject {
         let listId = discoverItem?.uuid ?? listId
 
         DiscoverEpisodeViewModel.loadPodcast(podcastUuid, episodeUuid: episodeUuid)
+            .receive(on: DispatchQueue.main)
             .sink { [weak self] podcast in
                 // We don't need the fetched podcast but we want to make sure the episode is available.
                 guard podcast != nil, let self else {

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -3,6 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import Combine
 
+@MainActor
 class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
 
     var episode: EpisodeSearchResult?

--- a/podcasts/PlaybackActionHelper.swift
+++ b/podcasts/PlaybackActionHelper.swift
@@ -93,19 +93,7 @@ class PlaybackActionHelper {
                 AnalyticsHelper.playedEpisode()
             }
 
-            // if we're streaming an episode, try to make sure the URL is up to date. Authors can change URLs at any time, so this is handy to fix cases where they post the wrong one and update it later
-            if !FeatureFlag.whenPlayingOnlyUpdateEpisodeIfPlaybackFails.enabled,
-               let episode = episode as? Episode, let podcast = episode.parentPodcast(), !episode.downloaded(pathFinder: DownloadManager.shared) {
-                ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast) { @Sendable wasUpdated in
-                    guard let updatedEpisode = wasUpdated ? DataManager.sharedManager.findEpisode(uuid: episode.uuid) : episode else { return }
-
-                    Task { @MainActor in
-                        PlaybackManager.shared.load(episode: updatedEpisode, autoPlay: true, overrideUpNext: false)
-                    }
-                }
-            } else {
-                PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
-            }
+            PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
         }
         #if !os(tvOS)
         if let playlistUuid {

--- a/podcasts/PlaybackActionHelper.swift
+++ b/podcasts/PlaybackActionHelper.swift
@@ -3,6 +3,7 @@ import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 
+@MainActor
 class PlaybackActionHelper {
     class func play(episode: BaseEpisode, playlistUuid: String? = nil, podcastUuid: String? = nil, playlist: AutoplayHelper.Playlist? = nil) {
         HapticsHelper.triggerPlayPauseHaptic()
@@ -95,10 +96,12 @@ class PlaybackActionHelper {
             // if we're streaming an episode, try to make sure the URL is up to date. Authors can change URLs at any time, so this is handy to fix cases where they post the wrong one and update it later
             if !FeatureFlag.whenPlayingOnlyUpdateEpisodeIfPlaybackFails.enabled,
                let episode = episode as? Episode, let podcast = episode.parentPodcast(), !episode.downloaded(pathFinder: DownloadManager.shared) {
-                ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast) { wasUpdated in
+                ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast) { @Sendable wasUpdated in
                     guard let updatedEpisode = wasUpdated ? DataManager.sharedManager.findEpisode(uuid: episode.uuid) : episode else { return }
 
-                    PlaybackManager.shared.load(episode: updatedEpisode, autoPlay: true, overrideUpNext: false)
+                    Task { @MainActor in
+                        PlaybackManager.shared.load(episode: updatedEpisode, autoPlay: true, overrideUpNext: false)
+                    }
                 }
             } else {
                 PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)


### PR DESCRIPTION
Starts incremental `@MainActor` adoption top-down from the UI. `PlaybackActionHelper` calls *into* `PlaybackManager` rather than being called by it, so isolating it doesn't cascade — every caller was already main-isolated, making the fallout four one-line propagations.

Starting inside `PlaybackManager` instead doesn't work: isolation propagates callee → caller, and its playback methods are strongly connected (`load` → `switchTo` → `load`, `play` → `load`), so any interior method pulls in most of the class — 25 of 154 methods before it started spreading into `DefaultPlayer`, `EffectsPlayer` and `GoogleCastManager`. That needs its own change.

Two latent off-main calls surfaced and are fixed:

- `DiscoverEpisodeViewModel` — the `loadPodcast` sink had no `.receive(on:)` yet mutated `button.isPlaying` and called `delegate?.failedToLoadEpisode()`.
- `PlaybackActionHelper.performPlay` — `updatePodcastIfRequired`'s completion fires on a background queue, so `PlaybackManager.load` ran off-main. The closure is now `@Sendable` (otherwise it silently inherits main-actor isolation) and hops explicitly.

## To test

Play/pause still works and the UI updates at each entry point:

1. Discover → play button on an episode row for an unsubscribed podcast, then pause.
2. Discover → tap the row; details open.
3. Search → play/pause an episode result.
4. Podcast screen → play, pause, download, cancel download on an episode cell.
5. Files → play, pause, upload, cancel upload.
6. Now Playing widget → play/pause.
7. tvOS → play from a podcast row and from Discover.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
