### PR TITLE
Fix non-Sendable self capture warnings in WatchSyncManager (2 warnings)

### DIFF
--- a/Pocket Casts Watch App/UI/WatchSyncManager.swift
+++ b/Pocket Casts Watch App/UI/WatchSyncManager.swift
@@ -147,28 +147,26 @@ class WatchSyncManager {
     }
 
     func login() {
-        Task {
+        Task { @MainActor in
             do {
                 try await AuthenticationHelper.refreshLogin()
-                DispatchQueue.main.async {
-                    self.handleLogin()
-                }
+                handleLogin()
             }
             catch {
-                DispatchQueue.main.async {
-                    self.handleError(error)
-                }
+                handleError(error)
             }
         }
     }
 
+    @MainActor
     private func handleLogin() {
         FileLog.shared.addMessage("Login successful")
-        self.checkSubscriptionStatus()
+        checkSubscriptionStatus()
         NotificationCenter.default.post(name: WatchConstants.Notifications.loginStatusUpdated, object: nil)
         NotificationCenter.default.post(name: .userLoginDidChange, object: nil)
     }
 
+    @MainActor
     private func handleError(_ error: Error) {
         let error = error as? APIError
 


### PR DESCRIPTION
Fixes the two `Capture of 'self' with non-Sendable type 'WatchSyncManager' in a '@Sendable' closure` warnings in `WatchSyncManager.login()`.

`DispatchQueue.main.async` takes an `@escaping @Sendable` closure, so capturing the non-Sendable `WatchSyncManager` inside it warns. Isolating the surrounding `Task` to `@MainActor` removes the `@Sendable` closure entirely (`Task.init`'s operation parameter is `sending`, not `@Sendable`), and `handleLogin()` / `handleError(_:)` are now annotated `@MainActor` so the main-thread requirement is enforced instead of implied.

Behaviour is unchanged: `AuthenticationHelper.refreshLogin()` is a `nonisolated async` function, so the network and keychain work still runs off the main actor — only the two handlers hop to main, exactly as before.

## To test

1. Build the `Pocket Casts Watch App` scheme and confirm `WatchSyncManager.swift` no longer emits any warnings.
2. With the watch app signed out, sign in on the phone with a Plus account.
3. Open the watch app and confirm it picks up the login: the podcasts / Up Next lists populate instead of the signed-out screen.
4. Sign out on the phone and confirm the watch app returns to the signed-out state.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
