### PR TITLE
Remove redundant #available checks and dead code

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Extensions/UI/UIFontExtension.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/UI/UIFontExtension.swift
@@ -2,7 +2,6 @@ import Foundation
 import UIKit
 
 public extension UIFont {
-    @available(watchOS 8.0, *)
     static func systemFontWithMonospacedNumbers(_ size: CGFloat) -> UIFont {
         let features = [
             [
@@ -18,7 +17,6 @@ public extension UIFont {
         return UIFont(descriptor: fontDescriptor, size: size)
     }
 
-    @available(watchOS 8.0, *)
     func monospaced() -> UIFont {
         let fontDescriptorFeatureSettings = [
             [

--- a/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingControls.swift
+++ b/Pocket Casts Watch App/UI/Now Playing/Interface/NowPlayingControls.swift
@@ -17,17 +17,9 @@ struct NowPlayingControls: View {
                 // To take into account the page indicator view
                 Spacer().frame(height: Constants.pagingIndicatorHeight)
             }
-            .modify { content in
-                if #available(watchOS 10.0, *) {
-                    content.containerRelativeFrame(.vertical)
-                }
-            }
+            .containerRelativeFrame(.vertical)
         }
-        .modify { content in
-            if #available(watchOS 9.4, *) {
-                content.scrollBounceBehavior(.basedOnSize)
-            }
-        }
+        .scrollBounceBehavior(.basedOnSize)
         .ignoresSafeArea(.all, edges: .bottom)
     }
 

--- a/WidgetExtension/Sleep Timer/SleepTimerLiveActivityWidget.swift
+++ b/WidgetExtension/Sleep Timer/SleepTimerLiveActivityWidget.swift
@@ -135,7 +135,6 @@ private enum SleepTimerLiveActivityStyle {
     static let secondaryTextColor = Color.secondary
 }
 
-@available(iOSApplicationExtension 17.0, *)
 #Preview("Sleep Timer", as: .content, using: SleepTimerActivityAttributes()) {
     SleepTimerLiveActivityWidget()
 } contentStates: {

--- a/WidgetExtension/Up Next/UpNextLockScreenWidget.swift
+++ b/WidgetExtension/Up Next/UpNextLockScreenWidget.swift
@@ -32,7 +32,6 @@ struct UpNextLockScreenWidgetEntryView: View {
 
 // MARK: - Circular View
 
-@available(iOSApplicationExtension 16.0, *)
 struct UpNextCircularWidgetView: View {
     let entry: UpNextEntry
 
@@ -72,7 +71,6 @@ struct UpNextCircularWidgetView: View {
 
 // MARK: - Rectangle View
 
-@available(iOSApplicationExtension 16.0, *)
 struct UpNextRectangularWidgetView: View {
     let entry: UpNextEntry
 
@@ -131,7 +129,6 @@ struct UpNextRectangularWidgetView: View {
     }
 }
 
-@available(iOSApplicationExtension 16.0, *)
 struct UpNextLockScreenWidget_Previews: PreviewProvider {
     static var previews: some View {
         UpNextLockScreenWidgetEntryView(entry: UpNextEntry(date: Date(), isPlaying: false, upNextEpisodesCount: 18))

--- a/podcasts/Bookmarks/Episode/EpisodeDetailTabView.swift
+++ b/podcasts/Bookmarks/Episode/EpisodeDetailTabView.swift
@@ -75,14 +75,8 @@ struct EpisodeDetailTabView: View {
         ScrollView(.horizontal, showsIndicators: false) {
             content()
         }
-        .modify { view in
-            if #available(iOS 16.4, *) {
-                view.scrollIndicators(.never)
-                    .scrollBounceBehavior(.basedOnSize, axes: [.horizontal])
-            } else {
-                view
-            }
-        }
+        .scrollIndicators(.never)
+        .scrollBounceBehavior(.basedOnSize, axes: [.horizontal])
     }
 }
 

--- a/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyView.swift
+++ b/podcasts/Cancel Subscription/Cancel Subscription/Survey/CancelSubscriptionSurveyView.swift
@@ -50,11 +50,7 @@ struct CancelSubscriptionSurveyView: View {
                     }
                 }
                 .padding(.top, 48)
-                .modify {
-                    if #available(iOS 16.4, *) {
-                        $0.scrollBounceBehavior(.basedOnSize)
-                    }
-                }
+                .scrollBounceBehavior(.basedOnSize)
             }
 
             VStack {

--- a/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
@@ -37,9 +37,10 @@ struct Top5Podcasts2024Story: ShareableStory {
                         view
                     } else {
                         ScrollView(.vertical) {
-                            view.scrollIndicators(.never)
-                                .scrollBounceBehavior(.basedOnSize)
+                            view
                         }
+                        .scrollIndicators(.never)
+                        .scrollBounceBehavior(.basedOnSize)
                     }
                 }
                 .padding(.horizontal, 24)

--- a/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
+++ b/podcasts/End of Year/Stories/2024/Top5Podcasts2024Story.swift
@@ -37,12 +37,8 @@ struct Top5Podcasts2024Story: ShareableStory {
                         view
                     } else {
                         ScrollView(.vertical) {
-                            if #available(iOS 16.4, *) {
-                                view.scrollIndicators(.never)
-                                    .scrollBounceBehavior(.basedOnSize)
-                            } else {
-                                view
-                            }
+                            view.scrollIndicators(.never)
+                                .scrollBounceBehavior(.basedOnSize)
                         }
                     }
                 }

--- a/podcasts/End of Year/Stories/2025/Top5Podcasts2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/Top5Podcasts2025Story.swift
@@ -32,12 +32,8 @@ struct Top5Podcasts2025Story: ShareableStory {
                         view
                     } else {
                         ScrollView(.vertical) {
-                            if #available(iOS 16.4, *) {
-                                view.scrollIndicators(.never)
-                                    .scrollBounceBehavior(.basedOnSize)
-                            } else {
-                                view
-                            }
+                            view.scrollIndicators(.never)
+                                .scrollBounceBehavior(.basedOnSize)
                         }
                     }
                 }

--- a/podcasts/End of Year/Stories/2025/Top5Podcasts2025Story.swift
+++ b/podcasts/End of Year/Stories/2025/Top5Podcasts2025Story.swift
@@ -32,9 +32,10 @@ struct Top5Podcasts2025Story: ShareableStory {
                         view
                     } else {
                         ScrollView(.vertical) {
-                            view.scrollIndicators(.never)
-                                .scrollBounceBehavior(.basedOnSize)
+                            view
                         }
+                        .scrollIndicators(.never)
+                        .scrollBounceBehavior(.basedOnSize)
                     }
                 }
                 .disabled(!isSmallScreen) // Disable scrolling on larger where we shouldn't be clipping.

--- a/podcasts/New Search/Views/Results/PillSegmentControl.swift
+++ b/podcasts/New Search/Views/Results/PillSegmentControl.swift
@@ -34,11 +34,7 @@ struct PillSegmentControl<Data: RandomAccessCollection, Content: View>: View whe
             }
         }
         .scrollIndicators(.hidden)
-        .modify {
-            if #available(iOS 16.4, *) {
-                $0.scrollBounceBehavior(.basedOnSize, axes: .horizontal)
-            }
-        }
+        .scrollBounceBehavior(.basedOnSize, axes: .horizontal)
     }}
 
 

--- a/podcasts/Onboarding/Plus/PlusPurchaseModal.swift
+++ b/podcasts/Onboarding/Plus/PlusPurchaseModal.swift
@@ -108,11 +108,7 @@ struct PlusPurchaseModal: View {
             .padding(.vertical, sizeCategory.isAccessibilityCategory ? 24 : 0)
         }
         .background(Color.backgroundColor.ignoresSafeArea())
-        .modify {
-            if #available(iOS 16.4, *) {
-                $0.scrollBounceBehavior(.basedOnSize)
-            }
-        }
+        .scrollBounceBehavior(.basedOnSize)
     }
 
     private var pricingTermsLabel: String {

--- a/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallContainer.swift
+++ b/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallContainer.swift
@@ -70,16 +70,10 @@ struct PlusPaywallContainer: View {
     }
 
     @ViewBuilder private var purchaseModal: some View {
-        ZStack {
-            if #unavailable(iOS 16.4) {
-                Constants.sheetBackgroundColor
-                    .edgesIgnoringSafeArea(.all)
-            }
-            PlusPurchaseModal(coordinator: viewModel, selectedPrice: .yearly)
-                .setupDefaultEnvironment()
-        }
-        .presentationDetents([.custom(PlusPurchaseModalDetent.self)])
-        .presentationDragIndicator(.visible)
+        PlusPurchaseModal(coordinator: viewModel, selectedPrice: .yearly)
+            .setupDefaultEnvironment()
+            .presentationDetents([.custom(PlusPurchaseModalDetent.self)])
+            .presentationDragIndicator(.visible)
     }
 
     init(viewModel: PlusLandingViewModel, type: ContainerType) {
@@ -105,14 +99,8 @@ struct PlusPaywallContainer: View {
         .background(Constants.backgroundColor)
         .sheet(isPresented: $presentSubscriptionView) {
             purchaseModal
-                .modify {
-                    if #available(iOS 16.4, *) {
-                        $0.presentationBackground {
-                            Constants.sheetBackgroundColor
-                        }
-                    } else {
-                        $0
-                    }
+                .presentationBackground {
+                    Constants.sheetBackgroundColor
                 }
                 .onAppear {
                     OnboardingFlow.shared.track(.selectPaymentFrequencyShown)

--- a/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallContainer.swift
+++ b/podcasts/Onboarding/Plus/UpgradeExperiment/PlusPaywallContainer.swift
@@ -69,7 +69,7 @@ struct PlusPaywallContainer: View {
         .background(Constants.backgroundColor)
     }
 
-    @ViewBuilder private var purchaseModal: some View {
+    private var purchaseModal: some View {
         PlusPurchaseModal(coordinator: viewModel, selectedPrice: .yearly)
             .setupDefaultEnvironment()
             .presentationDetents([.custom(PlusPurchaseModalDetent.self)])

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -2402,14 +2402,12 @@ class PlaybackManager: ServerPlaybackDelegate {
             // receive a different notification which is already handled elsewhere.
             // Also put this new check behind a feature flag so we can remotely revert to the old logic if
             // we run into any issues
-            if #available(iOS 17, watchOS 10, *), FeatureFlag.ignoreRouteDisconnectedInterruption.enabled {
+            if FeatureFlag.ignoreRouteDisconnectedInterruption.enabled {
                 if interruptionReason != AVAudioSession.InterruptionReason.routeDisconnected.rawValue {
                     interruptInProgress = true
                 }
             } else {
-                // We do not get the InterruptionReason.routeDisconnected notification on older versions, so
-                // no need to perform the same check for older versions.
-                // Also, will default to the old behaviour if the feature flag is disabled on newer versions.
+                // Default to the old behaviour if the feature flag is disabled.
                 interruptInProgress = true
             }
 


### PR DESCRIPTION
Every target deploys to iOS 17.0 / watchOS 10.0 (`podcasts.xcodeproj`: 40× `IPHONEOS_DEPLOYMENT_TARGET = 17.0`, 8× `WATCHOS_DEPLOYMENT_TARGET = 10.0`; `Modules/Package.swift`: `.iOS(.v17), .watchOS(.v10), .macOS(.v13), .tvOS(.v17)`). Availability checks below those minimums can never fail, so the checks are noise and their `else` branches are unreachable.

**Redundant `#available` and the dead branches they guarded** — 7× `iOS 16.4`, `watchOS 10.0`, `watchOS 9.4`, and `iOS 17, watchOS 10`:

- `CancelSubscriptionSurveyView`, `PillSegmentControl`, `PlusPurchaseModal`, `EpisodeDetailTabView`, `Top5Podcasts2024Story`, `Top5Podcasts2025Story` — `scrollBounceBehavior`/`scrollIndicators` now applied directly instead of through `.modify { if #available … }`
- `PlusPaywallContainer` — `presentationBackground` applied directly
- `NowPlayingControls` — `containerRelativeFrame` and `scrollBounceBehavior` applied directly
- `PlaybackManager.handleAudioInterrupt` — the audio-interruption branch is now just the `ignoreRouteDisconnectedInterruption` feature-flag test; the two comment lines explaining the "older versions" path went with it

**Dead `#unavailable` branch:** `PlusPaywallContainer.purchaseModal` had `if #unavailable(iOS 16.4) { Constants.sheetBackgroundColor … }` inside a `ZStack`. Removing it leaves the `ZStack` with a single child, so that went too.

**Redundant `@available` attributes:** `UpNextLockScreenWidget` (3× `iOSApplicationExtension 16.0`), `SleepTimerLiveActivityWidget` (`iOSApplicationExtension 17.0`), `UIFontExtension` (2× `watchOS 8.0`).

Every removed branch was already unreachable on the minimum supported OS, so the availability cleanup itself is behaviour-neutral.

**One deliberate behaviour change on top of that**, from review feedback: in both Top 5 Podcasts stories, `scrollIndicators(.never)` and `scrollBounceBehavior(.basedOnSize)` were applied to the `ScrollView`'s *content* rather than to the `ScrollView`. Both are environment-propagating modifiers, so attached to a descendant they never reached the enclosing scroll view and did nothing. They're now applied to the `ScrollView`, which is what the original code intended — the stories no longer show a vertical scroll indicator and no longer bounce when the list fits. Pre-existing, but this PR rewrites exactly those lines.

Two things deliberately left alone:

- `fastlane/SnapshotHelper.swift` has a redundant `#available(iOS 10.0, *)`, but that file is regenerated by `fastlane snapshot update` and any edit would be overwritten.
- Still-meaningful checks remain: `iOS 17.1`, `iOS 18.0`, `iOS 26/26.0/26.4`, `watchOS 11.0`, and `#unavailable(iOS 27)` in `PodcastListViewController`.

`.modify` still has 12 call sites, so the helper stays.

## To test

Builds clean with no new warnings; the changes are compile-time only. To sanity-check the affected UI:

1. Open the Plus paywall (Profile → Upgrade to Plus), tap the subscribe button to present the purchase sheet — the sheet background and detents should look unchanged.
2. Open an episode with bookmarks (Episode details → Bookmarks tab) and scroll the horizontal tab strip — it should not bounce when the content fits.
3. Run a search and scroll the results pill segment control horizontally — same, no bounce when content fits.
4. Profile → Settings → Cancel subscription survey — scroll the survey, no bounce when the content fits.
5. End of Year 2024 and 2025 → Top 5 Podcasts story — on a small screen (iPhone SE) the list still scrolls; on a large screen it doesn't bounce and shows no scroll indicator. This is the one intentional behaviour change, so worth a look on both.
6. On watchOS, open Now Playing — the controls page should still fill the screen vertically and not overscroll.
7. Playback: disconnect a Bluetooth/AirPods route mid-playback and confirm playback pauses without getting stuck in an interrupted state (`ignoreRouteDisconnectedInterruption` flag on).

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
