### PR TITLE
Make AnalyticsCoordinator and AnalyticsSourceProvider MainActor-isolated

### DIFF
--- a/Pocket Casts TV App/Analytics/SearchAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/SearchAnalytics.swift
@@ -7,6 +7,7 @@ enum SearchAnalytics {
 
     static let source = "search"
 
+    @MainActor
     static func episodeTapped(_ episode: EpisodeSearchResult) {
         AnalyticsPlaybackHelper.shared.currentSource = .search
         Analytics.track(.searchResultTapped, properties: [

--- a/Pocket Casts TV App/UI/AppCoordinator.swift
+++ b/Pocket Casts TV App/UI/AppCoordinator.swift
@@ -194,6 +194,7 @@ class AppCoordinator {
         UserDefaults.standard.synchronize()
     }
 
+    @MainActor
     func remotePlayPauseToggle() {
         AnalyticsPlaybackHelper.shared.timestampOfLastRemoteAction = .now
         PlaybackManager.shared.remotePlayPauseToggle()

--- a/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
+++ b/Pocket Casts TV App/UI/Player/PlayerStatusObserver.swift
@@ -37,6 +37,7 @@ class PlayerStatusObserver {
         remainingEventsToSkip = amount
     }
 
+    @MainActor
     private func updatePlayState() {
         guard let player else {
             return

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -73,7 +73,7 @@ protocol SearchableViewModel: AnyObject, Observation.Observable {
 
     func saveHistory(_ term: String)
 
-    func playEpisode(_ episode: EpisodeSearchResult) async -> Bool
+    @MainActor func playEpisode(_ episode: EpisodeSearchResult) async -> Bool
 
     var isInSearchMode: Bool { get }
 }

--- a/PocketCastsTests/Tests/Analytics/AnalyticsPlaybackHelperTests.swift
+++ b/PocketCastsTests/Tests/Analytics/AnalyticsPlaybackHelperTests.swift
@@ -4,6 +4,7 @@ import PocketCastsUtils
 
 @testable import podcasts
 
+@MainActor
 class AnalyticsPlaybackHelperTests: XCTestCase {
     override func tearDown() {
         FeatureFlagOverrideStore().resetOverrides()
@@ -189,9 +190,7 @@ class AnalyticsPlaybackHelperTests: XCTestCase {
 
         AnalyticsPlaybackHelper.shared.play()
 
-        eventually {
-            XCTAssertNil(AnalyticsPlaybackHelper.shared.currentSource)
-        }
+        XCTAssertNil(AnalyticsPlaybackHelper.shared.currentSource)
     }
 
     func testSeekToDoesntCrashWithNanOrInfinite() {
@@ -228,6 +227,7 @@ class AnalyticsPlaybackHelperTests: XCTestCase {
 
 // MARK: - AnalyticsPlaybackHelper Mock
 
+@MainActor
 private class AnalyticsPlaybackHelperMock: AnalyticsPlaybackHelper {
     var lastEvent: TrackEvent?
 

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 import PocketCastsDataModel
 
+@MainActor
 protocol AnalyticsSourceProvider {
     /// Used to define the source view for the various analytics actions
     var analyticsSource: AnalyticsSource { get }
@@ -69,6 +70,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     var analyticsDescription: String { rawValue }
 }
 
+@MainActor
 class AnalyticsCoordinator {
     /// Sometimes the playback source can't be inferred, just inform it here
     var currentSource: AnalyticsSource?
@@ -98,34 +100,26 @@ class AnalyticsCoordinator {
     }
 
 #if !os(watchOS) && !APPCLIP
-        func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {
-            // Only dispatch async on the main thread if needed
-            guard Thread.isMainThread else {
-                DispatchQueue.main.async {
-                    self.track(event, properties: properties)
-                }
-                return
-            }
-
-            let defaultProperties: [String: Any] = ["source": currentAnalyticsSource, "content_type": currentEpisodeIsVideo ? "video" : "audio"]
-            let mergedProperties = defaultProperties.merging(properties ?? [:]) { current, _ in current }
-            Analytics.track(event, properties: mergedProperties)
-        }
+    func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {
+        let defaultProperties: [String: Any] = ["source": currentAnalyticsSource, "content_type": currentEpisodeIsVideo ? "video" : "audio"]
+        let mergedProperties = defaultProperties.merging(properties ?? [:]) { current, _ in current }
+        Analytics.track(event, properties: mergedProperties)
+    }
 
     func getTopViewController(base: UIViewController? = SceneHelper.rootViewController()) -> UIViewController? {
-            guard UIApplication.shared.applicationState == .active else {
-                return nil
-            }
-
-            if let nav = base as? UINavigationController {
-                return getTopViewController(base: nav.visibleViewController)
-            } else if let tab = base as? UITabBarController, let selected = tab.selectedViewController {
-                return getTopViewController(base: selected)
-            } else if let presented = base?.presentedViewController {
-                return getTopViewController(base: presented)
-            }
-            return base
+        guard UIApplication.shared.applicationState == .active else {
+            return nil
         }
+
+        if let nav = base as? UINavigationController {
+            return getTopViewController(base: nav.visibleViewController)
+        } else if let tab = base as? UITabBarController, let selected = tab.selectedViewController {
+            return getTopViewController(base: selected)
+        } else if let presented = base?.presentedViewController {
+            return getTopViewController(base: presented)
+        }
+        return base
+    }
 
     func topAnalyticsSourceProvider() -> AnalyticsSourceProvider? {
         guard let topViewController = getTopViewController() else { return nil }
@@ -140,8 +134,8 @@ class AnalyticsCoordinator {
 
         return nil
     }
-    #else
-        /// NOOP track event to preventing needing to wrap all the events in #if checks
-        func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {}
-    #endif
+#else
+    /// NOOP track event to preventing needing to wrap all the events in #if checks
+    func track(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {}
+#endif
 }

--- a/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsEpisodeHelper.swift
@@ -9,7 +9,7 @@ class AnalyticsEpisodeHelper: AnalyticsCoordinator {
     private var episodeDownloadQueue: Set<String> = []
     private var episodeUploadQueue: Set<String> = []
     // Keep track of where a download was initiated so completion/failure logs use the same source
-    private let episodeDownloadSources = ThreadSafeDictionary<String, AnalyticsSource>()
+    private var episodeDownloadSources: [String: AnalyticsSource] = [:]
 
     override init() {
         super.init()
@@ -212,48 +212,62 @@ private extension AnalyticsEpisodeHelper {
     func addNotificationObservers() {
         #if !os(watchOS)
             NotificationCenter.default.addObserver(forName: Constants.Notifications.episodeDownloaded, object: nil, queue: .main) { notification in
-                // Verify the UUID is one that we're tracking
-                guard let uuid = notification.object as? String, self.episodeDownloadQueue.contains(uuid) else {
-                    return
+                MainActor.assumeIsolated {
+                    self.episodeDownloadedNotificationReceived(notification)
                 }
-
-                // Verify that the file has finished downloading
-                guard
-                    let episode = DataManager.sharedManager.findEpisode(uuid: uuid),
-                    let status = DownloadStatus(rawValue: episode.episodeStatus),
-                    status == .downloaded
-                else {
-                    return
-                }
-
-                self.episodeDownloadQueue.remove(uuid)
-                self.downloadFinished(episodeUUID: uuid)
             }
 
             NotificationCenter.default.addObserver(forName: ServerNotifications.userEpisodeUploadStatusChanged, object: nil, queue: .main) { notification in
-                // Verify the UUID is one that we're tracking
-                guard let uuid = notification.object as? String, self.episodeUploadQueue.contains(uuid) else {
-                    return
-                }
-
-                // Verify that the file has finished uploading
-                guard
-                    let episode = DataManager.sharedManager.findUserEpisode(uuid: uuid),
-                    let status = UploadStatus(rawValue: episode.uploadStatus)
-                else {
-                    return
-                }
-
-                switch status {
-                case .uploaded:
-                    self.episodeUploadQueue.remove(uuid)
-                    self.episodeUploadFinished(episodeUUID: uuid)
-                case .uploadFailed:
-                    self.episodeUploadFailed(episodeUUID: uuid)
-                default:
-                    break
+                MainActor.assumeIsolated {
+                    self.userEpisodeUploadStatusChangedNotificationReceived(notification)
                 }
             }
         #endif
     }
+
+    #if !os(watchOS)
+    func episodeDownloadedNotificationReceived(_ notification: Notification) {
+        // Verify the UUID is one that we're tracking
+        guard let uuid = notification.object as? String, episodeDownloadQueue.contains(uuid) else {
+            return
+        }
+
+        // Verify that the file has finished downloading
+        guard
+            let episode = DataManager.sharedManager.findEpisode(uuid: uuid),
+            let status = DownloadStatus(rawValue: episode.episodeStatus),
+            status == .downloaded
+        else {
+            return
+        }
+
+        episodeDownloadQueue.remove(uuid)
+        downloadFinished(episodeUUID: uuid)
+    }
+
+    func userEpisodeUploadStatusChangedNotificationReceived(_ notification: Notification) {
+        // Verify the UUID is one that we're tracking
+        guard let uuid = notification.object as? String, episodeUploadQueue.contains(uuid) else {
+            return
+        }
+
+        // Verify that the file has finished uploading
+        guard
+            let episode = DataManager.sharedManager.findUserEpisode(uuid: uuid),
+            let status = UploadStatus(rawValue: episode.uploadStatus)
+        else {
+            return
+        }
+
+        switch status {
+        case .uploaded:
+            episodeUploadQueue.remove(uuid)
+            episodeUploadFinished(episodeUUID: uuid)
+        case .uploadFailed:
+            episodeUploadFailed(episodeUUID: uuid)
+        default:
+            break
+        }
+    }
+    #endif
 }

--- a/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsPlaybackHelper.swift
@@ -156,7 +156,7 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     /// Pass `isCurrentEpisode: false` for an episode that hasn't started yet (e.g. the next autoplay
     /// episode): the per-session video toggle only applies to the episode currently playing, so
     /// `audio_only_mode` should reflect just the global "Audio only" setting for an upcoming one.
-    static func hlsLifecycleProperties(for episode: BaseEpisode?, isCurrentEpisode: Bool = true) -> [String: Any] {
+    nonisolated static func hlsLifecycleProperties(for episode: BaseEpisode?, isCurrentEpisode: Bool = true) -> [String: Any] {
         guard FeatureFlag.hls.enabled else { return [:] }
         var properties: [String: Any] = ["hls_available": episodeOffersHLS(episode)]
         if let audioOnlyMode = audioOnlyMode(for: episode, isCurrentEpisode: isCurrentEpisode) {
@@ -172,7 +172,7 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
     /// For the episode currently playing this is the full state (global setting OR per-session toggle).
     /// For an episode that hasn't started yet the per-session toggle doesn't apply — it resets to video
     /// when the episode opens — so only the global "Audio only" setting carries over.
-    private static func audioOnlyMode(for episode: BaseEpisode?, isCurrentEpisode: Bool) -> Bool? {
+    nonisolated private static func audioOnlyMode(for episode: BaseEpisode?, isCurrentEpisode: Bool) -> Bool? {
         guard let episode, EpisodeManager.willPlayViaHLS(episode) else { return nil }
         let manager = PlaybackManager.shared
         return isCurrentEpisode ? manager.isAudioOnlyMode : manager.isAudioOnlyForced
@@ -180,13 +180,13 @@ class AnalyticsPlaybackHelper: AnalyticsCoordinator {
 
     /// The protocol an episode's source resolves to for playback (`hls`/`progressive`), for events
     /// where the source is known. Empty unless the HLS feature flag is on.
-    static func hlsProtocolProperties(for episode: BaseEpisode) -> [String: Any] {
+    nonisolated static func hlsProtocolProperties(for episode: BaseEpisode) -> [String: Any] {
         guard FeatureFlag.hls.enabled else { return [:] }
         return ["playback_protocol": EpisodeManager.willPlayViaHLS(episode) ? "hls" : "progressive"]
     }
 
     /// Whether the episode advertises an HLS stream, independent of whether it's the selected source.
-    private static func episodeOffersHLS(_ episode: BaseEpisode?) -> Bool {
+    nonisolated private static func episodeOffersHLS(_ episode: BaseEpisode?) -> Bool {
         guard let episode = episode as? Episode, let hlsUrl = episode.hlsUrl else { return false }
         return !hlsUrl.isEmpty
     }

--- a/podcasts/DownloadManager+Logging.swift
+++ b/podcasts/DownloadManager+Logging.swift
@@ -6,9 +6,13 @@ import Combine
 extension DownloadManager {
     func logDownload(_ episode: BaseEpisode, failure: FailureReason, extraProperties: [String: Any?] = [:]) {
         let properties = ["reason": failure.localizedDescription].merging(extraProperties) { current, _ in return current }
-        AnalyticsEpisodeHelper.shared.downloadFailed(episodeUUID: episode.uuid,
-                                                     podcastUUID: episode.parentIdentifier(),
-                                                     extraProperties: properties.compactMapValues({ $0 }))
+        let episodeUUID = episode.uuid
+        let podcastUUID = episode.parentIdentifier()
+        Task { @MainActor in
+            AnalyticsEpisodeHelper.shared.downloadFailed(episodeUUID: episodeUUID,
+                                                         podcastUUID: podcastUUID,
+                                                         extraProperties: properties.compactMapValues({ $0 }))
+        }
     }
 
     func logDownload(_ episode: BaseEpisode, failure: FailureReason, metrics: URLSessionTaskMetrics, session: URLSession) {

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -35,7 +35,9 @@ class DownloadManager: NSObject, FilePathProtocol {
 
     static let shared: DownloadManager = {
         let manager = DownloadManager(dataManager: DataManager.sharedManager)
-        AnalyticsEpisodeHelper.shared.setup()
+        Task { @MainActor in
+            AnalyticsEpisodeHelper.shared.setup()
+        }
         return manager
     }()
 

--- a/podcasts/EpisodeManager.swift
+++ b/podcasts/EpisodeManager.swift
@@ -4,7 +4,7 @@ import PocketCastsServer
 import PocketCastsUtils
 
 class EpisodeManager: NSObject {
-    static var analyticsHelper = AnalyticsEpisodeHelper.shared
+    @MainActor static let analyticsHelper = AnalyticsEpisodeHelper.shared
 
     class func markAsPlayed(episode: BaseEpisode, fireNotification: Bool, userInitiated: Bool = true) {
         // request to remove it from the download queue, just in case it's in there
@@ -36,7 +36,9 @@ class EpisodeManager: NSObject {
         }
 
         if userInitiated {
-            analyticsHelper.markAsPlayed(episode: episode)
+            Task { @MainActor in
+                analyticsHelper.markAsPlayed(episode: episode)
+            }
         }
     }
 
@@ -100,7 +102,10 @@ class EpisodeManager: NSObject {
         }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
 
-        analyticsHelper.bulkMarkAsPlayed(count: episodesMinusCurrent.count)
+        let markedAsPlayedCount = episodesMinusCurrent.count
+        Task { @MainActor in
+            analyticsHelper.bulkMarkAsPlayed(count: markedAsPlayedCount)
+        }
     }
 
     class func deleteDownloadedFiles(episode: BaseEpisode, userInitated: Bool = false) {
@@ -114,7 +119,9 @@ class EpisodeManager: NSObject {
         }
 
         if userInitated {
-            analyticsHelper.downloadDeleted(episode: episode)
+            Task { @MainActor in
+                analyticsHelper.downloadDeleted(episode: episode)
+            }
         }
     }
 
@@ -146,7 +153,9 @@ class EpisodeManager: NSObject {
         }
 
         if userInitiated {
-            analyticsHelper.markAsUnplayed(episode: episode)
+            Task { @MainActor in
+                analyticsHelper.markAsUnplayed(episode: episode)
+            }
         }
     }
 
@@ -154,7 +163,9 @@ class EpisodeManager: NSObject {
         DataManager.sharedManager.bulkMarkAsUnPlayed(baseEpisodes: baseEpisodes, updateSyncFlag: SyncManager.isUserLoggedIn())
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
 
-        analyticsHelper.bulkMarkAsUnplayed(count: baseEpisodes.count)
+        Task { @MainActor in
+            analyticsHelper.bulkMarkAsUnplayed(count: baseEpisodes.count)
+        }
     }
 
     class func archiveEpisode(episode: Episode, fireNotification: Bool, removeFromPlayer: Bool = true, userInitiated: Bool = true) {
@@ -178,7 +189,9 @@ class EpisodeManager: NSObject {
         }
 
         if userInitiated {
-            analyticsHelper.archiveEpisode(episode)
+            Task { @MainActor in
+                analyticsHelper.archiveEpisode(episode)
+            }
         }
     }
 
@@ -207,7 +220,9 @@ class EpisodeManager: NSObject {
         }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
 
-        analyticsHelper.bulkArchiveEpisodes(count: episodes.count)
+        Task { @MainActor in
+            analyticsHelper.bulkArchiveEpisodes(count: episodes.count)
+        }
     }
 
     class func unarchiveEpisode(episode: Episode, fireNotification: Bool, userInitiated: Bool = true) {
@@ -225,7 +240,9 @@ class EpisodeManager: NSObject {
         }
 
         if userInitiated {
-            analyticsHelper.unarchiveEpisode(episode)
+            Task { @MainActor in
+                analyticsHelper.unarchiveEpisode(episode)
+            }
         }
     }
 
@@ -235,7 +252,9 @@ class EpisodeManager: NSObject {
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
 
         if trackEvent {
-            analyticsHelper.bulkUnarchiveEpisodes(count: episodes.count)
+            Task { @MainActor in
+                analyticsHelper.bulkUnarchiveEpisodes(count: episodes.count)
+            }
         }
     }
 
@@ -244,7 +263,9 @@ class EpisodeManager: NSObject {
             DataManager.sharedManager.clearEpisodePlaybackInteractionDate(episodeUuid: episode.uuid)
         }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.listeningHistoryChanged)
-        analyticsHelper.bulkRemoveFromListeningHistory(count: episodes.count)
+        Task { @MainActor in
+            analyticsHelper.bulkRemoveFromListeningHistory(count: episodes.count)
+        }
     }
 
     class func deleteAllEpisodesInPodcast(id: Int64) {
@@ -280,10 +301,12 @@ class EpisodeManager: NSObject {
 
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.episodeStarredChanged, object: episode.uuid)
 
-        if starred {
-            analyticsHelper.star(episode: episode)
-        } else {
-            analyticsHelper.unstar(episode: episode)
+        Task { @MainActor in
+            if starred {
+                analyticsHelper.star(episode: episode)
+            } else {
+                analyticsHelper.unstar(episode: episode)
+            }
         }
     }
 
@@ -297,10 +320,12 @@ class EpisodeManager: NSObject {
         }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
 
-        if starred {
-            analyticsHelper.bulkStar(count: episodes.count)
-        } else {
-            analyticsHelper.bulkUnstar(count: episodes.count)
+        Task { @MainActor in
+            if starred {
+                analyticsHelper.bulkStar(count: episodes.count)
+            } else {
+                analyticsHelper.bulkUnstar(count: episodes.count)
+            }
         }
     }
 
@@ -592,6 +617,9 @@ class EpisodeManager: NSObject {
         DataManager.sharedManager.bulkUserFileDelete(baseEpisodes: episodesToMarkAsNotDownloaded)
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.manyEpisodesChanged)
 
-        analyticsHelper.bulkDeleteDownloadedEpisodes(count: episodesToRemoveFromQueue.count)
+        let removedFromQueueCount = episodesToRemoveFromQueue.count
+        Task { @MainActor in
+            analyticsHelper.bulkDeleteDownloadedEpisodes(count: removedFromQueueCount)
+        }
     }
 }

--- a/podcasts/Google Cast/GoogleCastManager.swift
+++ b/podcasts/Google Cast/GoogleCastManager.swift
@@ -297,7 +297,9 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
 
     func remoteMediaClient(_ client: GCKRemoteMediaClient, didUpdate mediaStatus: GCKMediaStatus?) {
         guard let mediaStatus else { return }
-        AnalyticsPlaybackHelper.shared.currentSource = .chromecast
+        Task { @MainActor in
+            AnalyticsPlaybackHelper.shared.currentSource = .chromecast
+        }
 
         if mediaStatus.playerState == .playing {
             if bufferingInitialPartOfEpisode {
@@ -318,7 +320,9 @@ class GoogleCastManager: NSObject, GCKRemoteMediaClientListener, GCKSessionManag
 
             if let playingEpisodeUuid = customData[episodeUuidKey] {
                 episodeUuidLoadedOnConnect = playingEpisodeUuid
-                AnalyticsPlaybackHelper.shared.currentSource = .chromecast
+                Task { @MainActor in
+                    AnalyticsPlaybackHelper.shared.currentSource = .chromecast
+                }
                 PlaybackManager.shared.remoteDeviceAutoConnected(episodeUuidLoadedOnConnect)
             }
         }

--- a/podcasts/Onboarding/OnboardingFlow.swift
+++ b/podcasts/Onboarding/OnboardingFlow.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PocketCastsUtils
 
-struct OnboardingFlow: AnalyticsSourceProvider {
+struct OnboardingFlow {
     typealias Context = [String: Any]
 
     static var shared = OnboardingFlow()
@@ -175,7 +175,9 @@ struct OnboardingFlow: AnalyticsSourceProvider {
             }
         }
     }
+}
 
+extension OnboardingFlow: AnalyticsSourceProvider {
     var analyticsSource: AnalyticsSource {
         .onboarding
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -79,8 +79,6 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     private let catchUpHelper = PlaybackCatchUpHelper()
 
-    private let analyticsPlaybackHelper = AnalyticsPlaybackHelper.shared
-
     #if !APPCLIP
     private(set) lazy var bookmarkManager: BookmarkManager = {
         BookmarkManager(playbackManager: self)
@@ -262,7 +260,9 @@ class PlaybackManager: ServerPlaybackDelegate {
     func seekToStartingPosition() {
         let startingTime = requiredStartingPosition()
         player?.play { [weak self] in
-            self?.analyticsPlaybackHelper.currentSource = .sync
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.currentSource = .sync
+            }
             self?.seekTo(time: startingTime, startPlaybackAfterSeek: false)
             self?.player?.pause()
         }
@@ -286,7 +286,9 @@ class PlaybackManager: ServerPlaybackDelegate {
         FileLog.shared.addMessage("PlaybackManager Play \(currentEpisode?.title ?? "unknown episode") userInitiated: \(userInitiated)")
 
         if userInitiated {
-            analyticsPlaybackHelper.play()
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.play()
+            }
         }
 
         aboutToPlay.value = true
@@ -332,7 +334,9 @@ class PlaybackManager: ServerPlaybackDelegate {
             // current episode still matches the one we started: activation can run async, and if the
             // user has since switched episodes the new play cycle reports its own resolved source.
             if shouldReportSourceResolved, self.currentEpisode?.uuid == currEpisode.uuid {
-                self.analyticsPlaybackHelper.playbackSourceResolved(for: currEpisode)
+                Task { @MainActor in
+                    AnalyticsPlaybackHelper.shared.playbackSourceResolved(for: currEpisode)
+                }
             }
 
             if currEpisode.videoPodcast() {
@@ -350,7 +354,9 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         // Only trigger the event if we are already playing
         if isPlaying, userInitiated == true {
-            analyticsPlaybackHelper.pause()
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.pause()
+            }
         }
 
         // one kind of interruption would be to launch siri and ask it to pause, handle this here
@@ -391,7 +397,9 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private func skipBack(amount: TimeInterval) {
-        analyticsPlaybackHelper.skipBack()
+        Task { @MainActor in
+            AnalyticsPlaybackHelper.shared.skipBack()
+        }
 
         let currPos = currentTime()
         let backTime = max(currPos - amount, 0)
@@ -404,7 +412,9 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private func skipForward(amount: TimeInterval) {
-        analyticsPlaybackHelper.skipForward()
+        Task { @MainActor in
+            AnalyticsPlaybackHelper.shared.skipForward()
+        }
 
         let forwardTime = min(currentTime() + amount, duration())
         seekTo(time: forwardTime)
@@ -535,7 +545,9 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func seekToFromSync(time: TimeInterval, syncChanges: Bool, startPlaybackAfterSeek: Bool) {
-        analyticsPlaybackHelper.currentSource = .sync
+        Task { @MainActor in
+            AnalyticsPlaybackHelper.shared.currentSource = .sync
+        }
         seekTo(time: time, syncChanges: syncChanges, startPlaybackAfterSeek: startPlaybackAfterSeek)
     }
 
@@ -595,7 +607,10 @@ class PlaybackManager: ServerPlaybackDelegate {
             }
         }
 
-        analyticsPlaybackHelper.seek(from: currentTime, to: time, duration: playingEpisode.duration)
+        let duration = playingEpisode.duration
+        Task { @MainActor in
+            AnalyticsPlaybackHelper.shared.seek(from: currentTime, to: time, duration: duration)
+        }
     }
 
     private var previousSeekTime: TimeInterval?
@@ -665,7 +680,9 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func addToUpNext(episode: BaseEpisode, ignoringQueueLimit: Bool = false, toTop: Bool = false, userInitiated: Bool) {
         if userInitiated {
-            AnalyticsEpisodeHelper.shared.episodeAddedToUpNext(episode: episode, toTop: toTop)
+            Task { @MainActor in
+                AnalyticsEpisodeHelper.shared.episodeAddedToUpNext(episode: episode, toTop: toTop)
+            }
         }
 
         // If we don't have a current episode, reload the persisted queue to updated our cache just in case
@@ -708,7 +725,9 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func removeIfPlayingOrQueued(episode: BaseEpisode?, fireNotification: Bool, saveCurrentEpisode: Bool = true, userInitiated: Bool = false) {
         if userInitiated, let episode {
-            AnalyticsEpisodeHelper.shared.episodeRemovedFromUpNext(episode: episode)
+            Task { @MainActor in
+                AnalyticsEpisodeHelper.shared.episodeRemovedFromUpNext(episode: episode)
+            }
         }
         if let episode, isCurrentEpisode(uuid: episode.uuid) {
             autoplayIfNeeded()
@@ -906,7 +925,9 @@ class PlaybackManager: ServerPlaybackDelegate {
             videoRenderingEnabled.toggle()
             switchedToVideo = videoRenderingEnabled.value
         }
-        analyticsPlaybackHelper.videoRenderingToggled(switchedToVideo: switchedToVideo, episode: episode)
+        Task { @MainActor in
+            AnalyticsPlaybackHelper.shared.videoRenderingToggled(switchedToVideo: switchedToVideo, episode: episode)
+        }
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.videoRenderingToggled)
     }
 
@@ -1317,7 +1338,11 @@ class PlaybackManager: ServerPlaybackDelegate {
     func playbackDidFail(error: PlaybackError, fallbackToDefaultPlayer: Bool = false) {
         FileLog.shared.addMessage("[PlaybackManager] Playback did fail with error: \(error.logMessage ?? "No error detail provided")")
 
-        AnalyticsPlaybackHelper.shared.playbackFailed(episode: currentEpisode, error: error.logMessage ?? "Unknown", hlsErrorDetail: error.analyticsDetail, player: player)
+        let failedEpisode = currentEpisode
+        let failedPlayer = player
+        Task { @MainActor in
+            AnalyticsPlaybackHelper.shared.playbackFailed(episode: failedEpisode, error: error.logMessage ?? "Unknown", hlsErrorDetail: error.analyticsDetail, player: failedPlayer)
+        }
 
         #if !os(watchOS)
         if fallbackToDefaultPlayer, let episode = currentEpisode {
@@ -1345,10 +1370,15 @@ class PlaybackManager: ServerPlaybackDelegate {
         // - Is the duration actually reasonable?
         // if either of these is false, flag it as an error, otherwise we got close enough to the end
         if episode.playedUpTo < 1.minutes || episode.duration <= 0 || ((episode.playedUpTo + 3.minutes) < episode.duration) {
-            let previousSource = AnalyticsPlaybackHelper.shared.currentSource
-            AnalyticsPlaybackHelper.shared.currentSource = .playbackFailed
+            let previousSource = Task { @MainActor () -> AnalyticsSource? in
+                let previousSource = AnalyticsPlaybackHelper.shared.currentSource
+                AnalyticsPlaybackHelper.shared.currentSource = .playbackFailed
+                return previousSource
+            }
             pause(userInitiated: false)
-            AnalyticsPlaybackHelper.shared.currentSource = previousSource
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.currentSource = await previousSource.value
+            }
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackPaused)
             activeError = error
             let message = error.userMessage
@@ -1510,7 +1540,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
         queue.bulkOperationDidComplete()
 
-        AnalyticsEpisodeHelper.shared.bulkAddToUpNext(count: episodesToAdd.count, toTop: toTop)
+        let addedCount = episodesToAdd.count
+        Task { @MainActor in
+            AnalyticsEpisodeHelper.shared.bulkAddToUpNext(count: addedCount, toTop: toTop)
+        }
     }
 
     // MARK: - Helper Methods
@@ -1994,7 +2027,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard self.currentEpisode != nil else {
             return
         }
-        analyticsPlaybackHelper.currentSource = self.commandCenterSource
+        let source = self.commandCenterSource
+        Task { @MainActor in
+            AnalyticsPlaybackHelper.shared.currentSource = source
+        }
         FileLog.shared.addMessage("Remote control: togglePlayPauseCommand")
         playPause()
     }
@@ -2011,7 +2047,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         commandCenter.pauseCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
             guard let strongSelf = self, let _ = strongSelf.currentEpisode else { return .noActionableNowPlayingItem }
 
-            strongSelf.analyticsPlaybackHelper.currentSource = strongSelf.commandCenterSource
+            let source = strongSelf.commandCenterSource
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.currentSource = source
+            }
 
             FileLog.shared.addMessage("Remote control: pauseCommand")
             strongSelf.pause()
@@ -2022,7 +2061,10 @@ class PlaybackManager: ServerPlaybackDelegate {
         commandCenter.playCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
             guard let strongSelf = self, let _ = strongSelf.currentEpisode else { return .noActionableNowPlayingItem }
 
-            strongSelf.analyticsPlaybackHelper.currentSource = strongSelf.commandCenterSource
+            let source = strongSelf.commandCenterSource
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.currentSource = source
+            }
 
             if Settings.legacyBluetoothModeEnabled() {
                 FileLog.shared.addMessage("Remote control: playCommand, treating as play (Legacy BT Mode is on)")
@@ -2126,7 +2168,10 @@ class PlaybackManager: ServerPlaybackDelegate {
 
                 guard let self, let _ = currentEpisode else { return .noActionableNowPlayingItem }
 
-                analyticsPlaybackHelper.currentSource = commandCenterSource
+                let source = commandCenterSource
+                Task { @MainActor in
+                    AnalyticsPlaybackHelper.shared.currentSource = source
+                }
 
                 if let seekEvent = event as? MPChangePlaybackPositionCommandEvent {
                     if Settings.legacyBluetoothModeEnabled(), seekEvent.positionTime < 1 {
@@ -2170,7 +2215,10 @@ class PlaybackManager: ServerPlaybackDelegate {
             markPlayedCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
                 guard let strongSelf = self, let episode = strongSelf.currentEpisode else { return .noActionableNowPlayingItem }
 
-                AnalyticsEpisodeHelper.shared.currentSource = strongSelf.commandCenterSource
+                let source = strongSelf.commandCenterSource
+                Task { @MainActor in
+                    AnalyticsEpisodeHelper.shared.currentSource = source
+                }
                 EpisodeManager.markAsPlayed(episode: episode, fireNotification: true)
                 return .success
             }
@@ -2230,7 +2278,10 @@ class PlaybackManager: ServerPlaybackDelegate {
                     }
                 }
 
-                self.analyticsPlaybackHelper.currentSource = self.commandCenterSource
+                let source = self.commandCenterSource
+                Task { @MainActor in
+                    AnalyticsPlaybackHelper.shared.currentSource = source
+                }
 
                 if let skipEvent = event as? MPSkipIntervalCommandEvent, skipEvent.interval > 0 {
                     self.skipBack(amount: skipEvent.interval)
@@ -2260,7 +2311,10 @@ class PlaybackManager: ServerPlaybackDelegate {
                     }
                 }
 
-                self.analyticsPlaybackHelper.currentSource = self.commandCenterSource
+                let source = self.commandCenterSource
+                Task { @MainActor in
+                    AnalyticsPlaybackHelper.shared.currentSource = source
+                }
 
                 if let skipEvent = event as? MPSkipIntervalCommandEvent, skipEvent.interval > 0 {
                     self.skipForward(amount: skipEvent.interval)
@@ -2402,10 +2456,14 @@ class PlaybackManager: ServerPlaybackDelegate {
         AnalyticsHelper.didConnectToChromecast()
         if let episode = currentEpisode {
             if playerSwitchRequired() {
-                AnalyticsPlaybackHelper.shared.currentSource = .chromecast
+                Task { @MainActor in
+                    AnalyticsPlaybackHelper.shared.currentSource = .chromecast
+                }
                 pause()
 
-                AnalyticsPlaybackHelper.shared.currentSource = .chromecast
+                Task { @MainActor in
+                    AnalyticsPlaybackHelper.shared.currentSource = .chromecast
+                }
                 load(episode: episode, autoPlay: true, overrideUpNext: false)
             }
         }
@@ -2694,7 +2752,10 @@ extension PlaybackManager {
     // MARK: - Analytics
 
     private func trackChapterSkipped() {
-        analyticsPlaybackHelper.chapterSkipped(properties: chapterManager.chaptersAnalyticsProperties)
+        let properties = chapterManager.chaptersAnalyticsProperties
+        Task { @MainActor in
+            AnalyticsPlaybackHelper.shared.chapterSkipped(properties: properties)
+        }
     }
 
     func trackChapterEvent(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {
@@ -2702,7 +2763,10 @@ extension PlaybackManager {
         if let extraProperties = properties {
             baseProperties = baseProperties.merging(extraProperties, uniquingKeysWith: { current, _ in return current})
         }
-        analyticsPlaybackHelper.track(event, properties: baseProperties)
+        let mergedProperties = baseProperties
+        Task { @MainActor in
+            AnalyticsPlaybackHelper.shared.track(event, properties: mergedProperties)
+        }
     }
 }
 
@@ -2770,7 +2834,7 @@ extension PlaybackManager {
 
         Analytics.track(.bookmarkPlayTapped, source: source)
 
-        analyticsPlaybackHelper.currentSource = .bookmark
+        AnalyticsPlaybackHelper.shared.currentSource = .bookmark
 
         #if !os(watchOS) && !os(tvOS)
         // A bookmark's `referenceTime` sits on the transcript's canonical timeline, which

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -989,8 +989,11 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
         DispatchQueue.global().async {
             DataManager.sharedManager.markAllUnarchivedForPodcast(id: podcast.id)
 
-            AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
-            AnalyticsEpisodeHelper.shared.bulkUnarchiveEpisodes(count: self.episodeCount())
+            let count = self.episodeCount()
+            Task { @MainActor in
+                AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
+                AnalyticsEpisodeHelper.shared.bulkUnarchiveEpisodes(count: count)
+            }
 
             DispatchQueue.main.async { [weak self] in
                 guard let strongSelf = self else { return }
@@ -1015,8 +1018,10 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
                 count += 1
             }
 
-            AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
-            AnalyticsEpisodeHelper.shared.bulkArchiveEpisodes(count: count)
+            Task { @MainActor in
+                AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
+                AnalyticsEpisodeHelper.shared.bulkArchiveEpisodes(count: count)
+            }
 
             DispatchQueue.main.async { [weak self] in
                 guard let strongSelf = self else { return }
@@ -1031,8 +1036,10 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
             guard let self, let allObjects = self.episodeInfo[safe: 1]?.elements, !allObjects.isEmpty else { return }
 
             let episodes = allObjects.compactMap { ($0 as? ListEpisode)?.episode }
-            AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
-            AnalyticsEpisodeHelper.shared.bulkDownloadEpisodes(episodes: episodes)
+            Task { @MainActor in
+                AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
+                AnalyticsEpisodeHelper.shared.bulkDownloadEpisodes(episodes: episodes)
+            }
 
             self.downloadItems(allObjects: allObjects)
         }
@@ -1132,8 +1139,10 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
             DispatchQueue.global().async {
                 guard let self else { return }
 
-                AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
-                AnalyticsEpisodeHelper.shared.bulkDownloadEpisodes(episodes: episodes)
+                Task { @MainActor in
+                    AnalyticsEpisodeHelper.shared.currentSource = .podcastScreen
+                    AnalyticsEpisodeHelper.shared.bulkDownloadEpisodes(episodes: episodes)
+                }
 
                 if later {
                     self.queueItems(allObjects: listEpisodesForSeason)

--- a/podcasts/ServerSyncManager.swift
+++ b/podcasts/ServerSyncManager.swift
@@ -176,7 +176,9 @@ class ServerSyncManager: ServerSyncDelegate {
         if Settings.autoDownloadEnabled() {
             if Settings.autoDownloadMobileDataAllowed() || NetworkUtils.shared.isConnectedToUnexpensiveConnection() {
                 for uuid in uuids {
-                    AnalyticsEpisodeHelper.shared.downloaded(episodeUUID: uuid)
+                    Task { @MainActor in
+                        AnalyticsEpisodeHelper.shared.downloaded(episodeUUID: uuid)
+                    }
                     DownloadManager.shared.addToQueue(episodeUuid: uuid)
                 }
             }

--- a/podcasts/SiriShortcutsManager.swift
+++ b/podcasts/SiriShortcutsManager.swift
@@ -352,7 +352,10 @@ class SiriShortcutsManager: CustomObserver {
     func resumePlayback() -> INPlayMediaIntentResponseCode {
         AnalyticsHelper.siriResume()
         if PlaybackManager.shared.currentEpisode != nil {
-            AnalyticsPlaybackHelper.shared.currentSource = analyticsSource
+            let source = analyticsSource
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.currentSource = source
+            }
             PlaybackManager.shared.play()
             return INPlayMediaIntentResponseCode.success
         }
@@ -361,7 +364,10 @@ class SiriShortcutsManager: CustomObserver {
 
     func pausePlayback() -> INPlayMediaIntentResponseCode {
         AnalyticsHelper.siriPause()
-        AnalyticsPlaybackHelper.shared.currentSource = analyticsSource
+        let source = analyticsSource
+        Task { @MainActor in
+            AnalyticsPlaybackHelper.shared.currentSource = source
+        }
         PlaybackManager.shared.pause()
         return INPlayMediaIntentResponseCode.success
     }
@@ -371,7 +377,10 @@ class SiriShortcutsManager: CustomObserver {
         guard let currentEpisode = PlaybackManager.shared.currentEpisode else {
             return INPlayMediaIntentResponseCode.failureNoUnplayedContent
         }
-        AnalyticsEpisodeHelper.shared.currentSource = analyticsSource
+        let source = analyticsSource
+        Task { @MainActor in
+            AnalyticsEpisodeHelper.shared.currentSource = source
+        }
         EpisodeManager.markAsPlayed(episode: currentEpisode, fireNotification: true)
         return INPlayMediaIntentResponseCode.success
     }
@@ -394,12 +403,18 @@ class SiriShortcutsManager: CustomObserver {
         }
 
         if let episode = DataManager.sharedManager.findEpisode(uuid: episodeInfo.uuid) {
-            AnalyticsPlaybackHelper.shared.currentSource = analyticsSource
+            let source = analyticsSource
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.currentSource = source
+            }
             PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
         } else {
             ServerPodcastManager.shared.addFromUuid(podcastUuid: episodeInfo.podcastUuid, subscribe: false, completion: { [weak self] success in
                 if let episode = DataManager.sharedManager.findEpisode(uuid: episodeInfo.uuid), success {
-                    AnalyticsPlaybackHelper.shared.currentSource = self?.analyticsSource
+                    let source = self?.analyticsSource
+                    Task { @MainActor in
+                        AnalyticsPlaybackHelper.shared.currentSource = source
+                    }
                     PlaybackManager.shared.load(episode: episode, autoPlay: true, overrideUpNext: false)
                 }
             })
@@ -448,7 +463,10 @@ class SiriShortcutsManager: CustomObserver {
 
         let query = PlaylistQueryBuilder.queryFor(filter: filter, episodeUuidToAdd: filter.episodeUuidToAddToQueries(), limit: 1)
         if let topEpisode = DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: nil).first {
-            AnalyticsPlaybackHelper.shared.currentSource = analyticsSource
+            let source = analyticsSource
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.currentSource = source
+            }
             PlaybackManager.shared.load(episode: topEpisode, autoPlay: true, overrideUpNext: false)
             return INPlayMediaIntentResponseCode.success
         } else {
@@ -476,7 +494,10 @@ class SiriShortcutsManager: CustomObserver {
         let sortStr = PodcastEpisodeSortOrder.newestToOldest == episodeSortOrder ? "DESC" : "ASC"
         let query = "podcast_id = \(podcast.id) AND playingStatus <> \(PlayingStatus.completed.rawValue) AND archived = 0 ORDER BY publishedDate \(sortStr), addedDate \(sortStr) LIMIT 1"
         if let topEpisode = DataManager.sharedManager.findEpisodesWhere(customWhere: query, arguments: nil).first {
-            AnalyticsPlaybackHelper.shared.currentSource = analyticsSource
+            let source = analyticsSource
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.currentSource = source
+            }
             PlaybackManager.shared.load(episode: topEpisode, autoPlay: true, overrideUpNext: false)
             return INPlayMediaIntentResponseCode.success
         } else {

--- a/podcasts/UserEpisodeManager.swift
+++ b/podcasts/UserEpisodeManager.swift
@@ -87,7 +87,9 @@ struct UserEpisodeManager {
         })
 
         #if !os(watchOS) && !os(tvOS)
-            AnalyticsEpisodeHelper.shared.episodeDeletedFromCloud(episode: episode)
+            Task { @MainActor in
+                AnalyticsEpisodeHelper.shared.episodeDeletedFromCloud(episode: episode)
+            }
         #endif
     }
 

--- a/podcasts/Watch Communication/WatchManager.swift
+++ b/podcasts/Watch Communication/WatchManager.swift
@@ -143,19 +143,23 @@ class WatchManager: NSObject, WCSessionDelegate {
                 handlePlayRequest(episodeUuid: episodeUuid, playlist: playlist)
             }
         } else if WatchConstants.Messages.PlayPauseRequest.type == messageType {
-            AnalyticsPlaybackHelper.shared.currentSource = .watch
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.currentSource = .watch
+            }
             if PlaybackManager.shared.isPlaying {
                 PlaybackManager.shared.pause()
             } else {
                 PlaybackManager.shared.play()
             }
         } else if WatchConstants.Messages.SkipBackRequest.type == messageType {
-            AnalyticsPlaybackHelper.shared.currentSource = .watch
-            DispatchQueue.main.async {
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.currentSource = .watch
                 PlaybackManager.shared.skipBack()
             }
         } else if WatchConstants.Messages.SkipForwardRequest.type == messageType {
-            AnalyticsPlaybackHelper.shared.currentSource = .watch
+            Task { @MainActor in
+                AnalyticsPlaybackHelper.shared.currentSource = .watch
+            }
             PlaybackManager.shared.skipForward()
         } else if WatchConstants.Messages.StarRequest.type == messageType {
             if let starred = payload[WatchConstants.Messages.StarRequest.star] as? Bool, let uuid = payload[WatchConstants.Messages.StarRequest.episodeUuid] as? String {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Marks `AnalyticsSourceProvider` and `AnalyticsCoordinator` (and therefore `AnalyticsEpisodeHelper` / `AnalyticsPlaybackHelper`) as `@MainActor`.

`track()` used to check `Thread.isMainThread` and re-dispatch itself with `DispatchQueue.main.async`. That check is gone — the isolation now guarantees it. It also fixes a real bug: only `track()` hopped, so the surrounding `currentSource` bookkeeping ran inline on the caller's thread, and `currentAnalyticsSource` would reach `SceneHelper.rootViewController()` and `UIApplication.shared.applicationState` off the main thread.

### ⚠️ The `Task { @MainActor in … }` hops are temporary

**Draft** because the hops added at non-isolated call sites are scaffolding, not the destination. They exist only so this can land ahead of the callers, and they should disappear one by one as `PlaybackManager`, `EpisodeManager`, `SiriShortcutsManager`, `DownloadManager` and friends become main-actor isolated themselves — continuing the incremental top-down adoption from #4953. Once a caller is isolated, its hop collapses into a plain synchronous call, which is what most of the analytics call sites in this diff already look like.

Reviewing the hops as permanent API would be reading them wrong; the thing to check here is the isolation of the two analytics types and that no call site changed meaning.

All 110 call sites were checked. The ones already on the main actor (view controllers, `MultiSelectHelper`, `PlaybackActionHelper`, `PlaybackManager.playBookmark`, the tvOS SwiftUI views) call through synchronously with no hop at all. The genuinely non-isolated ones got an explicit `Task { @MainActor in … }`: `PlaybackManager`, `EpisodeManager`, `SiriShortcutsManager`, `ServerSyncManager`, `DownloadManager`, `GoogleCastManager`, `WatchManager`, `UserEpisodeManager`, and four `DispatchQueue.global()` blocks in `PodcastViewController`. Ordering within each call chain is preserved because the hops are enqueued in source order — which matters for the set-`currentSource`-then-track and `ignoreNextSeek` patterns.

Other notes:

- On tvOS, `SearchAnalytics.episodeTapped`, `AppCoordinator.remotePlayPauseToggle`, `PlayerStatusObserver.updatePlayState` and the `SearchableViewModel.playEpisode` requirement were annotated `@MainActor` instead of hopping — their callers are all main-actor already.
- `OnboardingFlow`'s `AnalyticsSourceProvider` conformance moved to an extension so the struct itself doesn't inherit `@MainActor` (it's reached from the non-isolated `IAPHelper`).
- The pure HLS property builders on `AnalyticsPlaybackHelper` are `nonisolated` — they only read a feature flag, the episode and `PlaybackManager.shared`, so non-isolated callers and the tests don't need a hop.
- `AnalyticsEpisodeHelper`'s `ThreadSafeDictionary` is now a plain dictionary, and its two notification observer bodies were extracted into named methods.
- `PlaybackManager.playbackDidFail` saves/overrides/restores `currentSource` around `pause(userInitiated: false)`. I kept it faithful rather than move `pause()` into the hop, since `cleanupCurrentPlayer` below depends on the pause having run. Worth flagging that this block is inert today: it was written in 5064b7142 when the call was `pause()`, and `userInitiated: false` now suppresses the very event it was meant to attribute. Happy to remove it in a follow-up.

## To test

1. Build and run — no functional change is expected anywhere.
2. Start playing an episode, then pause, skip back and skip forward from the full player. Confirm `playback_play` / `playback_pause` / `playback_skip_back` / `playback_skip_forward` are logged with `source: player`.
3. Do the same from the mini player, lock screen and CarPlay, and confirm the `source` matches the surface you used rather than falling back to `unknown`.
4. Scrub the player and confirm a `playback_seek` fires, and that skipping back/forward does *not* additionally fire one.
5. Download an episode from the podcast screen, then let it finish. Confirm `episode_download_queued` and `episode_download_finished` both report `source: podcast_screen`.
6. Multi-select several episodes in a filter and archive/star/mark as played. Confirm the bulk events report `source: filters`.
7. On the podcast screen use Download All / Archive All / Unarchive All (these run on a background queue) and confirm the bulk events still report `source: podcast_screen`.
8. Ask Siri to pause/resume playback and confirm the events report `source: siri`.
9. Play/pause from the Apple Watch and confirm `source: watch`.
10. tvOS: play an episode from search and confirm `search_result_tapped` plus `playback_play` with `source: search`.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
