### PR TITLE
Make CancellationFlag Sendable with OSAllocatedUnfairLock (2 warnings)

### DIFF
--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -4,6 +4,7 @@ import Foundation
 import Fingerprint
 import PocketCastsDataModel
 import PocketCastsUtils
+import os
 
 final class FingerprintTimingManager: NSObject {
 
@@ -1986,16 +1987,15 @@ final class FingerprintTimingManager: NSObject {
 
 // MARK: - Cancellation
 
-private final class CancellationFlag {
-    private let lock = NSLock()
-    private var cancelled = false
+private final class CancellationFlag: Sendable {
+    private let cancelled = OSAllocatedUnfairLock(initialState: false)
 
     var isCancelled: Bool {
-        lock.withLock { cancelled }
+        cancelled.withLock { $0 }
     }
 
     func cancel() {
-        lock.withLock { cancelled = true }
+        cancelled.withLock { $0 = true }
     }
 }
 


### PR DESCRIPTION
`CancellationFlag` in `FingerprintTimingManager` is captured by detached fingerprinting tasks, which produced three Swift concurrency warnings because the type wasn't `Sendable`.

It was already thread-safe via an `NSLock`, but `NSLock` + mutable stored state can't be checked by the compiler. Swapping it for `OSAllocatedUnfairLock` — which is `Sendable` and holds the state inside the lock — lets the class declare a plain, compiler-verified `Sendable` conformance instead of `@unchecked Sendable`.

No behavior change.

## To test

1. Build the app — the three `CancellationFlag` Sendable warnings in `FingerprintTimingManager.swift` are gone.
2. Play an episode with fingerprint-based intro/outro detection and confirm detection still runs and reports timings as before.
3. Skip to another episode mid-detection to confirm cancellation still stops the in-flight work.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
