### PR TITLE
PlaybackManager: Incremental @MainActor adoption from the UI side – Part 2

### DIFF
--- a/Pocket Casts TV App/UI/History/ListeningHistoryViewModel.swift
+++ b/Pocket Casts TV App/UI/History/ListeningHistoryViewModel.swift
@@ -28,18 +28,18 @@ class ListeningHistoryViewModel {
 
     private func fetchLocalData() {
         Task.detached { [dataManager] in
-            let episodes = self.loadEpisodeViewModels(using: dataManager)
+            let episodes = self.loadEpisodes(using: dataManager)
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                self.episodes = episodes
+                self.episodes = episodes.map { EpisodeRowViewModel(episode: $0.episode, podcast: $0.podcast, source: .listeningHistory) }
                 self.state = episodes.isEmpty ? .empty : .ready
             }
         }
     }
 
-    nonisolated private func loadEpisodeViewModels(using dataManager: DataManager) -> [EpisodeRowViewModel] {
+    nonisolated private func loadEpisodes(using dataManager: DataManager) -> [(episode: Episode, podcast: Podcast?)] {
         dataManager.fetchHistoryEpisodes().map { episode in
-            EpisodeRowViewModel(episode: episode, podcast: episode.parentPodcast(dataManager: dataManager), source: .listeningHistory)
+            (episode, episode.parentPodcast(dataManager: dataManager))
         }
     }
 

--- a/Pocket Casts TV App/UI/Home/HomeViewModel.swift
+++ b/Pocket Casts TV App/UI/Home/HomeViewModel.swift
@@ -33,24 +33,20 @@ class HomeViewModel {
     func load() {
         Task {
             let upNextEpisodes = dataManager.allUpNextEpisodes()
-            let newEpisodes = dataManager.findNewReleaseEpisodes(limit: 12).map { episode in
-                makeRowViewModel(for: episode)
-            }
-            let newVideoReleases = dataManager.findNewVideoReleaseEpisodes(limit: 12).map { episode in
-                makeRowViewModel(for: episode)
-            }
-            await MainActor.run { [weak self, newEpisodes] in
+            let currentlyPlaying = upNextEpisodes.first.map { withPodcast($0) }
+            let upNextEntries = Array(upNextEpisodes.dropFirst().prefix(12)).map { withPodcast($0) }
+            let newEpisodes = dataManager.findNewReleaseEpisodes(limit: 12).map { withPodcast($0) }
+            let newVideoReleases = dataManager.findNewVideoReleaseEpisodes(limit: 12).map { withPodcast($0) }
+            await MainActor.run { [weak self] in
                 guard let self else { return }
-                upNext = Array(upNextEpisodes.dropFirst().prefix(12)).map { episode in
-                    self.makeRowViewModel(for: episode)
+                self.upNext = upNextEntries.map { self.makeRowViewModel(for: $0) }
+                if let currentlyPlaying {
+                    self.currentPlaying = self.makeRowViewModel(for: currentlyPlaying)
                 }
-                if let currentlyPlaying = upNextEpisodes.first {
-                    currentPlaying = makeRowViewModel(for: currentlyPlaying)
-                }
-                newReleases = newEpisodes
-                self.newVideoReleases = newVideoReleases
+                self.newReleases = newEpisodes.map { self.makeRowViewModel(for: $0) }
+                self.newVideoReleases = newVideoReleases.map { self.makeRowViewModel(for: $0) }
 
-                state = .ready
+                self.state = .ready
             }
         }
     }
@@ -59,9 +55,13 @@ class HomeViewModel {
         RefreshManager.shared.refreshPodcasts()
     }
 
-    private func makeRowViewModel(for episode: BaseEpisode) -> EpisodeRowViewModel {
-        let podcast = (episode as? Episode).flatMap { $0.parentPodcast(dataManager: dataManager) }
-        return EpisodeRowViewModel(episode: episode, podcast: podcast, source: .home)
+    private func withPodcast(_ episode: BaseEpisode) -> (episode: BaseEpisode, podcast: Podcast?) {
+        (episode, (episode as? Episode).flatMap { $0.parentPodcast(dataManager: dataManager) })
+    }
+
+    @MainActor
+    private func makeRowViewModel(for entry: (episode: BaseEpisode, podcast: Podcast?)) -> EpisodeRowViewModel {
+        EpisodeRowViewModel(episode: entry.episode, podcast: entry.podcast, source: .home)
     }
 
     private func observeDataChanges() {

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRow.swift
@@ -363,8 +363,8 @@ struct DiscoveryEpisodeMenuButtons: View {
         Button(L10n.playLastInUpNext) { requireAccount { load { EpisodeUpNextActions.playLast($0.episode) } } }
     }
 
-    private func load(_ action: @escaping (DiscoveryLoadedEpisode) -> Void) {
-        Task {
+    private func load(_ action: @escaping @MainActor (DiscoveryLoadedEpisode) -> Void) {
+        Task { @MainActor in
             guard let result = await TVDataManager.shared.loadEpisode(podcastUuid: podcastUuid, episodeUuid: episodeUuid) else {
                 ToastManager.shared.show(L10n.playbackFailed)
                 return

--- a/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/EpisodeRowViewModel.swift
@@ -4,7 +4,7 @@ import PocketCastsUtils
 import SwiftUI
 import Combine
 
-@Observable
+@MainActor @Observable
 class EpisodeRowViewModel: Identifiable {
 
     static func == (lhs: EpisodeRowViewModel, rhs: EpisodeRowViewModel) -> Bool {
@@ -82,7 +82,6 @@ class EpisodeRowViewModel: Identifiable {
         }
     }
 
-    @MainActor
     func play() {
         guard !playbackManager.isActivelyPlaying(episodeUuid: episode.uuid) else { return }
         AnalyticsPlaybackHelper.shared.currentSource = source
@@ -202,6 +201,7 @@ class EpisodeRowViewModel: Identifiable {
 
 /// Up Next queue actions shared by the episode view model and the lazily-loaded
 /// discovery/search context menus, so the move-vs-add queue logic lives in one place.
+@MainActor
 enum EpisodeUpNextActions {
     static func playNext(_ episode: BaseEpisode, playbackManager: PlaybackManager = .shared) {
         if playbackManager.inUpNext(episode: episode) {

--- a/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
+++ b/Pocket Casts TV App/UI/Podcasts/PodcastDetailViewModel.swift
@@ -89,13 +89,13 @@ class PodcastDetailViewModel {
                 await MainActor.run { state = .failed }
                 return
             }
-            let allEpisodes = dataManager.fetchEpisodes(podcast: podcast, includeArchived: showArchived).map {
-                EpisodeRowViewModel(episode: $0, podcast: podcast, isDiscover: isDiscover, source: .podcastScreen)
-            }
+            let allEpisodes = dataManager.fetchEpisodes(podcast: podcast, includeArchived: showArchived)
             await MainActor.run {
                 self.podcast = podcast
                 self.isFollowing = podcast.subscribed != 0
-                self.episodes = allEpisodes
+                self.episodes = allEpisodes.map {
+                    EpisodeRowViewModel(episode: $0, podcast: podcast, isDiscover: isDiscover, source: .podcastScreen)
+                }
                 self.recommendedEpisode = nil
                 self.sortOrder = podcast.podcastSortOrder ?? .newestToOldest
                 self.state = .ready
@@ -126,16 +126,14 @@ class PodcastDetailViewModel {
         NotificationCenter.default.publisher(for: Constants.Notifications.episodeArchiveStatusChanged)
         .receive(on: DispatchQueue.main)
         .sink { [weak self] notification in
-            guard let self else {
+            guard let self, let uuid = notification.object as? String else {
                 return
             }
-            if let uuid = notification.object as? String {
-                let contains = episodes.contains { episode in
-                    episode.id == uuid
+            Task { @MainActor in
+                guard self.episodes.contains(where: { $0.id == uuid }) else {
+                    return
                 }
-                if contains {
-                    load()
-                }
+                self.load()
             }
         }
         .store(in: &cancellables)

--- a/Pocket Casts TV App/UI/Starred/StarredEpisodesViewModel.swift
+++ b/Pocket Casts TV App/UI/Starred/StarredEpisodesViewModel.swift
@@ -46,18 +46,18 @@ class StarredEpisodesViewModel {
 
     private func fetchLocalData() {
         Task.detached { [dataManager] in
-            let episodes = self.loadEpisodeViewModels(using: dataManager)
+            let episodes = self.loadEpisodes(using: dataManager)
             await MainActor.run { [weak self] in
                 guard let self else { return }
-                self.episodes = episodes
+                self.episodes = episodes.map { EpisodeRowViewModel(episode: $0.episode, podcast: $0.podcast, source: .starred) }
                 self.state = episodes.isEmpty ? .empty : .ready
             }
         }
     }
 
-    nonisolated private func loadEpisodeViewModels(using dataManager: DataManager) -> [EpisodeRowViewModel] {
+    nonisolated private func loadEpisodes(using dataManager: DataManager) -> [(episode: Episode, podcast: Podcast?)] {
         dataManager.fetchStarredEpisodes().map { episode in
-            EpisodeRowViewModel(episode: episode, podcast: episode.parentPodcast(dataManager: dataManager), source: .starred)
+            (episode, episode.parentPodcast(dataManager: dataManager))
         }
     }
 

--- a/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
+++ b/Pocket Casts TV App/UI/UpNext/UpNextViewModel.swift
@@ -38,19 +38,19 @@ class UpNextViewModel {
 
     private func fetchLocalData() {
         Task.detached { [dataManager] in
-            let episodes = self.loadEpisodeViewModels(using: dataManager)
+            let episodes = self.loadEpisodes(using: dataManager)
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 state = episodes.isEmpty ? .empty : .ready
-                self.episodes = episodes
+                self.episodes = episodes.map { EpisodeRowViewModel(episode: $0.episode, podcast: $0.podcast, source: .upNext) }
             }
         }
     }
 
-    private func loadEpisodeViewModels(using dataManager: DataManager) -> [EpisodeRowViewModel] {
+    private func loadEpisodes(using dataManager: DataManager) -> [(episode: BaseEpisode, podcast: Podcast?)] {
         dataManager.allUpNextEpisodes().dropFirst().map { episode in
             let podcast = (episode as? Episode).flatMap { $0.parentPodcast(dataManager: dataManager) }
-            return EpisodeRowViewModel(episode: episode, podcast: podcast, source: .upNext)
+            return (episode, podcast)
         }
     }
 

--- a/podcasts/New Search/Views/Results/SearchResultCellModel.swift
+++ b/podcasts/New Search/Views/Results/SearchResultCellModel.swift
@@ -3,6 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 import Combine
 
+@MainActor
 class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
 
     var episode: EpisodeSearchResult?
@@ -30,8 +31,8 @@ class SearchResultCellModel: ObservableObject, MainEpisodeActionViewDelegate {
             return
         }
         isLoadingEpisode = true
-        Task { @MainActor in
-            let spinnerTask = Task { @MainActor in
+        Task {
+            let spinnerTask = Task {
                 try await Task.sleep(nanoseconds: UInt64(Self.loadingSpinnerDelay * TimeInterval(NSEC_PER_SEC)))
                 try Task.checkCancellation()
                 showsLoadingSpinner = true


### PR DESCRIPTION
Stacked on #4947.

Part 1 left three per-method `@MainActor` annotations as placeholders where the whole type should be isolated. This promotes them to type-level and closes the ring of callers that pulled in.

- `SearchResultCellModel`, `EpisodeRowViewModel` (tvOS) and `EpisodeUpNextActions` are now `@MainActor`. The redundant `@MainActor` on the inner `Task`s and on `play()` goes away with it.
- Five call sites built `EpisodeRowViewModel` off-main inside `Task.detached`. Rather than weaken the annotation, each one now keeps the database work off-main and constructs the view models on main. `HomeViewModel` gets slightly faster out of this — it was calling `parentPodcast(dataManager:)` for the Up Next rows *inside* `MainActor.run`, so that query moves off-main.

One latent off-main call surfaced and is fixed: `DiscoveryEpisodeMenuButtons.load(_:)` ran its completion on the generic executor, so Play Next / Play Last in the Discover and Search context menus mutated the Up Next queue, wrote a `@Binding`, and showed a toast off the main thread.

The `Task { @MainActor in }` added to `PodcastDetailViewModel`'s archive observer is redundant at runtime — the publisher is already `.receive(on: DispatchQueue.main)`. It is there only because the class itself isn't isolated yet. `PodcastDetailViewModel`, `HomeViewModel` and `UpNextViewModel` should follow, which would delete the `MainActor.run` dance in all three, but that first needs `TVDataManager.loadPodcast` and `fetchEpisodes` to move off-main or the podcast-detail query lands on the main thread.

## To test

tvOS — the episode lists still populate and act correctly:

1. Home → Up Next and New Releases rows populate; play an episode from each.
2. Podcasts → open a podcast; the episode list loads. Toggle Show Archived and change the sort order; the list reloads in the new order.
3. Podcasts → archive an episode from the context menu; the list refreshes.
4. Up Next → the queue populates; Play Next, Play Last and Remove From Up Next work.
5. Starred and Listening History → both lists populate.
6. Discover → open the context menu on an episode; Play Next and Play Last add it to Up Next and show the toast.

iOS:

7. Search → play an episode result; the spinner appears for slow loads, then playback starts. Pause it again.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
