### PR TITLE
Simplify always-true autoPlay check in playerDidFinishPlayingEpisode

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1468,7 +1468,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
             cancelSleepTimer()
         } else {
-            playNextEpisode(autoPlay: !(numberOfEpisodesToSleepAfter == 1))
+            playNextEpisode(autoPlay: true)
         }
     }
 


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Removes an always-true condition in `PlaybackManager.playerDidFinishPlayingEpisode()`. No behavior change.

The method opens with an early return for the last-episode-before-sleep case:

```swift
if numberOfEpisodesToSleepAfter == 1 {
    pauseAndRecordSleepTimerFinished()
    cancelSleepTimer()
    return
}
```

so by the time control reaches the `else` branch at the bottom, `!(numberOfEpisodesToSleepAfter == 1)` is provably `true`. Nothing in between can make it `1` again: the only in-class write is the `-= 1` inside `playNextEpisode`, which happens *after* the argument is evaluated, and the external writes come from `SleepTimerViewController` (user-initiated) and `SleepTimerManager.episodeDurationChanged`, which observes `episodeDurationChanged` — a notification this path never posts.

The argument is now just `true`, which makes the pause-vs-continue decision visible in one place (the early return) instead of being re-derived at the call site.

## To test

Sleep timer behavior should be unchanged.

1. Start playing an episode with several episodes in Up Next.
2. Open the sleep timer and choose "End of episode".
3. Let the episode finish, and confirm playback pauses instead of moving to the next episode.
4. Set the sleep timer to end after 2 or more episodes.
5. Let an episode finish, and confirm playback continues into the next episode and the remaining count goes down.
6. With the sleep timer off, let an episode finish and confirm the next episode plays automatically.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
