### PR TITLE
Only show the Listening History empty states once a load has finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 8.20
 -----
+- Fix Listening History search showing "No episodes found" before the search had finished, and results not turning up until the query was retyped when history synced late [#4984](https://github.com/Automattic/pocket-casts-ios/pull/4984)
 
 
 8.19

--- a/PocketCastsTests/Tests/ListeningHistoryContentStateTests.swift
+++ b/PocketCastsTests/Tests/ListeningHistoryContentStateTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import podcasts
+
+final class ListeningHistoryContentStateTests: XCTestCase {
+
+    // MARK: - Bug Fix: PCIOS-897
+    // Listening History showed the "No episodes found" empty state while the first search of the
+    // session was still running, because the state was derived from the row count alone.
+
+    func testShowsLoadingWhileTheSearchIsStillRunning() {
+        let state = ListeningHistoryContentState(isEmpty: true, hasLoaded: false, isSearching: true)
+
+        XCTAssertEqual(state, .loading, "A search that hasn't finished should show a loading indicator, not an empty state")
+    }
+
+    func testShowsNoSearchResultsOnceTheSearchHasFinished() {
+        let state = ListeningHistoryContentState(isEmpty: true, hasLoaded: true, isSearching: true)
+
+        XCTAssertEqual(state, .noSearchResults)
+    }
+
+    func testShowsLoadingWhileTheHistoryIsStillLoading() {
+        let state = ListeningHistoryContentState(isEmpty: true, hasLoaded: false, isSearching: false)
+
+        XCTAssertEqual(state, .loading)
+    }
+
+    func testShowsNoHistoryOnceTheHistoryHasLoaded() {
+        let state = ListeningHistoryContentState(isEmpty: true, hasLoaded: true, isSearching: false)
+
+        XCTAssertEqual(state, .noHistory)
+    }
+
+    func testShowsContentWheneverThereAreEpisodes() {
+        for hasLoaded in [true, false] {
+            for isSearching in [true, false] {
+                let state = ListeningHistoryContentState(isEmpty: false, hasLoaded: hasLoaded, isSearching: isSearching)
+
+                XCTAssertEqual(state, .content, "Episodes should stay on screen while another load runs (hasLoaded: \(hasLoaded), isSearching: \(isSearching))")
+            }
+        }
+    }
+}

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -156,6 +156,17 @@ class ListeningHistoryViewController: PCViewController {
         operationQueue.addOperation { [weak self] in
             guard let self else { return }
 
+            // The queue is serial, so a superseded term is dropped before its query runs rather
+            // than after: running it anyway would hold up the current term for its full duration.
+            let isCurrent = DispatchQueue.main.sync { () -> Bool in
+                guard searchTerm == self.searchTerm else {
+                    completion?()
+                    return false
+                }
+                return true
+            }
+            guard isCurrent else { return }
+
             let newData = searchTerm.map { self.episodesDataManager.searchEpisodes(for: $0) } ?? self.episodesDataManager.listeningHistoryEpisodes()
 
             DispatchQueue.main.sync {

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -6,16 +6,30 @@ import PocketCastsUtils
 import UIKit
 
 class ListeningHistoryViewController: PCViewController {
-    var episodes = [ArraySection<String, ListEpisode>]() {
+    var episodes = [ArraySection<String, ListEpisode>]()
+
+    /// The term the list is filtered by, `nil` when not searching. Loads that happen while a search
+    /// is active re-run the search instead of replacing the results with the full history.
+    private var searchTerm: String? {
         didSet {
-            refreshContentUnavailable()
+            guard searchTerm != oldValue else { return }
+
+            hasLoadedSearchTerm = false
         }
     }
-    var tempEpisodes = [ArraySection<String, ListEpisode>]() {
+
+    /// Whether a load for the current `searchTerm` has finished. Until it has there's no answer to
+    /// show yet, so the list shows a loading indicator rather than an empty state.
+    private var hasLoadedSearchTerm = false
+
+    private var contentState = ListeningHistoryContentState.content {
         didSet {
-            refreshContentUnavailable()
+            guard contentState != oldValue else { return }
+
+            applyContentState()
         }
     }
+
     private let operationQueue = OperationQueue()
     var cellHeights: [IndexPath: CGFloat] = [:]
 
@@ -111,10 +125,17 @@ class ListeningHistoryViewController: PCViewController {
         addCustomObserver(Constants.Notifications.episodePlayStatusChanged, selector: #selector(refreshEpisodesFromNotification))
         addCustomObserver(Constants.Notifications.manyEpisodesChanged, selector: #selector(refreshEpisodesFromNotification))
         addCustomObserver(Constants.Notifications.listeningHistoryChanged, selector: #selector(refreshEpisodesFromNotification))
+        addCustomObserver(ServerNotifications.syncCompleted, selector: #selector(refreshEpisodesFromBackgroundNotification))
     }
 
     @objc private func refreshEpisodesFromNotification() {
         refreshEpisodes(animated: true)
+    }
+
+    @objc private func refreshEpisodesFromBackgroundNotification() {
+        DispatchQueue.main.async { [weak self] in
+            self?.refreshEpisodes(animated: true)
+        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -127,24 +148,36 @@ class ListeningHistoryViewController: PCViewController {
         listeningHistoryTable.reloadData()
     }
 
-    func refreshEpisodes(animated: Bool) {
+    func refreshEpisodes(animated: Bool, completion: (() -> Void)? = nil) {
+        let searchTerm = searchTerm
+        refreshContentUnavailable()
+
         operationQueue.addOperation { [weak self] in
             guard let self else { return }
 
-            let oldData = self.episodes
-            let newData = self.episodesDataManager.listeningHistoryEpisodes()
+            let newData = searchTerm.map { self.episodesDataManager.searchEpisodes(for: $0) } ?? self.episodesDataManager.listeningHistoryEpisodes()
 
             DispatchQueue.main.sync {
-                if animated {
-                    let changeSet = StagedChangeset(source: oldData, target: newData)
-                    self.listeningHistoryTable.reload(using: changeSet, with: .none, setData: { data in
-                        self.episodes = data
-                    })
-                } else {
-                    self.episodes = newData
-                    self.listeningHistoryTable.reloadData()
-                }
+                defer { completion?() }
+
+                guard searchTerm == self.searchTerm else { return }
+
+                self.setEpisodes(newData, animated: animated)
+                self.hasLoadedSearchTerm = true
+                self.refreshContentUnavailable()
             }
+        }
+    }
+
+    private func setEpisodes(_ newData: [ArraySection<String, ListEpisode>], animated: Bool) {
+        if animated {
+            let changeSet = StagedChangeset(source: episodes, target: newData)
+            listeningHistoryTable.reload(using: changeSet, with: .none, setData: { data in
+                self.episodes = data
+            })
+        } else {
+            episodes = newData
+            listeningHistoryTable.reloadData()
         }
     }
 
@@ -211,37 +244,77 @@ class ListeningHistoryViewController: PCViewController {
     }
 
     private func refreshContentUnavailable() {
-        var config: UIContentConfiguration?
+        contentState = ListeningHistoryContentState(
+            isEmpty: episodes.isEmpty,
+            hasLoaded: hasLoadedSearchTerm,
+            isSearching: searchTerm != nil
+        )
+    }
 
+    private func applyContentState() {
         listeningHistoryTable.backgroundView = UIView()
         listeningHistoryTable.themeStyle = LiquidGlass.isEnabled ? .primaryUi02 : .primaryUi04
+        listeningHistoryTable.isHidden = false
+        contentUnavailableConfiguration = nil
 
-        if episodes.isEmpty {
-            if searchController?.searchTextField.text?.isEmpty == false {
-                // Empty State when searching
-                let title = L10n.listeningHistorySearchNoEpisodesTitle
-                let message = L10n.listeningHistorySearchNoEpisodesText
-                config = ContentUnavailableConfiguration.emptyState(
-                    title: title,
-                    message: message,
-                    icon: { Image("profile-download").renderingMode(.template) }
-                )
+        switch contentState {
+        case .content:
+            break
+        case .loading:
+            listeningHistoryTable.backgroundView = ContentUnavailableConfiguration.loading().makeContentView()
+        case .noSearchResults:
+            let config = ContentUnavailableConfiguration.emptyState(
+                title: L10n.listeningHistorySearchNoEpisodesTitle,
+                message: L10n.listeningHistorySearchNoEpisodesText,
+                icon: { Image("profile-download").renderingMode(.template) }
+            )
 
-                listeningHistoryTable.backgroundColor = UIColor(Theme.sharedTheme.primaryUi02)
-                listeningHistoryTable.backgroundView = config?.makeContentView()
-            } else {
-                // Empty State when not searching
-                let title = L10n.profileListeningHistoryEmptyTitle
-                let message = L10n.profileListeningHistoryEmptyDescription
-                config = ContentUnavailableConfiguration.emptyState(title: title, message: message, icon: { Image("options-history").renderingMode(.template) }, actions: [
+            listeningHistoryTable.backgroundColor = UIColor(Theme.sharedTheme.primaryUi02)
+            listeningHistoryTable.backgroundView = config.makeContentView()
+        case .noHistory:
+            listeningHistoryTable.isHidden = true
+            contentUnavailableConfiguration = ContentUnavailableConfiguration.emptyState(
+                title: L10n.profileListeningHistoryEmptyTitle,
+                message: L10n.profileListeningHistoryEmptyDescription,
+                icon: { Image("options-history").renderingMode(.template) },
+                actions: [
                     .init(title: L10n.goToDiscover, action: {
                         Analytics.track(.listeningHistoryDiscoverButtonTapped)
                         NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey)
                     })
-                ])
+                ]
+            )
+        }
+    }
+}
 
-                self.contentUnavailableConfiguration = config
-            }
+// MARK: - Content state
+
+/// What the list shows in place of its rows. Derived from what has actually been loaded rather than
+/// from the row count alone, so a load that's still running never reads as "no episodes".
+enum ListeningHistoryContentState: Equatable {
+    /// The rows themselves.
+    case content
+
+    /// The load for the current search term hasn't produced an answer yet.
+    case loading
+
+    /// The search finished without matching anything.
+    case noSearchResults
+
+    /// There's nothing in the listening history.
+    case noHistory
+
+    init(isEmpty: Bool, hasLoaded: Bool, isSearching: Bool) {
+        switch (isEmpty, hasLoaded, isSearching) {
+        case (false, _, _):
+            self = .content
+        case (true, false, _):
+            self = .loading
+        case (true, true, true):
+            self = .noSearchResults
+        case (true, true, false):
+            self = .noHistory
         }
     }
 }
@@ -257,23 +330,16 @@ extension ListeningHistoryViewController: AnalyticsSourceProvider {
 // MARK: - Analytics
 
 extension ListeningHistoryViewController: PCSearchBarDelegate {
-    func searchDidBegin() {
-        tempEpisodes = episodes
-    }
+    func searchDidBegin() { }
 
     func searchDidEnd() {
-        listeningHistoryTable.isHidden = tempEpisodes.isEmpty
-        episodes = tempEpisodes
-        listeningHistoryTable.reloadData()
-        tempEpisodes.removeAll()
+        endSearch()
     }
 
     func searchWasCleared() {
         Analytics.track(.searchCleared, source: analyticsSource)
 
-        listeningHistoryTable.isHidden = tempEpisodes.isEmpty
-        episodes = tempEpisodes
-        listeningHistoryTable.reloadData()
+        endSearch()
     }
 
     func searchTermChanged(_ searchTerm: String) { }
@@ -281,14 +347,15 @@ extension ListeningHistoryViewController: PCSearchBarDelegate {
     func performSearch(searchTerm: String, triggeredByTimer: Bool, completion: @escaping (() -> Void)) {
         Analytics.track(.searchPerformed, source: analyticsSource)
 
-        let oldData = episodes
-        let newData = episodesDataManager.searchEpisodes(for: searchTerm)
+        self.searchTerm = searchTerm
+        refreshEpisodes(animated: false, completion: completion)
+    }
 
-        let changeSet = StagedChangeset(source: oldData, target: newData)
-        self.listeningHistoryTable.reload(using: changeSet, with: .none, setData: { data in
-            self.episodes = data
-        })
-        completion()
+    private func endSearch() {
+        guard searchTerm != nil else { return }
+
+        searchTerm = nil
+        refreshEpisodes(animated: false)
     }
 
     private func setupSearchController() {

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -269,7 +269,7 @@ class ListeningHistoryViewController: PCViewController {
                 icon: { Image("profile-download").renderingMode(.template) }
             )
 
-            listeningHistoryTable.backgroundColor = UIColor(Theme.sharedTheme.primaryUi02)
+            listeningHistoryTable.themeStyle = .primaryUi02
             listeningHistoryTable.backgroundView = config.makeContentView()
         case .noHistory:
             listeningHistoryTable.isHidden = true

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -160,7 +160,7 @@ class ListeningHistoryViewController: PCViewController {
             // than after: running it anyway would hold up the current term for its full duration.
             let isCurrent = DispatchQueue.main.sync { () -> Bool in
                 guard searchTerm == self.searchTerm else {
-                    completion?()
+                    self.finishSuperseded(completion)
                     return false
                 }
                 return true
@@ -170,15 +170,26 @@ class ListeningHistoryViewController: PCViewController {
             let newData = searchTerm.map { self.episodesDataManager.searchEpisodes(for: $0) } ?? self.episodesDataManager.listeningHistoryEpisodes()
 
             DispatchQueue.main.sync {
-                defer { completion?() }
-
-                guard searchTerm == self.searchTerm else { return }
+                guard searchTerm == self.searchTerm else {
+                    self.finishSuperseded(completion)
+                    return
+                }
 
                 self.setEpisodes(newData, animated: animated)
                 self.hasLoadedSearchTerm = true
                 self.refreshContentUnavailable()
+                completion?()
             }
         }
+    }
+
+    /// The search bar has a single spinner and no refcount, so a superseded term must leave the
+    /// completion to the newer load that replaced it. A cleared or cancelled search queues no such
+    /// completion, so that one still has to be called here.
+    private func finishSuperseded(_ completion: (() -> Void)?) {
+        guard searchTerm == nil else { return }
+
+        completion?()
     }
 
     private func setEpisodes(_ newData: [ArraySection<String, ListEpisode>], animated: Bool) {

--- a/podcasts/ListeningHistoryViewController.swift
+++ b/podcasts/ListeningHistoryViewController.swift
@@ -148,6 +148,7 @@ class ListeningHistoryViewController: PCViewController {
         listeningHistoryTable.reloadData()
     }
 
+    @MainActor
     func refreshEpisodes(animated: Bool, completion: (() -> Void)? = nil) {
         let searchTerm = searchTerm
         refreshContentUnavailable()

--- a/podcasts/Utilities/ContentUnavailableConfiguration.swift
+++ b/podcasts/Utilities/ContentUnavailableConfiguration.swift
@@ -50,6 +50,7 @@ struct LoadingView: View {
                 .padding()
                 .tint(theme.primaryIcon01)
         }
+        .frame(maxWidth: .infinity)
     }
 }
 


### PR DESCRIPTION
Fixes PCIOS-897

Listening History rendered the "No episodes found" empty state whenever the list happened to be empty, with no notion of a load being in progress. On the first search of a session — before the background history load or the history sync had landed — that meant the empty state appeared immediately and was replaced by results a few seconds later, so search looked broken.

The state is now derived from whether a load for the current search term has actually finished:

- New `ListeningHistoryContentState` (`content` / `loading` / `noSearchResults` / `noHistory`). `noSearchResults` is only reachable once a load for the current term has produced an answer; anything still in flight shows a loading indicator. The configuration is always reassigned, so states clear properly — previously `contentUnavailableConfiguration` was only ever set inside the `isEmpty` branch and never cleared.
- The search query runs on the same serial queue as the history load instead of blocking the main thread, and results for a term that has since changed are discarded. The search bar's own spinner now reflects the real query duration.
- Refreshes re-apply the active search term instead of replacing filtered results with the full history, and the screen now also refreshes on `syncCompleted` — the reported case was history arriving late on a weak connection, which previously required retyping the query to see.
- Dropped the `tempEpisodes` snapshot. It was taken when the search field was focused, so if that happened before the initial load finished, cancelling the search left the list empty and the table permanently hidden.
- `LoadingView` was only as wide as its spinner and `UIHostingConfiguration` leading-aligns content that does not claim the width, so the spinner sat near the leading edge. This also fixes Discover's loading cell.

## To test

1. Cold launch the app, go to Profile → Listening History, and immediately tap the search bar and type a query matching an episode in your history.
2. While the search is running you should see a loading indicator, centered, and never "No episodes found". Results replace it when the query finishes.
3. Search for something that matches nothing: the loading indicator appears first, then "No episodes found".
4. Cancel or clear the search: the full history comes back, without animation.
5. On an account whose history is still syncing (Network Link Conditioner on a slow profile helps), search for an episode that only exists on the server. Once the sync lands the results appear without retyping.
6. With an empty listening history, confirm the "Your listening history is empty / Go to Discover" state still shows and that it disappears once episodes are added.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
