### PR TITLE
Remove switchingToDifferentUpNextEpisode recursion in PlaybackManager

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -38,7 +38,6 @@ class PlaybackManager: ServerPlaybackDelegate {
     private var currentEffects: PlaybackEffects?
     private var player: PlaybackProtocol?
 
-    private var switchingToDifferentUpNextEpisode = false
     private var interruptInProgress = false
 
     private var wasPlayingBeforeInterruption = false
@@ -184,6 +183,26 @@ class PlaybackManager: ServerPlaybackDelegate {
     func load(episode: BaseEpisode, autoPlay: Bool, overrideUpNext: Bool, saveCurrentEpisode: Bool = true, completion: (() -> Void)? = nil) {
         FileLog.shared.addMessage("Loading \(episode.displayableTitle()) with UUID \(episode.uuid) autoPlay \(autoPlay) overrideUpNext: \(overrideUpNext)")
 
+        // if the user has built an Up Next list, preserve that but make this the currently playing episode
+        if !overrideUpNext, queue.upNextCount() > 0, let currEpisode = currentEpisode, currEpisode.uuid != episode.uuid {
+            switchTo(episodeToPlay: episode, autoPlay: autoPlay, completion: completion)
+
+            return
+        }
+
+        performLoad(episode: episode, autoPlay: autoPlay, overrideUpNext: overrideUpNext, saveCurrentEpisode: saveCurrentEpisode, completion: completion)
+    }
+
+    private func switchTo(episodeToPlay: BaseEpisode, autoPlay: Bool, completion: (() -> Void)? = nil) {
+        cancelUpdateTimer()
+
+        performLoad(episode: episodeToPlay, autoPlay: autoPlay, overrideUpNext: false, saveCurrentEpisode: false, completion: completion)
+
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.upNextQueueChanged)
+    }
+
+    private func performLoad(episode: BaseEpisode, autoPlay: Bool, overrideUpNext: Bool, saveCurrentEpisode: Bool, completion: (() -> Void)?) {
         let episodeIsChanging = episode.uuid != currentEpisode?.uuid
 
         // A new episode shouldn't inherit the previous one's "watch downloaded video" choice.
@@ -191,20 +210,11 @@ class PlaybackManager: ServerPlaybackDelegate {
             streamingVideoForDownloadedEpisode.value = false
         }
 
-        // if the user has built an Up Next list, preserve that but make this the currently playing episode
-        if !overrideUpNext && !switchingToDifferentUpNextEpisode && queue.upNextCount() > 0 {
-            if let currEpisode = currentEpisode, currEpisode.uuid != episode.uuid {
-                switchTo(episodeToPlay: episode, autoPlay: autoPlay, completion: completion)
-
-                return
-            }
-        }
-
         if let uuid = currentEpisode?.uuid, uuid != episode.uuid {
             chapterManager.clearChapterInfo()
         }
 
-        if saveCurrentEpisode && currentEpisode != nil && !switchingToDifferentUpNextEpisode {
+        if saveCurrentEpisode, currentEpisode != nil {
             recordPlaybackPosition(sendToServerImmediately: false, fireNotifications: false)
         }
 
@@ -767,17 +777,6 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         numberOfEpisodesToSleepAfter -= 1
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
-    }
-
-    private func switchTo(episodeToPlay: BaseEpisode, autoPlay: Bool, completion: (() -> Void)? = nil) {
-        cancelUpdateTimer()
-
-        switchingToDifferentUpNextEpisode = true
-        load(episode: episodeToPlay, autoPlay: autoPlay, overrideUpNext: false, completion: completion)
-        switchingToDifferentUpNextEpisode = false
-
-        NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackTrackChanged)
-        NotificationCenter.postOnMainThread(notification: Constants.Notifications.upNextQueueChanged)
     }
 
     func play(playlist: EpisodeFilter) {


### PR DESCRIPTION
`load(episode:autoPlay:overrideUpNext:saveCurrentEpisode:completion:)` called `switchTo`, which called `load` again. The `switchingToDifferentUpNextEpisode` flag existed only to suppress two branches during that one-level recursion: the Up Next check that would have bounced back into `switchTo`, and the `recordPlaybackPosition` call.

This extracts `performLoad` — everything `load` did after the Up Next check — so `switchTo` calls it directly instead of re-entering `load`. Both branches are then gone by construction rather than by flag, and the flag is deleted:

- The Up Next check lives only in `load`; `switchTo` skips it because it starts one level down.
- Suppressing `recordPlaybackPosition` is now expressed by passing `saveCurrentEpisode: false`, which is what the flag stood in for.

Two incidental effects of no longer running the top of `load` twice: the duplicate `Loading …` log line is gone, and `streamingVideoForDownloadedEpisode` is reset once instead of twice on the switch path (same resulting value). Every non-switch path is unchanged.

The two other `saveCurrentEpisode: false` callers (`reloadCurrentEpisodeSource` and the refreshed-episode reload in `handleEpisodeDidDownload`) both reload the *current* episode, so they never took the `switchTo` branch before or now.

## To test

Regression check on Up Next playback:

1. Play an episode, then add two or three other episodes to Up Next.
2. Open Up Next and tap a different episode in the list to play it.
3. Verify it starts playing, the previously playing episode stays in the queue rather than being replaced, and the rest of Up Next is preserved.
4. Reopen the episode you were originally playing and verify its playback position was saved from before the switch.
5. Play an episode with chapters, switch to a different Up Next episode, and verify the chapter list updates to the new episode.
6. With Up Next empty, tap play on any episode and verify it loads and plays normally.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
