### PR TITLE
PlaybackManager: Incremental @MainActor adoption from the UI side – Part 3

### DIFF
--- a/podcasts/Episode Cells/SwipeActionsHelper.swift
+++ b/podcasts/Episode Cells/SwipeActionsHelper.swift
@@ -43,6 +43,7 @@ protocol SwipeHandler: AnyObject {
     func removeFromManualPlaylist(episode: Episode, at: IndexPath)
 }
 
+@MainActor
 enum SwipeActionsHelper {
     // Contrast themes prioritise readability; the green `support02` background
     // doesn't pass against the white "+" icon, so fall back to `support06` (the
@@ -227,6 +228,7 @@ enum SwipeActionsHelper {
     }
 }
 
+@MainActor
 fileprivate extension TableSwipeAction {
     static func removeAction(indexPath: IndexPath, tableView: UITableView, swipeHandler: SwipeHandler, episode: Episode) -> TableSwipeAction {
         return TableSwipeAction(indexPath: indexPath, title: L10n.delete, removesFromList: true, backgroundColor: ThemeColor.support05(), icon: UIImage(named: "delete"), tableView: tableView, handler: { _ -> Bool in

--- a/podcasts/Fingerprint/GeneratedChapterSeeker.swift
+++ b/podcasts/Fingerprint/GeneratedChapterSeeker.swift
@@ -10,6 +10,7 @@ import PocketCastsUtils
 /// playback position first, with a graceful fallback to the raw seek. Embedded /
 /// podcast-index chapters already carry real playback times and must not be
 /// routed here.
+@MainActor
 enum GeneratedChapterSeeker {
 
     /// Whether generated-chapter navigation should resolve via fingerprinting
@@ -28,8 +29,6 @@ enum GeneratedChapterSeeker {
     ///   already-resolved cache hit, which seeks synchronously.
     /// - `startPlayback` matches each call site's existing behaviour: the chapters
     ///   list starts playback on a tap, the player's skip buttons don't.
-    ///
-    /// Must be called on the main queue.
     static func seek(
         to chapter: ChapterInfo,
         startPlayback: Bool,

--- a/podcasts/LiquidGlass.swift
+++ b/podcasts/LiquidGlass.swift
@@ -29,6 +29,7 @@ extension Theme {
     static var systemIsDark: Bool = false
 }
 
+@MainActor
 extension Constants {
     static var effectiveMiniPlayerOffset: CGFloat {
         if LiquidGlass.isEnabled {

--- a/podcasts/Sharing/SharingModal.swift
+++ b/podcasts/Sharing/SharingModal.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import PocketCastsUtils
 import EndOfYear
 
+@MainActor
 enum SharingModal {
 
     /// Share options including which type of content will be shared

--- a/podcasts/SharingHelper.swift
+++ b/podcasts/SharingHelper.swift
@@ -3,6 +3,7 @@ import PocketCastsServer
 import UIKit
 import PocketCastsUtils
 
+@MainActor
 class SharingHelper: NSObject {
     static let shared = SharingHelper()
     var activityController: UIActivityViewController?

--- a/podcasts/TranscriptShelfButton.swift
+++ b/podcasts/TranscriptShelfButton.swift
@@ -25,6 +25,7 @@ class TranscriptShelfButton: UIButton, CheckTranscriptAvailability {
     }
 }
 
+@MainActor
 protocol CheckTranscriptAvailability: AnyObject {
     var isTranscriptEnabled: Bool { get set }
     var hasGeneratedTranscripts: Bool { get set }
@@ -36,19 +37,23 @@ protocol CheckTranscriptAvailability: AnyObject {
 extension CheckTranscriptAvailability {
     func addTranscriptObservers() {
         NotificationCenter.default.addObserver(forName: Constants.Notifications.episodeTranscriptAvailabilityChanged, object: nil, queue: .main) { [weak self] notification in
-            guard let episodeUuid = notification.userInfo?["episodeUuid"] as? String,
-                  let isAvailable = notification.userInfo?["isAvailable"] as? Bool,
-                  let hasGeneratedTranscripts = notification.userInfo?["hasGeneratedTranscripts"] as? Bool,
-                  episodeUuid == PlaybackManager.shared.currentEpisode?.uuid else {
-                return
-            }
+            MainActor.assumeIsolated {
+                guard let episodeUuid = notification.userInfo?["episodeUuid"] as? String,
+                      let isAvailable = notification.userInfo?["isAvailable"] as? Bool,
+                      let hasGeneratedTranscripts = notification.userInfo?["hasGeneratedTranscripts"] as? Bool,
+                      episodeUuid == PlaybackManager.shared.currentEpisode?.uuid else {
+                    return
+                }
 
-            self?.isTranscriptEnabled = isAvailable
-            self?.hasGeneratedTranscripts = hasGeneratedTranscripts
+                self?.isTranscriptEnabled = isAvailable
+                self?.hasGeneratedTranscripts = hasGeneratedTranscripts
+            }
         }
 
         NotificationCenter.default.addObserver(forName: Constants.Notifications.playbackTrackChanged, object: nil, queue: .main) { [weak self] _ in
-            self?.checkTranscriptAvailability()
+            MainActor.assumeIsolated {
+                self?.checkTranscriptAvailability()
+            }
         }
     }
 

--- a/podcasts/Up Next History/UpNextHistoryModel.swift
+++ b/podcasts/Up Next History/UpNextHistoryModel.swift
@@ -2,6 +2,7 @@ import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 
+@MainActor
 class UpNextHistoryModel: ObservableObject {
     @Published var historyEntries: [UpNextHistoryManager.UpNextHistoryEntry] = []
     @Published var episodes: [BaseEpisode] = []
@@ -12,14 +13,12 @@ class UpNextHistoryModel: ObservableObject {
         self.dataManager = dataManager
     }
 
-    @MainActor
     func loadEntries() {
         Task {
             historyEntries = dataManager.upNextHistoryEntries()
         }
     }
 
-    @MainActor
     func loadEpisodes(for entry: Date) {
         Task {
             let episodesUuid = dataManager.upNextHistoryEpisodes(entry: entry)


### PR DESCRIPTION
Part 3 of the incremental `@MainActor` adoption, continuing top-down from the UI side toward `PlaybackManager` (after #4947 and #4953).

UIKit and SwiftUI types already inherit isolation from their base classes and protocols, so this pass covers the plain helper types that call into `PlaybackManager` from the main thread without saying so: `SwipeActionsHelper`, `GeneratedChapterSeeker`, the `Constants` extension in `LiquidGlass.swift`, `SharingModal` (which pulls in `SharingHelper`), `CheckTranscriptAvailability`, and `UpNextHistoryModel`.

Two are more than annotations:

- **`UpNextHistoryModel`** moves from two per-method `@MainActor`s to type-level isolation. `reAddMissingItems` was the one method without an annotation, so its `Task { }` ran on the concurrent executor and mutated the Up Next queue off the main thread. Its DB reads move to main as a result, matching `loadEntries` and `loadEpisodes`.
- **`CheckTranscriptAvailability`**'s two notification observers now use `MainActor.assumeIsolated`. They're registered with `queue: .main`, but the closure is `@Sendable`, so without the explicit hop it would silently inherit isolation rather than assert it.

Types *below* `PlaybackManager` are left alone — annotating those pushes isolation upward into it instead of toward it. `PlayerColorHelper` is main-only too, but cascades through the SwiftUI theming layer into isolated-default-value errors in `Toast.show` and `EmptyStateView.init`; that needs its own PR.

The review also found call sites that genuinely run off the main thread today and will need fixing before `PlaybackManager` can be isolated: `WatchManager.handleWatchAction` (WCSession delegate thread — `skipBack` is hopped to main, `skipForward` two lines later isn't), `ShortcutManager.updateShortcuts` (`DispatchQueue.global()`), `ServerSyncManager`'s sync-delegate callbacks, and the archive/cleanup paths. Follow-ups, not part of this PR.

## To test

Compile-time change plus one behavioral fix; no visible difference except Up Next History.

1. Open the full player → Chapters tab, tap a chapter (including on an episode with generated chapters).
2. Swipe an episode row and use the Up Next / archive / delete actions.
3. Share a podcast and an episode, including "share from current position".
4. Profile → Up Next History: open an entry and restore it. The queue should restore correctly without hitching.
5. Switch between episodes with and without transcripts; the transcript shelf button still enables/disables.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
