### PR TITLE
Replace fingerprint uuid staleness checks with a generation counter

### DIFF
--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -38,6 +38,10 @@ final class FingerprintTimingManager: NSObject {
     // MARK: - Internal Types
 
     private struct GenerationContext {
+        /// Identifies one stream run. A restart builds a fresh context for the
+        /// same episode, so work in flight has to be matched against this rather
+        /// than against `episodeUuid` to be recognised as stale.
+        let generation: Int
         let episodeUuid: String
         let audioFileURL: URL
         /// True when `audioFileURL` points at a streaming buffer that may still be
@@ -116,6 +120,9 @@ final class FingerprintTimingManager: NSObject {
         qos: .userInitiated
     )
     private var context: GenerationContext?
+    /// Source of `GenerationContext.generation`. Only touched on `queue`, where
+    /// every context is built.
+    private var lastGeneration = 0
     private var cancellationFlag = CancellationFlag()
     private var fetchTask: Task<Void, Never>?
 
@@ -273,6 +280,7 @@ final class FingerprintTimingManager: NSObject {
         cancellationFlag = CancellationFlag()
         let flag = cancellationFlag
         let newContext = GenerationContext(
+            generation: nextGeneration(),
             episodeUuid: ctx.episodeUuid,
             audioFileURL: ctx.audioFileURL,
             isStreaming: ctx.isStreaming,
@@ -848,6 +856,11 @@ final class FingerprintTimingManager: NSObject {
         main.filterCandidatePool.removeAll()
     }
 
+    private func nextGeneration() -> Int {
+        lastGeneration += 1
+        return lastGeneration
+    }
+
     private func track(_ event: AnalyticsEvent, properties: [String: Sendable] = [:]) {
         var properties = properties
         if let episodeUuid = context?.episodeUuid {
@@ -965,6 +978,7 @@ final class FingerprintTimingManager: NSObject {
         let flag = cancellationFlag
         let refPath = referencePath(for: episode)
         let newContext = GenerationContext(
+            generation: nextGeneration(),
             episodeUuid: uuid,
             audioFileURL: audioFileURL,
             isStreaming: isStreaming,
@@ -1125,7 +1139,7 @@ final class FingerprintTimingManager: NSObject {
     /// abandoned context would clobber a healthy state.
     private func finishIfStillPreparing(terminalState: State, context ctx: GenerationContext) {
         queue.async { [weak self] in
-            guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
+            guard let self, self.context?.generation == ctx.generation else { return }
             let durationMs = self.preparationDurationMs
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
@@ -1476,6 +1490,10 @@ final class FingerprintTimingManager: NSObject {
     /// on `generationQueue` so they don't stall `queue.sync` callers (the
     /// `referenceTime(forPlaybackTime:)` / `playbackTime(forReferenceTime:)`
     /// queries that drive transcript highlighting and tap-to-seek).
+    ///
+    /// Guarded on `episodeUuid` rather than `generation`: the question here is
+    /// whether `main` still holds this episode's mapping, and a restart keeps
+    /// that mapping intact for the same audio file and reference.
     private func persistMappingCacheIfFull(context ctx: GenerationContext) {
         guard !ctx.isStreaming else { return }
         queue.async { [weak self] in
@@ -1534,7 +1552,7 @@ final class FingerprintTimingManager: NSObject {
         context ctx: GenerationContext
     ) {
         queue.async { [weak self] in
-            guard let self, self.context?.episodeUuid == ctx.episodeUuid else { return }
+            guard let self, self.context?.generation == ctx.generation else { return }
             self.processMatches(windows: windows, startOffset: startOffset, context: ctx)
         }
     }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Second of five steps toward replacing `FingerprintTimingManager`'s serial `DispatchQueue` with an actor. Still no isolation changes — this one fixes a staleness check that the later steps would otherwise make much easier to hit.

`dispatchProcessMatches` and `finishIfStillPreparing` decided "is this work still current?" with `context?.episodeUuid == ctx.episodeUuid`. But `restart()` builds a new context for the *same* episode, so that guard can't tell the two runs apart. A batch decoded on `generationQueue` hops to `queue`; if a `handlePlaybackProgress` restart lands first — clearing `filterLastTrusted` and `filterCandidatePool` — the stale batch passes the guard and feeds pre-restart candidates into the freshly-reset filter, corrupting the bootstrap the new stream is building. `finishIfStillPreparing` has the same shape: a cancelled stream throws `.cancelled` and is handled, but a non-cancellation error thrown as a restart commits (e.g. `audioFile.read` failing) reaches the guard, passes it, and pushes `.failed` over the new stream's `.preparing`.

`GenerationContext` now carries a monotonic `generation: Int`, sourced from a counter only touched on `queue` — the one place contexts are built. Both guards compare that instead.

`persistMappingCacheIfFull` deliberately keeps its uuid guard: its question is "does `main` still hold this episode's mapping", and `restart()` preserves that mapping while only `resetState()` clears it. Switching it to generation would be a regression — a restart landing between EOF and the persist hop would suppress a legitimate cache write for the same audio file and reference.

Worth it on its own, and a prerequisite for steps 4–5: once isolation domains change, hops stop arriving in FIFO order and staleness has to be decided by id rather than by arrival.

No test. The guard covers a race the current harness can't drive deterministically — the suite runs the real pipeline over fixture audio, and there's no seam to hold a stale `GenerationContext` and dispatch a batch through it at the moment a restart commits. Adding one means exposing private stream plumbing, which is a bigger change than the fix.

## To test

Behavior-preserving except that a mid-restart batch is now dropped instead of miscommitted, so this is a regression check:

1. Play a downloaded episode with synced transcripts and open the transcript. Highlighting follows playback and stops across a dynamic ad.
2. Scrub around repeatedly — jumps over 30s trigger `restart()`. Highlighting re-locks after each seek and doesn't stick to wrong lines.
3. Open the fingerprint debug overlay while scrubbing. Anchors stay on-trend across restarts; no jump-around clusters appear right after a seek.
4. Play a still-streaming episode and seek forward past the buffered region, then back. The grow-loop restarts and coverage rebuilds without the manager dropping to `failed`/`unavailable`.
5. `make test_staging ONLY_TESTING=PocketCastsTests/FingerprintTimingManagerTests` (plus `FingerprintPreparationTests`, `FingerprintResolveTests`, `FingerprintMappingCacheTests`) — 49 tests, unchanged by this PR.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
