### PR TITLE
Run the API sync tasks as async operations

### DIFF
--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ApiBaseTask.swift
@@ -12,11 +12,53 @@ class ApiBaseTask: Operation, @unchecked Sendable {
     private let urlConnection: URLConnection
     private let tokenHelper: TokenHelper
 
+    /// Read once, so that flipping the flag while an operation is in flight can't leave it in a state
+    /// where it starts asynchronously but reports its progress synchronously (or vice versa).
+    private let runsAsynchronously = FeatureFlag.asyncApiTasks.enabled
+
+    private let stateLock = NSLock()
+    private var _isExecuting = false
+    private var _isFinished = false
+
     init(dataManager: DataManager = .sharedManager, urlConnection: URLConnection = URLConnection(handler: URLSession.shared)) {
         self.dataManager = dataManager
         self.urlConnection = urlConnection
         self.tokenHelper = TokenHelper(urlConnection: urlConnection)
         super.init()
+    }
+
+    // MARK: - Operation
+
+    override var isAsynchronous: Bool { runsAsynchronously }
+
+    override var isExecuting: Bool {
+        guard runsAsynchronously else { return super.isExecuting }
+
+        return stateLock.withLock { _isExecuting }
+    }
+
+    override var isFinished: Bool {
+        guard runsAsynchronously else { return super.isFinished }
+
+        return stateLock.withLock { _isFinished }
+    }
+
+    override func start() {
+        guard runsAsynchronously else {
+            super.start()
+            return
+        }
+
+        guard !isCancelled else {
+            markFinished()
+            return
+        }
+
+        markExecuting()
+        Task.detached(priority: .utility) { [self] in
+            await runTask()
+            markFinished()
+        }
     }
 
     override func main() {
@@ -25,40 +67,69 @@ class ApiBaseTask: Operation, @unchecked Sendable {
         }
     }
 
+    /// Runs the task, blocking the calling thread until it has finished.
     func runTaskSynchronously() {
-        if let token = acquiredToken() {
-            apiTokenAcquired(token: token)
+        let semaphore = DispatchSemaphore(value: 0)
+        Task.detached(priority: .utility) { [self] in
+            await runTask()
+            semaphore.signal()
+        }
+        semaphore.wait()
+    }
+
+    func runTask() async {
+        if let token = await acquiredToken() {
+            await apiTokenAcquired(token: token)
         } else {
             apiTokenAcquisitionFailed()
         }
     }
 
-    func acquiredToken() -> String? {
+    private func markExecuting() {
+        willChangeValue(forKey: #keyPath(ApiBaseTask.isExecuting))
+        stateLock.withLock { _isExecuting = true }
+        didChangeValue(forKey: #keyPath(ApiBaseTask.isExecuting))
+    }
+
+    private func markFinished() {
+        willChangeValue(forKey: #keyPath(ApiBaseTask.isExecuting))
+        willChangeValue(forKey: #keyPath(ApiBaseTask.isFinished))
+        stateLock.withLock {
+            _isExecuting = false
+            _isFinished = true
+        }
+        didChangeValue(forKey: #keyPath(ApiBaseTask.isFinished))
+        didChangeValue(forKey: #keyPath(ApiBaseTask.isExecuting))
+    }
+
+    // MARK: - Requests
+
+    func acquiredToken() async -> String? {
         if let token = try? KeychainHelper.string(for: ServerConstants.Values.syncingV2TokenKey) {
             return token
-        } else if let token = tokenHelper.acquireToken() {
+        } else if let token = await tokenHelper.acquireToken() {
             return token
         }
         return nil
     }
 
-    func postToServer(url: String, token: String, data: Data) -> (Data?, Int) {
-        return performPostToServer(url: url, token: token, data: data)
+    func postToServer(url: String, token: String, data: Data) async -> (Data?, Int) {
+        return await performPostToServer(url: url, token: token, data: data)
     }
 
-    func performPostToServer(url: String, token: String?, data: Data, retryOnUnauthorized: Bool = true) -> (Data?, Int) {
+    func performPostToServer(url: String, token: String?, data: Data, retryOnUnauthorized: Bool = true) async -> (Data?, Int) {
         let requestUrl = ServerHelper.asUrl(url)
         let method = "POST"
         var request = createRequest(url: requestUrl, method: method, token: token)
         do {
             request.httpBody = data
 
-            let (responseData, response) = try urlConnection.sendSynchronousRequest(with: request)
+            let (responseData, response) = try await urlConnection.send(request: request)
             guard let httpResponse = response as? HTTPURLResponse else { return (nil, ServerConstants.HttpConstants.serverError) }
             if httpResponse.statusCode == ServerConstants.HttpConstants.unauthorized {
-                if retryOnUnauthorized, let newToken = tokenHelper.acquireToken() {
+                if retryOnUnauthorized, let newToken = await tokenHelper.acquireToken() {
                     FileLog.shared.addMessage("ApiBaseTask: Retrying 401 unauthorized POST to \(url)")
-                    return performPostToServer(url: url, token: newToken, data: data, retryOnUnauthorized: false)
+                    return await performPostToServer(url: url, token: newToken, data: data, retryOnUnauthorized: false)
                 }
 
                 // our token may have expired, remove it so next time a sync happens we'll acquire a new one
@@ -75,11 +146,11 @@ class ApiBaseTask: Operation, @unchecked Sendable {
         return (nil, ServerConstants.HttpConstants.serverError)
     }
 
-    func getToServer(url: String, token: String, customHeaders: [String: String]? = nil) -> (Data?, HTTPURLResponse?) {
-        return performGetToServer(url: url, token: token, customHeaders: customHeaders)
+    func getToServer(url: String, token: String, customHeaders: [String: String]? = nil) async -> (Data?, HTTPURLResponse?) {
+        return await performGetToServer(url: url, token: token, customHeaders: customHeaders)
     }
 
-    func performGetToServer(url: String, token: String, retryOnUnauthorized: Bool = true, customHeaders: [String: String]? = nil) -> (Data?, HTTPURLResponse?) {
+    func performGetToServer(url: String, token: String, retryOnUnauthorized: Bool = true, customHeaders: [String: String]? = nil) async -> (Data?, HTTPURLResponse?) {
         let requestUrl = ServerHelper.asUrl(url)
         let method = "GET"
         var request = createRequest(url: requestUrl, method: method, token: token)
@@ -90,12 +161,12 @@ class ApiBaseTask: Operation, @unchecked Sendable {
         }
 
         do {
-            let (responseData, response) = try urlConnection.sendSynchronousRequest(with: request)
+            let (responseData, response) = try await urlConnection.send(request: request)
             guard let httpResponse = response as? HTTPURLResponse else { return (nil, nil) }
             if httpResponse.statusCode == ServerConstants.HttpConstants.unauthorized {
-                if retryOnUnauthorized, let newToken = tokenHelper.acquireToken() {
+                if retryOnUnauthorized, let newToken = await tokenHelper.acquireToken() {
                     FileLog.shared.addMessage("ApiBaseTask: Retrying 401 unauthorized GET to \(url)")
-                    return performGetToServer(url: url, token: newToken, retryOnUnauthorized: false, customHeaders: customHeaders)
+                    return await performGetToServer(url: url, token: newToken, retryOnUnauthorized: false, customHeaders: customHeaders)
                 }
 
                 // our token may have expired, remove it so next time a sync happens we'll acquire a new one
@@ -112,14 +183,14 @@ class ApiBaseTask: Operation, @unchecked Sendable {
         return (nil, nil)
     }
 
-    func deleteToServer(url: String, token: String?, data: Data) -> (Data?, Int) {
+    func deleteToServer(url: String, token: String?, data: Data) async -> (Data?, Int) {
         let url = ServerHelper.asUrl(url)
         let method = "DELETE"
         var request = createRequest(url: url, method: method, token: token)
         do {
             request.httpBody = data
 
-            let (responseData, response) = try urlConnection.sendSynchronousRequest(with: request)
+            let (responseData, response) = try await urlConnection.send(request: request)
             guard let httpResponse = response as? HTTPURLResponse else { return (nil, ServerConstants.HttpConstants.serverError) }
             if httpResponse.statusCode == ServerConstants.HttpConstants.unauthorized {
                 // our token may have expired, remove it so next time a sync happens we'll acquire a new one
@@ -159,7 +230,7 @@ class ApiBaseTask: Operation, @unchecked Sendable {
     }
 
     // for subclasses that talk to the API server to override
-    func apiTokenAcquired(token: String) {}
+    func apiTokenAcquired(token: String) async {}
     func apiTokenAcquisitionFailed() { print("\(self) apiTokenAcquisitionFailed") }
 
     private func logFailure(method: String, url: String, error: Error) {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/CancelSubscriptionSurveyTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/CancelSubscriptionSurveyTask.swift
@@ -13,7 +13,7 @@ class CancelSubscriptionSurveyTask: ApiBaseTask, @unchecked Sendable {
         self.other = other
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         do {
             let urlString = "\(ServerConstants.Urls.api())subscription/survey"
             var request = Api_UserSubscriptionSurveyRequest()
@@ -25,7 +25,7 @@ class CancelSubscriptionSurveyTask: ApiBaseTask, @unchecked Sendable {
             FileLog.shared.addMessage("Post survey for reason \(reason), other: \(other ?? "nil")")
 
             let data = try request.serializedData()
-            let (response, httpStatus) = postToServer(url: urlString, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: urlString, token: token, data: data)
             if response == nil {
                 FileLog.shared.addMessage("Failed to post survey. Response nil.")
                 completion?(false)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/CancelSubscriptionTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/CancelSubscriptionTask.swift
@@ -14,14 +14,14 @@ class CancelSubscriptionTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "subscription/cancel/web"
         do {
             var cancelRequest = Api_CancelUserSubscriptionRequest()
             cancelRequest.bundleUuid = bundleUuid
             let data = try cancelRequest.serializedData()
 
-            let (_, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (_, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             completion?(httpStatus == ServerConstants.HttpConstants.ok)
         } catch {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangeEmailTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangeEmailTask.swift
@@ -15,7 +15,7 @@ class ChangeEmailTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "user/change_email"
 
         do {
@@ -26,7 +26,7 @@ class ChangeEmailTask: ApiBaseTask, @unchecked Sendable {
 
             let data = try changeRequest.serializedData()
 
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 completion?(false)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangePasswordTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ChangePasswordTask.swift
@@ -15,7 +15,7 @@ class ChangePasswordTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "user/change_password"
 
         do {
@@ -26,7 +26,7 @@ class ChangePasswordTask: ApiBaseTask, @unchecked Sendable {
 
             let data = try changeRequest.serializedData()
 
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 completion?(false)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/DeleteAccountTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/DeleteAccountTask.swift
@@ -5,14 +5,14 @@ import SwiftProtobuf
 class DeleteAccountTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool, String?) -> Void)?
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "user/delete_account"
 
         do {
             let request = Api_BasicRequest()
             let data = try request.serializedData()
 
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 completion?(false, nil)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/DeviceApproveTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/DeviceApproveTask.swift
@@ -17,7 +17,7 @@ class DeviceApproveTask: ApiBaseTask, @unchecked Sendable {
     }
     var completion: ((Result<DeviceApproveResult, Error>) -> Void)?
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let urlString = "\(ServerConstants.Urls.api())device/approve"
 
         do {
@@ -27,7 +27,7 @@ class DeviceApproveTask: ApiBaseTask, @unchecked Sendable {
 
             let data = try request.serializedData()
 
-            let (responseData, httpStatus) = postToServer(url: urlString, token: token, data: data)
+            let (responseData, httpStatus) = await postToServer(url: urlString, token: token, data: data)
 
             guard let responseData, httpStatus == ServerConstants.HttpConstants.ok else {
                 if let errorResponse = ApiServerHandler.extractErrorResponse(data: responseData, response: nil, error: nil) {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ExchangeSonosTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ExchangeSonosTask.swift
@@ -4,10 +4,10 @@ import Foundation
 class ExchangeSonosTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((String?) -> Void)?
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "user/exchange_sonos"
 
-        let (response, httpStatus) = postToServer(url: url, token: token, data: .init())
+        let (response, httpStatus) = await postToServer(url: url, token: token, data: .init())
 
         guard httpStatus == ServerConstants.HttpConstants.ok, let response else {
             completion?(nil)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/PositionSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/PositionSyncTask.swift
@@ -16,7 +16,7 @@ class PositionSyncTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "sync/update_episode"
         do {
             var updateRequest = Api_UpdateEpisodeRequest()
@@ -28,7 +28,7 @@ class PositionSyncTask: ApiBaseTask, @unchecked Sendable {
             updateRequest.duration = Int32(duration)
 
             let data = try updateRequest.serializedData()
-            let (_, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (_, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             if httpStatus == ServerConstants.HttpConstants.ok {
                 FileLog.shared.addMessage("Sent position \(upToAsInt) status \(episode.playingStatus) for episode \(episode.displayableTitle()) to server")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/PurchaseReceiptTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/PurchaseReceiptTask.swift
@@ -5,7 +5,7 @@ import UIKit
 
 class PurchaseReceiptTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool) -> Void)?
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "subscription/purchase/ios"
 
         // Load the receipt into a Data object
@@ -27,7 +27,7 @@ class PurchaseReceiptTask: ApiBaseTask, @unchecked Sendable {
 
         do {
             let data = try updateRequest.serializedData()
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 FileLog.shared.addMessage("Purchase Receipt send failed \(httpStatus)")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RecommendEpisodesTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RecommendEpisodesTask.swift
@@ -6,14 +6,14 @@ import SwiftProtobuf
 class RecommendEpisodesTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Episode?) -> Void)?
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "discover/recommend_episodes"
 
         do {
             let request = Api_BasicRequest()
             let data = try request.serializedData()
 
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 completion?(nil)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RedeemPromoCodeTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RedeemPromoCodeTask.swift
@@ -12,7 +12,7 @@ class RedeemPromoCodeTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "subscription/promo/redeem"
 
         var codeToValidate = Api_PromotionCode()
@@ -20,7 +20,7 @@ class RedeemPromoCodeTask: ApiBaseTask, @unchecked Sendable {
 
         do {
             let data = try codeToValidate.serializedData()
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response else {
                 completion?(httpStatus, nil, APIError.UNKNOWN)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralGetCodeTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralGetCodeTask.swift
@@ -10,11 +10,11 @@ public struct ReferralCode: Codable {
 class ReferralGetCodeTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((ReferralCode?) -> Void)?
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let urlString = "\(ServerConstants.Urls.api())referrals/code"
 
         do {
-            let (data, httpResponse) = getToServer(url: urlString, token: token)
+            let (data, httpResponse) = await getToServer(url: urlString, token: token)
 
             guard let responseData = data,
                   httpResponse?.statusCode == ServerConstants.HttpConstants.ok

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralRedeemTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralRedeemTask.swift
@@ -11,7 +11,7 @@ class ReferralRedeemTask: ApiBaseTask, @unchecked Sendable {
         self.code = code
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let urlString = "\(ServerConstants.Urls.api())referrals/redeem"
 
         do {
@@ -20,7 +20,7 @@ class ReferralRedeemTask: ApiBaseTask, @unchecked Sendable {
 
             let data = try request.serializedData()
 
-            let (response, httpStatus) = postToServer(url: urlString, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: urlString, token: token, data: data)
 
             if response == nil {
                 FileLog.shared.addMessage("Referral failed to redeem offer \(code) because response is empty")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralValidateTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/ReferralValidateTask.swift
@@ -28,11 +28,11 @@ class ReferralValidateTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let urlString = "\(ServerConstants.Urls.api())referrals/validate?code=\(code)&platform=ios"
 
         do {
-            let (data, httpResponse) = getToServer(url: urlString, token: token)
+            let (data, httpResponse) = await getToServer(url: urlString, token: token)
 
             guard let responseData = data,
                   httpResponse?.statusCode == ServerConstants.HttpConstants.ok

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveBookmarksTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveBookmarksTask.swift
@@ -13,7 +13,7 @@ class RetrieveBookmarksTask: ApiBaseTask, @unchecked Sendable {
         super.init(dataManager: dataManager)
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "user/bookmark/list"
 
         guard let data = try? Api_BookmarkRequest().serializedData() else {
@@ -21,7 +21,7 @@ class RetrieveBookmarksTask: ApiBaseTask, @unchecked Sendable {
             return
         }
 
-        let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+        let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
         guard let response, httpStatus == ServerConstants.HttpConstants.ok else {
             failed("Retrieve bookmarks received an invalid response: Status: \(httpStatus) - Response: \(String(describing: (response as? NSData)))")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveCustomFilesTask.swift
@@ -4,7 +4,7 @@ import PocketCastsUtils
 import SwiftProtobuf
 
 class RetrieveCustomFilesTask: ApiBaseTask, @unchecked Sendable {
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "files"
 
         do {
@@ -12,7 +12,7 @@ class RetrieveCustomFilesTask: ApiBaseTask, @unchecked Sendable {
             if let lastModified = ServerSettings.filesLastModified() {
                 headers = [ServerConstants.HttpHeaders.ifModifiedSince: lastModified]
             }
-            let (data, httpResponse) = getToServer(url: url, token: token, customHeaders: headers)
+            let (data, httpResponse) = await getToServer(url: url, token: token, customHeaders: headers)
 
             if httpResponse?.statusCode == ServerConstants.HttpConstants.notModified {
                 FileLog.shared.addMessage("RetrieveCustomFilesTask - not modified, no changes required")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveEpisodesTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveEpisodesTask.swift
@@ -21,7 +21,7 @@ class RetrieveEpisodesTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "user/podcast/episodes"
 
         do {
@@ -30,7 +30,7 @@ class RetrieveEpisodesTask: ApiBaseTask, @unchecked Sendable {
             episodesRequest.uuid = podcastUuid
             let data = try episodesRequest.serializedData()
 
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 completion?(nil)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUploadStatus.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUploadStatus.swift
@@ -12,11 +12,11 @@ class RetrieveFileUploadStatusTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "files/upload/status/" + episode.uuid
 
         do {
-            let (data, httpResponse) = getToServer(url: url, token: token, customHeaders: nil)
+            let (data, httpResponse) = await getToServer(url: url, token: token, customHeaders: nil)
 
             if httpResponse?.statusCode == ServerConstants.HttpConstants.notModified {
                 FileLog.shared.addMessage("RetrieveFileUploadStatusTask - not modified, no changes required")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUsageTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveFileUsageTask.swift
@@ -4,7 +4,7 @@ import PocketCastsUtils
 import SwiftProtobuf
 
 class RetrieveFileUsageTask: ApiBaseTask, @unchecked Sendable {
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "files/usage/"
 
         do {
@@ -12,7 +12,7 @@ class RetrieveFileUsageTask: ApiBaseTask, @unchecked Sendable {
             if let lastModified = ServerSettings.filesUsageLastModified() {
                 headers = [ServerConstants.HttpHeaders.ifModifiedSince: lastModified]
             }
-            let (data, httpResponse) = getToServer(url: url, token: token, customHeaders: headers)
+            let (data, httpResponse) = await getToServer(url: url, token: token, customHeaders: headers)
 
             if httpResponse?.statusCode == ServerConstants.HttpConstants.notModified {
                 FileLog.shared.addMessage("RetrieveFileUsageTask - not modified, no changes required")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveLastSyncDateTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveLastSyncDateTask.swift
@@ -5,14 +5,14 @@ import SwiftProtobuf
 class RetrieveLastSyncDateTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((String?) -> Void)?
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "user/last_sync_at"
 
         do {
             let lastSyncRequest = Api_EmptyRequest()
             let data = try lastSyncRequest.serializedData()
 
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 completion?(nil)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePlaylistsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePlaylistsTask.swift
@@ -6,7 +6,7 @@ import SwiftProtobuf
 class RetrievePlaylistsTask: ApiBaseTask, @unchecked Sendable {
     var completion: (([(EpisodeFilter, [Episode])]?) -> Void)?
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "user/playlist/list"
 
         do {
@@ -14,7 +14,7 @@ class RetrievePlaylistsTask: ApiBaseTask, @unchecked Sendable {
             playlistRequest.m = ServerConstants.Values.apiScope
             let data = try playlistRequest.serializedData()
 
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 completion?(nil)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePodcastsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrievePodcastsTask.swift
@@ -6,7 +6,7 @@ import SwiftProtobuf
 class RetrievePodcastsTask: ApiBaseTask, @unchecked Sendable {
     var completion: (([PodcastSyncInfo]?, [FolderSyncInfo]?, Bool) -> Void)?
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         // this endpoint now returns folders and podcasts
         let url = ServerConstants.Urls.api() + "user/podcast/list"
 
@@ -15,7 +15,7 @@ class RetrievePodcastsTask: ApiBaseTask, @unchecked Sendable {
             podcastRequest.m = ServerConstants.Values.apiScope
             let data = try podcastRequest.serializedData()
 
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 completion?(nil, nil, false)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveRatingsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveRatingsTask.swift
@@ -16,11 +16,11 @@ class RetrieveRatingsTask: ApiBaseTask, @unchecked Sendable {
         return dispatchGroup
     }()
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "user/podcast_rating/list"
 
         do {
-            let (response, httpStatus) = getToServer(url: url, token: token)
+            let (response, httpStatus) = await getToServer(url: url, token: token)
 
             guard let responseData = response, httpStatus?.statusCode == ServerConstants.HttpConstants.ok else {
                 completion?(nil)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStarredTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStarredTask.swift
@@ -8,20 +8,14 @@ class RetrieveStarredTask: ApiBaseTask, @unchecked Sendable {
 
     private var convertedEpisodes = [Episode]()
 
-    private lazy var addEpisodeGroup: DispatchGroup = {
-        let dispatchGroup = DispatchGroup()
-
-        return dispatchGroup
-    }()
-
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "starred/list"
 
         do {
             let starredRequest = Api_EmptyRequest()
             let data = try starredRequest.serializedData()
 
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 completion?(nil)
@@ -38,9 +32,7 @@ class RetrieveStarredTask: ApiBaseTask, @unchecked Sendable {
                 }
 
                 for serverEpisode in serverEpisodes {
-                    addEpisodeGroup.enter()
-                    processEpisode(serverEpisode)
-                    addEpisodeGroup.wait()
+                    await processEpisode(serverEpisode)
                 }
 
                 completion?(convertedEpisodes)
@@ -54,31 +46,33 @@ class RetrieveStarredTask: ApiBaseTask, @unchecked Sendable {
         }
     }
 
-    private func processEpisode(_ protoEpisode: Api_StarredEpisode) {
+    private func processEpisode(_ protoEpisode: Api_StarredEpisode) async {
         // take the easy case first, do we have this episode locally?
         if convertLocalEpisode(protoEpisode: protoEpisode) {
-            addEpisodeGroup.leave()
-
             return
         }
 
         // we don't have the episode, see if we have the podcast
         if let podcast = DataManager.sharedManager.findPodcast(uuid: protoEpisode.podcastUuid, includeUnsubscribed: true) {
             // we do, so try and refresh it
-            ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast) { [weak self] updated in
-                if updated {
-                    // the podcast was updated, try to convert the episode
-                    self?.convertLocalEpisode(protoEpisode: protoEpisode)
-                }
+            await withCheckedContinuation { continuation in
+                ServerPodcastManager.shared.updatePodcastIfRequired(podcast: podcast) { [weak self] updated in
+                    if updated {
+                        // the podcast was updated, try to convert the episode
+                        self?.convertLocalEpisode(protoEpisode: protoEpisode)
+                    }
 
-                self?.addEpisodeGroup.leave()
+                    continuation.resume()
+                }
             }
         } else {
             // we don't, so try and add it
-            ServerPodcastManager.shared.addFromUuid(podcastUuid: protoEpisode.podcastUuid, subscribe: false) { [weak self] _ in
-                // this will convert the episode if we now have it, if we don't not much we can do
-                self?.convertLocalEpisode(protoEpisode: protoEpisode)
-                self?.addEpisodeGroup.leave()
+            await withCheckedContinuation { continuation in
+                ServerPodcastManager.shared.addFromUuid(podcastUuid: protoEpisode.podcastUuid, subscribe: false) { [weak self] _ in
+                    // this will convert the episode if we now have it, if we don't not much we can do
+                    self?.convertLocalEpisode(protoEpisode: protoEpisode)
+                    continuation.resume()
+                }
             }
         }
     }

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStatsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/RetrieveStatsTask.swift
@@ -8,7 +8,7 @@ class RetrieveStatsTask: ApiBaseTask, @unchecked Sendable {
 
     var getFullStatsData = false
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "user/stats/summary"
 
         do {
@@ -22,7 +22,7 @@ class RetrieveStatsTask: ApiBaseTask, @unchecked Sendable {
             statsRequest.deviceType = ServerConstants.Values.deviceTypeiOS
             let data = try statsRequest.serializedData()
 
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 completion?(nil)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/StarredSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/StarredSyncTask.swift
@@ -12,7 +12,7 @@ class StarredSyncTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "sync/update_episode_star"
         do {
             var updateRequest = Api_UpdateEpisodeStarRequest()
@@ -21,7 +21,7 @@ class StarredSyncTask: ApiBaseTask, @unchecked Sendable {
             updateRequest.star = episode.keepEpisode
 
             let data = try updateRequest.serializedData()
-            let (_, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (_, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             if httpStatus == ServerConstants.HttpConstants.ok {
                 DataManager.sharedManager.clearKeepEpisodeModified(episode: episode)

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/SubscriptionStatusTask.swift
@@ -6,10 +6,10 @@ import SwiftProtobuf
 class SubscriptionStatusTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((Bool) -> Void)?
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "subscription/status"
         do {
-            let (response, httpStatus) = getToServer(url: url, token: token)
+            let (response, httpStatus) = await getToServer(url: url, token: token)
 
             guard let responseData = response, httpStatus?.statusCode == ServerConstants.HttpConstants.ok else {
                 FileLog.shared.addMessage("Subscription status failed \(httpStatus?.statusCode ?? -1)")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/SuggestedFolderTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/SuggestedFolderTask.swift
@@ -17,11 +17,11 @@ class SuggestedFoldersTask: ApiBaseTask, @unchecked Sendable {
         self.completion = completion
     }
 
-    override func main() {
-        doNetworkCall()
+    override func runTask() async {
+        await doNetworkCall()
     }
 
-    func doNetworkCall() {
+    func doNetworkCall() async {
         let urlString = "\(ServerConstants.Urls.cache())podcast/suggest_folders"
 
         do {
@@ -31,7 +31,7 @@ class SuggestedFoldersTask: ApiBaseTask, @unchecked Sendable {
                 return
             }
 
-            let (data, statusCode) = super.performPostToServer(url: urlString, token: nil, data: requestData)
+            let (data, statusCode) = await super.performPostToServer(url: urlString, token: nil, data: requestData)
             guard let responseData = data,
                   statusCode == ServerConstants.HttpConstants.ok
             else {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/SupportFeedbackTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/SupportFeedbackTask.swift
@@ -11,17 +11,15 @@ class SupportFeedbackTask: ApiBaseTask, @unchecked Sendable {
         self.message = message
     }
 
-    override func main() {
-        autoreleasepool {
-            if SyncManager.isUserLoggedIn(), let token = acquiredToken() {
-                startRequest(token: token, feedbackType: .authenticated)
-            } else {
-                startRequest(feedbackType: .anonymous)
-            }
+    override func runTask() async {
+        if SyncManager.isUserLoggedIn(), let token = await acquiredToken() {
+            await startRequest(token: token, feedbackType: .authenticated)
+        } else {
+            await startRequest(feedbackType: .anonymous)
         }
     }
 
-    func startRequest(token: String? = nil, feedbackType: FeedbackType) {
+    func startRequest(token: String? = nil, feedbackType: FeedbackType) async {
         do {
             let urlString = "\(ServerConstants.Urls.api())\(feedbackType.endpoint)"
 
@@ -32,7 +30,7 @@ class SupportFeedbackTask: ApiBaseTask, @unchecked Sendable {
 
             let data = try request.serializedData()
 
-            let (response, httpStatus) = performPostToServer(url: urlString, token: token, data: data)
+            let (response, httpStatus) = await performPostToServer(url: urlString, token: token, data: data)
 
             if response == nil {
                 FileLog.shared.addMessage("Failed to send the feedback message because response is empty")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFileDeleteTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFileDeleteTask.swift
@@ -13,13 +13,13 @@ class UploadFileDeleteTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "files/" + episode.uuid
         do {
             var deleteRequest = Files_FileDeleteRequest()
             deleteRequest.uuid = episode.uuid
             let data = try deleteRequest.serializedData()
-            let (_, httpStatus) = deleteToServer(url: url, token: token, data: data)
+            let (_, httpStatus) = await deleteToServer(url: url, token: token, data: data)
 
             // if the delete request 404's, then it has already been deleted and this is also considered successful
             guard httpStatus == ServerConstants.HttpConstants.ok || httpStatus == ServerConstants.HttpConstants.notFound else {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFilePlayRequestTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFilePlayRequestTask.swift
@@ -13,10 +13,10 @@ class UploadFilePlayRequestTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "files/play/" + episode.uuid
         do {
-            let (response, httpStatus) = getToServer(url: url, token: token)
+            let (response, httpStatus) = await getToServer(url: url, token: token)
 
             guard let responseData = response else {
                 FileLog.shared.addMessage("Upload file play request missing response data \(httpStatus?.statusCode ?? -1)")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFileRequestTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFileRequestTask.swift
@@ -13,7 +13,7 @@ class UploadFileRequestTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "files/upload/request"
         do {
             var uploadRequest = Files_FileUploadRequest()
@@ -25,7 +25,7 @@ class UploadFileRequestTask: ApiBaseTask, @unchecked Sendable {
             uploadRequest.colour = Google_Protobuf_Int32Value(episode.imageColor)
             uploadRequest.hasCustomImage_p = episode.hasCustomImage
             let data = try uploadRequest.serializedData()
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 FileLog.shared.addMessage("Upload file request failed \(httpStatus)")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFilesUpdateTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadFilesUpdateTask.swift
@@ -14,7 +14,7 @@ class UploadFilesUpdateTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "files"
 
         var updateRequest = Files_FileListUpdateRequest()
@@ -43,7 +43,7 @@ class UploadFilesUpdateTask: ApiBaseTask, @unchecked Sendable {
 
         do {
             let data = try updateRequest.serializedData()
-            let (_, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (_, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard httpStatus == ServerConstants.HttpConstants.ok else {
                 FileLog.shared.addMessage("Upload file Update failed \(httpStatus)")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadImageDeleteTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadImageDeleteTask.swift
@@ -13,13 +13,13 @@ class UploadImageDeleteTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "files/image/" + episode.uuid
         do {
             var deleteRequest = Files_FileDeleteRequest()
             deleteRequest.uuid = episode.uuid
             let data = try deleteRequest.serializedData()
-            let (_, httpStatus) = deleteToServer(url: url, token: token, data: data)
+            let (_, httpStatus) = await deleteToServer(url: url, token: token, data: data)
 
             // if the delete request 404's, then it has already been deleted and this is also considered successful
             guard httpStatus == ServerConstants.HttpConstants.ok || httpStatus == ServerConstants.HttpConstants.notFound else {

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadImageRequestTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UploadImageRequestTask.swift
@@ -13,7 +13,7 @@ class UploadImageRequestTask: ApiBaseTask, @unchecked Sendable {
         super.init()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "files/upload/image"
 
         let fileString = UploadManager.shared.customImageDirectory + "/" + episode.uuid + ".jpg"
@@ -38,7 +38,7 @@ class UploadImageRequestTask: ApiBaseTask, @unchecked Sendable {
             uploadRequest.size = Int64(fileSize)
             uploadRequest.contentType = "image/jpeg"
             let data = try uploadRequest.serializedData()
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 FileLog.shared.addMessage("Upload image file request failed \(httpStatus)")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/UserPodcastRatingTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/UserPodcastRatingTask.swift
@@ -14,7 +14,7 @@ class UserPodcastRatingAddTask: ApiBaseTask, @unchecked Sendable {
         self.rating = rating
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let urlString = "\(ServerConstants.Urls.api())user/podcast_rating/add"
 
         do {
@@ -24,7 +24,7 @@ class UserPodcastRatingAddTask: ApiBaseTask, @unchecked Sendable {
 
             let data = try request.serializedData()
 
-            let (response, httpStatus) = postToServer(url: urlString, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: urlString, token: token, data: data)
 
             if response == nil {
                 FileLog.shared.addMessage("Failed to get rating for podcast \(uuid) because response is empty")
@@ -54,7 +54,7 @@ class UserPodcastRatingGetTask: ApiBaseTask, @unchecked Sendable {
         self.uuid = uuid
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let urlString = "\(ServerConstants.Urls.api())user/podcast_rating/show"
 
         do {
@@ -63,7 +63,7 @@ class UserPodcastRatingGetTask: ApiBaseTask, @unchecked Sendable {
 
             let data = try request.serializedData()
 
-            let (response, httpStatus) = postToServer(url: urlString, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: urlString, token: token, data: data)
 
             guard let responseData = response, httpStatus == ServerConstants.HttpConstants.ok else {
                 FileLog.shared.addMessage("Failed to get rating for podcast \(uuid), http status \(httpStatus)")

--- a/Modules/Sources/PocketCastsServer/Private/API Tasks/WinbackOfferTask.swift
+++ b/Modules/Sources/PocketCastsServer/Private/API Tasks/WinbackOfferTask.swift
@@ -13,11 +13,11 @@ public struct WinbackOfferInfo: Codable {
 class WinbackOfferTask: ApiBaseTask, @unchecked Sendable {
     var completion: ((WinbackOfferInfo?) -> Void)?
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let urlString = "\(ServerConstants.Urls.api())referrals/winback_offers?platform=ios"
 
         do {
-            let (data, httpResponse) = getToServer(url: urlString, token: token)
+            let (data, httpResponse) = await getToServer(url: urlString, token: token)
             guard let responseData = data,
                   httpResponse?.statusCode == ServerConstants.HttpConstants.ok
             else {

--- a/Modules/Sources/PocketCastsServer/Private/AsyncLock.swift
+++ b/Modules/Sources/PocketCastsServer/Private/AsyncLock.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// A mutex that can be held across suspension points.
+///
+/// `objc_sync_enter` and `NSLock` tie ownership to a thread, so they can't guard work that awaits,
+/// and an actor on its own isn't enough because actors are reentrant: another call can interleave
+/// while the first one is suspended. Work between `lock()` and `unlock()` runs to completion before
+/// the next caller gets the lock.
+actor AsyncLock {
+    private var isLocked = false
+    private var waiting: [CheckedContinuation<Void, Never>] = []
+
+    func lock() async {
+        guard isLocked else {
+            isLocked = true
+
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiting.append(continuation)
+        }
+    }
+
+    func unlock() {
+        guard !waiting.isEmpty else {
+            isLocked = false
+
+            return
+        }
+
+        // hand the lock straight to the next caller in line
+        waiting.removeFirst().resume()
+    }
+}

--- a/Modules/Sources/PocketCastsServer/Private/OperationQueue+Async.swift
+++ b/Modules/Sources/PocketCastsServer/Private/OperationQueue+Async.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension OperationQueue {
+    /// Suspends until all the operations currently in the queue have finished, without blocking a
+    /// thread the way `waitUntilAllOperationsAreFinished()` does.
+    func allOperationsFinished() async {
+        await withCheckedContinuation { continuation in
+            addBarrierBlock {
+                continuation.resume()
+            }
+        }
+    }
+}
+
+extension DispatchGroup {
+    /// Suspends until the group is empty, without blocking a thread the way `wait()` does.
+    func finished() async {
+        await withCheckedContinuation { continuation in
+            notify(queue: .global()) {
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/Modules/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -81,6 +81,50 @@ class TokenHelper {
         }
     }
 
+    /// Acquires a token without blocking the calling thread.
+    func acquireToken() async -> String? {
+        var refreshedToken: String?
+        var refreshedRefreshToken: String?
+        var acquireError: Error?
+
+        do {
+            let authenticationResponse = try await acquireAuthenticationResponse()
+            refreshedToken = authenticationResponse?.token
+            refreshedRefreshToken = authenticationResponse?.refreshToken
+        } catch {
+            refreshedToken = nil
+            acquireError = error
+        }
+
+        guard let token = refreshedToken, !token.isEmpty else {
+            await handleFailureToAcquireToken(error: acquireError)
+
+            return nil
+        }
+
+        ServerSettings.syncingV2Token = token
+        ServerSettings.setRefreshToken(refreshedRefreshToken)
+
+        return token
+    }
+
+    private func handleFailureToAcquireToken(error: Error?) async {
+        if await isApplicationBackgrounded() {
+            FileLog.shared.addMessage("TokenHelper: Skipped logout in background due to error: \(String(describing: error))")
+
+            return
+        }
+
+        // if the user doesn't have an email and password or SSO token, they aren't going to be able to acquire a sync token
+        switch error as? APIError {
+        case APIError.TOKEN_DEAUTH?, APIError.PERMISSION_DENIED?:
+            tokenCleanUp()
+        default:
+            // Do nothing so the user is not disrupted in the case of non-auth errors
+            FileLog.shared.addMessage("TokenHelper: Unable to acquire token but avoided logout due to error: \(String(describing: error))")
+        }
+    }
+
     func acquireToken() -> String? {
         let semaphore = DispatchSemaphore(value: 0)
         var refreshedToken: String? = nil
@@ -125,6 +169,19 @@ class TokenHelper {
         return refreshedToken
     }
 
+    private func isApplicationBackgrounded() async -> Bool {
+        await MainActor.run {
+            var isBackgrounded = false
+            #if os(iOS)
+            isBackgrounded = UIApplication.shared.applicationState == .background
+            #elseif os(watchOS)
+            isBackgrounded = WKExtension.shared().applicationState == .background
+            #endif
+
+            return isBackgrounded
+        }
+    }
+
     private func isApplicationBackgrounded() -> Bool {
         let semaphore = DispatchSemaphore(value: 0)
         var isBackgrounded = false
@@ -146,55 +203,95 @@ class TokenHelper {
     // MARK: - Email / Password Token
 
     func acquirePasswordToken() throws -> AuthenticationResponse? {
-        guard let email = ServerSettings.syncingEmail(), let password = ServerSettings.syncingPassword() else {
-            // if the user doesn't have an email and password, then we'll check if they're using SSO
-            return nil
-        }
-
-        let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login")
         do {
-            var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 30.seconds)
-            request.httpMethod = "POST"
-            request.addValue("application/octet-stream", forHTTPHeaderField: ServerConstants.HttpHeaders.accept)
-            request.setValue("application/octet-stream", forHTTPHeaderField: ServerConstants.HttpHeaders.contentType)
-            request.addLocalizationHeaders()
-            if let privateUserAgent = ServerConfig.shared.syncDelegate?.privateUserAgent() {
-                request.setValue(privateUserAgent, forHTTPHeaderField: ServerConstants.HttpHeaders.userAgent)
-            }
-
-            var loginRequest = Api_UserLoginRequest()
-            loginRequest.email = email
-            loginRequest.password = password
-            loginRequest.scope = ServerConstants.Values.apiScope
-            let data = try loginRequest.serializedData()
-            request.httpBody = data
-
-            let (responseData, response) = try urlConnection.sendSynchronousRequest(with: request)
-            guard let validData = responseData, let httpResponse = response as? HTTPURLResponse else {
-                FileLog.shared.addMessage("TokenHelper: Unable to acquire token")
+            guard let request = try passwordTokenRequest() else {
+                // if the user doesn't have an email and password, then we'll check if they're using SSO
                 return nil
             }
 
-            if httpResponse.statusCode == ServerConstants.HttpConstants.ok {
-                let userLoginResponse = try Api_UserLoginResponse(serializedBytes: validData)
-                return AuthenticationResponse(from: userLoginResponse)
-            }
+            let (responseData, response) = try urlConnection.sendSynchronousRequest(with: request)
 
-            if httpResponse.statusCode == ServerConstants.HttpConstants.unauthorized {
-                FileLog.shared.addMessage("TokenHelper logging user out, invalid password")
-                SyncManager.signout()
-            }
-
-            let errorResponse = ApiServerHandler.extractErrorResponse(data: responseData, response: response, error: nil)
-            throw errorResponse ?? .UNKNOWN
+            return try passwordToken(from: responseData, response: response)
         } catch {
             FileLog.shared.addMessage("TokenHelper acquireToken failed \(error.localizedDescription)")
             throw error
         }
     }
 
+    /// Acquires a password token without blocking the calling thread.
+    func acquirePasswordToken() async throws -> AuthenticationResponse? {
+        do {
+            guard let request = try passwordTokenRequest() else {
+                // if the user doesn't have an email and password, then we'll check if they're using SSO
+                return nil
+            }
+
+            let (responseData, response) = try await urlConnection.send(request: request)
+
+            return try passwordToken(from: responseData, response: response)
+        } catch {
+            FileLog.shared.addMessage("TokenHelper acquireToken failed \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    /// Returns nil when the user has no email and password stored
+    private func passwordTokenRequest() throws -> URLRequest? {
+        guard let email = ServerSettings.syncingEmail(), let password = ServerSettings.syncingPassword() else {
+            return nil
+        }
+
+        let url = ServerHelper.asUrl(ServerConstants.Urls.api() + "user/login")
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 30.seconds)
+        request.httpMethod = "POST"
+        request.addValue("application/octet-stream", forHTTPHeaderField: ServerConstants.HttpHeaders.accept)
+        request.setValue("application/octet-stream", forHTTPHeaderField: ServerConstants.HttpHeaders.contentType)
+        request.addLocalizationHeaders()
+        if let privateUserAgent = ServerConfig.shared.syncDelegate?.privateUserAgent() {
+            request.setValue(privateUserAgent, forHTTPHeaderField: ServerConstants.HttpHeaders.userAgent)
+        }
+
+        var loginRequest = Api_UserLoginRequest()
+        loginRequest.email = email
+        loginRequest.password = password
+        loginRequest.scope = ServerConstants.Values.apiScope
+        request.httpBody = try loginRequest.serializedData()
+
+        return request
+    }
+
+    private func passwordToken(from responseData: Data?, response: URLResponse?) throws -> AuthenticationResponse? {
+        guard let validData = responseData, let httpResponse = response as? HTTPURLResponse else {
+            FileLog.shared.addMessage("TokenHelper: Unable to acquire token")
+            return nil
+        }
+
+        if httpResponse.statusCode == ServerConstants.HttpConstants.ok {
+            let userLoginResponse = try Api_UserLoginResponse(serializedBytes: validData)
+            return AuthenticationResponse(from: userLoginResponse)
+        }
+
+        if httpResponse.statusCode == ServerConstants.HttpConstants.unauthorized {
+            FileLog.shared.addMessage("TokenHelper logging user out, invalid password")
+            SyncManager.signout()
+        }
+
+        let errorResponse = ApiServerHandler.extractErrorResponse(data: responseData, response: response, error: nil)
+        throw errorResponse ?? .UNKNOWN
+    }
+
 
     // MARK: - Email / Password Token
+
+    /// Acquires an authentication response, first with the stored email and password and,
+    /// failing that, with the SSO identity token. Doesn't block the calling thread.
+    private func acquireAuthenticationResponse() async throws -> AuthenticationResponse? {
+        if let authenticationResponse = try await acquirePasswordToken() {
+            return authenticationResponse
+        }
+
+        return try await acquireIdentityToken()
+    }
 
     func asyncAcquireToken(completion: @escaping (Result<AuthenticationResponse?, Error>) -> Void) {
         do {

--- a/Modules/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/BackgroundSyncManager+URLSession.swift
@@ -134,7 +134,14 @@ extension BackgroundSyncManager: URLSessionDelegate, URLSessionDownloadDelegate 
             // if this turns out to be an issue we could perhaps persist the UUIDs to UserDefaults, or come up with some other solution to this
             let episodesSynced: [Episode]
             episodesSynced = DataManager.sharedManager.unsyncedEpisodes(limit: ServerConstants.Limits.maxEpisodesToSync)
-            _ = syncTask.processSyncData(data, httpStatus: httpCode, episodesToSync: episodesSynced)
+
+            // the operation queue serialises the processing, so hold onto this thread until it's done
+            let semaphore = DispatchSemaphore(value: 0)
+            Task.detached(priority: .utility) {
+                _ = await syncTask.processSyncData(data, httpStatus: httpCode, episodesToSync: episodesSynced)
+                semaphore.signal()
+            }
+            semaphore.wait()
         }
     }
 

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncHistoryTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncHistoryTask.swift
@@ -8,7 +8,7 @@ class SyncHistoryTask: ApiBaseTask, @unchecked Sendable {
         case add = 1, delete = 2, clearAll = 3
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         var dataToSync = Api_HistorySyncRequest()
         dataToSync.deviceTime = TimeFormatter.currentUTCTimeInMillis()
         dataToSync.version = apiVersion
@@ -39,7 +39,7 @@ class SyncHistoryTask: ApiBaseTask, @unchecked Sendable {
         let url = ServerConstants.Urls.api() + "history/sync"
         do {
             let data = try dataToSync.serializedData()
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
             if httpStatus == ServerConstants.HttpConstants.notModified {
                 DataManager.sharedManager.markAllEpisodePlaybackHistorySynced()
             } else if let response, httpStatus == ServerConstants.HttpConstants.ok {

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncSettingsTask.swift
@@ -5,7 +5,7 @@ import SwiftProtobuf
 
 class SyncSettingsTask: ApiBaseTask, @unchecked Sendable {
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let url = ServerConstants.Urls.api() + "user/named_settings/update"
         do {
             var settingsRequest = Api_NamedSettingsRequest()
@@ -34,7 +34,7 @@ class SyncSettingsTask: ApiBaseTask, @unchecked Sendable {
             }
 
             let data = try settingsRequest.serializedData()
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
 
             if let response, httpStatus == ServerConstants.HttpConstants.ok {
                 process(serverData: response)

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+FullSync.swift
@@ -34,7 +34,7 @@ extension SyncTask {
         }
     }
 
-    func processServerHomeGrid(podcasts: [PodcastSyncInfo]?, folders: [FolderSyncInfo]?, lastSyncAt: String) {
+    func processServerHomeGrid(podcasts: [PodcastSyncInfo]?, folders: [FolderSyncInfo]?, lastSyncAt: String) async {
         // before looking at the server podcasts, mark any we have here locally as needing to be syncing so they get pushed up with the next sync
         DataManager.sharedManager.markAllPodcastsUnsyncedWhereLastSyncAtNot(lastSyncAt)
 
@@ -62,7 +62,7 @@ extension SyncTask {
                 self.processPodcast(podcast, lastSyncAt: lastSyncAt)
             }
         }
-        importQueue.waitUntilAllOperationsAreFinished()
+        await importQueue.allOperationsFinished()
 
         NotificationCenter.default.post(name: ServerNotifications.syncProgressImportedPodcasts, object: nil)
     }
@@ -136,36 +136,28 @@ extension SyncTask {
 
 extension SyncTask {
     /// Fully imports the server bookmarks and replaces the existing data if there is any available
-    func processServerBookmarks(_ bookmarks: [Api_BookmarkResponse]) {
-        let semaphore = DispatchSemaphore(value: 0)
+    func processServerBookmarks(_ bookmarks: [Api_BookmarkResponse]) async {
+        let bookmarkManager = dataManager.bookmarks
 
-        Task {
-            let bookmarkManager = dataManager.bookmarks
+        // Set all the bookmarks as synced
+        await bookmarkManager.markAllBookmarksAsSynced()
 
-            // Set all the bookmarks as synced
-            await bookmarkManager.markAllBookmarksAsSynced()
+        for apiBookmark in bookmarks {
+            // The response doesn't include the passage fields — they only flow through the
+            // incremental sync records — so carry them over from the replaced bookmark
+            let existingBookmark = bookmarkManager.bookmark(for: apiBookmark.bookmarkUuid, allowDeleted: true)
 
-            for apiBookmark in bookmarks {
-                // The response doesn't include the passage fields — they only flow through the
-                // incremental sync records — so carry them over from the replaced bookmark
-                let existingBookmark = bookmarkManager.bookmark(for: apiBookmark.bookmarkUuid, allowDeleted: true)
-
-                if let existingBookmark {
-                    await bookmarkManager.permanentlyDelete(bookmarks: [existingBookmark]).when(false) {
-                        FileLog.shared.addMessage("SyncTask: Process Server Bookmarks - Could not delete existing bookmark: \(apiBookmark.bookmarkUuid)")
-                    }
-                }
-
-                // Add the incoming bookmark to the database
-                bookmarkManager.add(from: apiBookmark, passageFieldsFrom: existingBookmark).when(.none) {
-                    FileLog.shared.addMessage("SyncTask: Process Server Bookmarks - Could not add bookmark: \(String(describing: try? apiBookmark.jsonString()))")
+            if let existingBookmark {
+                await bookmarkManager.permanentlyDelete(bookmarks: [existingBookmark]).when(false) {
+                    FileLog.shared.addMessage("SyncTask: Process Server Bookmarks - Could not delete existing bookmark: \(apiBookmark.bookmarkUuid)")
                 }
             }
 
-            semaphore.signal()
+            // Add the incoming bookmark to the database
+            bookmarkManager.add(from: apiBookmark, passageFieldsFrom: existingBookmark).when(.none) {
+                FileLog.shared.addMessage("SyncTask: Process Server Bookmarks - Could not add bookmark: \(String(describing: try? apiBookmark.jsonString()))")
+            }
         }
-
-        semaphore.wait()
     }
 }
 

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask+ServerChanges.swift
@@ -3,7 +3,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 
 extension SyncTask {
-    func processServerData(response: Api_SyncUpdateResponse) {
+    func processServerData(response: Api_SyncUpdateResponse) async {
         var podcastsToImport = [Api_SyncUserPodcast]()
         var episodesToImport = [Api_SyncUserEpisode]()
         var playlistsToImport = [Api_SyncUserPlaylist]()
@@ -57,7 +57,7 @@ extension SyncTask {
                 strongSelf.importPodcast(podcastItem)
             }
         }
-        importQueue.waitUntilAllOperationsAreFinished()
+        await importQueue.allOperationsFinished()
         NotificationCenter.default.post(name: ServerNotifications.syncProgressImportedPodcasts, object: nil)
 
         for episodeItem in episodesToImport {
@@ -92,7 +92,7 @@ extension SyncTask {
             }
         }
 
-        importQueue.waitUntilAllOperationsAreFinished()
+        await importQueue.allOperationsFinished()
 
         // If any podcasts were moved out of their folders, the app saves this info
         // In case of sync errors the user can restore.

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncTask.swift
@@ -4,7 +4,7 @@ import PocketCastsDataModel
 import PocketCastsUtils
 
 class SyncTask: ApiBaseTask, @unchecked Sendable {
-    private static let processDataLock = NSObject()
+    private static let processDataLock = AsyncLock()
 
     lazy var importQueue: OperationQueue = {
         let queue = OperationQueue()
@@ -32,8 +32,8 @@ class SyncTask: ApiBaseTask, @unchecked Sendable {
         return formatter
     }()
 
-    override func apiTokenAcquired(token: String) {
-        performSync(token: token)
+    override func apiTokenAcquired(token: String) async {
+        await performSync(token: token)
     }
 
     override func apiTokenAcquisitionFailed() {
@@ -54,19 +54,19 @@ class SyncTask: ApiBaseTask, @unchecked Sendable {
         return request
     }
 
-    private func performSync(token: String) {
+    private func performSync(token: String) async {
         if let lastServerModified = UserDefaults.standard.string(forKey: ServerConstants.UserDefaults.lastModifiedServerDate), !lastServerModified.isEmpty {
             if ServerSettings.homeGridNeedsRefresh() {
-                performHomeGridRefresh()
+                await performHomeGridRefresh()
             }
 
-            performIncrementalSync(token: token)
+            await performIncrementalSync(token: token)
         } else {
-            performFullSync(token: token)
+            await performFullSync(token: token)
         }
     }
 
-    private func performHomeGridRefresh() {
+    private func performHomeGridRefresh() async {
         FileLog.shared.addMessage("Performing home grid refresh")
         let retrievePodcastsTask = RetrievePodcastsTask()
 
@@ -113,10 +113,10 @@ class SyncTask: ApiBaseTask, @unchecked Sendable {
 
             ServerSettings.setHomeGridNeedsRefresh(false)
         }
-        retrievePodcastsTask.runTaskSynchronously()
+        await retrievePodcastsTask.runTask()
     }
 
-    private func performFullSync(token: String) {
+    private func performFullSync(token: String) async {
         FileLog.shared.addMessage("Performing initial full sync")
 
         // grab the last sync date before we begin
@@ -125,7 +125,7 @@ class SyncTask: ApiBaseTask, @unchecked Sendable {
         retrieveLastSyncTask.completion = { lastSync in
             lastSyncAt = lastSync
         }
-        retrieveLastSyncTask.runTaskSynchronously()
+        await retrieveLastSyncTask.runTask()
         guard let lastSyncDate = lastSyncAt else {
             status = .failed
             return
@@ -136,14 +136,19 @@ class SyncTask: ApiBaseTask, @unchecked Sendable {
         // in a full sync we first ask for all the users podcasts
         let retrievePodcastsTask = RetrievePodcastsTask()
         var podcastRetrieveCallSucceeded = false
+        var podcastsToProcess: (podcasts: [PodcastSyncInfo]?, folders: [FolderSyncInfo]?)?
         retrievePodcastsTask.completion = { podcasts, folders, success in
             podcastRetrieveCallSucceeded = success
 
             if success {
-                self.processServerHomeGrid(podcasts: podcasts, folders: folders, lastSyncAt: lastSyncDate)
+                podcastsToProcess = (podcasts, folders)
             }
         }
-        retrievePodcastsTask.runTaskSynchronously()
+        await retrievePodcastsTask.runTask()
+
+        if let podcastsToProcess {
+            await processServerHomeGrid(podcasts: podcastsToProcess.podcasts, folders: podcastsToProcess.folders, lastSyncAt: lastSyncDate)
+        }
 
         if !podcastRetrieveCallSucceeded {
             status = .failed
@@ -157,21 +162,24 @@ class SyncTask: ApiBaseTask, @unchecked Sendable {
 
             self.processServerPlaylists(playlists)
         }
-        retrievePlaylistsTask.runTaskSynchronously()
+        await retrievePlaylistsTask.runTask()
 
         // Retrieve all the bookmarks
-        RetrieveBookmarksTask { bookmarks in
-            guard let bookmarks else { return }
+        var bookmarksToProcess: [Api_BookmarkResponse]?
+        await RetrieveBookmarksTask { bookmarks in
+            bookmarksToProcess = bookmarks
+        }.runTask()
 
-            self.processServerBookmarks(bookmarks)
-        }.runTaskSynchronously()
+        if let bookmarksToProcess {
+            await processServerBookmarks(bookmarksToProcess)
+        }
 
         UserDefaults.standard.set(lastSyncDate, forKey: ServerConstants.UserDefaults.lastModifiedServerDate)
 
         status = .successNewData
     }
 
-    private func performIncrementalSync(token: String) {
+    private func performIncrementalSync(token: String) async {
         if isCancelled {
             status = .cancelled
             return
@@ -188,8 +196,8 @@ class SyncTask: ApiBaseTask, @unchecked Sendable {
         }
 
         let url = ServerConstants.Urls.api() + "user/sync/update"
-        let (data, httpStatus) = postToServer(url: url, token: token, data: dataToSend)
-        status = processSyncData(data, httpStatus: httpStatus, episodesToSync: episodesToSync)
+        let (data, httpStatus) = await postToServer(url: url, token: token, data: dataToSend)
+        status = await processSyncData(data, httpStatus: httpStatus, episodesToSync: episodesToSync)
         if status == .failed {
             ServerNotificationsHelper.shared.fireSyncFailed()
             return
@@ -198,17 +206,22 @@ class SyncTask: ApiBaseTask, @unchecked Sendable {
         status = .success
     }
 
-    func processSyncData(_ data: Data?, httpStatus: Int, episodesToSync: [Episode]) -> UpdateStatus {
+    func processSyncData(_ data: Data?, httpStatus: Int, episodesToSync: [Episode]) async -> UpdateStatus {
         guard let responseData = data, httpStatus == ServerConstants.HttpConstants.ok else {
             FileLog.shared.addMessage("SyncTask: syncing failed with status \(httpStatus)")
 
             return .failed
         }
 
-        // ensure that only one thread can be processing data at once. The code below isn't thread safe, and will lead to potential issues otherwise
-        objc_sync_enter(SyncTask.processDataLock)
-        defer { objc_sync_exit(SyncTask.processDataLock) }
+        // ensure that only one sync can be processing data at once. The code below isn't thread safe, and will lead to potential issues otherwise
+        await SyncTask.processDataLock.lock()
+        let status = await process(responseData: responseData)
+        await SyncTask.processDataLock.unlock()
 
+        return status
+    }
+
+    private func process(responseData: Data) async -> UpdateStatus {
         do {
             DataManager.sharedManager.markAllPodcastsSynced()
             DataManager.sharedManager.markAllPlaylistsSynced()
@@ -219,7 +232,7 @@ class SyncTask: ApiBaseTask, @unchecked Sendable {
             }
 
             let response = try Api_SyncUpdateResponse(serializedBytes: responseData)
-            processServerData(response: response)
+            await processServerData(response: response)
 
             StatsManager.shared.setSyncStatus(.synced)
 

--- a/Modules/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/SyncYearListeningHistoryTask.swift
@@ -39,13 +39,13 @@ class SyncYearListeningHistoryTask: ApiBaseTask, @unchecked Sendable {
         self.yearToSync = year
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         self.token = token
 
-        performRequest(token: token, shouldSync: false)
+        await performRequest(token: token, shouldSync: false)
     }
 
-    private func performRequest(token: String, shouldSync: Bool) {
+    private func performRequest(token: String, shouldSync: Bool) async {
         var dataToSync = Api_YearHistoryRequest()
         dataToSync.version = apiVersion
         dataToSync.year = yearToSync
@@ -54,12 +54,12 @@ class SyncYearListeningHistoryTask: ApiBaseTask, @unchecked Sendable {
         let url = ServerConstants.Urls.api() + "history/year"
         do {
             let data = try dataToSync.serializedData()
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
             if let response, httpStatus == ServerConstants.HttpConstants.ok {
                 if !shouldSync {
-                    compareNumberOfEpisodes(serverData: response)
+                    await compareNumberOfEpisodes(serverData: response)
                 } else {
-                    syncMissingEpisodes(serverData: response)
+                    await syncMissingEpisodes(serverData: response)
                 }
             } else {
                 print("SyncYearListeningHistory Unable to sync with server got status \(httpStatus)")
@@ -69,7 +69,7 @@ class SyncYearListeningHistoryTask: ApiBaseTask, @unchecked Sendable {
         }
     }
 
-    private func compareNumberOfEpisodes(serverData: Data) {
+    private func compareNumberOfEpisodes(serverData: Data) async {
         do {
             let response = try Api_YearHistoryResponse(serializedBytes: serverData)
 
@@ -77,7 +77,7 @@ class SyncYearListeningHistoryTask: ApiBaseTask, @unchecked Sendable {
 
             if response.count > localNumberOfEpisodes, let token {
                 print("SyncYearListeningHistory: \(Int(response.count) - localNumberOfEpisodes) episodes missing, adding them...")
-                performRequest(token: token, shouldSync: true)
+                await performRequest(token: token, shouldSync: true)
             } else {
                 success = true
             }
@@ -86,13 +86,13 @@ class SyncYearListeningHistoryTask: ApiBaseTask, @unchecked Sendable {
         }
     }
 
-    private func syncMissingEpisodes(serverData: Data) {
+    private func syncMissingEpisodes(serverData: Data) async {
         do {
             let response = try Api_YearHistoryResponse(serializedBytes: serverData)
 
             // on watchOS, we don't show history, so we also don't process server changes we only want to push changes up, not down
             #if !os(watchOS)
-            updateEpisodes(updates: response.history.changes)
+            await updateEpisodes(updates: response.history.changes)
             #endif
 
             success = true
@@ -101,7 +101,7 @@ class SyncYearListeningHistoryTask: ApiBaseTask, @unchecked Sendable {
         }
     }
 
-    private func updateEpisodes(updates: [Api_HistoryChange]) {
+    private func updateEpisodes(updates: [Api_HistoryChange]) async {
         let lock = NSLock()
 
         var podcastsToUpdate: Set<String> = []
@@ -137,13 +137,13 @@ class SyncYearListeningHistoryTask: ApiBaseTask, @unchecked Sendable {
             }
         }
 
-        dispatchGroup.wait()
+        await dispatchGroup.finished()
 
         // Sync episode status for the retrieved podcasts' episodes
-        updateEpisodes(for: podcastsToUpdate)
+        await updateEpisodes(for: podcastsToUpdate)
     }
 
-    private func updateEpisodes(for podcastsUuids: Set<String>) {
+    private func updateEpisodes(for podcastsUuids: Set<String>) async {
         let dispatchGroup = DispatchGroup()
 
         podcastsUuids.forEach { podcastUuid in
@@ -158,7 +158,7 @@ class SyncYearListeningHistoryTask: ApiBaseTask, @unchecked Sendable {
             }
         }
 
-        dispatchGroup.wait()
+        await dispatchGroup.finished()
     }
 }
 
@@ -201,13 +201,13 @@ public class YearListeningHistory {
             DispatchQueue.global(qos: .userInitiated).async {
                 let syncYearListeningHistory = SyncYearListeningHistoryTask(year: yearToSync)
 
-                syncYearListeningHistory.start()
+                syncYearListeningHistory.runTaskSynchronously()
 
                 syncResults.append(syncYearListeningHistory.success)
 
                 let syncRatings = RetrieveRatingsTask()
 
-                syncRatings.start()
+                syncRatings.runTaskSynchronously()
 
                 syncResults.append(syncRatings.success)
 

--- a/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Sync/UpNextSyncTask.swift
@@ -32,7 +32,7 @@ public enum UpNextSyncError: LocalizedError {
 class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
     private static let processDataLock = NSObject()
 
-    override func main() {
+    override func runTask() async {
         // Skip sync when protected data is unavailable to prevent reading incorrect
         // UserDefaults values (which may return defaults instead of actual stored values)
         // This can happen when the app launches in background before first unlock after reboot
@@ -44,10 +44,10 @@ class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
         }
 
         logProtectedDataAvailable()
-        super.main()
+        await super.runTask()
     }
 
-    override func apiTokenAcquired(token: String) {
+    override func apiTokenAcquired(token: String) async {
         let trace = TraceManager.shared.beginTracing(eventName: "SERVER_UP_NEXT_SYNC")
         defer { TraceManager.shared.endTracing(trace: trace) }
 
@@ -55,7 +55,7 @@ class UpNextSyncTask: ApiBaseTask, @unchecked Sendable {
         let url = ServerConstants.Urls.api() + "up_next/sync"
         do {
             let data = try syncRequest.serializedData()
-            let (response, httpStatus) = postToServer(url: url, token: token, data: data)
+            let (response, httpStatus) = await postToServer(url: url, token: token, data: data)
             if httpStatus == ServerConstants.HttpConstants.notModified {
                 // no changes that we need to process
                 FileLog.shared.addMessage("UpNextSyncTask: Server returned not modified to Up Next sync, no changes required")

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -319,6 +319,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// Show a Live Activity on the Lock Screen and Dynamic Island while the sleep timer is running
     case sleepTimerLiveActivity
 
+    /// Run the sync/API tasks (`ApiBaseTask` and its subclasses) as asynchronous operations that
+    /// perform their networking with Swift concurrency instead of blocking a thread per request
+    case asyncApiTasks
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -533,6 +537,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .sleepTimerLiveActivity:
             true
+        case .asyncApiTasks:
+            false
         }
     }
 

--- a/Modules/Tests/PocketCastsServerTests/ApiBaseTaskTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/ApiBaseTaskTests.swift
@@ -1,0 +1,198 @@
+@testable import PocketCastsServer
+@testable import PocketCastsDataModel
+@testable import PocketCastsUtils
+import XCTest
+import GRDB
+
+final class ApiBaseTaskTests: XCTestCase {
+    private var dataManager: DataManager!
+
+    override func setUp() {
+        dataManager = DataManager(dbQueue: GRDBQueue(dbPool: try! DatabasePool(path: NSTemporaryDirectory().appending("\(UUID().uuidString).sqlite"))))
+    }
+
+    override func tearDown() {
+        FeatureFlagMock().reset()
+    }
+
+    func testTaskStartsAsynchronouslyWhenFlagIsEnabled() {
+        FeatureFlagMock().set(.asyncApiTasks, value: true)
+
+        let task = GatedTask(dataManager: dataManager)
+        XCTAssertTrue(task.isAsynchronous)
+
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        queue.addOperation(task)
+
+        wait(for: [task.didStart], timeout: 5)
+
+        // the work hasn't completed, so the operation is still executing and holds up the queue
+        XCTAssertTrue(task.isExecuting)
+        XCTAssertFalse(task.isFinished)
+
+        task.finishWork()
+        queue.waitUntilAllOperationsAreFinished()
+
+        XCTAssertFalse(task.isExecuting)
+        XCTAssertTrue(task.isFinished)
+    }
+
+    func testStartDoesNotBlockTheCallingThreadWhenFlagIsEnabled() {
+        FeatureFlagMock().set(.asyncApiTasks, value: true)
+
+        let task = GatedTask(dataManager: dataManager)
+        task.start()
+
+        // start() returns while the task is still running its work
+        XCTAssertFalse(task.isFinished)
+
+        task.finishWork()
+        wait(for: [task.didFinish], timeout: 5)
+        XCTAssertTrue(task.isFinished)
+    }
+
+    func testTaskRunsSynchronouslyWhenFlagIsDisabled() {
+        FeatureFlagMock().set(.asyncApiTasks, value: false)
+
+        let task = GatedTask(dataManager: dataManager, opensGateOnStart: true)
+        XCTAssertFalse(task.isAsynchronous)
+
+        task.start()
+
+        // with the flag off start() only returns once the work has completed
+        XCTAssertTrue(task.didRunToCompletion)
+        XCTAssertTrue(task.isFinished)
+    }
+
+    func testCancelledTaskFinishesWithoutRunning() {
+        FeatureFlagMock().set(.asyncApiTasks, value: true)
+
+        let task = GatedTask(dataManager: dataManager)
+        task.cancel()
+        task.start()
+
+        XCTAssertTrue(task.isFinished)
+        XCTAssertFalse(task.isExecuting)
+        XCTAssertFalse(task.didRunToCompletion)
+    }
+
+    func testSerialQueueRunsAsyncTasksOneAtATime() {
+        FeatureFlagMock().set(.asyncApiTasks, value: true)
+
+        let first = GatedTask(dataManager: dataManager)
+        let second = GatedTask(dataManager: dataManager)
+
+        let queue = OperationQueue()
+        queue.maxConcurrentOperationCount = 1
+        queue.addOperation(first)
+        queue.addOperation(second)
+
+        wait(for: [first.didStart], timeout: 5)
+        XCTAssertFalse(second.isExecuting, "The second task shouldn't start until the first one has finished")
+
+        first.finishWork()
+        wait(for: [second.didStart], timeout: 5)
+
+        second.finishWork()
+        queue.waitUntilAllOperationsAreFinished()
+    }
+
+    func testPostToServerReturnsTheServerResponse() async {
+        let responseData = Data("response".utf8)
+        let task = ApiBaseTask(dataManager: dataManager, urlConnection: URLConnection(mockHandler: { request in
+            (responseData, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil))
+        }))
+
+        let (data, httpStatus) = await task.postToServer(url: "\(ServerConstants.Urls.api())test", token: "token", data: Data())
+
+        XCTAssertEqual(data, responseData)
+        XCTAssertEqual(httpStatus, ServerConstants.HttpConstants.ok)
+    }
+
+    func testGetToServerReturnsTheServerResponse() async {
+        let responseData = Data("response".utf8)
+        let task = ApiBaseTask(dataManager: dataManager, urlConnection: URLConnection(mockHandler: { request in
+            (responseData, HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil))
+        }))
+
+        let (data, response) = await task.getToServer(url: "\(ServerConstants.Urls.api())test", token: "token")
+
+        XCTAssertEqual(data, responseData)
+        XCTAssertEqual(response?.statusCode, ServerConstants.HttpConstants.ok)
+    }
+
+    func testFailedRequestIsReportedAsAServerError() async {
+        let task = ApiBaseTask(dataManager: dataManager, urlConnection: URLConnection(mockHandler: { _ in
+            throw URLError(.notConnectedToInternet)
+        }))
+
+        let (data, httpStatus) = await task.postToServer(url: "\(ServerConstants.Urls.api())test", token: "token", data: Data())
+
+        XCTAssertNil(data)
+        XCTAssertEqual(httpStatus, ServerConstants.HttpConstants.serverError)
+    }
+}
+
+/// A task whose work only completes once the test opens the gate
+private final class GatedTask: ApiBaseTask, @unchecked Sendable {
+    let didStart = XCTestExpectation(description: "Task started")
+    let didFinish = XCTestExpectation(description: "Task finished")
+
+    private(set) var didRunToCompletion = false
+
+    private let gate = AsyncGate()
+    private let opensGateOnStart: Bool
+
+    init(dataManager: DataManager, opensGateOnStart: Bool = false) {
+        self.opensGateOnStart = opensGateOnStart
+
+        super.init(dataManager: dataManager, urlConnection: URLConnection(mockHandler: { _ in (nil, nil) }))
+    }
+
+    func finishWork() {
+        gate.open()
+    }
+
+    override func runTask() async {
+        if opensGateOnStart {
+            gate.open()
+        }
+
+        didStart.fulfill()
+        await gate.opened()
+        didRunToCompletion = true
+        didFinish.fulfill()
+    }
+}
+
+private final class AsyncGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isOpen = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func opened() async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if isOpen {
+                lock.unlock()
+                continuation.resume()
+
+                return
+            }
+
+            self.continuation = continuation
+            lock.unlock()
+        }
+    }
+
+    func open() {
+        lock.lock()
+        isOpen = true
+        let continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+
+        continuation?.resume()
+    }
+}

--- a/Modules/Tests/PocketCastsServerTests/AsyncLockTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/AsyncLockTests.swift
@@ -1,0 +1,44 @@
+@testable import PocketCastsServer
+import XCTest
+
+final class AsyncLockTests: XCTestCase {
+    func testWorkIsSerialisedAcrossSuspensionPoints() async {
+        let lock = AsyncLock()
+        let counter = Counter()
+
+        // without the lock the read and the write below interleave and updates are lost
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 10 {
+                group.addTask {
+                    await lock.lock()
+                    let value = await counter.value
+                    await Task.yield()
+                    await counter.set(value + 1)
+                    await lock.unlock()
+                }
+            }
+        }
+
+        let value = await counter.value
+        XCTAssertEqual(value, 10)
+    }
+
+    func testLockIsReleasedForTheNextCaller() async {
+        let lock = AsyncLock()
+
+        await lock.lock()
+        await lock.unlock()
+
+        // a second lock/unlock cycle would hang if the first one didn't release the lock
+        await lock.lock()
+        await lock.unlock()
+    }
+}
+
+private actor Counter {
+    private(set) var value = 0
+
+    func set(_ newValue: Int) {
+        value = newValue
+    }
+}

--- a/Modules/Tests/PocketCastsServerTests/SyncTaskManualPlaylistTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/SyncTaskManualPlaylistTests.swift
@@ -134,7 +134,7 @@ final class SyncTaskManualPlaylistTests: XCTestCase {
         XCTAssertEqual(episode.addedDate?.timeIntervalSince1970, 123_000)
     }
 
-    func testProcessServerDataAddsMissingEpisodesFromPlaylist() {
+    func testProcessServerDataAddsMissingEpisodesFromPlaylist() async {
         FailingURLProtocol.requestCount = 0
         URLProtocol.registerClass(FailingURLProtocol.self)
         defer { URLProtocol.unregisterClass(FailingURLProtocol.self) }
@@ -180,7 +180,7 @@ final class SyncTaskManualPlaylistTests: XCTestCase {
         var response = Api_SyncUpdateResponse()
         response.records = [record]
 
-        syncTask.processServerData(response: response)
+        await syncTask.processServerData(response: response)
 
         // Missing episode should be added
         let added = dataManager.findEpisode(uuid: "miss-2")

--- a/Modules/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
+++ b/Modules/Tests/PocketCastsServerTests/SyncTaskTests+BookmarkImport.swift
@@ -215,7 +215,7 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
         XCTAssertFalse(record?.hasReferenceTimeModified ?? true)
     }
 
-    func testFullSyncKeepsLocalPassageFields() throws {
+    func testFullSyncKeepsLocalPassageFields() async throws {
         let passageModified = Date(timeIntervalSince1970: 100)
         let uuid = try XCTUnwrap(bookmarkManager.add(episodeUuid: "episode-1",
                                                      podcastUuid: "podcast-uuid",
@@ -228,7 +228,7 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
                                                      referenceTimeModified: passageModified))
         let bookmark = try XCTUnwrap(bookmarkManager.bookmark(for: uuid))
 
-        syncTask.processServerBookmarks([.fromBookmark(bookmark)])
+        await syncTask.processServerBookmarks([.fromBookmark(bookmark)])
 
         let replaced = bookmarkManager.bookmark(for: uuid)
         XCTAssertEqual(replaced?.passage, "Local passage", "The passage fields should survive the full sync replacing the bookmark")
@@ -240,17 +240,17 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
 
     // MARK: - Server Data Processed
 
-    func testProcessServerDataParsesBookmarksCorrectly() {
+    func testProcessServerDataParsesBookmarksCorrectly() async {
         let count = 2000
         let deletedCount = 321
-        syncTask.processServerData(response: .bookmarkResponse(count: count, deletedCount: deletedCount))
+        await syncTask.processServerData(response: .bookmarkResponse(count: count, deletedCount: deletedCount))
 
         XCTAssertEqual(bookmarkManager.allBookmarks().count, count - deletedCount)
     }
 
     // MARK: - Full Sync
 
-    func testFullSyncMarksAllAsSynced() {
+    func testFullSyncMarksAllAsSynced() async {
         let bookmarks = [
             addBookmark(time: 1),
             addBookmark(time: 2),
@@ -261,12 +261,12 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
             Api_BookmarkResponse.fromBookmark($0)
         }
 
-        syncTask.processServerBookmarks(server)
+        await syncTask.processServerBookmarks(server)
 
         XCTAssertEqual(bookmarkManager.bookmarksToSync().count, 0)
     }
 
-    func testFullSyncReplacesExistingUUIDs() {
+    func testFullSyncReplacesExistingUUIDs() async {
         let bookmarks = [
             addBookmark(time: 1),
             addBookmark(time: 2),
@@ -280,7 +280,7 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
             Api_BookmarkResponse.forTesting(uuid: $0.uuid, episode: $0.episodeUuid, podcast: $0.podcastUuid, title: newTitle, time: $0.time, created: created)
         }
 
-        syncTask.processServerBookmarks(server)
+        await syncTask.processServerBookmarks(server)
 
         let allBookmarks = bookmarkManager.allBookmarks()
 
@@ -288,14 +288,14 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
         XCTAssertEqual(allBookmarks.map(\.created), Array(repeating: created, count: bookmarks.count))
     }
 
-    func testFullSyncImportsDataCorrectly() {
+    func testFullSyncImportsDataCorrectly() async {
         let serverData: [Api_BookmarkResponse] = [
             .forTesting(uuid: "one", episode: "two", podcast: "three", title: "four", time: 5, created: .init(timeIntervalSince1970: 6)),
             .forTesting(uuid: "seven", episode: "eight", podcast: "nine", title: "ten", time: 11, created: .init(timeIntervalSince1970: 12)),
             .forTesting(uuid: "thirteen", episode: "fourteen", podcast: "fifteen", title: "sixteen", time: 17, created: .init(timeIntervalSince1970: 18))
         ]
 
-        syncTask.processServerBookmarks(serverData)
+        await syncTask.processServerBookmarks(serverData)
 
         let allBookmarks = bookmarkManager.allBookmarks(sorted: .timestamp)
 
@@ -308,7 +308,7 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
         XCTAssertEqual(allBookmarks.map(\.created), [.init(timeIntervalSince1970: 6), .init(timeIntervalSince1970: 12), .init(timeIntervalSince1970: 18)])
     }
 
-    func testFullSyncIgnoresExistingItems() {
+    func testFullSyncIgnoresExistingItems() async {
         addBookmark(time: 1)
         addBookmark(time: 2)
         addBookmark(time: 3)
@@ -319,7 +319,7 @@ final class SyncTaskTests_BookmarkImport: XCTestCase {
             .forTesting(uuid: "thirteen", episode: "fourteen", podcast: "fifteen", title: "sixteen", time: 17, created: .init(timeIntervalSince1970: 18))
         ]
 
-        syncTask.processServerBookmarks(serverData)
+        await syncTask.processServerBookmarks(serverData)
 
         XCTAssertEqual( bookmarkManager.allBookmarks().count, 6)
     }

--- a/Modules/Tests/PocketCastsServerTests/SyncTaskTests+Episodes.swift
+++ b/Modules/Tests/PocketCastsServerTests/SyncTaskTests+Episodes.swift
@@ -14,7 +14,7 @@ final class SyncTaskTests_EpisodeImport: XCTestCase {
         FeatureFlagMock().reset()
     }
 
-    func testSyncingEpisodes() throws {
+    func testSyncingEpisodes() async throws {
         let beforeUnsynced = DataManager.sharedManager.unsyncedEpisodes(limit: ServerConstants.Limits.maxEpisodesToSync)
         XCTAssertEqual(beforeUnsynced.count, 0)
 
@@ -30,7 +30,7 @@ final class SyncTaskTests_EpisodeImport: XCTestCase {
         XCTAssertEqual(afterUnsynced.count, episodeCount)
 
         let response = Api_SyncUpdateResponse.episodesResponse(episodes: afterUnsynced)
-        syncTask.processServerData(response: response)
+        await syncTask.processServerData(response: response)
 
         let unsyncedEpisodes = DataManager.sharedManager.unsyncedEpisodes(limit: ServerConstants.Limits.maxEpisodesToSync)
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Under the new `asyncApiTasks` feature flag (off by default), `ApiBaseTask` becomes an asynchronous `Operation`: `start()` returns immediately and the operation finishes when its async work completes, so no thread is held for the duration of a request. With the flag off, `start()` falls through to `Operation`'s default and blocks the queue thread until the work finishes, so queues, ordering and `waitUntilAllOperationsAreFinished()` behave exactly as they do today.

All the requests now go through `URLConnection.send(request:)` instead of `sendSynchronousRequest`, and all 40 task subclasses perform their work in an async closure. `TokenHelper` gained non-blocking `acquireToken()`/`acquirePasswordToken()` counterparts (the existing blocking ones are still used by their non-task callers).

A few things that came with the conversion:

- Nested task calls (`SyncTask` → retrieve podcasts/playlists/bookmarks/last sync) `await runTask()` instead of blocking a thread each.
- Unbounded blocking waits inside task bodies were converted so they can't clog the cooperative pool: `importQueue.waitUntilAllOperationsAreFinished()` → a barrier block, plus the bookmark import semaphore, the starred episode `DispatchGroup` and the year history groups. Waits that are bounded by a timeout and run on their own queue threads were left alone.
- `YearListeningHistory.sync` called `task.start()` and read `task.success` on the next line, which silently breaks with an asynchronous operation, so it now calls `runTaskSynchronously()`.
- `SyncTask.processSyncData` held an `objc_sync` lock across the new `await`. That lock is owned by the thread that took it, so it would be released from the wrong thread and eventually wedge every sync. It now uses `AsyncLock`, a non-reentrant mutex that can be held across suspension points.

## To test

1. Enable `asyncApiTasks` in Settings → Developer → Feature Flags.
2. Pull to refresh on the Podcasts screen and confirm the sync completes and the grid updates.
3. Play an episode, scrub, star it, and add a bookmark. Force a sync and confirm the changes reach another device.
4. Change the Up Next queue and confirm it syncs both ways.
5. Log out and log back in and confirm the full sync imports podcasts, filters and bookmarks.
6. Repeat steps 2-5 with the flag off and confirm nothing changed.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.