### PR TITLE
Make tab bar minimizing opt-in behind a feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [tvOS] Add support server driven home page layout [#4854](https://github.com/Automattic/pocket-casts-ios/pull/4854)
 - [tvOS] Add support for HLS episodes previews in episodes video list [#4921](https://github.com/Automattic/pocket-casts-ios/pull/4921)
 - Recognise more HLS content types in alternate enclosures [#4935](https://github.com/Automattic/pocket-casts-ios/pull/4935)
-- Disable "Tab Bar Minimizing" by default – there is an option to opt-in in Appearance Settings
+- Disable "Tab Bar Minimizing" by default – there is an option to opt-in in Appearance Settings [#4950](https://github.com/Automattic/pocket-casts-ios/pull/4950)
 
 8.17
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [tvOS] Add support server driven home page layout [#4854](https://github.com/Automattic/pocket-casts-ios/pull/4854)
 - [tvOS] Add support for HLS episodes previews in episodes video list [#4921](https://github.com/Automattic/pocket-casts-ios/pull/4921)
 - Recognise more HLS content types in alternate enclosures [#4935](https://github.com/Automattic/pocket-casts-ios/pull/4935)
+- Disable "Tab Bar Minimizing" by default – there is an option to opt-in in Appearance Settings
 
 8.17
 -----

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -317,6 +317,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// Show the Categories and Curated rows on the tvOS Home screen
     case tvHomeCategoriesAndCurated
 
+    /// Make the tab bar's minimize-on-scroll behavior opt-in: it's off unless the
+    /// user turns it on in Appearance
+    case minimizeTabsOptIn
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -535,6 +539,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .tvHomeCategoriesAndCurated:
             false
+        case .minimizeTabsOptIn:
+            true
         }
     }
 

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -214,7 +214,9 @@ struct Constants {
 
         enum appearance {
             static let darkUpNextTheme = SettingValue("appearance.darkUpNextTheme", defaultValue: true)
-            static let tabBarMinimizingEnabled = SettingValue("appearance.tabBarMinimizingEnabled", defaultValue: true)
+            static var tabBarMinimizingEnabled: SettingValue<Bool> {
+                SettingValue("appearance.tabBarMinimizingEnabled", defaultValue: !FeatureFlag.minimizeTabsOptIn.enabled)
+            }
         }
 
         enum kidsProfile {


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Adds the `minimizeTabsOptIn` feature flag (on by default). While it's on, the tab bar's minimize-on-scroll behavior is off unless the user turns it on in Settings → Appearance → Minimize on Scroll.

Only the *default* changes: a value the user already stored still wins, so anyone who explicitly toggled the setting keeps their choice. Turning the flag off restores the previous behavior of minimizing being enabled by default.

## To test

Requires iOS 26 (Liquid Glass), since the minimize-on-scroll tab bar only exists there.

1. Install on a device/simulator that has never had the app (or reset the app data) so the setting has no stored value.
2. Play an episode so the mini player appears, then scroll a list (e.g. Podcasts).
3. Verify the tab bar does **not** minimize into a pill.
4. Go to Settings → Appearance → Tab Bar and turn on "Minimize on Scroll".
5. Scroll again and verify the tab bar now minimizes.
6. Turn the toggle back off and verify it stops minimizing again.
7. In Developer settings → Feature Flags, turn `minimizeTabsOptIn` off and relaunch. On a fresh install the tab bar minimizes by default again, and the Appearance toggle is on.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
