### PR TITLE
Cover the fingerprint pipeline end to end

### DIFF
--- a/PocketCastsTests/Tests/Fingerprint/FingerprintFixtures.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintFixtures.swift
@@ -1,0 +1,258 @@
+import AVFoundation
+import Fingerprint
+import Foundation
+
+@testable import podcasts
+
+/// The two on-disk inputs a fingerprint run needs: an audio file, and a reference
+/// fingerprint built from that same audio the way the server builds one from the
+/// publisher's copy of the episode.
+enum FingerprintFixtures {
+
+    static let defaultSampleRate: Double = 44100
+
+    /// The reference grid `makeReference` fingerprints on, matching the shape of a
+    /// server-generated reference: a checkpoint every 2 s, each covering 8 s.
+    static let checkpointIntervalSeconds = 2
+    static let checkpointDurationSeconds = 8
+
+    enum FixtureError: Error {
+        case bufferAllocationFailed
+        case openForWritingFailed(String)
+        case openForReadingFailed(String)
+        case readFailed(String)
+    }
+
+    static let contentSeed: UInt64 = 0xF1_9E_2B_71
+    static let adSeed: UInt64 = 0x2C_0F_FE_E1
+
+    // MARK: - Audio
+
+    /// `seconds` of deterministic mono audio.
+    ///
+    /// Every 250 ms the tones change, drawn from a seeded generator, so no two
+    /// moments share a spectrum — the property a fingerprint relies on to tie a
+    /// window to one point on the timeline. A little broadband noise underneath
+    /// keeps the spectrum from being three bare spikes.
+    ///
+    /// A pure function of `(seed, frame index)`, so a slice of one episode's audio
+    /// is sample-identical to the same slice of another built from the same seed —
+    /// which is what lets a fixture splice an ad into the middle of an episode and
+    /// still expect an exact match either side of it.
+    static func samples(
+        seconds: Double,
+        seed: UInt64 = contentSeed,
+        sampleRate: Double = defaultSampleRate
+    ) -> [Float] {
+        // Two octaves of semitones from A3 up, so consecutive segments are always
+        // clearly distinguishable in the spectrum.
+        let scale = (0..<24).map { 220.0 * pow(2.0, Double($0) / 12.0) }
+        var random = SeededGenerator(seed: seed)
+
+        let totalFrames = frameCount(forSeconds: seconds, sampleRate: sampleRate)
+        let segmentFrames = frameCount(forSeconds: 0.25, sampleRate: sampleRate)
+        var samples = [Float](repeating: 0, count: totalFrames)
+
+        var index = 0
+        while index < totalFrames {
+            let tones = (0..<3).map { _ in scale[random.nextIndex(upperBound: scale.count)] }
+            for frame in index..<min(index + segmentFrames, totalFrames) {
+                let time = Double(frame) / sampleRate
+                var value = 0.0
+                for tone in tones {
+                    value += sin(2 * .pi * tone * time)
+                }
+                samples[frame] = Float(value * 0.25 + (random.nextUnit() - 0.5) * 0.04)
+            }
+            index += segmentFrames
+        }
+        return samples
+    }
+
+    static func frameCount(forSeconds seconds: Double, sampleRate: Double = defaultSampleRate) -> Int {
+        Int(seconds * sampleRate)
+    }
+
+    /// Generates and writes `seconds` of audio in one step.
+    static func writeAudio(
+        seconds: Double,
+        seed: UInt64 = contentSeed,
+        sampleRate: Double = defaultSampleRate,
+        to url: URL
+    ) throws {
+        try writeAudio(
+            samples(seconds: seconds, seed: seed, sampleRate: sampleRate),
+            sampleRate: sampleRate,
+            to: url
+        )
+    }
+
+    static func writeAudio(_ samples: [Float], sampleRate: Double = defaultSampleRate, to url: URL) throws {
+        // The file is only closed (and its header finalized) when the last
+        // reference to it goes away, so it stays scoped to this pool — the
+        // caller's next move is to open the same path for reading.
+        try autoreleasepool {
+            try write(samples, sampleRate: sampleRate, to: url)
+        }
+    }
+
+    private static func write(_ samples: [Float], sampleRate: Double, to url: URL) throws {
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVSampleRateKey: sampleRate,
+            AVNumberOfChannelsKey: 1,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsNonInterleaved: false
+        ]
+        let file: AVAudioFile
+        do {
+            file = try AVAudioFile(forWriting: url, settings: settings)
+        } catch {
+            throw FixtureError.openForWritingFailed("\(error)")
+        }
+        let format = file.processingFormat
+
+        let chunkFrames = AVAudioFrameCount(sampleRate)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
+            throw FixtureError.bufferAllocationFailed
+        }
+
+        var written = 0
+        while written < samples.count {
+            let frames = min(Int(chunkFrames), samples.count - written)
+            buffer.frameLength = AVAudioFrameCount(frames)
+            guard let channel = buffer.floatChannelData?[0] else { throw FixtureError.bufferAllocationFailed }
+            for frame in 0..<frames {
+                channel[frame] = samples[written + frame]
+            }
+            try file.write(from: buffer)
+            written += frames
+        }
+    }
+
+    /// A reference whose checkpoint list is empty — a well-formed payload the
+    /// matcher can't build anything from.
+    static func referenceWithoutCheckpoints(totalDuration: Double) throws -> Data {
+        let json: [String: Any] = [
+            "format": ReferenceFingerprint.supportedFormat,
+            "total_duration": totalDuration,
+            "checkpoint_interval": checkpointIntervalSeconds,
+            "checkpoint_duration": checkpointDurationSeconds,
+            "timestamp_quantum": 1,
+            "checkpoints": []
+        ]
+        return try JSONSerialization.data(withJSONObject: json)
+    }
+
+    // MARK: - Reference fingerprint
+
+    /// Fingerprints `url` on a checkpoint grid and encodes the result as the
+    /// compact-v2 JSON the app downloads from the server, so a run against this
+    /// audio should map every window onto its own timestamp.
+    static func makeReference(
+        forAudioAt url: URL,
+        checkpointIntervalSeconds: Int = checkpointIntervalSeconds,
+        checkpointDurationSeconds: Int = checkpointDurationSeconds
+    ) throws -> Data {
+        let file: AVAudioFile
+        do {
+            file = try AVAudioFile(forReading: url, commonFormat: .pcmFormatFloat32, interleaved: false)
+        } catch {
+            throw FixtureError.openForReadingFailed("\(error)")
+        }
+        let format = file.processingFormat
+        let windowDurationMs = UInt32(checkpointDurationSeconds * 1000)
+
+        let fingerprinter = StreamingWindowedFingerprinter(
+            sampleRate: UInt32(format.sampleRate),
+            channels: UInt16(format.channelCount),
+            windowDurationMs: windowDurationMs,
+            windowIntervalMs: UInt32(checkpointIntervalSeconds * 1000)
+        )
+
+        let chunkFrames = AVAudioFrameCount(format.sampleRate * 5)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: chunkFrames) else {
+            throw FixtureError.bufferAllocationFailed
+        }
+
+        var windows: [WindowedFingerprint] = []
+        // Bounded by `length` rather than by a zero-length read: `read` throws at
+        // EOF instead of returning no frames.
+        while file.framePosition < file.length {
+            do {
+                try file.read(into: buffer, frameCount: chunkFrames)
+            } catch {
+                throw FixtureError.readFailed("\(error)")
+            }
+            if buffer.frameLength == 0 { break }
+            guard let channel = buffer.floatChannelData?[0] else { break }
+            let samples = Array(UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength)))
+            windows += fingerprinter.pushSamplesF32(samples: samples, channels: UInt16(format.channelCount))
+        }
+        windows += fingerprinter.flush()
+
+        // A trailing partial window covers less audio than the grid promises, so
+        // it would anchor a matching window to the wrong reference time.
+        windows = windows.filter { $0.durationMs == windowDurationMs }
+
+        var checkpoints: [[Any]] = []
+        var previousSecond = 0
+        for window in windows {
+            let second = Int(window.timestampMs) / 1000
+            guard checkpoints.isEmpty || second > previousSecond else { continue }
+            checkpoints.append([second - previousSecond, base64(hashes: window.hashes)])
+            previousSecond = second
+        }
+
+        let json: [String: Any] = [
+            "format": ReferenceFingerprint.supportedFormat,
+            "total_duration": Double(file.length) / format.sampleRate,
+            "checkpoint_interval": checkpointIntervalSeconds,
+            "checkpoint_duration": checkpointDurationSeconds,
+            "timestamp_quantum": 1,
+            "checkpoints": checkpoints
+        ]
+        return try JSONSerialization.data(withJSONObject: json)
+    }
+
+    /// Little-endian `UInt32` packing, the inverse of `ReferenceFingerprint.libraryCheckpoints()`.
+    private static func base64(hashes: [UInt32]) -> String {
+        var payload = Data(capacity: hashes.count * 4)
+        for hash in hashes {
+            payload.append(UInt8(truncatingIfNeeded: hash))
+            payload.append(UInt8(truncatingIfNeeded: hash >> 8))
+            payload.append(UInt8(truncatingIfNeeded: hash >> 16))
+            payload.append(UInt8(truncatingIfNeeded: hash >> 24))
+        }
+        return payload.base64EncodedString()
+    }
+}
+
+/// SplitMix64 — the fixtures need to be byte-identical from run to run, which
+/// rules out `SystemRandomNumberGenerator`.
+private struct SeededGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z >> 31)
+    }
+
+    mutating func nextIndex(upperBound: Int) -> Int {
+        Int(next() % UInt64(upperBound))
+    }
+
+    /// A value in `0..<1`.
+    mutating func nextUnit() -> Double {
+        Double(next() >> 11) * (1.0 / 9_007_199_254_740_992.0)
+    }
+}

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintPreparationTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintPreparationTests.swift
@@ -1,0 +1,314 @@
+import XCTest
+
+@testable import PocketCastsUtils
+@testable import podcasts
+
+/// End-to-end coverage of preparation: a reference fingerprint on disk, a real
+/// decode of a real audio file, the real matcher, and the real drift filter. Only
+/// the episode's audio and its reference are synthesized — and the reference is
+/// built from that same audio, so a correct run maps every anchor onto its own
+/// timestamp and any drift shows up as an assertion failure.
+@MainActor
+final class FingerprintPreparationTests: XCTestCase {
+
+    /// Long enough to commit anchors across the whole file: the first window can't
+    /// be emitted until 8 s of audio have been decoded, and the drift filter needs
+    /// three consecutive in-trend candidates before it commits anything.
+    private static let episodeDuration: Double = 45
+
+    /// The dynamic-ad fixture: a 10 s ad spliced 20 s into a 45 s episode.
+    private static let contentDuration: Double = 45
+    private static let adStart: Double = 20
+    private static let adDuration: Double = 10
+    private static var adEnd: Double { adStart + adDuration }
+
+    private let featureFlags = FeatureFlagMock()
+    private var manager: FingerprintTimingManager!
+    private var fixture: FingerprintEpisodeFixture!
+    private var currentEpisode: CurrentEpisodeOverride!
+    /// Scratch space for a publisher's copy of an episode — audio the listener
+    /// never has, which only exists to be fingerprinted into a reference.
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        featureFlags.set(.syncedTranscripts, value: true)
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("FingerprintPreparationTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        manager?.stop()
+        manager = nil
+        currentEpisode?.restore()
+        currentEpisode = nil
+        fixture?.removeFiles()
+        fixture = nil
+        try? FileManager.default.removeItem(at: directory)
+        directory = nil
+        featureFlags.reset()
+        super.tearDown()
+    }
+
+    func testPreparationMapsDownloadedEpisodeOntoItsReference() async throws {
+        try prepareFixture(duration: Self.episodeDuration) { fixture in
+            try fixture.writeAudio(seconds: Self.episodeDuration)
+            try fixture.writeReference()
+        }
+
+        manager.prepareForCurrentEpisode()
+        await waitForPass(manager)
+
+        guard case .active(let coverage) = manager.state else {
+            XCTFail("expected .active after a full pass, got \(manager.state)")
+            return
+        }
+
+        let entries = manager.debugMappingSnapshot()
+        XCTAssertEqual(coverage, entries.count)
+        // Windows are emitted every second but the reference's checkpoints sit every
+        // two, so the off-grid windows straddle a pair and are dropped by the
+        // dominance gate. What's left is one anchor per checkpoint — 19 of them in a
+        // 45 s file, allowing a few to fall out at the edges.
+        XCTAssertGreaterThanOrEqual(entries.count, 15)
+
+        // The reference was built from this exact audio, so an anchor with a
+        // checkpoint at its own timestamp should map onto itself. A window that
+        // matched a neighbouring checkpoint instead would still pass the drift
+        // filter (rate 1, just offset), and would show up here. The last window
+        // starts within a window's length of the end, where the checkpoint grid has
+        // run out — nothing exact is left for it, so it settles for the nearest.
+        let gridEnd = Self.episodeDuration - Double(FingerprintFixtures.checkpointDurationSeconds)
+        for entry in entries {
+            XCTAssertEqual(
+                entry.referenceTime,
+                entry.playbackTime,
+                accuracy: entry.playbackTime < gridEnd ? 0.001 : Double(FingerprintFixtures.checkpointIntervalSeconds),
+                "anchor at playback \(entry.playbackTime)s mapped to reference \(entry.referenceTime)s"
+            )
+            XCTAssertGreaterThanOrEqual(entry.score, FingerprintConstants.driftAnchorScoreThreshold)
+        }
+
+        // Coverage reaches both ends of the file, not just the region around the
+        // first few chunks.
+        XCTAssertLessThanOrEqual(try XCTUnwrap(entries.first).playbackTime, 4)
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(entries.last).playbackTime, gridEnd - 4)
+
+        // The committed mapping is kept sorted as it grows, not just at the end.
+        XCTAssertEqual(entries.map(\.playbackTime), entries.map(\.playbackTime).sorted())
+
+        // What the transcript UI actually calls: mid-episode is matched content,
+        // and both directions agree there.
+        let midpoint = Self.episodeDuration / 2
+        XCTAssertTrue(manager.isWithinMatchedContent(forPlaybackTime: midpoint))
+        XCTAssertEqual(try XCTUnwrap(manager.matchedReferenceTime(forPlaybackTime: midpoint)), midpoint, accuracy: 0.5)
+        XCTAssertEqual(try XCTUnwrap(manager.playbackTime(forReferenceTime: midpoint)), midpoint, accuracy: 0.5)
+    }
+
+    /// The case the whole subsystem exists for: this listener's copy has a dynamic
+    /// ad the reference doesn't, so everything after it sits later in the audio than
+    /// the transcript says. The mapping has to absorb that shift, and highlighting
+    /// has to switch off while the ad plays.
+    func testPreparationAbsorbsADynamicAdInsertedIntoTheEpisode() async throws {
+        let content = FingerprintFixtures.samples(seconds: Self.contentDuration)
+        let ad = FingerprintFixtures.samples(seconds: Self.adDuration, seed: FingerprintFixtures.adSeed)
+        let breakpoint = FingerprintFixtures.frameCount(forSeconds: Self.adStart)
+
+        try prepareFixture(duration: Self.contentDuration + Self.adDuration) { fixture in
+            // The reference is the publisher's copy — content only, no ad.
+            let referenceAudioURL = self.directory.appendingPathComponent("reference-episode.wav")
+            try FingerprintFixtures.writeAudio(content, to: referenceAudioURL)
+            try fixture.writeReference(forAudioAt: referenceAudioURL)
+
+            // This listener's copy — the same content with the ad spliced in.
+            try fixture.writeAudio(Array(content[0..<breakpoint]) + ad + Array(content[breakpoint...]))
+        }
+
+        manager.prepareForCurrentEpisode()
+        await waitForPass(manager)
+
+        XCTAssertEqual(manager.state.analyticsName, "active")
+        let entries = manager.debugMappingSnapshot()
+        XCTAssertFalse(entries.isEmpty)
+
+        // Every anchor sits either before the ad (no shift yet) or after it (shifted
+        // by the ad's whole length). Anything in between never anchors: those windows
+        // straddle the splice and match nothing.
+        let gridEnd = Self.contentDuration - Double(FingerprintFixtures.checkpointDurationSeconds)
+        for entry in entries {
+            let shift = entry.playbackTime < Self.adStart ? 0 : Self.adDuration
+            let expected = entry.playbackTime - shift
+            XCTAssertEqual(
+                entry.referenceTime,
+                expected,
+                accuracy: expected < gridEnd ? 0.001 : Double(FingerprintFixtures.checkpointIntervalSeconds),
+                "anchor at playback \(entry.playbackTime)s mapped to reference \(entry.referenceTime)s"
+            )
+        }
+        XCTAssertTrue(entries.contains { $0.playbackTime < Self.adStart }, "nothing anchored before the ad")
+        XCTAssertTrue(entries.contains { $0.playbackTime > Self.adEnd }, "nothing anchored after the ad")
+
+        // A transcript cue 25 s into the reference is 35 s into this listener's audio.
+        XCTAssertEqual(try XCTUnwrap(manager.playbackTime(forReferenceTime: 25)), 35, accuracy: 0.5)
+        XCTAssertEqual(try XCTUnwrap(manager.referenceTime(forPlaybackTime: 35)), 25, accuracy: 0.5)
+
+        // Highlighting follows content either side of the ad and stops during it,
+        // with no ad detection anywhere in the pipeline.
+        XCTAssertTrue(manager.isWithinMatchedContent(forPlaybackTime: 8))
+        XCTAssertTrue(manager.isWithinMatchedContent(forPlaybackTime: 38))
+        XCTAssertFalse(manager.isWithinMatchedContent(forPlaybackTime: Self.adStart + Self.adDuration / 2))
+        XCTAssertNil(manager.matchedReferenceTime(forPlaybackTime: Self.adStart + Self.adDuration / 2))
+    }
+
+    /// A pass over audio that isn't the reference's episode has to end with nothing
+    /// committed — a confident-looking mapping built out of correlated noise is
+    /// worse than no transcript sync at all.
+    func testPreparationCommitsNothingWhenTheAudioDoesNotMatchTheReference() async throws {
+        try prepareFixture(duration: Self.episodeDuration) { fixture in
+            try fixture.writeAudio(seconds: Self.episodeDuration)
+
+            // A reference built from a different episode entirely.
+            let otherAudioURL = self.directory.appendingPathComponent("other-episode.wav")
+            try FingerprintFixtures.writeAudio(
+                seconds: Self.episodeDuration,
+                seed: FingerprintFixtures.adSeed,
+                to: otherAudioURL
+            )
+            try fixture.writeReference(forAudioAt: otherAudioURL)
+        }
+
+        manager.prepareForCurrentEpisode()
+        await waitForPass(manager)
+
+        XCTAssertTrue(manager.debugMappingSnapshot().isEmpty)
+        // The terminal state isn't asserted: `AVAudioFile.read` throws at EOF rather
+        // than returning no frames, so a pass that reaches the end of the file
+        // currently lands in `.failed` instead of `.unavailable`. What matters
+        // either way is that nothing was committed.
+        XCTAssertNotEqual(manager.state.analyticsName, "active")
+        XCTAssertNil(manager.referenceTime(forPlaybackTime: Self.episodeDuration / 2))
+    }
+
+    /// Re-opening a transcript for an episode already fingerprinted once should cost
+    /// nothing: the mapping is read back off disk and no audio is decoded at all.
+    func testPreparationLoadsAPersistedMappingCacheInsteadOfDecoding() async throws {
+        // Short: nothing here is decoded, and the cache is validated against the
+        // audio file's size, mtime and leading bytes rather than its contents.
+        let duration: Double = 20
+        try prepareFixture(duration: duration) { fixture in
+            try fixture.writeAudio(seconds: duration, sampleRate: 16000)
+            try fixture.writeReference()
+        }
+
+        // The cache is all-or-nothing: it's only loaded when it covers the whole
+        // reference timeline for this exact pair of files.
+        let cached = stride(from: 0.0, through: duration - 0.5, by: 0.5).map {
+            FingerprintTimingManager.TimeMappingEntry(playbackTime: $0, referenceTime: $0, score: 1)
+        }
+        FingerprintMappingCache.save(
+            cached,
+            audioFilePath: fixture.audioURL.path,
+            referenceFilePath: fixture.referenceURL.path,
+            referenceData: try Data(contentsOf: fixture.referenceURL),
+            referenceDuration: duration
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: fixture.mappingCachePath),
+            "the cache under test was never written"
+        )
+
+        manager.prepareForCurrentEpisode()
+
+        await waitUntil("the cached mapping to be loaded") { self.manager.state.analyticsName == "active" }
+        XCTAssertEqual(manager.debugMappingSnapshot().map(\.playbackTime), cached.map(\.playbackTime))
+        XCTAssertEqual(manager.debugMappingSnapshot().map(\.referenceTime), cached.map(\.referenceTime))
+
+        // A pass that decoded instead would keep committing anchors of its own
+        // after this point, and it would have had to pass through `.preparing`.
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+        XCTAssertEqual(manager.state.analyticsName, "active")
+        XCTAssertEqual(manager.debugMappingSnapshot().count, cached.count)
+    }
+
+    /// Closing the transcript has to leave nothing running and nothing mapped — the
+    /// next episode starts from a clean manager.
+    func testStopCancelsThePassAndClearsTheMapping() async throws {
+        try prepareFixture(duration: Self.episodeDuration) { fixture in
+            try fixture.writeAudio(seconds: Self.episodeDuration)
+            try fixture.writeReference()
+        }
+
+        manager.prepareForCurrentEpisode()
+        await waitUntil("the pass to commit its first anchors") { !self.manager.debugMappingSnapshot().isEmpty }
+
+        manager.stop()
+
+        await waitUntil("the manager to return to idle") { self.manager.state.analyticsName == "idle" }
+        XCTAssertTrue(manager.debugMappingSnapshot().isEmpty)
+
+        // The pass was cancelled rather than left running: nothing it commits after
+        // this point can reach the mapping.
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+        XCTAssertTrue(manager.debugMappingSnapshot().isEmpty)
+        XCTAssertEqual(manager.state.analyticsName, "idle")
+    }
+
+    /// An episode whose duration the database doesn't know yet can't be windowed at
+    /// all, so preparation stops before it starts decoding.
+    func testPreparationIsUnavailableWhenTheEpisodeHasNoDuration() async throws {
+        try prepareFixture(duration: 0) { fixture in
+            try fixture.writeReference(
+                data: FingerprintFixtures.referenceWithoutCheckpoints(totalDuration: Self.episodeDuration)
+            )
+        }
+
+        manager.prepareForCurrentEpisode()
+
+        await waitUntil("preparation to report unavailable") { self.manager.state.analyticsName == "unavailable" }
+        XCTAssertTrue(manager.debugMappingSnapshot().isEmpty)
+    }
+
+    /// A reference that decodes but yields nothing to match against is as good as no
+    /// reference at all.
+    func testPreparationIsUnavailableWhenTheReferenceHasNoCheckpoints() async throws {
+        try prepareFixture(duration: Self.episodeDuration) { fixture in
+            try fixture.writeReference(
+                data: FingerprintFixtures.referenceWithoutCheckpoints(totalDuration: Self.episodeDuration)
+            )
+        }
+
+        manager.prepareForCurrentEpisode()
+
+        await waitUntil("preparation to report unavailable") { self.manager.state.analyticsName == "unavailable" }
+        XCTAssertTrue(manager.debugMappingSnapshot().isEmpty)
+    }
+
+    /// The entry point's first guard — with the flag off nothing is read, fetched
+    /// or decoded.
+    func testPrepareForCurrentEpisodeIsUnavailableWhenTheFeatureFlagIsOff() async throws {
+        featureFlags.set(.syncedTranscripts, value: false)
+        try prepareFixture(duration: Self.episodeDuration) { fixture in
+            try fixture.writeAudio(seconds: Self.episodeDuration)
+            try fixture.writeReference()
+        }
+
+        manager.prepareForCurrentEpisode()
+
+        await waitUntil("preparation to report unavailable") { self.manager.state.analyticsName == "unavailable" }
+        XCTAssertTrue(manager.debugMappingSnapshot().isEmpty)
+    }
+
+    /// Puts an episode's files where the manager looks for them, makes it the
+    /// episode preparation will pick up, and hands back a fresh manager.
+    private func prepareFixture(
+        duration: Double,
+        writeFiles: (FingerprintEpisodeFixture) throws -> Void
+    ) throws {
+        let fixture = FingerprintEpisodeFixture(duration: duration)
+        try writeFiles(fixture)
+        self.fixture = fixture
+        currentEpisode = CurrentEpisodeOverride(episode: fixture.episode)
+        manager = FingerprintTimingManager()
+    }
+}

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintResolveTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintResolveTests.swift
@@ -1,0 +1,159 @@
+import XCTest
+
+@testable import PocketCastsDataModel
+@testable import podcasts
+
+/// The one-shot resolves — a tapped chapter and a played bookmark — against an
+/// episode whose audio carries a dynamic ad the reference doesn't. Both run the
+/// real bounded decode and matcher; only the audio and its reference are
+/// synthesized.
+@MainActor
+final class FingerprintResolveTests: XCTestCase {
+
+    private static let contentDuration: Double = 45
+    private static let adStart: Double = 20
+    private static let adDuration: Double = 10
+    /// Everything here is below 1 kHz, so a lower rate costs the matcher nothing
+    /// and keeps each resolve well inside its timeout.
+    private static let sampleRate: Double = 16000
+
+    /// A cue this far into the reference sits `adDuration` later in the listener's
+    /// audio, because the ad has already played by then.
+    private static let referenceCue: Double = 30
+    private static var playbackCue: Double { referenceCue + adDuration }
+
+    private var directory: URL!
+    private var fixture: FingerprintEpisodeFixture!
+    private var extraFixtures: [FingerprintEpisodeFixture] = []
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("FingerprintResolveTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let content = FingerprintFixtures.samples(seconds: Self.contentDuration, sampleRate: Self.sampleRate)
+        let ad = FingerprintFixtures.samples(
+            seconds: Self.adDuration,
+            seed: FingerprintFixtures.adSeed,
+            sampleRate: Self.sampleRate
+        )
+        let breakpoint = FingerprintFixtures.frameCount(forSeconds: Self.adStart, sampleRate: Self.sampleRate)
+
+        fixture = FingerprintEpisodeFixture(duration: Self.contentDuration + Self.adDuration)
+
+        // The reference is the publisher's copy — content only, no ad.
+        let referenceAudioURL = directory.appendingPathComponent("reference-episode.wav")
+        try FingerprintFixtures.writeAudio(content, sampleRate: Self.sampleRate, to: referenceAudioURL)
+        try fixture.writeReference(forAudioAt: referenceAudioURL)
+
+        // This listener's copy — the same content with the ad spliced in.
+        try fixture.writeAudio(
+            Array(content[0..<breakpoint]) + ad + Array(content[breakpoint...]),
+            sampleRate: Self.sampleRate
+        )
+    }
+
+    override func tearDown() {
+        fixture?.removeFiles()
+        fixture = nil
+        extraFixtures.forEach { $0.removeFiles() }
+        extraFixtures = []
+        try? FileManager.default.removeItem(at: directory)
+        directory = nil
+        super.tearDown()
+    }
+
+    /// Tapping a generated chapter: the chapter's time is on the reference
+    /// timeline, and seeking there directly would land the listener before the
+    /// content they asked for by the length of the ad.
+    func testChapterResolveFindsTheAdShiftedPlaybackTime() async throws {
+        let manager = FingerprintTimingManager()
+
+        let result = await resolveChapter(manager, referenceTime: Self.referenceCue, episode: fixture.episode)
+
+        guard case .resolved(let playbackTime, let usedPrior, let isStreaming, _) = result else {
+            XCTFail("expected a resolved chapter seek, got \(result)")
+            return
+        }
+        XCTAssertEqual(playbackTime, Self.playbackCue, accuracy: 0.5)
+        // Cold path: no continuous mapping exists to warm-start from.
+        XCTAssertFalse(usedPrior)
+        XCTAssertFalse(isStreaming)
+
+        // A one-shot resolve matches into its own scratch mapping. Nothing the
+        // transcript highlighter reads may have moved.
+        XCTAssertTrue(manager.debugMappingSnapshot().isEmpty)
+        XCTAssertEqual(manager.state.analyticsName, "idle")
+    }
+
+    /// The bookmark variant of the same resolve. It differs only in waiting for a
+    /// streaming buffer, which a downloaded episode skips.
+    func testBookmarkSeekResolveFindsTheAdShiftedPlaybackTime() async throws {
+        let manager = FingerprintTimingManager()
+
+        let result = await manager.resolveBookmarkPlaybackTime(
+            forReferenceTime: Self.referenceCue,
+            episode: fixture.episode
+        )
+
+        guard case .resolved(let playbackTime, _, _, _) = result else {
+            XCTFail("expected a resolved bookmark seek, got \(result)")
+            return
+        }
+        XCTAssertEqual(playbackTime, Self.playbackCue, accuracy: 0.5)
+    }
+
+    /// The opposite direction: a bookmark is stored at a position in this
+    /// listener's audio, and reading the transcript at that moment needs the
+    /// reference time it corresponds to.
+    func testBookmarkReferenceResolveMapsPlaybackBackOntoTheReference() async throws {
+        let manager = FingerprintTimingManager()
+
+        let referenceTime = await manager.resolveReferenceTime(
+            forPlaybackTime: Self.playbackCue,
+            episode: fixture.episode
+        )
+
+        XCTAssertEqual(try XCTUnwrap(referenceTime), Self.referenceCue, accuracy: 0.5)
+        XCTAssertTrue(manager.debugMappingSnapshot().isEmpty)
+    }
+
+    /// A resolve against audio that isn't the reference's episode reports that it
+    /// found nothing, rather than a confident wrong answer the player would seek to.
+    func testChapterResolveReportsNoMatchForUnrelatedAudio() async throws {
+        let unrelated = FingerprintEpisodeFixture(duration: Self.contentDuration)
+        extraFixtures.append(unrelated)
+        try unrelated.writeAudio(
+            seconds: Self.contentDuration,
+            seed: 0xAB_CD_EF_01,
+            sampleRate: Self.sampleRate
+        )
+        // Same reference, different audio: the episode the listener has isn't the
+        // one the reference was built from.
+        try unrelated.writeReference(data: Data(contentsOf: fixture.referenceURL))
+
+        let manager = FingerprintTimingManager()
+        let result = await resolveChapter(manager, referenceTime: Self.referenceCue, episode: unrelated.episode)
+
+        guard case .unresolved(let reason, _) = result else {
+            XCTFail("expected an unresolved chapter seek, got \(result)")
+            return
+        }
+        XCTAssertEqual(reason, "no_match")
+    }
+
+    /// The chapter resolve reports through a completion block, which is where the
+    /// player's seek happens.
+    private func resolveChapter(
+        _ manager: FingerprintTimingManager,
+        referenceTime: Double,
+        episode: BaseEpisode
+    ) async -> FingerprintTimingManager.ChapterSeekResult {
+        await withCheckedContinuation { continuation in
+            manager.resolvePlaybackTime(forReferenceTime: referenceTime, episode: episode) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+}

--- a/PocketCastsTests/Tests/Fingerprint/FingerprintTestSupport.swift
+++ b/PocketCastsTests/Tests/Fingerprint/FingerprintTestSupport.swift
@@ -1,0 +1,171 @@
+import Foundation
+import XCTest
+
+@testable import PocketCastsDataModel
+@testable import podcasts
+
+/// An episode the fingerprint subsystem can actually find.
+///
+/// `FingerprintTimingManager` takes no file paths: it asks `DownloadManager` where
+/// this episode's audio lives and reads its reference fingerprint from the sibling
+/// path. So a fixture is an episode plus the files sitting where those lookups
+/// point, which is also what a real downloaded episode looks like on disk.
+final class FingerprintEpisodeFixture {
+
+    let episode: Episode
+    /// Where `DownloadManager` says this episode's audio is, i.e. what the
+    /// fingerprint pass will decode.
+    let audioURL: URL
+    /// The reference fingerprint's path, derived from `audioURL` the same way
+    /// `FingerprintTimingManager` derives it.
+    let referenceURL: URL
+
+    var mappingCachePath: String {
+        FingerprintMappingCache.mappingPath(forAudioFilePath: audioURL.path)
+    }
+
+    /// - Parameter duration: the episode's duration as the database knows it.
+    ///   Preparation refuses to run without one.
+    init(duration: Double) {
+        episode = Episode()
+        episode.uuid = "fingerprint-tests-\(UUID().uuidString)"
+        episode.podcastUuid = "fingerprint-tests-podcast"
+        episode.duration = duration
+        // Picks the extension `pathForEpisode` builds, which in turn picks the
+        // container `AVAudioFile` writes the fixture audio into.
+        episode.contentType = "audio/wav"
+
+        audioURL = URL(fileURLWithPath: DownloadManager.shared.pathForEpisode(episode))
+        referenceURL = URL(
+            fileURLWithPath: (audioURL.path as NSString).deletingPathExtension + ".ref.fp.json"
+        )
+    }
+
+    @discardableResult
+    func writeAudio(
+        seconds: Double,
+        seed: UInt64 = FingerprintFixtures.contentSeed,
+        sampleRate: Double = FingerprintFixtures.defaultSampleRate
+    ) throws -> URL {
+        try FingerprintFixtures.writeAudio(seconds: seconds, seed: seed, sampleRate: sampleRate, to: audioURL)
+        return audioURL
+    }
+
+    @discardableResult
+    func writeAudio(_ samples: [Float], sampleRate: Double = FingerprintFixtures.defaultSampleRate) throws -> URL {
+        try FingerprintFixtures.writeAudio(samples, sampleRate: sampleRate, to: audioURL)
+        return audioURL
+    }
+
+    /// Builds the reference fingerprint from `url` (this episode's own audio unless
+    /// a publisher's copy is passed in) and writes it where the manager looks.
+    func writeReference(forAudioAt url: URL? = nil) throws {
+        try FingerprintFixtures.makeReference(forAudioAt: url ?? audioURL).write(to: referenceURL)
+    }
+
+    func writeReference(data: Data) throws {
+        try data.write(to: referenceURL)
+    }
+
+    /// Removes everything this fixture put in the shared podcasts directory —
+    /// audio, reference, and any mapping cache a pass persisted next to them.
+    func removeFiles() {
+        for path in [audioURL.path, referenceURL.path, mappingCachePath] {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+    }
+}
+
+/// Makes an episode the one `PlaybackManager.shared.currentEpisode` hands back, so
+/// `prepareForCurrentEpisode()` prepares for it.
+///
+/// The queue caches the now-playing episode off the shared `DataManager`, so this
+/// swaps in one that reports the fixture at the top of Up Next and re-caches. No
+/// rows are written, and `restore()` puts the real manager (and its cached
+/// episode) back.
+final class CurrentEpisodeOverride {
+
+    private let previousDataManager: DataManager
+
+    init(episode: BaseEpisode) {
+        previousDataManager = DataManager.sharedManager
+
+        let stub = NowPlayingStubDataManager(dbQueue: previousDataManager.dbQueue)
+        stub.nowPlaying = episode
+        DataManager.sharedManager = stub
+        PlaybackManager.shared.queue.loadPersistedQueue()
+    }
+
+    func restore() {
+        DataManager.sharedManager = previousDataManager
+        PlaybackManager.shared.queue.loadPersistedQueue()
+    }
+}
+
+private final class NowPlayingStubDataManager: DataManager {
+    var nowPlaying: BaseEpisode?
+
+    override func episodeInUpNextAt(index: Int) -> BaseEpisode? {
+        index == 0 ? nowPlaying : nil
+    }
+}
+
+extension XCTestCase {
+
+    /// Polls `condition` on the main actor, which is also where the timing manager
+    /// publishes its state — awaiting between checks lets those hops run.
+    @MainActor
+    func waitUntil(
+        _ description: String,
+        timeout: TimeInterval = 30,
+        pollInterval: TimeInterval = 0.05,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        condition: @MainActor () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            guard Date() < deadline else {
+                XCTFail("Timed out waiting for \(description)", file: file, line: line)
+                return
+            }
+            try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+        }
+    }
+
+    /// Waits for a fingerprint pass to run itself out.
+    ///
+    /// The manager reports no completion — `.active` lands as soon as the first
+    /// couple of anchors commit, with most of the file still to decode. So a pass
+    /// is finished once it has left `.preparing` and its committed mapping has
+    /// stopped growing for `quiet`.
+    @MainActor
+    func waitForPass(
+        _ manager: FingerprintTimingManager,
+        quiet: TimeInterval = 1,
+        timeout: TimeInterval = 120,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        await waitUntil("the pass to start", timeout: timeout, file: file, line: line) {
+            manager.state.analyticsName != "idle"
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastCoverage = -1
+        var unchangedSince = Date()
+        while Date() < deadline {
+            let coverage = manager.debugMappingSnapshot().count
+            if coverage != lastCoverage {
+                lastCoverage = coverage
+                unchangedSince = Date()
+            }
+            if manager.state.analyticsName != "preparing",
+               Date().timeIntervalSince(unchangedSince) >= quiet {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        XCTFail("Timed out waiting for the fingerprint pass to finish", file: file, line: line)
+    }
+}

--- a/PocketCastsTests/Tests/Fingerprint/ReferenceFingerprintTests.swift
+++ b/PocketCastsTests/Tests/Fingerprint/ReferenceFingerprintTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+
+@testable import podcasts
+
+/// The server payload's decoding rules. Everything downstream trusts these
+/// timestamps, so a silently mis-scaled one would shift an entire episode's
+/// mapping without any stage noticing.
+final class ReferenceFingerprintTests: XCTestCase {
+
+    // MARK: - Decoding
+
+    func testDecodesASupportedPayload() throws {
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: Self.payload()))
+
+        XCTAssertEqual(reference.format, ReferenceFingerprint.supportedFormat)
+        XCTAssertEqual(reference.totalDuration, 120, accuracy: 0.001)
+        XCTAssertEqual(reference.checkpointInterval, 2)
+        XCTAssertEqual(reference.checkpointDuration, 8)
+        XCTAssertEqual(reference.checkpointDurationSeconds, 8, accuracy: 0.001)
+        XCTAssertEqual(reference.checkpoints.count, 3)
+    }
+
+    func testRejectsAnUnknownFormat() throws {
+        let payload = try Self.payload(overrides: ["format": "fingerprint-compact-v1"])
+
+        XCTAssertNil(ReferenceFingerprint.decode(from: payload))
+    }
+
+    func testRejectsPayloadThatIsNotJSON() {
+        XCTAssertNil(ReferenceFingerprint.decode(from: Data("not json".utf8)))
+    }
+
+    // MARK: - Library checkpoints
+
+    func testTimestampsAccumulateDeltasScaledByTheQuantum() throws {
+        // Deltas 0, 2, 2 at one second per unit.
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: Self.payload()))
+
+        XCTAssertEqual(reference.libraryCheckpoints().map(\.timestampSeconds), [0, 2, 4])
+    }
+
+    func testQuantumScalesTheTimestampsRatherThanBeingMilliseconds() throws {
+        // The same deltas at two seconds per unit land twice as far apart — a
+        // /1000 conversion here would collapse them all onto zero.
+        let payload = try Self.payload(overrides: ["timestamp_quantum": 2])
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: payload))
+
+        XCTAssertEqual(reference.libraryCheckpoints().map(\.timestampSeconds), [0, 4, 8])
+    }
+
+    func testHashesAreDecodedLittleEndian() throws {
+        let payload = try Self.payload(checkpoints: [[0, Data([0x01, 0x02, 0x03, 0x04]).base64EncodedString()]])
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: payload))
+
+        XCTAssertEqual(try XCTUnwrap(reference.libraryCheckpoints().first).hashes, [0x0403_0201])
+    }
+
+    func testSkipsCheckpointsThatAreNotValidBase64() throws {
+        let payload = try Self.payload(checkpoints: [
+            [0, "!!!not base64!!!"],
+            [2, Data([0x01, 0x00, 0x00, 0x00]).base64EncodedString()]
+        ])
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: payload))
+
+        let checkpoints = reference.libraryCheckpoints()
+        XCTAssertEqual(checkpoints.count, 1)
+        // The skipped checkpoint still advances the accumulated timestamp, so the
+        // survivor keeps its own place on the timeline.
+        XCTAssertEqual(try XCTUnwrap(checkpoints.first).timestampSeconds, 2)
+    }
+
+    func testSkipsCheckpointsWhosePayloadIsNotWholeHashes() throws {
+        let payload = try Self.payload(checkpoints: [
+            [0, Data([0x01, 0x02, 0x03]).base64EncodedString()],
+            [2, Data([0x01, 0x00, 0x00, 0x00]).base64EncodedString()]
+        ])
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: payload))
+
+        XCTAssertEqual(reference.libraryCheckpoints().count, 1)
+    }
+
+    func testEmptyCheckpointListDecodesToNothingUsable() throws {
+        let payload = try Self.payload(checkpoints: [])
+        let reference = try XCTUnwrap(ReferenceFingerprint.decode(from: payload))
+
+        XCTAssertTrue(reference.libraryCheckpoints().isEmpty)
+    }
+
+    // MARK: - Helpers
+
+    private static func payload(
+        checkpoints: [[Any]]? = nil,
+        overrides: [String: Any] = [:]
+    ) throws -> Data {
+        let hashes = Data([0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]).base64EncodedString()
+        var json: [String: Any] = [
+            "format": ReferenceFingerprint.supportedFormat,
+            "total_duration": 120.0,
+            "checkpoint_interval": 2,
+            "checkpoint_duration": 8,
+            "timestamp_quantum": 1,
+            "checkpoints": checkpoints ?? [[0, hashes], [2, hashes], [2, hashes]]
+        ]
+        json.merge(overrides) { _, new in new }
+        return try JSONSerialization.data(withJSONObject: json)
+    }
+}


### PR DESCRIPTION
Ports the fingerprint test suite from #4920 onto trunk's API, without the Swift Concurrency refactor those tests were written against. 21 tests, no production changes.

The fixtures synthesize an episode's audio and build its reference fingerprint from that same audio, then run the real pipeline — decode, matcher, score and dominance gates, drift filter — so the expected mapping is exact and drift fails an assertion rather than looking plausible. Covers the dynamic-ad case the subsystem exists for (an ad spliced into the listener's copy shifts the mapping by exactly its length, and highlighting stops while it plays), both one-shot resolves, the mapping cache, teardown, and the preparation guards. Plus unit tests for reference decoding.

Preparation takes its episode from `PlaybackManager` and its files from `DownloadManager`, so a fixture is an episode with audio written where those lookups point, plus a stub Up Next that reports it as now playing (restored in teardown, no rows written). `FingerprintTestSupport` holds that plumbing and the polling helpers the tests wait on, since the manager reports no completion — a pass is finished once it has left `.preparing` and its committed mapping has stopped growing.

### Two tests differ from #4920

Both because of the bug that PR also fixes: `AVAudioFile.read` throws at EOF rather than returning no frames (reproduced on wav, caf and m4a), so every completed pass exits through the error path.

- **Mapping cache.** Trunk never persists one, so the round trip can't be tested. The cache is seeded through `FingerprintMappingCache.save` and the load path asserted instead — instant `.active`, cached entries, no decode.
- **Unmatched audio.** The pass lands in `.failed` rather than `.unavailable`, so the test asserts what it committed (nothing) instead of its terminal state.

#4920's `FingerprintPCMTests` isn't here: it targets `FingerprintPCM.interleave`, which that PR extracted. On trunk it's `private` inside `FingerprintTimingManager`, and `@testable` can't reach it.

## To test

Nothing user-facing changed — this is a test-only PR.

1. Run the new suites: `make test_staging ONLY_TESTING=PocketCastsTests/FingerprintPreparationTests`, then the same for `FingerprintResolveTests` and `ReferenceFingerprintTests`. 21 tests, all green, ~25s.
2. Run them alongside the existing `FingerprintTimingManagerTests` and `FingerprintMappingCacheTests`, plus a DB-backed class (`EpisodeManagerTests`, `PodcastManagerTests`), to confirm the stubbed `DataManager` and the files written into the podcasts directory are cleaned up after each test. 81 tests, all green.
3. `make lint` is clean.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
