### PR TITLE
PlaybackManager: Incremental @MainActor adoption from the UI side – Part 2

### DIFF
--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewController.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewController.swift
@@ -2,6 +2,7 @@ import PocketCastsDataModel
 import SwiftUI
 
 /// Hosts `BookmarkDetailsView` and performs the actions its navigation bar offers.
+@MainActor
 class BookmarkDetailsViewController: ThemedHostingController<BookmarkDetailsView> {
     private let bookmarkManager: BookmarkManager
     private let playbackManager: PlaybackManager

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -2,6 +2,7 @@ import Combine
 import PocketCastsDataModel
 import SwiftUI
 
+@MainActor
 class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeListView> {
     private let playbackManager: PlaybackManager
     private let bookmarkManager: BookmarkManager

--- a/podcasts/Bookmarks/List/BookmarkListRouter.swift
+++ b/podcasts/Bookmarks/List/BookmarkListRouter.swift
@@ -1,6 +1,7 @@
 import PocketCastsDataModel
 import UIKit
 
+@MainActor
 protocol BookmarkListRouter: AnyObject {
     func bookmarkPlay(_ bookmark: Bookmark) async throws
     func bookmarkEdit(_ bookmark: Bookmark)

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -4,6 +4,7 @@ import PocketCastsServer
 import PocketCastsUtils
 import SwiftUI
 
+@MainActor
 class BookmarkListViewModel: SearchableListViewModel<Bookmark>, MultiSelectable {
     typealias SortSetting = Binding<BookmarkSortOption>
 

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -3,6 +3,7 @@ import Combine
 import PocketCastsDataModel
 
 /// Wraps the SwiftUI view in a `PlayerItemViewController` and adds some basic listeners
+@MainActor
 class BookmarksPlayerTabController: PlayerItemViewController {
     private let playbackManager: PlaybackManager
     private let bookmarkManager: BookmarkManager

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
@@ -2,6 +2,7 @@ import Combine
 import PocketCastsDataModel
 import SwiftUI
 
+@MainActor
 class BookmarksProfileListController: ThemedHostingController<BookmarksProfileListView> {
     private let playbackManager: PlaybackManager
     private let bookmarkManager: BookmarkManager

--- a/podcasts/Common Components/MainEpisodeActionView.swift
+++ b/podcasts/Common Components/MainEpisodeActionView.swift
@@ -11,6 +11,7 @@ protocol MainEpisodeActionViewDelegate: AnyObject {
     func waitingForWifiTapped()
 }
 
+@MainActor
 class MainEpisodeActionView: UIView {
     enum ButtonState {
         case download, pauseDownload, play, pause, error, waitingForWifi, playedPlay, playedDownload

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -2,6 +2,7 @@ import PocketCastsDataModel
 import PocketCastsServer
 import UIKit
 
+@MainActor
 class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     private static let playedAlpha: CGFloat = 0.5
 

--- a/podcasts/Episode Cells/EpisodeCell.swift
+++ b/podcasts/Episode Cells/EpisodeCell.swift
@@ -521,6 +521,14 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
     }
 
     @objc private func uploadProgressDidUpdate() {
+        if Thread.isMainThread {
+            MainActor.assumeIsolated { uploadProgressDidUpdateOnMain() }
+        } else {
+            Task { @MainActor in uploadProgressDidUpdateOnMain() }
+        }
+    }
+
+    private func uploadProgressDidUpdateOnMain() {
         guard let ourEpisode = episode as? UserEpisode, let _ = UploadManager.shared.progressManager.progressForEpisode(ourEpisode.uuid) else { return }
 
         // if this episode isn't listed as uploading, update it from the DB
@@ -528,15 +536,7 @@ class EpisodeCell: ThemeableSwipeCell, MainEpisodeActionViewDelegate {
             episode = reloadEpisode()
         }
 
-        if Thread.isMainThread {
-            populate(progressOnly: true)
-        } else {
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-
-                self.populate(progressOnly: true)
-            }
-        }
+        populate(progressOnly: true)
     }
 
     @objc func reloadArtwork(_ notification: Notification) {

--- a/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
+++ b/podcasts/NowPlayingPlayerItemViewController+Shelf.swift
@@ -4,6 +4,7 @@ import UIKit
 import PocketCastsDataModel
 import PocketCastsUtils
 
+@MainActor
 protocol NowPlayingActionsDelegate: AnyObject {
     func starEpisodeTapped()
     func effectsTapped()
@@ -632,7 +633,7 @@ extension NowPlayingPlayerItemViewController {
 }
 #endif
 
-extension NowPlayingPlayerItemViewController: AVRoutePickerViewDelegate {
+extension NowPlayingPlayerItemViewController: @preconcurrency AVRoutePickerViewDelegate {
     func routePickerViewWillBeginPresentingRoutes(_ routePickerView: AVRoutePickerView) {
 
         // This prepares routing options without activating the session

--- a/podcasts/NowPlayingPlayerItemViewController.swift
+++ b/podcasts/NowPlayingPlayerItemViewController.swift
@@ -8,6 +8,7 @@ import PocketCastsUtils
 import SwiftUI
 import PocketCastsServer
 
+@MainActor
 class NowPlayingPlayerItemViewController: PlayerItemViewController {
     var showingCustomImage = false
     var lastChapterIndexRendered = -1

--- a/podcasts/PlayerChapterCell.swift
+++ b/podcasts/PlayerChapterCell.swift
@@ -2,6 +2,7 @@ import PocketCastsUtils
 import PocketCastsDataModel
 import UIKit
 
+@MainActor
 class PlayerChapterCell: UITableViewCell {
     @IBOutlet var chapterName: UILabel! {
         didSet {

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -1,7 +1,6 @@
 import PocketCastsUtils
 import UIKit
 
-@MainActor
 class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTabDelegate, PlayerItemContainerDelegate {
     @IBOutlet var headerView: UIView!
     @IBOutlet var tabsView: PlayerTabsView! {
@@ -427,7 +426,7 @@ private extension PlayerContainerViewController {
     }
 }
 
-extension PlayerContainerViewController: @preconcurrency AnalyticsSourceProvider {
+extension PlayerContainerViewController: AnalyticsSourceProvider {
     var analyticsSource: AnalyticsSource {
         .player
     }

--- a/podcasts/PlayerContainerViewController.swift
+++ b/podcasts/PlayerContainerViewController.swift
@@ -1,6 +1,7 @@
 import PocketCastsUtils
 import UIKit
 
+@MainActor
 class PlayerContainerViewController: SimpleNotificationsViewController, PlayerTabDelegate, PlayerItemContainerDelegate {
     @IBOutlet var headerView: UIView!
     @IBOutlet var tabsView: PlayerTabsView! {
@@ -426,7 +427,7 @@ private extension PlayerContainerViewController {
     }
 }
 
-extension PlayerContainerViewController: AnalyticsSourceProvider {
+extension PlayerContainerViewController: @preconcurrency AnalyticsSourceProvider {
     var analyticsSource: AnalyticsSource {
         .player
     }

--- a/podcasts/PlayerItemViewController.swift
+++ b/podcasts/PlayerItemViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 protocol PlayerItemContainerDelegate: AnyObject {
     func scrollToCurrentChapter()
     func scrollToNowPlaying()
@@ -8,6 +9,7 @@ protocol PlayerItemContainerDelegate: AnyObject {
     func dismissTranscript()
 }
 
+@MainActor
 class PlayerItemViewController: SimpleNotificationsViewController {
     func willBeAddedToPlayer() {}
     func willBeRemovedFromPlayer() {}

--- a/podcasts/PlayerTabsView.swift
+++ b/podcasts/PlayerTabsView.swift
@@ -1,6 +1,7 @@
 import PocketCastsUtils
 import UIKit
 
+@MainActor
 protocol PlayerTabDelegate: AnyObject {
     func didSwitchToTab(index: Int)
 }
@@ -25,6 +26,7 @@ enum PlayerTabs: Int {
     }
 }
 
+@MainActor
 class PlayerTabsView: UIScrollView {
     var tabs: [PlayerTabs] = [.nowPlaying] {
         didSet {

--- a/podcasts/PlayerZoomAnimator.swift
+++ b/podcasts/PlayerZoomAnimator.swift
@@ -1,6 +1,7 @@
 import UIKit
 
 @available(iOS 26, *)
+@MainActor
 final class PlayerZoomAnimator: NSObject, UIViewControllerAnimatedTransitioning {
     let isPresenting: Bool
     let fullPlayer: PlayerContainerViewController
@@ -495,6 +496,7 @@ extension PlayerContainerViewController {
         let verticalSizeClass: UIUserInterfaceSizeClass
         let displayScale: CGFloat
 
+        @MainActor
         init(window: UIWindow) {
             bounds = window.bounds
             userInterfaceIdiom = window.traitCollection.userInterfaceIdiom

--- a/podcasts/ShowNotesPlayerItemViewController.swift
+++ b/podcasts/ShowNotesPlayerItemViewController.swift
@@ -5,7 +5,8 @@ import SafariServices
 import UIKit
 import WebKit
 
-class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewControllerDelegate, WKNavigationDelegate {
+@MainActor
+class ShowNotesPlayerItemViewController: PlayerItemViewController, @preconcurrency SFSafariViewControllerDelegate, WKNavigationDelegate {
     @IBOutlet var episodeTitle: UILabel! {
         didSet {
             episodeTitle.font = UIFont.font(ofSize: 22, weight: .bold, scalingWith: .title2)
@@ -86,10 +87,6 @@ class ShowNotesPlayerItemViewController: PlayerItemViewController, SFSafariViewC
         showNotesWebView.isOpaque = false
         showNotesWebView.backgroundColor = UIColor.clear
         showNotesWebView.scrollView.backgroundColor = UIColor.clear
-    }
-
-    deinit {
-        showNotesWebView?.navigationDelegate = nil
     }
 
     override func willBeAddedToPlayer() {

--- a/podcasts/TimeSliderDelegate.swift
+++ b/podcasts/TimeSliderDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@MainActor
 protocol TimeSliderDelegate: AnyObject {
     func sliderDidBeginSliding()
     func sliderDidEndSliding()

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -543,27 +543,27 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         loadTranscript()
         addObservers()
         transcriptView.delegate = self
-        #if DEBUG
+#if DEBUG
         let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
-            Task { @MainActor in
+            MainActor.assumeIsolated {
                 self?.debugOverlay?.update()
             }
         }
         RunLoop.main.add(timer, forMode: .common)
         debugTimer = timer
-        #endif
+#endif
     }
-
+    
     override func willBeRemovedFromPlayer() {
         removeAllCustomObservers()
         stopHighlightDisplayLink()
         if FeatureFlag.syncedTranscripts.enabled {
             FingerprintTimingManager.shared.stop()
         }
-        #if DEBUG
+#if DEBUG
         debugTimer?.invalidate()
         debugTimer = nil
-        #endif
+#endif
     }
 
     private func stopSyncedTranscripts() {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -545,7 +545,9 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         transcriptView.delegate = self
         #if DEBUG
         let timer = Timer(timeInterval: 0.25, repeats: true) { [weak self] _ in
-            self?.debugOverlay?.update()
+            Task { @MainActor in
+                self?.debugOverlay?.update()
+            }
         }
         RunLoop.main.add(timer, forMode: .common)
         debugTimer = timer

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -553,7 +553,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         debugTimer = timer
 #endif
     }
-    
+
     override func willBeRemovedFromPlayer() {
         removeAllCustomObservers()
         stopHighlightDisplayLink()

--- a/podcasts/UserEpisodeDetailViewController.swift
+++ b/podcasts/UserEpisodeDetailViewController.swift
@@ -2,6 +2,7 @@ import PocketCastsDataModel
 import PocketCastsServer
 import UIKit
 
+@MainActor
 protocol UserEpisodeDetailProtocol: AnyObject {
     func showEdit(userEpisode: UserEpisode)
     func showDeleteConfirmation(userEpisode: UserEpisode)


### PR DESCRIPTION
Continues the incremental `@MainActor` adoption started in #4947 (Part 1) and #4948 (Part 2). Independent of Part 2 — no overlapping files — so it targets `trunk` directly rather than stacking.

Closes three more caller-side rings:

- `MainEpisodeActionView` and `EpisodeCell` are now `@MainActor`, finishing the type-level isolation Part 1 only started on `MainEpisodeActionViewDelegate`. `EpisodeCell` is the main app's episode-row cell (Podcasts, Downloads, Starred, Uploaded, Listening History, Playlists).
- `BookmarkListRouter`, `BookmarkListViewModel` (and its two subclasses `BookmarkEpisodeListViewModel`/`BookmarkPodcastListViewModel`), and the four bookmark hosting controllers (`BookmarkDetailsViewController`, `BookmarkEpisodeListController`, `BookmarksProfileListController`, `BookmarksPlayerTabController`) are now `@MainActor`.
- The now-playing player screen: `PlayerItemViewController` (base class), `PlayerContainerViewController`, `NowPlayingPlayerItemViewController`, `ShowNotesPlayerItemViewController`, `PlayerTabsView`, `PlayerChapterCell`, and `PlayerZoomAnimator` are now `@MainActor`, along with the `PlayerItemContainerDelegate`, `PlayerTabDelegate`, `NowPlayingActionsDelegate`, and `TimeSliderDelegate` protocols. `ChaptersViewController` and `TranscriptViewController` pick up isolation automatically via the base class.

`UserEpisodeDetailProtocol` is promoted from a per-method placeholder to full type-level `@MainActor`.

All rings closed cleanly. The player UI ring surfaced a couple of real fixes along the way:
- `BookmarkListRouter` needed its own `@MainActor` once its conformers were isolated, and `UserEpisodeDetailProtocol`'s `showBookmarks` default implementation needed explicit isolation since it lives in a protocol extension rather than a conforming type.
- A few SDK delegate protocols (`AVRoutePickerViewDelegate`, `SFSafariViewControllerDelegate`) and one widely-used app protocol (`AnalyticsSourceProvider`) aren't `@MainActor`-audited upstream, so those specific conformances use `@preconcurrency` rather than promoting the shared protocols (`AnalyticsSourceProvider` alone has 24 unrelated conformers app-wide).
- `ShowNotesPlayerItemViewController`'s `deinit` was nil-ing out a `weak` delegate — redundant, since ARC already zeroes weak references on deallocation, and not something `deinit` (always non-isolated) can safely do to a `@MainActor` property anyway. Removed.
- `TranscriptViewController`'s `Task.detached` transcript loader now correctly hops back to `@MainActor` for its UI-touching completion work (`show(transcript:)`, `show(error:)`, `track(...)`), which the compiler couldn't previously verify.

## To test

1. Any episode list (Podcasts, Downloads, Starred, Uploaded, Listening History, Playlists) — tap play/pause/download/error/waiting-for-wifi on an episode cell; confirm each action still works.
2. Player → Bookmarks tab — play, edit, share, and delete a bookmark.
3. A podcast episode's bookmark list and Profile → Bookmarks — same actions, plus sorting and multi-select.
4. Uploaded file detail sheet → tap the Bookmarks row; confirm the standalone bookmark list opens.
5. Full player screen — play/pause/skip, seek, chapters, show notes, transcript (including search and generated-transcript sync), and the mini-player ↔ full-player zoom transition.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
