### PR TITLE
Add flow property to account creation analytics events

### DIFF
--- a/podcasts/NewEmailViewController.swift
+++ b/podcasts/NewEmailViewController.swift
@@ -165,7 +165,7 @@ class NewEmailViewController: PCViewController, UITextFieldDelegate {
     }
 
     private func startRegister(_ username: String, password: String) {
-        Analytics.track(.createAccountNextButtonTapped)
+        OnboardingFlow.shared.track(.createAccountNextButtonTapped)
 
         passwordBorderView.layer.borderColor = ThemeColor.primaryUi05().cgColor
         contentView.alpha = 0.3

--- a/podcasts/Onboarding/LoginCoordinator.swift
+++ b/podcasts/Onboarding/LoginCoordinator.swift
@@ -213,7 +213,7 @@ extension LoginCoordinator: SyncSigninDelegate, CreateAccountDelegate {
     }
 
     func handleAccountCreated() {
-        Analytics.track(.userAccountCreated, properties: ["source": socialAuthProvider ?? "password"])
+        Analytics.track(.userAccountCreated, properties: ["source": socialAuthProvider ?? "password", "flow": OnboardingFlow.shared.currentFlow])
         OnboardingFlow.shared.accountCreated?(true)
         if OnboardingFlow.shared.currentFlow.shouldDismiss {
             handleDismiss()


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Adds a `flow` property to two account-creation analytics events so they can be attributed to the onboarding flow (entry point) that triggered them:

- `create_account_next_button_tapped` — now routed through `OnboardingFlow.shared.track`, matching how `create_account_shown` is already tracked in the same view controller. This adds both `flow` and `source`.
- `user_account_created` — adds `"flow": OnboardingFlow.shared.currentFlow` inline. This one is intentionally **not** routed through `OnboardingFlow.shared.track`: that method merges its own default properties keeping the defaults, which would overwrite the existing `source` (social auth provider vs. `"password"`) this event already reports.

The `Flow` enum conforms to `AnalyticsDescribable`, so it serializes to its snake_case string value automatically.

Note: the tvOS `CreateAccountView` also tracks `user_account_created` (with `source: "qr_code"`), but the TV app has no `OnboardingFlow` concept, so it was left unchanged.

## To test

1. Enter an onboarding flow (e.g. initial onboarding, or a plus upsell that leads to account creation).
2. Create a new account via email/password and via a social provider.
3. Verify in the analytics debug console that `create_account_next_button_tapped` and `user_account_created` both include a `flow` property matching the flow you entered, and that `user_account_created` still reports the correct `source`.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)