### PR TITLE
PCIOS-899: iOS: Smart playlists with "Not Downloaded" rule no longer remove episodes live when a download completes (regression in 8.16 via #4648)

### DIFF
--- a/podcasts/New Detail/PlaylistDetailViewController+Observers.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+Observers.swift
@@ -19,9 +19,16 @@ extension PlaylistDetailViewController {
         addCustomObserver(Constants.Notifications.episodePlayStatusChanged, selector: #selector(refreshEpisodesFromNotification))
         addCustomObserver(Constants.Notifications.episodeArchiveStatusChanged, selector: #selector(refreshEpisodesFromNotification))
         addCustomObserver(Constants.Notifications.episodeStarredChanged, selector: #selector(refreshEpisodesFromNotification))
+        addCustomObserver(Constants.Notifications.episodeDownloaded, selector: #selector(refreshEpisodesIfDownloadStatusMatters))
+        addCustomObserver(Constants.Notifications.episodeDownloadStatusChanged, selector: #selector(refreshEpisodesIfDownloadStatusMatters))
         addCustomObserver(Constants.Notifications.manyEpisodesChanged, selector: #selector(refreshEpisodesFromNotification))
         addCustomObserver(UIResponder.keyboardWillShowNotification, selector: #selector(keyboardWillShow(_:)))
         addCustomObserver(UIResponder.keyboardWillHideNotification, selector: #selector(keyboardWillHide(_:)))
+    }
+
+    @objc func refreshEpisodesIfDownloadStatusMatters(notification: Notification) {
+        guard viewModel.playlist.isAffected(by: .downloadStatus) else { return }
+        reloader.request(.episodes)
     }
 
     @objc func keyboardWillShow(_ notification: Notification) {


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-899/ios-smart-playlists-with-not-downloaded-rule-no-longer-remove-episodes

## Summary
Re-adds the `episodeDownloaded` and `episodeDownloadStatusChanged` notification observers to `PlaylistDetailViewController`, which were removed in PR #4648. The observers now use a conditional handler that only triggers a reload when the playlist's smart rules include a download-status filter, avoiding the scroll-jump regression that #4648 originally fixed (PCIOS-804).

## Changes
- Added `episodeDownloaded` and `episodeDownloadStatusChanged` observers in `addObservers()` pointing to a new `refreshEpisodesIfDownloadStatusMatters` handler
- The handler checks `viewModel.playlist.isAffected(by: .downloadStatus)` — which returns `true` only when `filterDownloaded` or `filterNotDownloaded` is set — before requesting an episode list reload
- Playlists without download-status rules are unaffected and will not reload on download events (preserving the PCIOS-804 fix)

## Verification
- **Lint**: PASS — formatter made no changes
- **Tests**: FAIL — pre-existing `GenerateCredentials` build phase failure, identical on trunk (not caused by this change)
- **Diff review**: PASS — single file changed, minimal and focused diff, no unintended changes

## Confidence
**HIGH** — The root cause is precisely identified (PR #4648 removed these observers), the fix surgically restores them with the exact conditional guard needed to avoid regressing PCIOS-804, and the `isAffected(by:)` method is already well-tested via `PlaylistCacheInvalidationCoordinator`.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/PCIOS-899/ios-smart-playlists-with-not-downloaded-rule-no-longer-remove-episodes)