### PR TITLE
Update smart playlists live when a download changes their contents

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -87,6 +87,14 @@ public class EpisodeFilter: NSObject {
         !filterDownloaded
     }
 
+    /// Whether an episode's download status decides if it belongs to this playlist.
+    public var filtersByDownloadStatus: Bool {
+        let allStatuses = filterDownloaded && filterDownloading && filterNotDownloaded
+        let anyStatus = filterDownloaded || filterDownloading || filterNotDownloaded
+
+        return !allStatuses && anyStatus
+    }
+
     public func addPodcast(podcastUuid: String) {
         if podcastUuids.isEmpty {
             filterAllPodcasts = false

--- a/Modules/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/PlaylistQueryBuilder.swift
@@ -736,7 +736,7 @@ public class PlaylistQueryBuilder {
         queryString: inout String,
         haveStartedWhere: inout Bool
     ) {
-        if !(playlist.filterDownloaded && playlist.filterDownloading && playlist.filterNotDownloaded), playlist.filterDownloaded || playlist.filterDownloading || playlist.filterNotDownloaded {
+        if playlist.filtersByDownloadStatus {
             if haveStartedWhere { queryString += "AND " }
             queryString += "("
             if playlist.filterDownloaded {
@@ -906,7 +906,7 @@ public class PlaylistQueryBuilder {
         }
 
         // Download Status
-        if !(filter.filterDownloaded && filter.filterDownloading && filter.filterNotDownloaded), filter.filterDownloaded || filter.filterDownloading || filter.filterNotDownloaded {
+        if filter.filtersByDownloadStatus {
             if haveStartedWhere { queryString += "AND " }
             queryString += "("
             if filter.filterDownloaded {

--- a/Modules/Tests/PocketCastsDataModelTests/EpisodeFilterDownloadStatusTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/EpisodeFilterDownloadStatusTests.swift
@@ -11,15 +11,23 @@ final class EpisodeFilterDownloadStatusTests: XCTestCase {
         XCTAssertFalse(filter.filtersByDownloadStatus)
     }
 
-    func testFiltersByDownloadStatusWhenOnlyNotDownloadedIsIncluded() {
+    func testFiltersByDownloadStatusWhenDownloadedIsExcluded() {
         let filter = EpisodeFilter.makeDefault()
         filter.filterDownloaded = false
 
         XCTAssertTrue(filter.filtersByDownloadStatus)
     }
 
-    func testFiltersByDownloadStatusWhenOnlyDownloadedIsIncluded() {
+    func testFiltersByDownloadStatusWhenNotDownloadedIsExcluded() {
         let filter = EpisodeFilter.makeDefault()
+        filter.filterNotDownloaded = false
+
+        XCTAssertTrue(filter.filtersByDownloadStatus)
+    }
+
+    func testFiltersByDownloadStatusWhenOnlyDownloadingIsIncluded() {
+        let filter = EpisodeFilter.makeDefault()
+        filter.filterDownloaded = false
         filter.filterNotDownloaded = false
 
         XCTAssertTrue(filter.filtersByDownloadStatus)
@@ -34,21 +42,24 @@ final class EpisodeFilterDownloadStatusTests: XCTestCase {
 
         XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
         XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.queued.rawValue)"))
         XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
     }
 
-    func testQueryExcludesDownloadedEpisodesWhenOnlyNotDownloadedIsIncluded() throws {
+    func testQueryStillMatchesDownloadingEpisodesWhenDownloadedIsExcluded() throws {
         let filter = EpisodeFilter.makeDefault()
         filter.filterDownloaded = false
 
         let query = PlaylistQueryBuilder.query(clause: .episode, for: filter)
 
         XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.queued.rawValue)"))
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.downloading.rawValue)"))
         XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
         XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
     }
 
-    func testQueryOnlyIncludesDownloadedEpisodesWhenOnlyDownloadedIsIncluded() throws {
+    func testQueryStillMatchesDownloadingEpisodesWhenNotDownloadedIsExcluded() throws {
         let filter = EpisodeFilter.makeDefault()
         filter.filterNotDownloaded = false
 
@@ -56,6 +67,22 @@ final class EpisodeFilterDownloadStatusTests: XCTestCase {
 
         XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
         XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.queued.rawValue)"))
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.downloading.rawValue)"))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
+    }
+
+    func testQueryOnlyMatchesDownloadingEpisodesWhenOnlyDownloadingIsIncluded() throws {
+        let filter = EpisodeFilter.makeDefault()
+        filter.filterDownloaded = false
+        filter.filterNotDownloaded = false
+
+        let query = PlaylistQueryBuilder.query(clause: .episode, for: filter)
+
+        XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.queued.rawValue)"))
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.downloading.rawValue)"))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
         XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
     }
 
@@ -65,16 +92,31 @@ final class EpisodeFilterDownloadStatusTests: XCTestCase {
         let query = PlaylistQueryBuilder.queryFor(filter: filter, episodeUuidToAdd: nil, limit: 0)
 
         XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.queued.rawValue)"))
         XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
     }
 
-    func testLegacyQueryExcludesDownloadedEpisodesWhenOnlyNotDownloadedIsIncluded() {
+    func testLegacyQueryStillMatchesDownloadingEpisodesWhenDownloadedIsExcluded() {
         let filter = EpisodeFilter.makeDefault()
         filter.filterDownloaded = false
 
         let query = PlaylistQueryBuilder.queryFor(filter: filter, episodeUuidToAdd: nil, limit: 0)
 
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.queued.rawValue)"))
         XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
         XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
+    }
+
+    func testLegacyQueryOnlyMatchesDownloadingEpisodesWhenOnlyDownloadingIsIncluded() {
+        let filter = EpisodeFilter.makeDefault()
+        filter.filterDownloaded = false
+        filter.filterNotDownloaded = false
+
+        let query = PlaylistQueryBuilder.queryFor(filter: filter, episodeUuidToAdd: nil, limit: 0)
+
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.queued.rawValue)"))
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.downloading.rawValue)"))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
     }
 }

--- a/Modules/Tests/PocketCastsDataModelTests/EpisodeFilterDownloadStatusTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/EpisodeFilterDownloadStatusTests.swift
@@ -1,0 +1,80 @@
+@testable import PocketCastsDataModel
+import XCTest
+
+final class EpisodeFilterDownloadStatusTests: XCTestCase {
+
+    // MARK: - filtersByDownloadStatus
+
+    func testDoesNotFilterByDownloadStatusWhenEveryStatusIsIncluded() {
+        let filter = EpisodeFilter.makeDefault()
+
+        XCTAssertFalse(filter.filtersByDownloadStatus)
+    }
+
+    func testFiltersByDownloadStatusWhenOnlyNotDownloadedIsIncluded() {
+        let filter = EpisodeFilter.makeDefault()
+        filter.filterDownloaded = false
+
+        XCTAssertTrue(filter.filtersByDownloadStatus)
+    }
+
+    func testFiltersByDownloadStatusWhenOnlyDownloadedIsIncluded() {
+        let filter = EpisodeFilter.makeDefault()
+        filter.filterNotDownloaded = false
+
+        XCTAssertTrue(filter.filtersByDownloadStatus)
+    }
+
+    // MARK: - Query
+
+    func testQueryHasNoDownloadStatusClauseWhenEveryStatusIsIncluded() throws {
+        let filter = EpisodeFilter.makeDefault()
+
+        let query = PlaylistQueryBuilder.query(clause: .episode, for: filter)
+
+        XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
+    }
+
+    func testQueryExcludesDownloadedEpisodesWhenOnlyNotDownloadedIsIncluded() throws {
+        let filter = EpisodeFilter.makeDefault()
+        filter.filterDownloaded = false
+
+        let query = PlaylistQueryBuilder.query(clause: .episode, for: filter)
+
+        XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
+    }
+
+    func testQueryOnlyIncludesDownloadedEpisodesWhenOnlyDownloadedIsIncluded() throws {
+        let filter = EpisodeFilter.makeDefault()
+        filter.filterNotDownloaded = false
+
+        let query = PlaylistQueryBuilder.query(clause: .episode, for: filter)
+
+        XCTAssertNoThrow(try SQLiteValidator.validate(sql: query))
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
+    }
+
+    func testLegacyQueryHasNoDownloadStatusClauseWhenEveryStatusIsIncluded() {
+        let filter = EpisodeFilter.makeDefault()
+
+        let query = PlaylistQueryBuilder.queryFor(filter: filter, episodeUuidToAdd: nil, limit: 0)
+
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
+    }
+
+    func testLegacyQueryExcludesDownloadedEpisodesWhenOnlyNotDownloadedIsIncluded() {
+        let filter = EpisodeFilter.makeDefault()
+        filter.filterDownloaded = false
+
+        let query = PlaylistQueryBuilder.queryFor(filter: filter, episodeUuidToAdd: nil, limit: 0)
+
+        XCTAssertTrue(query.contains("episodeStatus = \(DownloadStatus.waitingForWifi.rawValue)"))
+        XCTAssertFalse(query.contains("episodeStatus = \(DownloadStatus.downloaded.rawValue)"))
+    }
+}

--- a/PocketCastsTests/Tests/Playlists/EpisodeFilterChangeTypeTests.swift
+++ b/PocketCastsTests/Tests/Playlists/EpisodeFilterChangeTypeTests.swift
@@ -1,0 +1,40 @@
+import PocketCastsDataModel
+import XCTest
+@testable import podcasts
+
+final class EpisodeFilterChangeTypeTests: XCTestCase {
+
+    func testSmartPlaylistIsNotAffectedByDownloadStatusWhenEveryStatusIsIncluded() {
+        let playlist = EpisodeFilter.makeDefault()
+
+        XCTAssertFalse(playlist.isAffected(by: .downloadStatus))
+    }
+
+    func testSmartPlaylistIsAffectedByDownloadStatusWhenOnlyNotDownloadedIsIncluded() {
+        let playlist = EpisodeFilter.makeDefault()
+        playlist.filterDownloaded = false
+
+        XCTAssertTrue(playlist.isAffected(by: .downloadStatus))
+    }
+
+    func testSmartPlaylistIsAffectedByDownloadStatusWhenOnlyDownloadedIsIncluded() {
+        let playlist = EpisodeFilter.makeDefault()
+        playlist.filterNotDownloaded = false
+
+        XCTAssertTrue(playlist.isAffected(by: .downloadStatus))
+    }
+
+    func testManualPlaylistIsNotAffectedByDownloadStatus() {
+        let playlist = EpisodeFilter.makeDefault()
+        playlist.manual = true
+        playlist.filterDownloaded = false
+
+        XCTAssertFalse(playlist.isAffected(by: .downloadStatus))
+    }
+
+    func testPlaylistIsAffectedByArchiveChanges() {
+        let playlist = EpisodeFilter.makeDefault()
+
+        XCTAssertTrue(playlist.isAffected(by: .archived))
+    }
+}

--- a/PocketCastsTests/Tests/Playlists/EpisodeFilterChangeTypeTests.swift
+++ b/PocketCastsTests/Tests/Playlists/EpisodeFilterChangeTypeTests.swift
@@ -10,15 +10,23 @@ final class EpisodeFilterChangeTypeTests: XCTestCase {
         XCTAssertFalse(playlist.isAffected(by: .downloadStatus))
     }
 
-    func testSmartPlaylistIsAffectedByDownloadStatusWhenOnlyNotDownloadedIsIncluded() {
+    func testSmartPlaylistIsAffectedByDownloadStatusWhenDownloadedIsExcluded() {
         let playlist = EpisodeFilter.makeDefault()
         playlist.filterDownloaded = false
 
         XCTAssertTrue(playlist.isAffected(by: .downloadStatus))
     }
 
-    func testSmartPlaylistIsAffectedByDownloadStatusWhenOnlyDownloadedIsIncluded() {
+    func testSmartPlaylistIsAffectedByDownloadStatusWhenNotDownloadedIsExcluded() {
         let playlist = EpisodeFilter.makeDefault()
+        playlist.filterNotDownloaded = false
+
+        XCTAssertTrue(playlist.isAffected(by: .downloadStatus))
+    }
+
+    func testSmartPlaylistIsAffectedByDownloadStatusWhenOnlyDownloadingIsIncluded() {
+        let playlist = EpisodeFilter.makeDefault()
+        playlist.filterDownloaded = false
         playlist.filterNotDownloaded = false
 
         XCTAssertTrue(playlist.isAffected(by: .downloadStatus))

--- a/podcasts/New Detail/PlaylistDetailViewController+Observers.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController+Observers.swift
@@ -19,9 +19,17 @@ extension PlaylistDetailViewController {
         addCustomObserver(Constants.Notifications.episodePlayStatusChanged, selector: #selector(refreshEpisodesFromNotification))
         addCustomObserver(Constants.Notifications.episodeArchiveStatusChanged, selector: #selector(refreshEpisodesFromNotification))
         addCustomObserver(Constants.Notifications.episodeStarredChanged, selector: #selector(refreshEpisodesFromNotification))
+        addCustomObserver(Constants.Notifications.episodeDownloaded, selector: #selector(refreshEpisodesIfFilteringByDownloadStatus))
+        addCustomObserver(Constants.Notifications.episodeDownloadStatusChanged, selector: #selector(refreshEpisodesIfFilteringByDownloadStatus))
         addCustomObserver(Constants.Notifications.manyEpisodesChanged, selector: #selector(refreshEpisodesFromNotification))
         addCustomObserver(UIResponder.keyboardWillShowNotification, selector: #selector(keyboardWillShow(_:)))
         addCustomObserver(UIResponder.keyboardWillHideNotification, selector: #selector(keyboardWillHide(_:)))
+    }
+
+    @objc func refreshEpisodesIfFilteringByDownloadStatus(notification: Notification) {
+        guard viewModel.playlist.isAffected(by: .downloadStatus) else { return }
+
+        reloader.request(.episodes)
     }
 
     @objc func keyboardWillShow(_ notification: Notification) {

--- a/podcasts/PlaylistMetadataLoader/EpisodeFilter+ChangeType.swift
+++ b/podcasts/PlaylistMetadataLoader/EpisodeFilter+ChangeType.swift
@@ -28,7 +28,7 @@ extension EpisodeFilter {
 
         case .downloadStatus:
             // Affected if filtering by download status
-            return filterDownloaded || filterNotDownloaded
+            return filtersByDownloadStatus
 
         case .starred:
             // Affected if filtering by starred


### PR DESCRIPTION
Fixes PCIOS-899

Since 8.16, downloading an episode from a smart playlist whose rules include Download Status = "Not Downloaded" left the row in the list until the playlist was re-entered.

[#4648](https://github.com/Automattic/pocket-casts-ios/pull/4648) removed the `episodeDownloaded` / `episodeDownloadStatusChanged` observers from the playlist detail screen to stop the list from jumping, on the grounds that `EpisodeCell` updates itself in place. That holds for cell state, but not for membership: when a playlist filters by download status, a finished download takes the episode out of the query's result set. The screen has no other live-update path, so the row stayed until `viewWillAppear` re-ran the query. Archiving kept working because only the download observers were removed.

The observers are back, but they now request a reload only when the playlist's rules actually key on the download status, so playlists that include every status (New Releases, In Progress, and anything else created with "All") stay as quiet as they are today and don't reintroduce PCIOS-804.

The gate is `EpisodeFilter.filtersByDownloadStatus`, which mirrors the download status clause in `PlaylistQueryBuilder` — the clause is only emitted when some, but not all, of the statuses are included. `PlaylistQueryBuilder` now uses the same property at both of its (duplicated) sites, so the gate can't drift from the SQL. `EpisodeFilter.isAffected(by: .downloadStatus)` uses it too, which also stops the playlist metadata cache from recounting playlists a download can't change.

## To test

1. In the Playlists tab, open a smart playlist and set Smart rules > Download Status = **Not Downloaded**.
2. Download an episode from the list and stay on the screen.
3. When the download completes, the row is removed. Delete the download from elsewhere and it comes back.
4. Set Download Status = **Downloaded** on the same playlist: the episode should appear as the download finishes and disappear when the file is deleted.
5. Set Download Status = **All** (or open New Releases), scroll down, and start a download on an off-screen-ish episode: the list must not jump or reload while the download runs and finishes, and the cell still updates its own download state (this is the PCIOS-804 case #4648 fixed).
6. Archiving from a playlist still removes the row immediately.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
