### PR TITLE
Fix the episode details screen insets on watchOS 26

### DIFF
--- a/Pocket Casts Watch App/UI/Episode/EpisodeView.swift
+++ b/Pocket Casts Watch App/UI/Episode/EpisodeView.swift
@@ -12,11 +12,14 @@ struct EpisodeView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 7) {
                     artwork
-                    episodeDetails
-                        .offset(y: geo.size.width * -0.6)
-                        .padding(.bottom, geo.size.width * -0.6)
-                    Divider()
-                    episodeActions
+                    VStack(alignment: .leading, spacing: 7) {
+                        episodeDetails
+                            .offset(y: geo.size.width * -0.6)
+                            .padding(.bottom, geo.size.width * -0.6)
+                        Divider()
+                        episodeActions
+                    }
+                    .scenePadding(.horizontal)
                 }
             }
             .navigationTitle(listTitle)
@@ -108,7 +111,14 @@ struct EpisodeView: View {
 }
 
 struct EpisodeView_Previews: PreviewProvider {
-    static let testViewModel = EpisodeDetailsViewModel(episode: Episode(), playlist: nil)
+    static let testEpisode: Episode = {
+        let episode = Episode()
+        episode.title = "An Episode Title That Wraps Onto Multiple Lines"
+        episode.episodeDescription = "A sample episode description that is long enough to wrap so the layout can be checked."
+        return episode
+    }()
+
+    static let testViewModel = EpisodeDetailsViewModel(episode: testEpisode, playlist: nil)
     static var previews: some View {
         ForEach(PreviewDevice.previewDevices, id: \.rawValue) { device in
             EpisodeView(viewModel: testViewModel, listTitle: "Test")


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Noticed when testing https://github.com/Automattic/pocket-casts-ios/pull/4976.

On watchOS 26 the episode details content ran all the way to the display edge, so the title, date, description and the play button were clipped by the rounded corners. The action buttons were already the correct system width, but the leading-aligned `VStack` pinned them to the edge instead of centering them, which left them visibly offset.

Everything below the artwork now sits in a container with `scenePadding(.horizontal)`, putting it on the same content column the system button style already uses. The artwork keeps its full-bleed treatment.

The SwiftUI preview now feeds in a sample title and description so this layout is actually visible in the canvas — previously it used an empty `Episode()`.

Before / After
<img width="255" height="353" alt="Screenshot 2026-08-19 at 12 38 51 PM" src="https://github.com/user-attachments/assets/398fc373-a075-41b9-88b6-afd014a80105" /> <img width="255" height="353" alt="Screenshot 2026-08-19 at 1 32 49 PM" src="https://github.com/user-attachments/assets/360a41f0-f597-44f6-9cee-c6bc0da39504" />

## To test

1. Run the watch app on a watchOS 26 simulator or device.
2. Open Up Next (or any episode list) and tap an episode.
3. The title, date, duration and description should be inset from the display edge rather than clipped by the rounded corners, and should line up with the artwork's play button.
4. Scroll down: the divider and the action buttons (Download, Play Next, Archive, …) should be centered on the display, not pushed against the leading edge.
5. The artwork should still span the full width.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
