### PR TITLE
feat: add on-demand transcript generation

### DIFF
--- a/Modules/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
+++ b/Modules/Sources/PocketCastsServer/Private/Protobuffer/api.pb.swift
@@ -20,6 +20,184 @@ fileprivate nonisolated struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobu
   typealias Version = _2
 }
 
+nonisolated enum Api_OnDemandTranscriptOutcome: SwiftProtobuf.Enum, Swift.CaseIterable {
+  typealias RawValue = Int
+  case outcomeUnspecified // = 0
+  case queued // = 1
+  case inProgress // = 2
+  case available // = 3
+  case notEligible // = 4
+  case transientFailure // = 5
+  case throttled // = 6
+  case UNRECOGNIZED(Int)
+
+  init() {
+    self = .outcomeUnspecified
+  }
+
+  init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .outcomeUnspecified
+    case 1: self = .queued
+    case 2: self = .inProgress
+    case 3: self = .available
+    case 4: self = .notEligible
+    case 5: self = .transientFailure
+    case 6: self = .throttled
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  var rawValue: Int {
+    switch self {
+    case .outcomeUnspecified: return 0
+    case .queued: return 1
+    case .inProgress: return 2
+    case .available: return 3
+    case .notEligible: return 4
+    case .transientFailure: return 5
+    case .throttled: return 6
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  static let allCases: [Api_OnDemandTranscriptOutcome] = [
+    .outcomeUnspecified,
+    .queued,
+    .inProgress,
+    .available,
+    .notEligible,
+    .transientFailure,
+    .throttled,
+  ]
+
+}
+
+nonisolated enum Api_OnDemandTranscriptEnablement: SwiftProtobuf.Enum, Swift.CaseIterable {
+  typealias RawValue = Int
+  case enablementUnspecified // = 0
+  case enabled // = 1
+  case alreadyEnabled // = 2
+  case alreadyEligible // = 3
+  case notEnabled // = 4
+  case UNRECOGNIZED(Int)
+
+  init() {
+    self = .enablementUnspecified
+  }
+
+  init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .enablementUnspecified
+    case 1: self = .enabled
+    case 2: self = .alreadyEnabled
+    case 3: self = .alreadyEligible
+    case 4: self = .notEnabled
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  var rawValue: Int {
+    switch self {
+    case .enablementUnspecified: return 0
+    case .enabled: return 1
+    case .alreadyEnabled: return 2
+    case .alreadyEligible: return 3
+    case .notEnabled: return 4
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  static let allCases: [Api_OnDemandTranscriptEnablement] = [
+    .enablementUnspecified,
+    .enabled,
+    .alreadyEnabled,
+    .alreadyEligible,
+    .notEnabled,
+  ]
+
+}
+
+nonisolated enum Api_OnDemandTranscriptReason: SwiftProtobuf.Enum, Swift.CaseIterable {
+  typealias RawValue = Int
+  case reasonUnspecified // = 0
+  case featureDisabled // = 1
+  case podcastNotFound // = 2
+  case episodeNotFound // = 3
+  case episodeNotInPodcast // = 4
+  case podcastDisabled // = 5
+  case podcastDisallowed // = 6
+  case hostIgnored // = 7
+  case transcriptIneligible // = 8
+  case queueingFailed // = 9
+  case retryNotAvailable // = 10
+  case internalError // = 11
+  case unknownReason // = 12
+  case UNRECOGNIZED(Int)
+
+  init() {
+    self = .reasonUnspecified
+  }
+
+  init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .reasonUnspecified
+    case 1: self = .featureDisabled
+    case 2: self = .podcastNotFound
+    case 3: self = .episodeNotFound
+    case 4: self = .episodeNotInPodcast
+    case 5: self = .podcastDisabled
+    case 6: self = .podcastDisallowed
+    case 7: self = .hostIgnored
+    case 8: self = .transcriptIneligible
+    case 9: self = .queueingFailed
+    case 10: self = .retryNotAvailable
+    case 11: self = .internalError
+    case 12: self = .unknownReason
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  var rawValue: Int {
+    switch self {
+    case .reasonUnspecified: return 0
+    case .featureDisabled: return 1
+    case .podcastNotFound: return 2
+    case .episodeNotFound: return 3
+    case .episodeNotInPodcast: return 4
+    case .podcastDisabled: return 5
+    case .podcastDisallowed: return 6
+    case .hostIgnored: return 7
+    case .transcriptIneligible: return 8
+    case .queueingFailed: return 9
+    case .retryNotAvailable: return 10
+    case .internalError: return 11
+    case .unknownReason: return 12
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  static let allCases: [Api_OnDemandTranscriptReason] = [
+    .reasonUnspecified,
+    .featureDisabled,
+    .podcastNotFound,
+    .episodeNotFound,
+    .episodeNotInPodcast,
+    .podcastDisabled,
+    .podcastDisallowed,
+    .hostIgnored,
+    .transcriptIneligible,
+    .queueingFailed,
+    .retryNotAvailable,
+    .internalError,
+    .unknownReason,
+  ]
+
+}
+
 nonisolated struct Api_UserChangeResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -119,6 +297,38 @@ nonisolated struct Api_EmptyResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+nonisolated struct Api_OnDemandTranscriptRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var podcastUuid: String = String()
+
+  var episodeUuid: String = String()
+
+  var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  init() {}
+}
+
+nonisolated struct Api_OnDemandTranscriptResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  var outcome: Api_OnDemandTranscriptOutcome = .outcomeUnspecified
+
+  var reason: Api_OnDemandTranscriptReason = .reasonUnspecified
+
+  var enablement: Api_OnDemandTranscriptEnablement = .enablementUnspecified
+
+  var newlyQueuedCount: UInt32 = 0
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -3669,6 +3879,8 @@ nonisolated struct Api_AlternateEnclosure: Sendable {
   var type: String = String()
 
   var sources: [Api_AlternateEnclosure.Source] = []
+
+  var mediaKind: String = String()
 
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -8404,6 +8616,18 @@ nonisolated struct Api_PlaylistReorderRequest: Sendable {
 
 fileprivate nonisolated let _protobuf_package = "api"
 
+nonisolated extension Api_OnDemandTranscriptOutcome: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0OUTCOME_UNSPECIFIED\0\u{1}QUEUED\0\u{1}IN_PROGRESS\0\u{1}AVAILABLE\0\u{1}NOT_ELIGIBLE\0\u{1}TRANSIENT_FAILURE\0\u{1}THROTTLED\0")
+}
+
+nonisolated extension Api_OnDemandTranscriptEnablement: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0ENABLEMENT_UNSPECIFIED\0\u{1}ENABLED\0\u{1}ALREADY_ENABLED\0\u{1}ALREADY_ELIGIBLE\0\u{1}NOT_ENABLED\0")
+}
+
+nonisolated extension Api_OnDemandTranscriptReason: SwiftProtobuf._ProtoNameProviding {
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0REASON_UNSPECIFIED\0\u{1}FEATURE_DISABLED\0\u{1}PODCAST_NOT_FOUND\0\u{1}EPISODE_NOT_FOUND\0\u{1}EPISODE_NOT_IN_PODCAST\0\u{1}PODCAST_DISABLED\0\u{1}PODCAST_DISALLOWED\0\u{1}HOST_IGNORED\0\u{1}TRANSCRIPT_INELIGIBLE\0\u{1}QUEUEING_FAILED\0\u{1}RETRY_NOT_AVAILABLE\0\u{1}INTERNAL_ERROR\0\u{1}UNKNOWN_REASON\0")
+}
+
 nonisolated extension Api_UserChangeResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".UserChangeResponse"
   static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}success\0\u{1}message\0\u{1}messageId\0")
@@ -8631,6 +8855,86 @@ nonisolated extension Api_EmptyResponse: SwiftProtobuf.Message, SwiftProtobuf._M
   }
 
   static func ==(lhs: Api_EmptyResponse, rhs: Api_EmptyResponse) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Api_OnDemandTranscriptRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".OnDemandTranscriptRequest"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}podcast_uuid\0\u{3}episode_uuid\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.podcastUuid) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.episodeUuid) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.podcastUuid.isEmpty {
+      try visitor.visitSingularStringField(value: self.podcastUuid, fieldNumber: 1)
+    }
+    if !self.episodeUuid.isEmpty {
+      try visitor.visitSingularStringField(value: self.episodeUuid, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Api_OnDemandTranscriptRequest, rhs: Api_OnDemandTranscriptRequest) -> Bool {
+    if lhs.podcastUuid != rhs.podcastUuid {return false}
+    if lhs.episodeUuid != rhs.episodeUuid {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+nonisolated extension Api_OnDemandTranscriptResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  static let protoMessageName: String = _protobuf_package + ".OnDemandTranscriptResponse"
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}outcome\0\u{1}reason\0\u{1}enablement\0\u{3}newly_queued_count\0")
+
+  mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularEnumField(value: &self.outcome) }()
+      case 2: try { try decoder.decodeSingularEnumField(value: &self.reason) }()
+      case 3: try { try decoder.decodeSingularEnumField(value: &self.enablement) }()
+      case 4: try { try decoder.decodeSingularUInt32Field(value: &self.newlyQueuedCount) }()
+      default: break
+      }
+    }
+  }
+
+  func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.outcome != .outcomeUnspecified {
+      try visitor.visitSingularEnumField(value: self.outcome, fieldNumber: 1)
+    }
+    if self.reason != .reasonUnspecified {
+      try visitor.visitSingularEnumField(value: self.reason, fieldNumber: 2)
+    }
+    if self.enablement != .enablementUnspecified {
+      try visitor.visitSingularEnumField(value: self.enablement, fieldNumber: 3)
+    }
+    if self.newlyQueuedCount != 0 {
+      try visitor.visitSingularUInt32Field(value: self.newlyQueuedCount, fieldNumber: 4)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  static func ==(lhs: Api_OnDemandTranscriptResponse, rhs: Api_OnDemandTranscriptResponse) -> Bool {
+    if lhs.outcome != rhs.outcome {return false}
+    if lhs.reason != rhs.reason {return false}
+    if lhs.enablement != rhs.enablement {return false}
+    if lhs.newlyQueuedCount != rhs.newlyQueuedCount {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -12331,7 +12635,7 @@ nonisolated extension Api_FindUserEpisodeRequest: SwiftProtobuf.Message, SwiftPr
 
 nonisolated extension Api_AlternateEnclosure: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   static let protoMessageName: String = _protobuf_package + ".AlternateEnclosure"
-  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{1}sources\0")
+  static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}type\0\u{1}sources\0\u{3}media_kind\0")
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -12341,6 +12645,7 @@ nonisolated extension Api_AlternateEnclosure: SwiftProtobuf.Message, SwiftProtob
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.type) }()
       case 2: try { try decoder.decodeRepeatedMessageField(value: &self.sources) }()
+      case 3: try { try decoder.decodeSingularStringField(value: &self.mediaKind) }()
       default: break
       }
     }
@@ -12353,12 +12658,16 @@ nonisolated extension Api_AlternateEnclosure: SwiftProtobuf.Message, SwiftProtob
     if !self.sources.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.sources, fieldNumber: 2)
     }
+    if !self.mediaKind.isEmpty {
+      try visitor.visitSingularStringField(value: self.mediaKind, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: Api_AlternateEnclosure, rhs: Api_AlternateEnclosure) -> Bool {
     if lhs.type != rhs.type {return false}
     if lhs.sources != rhs.sources {return false}
+    if lhs.mediaKind != rhs.mediaKind {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/Modules/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -3,7 +3,12 @@ import PocketCastsUtils
 
 /// Request information about an episode using the show notes endpoint
 public actor ShowInfoDataRetriever {
-    private var dataRequestMap: [String: Task<Data, Error>] = [:]
+    private struct RequestKey: Hashable {
+        let podcastUuid: String
+        let ignoreCache: Bool
+    }
+
+    private var dataRequestMap: [RequestKey: Task<Data, Error>] = [:]
 
     private let cache: URLCache
 
@@ -60,7 +65,7 @@ public actor ShowInfoDataRetriever {
         for podcastUuid: String,
         ignoreCache: Bool = false
     ) async throws -> Data {
-        let requestKey = ignoreCache ? "\(podcastUuid)-ignore-cache" : podcastUuid
+        let requestKey = RequestKey(podcastUuid: podcastUuid, ignoreCache: ignoreCache)
         if let task = dataRequestMap[requestKey] {
             return try await task.value
         }
@@ -111,8 +116,8 @@ public actor ShowInfoDataRetriever {
         return try await task.value
     }
 
-    private func setDataRequestMapToNil(for podcastUuid: String) {
-        dataRequestMap[podcastUuid] = nil
+    private func setDataRequestMapToNil(for requestKey: RequestKey) {
+        dataRequestMap[requestKey] = nil
     }
 
     private func loadEpisodeData(

--- a/Modules/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Cache/ShowInfoDataRetriever.swift
@@ -20,7 +20,8 @@ public actor ShowInfoDataRetriever {
     public func loadEpisodeDataFromCache(
         for podcastUuid: String,
         episodeUuid: String,
-        useCacheOnly: Bool = false
+        useCacheOnly: Bool = false,
+        ignoreCache: Bool = false
     ) async throws -> String? {
         if useCacheOnly {
             let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
@@ -35,9 +36,9 @@ public actor ShowInfoDataRetriever {
         }
 
         do {
-            return try await loadEpisodeData(for: podcastUuid, episodeUuid: episodeUuid)
+            return try await loadEpisodeData(for: podcastUuid, episodeUuid: episodeUuid, ignoreCache: ignoreCache)
         } catch {
-            if isNetworkUnavailableError(error) {
+            if !ignoreCache, isNetworkUnavailableError(error) {
                 FileLog.shared.addMessage("Show Info: network unavailable, falling back to cache for episode \(episodeUuid)")
                 return try await loadEpisodeDataFromCache(for: podcastUuid, episodeUuid: episodeUuid, useCacheOnly: true)
             }
@@ -56,18 +57,20 @@ public actor ShowInfoDataRetriever {
     }
 
     public func loadShowInfoData(
-        for podcastUuid: String
+        for podcastUuid: String,
+        ignoreCache: Bool = false
     ) async throws -> Data {
-        if let task = dataRequestMap[podcastUuid] {
+        let requestKey = ignoreCache ? "\(podcastUuid)-ignore-cache" : podcastUuid
+        if let task = dataRequestMap[requestKey] {
             return try await task.value
         }
 
         let url = ServerHelper.asUrl(ServerConstants.Urls.cache() + "mobile/show_notes/full/\(podcastUuid)")
-        let cachePolicy: URLRequest.CachePolicy = .reloadRevalidatingCacheData
+        let cachePolicy: URLRequest.CachePolicy = ignoreCache ? .reloadIgnoringLocalAndRemoteCacheData : .reloadRevalidatingCacheData
         var request = URLRequest(url: url, cachePolicy: cachePolicy)
         request.addLocalizationHeaders()
 
-        if let cachedResponse = cache.cachedResponse(for: URLRequest(url: url)) {
+        if !ignoreCache, let cachedResponse = cache.cachedResponse(for: URLRequest(url: url)) {
             if let etag = cachedResponse.response.etag {
                 request.setValue(etag, forHTTPHeaderField: ServerConstants.HttpHeaders.ifNoneMatch)
             }
@@ -89,21 +92,21 @@ public actor ShowInfoDataRetriever {
                     let responseToCache = CachedURLResponse(response: response, data: data)
                     cache.storeCachedResponse(responseToCache, for: request)
                     FileLog.shared.addMessage("Show Info: request succeeded for podcast \(podcastUuid).")
-                } else if let data = cache.cachedResponse(for: request)?.data {
-                    await setDataRequestMapToNil(for: podcastUuid)
+                } else if !ignoreCache, let data = cache.cachedResponse(for: request)?.data {
+                    await setDataRequestMapToNil(for: requestKey)
                     FileLog.shared.addMessage("Show Info: request failed for podcast \(podcastUuid). Returning cached data")
                     return data
                 }
 
-                await setDataRequestMapToNil(for: podcastUuid)
+                await setDataRequestMapToNil(for: requestKey)
                 return data
             } catch {
                 FileLog.shared.addMessage("Show Info: request failed for podcast \(podcastUuid): \(error.localizedDescription). Returning cached data")
-                await setDataRequestMapToNil(for: podcastUuid)
+                await setDataRequestMapToNil(for: requestKey)
                 throw error
             }
         }
-        dataRequestMap[podcastUuid] = task
+        dataRequestMap[requestKey] = task
 
         return try await task.value
     }
@@ -114,13 +117,11 @@ public actor ShowInfoDataRetriever {
 
     private func loadEpisodeData(
         for podcastUuid: String,
-        episodeUuid: String
+        episodeUuid: String,
+        ignoreCache: Bool
     ) async throws -> String? {
-        if let data = try? await loadShowInfoData(for: podcastUuid) {
-            return extractMetadata(for: episodeUuid, from: data)
-        }
-
-        return nil
+        let data = try await loadShowInfoData(for: podcastUuid, ignoreCache: ignoreCache)
+        return extractMetadata(for: episodeUuid, from: data)
     }
 
     private func extractMetadata(for episodeUuid: String, from data: Data) -> String? {

--- a/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sharing/Structs/ServerConstants.swift
@@ -87,6 +87,8 @@ public enum ServerConstants {
         public static let serverError = 500
         public static let badRequest = 400
         public static let conflict = 409
+        public static let tooManyRequests = 429
+        public static let serviceUnavailable = 503
     }
 
     public enum HttpHeaders {

--- a/Modules/Sources/PocketCastsServer/Public/Transcripts/OnDemandTranscriptService.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Transcripts/OnDemandTranscriptService.swift
@@ -58,11 +58,13 @@ public enum OnDemandTranscriptServiceError: Error, Equatable {
     case unauthenticated
     case accessDenied
     case notFound
+    case throttled
     case transient
     case invalidResponse
     case unexpectedStatus(Int)
 }
 
+// The service has no mutable state; TokenHelper owns the synchronization of its secure requests.
 public final class OnDemandTranscriptService: OnDemandTranscriptRequesting, @unchecked Sendable {
     public static let shared = OnDemandTranscriptService()
 
@@ -103,11 +105,13 @@ public final class OnDemandTranscriptService: OnDemandTranscriptRequesting, @unc
             throw OnDemandTranscriptServiceError.malformedRequest
         case ServerConstants.HttpConstants.unauthorized:
             throw OnDemandTranscriptServiceError.unauthenticated
-        case 403:
+        case ServerConstants.HttpConstants.forbidden:
             throw OnDemandTranscriptServiceError.accessDenied
         case ServerConstants.HttpConstants.notFound:
             throw OnDemandTranscriptServiceError.notFound
-        case 503:
+        case ServerConstants.HttpConstants.tooManyRequests:
+            throw OnDemandTranscriptServiceError.throttled
+        case ServerConstants.HttpConstants.serviceUnavailable:
             throw OnDemandTranscriptServiceError.transient
         default:
             throw OnDemandTranscriptServiceError.unexpectedStatus(statusCode)

--- a/Modules/Sources/PocketCastsServer/Public/Transcripts/OnDemandTranscriptService.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Transcripts/OnDemandTranscriptService.swift
@@ -1,0 +1,159 @@
+import Foundation
+import SwiftProtobuf
+
+public protocol OnDemandTranscriptRequesting: Sendable {
+    func requestTranscript(podcastUUID: String, episodeUUID: String) async throws -> OnDemandTranscriptResponse
+}
+
+public struct OnDemandTranscriptResponse: Equatable, Sendable {
+    public enum Outcome: String, Sendable {
+        case queued
+        case inProgress
+        case available
+        case notEligible
+        case transientFailure
+        case throttled
+        case unspecified
+    }
+
+    public enum Reason: String, Sendable {
+        case featureDisabled
+        case podcastNotFound
+        case episodeNotFound
+        case episodeNotInPodcast
+        case podcastDisabled
+        case podcastDisallowed
+        case hostIgnored
+        case transcriptIneligible
+        case queueingFailed
+        case retryNotAvailable
+        case internalError
+        case unknown
+        case unspecified
+    }
+
+    public enum Enablement: String, Sendable {
+        case enabled
+        case alreadyEnabled
+        case alreadyEligible
+        case notEnabled
+        case unspecified
+    }
+
+    public let outcome: Outcome
+    public let reason: Reason
+    public let enablement: Enablement
+    public let newlyQueuedCount: UInt32
+
+    public init(outcome: Outcome, reason: Reason, enablement: Enablement, newlyQueuedCount: UInt32) {
+        self.outcome = outcome
+        self.reason = reason
+        self.enablement = enablement
+        self.newlyQueuedCount = newlyQueuedCount
+    }
+}
+
+public enum OnDemandTranscriptServiceError: Error, Equatable {
+    case malformedRequest
+    case unauthenticated
+    case accessDenied
+    case notFound
+    case transient
+    case invalidResponse
+    case unexpectedStatus(Int)
+}
+
+public final class OnDemandTranscriptService: OnDemandTranscriptRequesting, @unchecked Sendable {
+    public static let shared = OnDemandTranscriptService()
+
+    private let tokenHelper: TokenHelper
+
+    public convenience init() {
+        self.init(tokenHelper: TokenHelper.shared)
+    }
+
+    init(tokenHelper: TokenHelper) {
+        self.tokenHelper = tokenHelper
+    }
+
+    public func requestTranscript(podcastUUID: String, episodeUUID: String) async throws -> OnDemandTranscriptResponse {
+        var body = Api_OnDemandTranscriptRequest()
+        body.podcastUuid = podcastUUID
+        body.episodeUuid = episodeUUID
+
+        let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/transcript/on_demand")
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalAndRemoteCacheData, timeoutInterval: 15)
+        request.httpMethod = "POST"
+        request.httpBody = try body.serializedData()
+        request.setValue("application/x-protobuf", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/x-protobuf", forHTTPHeaderField: "Accept")
+
+        let (response, data) = try await tokenHelper.callSecureUrl(request: request)
+        guard let statusCode = response?.statusCode else {
+            throw OnDemandTranscriptServiceError.transient
+        }
+
+        switch statusCode {
+        case ServerConstants.HttpConstants.ok:
+            guard let data else {
+                throw OnDemandTranscriptServiceError.invalidResponse
+            }
+            return try map(Api_OnDemandTranscriptResponse(serializedBytes: data))
+        case ServerConstants.HttpConstants.badRequest:
+            throw OnDemandTranscriptServiceError.malformedRequest
+        case ServerConstants.HttpConstants.unauthorized:
+            throw OnDemandTranscriptServiceError.unauthenticated
+        case 403:
+            throw OnDemandTranscriptServiceError.accessDenied
+        case ServerConstants.HttpConstants.notFound:
+            throw OnDemandTranscriptServiceError.notFound
+        case 503:
+            throw OnDemandTranscriptServiceError.transient
+        default:
+            throw OnDemandTranscriptServiceError.unexpectedStatus(statusCode)
+        }
+    }
+
+    private func map(_ response: Api_OnDemandTranscriptResponse) throws -> OnDemandTranscriptResponse {
+        let outcome: OnDemandTranscriptResponse.Outcome = switch response.outcome {
+        case .queued: .queued
+        case .inProgress: .inProgress
+        case .available: .available
+        case .notEligible: .notEligible
+        case .transientFailure: .transientFailure
+        case .throttled: .throttled
+        case .outcomeUnspecified, .UNRECOGNIZED: .unspecified
+        }
+
+        let reason: OnDemandTranscriptResponse.Reason = switch response.reason {
+        case .featureDisabled: .featureDisabled
+        case .podcastNotFound: .podcastNotFound
+        case .episodeNotFound: .episodeNotFound
+        case .episodeNotInPodcast: .episodeNotInPodcast
+        case .podcastDisabled: .podcastDisabled
+        case .podcastDisallowed: .podcastDisallowed
+        case .hostIgnored: .hostIgnored
+        case .transcriptIneligible: .transcriptIneligible
+        case .queueingFailed: .queueingFailed
+        case .retryNotAvailable: .retryNotAvailable
+        case .internalError: .internalError
+        case .unknownReason: .unknown
+        case .reasonUnspecified, .UNRECOGNIZED: .unspecified
+        }
+
+        let enablement: OnDemandTranscriptResponse.Enablement = switch response.enablement {
+        case .enabled: .enabled
+        case .alreadyEnabled: .alreadyEnabled
+        case .alreadyEligible: .alreadyEligible
+        case .notEnabled: .notEnabled
+        case .enablementUnspecified, .UNRECOGNIZED: .unspecified
+        }
+
+        return OnDemandTranscriptResponse(
+            outcome: outcome,
+            reason: reason,
+            enablement: enablement,
+            newlyQueuedCount: response.newlyQueuedCount
+        )
+    }
+}

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -114,6 +114,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable synced transcripts with playback timing
     case syncedTranscripts
 
+    /// Let eligible paid listeners request a missing transcript
+    case onDemandTranscripts
+
     /// Encourage Account Creation
     case encourageAccountCreation
 
@@ -399,6 +402,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .syncedTranscripts:
             true
+        case .onDemandTranscripts:
+            BuildEnvironment.current == .debug
         case .libroFm:
             false
         case .encourageAccountCreation:

--- a/Modules/Tests/PocketCastsServerTests/OnDemandTranscriptServiceTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/OnDemandTranscriptServiceTests.swift
@@ -1,0 +1,79 @@
+@testable import PocketCastsServer
+import SwiftProtobuf
+import XCTest
+
+final class OnDemandTranscriptServiceTests: XCTestCase {
+    private func makeService(mockHandler: @escaping MockRequestHandler.Handler) -> OnDemandTranscriptService {
+        OnDemandTranscriptService(tokenHelper: TokenHelper(urlConnection: URLConnection(mockHandler: mockHandler)))
+    }
+
+    func testRequestSendsProtobufAndMapsQueuedResponse() async throws {
+        var capturedRequest: URLRequest?
+        let service = makeService { request in
+            capturedRequest = request
+            var body = Api_OnDemandTranscriptResponse()
+            body.outcome = .queued
+            body.reason = .reasonUnspecified
+            body.enablement = .enabled
+            body.newlyQueuedCount = 4
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)
+            return (try body.serializedData(), response)
+        }
+
+        let result = try await service.requestTranscript(podcastUUID: "podcast-id", episodeUUID: "episode-id")
+
+        XCTAssertEqual(capturedRequest?.url?.absoluteString, ServerConstants.Urls.api() + "user/transcript/on_demand")
+        XCTAssertEqual(capturedRequest?.httpMethod, "POST")
+        XCTAssertEqual(capturedRequest?.value(forHTTPHeaderField: "Content-Type"), "application/x-protobuf")
+        let requestBody = try Api_OnDemandTranscriptRequest(serializedBytes: XCTUnwrap(capturedRequest?.httpBody))
+        XCTAssertEqual(requestBody.podcastUuid, "podcast-id")
+        XCTAssertEqual(requestBody.episodeUuid, "episode-id")
+        XCTAssertEqual(
+            result,
+            OnDemandTranscriptResponse(
+                outcome: .queued,
+                reason: .unspecified,
+                enablement: .enabled,
+                newlyQueuedCount: 4
+            )
+        )
+    }
+
+    func testRequestMapsNotEligibleDomainResponse() async throws {
+        let service = makeService { request in
+            var body = Api_OnDemandTranscriptResponse()
+            body.outcome = .notEligible
+            body.reason = .podcastDisallowed
+            body.enablement = .notEnabled
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)
+            return (try body.serializedData(), response)
+        }
+
+        let result = try await service.requestTranscript(podcastUUID: "podcast-id", episodeUUID: "episode-id")
+
+        XCTAssertEqual(result.outcome, .notEligible)
+        XCTAssertEqual(result.reason, .podcastDisallowed)
+        XCTAssertEqual(result.enablement, .notEnabled)
+    }
+
+    func testRequestMapsHTTPFailures() async {
+        for (statusCode, expectedError) in [
+            (400, OnDemandTranscriptServiceError.malformedRequest),
+            (403, .accessDenied),
+            (404, .notFound),
+            (503, .transient)
+        ] {
+            let service = makeService { request in
+                let response = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)
+                return (nil, response)
+            }
+
+            do {
+                _ = try await service.requestTranscript(podcastUUID: "podcast-id", episodeUUID: "episode-id")
+                XCTFail("Expected HTTP \(statusCode) to throw")
+            } catch {
+                XCTAssertEqual(error as? OnDemandTranscriptServiceError, expectedError)
+            }
+        }
+    }
+}

--- a/Modules/Tests/PocketCastsServerTests/OnDemandTranscriptServiceTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/OnDemandTranscriptServiceTests.swift
@@ -61,6 +61,7 @@ final class OnDemandTranscriptServiceTests: XCTestCase {
             (400, OnDemandTranscriptServiceError.malformedRequest),
             (403, .accessDenied),
             (404, .notFound),
+            (429, .throttled),
             (503, .transient)
         ] {
             let service = makeService { request in

--- a/Modules/Tests/PocketCastsUtilsTests/FeatureFlagTests.swift
+++ b/Modules/Tests/PocketCastsUtilsTests/FeatureFlagTests.swift
@@ -60,6 +60,20 @@ class FeatureFlagTests: XCTestCase {
         try? store.override(flag, withValue: false)
         XCTAssertFalse(store.isOverridden(flag))
     }
+
+    func testOnDemandTranscriptsDefaultsOnOnlyForDebugBuilds() {
+        let previousEnvironment = BuildEnvironment.current
+        defer { BuildEnvironment.current = previousEnvironment }
+
+        BuildEnvironment.current = .debug
+        XCTAssertTrue(FeatureFlag.onDemandTranscripts.default)
+
+        BuildEnvironment.current = .testFlight
+        XCTAssertFalse(FeatureFlag.onDemandTranscripts.default)
+
+        BuildEnvironment.current = .appStore
+        XCTAssertFalse(FeatureFlag.onDemandTranscripts.default)
+    }
 }
 
 enum MockFeatureFlag: OverrideableFlag {

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
@@ -1,8 +1,22 @@
 import XCTest
 @testable import PocketCastsDataModel
+@testable import PocketCastsServer
 @testable import podcasts
 
 final class TranscriptManagerTests: XCTestCase {
+    actor MockOnDemandService: OnDemandTranscriptRequesting {
+        private(set) var requestCount = 0
+        var result: Result<OnDemandTranscriptResponse, Error>
+
+        init(result: Result<OnDemandTranscriptResponse, Error>) {
+            self.result = result
+        }
+
+        func requestTranscript(podcastUUID: String, episodeUUID: String) async throws -> OnDemandTranscriptResponse {
+            requestCount += 1
+            return try result.get()
+        }
+    }
 
     class MockShowCoordinator: ShowInfoCoordinating {
         func loadShowNotes(podcastUuid: String, episodeUuid: String) async throws -> String {
@@ -46,6 +60,12 @@ final class TranscriptManagerTests: XCTestCase {
         }
     }
 
+    class MissingMockShowCoordinator: MockShowCoordinator {
+        override func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
+            (transcripts: [], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
+        }
+    }
+
     func testLoadingTranscript() async throws {
         let mockShowCoordinator = MockShowCoordinator()
         let manager = TranscriptManager(episodeUUID: UUID().uuidString, podcastUUID: UUID().uuidString, showCoordinator: mockShowCoordinator)
@@ -78,6 +98,147 @@ final class TranscriptManagerTests: XCTestCase {
             _ = try await manager.loadTranscript()
         } catch {
             XCTAssertTrue(error is TranscriptError)
+        }
+    }
+
+    func testOnDemandEligibilityAllowsPlusAndPatronOnly() {
+        XCTAssertTrue(OnDemandTranscriptEligibility.isEligible(isLoggedIn: true, hasActiveSubscription: true, tier: .plus, flagEnabled: true))
+        XCTAssertTrue(OnDemandTranscriptEligibility.isEligible(isLoggedIn: true, hasActiveSubscription: true, tier: .patron, flagEnabled: true))
+        XCTAssertFalse(OnDemandTranscriptEligibility.isEligible(isLoggedIn: true, hasActiveSubscription: false, tier: .none, flagEnabled: true))
+        XCTAssertFalse(OnDemandTranscriptEligibility.isEligible(isLoggedIn: false, hasActiveSubscription: true, tier: .plus, flagEnabled: true))
+        XCTAssertFalse(OnDemandTranscriptEligibility.isEligible(isLoggedIn: true, hasActiveSubscription: true, tier: .plus, flagEnabled: false))
+    }
+
+    func testDefaultPollingPolicyMatchesSharedPrototype() {
+        XCTAssertEqual(TranscriptManager.defaultPollingInterval, 15)
+        XCTAssertEqual(TranscriptManager.defaultPollingTimeout, 5 * 60)
+    }
+
+    func testPollingBudgetAccumulatesForegroundTimeAcrossResumes() {
+        var budget = TranscriptForegroundPollingBudget(duration: 5 * 60)
+        let firstStart = Date(timeIntervalSinceReferenceDate: 0)
+        budget.consume(from: firstStart, to: firstStart.addingTimeInterval(2 * 60))
+        XCTAssertEqual(budget.remaining, 3 * 60)
+
+        let resumedStart = Date(timeIntervalSinceReferenceDate: 10 * 60)
+        budget.consume(from: resumedStart, to: resumedStart.addingTimeInterval(3 * 60))
+        XCTAssertEqual(budget.remaining, 0)
+    }
+
+    func testAcceptedOnDemandRequestIsSentOnlyOncePerManager() async throws {
+        let response = OnDemandTranscriptResponse(outcome: .queued, reason: .unspecified, enablement: .enabled, newlyQueuedCount: 3)
+        let service = MockOnDemandService(result: .success(response))
+        let manager = TranscriptManager(
+            episodeUUID: "episode-id",
+            podcastUUID: "podcast-id",
+            showCoordinator: MissingMockShowCoordinator(),
+            onDemandService: service,
+            isEligibleForOnDemand: { true }
+        )
+
+        _ = try await manager.requestOnDemandTranscript()
+        var lifecycle = TranscriptLoadingLifecycle()
+        lifecycle.started()
+        lifecycle.enteredBackground()
+        XCTAssertTrue(lifecycle.shouldResumeOnForeground(isVisible: true))
+        _ = try await manager.requestOnDemandTranscript()
+
+        let requestCount = await service.requestCount
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    func testTranscriptLoadingDoesNotResumeAfterLeavingScreenInBackground() {
+        var lifecycle = TranscriptLoadingLifecycle()
+        lifecycle.started()
+        lifecycle.enteredBackground()
+        lifecycle.leftScreen()
+
+        XCTAssertFalse(lifecycle.shouldResumeOnForeground(isVisible: true))
+        XCTAssertFalse(lifecycle.isPending)
+    }
+
+    func testTranscriptLoadingDoesNotResumeWhenScreenIsNoLongerVisible() {
+        var lifecycle = TranscriptLoadingLifecycle()
+        lifecycle.started()
+        lifecycle.enteredBackground()
+
+        XCTAssertFalse(lifecycle.shouldResumeOnForeground(isVisible: false))
+        XCTAssertFalse(lifecycle.isPending)
+    }
+
+    func testRejectedOnDemandRequestDoesNotStartGeneration() async {
+        let response = OnDemandTranscriptResponse(
+            outcome: .notEligible,
+            reason: .podcastDisallowed,
+            enablement: .notEnabled,
+            newlyQueuedCount: 0
+        )
+        let manager = TranscriptManager(
+            episodeUUID: "episode-id",
+            podcastUUID: "podcast-id",
+            showCoordinator: MissingMockShowCoordinator(),
+            onDemandService: MockOnDemandService(result: .success(response)),
+            isEligibleForOnDemand: { true }
+        )
+
+        do {
+            _ = try await manager.requestOnDemandTranscript()
+            XCTFail("Expected request rejection")
+        } catch TranscriptGenerationError.rejected(let reason) {
+            XCTAssertEqual(reason, .podcastDisallowed)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testOfflineOnDemandRequestIsTransient() async {
+        let manager = TranscriptManager(
+            episodeUUID: "episode-id",
+            podcastUUID: "podcast-id",
+            showCoordinator: MissingMockShowCoordinator(),
+            onDemandService: MockOnDemandService(result: .failure(URLError(.notConnectedToInternet))),
+            isEligibleForOnDemand: { true }
+        )
+
+        do {
+            _ = try await manager.requestOnDemandTranscript()
+            XCTFail("Expected transient error")
+        } catch TranscriptGenerationError.transient {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testPollingCompletesWhenGeneratedTranscriptAppears() async throws {
+        let manager = TranscriptManager(
+            episodeUUID: "episode-id",
+            podcastUUID: "podcast-id",
+            showCoordinator: GeneratedMockShowCoordinator(),
+            pollingInterval: 0.001,
+            pollingTimeout: 1
+        )
+
+        try await manager.waitForGeneratedTranscript()
+
+        XCTAssertTrue(manager.hasGeneratedTranscripts)
+        XCTAssertTrue(manager.isDisplayingGeneratedTranscript)
+    }
+
+    func testPollingTimesOutWhenTranscriptRemainsMissing() async {
+        let manager = TranscriptManager(
+            episodeUUID: "episode-id",
+            podcastUUID: "podcast-id",
+            showCoordinator: MissingMockShowCoordinator(),
+            pollingInterval: 0.001,
+            pollingTimeout: 0.01
+        )
+
+        do {
+            try await manager.waitForGeneratedTranscript()
+            XCTFail("Expected timeout")
+        } catch TranscriptGenerationError.delayed {
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
     }
 }

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptManagerTests.swift
@@ -66,6 +66,12 @@ final class TranscriptManagerTests: XCTestCase {
         }
     }
 
+    class FailingMockShowCoordinator: MockShowCoordinator {
+        override func loadTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+
     func testLoadingTranscript() async throws {
         let mockShowCoordinator = MockShowCoordinator()
         let manager = TranscriptManager(episodeUUID: UUID().uuidString, podcastUUID: UUID().uuidString, showCoordinator: mockShowCoordinator)
@@ -98,6 +104,21 @@ final class TranscriptManagerTests: XCTestCase {
             _ = try await manager.loadTranscript()
         } catch {
             XCTAssertTrue(error is TranscriptError)
+        }
+    }
+
+    func testLoadingTranscriptPropagatesMetadataFailure() async {
+        let manager = TranscriptManager(
+            episodeUUID: UUID().uuidString,
+            podcastUUID: UUID().uuidString,
+            showCoordinator: FailingMockShowCoordinator()
+        )
+
+        do {
+            _ = try await manager.loadTranscript()
+            XCTFail("Expected metadata failure")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .notConnectedToInternet)
         }
     }
 

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -960,6 +960,10 @@ enum AnalyticsEvent: String {
     case episodeTranscriptShown
     case transcriptShared
     case transcriptTextHighlighted
+    case transcriptOnDemandRequested
+    case transcriptOnDemandOutcome
+    case transcriptOnDemandReady
+    case transcriptOnDemandTimedOut
     case syncedTranscriptsSeekUsed
     case syncedTranscriptsPreparationStarted
     case syncedTranscriptsPreparationCompleted

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinating.swift
@@ -24,4 +24,18 @@ protocol ShowInfoCoordinating {
         podcastUuid: String,
         episodeUuid: String
     ) async throws -> EpisodeTranscriptData
+
+    func refreshTranscriptsMetadata(
+        podcastUuid: String,
+        episodeUuid: String
+    ) async throws -> EpisodeTranscriptData
+}
+
+extension ShowInfoCoordinating {
+    func refreshTranscriptsMetadata(
+        podcastUuid: String,
+        episodeUuid: String
+    ) async throws -> EpisodeTranscriptData {
+        try await loadTranscriptsMetadata(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+    }
 }

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -95,7 +95,11 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
             ignoreCache: true
         )
         let metadata = await getShowInfo(for: data?.data(using: .utf8))
-        return transcriptData(from: metadata, podcastUuid: podcastUuid, episodeUuid: episodeUuid, preferRemoteGeneratedState: true)
+        let transcriptData = transcriptData(from: metadata, podcastUuid: podcastUuid, episodeUuid: episodeUuid, preferRemoteGeneratedState: true)
+        if metadata != nil {
+            persistGeneratedTranscriptState(transcriptData.hasGeneratedTranscripts, episodeUuid: episodeUuid)
+        }
+        return transcriptData
 #endif
     }
 
@@ -118,11 +122,6 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
                 }
             } else {
                 pocketCastsTranscripts = metadata?.pocketCastsTranscripts ?? []
-                if !pocketCastsTranscripts.isEmpty,
-                   let episode = dataManager.findEpisode(uuid: episodeUuid) {
-                    episode.hasGeneratedTranscript = true
-                    dataManager.save(episode: episode)
-                }
             }
 
             let isDisplayingGenerated = externalTranscripts.isEmpty && !pocketCastsTranscripts.isEmpty
@@ -134,6 +133,15 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
             return (transcripts: [], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
         }
         return (transcripts: transcripts, hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
+    }
+
+    private func persistGeneratedTranscriptState(_ hasGeneratedTranscript: Bool, episodeUuid: String) {
+        guard let episode = dataManager.findEpisode(uuid: episodeUuid),
+              episode.hasGeneratedTranscript != hasGeneratedTranscript else {
+            return
+        }
+        episode.hasGeneratedTranscript = hasGeneratedTranscript
+        dataManager.save(episode: episode)
     }
 #endif
 

--- a/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
+++ b/podcasts/Episode Info Coordinator/ShowInfoCoordinator.swift
@@ -81,11 +81,36 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
         return (transcripts: [], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
 #else
         let metadata = try await loadShowInfo(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
+        return transcriptData(from: metadata, podcastUuid: podcastUuid, episodeUuid: episodeUuid, preferRemoteGeneratedState: false)
+#endif
+    }
 
+    public func refreshTranscriptsMetadata(podcastUuid: String, episodeUuid: String) async throws -> EpisodeTranscriptData {
+#if os(watchOS)
+        return (transcripts: [], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
+#else
+        let data = try await dataRetriever.loadEpisodeDataFromCache(
+            for: podcastUuid,
+            episodeUuid: episodeUuid,
+            ignoreCache: true
+        )
+        let metadata = await getShowInfo(for: data?.data(using: .utf8))
+        return transcriptData(from: metadata, podcastUuid: podcastUuid, episodeUuid: episodeUuid, preferRemoteGeneratedState: true)
+#endif
+    }
+
+#if !os(watchOS)
+    private func transcriptData(
+        from metadata: Episode.Metadata?,
+        podcastUuid: String,
+        episodeUuid: String,
+        preferRemoteGeneratedState: Bool
+    ) -> EpisodeTranscriptData {
         if FeatureFlag.generatedTranscripts.enabled {
             let externalTranscripts = metadata?.transcripts ?? []
             var pocketCastsTranscripts: [Episode.Metadata.Transcript] = []
-            if let episode = dataManager.findEpisode(uuid: episodeUuid),
+            if !preferRemoteGeneratedState,
+               let episode = dataManager.findEpisode(uuid: episodeUuid),
                let hasTranscript = episode.hasGeneratedTranscript {
                 if hasTranscript {
                     let transcript = buildGeneratedTranscript(podcastUuid: podcastUuid, episodeUuid: episodeUuid)
@@ -93,6 +118,11 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
                 }
             } else {
                 pocketCastsTranscripts = metadata?.pocketCastsTranscripts ?? []
+                if !pocketCastsTranscripts.isEmpty,
+                   let episode = dataManager.findEpisode(uuid: episodeUuid) {
+                    episode.hasGeneratedTranscript = true
+                    dataManager.save(episode: episode)
+                }
             }
 
             let isDisplayingGenerated = externalTranscripts.isEmpty && !pocketCastsTranscripts.isEmpty
@@ -104,8 +134,8 @@ actor ShowInfoCoordinator: ShowInfoCoordinating {
             return (transcripts: [], hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
         }
         return (transcripts: transcripts, hasGeneratedTranscripts: false, isDisplayingGeneratedTranscript: false)
-#endif
     }
+#endif
 
     @discardableResult
     func loadShowInfo(

--- a/podcasts/Episode/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+ShowNotes.swift
@@ -52,11 +52,13 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
                     vc?.showNotesWebViewTopConstraint?.constant = 20.0
                 }
                 let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier, episodeUuid: episodeUUID)
-                if metadata?.transcripts.isEmpty == false || OnDemandTranscriptEligibility.isEligible {
+                let hasTranscript = metadata?.transcripts.isEmpty == false
+                if hasTranscript || OnDemandTranscriptEligibility.isEligible {
                     let viewModel = TranscriptExcerptViewModel(
                         episodeUUID: episodeUUID,
                         podcastUUID: parentIdentifier,
-                        isGeneratedTranscript: metadata?.hasGeneratedTranscripts == true || metadata?.transcripts.isEmpty != false
+                        isGeneratedTranscript: metadata?.hasGeneratedTranscripts == true,
+                        shouldLoadExcerpt: hasTranscript
                     ) {
                         DispatchQueue.main.async { [weak self] in
                             let playbackManager = TranscriptEpisodeInfoProvider(episodeUUID: episodeUUID, podcastUUID: parentIdentifier)

--- a/podcasts/Episode/EpisodeDetailViewController+ShowNotes.swift
+++ b/podcasts/Episode/EpisodeDetailViewController+ShowNotes.swift
@@ -51,8 +51,13 @@ extension EpisodeDetailViewController: WKNavigationDelegate, SFSafariViewControl
                     vc?.showNotesHolderTopAnchor?.constant = 0.0
                     vc?.showNotesWebViewTopConstraint?.constant = 20.0
                 }
-                if let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier, episodeUuid: episodeUUID), !metadata.transcripts.isEmpty {
-                    let viewModel = TranscriptExcerptViewModel(episodeUUID: episodeUUID, podcastUUID: parentIdentifier, isGeneratedTranscript: metadata.hasGeneratedTranscripts) {
+                let metadata = try? await ShowInfoCoordinator.shared.loadTranscriptsMetadata(podcastUuid: parentIdentifier, episodeUuid: episodeUUID)
+                if metadata?.transcripts.isEmpty == false || OnDemandTranscriptEligibility.isEligible {
+                    let viewModel = TranscriptExcerptViewModel(
+                        episodeUUID: episodeUUID,
+                        podcastUUID: parentIdentifier,
+                        isGeneratedTranscript: metadata?.hasGeneratedTranscripts == true || metadata?.transcripts.isEmpty != false
+                    ) {
                         DispatchQueue.main.async { [weak self] in
                             let playbackManager = TranscriptEpisodeInfoProvider(episodeUUID: episodeUUID, podcastUUID: parentIdentifier)
                             let controller = TranscriptContainerViewController(playbackManager: playbackManager)

--- a/podcasts/TranscriptErrorView.swift
+++ b/podcasts/TranscriptErrorView.swift
@@ -83,6 +83,14 @@ class TranscriptErrorView: UIView {
             updatedAttributes[.foregroundColor] = ThemeColor.primaryText01()
         }
         label.attributedText = NSAttributedString(string: message, attributes: updatedAttributes)
+        accessibilityLabel = message
+    }
+
+    func configure(isRetryVisible: Bool, isWarningVisible: Bool = true) {
+        retryButton.isHidden = !isRetryVisible
+        icon.isHidden = !isWarningVisible
+        isAccessibilityElement = true
+        accessibilityTraits = .staticText
     }
 
     func setTextAttributes(_ attributes: [NSAttributedString.Key: Any]) {

--- a/podcasts/TranscriptErrorView.swift
+++ b/podcasts/TranscriptErrorView.swift
@@ -89,7 +89,7 @@ class TranscriptErrorView: UIView {
     func configure(isRetryVisible: Bool, isWarningVisible: Bool = true) {
         retryButton.isHidden = !isRetryVisible
         icon.isHidden = !isWarningVisible
-        isAccessibilityElement = true
+        isAccessibilityElement = !isRetryVisible
         accessibilityTraits = .staticText
     }
 

--- a/podcasts/TranscriptExcerptView.swift
+++ b/podcasts/TranscriptExcerptView.swift
@@ -4,7 +4,7 @@ protocol TranscriptExcerptViewModeling: ObservableObject {
     var loadingState: TranscriptExcerptLoadingState { get set }
     var isGeneratedTranscript: Bool { get }
 
-    init(episodeUUID: String, podcastUUID: String, isGeneratedTranscript: Bool, tapAction: @escaping () -> Void)
+    init(episodeUUID: String, podcastUUID: String, isGeneratedTranscript: Bool, shouldLoadExcerpt: Bool, tapAction: @escaping () -> Void)
 
     func loadExcerptTranscript() async
     func excerptTapped()
@@ -26,16 +26,19 @@ class TranscriptExcerptViewModel: ObservableObject, TranscriptExcerptViewModelin
     private let tapAction: () -> Void
     private let episodeUUID: String
     private let podcastUUID: String
+    private let shouldLoadExcerpt: Bool
 
     required init(
         episodeUUID: String,
         podcastUUID: String,
         isGeneratedTranscript: Bool,
+        shouldLoadExcerpt: Bool,
         tapAction: @escaping () -> Void
     ) {
         self.episodeUUID = episodeUUID
         self.podcastUUID = podcastUUID
         self.isGeneratedTranscript = isGeneratedTranscript
+        self.shouldLoadExcerpt = shouldLoadExcerpt
         self.tapAction = tapAction
         self.manager = TranscriptManager(episodeUUID: episodeUUID, podcastUUID: podcastUUID)
     }
@@ -46,6 +49,7 @@ class TranscriptExcerptViewModel: ObservableObject, TranscriptExcerptViewModelin
     }
 
     func loadExcerptTranscript() async {
+        guard shouldLoadExcerpt else { return }
         if case .loading = loadingState { return }
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -143,11 +147,11 @@ private class MockTranscriptExcerptViewModel: TranscriptExcerptViewModeling {
     private var _privateLoadingState: TranscriptExcerptLoadingState = .loading
 
     convenience init(loadingState: TranscriptExcerptLoadingState, isGeneratedTranscript: Bool) {
-        self.init(episodeUUID: "", podcastUUID: "", isGeneratedTranscript: isGeneratedTranscript, tapAction: {  })
+        self.init(episodeUUID: "", podcastUUID: "", isGeneratedTranscript: isGeneratedTranscript, shouldLoadExcerpt: true, tapAction: {  })
         self._privateLoadingState = loadingState
     }
 
-    required init(episodeUUID: String, podcastUUID: String, isGeneratedTranscript: Bool, tapAction: () -> Void) {
+    required init(episodeUUID: String, podcastUUID: String, isGeneratedTranscript: Bool, shouldLoadExcerpt: Bool, tapAction: () -> Void) {
         self.isGeneratedTranscript = isGeneratedTranscript
     }
 

--- a/podcasts/TranscriptManager.swift
+++ b/podcasts/TranscriptManager.swift
@@ -1,5 +1,7 @@
 import Foundation
 import PocketCastsDataModel
+import PocketCastsServer
+import PocketCastsUtils
 #if !os(tvOS)
 import Sentry
 #endif
@@ -27,7 +29,51 @@ enum TranscriptError: Error {
     }
 }
 
+enum OnDemandTranscriptEligibility {
+    static var isEligible: Bool {
+        isEligible(
+            isLoggedIn: SyncManager.isUserLoggedIn(),
+            hasActiveSubscription: SubscriptionHelper.hasActiveSubscription(),
+            tier: SubscriptionHelper.activeTier,
+            flagEnabled: FeatureFlag.onDemandTranscripts.enabled
+        )
+    }
+
+    static func isEligible(
+        isLoggedIn: Bool,
+        hasActiveSubscription: Bool,
+        tier: SubscriptionTier,
+        flagEnabled: Bool
+    ) -> Bool {
+        guard flagEnabled, isLoggedIn, hasActiveSubscription else {
+            return false
+        }
+        return tier == .plus || tier == .patron
+    }
+}
+
+enum TranscriptGenerationError: Error {
+    case delayed
+    case rejected(OnDemandTranscriptResponse.Reason)
+    case transient
+}
+
+struct TranscriptForegroundPollingBudget {
+    let duration: TimeInterval
+    private(set) var consumed: TimeInterval = 0
+
+    var remaining: TimeInterval {
+        max(0, duration - consumed)
+    }
+
+    mutating func consume(from startDate: Date, to endDate: Date) {
+        consumed = min(duration, consumed + max(0, endDate.timeIntervalSince(startDate)))
+    }
+}
+
 class TranscriptManager {
+    static let defaultPollingInterval: TimeInterval = 15
+    static let defaultPollingTimeout: TimeInterval = 5 * 60
 
     typealias Transcript = Episode.Metadata.Transcript
 
@@ -36,14 +82,36 @@ class TranscriptManager {
     let podcastUUID: String
 
     let showCoordinator: ShowInfoCoordinating
+    private let onDemandService: OnDemandTranscriptRequesting
+    private let pollingInterval: TimeInterval
+    private var pollingBudget: TranscriptForegroundPollingBudget
+    private let isEligibleForOnDemand: @Sendable () -> Bool
+    private var acceptedOnDemandResponse: OnDemandTranscriptResponse?
+    private(set) var onDemandRequestAcceptedAt: Date?
+
+    var hasAcceptedOnDemandRequest: Bool {
+        acceptedOnDemandResponse != nil
+    }
 
     private(set) var hasGeneratedTranscripts: Bool = false
     private(set) var isDisplayingGeneratedTranscript: Bool = false
 
-    init(episodeUUID: String, podcastUUID: String, showCoordinator: ShowInfoCoordinating = ShowInfoCoordinator.shared) {
+    init(
+        episodeUUID: String,
+        podcastUUID: String,
+        showCoordinator: ShowInfoCoordinating = ShowInfoCoordinator.shared,
+        onDemandService: OnDemandTranscriptRequesting = OnDemandTranscriptService.shared,
+        pollingInterval: TimeInterval = TranscriptManager.defaultPollingInterval,
+        pollingTimeout: TimeInterval = TranscriptManager.defaultPollingTimeout,
+        isEligibleForOnDemand: @escaping @Sendable () -> Bool = { OnDemandTranscriptEligibility.isEligible }
+    ) {
         self.episodeUUID = episodeUUID
         self.podcastUUID = podcastUUID
         self.showCoordinator = showCoordinator
+        self.onDemandService = onDemandService
+        self.pollingInterval = pollingInterval
+        self.pollingBudget = TranscriptForegroundPollingBudget(duration: pollingTimeout)
+        self.isEligibleForOnDemand = isEligibleForOnDemand
     }
 
     public func loadTranscript() async throws -> TranscriptModel {
@@ -68,6 +136,60 @@ class TranscriptManager {
             }
         }
         throw TranscriptError.failedToLoad
+    }
+
+    func requestOnDemandTranscript() async throws -> OnDemandTranscriptResponse {
+        guard isEligibleForOnDemand() else {
+            throw TranscriptGenerationError.rejected(.transcriptIneligible)
+        }
+        if let acceptedOnDemandResponse {
+            return acceptedOnDemandResponse
+        }
+
+        do {
+            let response = try await onDemandService.requestTranscript(podcastUUID: podcastUUID, episodeUUID: episodeUUID)
+            switch response.outcome {
+            case .queued, .inProgress, .available:
+                acceptedOnDemandResponse = response
+                onDemandRequestAcceptedAt = Date()
+                return response
+            case .notEligible:
+                throw TranscriptGenerationError.rejected(response.reason)
+            case .transientFailure, .throttled, .unspecified:
+                throw TranscriptGenerationError.transient
+            }
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as TranscriptGenerationError {
+            throw error
+        } catch {
+            throw TranscriptGenerationError.transient
+        }
+    }
+
+    func waitForGeneratedTranscript() async throws {
+        let pollingStartedAt = Date()
+        let deadline = pollingStartedAt.addingTimeInterval(pollingBudget.remaining)
+        defer {
+            pollingBudget.consume(from: pollingStartedAt, to: Date())
+        }
+
+        while Date() < deadline {
+            try Task.checkCancellation()
+            let metadata = try await showCoordinator.refreshTranscriptsMetadata(
+                podcastUuid: podcastUUID,
+                episodeUuid: episodeUUID
+            )
+            if !metadata.transcripts.isEmpty {
+                hasGeneratedTranscripts = metadata.hasGeneratedTranscripts
+                isDisplayingGeneratedTranscript = metadata.isDisplayingGeneratedTranscript
+                return
+            }
+            let sleepDuration = min(pollingInterval, max(0, deadline.timeIntervalSinceNow))
+            guard sleepDuration > 0 else { break }
+            try await Task.sleep(nanoseconds: UInt64(sleepDuration * 1_000_000_000))
+        }
+        throw TranscriptGenerationError.delayed
     }
 
     private func loadTranscript(_ transcript: Transcript) async throws -> TranscriptModel {

--- a/podcasts/TranscriptManager.swift
+++ b/podcasts/TranscriptManager.swift
@@ -55,6 +55,7 @@ enum OnDemandTranscriptEligibility {
 enum TranscriptGenerationError: Error {
     case delayed
     case rejected(OnDemandTranscriptResponse.Reason)
+    case throttled
     case transient
 }
 
@@ -115,9 +116,8 @@ class TranscriptManager {
     }
 
     public func loadTranscript() async throws -> TranscriptModel {
-        guard
-            let metadata = try? await showCoordinator.loadTranscriptsMetadata(podcastUuid: podcastUUID, episodeUuid: episodeUUID),
-            !metadata.transcripts.isEmpty else {
+        let metadata = try await showCoordinator.loadTranscriptsMetadata(podcastUuid: podcastUUID, episodeUuid: episodeUUID)
+        guard !metadata.transcripts.isEmpty else {
             throw TranscriptError.notAvailable
         }
         var transcriptsAvailable = metadata.transcripts
@@ -155,14 +155,21 @@ class TranscriptManager {
                 return response
             case .notEligible:
                 throw TranscriptGenerationError.rejected(response.reason)
-            case .transientFailure, .throttled, .unspecified:
+            case .throttled:
+                throw TranscriptGenerationError.throttled
+            case .transientFailure, .unspecified:
                 throw TranscriptGenerationError.transient
             }
-        } catch is CancellationError {
-            throw CancellationError()
+        } catch let error as CancellationError {
+            throw error
         } catch let error as TranscriptGenerationError {
             throw error
+        } catch OnDemandTranscriptServiceError.throttled {
+            throw TranscriptGenerationError.throttled
         } catch {
+            if Task.isCancelled || (error as? URLError)?.code == .cancelled {
+                throw CancellationError()
+            }
             throw TranscriptGenerationError.transient
         }
     }
@@ -174,8 +181,16 @@ class TranscriptManager {
             pollingBudget.consume(from: pollingStartedAt, to: Date())
         }
 
+        var isFirstAttempt = true
         while Date() < deadline {
+            if !isFirstAttempt || acceptedOnDemandResponse?.outcome != .available {
+                let sleepDuration = min(pollingInterval, max(0, deadline.timeIntervalSinceNow))
+                guard sleepDuration > 0 else { break }
+                try await Task.sleep(nanoseconds: UInt64(sleepDuration * 1_000_000_000))
+            }
+            isFirstAttempt = false
             try Task.checkCancellation()
+            guard Date() < deadline else { break }
             let metadata = try await showCoordinator.refreshTranscriptsMetadata(
                 podcastUuid: podcastUUID,
                 episodeUuid: episodeUUID
@@ -185,9 +200,6 @@ class TranscriptManager {
                 isDisplayingGeneratedTranscript = metadata.isDisplayingGeneratedTranscript
                 return
             }
-            let sleepDuration = min(pollingInterval, max(0, deadline.timeIntervalSinceNow))
-            guard sleepDuration > 0 else { break }
-            try await Task.sleep(nanoseconds: UInt64(sleepDuration * 1_000_000_000))
         }
         throw TranscriptGenerationError.delayed
     }

--- a/podcasts/TranscriptShelfButton.swift
+++ b/podcasts/TranscriptShelfButton.swift
@@ -43,7 +43,7 @@ extension CheckTranscriptAvailability {
                 return
             }
 
-            self?.isTranscriptEnabled = isAvailable
+            self?.isTranscriptEnabled = isAvailable || OnDemandTranscriptEligibility.isEligible
             self?.hasGeneratedTranscripts = hasGeneratedTranscripts
         }
 
@@ -53,9 +53,9 @@ extension CheckTranscriptAvailability {
     }
 
     func checkTranscriptAvailability() {
-        isTranscriptEnabled = false
         hasGeneratedTranscripts = false
         let currentEpisode = PlaybackManager.shared.currentEpisode as? Episode
+        isTranscriptEnabled = currentEpisode != nil && OnDemandTranscriptEligibility.isEligible
         currentEpisode?.checkTranscriptAvailability()
     }
 }

--- a/podcasts/TranscriptShelfButton.swift
+++ b/podcasts/TranscriptShelfButton.swift
@@ -53,6 +53,7 @@ extension CheckTranscriptAvailability {
     }
 
     func checkTranscriptAvailability() {
+        isTranscriptEnabled = false
         hasGeneratedTranscripts = false
         let currentEpisode = PlaybackManager.shared.currentEpisode as? Episode
         isTranscriptEnabled = currentEpisode != nil && OnDemandTranscriptEligibility.isEligible

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -4,6 +4,39 @@ import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
 
+struct TranscriptLoadingLifecycle {
+    private(set) var isPending = false
+    private var resumeOnForeground = false
+
+    mutating func started() {
+        isPending = true
+    }
+
+    mutating func completed() {
+        isPending = false
+        resumeOnForeground = false
+    }
+
+    mutating func enteredBackground() {
+        resumeOnForeground = isPending
+    }
+
+    mutating func leftScreen() {
+        completed()
+    }
+
+    mutating func shouldResumeOnForeground(isVisible: Bool) -> Bool {
+        defer { resumeOnForeground = false }
+        guard resumeOnForeground, isPending, isVisible else {
+            if !isVisible {
+                isPending = false
+            }
+            return false
+        }
+        return true
+    }
+}
+
 class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvider {
     let analyticsSource: AnalyticsSource
 
@@ -58,6 +91,8 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     private var autoScrollSuppressedDate: Date?
 
     private var transcriptManager: TranscriptManager?
+    private var transcriptLoadingTask: Task<Void, Never>?
+    private var transcriptLoadingLifecycle = TranscriptLoadingLifecycle()
 
     #if DEBUG
     private var debugOverlay: FingerprintDebugOverlay?
@@ -106,11 +141,16 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         dismissSearch()
         resetSearch()
         cancelAutoScrollBack()
+        cancelTranscriptLoading()
+        if UIApplication.shared.applicationState != .background {
+            transcriptLoadingLifecycle.leftScreen()
+        }
     }
 
     deinit {
         autoScrollBackWorkItem?.cancel()
         highlightDisplayLink?.invalidate()
+        transcriptLoadingTask?.cancel()
     }
 
     private func startHighlightDisplayLink() {
@@ -237,7 +277,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         NSLayoutConstraint.activate(
             [
                 errorView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                errorView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+                errorView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 40),
                 errorView.widthAnchor.constraint(equalTo: view.readableContentGuide.widthAnchor, constant: -Sizes.textMargin)
             ]
         )
@@ -555,6 +595,8 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
     }
 
     override func willBeRemovedFromPlayer() {
+        cancelTranscriptLoading()
+        transcriptLoadingLifecycle.leftScreen()
         removeAllCustomObservers()
         stopHighlightDisplayLink()
         if FeatureFlag.syncedTranscripts.enabled {
@@ -614,6 +656,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         restoreControlButtonsLayout()
         setControlButtonsVisible(false)
         errorView.isHidden = true
+        errorView.configure(isRetryVisible: true)
         activityIndicatorView.startAnimating()
     }
 
@@ -642,7 +685,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
     private var currentEpisodeUUID: String?
 
-    private func loadTranscript() {
+    private func loadTranscript(using existingManager: TranscriptManager? = nil) {
         guard let episodeUUID = playbackManager.episodeUUID, let podcastUUID = playbackManager.podcastUUID else {
             return
         }
@@ -650,11 +693,14 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         let shouldResetPosition = currentEpisodeUUID != episodeUUID
         currentEpisodeUUID = episodeUUID
 
-        transcriptManager = TranscriptManager(episodeUUID: episodeUUID, podcastUUID: podcastUUID)
+        cancelTranscriptLoading()
+        let transcriptManager = existingManager ?? TranscriptManager(episodeUUID: episodeUUID, podcastUUID: podcastUUID)
+        self.transcriptManager = transcriptManager
+        transcriptLoadingLifecycle.started()
 
         setupLoadingState()
 
-        Task.detached { [weak self, transcriptManager] in
+        transcriptLoadingTask = Task.detached { [weak self, transcriptManager] in
             guard let self, let transcriptManager else {
                 return
             }
@@ -692,12 +738,108 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                     }
                 }
                 await show(transcript: transcript, resetPosition: shouldResetPosition)
+                await self.completeTranscriptLoading(using: transcriptManager)
+            } catch TranscriptError.notAvailable where OnDemandTranscriptEligibility.isEligible {
+                await self.requestAndWaitForTranscript(using: transcriptManager)
+            } catch is CancellationError {
+                return
             } catch {
                 await stopSyncedTranscripts()
                 await track(.transcriptError, properties: ["error_code": (error as NSError).code])
                 await show(error: error)
+                await self.completeTranscriptLoading(using: transcriptManager)
             }
         }
+    }
+
+    private func requestAndWaitForTranscript(using transcriptManager: TranscriptManager) async {
+        let attemptDate = Date()
+        do {
+            let wasAlreadyAccepted = transcriptManager.hasAcceptedOnDemandRequest
+            let response = try await transcriptManager.requestOnDemandTranscript()
+            let requestDate = transcriptManager.onDemandRequestAcceptedAt ?? attemptDate
+            await MainActor.run {
+                self.showGeneratingState()
+                if !wasAlreadyAccepted {
+                    self.track(.transcriptOnDemandRequested, properties: [
+                        "outcome": response.outcome.rawValue,
+                        "reason": response.reason.rawValue,
+                        "enablement": response.enablement.rawValue,
+                        "newly_queued_count": response.newlyQueuedCount
+                    ])
+                }
+            }
+
+            try await transcriptManager.waitForGeneratedTranscript()
+            let elapsedMilliseconds = Int(Date().timeIntervalSince(requestDate) * 1_000)
+            await MainActor.run {
+                self.track(.transcriptOnDemandReady, properties: [
+                    "elapsed_time_ms": elapsedMilliseconds
+                ])
+                UIAccessibility.post(notification: .announcement, argument: L10n.transcriptOnDemandCompleted)
+                self.loadTranscript(using: transcriptManager)
+            }
+        } catch is CancellationError {
+            return
+        } catch TranscriptGenerationError.delayed {
+            let requestDate = transcriptManager.onDemandRequestAcceptedAt ?? attemptDate
+            await MainActor.run {
+                self.track(.transcriptOnDemandTimedOut, properties: [
+                    "elapsed_time_ms": Int(Date().timeIntervalSince(requestDate) * 1_000)
+                ])
+                self.showGenerationError(message: L10n.transcriptOnDemandDelayed, canRetry: false)
+                self.completeTranscriptLoading(using: transcriptManager)
+            }
+        } catch TranscriptGenerationError.rejected(let reason) {
+            await MainActor.run {
+                self.track(.transcriptOnDemandOutcome, properties: [
+                    "outcome": OnDemandTranscriptResponse.Outcome.notEligible.rawValue,
+                    "reason": reason.rawValue
+                ])
+                self.showGenerationError(message: L10n.transcriptOnDemandUnavailable, canRetry: false)
+                self.completeTranscriptLoading(using: transcriptManager)
+            }
+        } catch {
+            await MainActor.run {
+                self.track(.transcriptOnDemandOutcome, properties: [
+                    "outcome": OnDemandTranscriptResponse.Outcome.transientFailure.rawValue
+                ])
+                self.showGenerationError(message: L10n.transcriptOnDemandError, canRetry: true)
+                self.completeTranscriptLoading(using: transcriptManager)
+            }
+        }
+    }
+
+    @MainActor
+    private func completeTranscriptLoading(using transcriptManager: TranscriptManager) {
+        guard self.transcriptManager === transcriptManager else { return }
+        transcriptLoadingLifecycle.completed()
+        transcriptLoadingTask = nil
+    }
+
+    @MainActor
+    private func showGeneratingState() {
+        transcriptView.isHidden = true
+        setControlButtonsVisible(false)
+        errorView.configure(isRetryVisible: false, isWarningVisible: false)
+        errorView.setMessage(L10n.transcriptOnDemandGenerating, attributes: makeStyle(alignment: .center))
+        errorView.isHidden = false
+        activityIndicatorView.startAnimating()
+        UIAccessibility.post(notification: .announcement, argument: L10n.transcriptOnDemandGenerating)
+    }
+
+    @MainActor
+    private func showGenerationError(message: String, canRetry: Bool) {
+        activityIndicatorView.stopAnimating()
+        errorView.configure(isRetryVisible: canRetry)
+        errorView.setMessage(message, attributes: makeStyle(alignment: .center))
+        errorView.isHidden = false
+        UIAccessibility.post(notification: .announcement, argument: message)
+    }
+
+    private func cancelTranscriptLoading() {
+        transcriptLoadingTask?.cancel()
+        transcriptLoadingTask = nil
     }
 
     @objc private func showUpsellView() {
@@ -719,7 +861,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
 
     private func retryLoad() {
         errorView.isHidden = true
-        loadTranscript()
+        loadTranscript(using: transcriptManager)
     }
 
     private func resetSearch() {
@@ -875,12 +1017,28 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         }
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+        addCustomObserver(UIApplication.didEnterBackgroundNotification, selector: #selector(appDidEnterBackground))
+        addCustomObserver(UIApplication.didBecomeActiveNotification, selector: #selector(appDidBecomeActive))
         if FeatureFlag.syncedTranscripts.enabled {
             addCustomObserver(Constants.Notifications.playbackProgress, selector: #selector(updateTranscriptPosition))
             addCustomObserver(Constants.Notifications.playbackStarted, selector: #selector(updateHighlightDisplayLinkPauseState))
             addCustomObserver(Constants.Notifications.playbackPaused, selector: #selector(updateHighlightDisplayLinkPauseState))
             addCustomObserver(Constants.Notifications.playbackEnded, selector: #selector(updateHighlightDisplayLinkPauseState))
         }
+    }
+
+    @objc private func appDidEnterBackground() {
+        transcriptLoadingLifecycle.enteredBackground()
+        cancelTranscriptLoading()
+    }
+
+    @objc private func appDidBecomeActive() {
+        let isVisible = isViewLoaded && view.window != nil
+        guard transcriptLoadingLifecycle.shouldResumeOnForeground(isVisible: isVisible),
+              let transcriptManager else {
+            return
+        }
+        loadTranscript(using: transcriptManager)
     }
 
     @objc private func updateTranscriptPosition() {

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -277,7 +277,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         NSLayoutConstraint.activate(
             [
                 errorView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                errorView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 40),
+                errorView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
                 errorView.widthAnchor.constraint(equalTo: view.readableContentGuide.widthAnchor, constant: -Sizes.textMargin)
             ]
         )
@@ -741,9 +741,10 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 await self.completeTranscriptLoading(using: transcriptManager)
             } catch TranscriptError.notAvailable where OnDemandTranscriptEligibility.isEligible {
                 await self.requestAndWaitForTranscript(using: transcriptManager)
-            } catch is CancellationError {
-                return
             } catch {
+                guard !Task.isCancelled, (error as? URLError)?.code != .cancelled else {
+                    return
+                }
                 await stopSyncedTranscripts()
                 await track(.transcriptError, properties: ["error_code": (error as NSError).code])
                 await show(error: error)
@@ -765,7 +766,7 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                         "outcome": response.outcome.rawValue,
                         "reason": response.reason.rawValue,
                         "enablement": response.enablement.rawValue,
-                        "newly_queued_count": response.newlyQueuedCount
+                        "newly_queued_count": Int(response.newlyQueuedCount)
                     ])
                 }
             }
@@ -779,8 +780,6 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 UIAccessibility.post(notification: .announcement, argument: L10n.transcriptOnDemandCompleted)
                 self.loadTranscript(using: transcriptManager)
             }
-        } catch is CancellationError {
-            return
         } catch TranscriptGenerationError.delayed {
             let requestDate = transcriptManager.onDemandRequestAcceptedAt ?? attemptDate
             await MainActor.run {
@@ -788,6 +787,14 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                     "elapsed_time_ms": Int(Date().timeIntervalSince(requestDate) * 1_000)
                 ])
                 self.showGenerationError(message: L10n.transcriptOnDemandDelayed, canRetry: false)
+                self.completeTranscriptLoading(using: transcriptManager)
+            }
+        } catch TranscriptGenerationError.throttled {
+            await MainActor.run {
+                self.track(.transcriptOnDemandOutcome, properties: [
+                    "outcome": OnDemandTranscriptResponse.Outcome.throttled.rawValue
+                ])
+                self.showGenerationError(message: L10n.transcriptOnDemandUnavailable, canRetry: false)
                 self.completeTranscriptLoading(using: transcriptManager)
             }
         } catch TranscriptGenerationError.rejected(let reason) {
@@ -800,6 +807,9 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
                 self.completeTranscriptLoading(using: transcriptManager)
             }
         } catch {
+            guard !Task.isCancelled, (error as? URLError)?.code != .cancelled else {
+                return
+            }
             await MainActor.run {
                 self.track(.transcriptOnDemandOutcome, properties: [
                     "outcome": OnDemandTranscriptResponse.Outcome.transientFailure.rawValue
@@ -1017,8 +1027,10 @@ class TranscriptViewController: PlayerItemViewController, AnalyticsSourceProvide
         }
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide(_:)), name: UIResponder.keyboardWillHideNotification, object: nil)
-        addCustomObserver(UIApplication.didEnterBackgroundNotification, selector: #selector(appDidEnterBackground))
-        addCustomObserver(UIApplication.didBecomeActiveNotification, selector: #selector(appDidBecomeActive))
+        if FeatureFlag.onDemandTranscripts.enabled {
+            addCustomObserver(UIApplication.didEnterBackgroundNotification, selector: #selector(appDidEnterBackground))
+            addCustomObserver(UIApplication.didBecomeActiveNotification, selector: #selector(appDidBecomeActive))
+        }
         if FeatureFlag.syncedTranscripts.enabled {
             addCustomObserver(Constants.Notifications.playbackProgress, selector: #selector(updateTranscriptPosition))
             addCustomObserver(Constants.Notifications.playbackStarted, selector: #selector(updateHighlightDisplayLinkPauseState))

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4907,6 +4907,21 @@
 /* Transcript error message when transcript is empty*/
 "transcript_error_empty" = "Sorry, but it looks this transcript is empty";
 
+/* Prototype status shown while an on-demand transcript is being generated. Copy must be reviewed before beta. */
+"transcript_on_demand_generating" = "We’re generating this transcript. It may take a few minutes.";
+
+/* Prototype status shown when an on-demand transcript is still unavailable after foreground refresh ends. Copy must be reviewed before beta. */
+"transcript_on_demand_delayed" = "This transcript is still being generated. Please check back later.";
+
+/* Prototype error shown when an on-demand transcript request fails temporarily. Copy must be reviewed before beta. */
+"transcript_on_demand_error" = "We couldn’t start this transcript right now. Please try again.";
+
+/* Prototype error shown when the server rejects an on-demand transcript request. Copy must be reviewed before beta. */
+"transcript_on_demand_unavailable" = "This episode isn’t available for transcript generation.";
+
+/* VoiceOver announcement when an on-demand transcript finishes generating. Copy must be reviewed before beta. */
+"transcript_on_demand_completed" = "Transcript ready.";
+
 /* Toast shown when the user taps inside the transcript but the fingerprint mapping has no anchors yet, so we can't resolve an accurate seek target. */
 "transcript_tap_to_seek_streaming_unavailable" = "Download the episode to tap to seek";
 


### PR DESCRIPTION
Linear: [PCIOS-901](https://linear.app/a8c/issue/PCIOS-901/request-and-display-on-demand-transcript-generation)

| 📘 Part of: On-demand transcripts cross-platform delivery |
|:---:|

Adds on-demand transcript generation for Plus and Patron listeners when an episode has no existing transcript. The client makes one authenticated request, shows accessible localized generation states, and refreshes metadata every 15 seconds for at most five cumulative foreground minutes. Existing creator and generated transcripts continue to take precedence, and the feature remains production-off.

## To test

1. Enable the on-demand transcripts feature in a development build and sign in with Plus or Patron.
2. Open a missing transcript and confirm generation is requested once.
3. Background and foreground the app; confirm polling resumes without another request.
4. Confirm polling stops when the transcript appears, the screen closes, or five foreground minutes elapse.
5. Verify free and signed-out listeners retain the existing behavior.
6. Verify creator-supplied and existing generated transcripts never trigger generation.
7. Exercise rejected, offline, delayed, and successful states with VoiceOver and larger text sizes.

## Verification

- `make format`
- PocketCastsServer generic iOS Simulator build
- Swift parsing, lint, and focused polling policy tests
- Full app build/tests still require the repository's local credentials file

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

Made with [Cursor](https://cursor.com)

## Review notes

- Show-info request errors intentionally propagate so the client can distinguish a failed metadata check from a confirmed missing transcript; existing show-notes and chapter callers retain their current fallbacks.
- The four new Event Horizon events must be added to the schema before this feature leaves debug-only enablement.