### PR TITLE
Enable the Smart Bookmarks feature flag by default

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -522,7 +522,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .troubleshooting:
             true
         case .smartBookmarks:
-            BuildEnvironment.current == .debug
+            true
         case .captureBestFrame:
             true
         case .tvHomeCategoriesAndCurated:


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS- <!-- issue number, if applicable -->

Turns `FeatureFlag.smartBookmarks` on by default so Smart Bookmarks ships in 8.19. It was `BuildEnvironment.current == .debug`, i.e. on in Debug only, off in Staging/Release.

The flag gates the on-device/server title suggestion for new bookmarks (`BookmarkManager.isTitleSuggestionEnabled`, which drives `transcriptSnippet`, `capturedSnippet` and `enrich`), the new edit form (`BookmarkEditTitleViewController` picks `BookmarkEditTitleViewModel` over `BookmarkEditViewModel`), and tapping a bookmark in the list to open its details.

It also unblocks the promo added in #4939: `SmartBookmarksPromo` requires both `smartBookmarks` and `smartBookmarksPromo` (already `true`) plus a `8.19`/`8.20`/`8.21` build, so the player tip and the "New" badge on Add Bookmark go live with this change on this branch.

Targets `release/8.19`. No CHANGELOG entry here — release notes for the feature are handled with the release.

## To test

1. Build Staging from this branch (`make build_staging`) and confirm **Smart Bookmarks** shows as on in Beta Features without an override.
2. Play an episode that has a transcript, add a bookmark from the player, and confirm the edit sheet is the new title form with a suggested title.
3. Add a bookmark with the headphone button or from CarPlay (no sheet) and confirm the bookmark is titled in the background instead of keeping the default name.
4. Open a podcast's Bookmarks tab and tap a bookmark — it opens the bookmark details.
5. On first launch of the player, confirm the Smart Bookmarks tip appears and **Add Bookmark** in ••• carries the "New" pill.
6. Toggle **Smart Bookmarks** off in Beta Features and relaunch: the old edit form returns, no title suggestion, tapping a bookmark does nothing, no tip or badge.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
