### PR TITLE
Fix Sendable warning in ApiSetting+ModifiedDate

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
@@ -39,7 +39,7 @@ extension ModifiedDate {
 
 extension ModifiedDate where Value: RawRepresentable {
     enum ApiUpdateError: Error {
-        case representableNotFound(value: Any, representable: Value.Type)
+        case representableNotFound(value: Any, representable: String)
     }
 
     /// Updates the ModifiedDate instance with values from an ApiSetting
@@ -48,7 +48,7 @@ extension ModifiedDate where Value: RawRepresentable {
         let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
         if setting.modifiedAt.date > modifiedAt ?? referenceDate {
             guard let value = Value(rawValue: setting.value.value) else {
-                throw ApiUpdateError.representableNotFound(value: setting.value.value, representable: Value.self)
+                throw ApiUpdateError.representableNotFound(value: setting.value.value, representable: String(describing: Value.self))
             }
             self = ModifiedDate(wrappedValue: value)
         }

--- a/Modules/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift
@@ -39,7 +39,7 @@ extension ModifiedDate {
 
 extension ModifiedDate where Value: RawRepresentable {
     enum ApiUpdateError: Error {
-        case representableNotFound(value: Any, representable: String)
+        case representableNotFound(value: String, representable: String)
     }
 
     /// Updates the ModifiedDate instance with values from an ApiSetting
@@ -48,7 +48,7 @@ extension ModifiedDate where Value: RawRepresentable {
         let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
         if setting.modifiedAt.date > modifiedAt ?? referenceDate {
             guard let value = Value(rawValue: setting.value.value) else {
-                throw ApiUpdateError.representableNotFound(value: setting.value.value, representable: String(describing: Value.self))
+                throw ApiUpdateError.representableNotFound(value: "\(setting.value.value)", representable: String(describing: Value.self))
             }
             self = ModifiedDate(wrappedValue: value)
         }


### PR DESCRIPTION
Fixes a compiler warning: `Associated value 'representableNotFound(value:representable:)' of 'Sendable'-conforming enum 'ApiUpdateError' contains non-Sendable type 'Value.Type'`.

`ApiUpdateError` conforms to `Error`, which requires `Sendable` under strict concurrency checking. The `representable: Value.Type` associated value stored a generic metatype that the compiler can't prove is `Sendable`. Since it's only ever used to print a type name in a log message, it's replaced with a `String` description instead.

## To test

1. Build the `PocketCastsServer` module (or the full app) and confirm no warning is emitted for `Modules/Sources/PocketCastsServer/Public/ApiSetting+ModifiedDate.swift`.
2. Confirm `FileLog` messages from `ModifiedDate.update(setting:)` still print a readable type name when `representableNotFound` is thrown.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.