### PR TITLE
Apply clipShape directly instead of through a no-op modify wrapper

### DIFF
--- a/podcasts/Sharing/Clip/MediaTrimBar.swift
+++ b/podcasts/Sharing/Clip/MediaTrimBar.swift
@@ -30,12 +30,10 @@ struct MediaTrimBar: View {
             TrimPlayButton(isPlaying: $isPlaying)
                 .frame(width: Constants.height)
                 .background(Constants.trimBorderColor)
-                .modify { view in
-                    view.clipShape(.rect(topLeadingRadius: Constants.borderRadius,
-                                         bottomLeadingRadius: Constants.borderRadius,
-                                         bottomTrailingRadius: 0,
-                                         topTrailingRadius: 0))
-                }
+                .clipShape(.rect(topLeadingRadius: Constants.borderRadius,
+                                 bottomLeadingRadius: Constants.borderRadius,
+                                 bottomTrailingRadius: 0,
+                                 topTrailingRadius: 0))
                 .onChange(of: isPlaying) { _, isPlaying in
                     if isPlaying {
                         playbackManager.play(episode: episode, clipTime: _clipTime)

--- a/podcasts/Sharing/Clip/TrimHandle.swift
+++ b/podcasts/Sharing/Clip/TrimHandle.swift
@@ -21,12 +21,10 @@ struct TrimHandle: View {
         ZStack {
             Rectangle()
                 .fill(.tint)
-                .modify { view in
-                    view.clipShape(.rect(topLeadingRadius: edgeRadius.leading,
-                                         bottomLeadingRadius: edgeRadius.leading,
-                                         bottomTrailingRadius: edgeRadius.trailing,
-                                         topTrailingRadius: edgeRadius.trailing))
-                }
+                .clipShape(.rect(topLeadingRadius: edgeRadius.leading,
+                                 bottomLeadingRadius: edgeRadius.leading,
+                                 bottomTrailingRadius: edgeRadius.trailing,
+                                 topTrailingRadius: edgeRadius.trailing))
             handleLine
         }
         .frame(width: width)


### PR DESCRIPTION
`MediaTrimBar` and `TrimHandle` both wrapped a `clipShape` in `View.modify`:

```swift
.modify { view in
    view.clipShape(.rect(topLeadingRadius: ..., ...))
}
```

`modify` exists to conditionally apply a modifier — it returns the transform's result when there is one and falls back to `self` otherwise. Neither of these transforms has a condition, so they always return a real view and the fallback is unreachable. All the wrapper does is put the content behind a `_ConditionalContent`. They look like leftovers from a removed `#available(iOS 16, *)` guard around `.rect(topLeadingRadius:)`, which the minimum deployment target (iOS 17) made redundant.

Both are now plain `.clipShape(...)` calls. `TrimHandle` still varies its corner radii by `edgeRadius` — that's an argument to `clipShape`, not a branch, so it works exactly as before.

No behaviour change. Follow-up to #4973.

## To test

1. Play an episode, open the share sheet from the player (⋯ → Share → Clip).
2. Confirm the play/pause button at the left of the trim bar still has rounded leading corners and square trailing corners, flush against the waveform.
3. Drag the leading and trailing trim handles. Each handle should keep its rounded outer edge and square inner edge, and follow the drag smoothly.
4. Switch themes and confirm the trim bar border and handle tint still render correctly.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.