### PR TITLE
Silence the Sendable warnings in FingerprintTimingManager

### DIFF
--- a/podcasts/Fingerprint/FingerprintTimingManager.swift
+++ b/podcasts/Fingerprint/FingerprintTimingManager.swift
@@ -1,12 +1,12 @@
 import AVFoundation
 import Accelerate
 import Foundation
-import Fingerprint
-import PocketCastsDataModel
+@preconcurrency import Fingerprint
+@preconcurrency import PocketCastsDataModel
 import PocketCastsUtils
 import os
 
-final class FingerprintTimingManager: NSObject {
+final class FingerprintTimingManager: NSObject, @unchecked Sendable {
 
     // MARK: - Public Types
 


### PR DESCRIPTION
`FingerprintTimingManager` emitted 8 strict-concurrency warnings, all from the same three root causes:

- **`self` captured in `@Sendable` closures** (the `onDemandQueue.async` blocks in `performResolve` / `resolveReferenceTime`, and the `queue.async` inside `prepareForEpisode`'s `Task`). The class already hand-synchronizes its mutable state — `context`, `main`, `lastGeneration`, and the cancellation flags live on the private serial `queue`, and the on-demand flags on the main queue — which is exactly the invariant `@unchecked Sendable` asserts, so the conformance is declared rather than the isolation re-plumbed.
- **`CheckpointMatcher` captured in a `@Sendable` closure**, from the `Fingerprint` module.
- **`BaseEpisode` captured in a `@Sendable` closure**, from `PocketCastsDataModel`.

Neither `CheckpointMatcher` nor `BaseEpisode` can be annotated from this file, so both imports take `@preconcurrency` — the compiler's own suggested fix-it for those two warnings.

No behaviour change; three lines touched.

## To test

1. Build the app — `FingerprintTimingManager.swift` should compile with no concurrency warnings. A clean build (or `make clean` first) is needed to see it: incremental builds replay the pre-fix diagnostics from other files' cached compile records, so the stale warnings keep showing up against the old line numbers.
2. Play an episode with a synced transcript and confirm the transcript still follows playback.
3. Tap a generated chapter and confirm the seek resolves to the right position.
4. Open a bookmark on a streaming episode and confirm it resolves to the right position.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
