### PR TITLE
Update fingerprint dependency to restore MinimumOSVersion

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -223,7 +223,7 @@
       "location" : "https://github.com/Automattic/pocket-casts-ios-fingerprint",
       "state" : {
         "branch" : "trunk",
-        "revision" : "4ca89cc127a444b918784839331b6044c1624ba2"
+        "revision" : "88abde829e54002e8d3a9428c7f0acce8fd72304"
       }
     },
     {


### PR DESCRIPTION
Updates the `pocket-casts-ios-fingerprint` dependency from `4ca89cc` to `88abde8` (latest `trunk`).

The previous pin regenerated the xcframework binaries and, as a side effect, stripped `MinimumOSVersion`, `CFBundleSupportedPlatforms`, and `DTPlatformName` from the `Info.plist` of both framework slices. Without `MinimumOSVersion`, App Store submission of an app embedding the xcframework is rejected. [pocket-casts-ios-fingerprint#4](https://github.com/Automattic/pocket-casts-ios-fingerprint/pull/4) restores those keys with the correct per-slice platform values; there are no binary changes.

## To test

1. Check out this branch and let SPM resolve — `Modules/Package.resolved` should report `Fingerprint` at `88abde8`.
2. Build the app and confirm it compiles and runs, and that chapter/fingerprint behaviour is unchanged (play an episode with generated chapters).
3. Confirm the resolved framework carries the key again:
   ```
   plutil -p Modules/.build/checkouts/pocket-casts-ios-fingerprint/Fingerprint.xcframework/ios-arm64/FingerprintFFI.framework/Info.plist | grep MinimumOSVersion
   ```
4. Archive the app — validation/upload should no longer be rejected for a missing `MinimumOSVersion`.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
