### PR TITLE
Hide the multi-select footer on the podcast screen when multi-select ends

### DIFF
--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -159,7 +159,9 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
                 self.selectedEpisodes.removeAll()
             }
             // The bookmarks tab shows the action bar of the bookmarks lists instead of the table's own footer
-            self.multiSelectFooter.isHidden = currentViewMode == .bookmarks
+            if currentViewMode == .bookmarks {
+                self.multiSelectFooter.isHidden = true
+            }
             self.updateMultiSelectNavBar()
             searchController?.isOverflowButtonEnabled = !self.isMultiSelectEnabled
             bookmarkList?.isOverflowButtonEnabled = !self.isMultiSelectEnabled


### PR DESCRIPTION
Regression from [#4904](https://github.com/Automattic/pocket-casts-ios/pull/4904), shipped in 8.19 beta.

The multi-select footer on the podcast screen stayed on screen after multi-select ended, leaving a stale status pill such as "Downloading 1" (with its spinner) floating above the mini player until the screen was left.

#4904 added `multiSelectFooter.isHidden = currentViewMode == .bookmarks` to `isMultiSelectEnabled`'s `didSet` so the Bookmarks tab shows the bookmark list's own action bar instead of the table's footer. Because it assigns rather than only hides, it also *unhid* the footer on every exit from multi-select in the Episodes tab, undoing the hide that `selectedEpisodes.removeAll()` had just performed through `setSelectedCount(count: 0)`.

It now only ever hides, which keeps the Bookmarks behaviour and restores the pre-#4904 behaviour everywhere else: on the Episodes tab the footer's visibility is driven by `setSelectedCount`, the same as on Starred, Downloads and Listening History.

This also fixes the footer being left behind when switching from an Episodes multi-select straight to the Bookmarks tab: `switchViewMode` clears `isMultiSelectEnabled` before updating `currentViewMode`, so the old line evaluated `.episodes` and kept the footer visible next to the bookmarks action bar.

## To test

1. Open a podcast, long press an episode to enter multi-select, pick one episode and tap Download.
2. The "Downloading 1" pill disappears together with multi-select. Before this change it stayed until you left the screen.
3. Enter multi-select on the Episodes tab, then switch to the Bookmarks tab: no leftover footer next to the bookmarks action bar.
4. Enter multi-select on the Bookmarks tab: only the bookmark list's action bar is shown, no table footer.
5. Multi-select on Starred / Downloads / Listening History still behaves as before.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
