### PR TITLE
Cosmetic: Clean up PlaybackManager readability

### DIFF
--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -206,7 +206,7 @@ class EffectsViewController: SimpleNotificationsViewController {
         setupAccessibility()
 
         if isCustomPlaybackSettingsEnabled {
-            playbackSettingsSegmentedControl.selectedSegmentIndex = PlaybackManager.shared.isCurrentEffectGlobal() ? 0 : 1
+            playbackSettingsSegmentedControl.selectedSegmentIndex = PlaybackManager.shared.isCurrentEffectGlobal ? 0 : 1
         }
         if let episode = PlaybackManager.shared.currentEpisode as? Episode, let podcast = episode.parentPodcast() {
             clearForPodcastImage.setPodcast(uuid: podcast.uuid, size: .list)

--- a/podcasts/NowPlayingPlayerItemViewController+Update.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Update.swift
@@ -298,7 +298,7 @@ extension NowPlayingPlayerItemViewController {
     // MARK: - Progress
 
     @objc func progressUpdated() {
-        if timeSlider.isScrubbing() || PlaybackManager.shared.isSeeking() { return }
+        if timeSlider.isScrubbing() || PlaybackManager.shared.isSeeking { return }
 
         updateUpTo(upTo: PlaybackManager.shared.currentTime(), duration: PlaybackManager.shared.duration(), moveSlider: true)
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -97,6 +97,10 @@ class PlaybackManager: ServerPlaybackDelegate {
     /// The time the episode was last switched as tracked by handleCurrentlyPlayingEpisodeUpdated
     private var episodeSwitchTime: Date?
 
+    private var lastSeekTime = Date()
+
+    private let commandCenterSource: AnalyticsSource = .nowPlayingWidget
+
     init() {
         queue = PlaybackQueue()
         queue.loadPersistedQueue()
@@ -1995,8 +1999,6 @@ class PlaybackManager: ServerPlaybackDelegate {
         playPause()
     }
 
-    private var lastSeekTime = Date()
-    private let commandCenterSource: AnalyticsSource = .nowPlayingWidget
     private func setupRemoteControlSupport() {
         let commandCenter = MPRemoteCommandCenter.shared()
 

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -522,7 +522,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
     }
 
-    func isSeeking() -> Bool {
+    var isSeeking: Bool {
         seekingTo != PlaybackManager.notSeeking
     }
 
@@ -1111,8 +1111,8 @@ class PlaybackManager: ServerPlaybackDelegate {
         effectsChangedExternally()
     }
 
-    func isCurrentEffectGlobal() -> Bool {
-        return effects().isGlobal
+    var isCurrentEffectGlobal: Bool {
+        effects().isGlobal
     }
 
     private func handlePlaybackEffectsChanged(effects: PlaybackEffects) {
@@ -1843,7 +1843,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private func fireProgressNotification() {
-        if isSeeking() { return } // don't fire these while the app is seeking
+        if isSeeking { return } // don't fire these while the app is seeking
 
         if Thread.isMainThread {
             if isBackgrounded() { return }
@@ -1996,6 +1996,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private var lastSeekTime = Date()
+    private let commandCenterSource: AnalyticsSource = .nowPlayingWidget
     private func setupRemoteControlSupport() {
         let commandCenter = MPRemoteCommandCenter.shared()
 
@@ -2626,11 +2627,6 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
         return true
     }
-
-    // MARK: - Analytics
-
-    private let commandCenterSource: AnalyticsSource = .nowPlayingWidget
-
 
     // MARK: - tvOS
 

--- a/podcasts/VideoViewController.swift
+++ b/podcasts/VideoViewController.swift
@@ -279,7 +279,7 @@ class VideoViewController: SimpleNotificationsViewController, AVPictureInPicture
     }
 
     @objc private func progressUpdated() {
-        if timeSlider.isScrubbing() || PlaybackManager.shared.isSeeking() { return }
+        if timeSlider.isScrubbing() || PlaybackManager.shared.isSeeking { return }
 
         updateUpTo(upTo: PlaybackManager.shared.currentTime(), duration: PlaybackManager.shared.duration(), moveSlider: true)
     }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Small readability cleanup in `PlaybackManager.swift`, continuing the recent cosmetic pass on this file:
- Turned `isSeeking()` and `isCurrentEffectGlobal()` into properties (`isSeeking`, `isCurrentEffectGlobal`), matching the existing `currentEpisode`/`playing`/`buffering` property style. Updated all call sites.
- Removed a duplicate `// MARK: - Analytics` section — it only held `commandCenterSource`, which is actually a Remote Control / Command Center concern, so it's now declared next to the remote control code that uses it, alongside the existing `lastSeekTime`. The real analytics code keeps the one remaining `Analytics` MARK.

No behavior change.

## To test

1. Build the app and confirm it compiles.
2. Scrub/seek the now playing progress bar or video player — should behave as before (no update fired mid-seek).
3. Open Playback Effects settings — the global/per-podcast segmented control should still reflect the correct state.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.