### PR TITLE
Remove unreachable branches in PlaybackManager

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -194,7 +194,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         // if the user has built an Up Next list, preserve that but make this the currently playing episode
         if !overrideUpNext && !switchingToDifferentUpNextEpisode && queue.upNextCount() > 0 {
             if let currEpisode = currentEpisode, currEpisode.uuid != episode.uuid {
-                switchTo(episodeToPlay: episode, moveExistingToUpNext: true, autoPlay: autoPlay, completion: completion)
+                switchTo(episodeToPlay: episode, autoPlay: autoPlay, completion: completion)
 
                 return
             }
@@ -769,12 +769,8 @@ class PlaybackManager: ServerPlaybackDelegate {
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
     }
 
-    private func switchTo(episodeToPlay: BaseEpisode, moveExistingToUpNext: Bool, autoPlay: Bool, completion: (() -> Void)? = nil) {
+    private func switchTo(episodeToPlay: BaseEpisode, autoPlay: Bool, completion: (() -> Void)? = nil) {
         cancelUpdateTimer()
-
-        if let previousEpisode = currentEpisode, !moveExistingToUpNext {
-            queue.remove(episode: previousEpisode, fireNotification: false)
-        }
 
         switchingToDifferentUpNextEpisode = true
         load(episode: episodeToPlay, autoPlay: autoPlay, overrideUpNext: false, completion: completion)
@@ -1515,21 +1511,16 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     // MARK: - Helper Methods
 
-    private func populateFrom(episodes: [BaseEpisode]?, startingAtEpisode: BaseEpisode) {
-        if episodes == nil, queue.upNextCount() > 0 {
-            // the user has chosen to play a single episode, and they have an up next list, so add this episode into up next and push the rest down
-            switchTo(episodeToPlay: startingAtEpisode, moveExistingToUpNext: true, autoPlay: true)
-        } else {
-            // there's a new list of episodes to play, so clear what's currently playing and play that
-            load(episode: startingAtEpisode, autoPlay: true, overrideUpNext: true)
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
+    private func populateFrom(episodes: [BaseEpisode], startingAtEpisode: BaseEpisode) {
+        // there's a new list of episodes to play, so clear what's currently playing and play that
+        load(episode: startingAtEpisode, autoPlay: true, overrideUpNext: true)
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
 
-            let filteredEpisodes = episodes!.filter { $0.uuid != startingAtEpisode.uuid }
-            if filteredEpisodes.isEmpty {
-                return
-            }
-            queue.bulkAdd(filteredEpisodes)
+        let filteredEpisodes = episodes.filter { $0.uuid != startingAtEpisode.uuid }
+        if filteredEpisodes.isEmpty {
+            return
         }
+        queue.bulkAdd(filteredEpisodes)
     }
 
     private func playerSwitchRequired() -> Bool {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -790,7 +790,15 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
         guard let startingEpisode = playlistEpisodes.first else { return }
 
-        populateFrom(episodes: playlistEpisodes, startingAtEpisode: startingEpisode)
+        // there's a new list of episodes to play, so clear what's currently playing and play that
+        load(episode: startingEpisode, autoPlay: true, overrideUpNext: true)
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
+
+        let remainingEpisodes = playlistEpisodes.filter { $0.uuid != startingEpisode.uuid }
+        if !remainingEpisodes.isEmpty {
+            queue.bulkAdd(remainingEpisodes)
+        }
+
         uuidOfPlayingList = playlist.uuid
     }
 
@@ -1510,18 +1518,6 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     // MARK: - Helper Methods
-
-    private func populateFrom(episodes: [BaseEpisode], startingAtEpisode: BaseEpisode) {
-        // there's a new list of episodes to play, so clear what's currently playing and play that
-        load(episode: startingAtEpisode, autoPlay: true, overrideUpNext: true)
-        NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
-
-        let filteredEpisodes = episodes.filter { $0.uuid != startingAtEpisode.uuid }
-        if filteredEpisodes.isEmpty {
-            return
-        }
-        queue.bulkAdd(filteredEpisodes)
-    }
 
     private func playerSwitchRequired() -> Bool {
         let possiblePlayers = supportedPlayers()


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Removes two unreachable code paths in `PlaybackManager`. No behavior change.

`populateFrom(episodes:startingAtEpisode:)` took an optional `[BaseEpisode]?` and branched on `episodes == nil`, but its only caller — `play(playlist:)` — passes a non-optional `[Episode]` that is also guaranteed non-empty (it's `guard`ed on `playlistEpisodes.first`). The nil branch was never taken, and the `episodes!` force-unwrap in the else branch was only safe by accident of that single call site. The parameter is now non-optional and the branch is gone.

The nil branch held the only call to `switchTo(...)` with `moveExistingToUpNext: true` being meaningful as a choice; with it removed, the sole remaining caller always passes `true`, so the `!moveExistingToUpNext` branch that removed the previous episode from the queue was also unreachable. The parameter has been dropped.

With the branching gone, `populateFrom` was five unconditional lines behind a name that no longer described it, and its `startingAtEpisode` argument was always `episodes.first`. It's now inlined into `play(playlist:)`, which already `guard`s on that same first element. The `isEmpty` check is kept because `PlaybackQueue.bulkAdd` fires `bulkOperationDidComplete` even for an empty array.

Both branches have been dead since the method was introduced in 708d2d941 — it was copied from the older `populateFromEpisodes(_:startingAtEpisode:)`, which already had the same single non-nil caller. That predecessor has since been deleted along with its feature flag.

## To test

Playback behavior should be unchanged. To verify the affected path:

1. Add several episodes to Up Next.
2. Go to a filter/playlist and tap Play All.
3. Confirm the playlist replaces Up Next and starts playing from the first episode.
4. With a non-empty Up Next, tap play on a single episode elsewhere in the app.
5. Confirm it starts playing and the existing Up Next queue is preserved below it.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
