### PR TITLE
Create a bookmark from a transcript text selection

### DIFF
--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptModelCueLookupTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptModelCueLookupTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+
+@testable import podcasts
+
+/// Covers the lookup that turns the start of a transcript text selection into the cue whose
+/// time the bookmark is created at.
+final class TranscriptModelCueLookupTests: XCTestCase {
+
+    private let transcript = """
+    WEBVTT
+
+    0:00:00.000 --> 0:00:05.000
+    <v Speaker 1>that's the thing about selective admissions.
+
+    0:00:05.000 --> 0:00:10.000
+    <v Speaker 1>The difference between the kid who gets in and the kid who doesn't is often basically noise.
+
+    0:00:10.000 --> 0:00:15.000
+    <v Speaker 2>Right, and that's why some researchers have floated the lottery idea.
+    """
+
+    private func makeModel() throws -> TranscriptModel {
+        try XCTUnwrap(TranscriptModel.makeModel(from: transcript, format: .vtt))
+    }
+
+    func testIndexInsideACueReturnsThatCue() throws {
+        let model = try makeModel()
+        let second = model.cues[1]
+
+        let cue = try XCTUnwrap(model.cue(atCharacterIndex: second.characterRange.location + 3))
+
+        XCTAssertEqual(cue.startTime, second.startTime)
+    }
+
+    func testFirstAndLastCharactersOfACueReturnThatCue() throws {
+        let model = try makeModel()
+        let second = model.cues[1]
+
+        XCTAssertEqual(model.cue(atCharacterIndex: second.characterRange.location)?.startTime, second.startTime)
+        XCTAssertEqual(model.cue(atCharacterIndex: second.characterRange.upperBound - 1)?.startTime, second.startTime)
+    }
+
+    func testIndexOnASpeakerNameReturnsTheCueItIntroduces() throws {
+        let model = try makeModel()
+        let third = model.cues[2]
+        // A speaker change writes the new name into the gap the previous cue leaves behind
+        let speakerIndex = model.cues[1].characterRange.upperBound
+        XCTAssertLessThan(speakerIndex, third.characterRange.location)
+
+        let cue = try XCTUnwrap(model.cue(atCharacterIndex: speakerIndex))
+
+        XCTAssertEqual(cue.startTime, third.startTime)
+    }
+
+    func testIndexBeforeTheFirstCueReturnsTheFirstCue() throws {
+        let model = try makeModel()
+        let first = model.cues[0]
+        XCTAssertGreaterThan(first.characterRange.location, 0)
+
+        XCTAssertEqual(model.cue(atCharacterIndex: 0)?.startTime, first.startTime)
+    }
+
+    func testIndexPastTheLastCueReturnsNil() throws {
+        let model = try makeModel()
+
+        XCTAssertNil(model.cue(atCharacterIndex: model.attributedText.length))
+    }
+
+    func testCueIsNilWithoutAnyCues() {
+        let model = TranscriptModel(attributedText: NSAttributedString(string: "No cues here"), cues: [], type: "", hasJavascript: false)
+
+        XCTAssertNil(model.cue(atCharacterIndex: 0))
+    }
+}

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -70,8 +70,19 @@ class BookmarkManager {
     }()
 
     /// Adds a new bookmark for an episode at the given time
+    ///
+    /// - Parameters:
+    ///   - passage: The transcript passage to store with the bookmark, for a bookmark made
+    ///     from one the user picked out. Left nil, the passage is captured afterwards from
+    ///     the transcript around `time`.
+    ///   - referenceTime: `time` on the transcript's reference timeline, when it's already known.
     @discardableResult
-    func add(to episode: BaseEpisode, at time: TimeInterval, title: String = L10n.bookmarkDefaultTitle, source: BookmarkAnalyticsSource = .unknown) -> Bookmark? {
+    func add(to episode: BaseEpisode,
+             at time: TimeInterval,
+             title: String = L10n.bookmarkDefaultTitle,
+             passage: BookmarkUpdateParameters.Passage? = nil,
+             referenceTime: TimeInterval? = nil,
+             source: BookmarkAnalyticsSource = .unknown) -> Bookmark? {
         // If the episode has a podcast attached, also save that
         let podcastUuid: String? = (episode as? Episode)?.podcastUuid
 
@@ -80,7 +91,18 @@ class BookmarkManager {
             return existing
         }
 
-        return dataManager.add(episodeUuid: episode.uuid, podcastUuid: podcastUuid, title: title, time: time).flatMap {
+        let now = Date()
+
+        return dataManager.add(episodeUuid: episode.uuid,
+                               podcastUuid: podcastUuid,
+                               title: title,
+                               time: time,
+                               dateCreated: now,
+                               passage: passage?.text,
+                               passageLocation: passage?.location,
+                               passageModified: passage != nil ? now : nil,
+                               referenceTime: referenceTime,
+                               referenceTimeModified: referenceTime != nil ? now : nil).flatMap {
             FileLog.shared.addMessage("[Bookmarks] Added bookmark for \(episode.displayableTitle()) at \(time)")
 
             // Inform the subscribers a bookmark was added

--- a/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
+++ b/podcasts/Bookmarks/BookmarkManager+TitleSuggestion.swift
@@ -17,7 +17,8 @@ extension BookmarkManager {
         FeatureFlag.smartBookmarks.enabled
     }
 
-    /// The transcript passage surrounding the bookmark, which the title is generated from.
+    /// The transcript passage the bookmark's title is generated from: the one it was created
+    /// with, when it carries one, and otherwise the transcript surrounding its position.
     ///
     /// Returns nil when suggestions are disabled or the episode has no usable transcript.
     func transcriptSnippet(for bookmark: Bookmark, episode: BaseEpisode) async -> BookmarkTranscriptSnippet? {
@@ -27,6 +28,12 @@ extension BookmarkManager {
 
         // Let the on-device model load while the transcript is fetched.
         prewarmTitleGeneration()
+
+        // A bookmark made from a transcript selection arrives with the passage the user
+        // picked out. Capturing a window around its position would throw that away.
+        if let captured = await capturedSnippet(for: bookmark, episode: episode) {
+            return captured
+        }
 
         let result = await BookmarkTranscriptSnippetExtractor().capture(forTime: bookmark.time, referenceTime: bookmark.referenceTime, episode: episode)
 

--- a/podcasts/Bookmarks/Bookmarks+Analytics.swift
+++ b/podcasts/Bookmarks/Bookmarks+Analytics.swift
@@ -11,6 +11,9 @@ enum BookmarkAnalyticsSource: String, AnalyticsDescribable {
     case headphones
     case whatsNew = "whats_new"
 
+    /// Created from a passage the user selected in the transcript
+    case transcript
+
     case unknown
 
     var analyticsDescription: String {

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -52,8 +52,9 @@ class BookmarksPlayerTabController: PlayerItemViewController {
 
         bookmarkManager.onBookmarkCreated
             .receive(on: RunLoop.main)
+            // A bookmark made from a transcript selection is titled by the transcript itself
             .filter { [weak self] event in
-                self?.viewModel.episode?.uuid == event.episode
+                self?.viewModel.episode?.uuid == event.episode && event.source != .transcript
             }
             .map { [weak self] event in
                 (event.isDuplicate, self?.bookmarkManager.bookmark(for: event.uuid))

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -960,7 +960,9 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
 private extension MainTabBarController {
     /// The edit sheet, where a bookmark is normally titled, only opens over the full screen player
-    /// with the app in the foreground — see `BookmarksPlayerTabController`
+    /// with the app in the foreground — see `BookmarksPlayerTabController`. A bookmark made from a
+    /// transcript selection is the exception: the transcript opens the sheet itself, wherever it's
+    /// shown from, so those are filtered out below rather than covered here.
     static var showsBookmarkEditSheet: Bool {
         UIApplication.shared.applicationState == .active
         && !CarPlayHelper.isConnectedToCarPlay
@@ -974,7 +976,7 @@ private extension MainTabBarController {
 
         bookmarkManager.onBookmarkCreated
             .receive(on: RunLoop.main)
-            .filter { !$0.isDuplicate && !Self.showsBookmarkEditSheet }
+            .filter { !$0.isDuplicate && $0.source != .transcript && !Self.showsBookmarkEditSheet }
             .compactMap { event in
                 bookmarkManager.bookmark(for: event.uuid).map { ($0, event.source) }
             }
@@ -992,8 +994,9 @@ private extension MainTabBarController {
 
         bookmarkManager.onBookmarkCreated
             .receive(on: RunLoop.main)
-            .filter { _ in
-                UIApplication.shared.applicationState == .active
+            .filter { event in
+                event.source != .transcript
+                && UIApplication.shared.applicationState == .active
                 && !CarPlayHelper.isConnectedToCarPlay
                 && NavigationManager.sharedManager.miniPlayer?.playerOpenState == .closed
             }

--- a/podcasts/TranscriptModel.swift
+++ b/podcasts/TranscriptModel.swift
@@ -79,6 +79,14 @@ struct TranscriptModel: Sendable {
         self.cues.first { $0.contains(timeInSeconds: secondsValue) }
     }
 
+    /// The cue the character at `characterIndex` reads as part of.
+    ///
+    /// A position that lands on a speaker name, or in the gap between two cues, belongs to
+    /// the cue that follows it rather than the one that ended before it.
+    func cue(atCharacterIndex characterIndex: Int) -> TranscriptCue? {
+        cues.first { NSLocationInRange(characterIndex, $0.characterRange) || $0.characterRange.location >= characterIndex }
+    }
+
     var isEmtpy: Bool {
         return attributedText.string.trim().isEmpty
     }

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -1229,7 +1229,9 @@ extension TranscriptViewController: UITextViewDelegate {
     func textView(_ textView: UITextView, editMenuForTextIn range: NSRange, suggestedActions: [UIMenuElement]) -> UIMenu? {
         guard let bookmarkAction = makeBookmarkAction(for: range) else { return nil }
 
-        return UIMenu(children: suggestedActions + [bookmarkAction])
+        // Leads the menu: bookmarking is what the transcript is selected for, and the system
+        // actions run several pages deep on a phone
+        return UIMenu(children: [bookmarkAction] + suggestedActions)
     }
 }
 

--- a/podcasts/TranscriptViewController.swift
+++ b/podcasts/TranscriptViewController.swift
@@ -1225,6 +1225,129 @@ extension TranscriptViewController: UITextViewDelegate {
             track(.transcriptTextHighlighted)
         }
     }
+
+    func textView(_ textView: UITextView, editMenuForTextIn range: NSRange, suggestedActions: [UIMenuElement]) -> UIMenu? {
+        guard let bookmarkAction = makeBookmarkAction(for: range) else { return nil }
+
+        return UIMenu(children: suggestedActions + [bookmarkAction])
+    }
+}
+
+// MARK: - Bookmarking a selection
+
+private extension TranscriptViewController {
+    /// Where a selected passage sits on the audio, and on the transcript's own timeline when
+    /// there is one worth recording.
+    struct BookmarkPosition {
+        /// The playback time the bookmark is created at
+        let time: TimeInterval
+
+        /// The same moment on the transcript's reference timeline, for a generated transcript;
+        /// nil for an external one, which is cued against the audio itself
+        let referenceTime: TimeInterval?
+    }
+
+    /// The "Bookmark" action to offer alongside the selection's system actions, or nil when
+    /// this selection can't be bookmarked.
+    func makeBookmarkAction(for range: NSRange) -> UIAction? {
+        guard range.length > 0, PaidFeature.bookmarks.isUnlocked,
+              let transcript,
+              let episode = playbackManager.episodeUUID.flatMap({ DataManager.sharedManager.findBaseEpisode(uuid: $0) }),
+              let position = bookmarkPosition(forSelectionStartingAt: range.location, in: transcript) else {
+            return nil
+        }
+
+        return UIAction(title: L10n.transcriptBookmarkSelection, image: UIImage(systemName: "bookmark")) { [weak self] _ in
+            self?.addBookmark(at: position, for: episode, selection: range, in: transcript)
+        }
+    }
+
+    /// The moment the selection starts at, which is where the cue holding its first character begins.
+    func bookmarkPosition(forSelectionStartingAt characterIndex: Int, in transcript: TranscriptModel) -> BookmarkPosition? {
+        guard let cue = transcript.cue(atCharacterIndex: characterIndex) else { return nil }
+
+        // An external transcript is cued against the audio, so its times are playback times
+        // already. A generated one is cued against a reference copy of the episode that
+        // dynamic ads shift away from, so the cue has to be mapped back onto this device's
+        // audio — and where it can't be, there's no time to bookmark.
+        guard transcriptManager?.isDisplayingGeneratedTranscript == true else {
+            return BookmarkPosition(time: cue.startTime, referenceTime: nil)
+        }
+
+        return FingerprintTimingManager.shared.playbackTime(forReferenceTime: cue.startTime).map {
+            BookmarkPosition(time: $0, referenceTime: cue.startTime)
+        }
+    }
+
+    func addBookmark(at position: BookmarkPosition, for episode: BaseEpisode, selection: NSRange, in transcript: TranscriptModel) {
+        let manager = PlaybackManager.shared.bookmarkManager
+
+        // The passage is only read by the Smart Bookmarks path, so it's stored on the same terms
+        let selectedText = BookmarkManager.isTitleSuggestionEnabled
+            ? BookmarkTranscriptSnippetExtractor.text(in: selection, of: transcript.attributedText)
+            : ""
+        let passage = selectedText.isEmpty ? nil : BookmarkUpdateParameters.Passage(text: selectedText, location: selection.location)
+
+        // Asked before adding, because `add` hands back the bookmark that's already there when
+        // this moment has one — the sheet then edits that one instead of titling a new one
+        let isNew = manager.dataManager.existingBookmark(forEpisode: episode.uuid, time: position.time) == nil
+
+        guard let bookmark = manager.add(to: episode,
+                                         at: position.time,
+                                         passage: passage,
+                                         referenceTime: position.referenceTime,
+                                         source: .transcript) else { return }
+
+        // Dropping the selection takes the menu with it, so the transcript is readable again
+        // behind the edit sheet
+        transcriptView.selectedRange = NSRange(location: selection.location, length: 0)
+
+        Analytics.track(.bookmarkCreated, source: BookmarkAnalyticsSource.transcript, properties: [
+            "episode_uuid": episode.uuid,
+            "podcast_uuid": (episode as? Episode)?.podcastUuid ?? "user_file",
+            "time": Int(position.time)
+        ])
+
+        showBookmarkEdit(bookmark, isNew: isNew, manager: manager)
+    }
+
+    /// The transcript titles its own bookmarks rather than leaving it to the player's bookmarks
+    /// tab, which can't present over a transcript opened from Episode Details and isn't there at
+    /// all until the full screen player has been opened.
+    func showBookmarkEdit(_ bookmark: Bookmark, isNew: Bool, manager: BookmarkManager) {
+        let controller = BookmarkEditTitleViewController(manager: manager,
+                                                        bookmark: bookmark,
+                                                        state: isNew ? .adding : .updating,
+                                                        style: showFromEpisode ? .themed : .player,
+                                                        source: .transcript) { [weak self] outcome in
+            self?.handleBookmarkEditDismissed(bookmark, isNew: isNew, manager: manager, outcome: outcome)
+        }
+
+        present(controller, animated: true)
+    }
+
+    func handleBookmarkEditDismissed(_ bookmark: Bookmark, isNew: Bool, manager: BookmarkManager, outcome: BookmarkEditOutcome) {
+        // Only a bookmark this selection just made is the sheet's to take back
+        guard isNew else { return }
+
+        switch outcome {
+        case .cancelled:
+            Task { await manager.remove([bookmark]) }
+
+        case .saved(let title):
+            let message = title == L10n.bookmarkDefaultTitle ? L10n.bookmarkAdded : L10n.bookmarkAddedNotification(title)
+
+            // Only the player has a bookmarks tab to send them to
+            let actions: [Toast.Action]? = showFromEpisode ? nil : [
+                .init(title: L10n.bookmarkAddedButtonTitle) { [weak self] in
+                    self?.containerDelegate?.dismissTranscript()
+                    self?.containerDelegate?.scrollToBookmarks()
+                }
+            ]
+
+            Toast.show(message, actions: actions, theme: .playerTheme)
+        }
+    }
 }
 
 extension TranscriptViewController: TranscriptSearchAccessoryViewDelegate {

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4910,6 +4910,9 @@
 /* Toast shown when the user taps inside the transcript but the fingerprint mapping has no anchors yet, so we can't resolve an accurate seek target. */
 "transcript_tap_to_seek_streaming_unavailable" = "Download the episode to tap to seek";
 
+/* Title of the action in the text selection menu of the transcript that creates a bookmark at the start of the selected text. Keep it short: it sits in a row of system actions such as Copy and Share. */
+"transcript_bookmark_selection" = "Bookmark";
+
 /* Highlighted transcripts What's New announcement sheet title */
 "transcript_highlight_announcement_title" = "Read along. Even at 2x.";
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Select text in a transcript and the selection menu now offers a **Bookmark** action. It creates a bookmark at the moment the selection starts, stores the selected text as the bookmark's passage, and opens the edit sheet to title it.

The time comes from the cue holding the selection's first character. For generated transcripts that's a reference time, so it goes through the same `FingerprintTimingManager` mapping tap-to-seek uses; without a confident mapping the action isn't offered.

The transcript presents the edit sheet itself, since `BookmarksPlayerTabController` can't present over a transcript opened from Episode Details. The ambient `onBookmarkCreated` subscribers skip `.transcript` events so nothing double-handles them.

New `BookmarkAnalyticsSource.transcript`; the matching EventHorizonSchemas change adds `transcript` to `bookmark_source_type` and `source_view_type`.

Targets `release/8.19`.

## To test

Needs Plus, and the `smartBookmarks` flag for the passage and title.

1. Open a transcript from the player, select a sentence, and tap **Bookmark** in the selection menu.
2. The edit sheet opens showing the selected text as the passage, with a title generated from it. Save it.
3. Tap **View** on the toast and confirm the bookmark's timestamp matches where that sentence is spoken. Play it to check.
4. Repeat from Episode Details → View Transcript. The sheet should open there too (previously only a toast), and the toast has no **View** action.
5. Dismiss the sheet with Cancel or a swipe — the bookmark is removed. Confirm only one sheet and one toast appear each time.
6. Check an external (non-generated) transcript still lands at the right time, and that **Bookmark** is absent on a streaming episode where tap-to-seek is also unavailable.
7. Confirm shelf, headphone, and CarPlay bookmarks are unchanged.

https://github.com/user-attachments/assets/81b0aeff-c322-48b9-a378-e08e0ada32f2

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
