### PR TITLE
Fix aboutToPlay getting stuck true after a player teardown

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -300,8 +300,6 @@ class PlaybackManager: ServerPlaybackDelegate {
             analyticsPlaybackHelper.play()
         }
 
-        aboutToPlay.value = true
-
         if playerSwitchRequired() {
             load(episode: currEpisode, autoPlay: false, overrideUpNext: false)
         }
@@ -309,6 +307,10 @@ class PlaybackManager: ServerPlaybackDelegate {
             player?.loadEpisode(currEpisode)
             haveCalledPlayerLoad = true
         }
+
+        // Marked after the player is in place: rebuilding it above goes through
+        // `cleanupCurrentPlayer`, which clears this flag.
+        aboutToPlay.value = true
 
         // Marked synchronously (before the async audio-session activation) so concurrent `play()`
         // calls can't each capture `true` and report twice for the same player. Only engaged when
@@ -319,7 +321,13 @@ class PlaybackManager: ServerPlaybackDelegate {
             hasReportedSourceResolved.value = true
         }
 
+        let playerToStart = player
+
         activateAudioSession(completion: { activated in
+            // Activation is asynchronous, so the player this call was started for can be torn down
+            // or replaced before it completes, leaving nothing to run the play command.
+            guard let player = self.player, player === playerToStart else { return }
+
             if !activated {
                 self.aboutToPlay.value = false
                 // Playback didn't start, so allow a later retry to report the resolved source.
@@ -329,7 +337,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 return
             }
 
-            self.player?.play {
+            player.play {
                 completion?()
             }
             self.startUpdateTimer()
@@ -1607,7 +1615,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             player.endPlayback(permanent: permanent)
         }
 
-        if permanent { aboutToPlay.value = false }
+        aboutToPlay.value = false
         currentEffects = nil
 
         // DefaultPlayer and EffectsPlayer both have issues if you discard them immediately after stopping them. DefaultPlayer will crash while trying to render more audio and EffectsPlayer has internal issues as well.


### PR DESCRIPTION
`aboutToPlay` could get stuck `true`, which made `isPlaying` report playback with no player and turned every play command into a no-op.

`isPlaying` returns `true` whenever `aboutToPlay` is set, and the only two things that clear it were `playerDidFinishPreparing` (which only fires from inside `player.play()`) and `cleanupCurrentPlayer(permanent: true)`. But `cleanupCurrentPlayer` nils the player in *both* modes, so a non-permanent teardown — `playbackDidFail` for a non-downloaded episode, or `handleSystemAudioReset` — left the flag set with nothing able to clear it.

Concrete path: play a streaming episode on flaky network. `play()` sets the flag and dispatches the audio session activation, the item fails, `playbackDidFail` tears the player down, and the activation completion then runs `self.player?.play { }` on `nil` — a silent no-op that still posted `playbackStarted` and started the update timer. Terminal state: `isPlaying == true`, `player == nil`, forever. Every branch of the play command is dead (`if !isPlaying { play() }` is skipped, `playPause()` routes to `pause()` which does nothing), the in-app buttons render as pause, and `progressTimerFired` bails on its `guard let player`, so nothing self-heals. The window widened in a2fa6a3ed, which made the activation always asynchronous.

Two changes:

1. `cleanupCurrentPlayer` clears `aboutToPlay` unconditionally. It's the only place `player` is set to nil, so this makes "no player ⇒ not about to play" hold by construction. It also covers a variant not in the original report: a failure arriving *after* `play()` reached the player but before it finished preparing (e.g. EffectsPlayer failing mid-prepare), which no fix on the completion side would catch. `play()` now sets the flag *after* its load block, so the `playerSwitchRequired()` → `load()` → `cleanupCurrentPlayer` path inside the same call no longer clears the flag it just set, keeping the optimistic-`isPlaying` window intact.

2. The activation completion captures the player it was started for and bails unless that player is still current. It no longer fires `playbackStarted`, the update timer, and the sleep timer restart for a player that has been torn down or replaced by a newer play cycle. `hasReportedSourceResolved` is deliberately untouched on that path — `cleanupCurrentPlayer` already resets it, and a newer cycle owns it.

As a side effect the deferred cleanup in `cleanupCurrentPlayer` now actually deactivates the audio session, instead of skipping on an `isPlaying` that was lying.

Not covered here: pausing during the activation window is still overridden when the pending completion lands, since the player identity is unchanged. That's a separate symptom and needs play cycles to be cancellable by `pause()`.

## To test

1. Start playing a streaming (non-downloaded) episode, then kill the network mid-startup (Airplane Mode, or Network Link Conditioner set to 100% loss) so playback fails.
2. Confirm the error surfaces and the mini player / full player show a **play** button, not pause.
3. Restore the network and tap play — the episode starts playing (before this change the button was stuck on pause and every tap was a no-op until relaunch).
4. Repeat with the lock screen / Control Center and CarPlay play buttons.
5. Regression: normal playback, pause/resume, skipping to the next episode, and switching episodes from Up Next all behave as before.
6. Regression: toggling trim silence / volume boost while playing (rebuilds the player) keeps playing.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
