### PR TITLE
Simplify PlaybackManager

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -371,7 +371,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackPaused)
         cancelUpdateTimer()
         syncSleepTimerLiveActivity(isPaused: true)
-        deactiveAudioSession()
+        deactivateAudioSession()
 
         updateIdleTimer()
     }
@@ -963,7 +963,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private var deactivateTimedActionHelper = TimedActionHelper()
-    private func deactiveAudioSession(waitBeforeDeactivating: Bool = true) {
+    private func deactivateAudioSession(waitBeforeDeactivating: Bool = true) {
         if !waitBeforeDeactivating {
             performDeactivate(audioSession: AVAudioSession.sharedInstance())
             return
@@ -984,9 +984,9 @@ class PlaybackManager: ServerPlaybackDelegate {
     private func performDeactivate(audioSession: AVAudioSession) {
         do {
             try audioSession.setActive(false)
-            FileLog.shared.addMessage("deactiveAudioSession succeeded")
+            FileLog.shared.addMessage("deactivateAudioSession succeeded")
         } catch {
-            FileLog.shared.addMessage("deactiveAudioSession failed")
+            FileLog.shared.addMessage("deactivateAudioSession failed")
         }
     }
 
@@ -1586,7 +1586,7 @@ class PlaybackManager: ServerPlaybackDelegate {
                 }
 
                 if !self.isPlaying {
-                    self.deactiveAudioSession(waitBeforeDeactivating: false)
+                    self.deactivateAudioSession(waitBeforeDeactivating: false)
                 }
             }
         }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -152,25 +152,17 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     var currentPodcast: Podcast? {
-        if let episode = currentEpisode as? Episode {
-            return episode.parentPodcast()
-        }
-
-        return nil
+        (currentEpisode as? Episode)?.parentPodcast()
     }
 
     var isPlaying: Bool {
         if aboutToPlay.value { return true }
 
-        guard let player else { return false }
-
-        return player.playing()
+        return player?.playing() ?? false
     }
 
     var isBuffering: Bool {
-        guard let player else { return false }
-
-        return player.buffering()
+        player?.buffering() ?? false
     }
 
     func futureBufferAvailable() -> TimeInterval {
@@ -294,7 +286,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     func play(completion: (() -> Void)? = nil, userInitiated: Bool = true) {
         guard let currEpisode = currentEpisode else { return }
 
-        FileLog.shared.addMessage("PlaybackManager Play \(currentEpisode?.title ?? "unknown episode") userInitiated: \(userInitiated)")
+        FileLog.shared.addMessage("PlaybackManager Play \(currEpisode.title ?? "unknown episode") userInitiated: \(userInitiated)")
 
         if userInitiated {
             analyticsPlaybackHelper.play()
@@ -368,13 +360,11 @@ class PlaybackManager: ServerPlaybackDelegate {
         // one kind of interruption would be to launch siri and ask it to pause, handle this here
         wasPlayingBeforeInterruption = false
 
-        FileLog.shared.addMessage("PlaybackManager pausing playback \(currentEpisode?.title ?? "unknown episode")")
+        FileLog.shared.addMessage("PlaybackManager pausing playback \(episode.title ?? "unknown episode")")
 
         recordPlaybackPosition(sendToServerImmediately: isPlaying, fireNotifications: true)
 
-        if let player {
-            player.pause()
-        }
+        player?.pause()
         updateNowPlayingInfo()
 
         catchUpHelper.playbackDidPause(of: episode)
@@ -1022,16 +1012,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func playingOverAirplay() -> Bool {
-        let currentRoute = AVAudioSession.sharedInstance().currentRoute
-
-        if currentRoute.outputs.isEmpty { return false }
-
-        let currentOutput = currentRoute.outputs[0]
-        if currentOutput.portType.rawValue == AVAudioSession.Port.airPlay.rawValue {
-            return true
-        }
-
-        return false
+        AVAudioSession.sharedInstance().currentRoute.outputs.first?.portType == .airPlay
     }
 
     func effects() -> PlaybackEffects {
@@ -1132,9 +1113,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             load(episode: episode, autoPlay: isPlaying, overrideUpNext: false)
         }
 
-        if let player {
-            player.effectsDidChange()
-        }
+        player?.effectsDidChange()
         updateAllNowPlayingData()
         checkIfStreamBufferRequired(episode: episode, effects: effects)
 
@@ -1210,9 +1189,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         aboutToPlay.value = false
 
         // make sure we load the saved speed for this track
-        if let player {
-            player.setPlaybackRate(effects().playbackSpeed)
-        }
+        player?.setPlaybackRate(effects().playbackSpeed)
 
         updateAllNowPlayingData()
     }
@@ -1603,9 +1580,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         videoRenderingEnabled.value = true
         seekingTo = PlaybackManager.notSeeking
         FileLog.shared.addMessage("cleanupCurrentPlayer permanent? \(permanent)")
-        if let player {
-            player.endPlayback(permanent: permanent)
-        }
+        player?.endPlayback(permanent: permanent)
 
         if permanent { aboutToPlay.value = false }
         currentEffects = nil
@@ -2041,7 +2016,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         let commandCenter = MPRemoteCommandCenter.shared()
 
         commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ -> MPRemoteCommandHandlerStatus in
-            guard let self, let _ = self.currentEpisode else { return .noActionableNowPlayingItem }
+            guard let self, currentEpisode != nil else { return .noActionableNowPlayingItem }
             remotePlayPauseToggle()
             return .success
         }
@@ -2162,7 +2137,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         if !Settings.isLockScreenScrubbingDisabled { // Only perform the seek if lock screen scrubbing is enabled
             commandCenter.changePlaybackPositionCommand.addTarget { [weak self] event -> MPRemoteCommandHandlerStatus in
 
-                guard let self, let _ = currentEpisode else { return .noActionableNowPlayingItem }
+                guard let self, currentEpisode != nil else { return .noActionableNowPlayingItem }
 
                 analyticsPlaybackHelper.currentSource = commandCenterSource
 
@@ -2360,13 +2335,13 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     private func logRouteChange(userInfo: [AnyHashable: Any]) {
         guard let changeReason = userInfo[AVAudioSessionRouteChangeReasonKey] as? NSNumber,
-              let previousRoute = userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription,
-              let currentRoute = AVAudioSession.sharedInstance().currentRoute as AVAudioSessionRouteDescription? else {
+              let previousRoute = userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription else {
             return
         }
 
-        let previousOutputDescriptions = previousRoute.outputs.map { $0.portName }.joined(separator: ", ")
-        let currentOutputDescriptions = currentRoute.outputs.map { $0.portName }.joined(separator: ", ")
+        let currentRoute = AVAudioSession.sharedInstance().currentRoute
+        let previousOutputDescriptions = previousRoute.outputs.map(\.portName).joined(separator: ", ")
+        let currentOutputDescriptions = currentRoute.outputs.map(\.portName).joined(separator: ", ")
         if let reason = AVAudioSession.RouteChangeReason(rawValue: UInt(changeReason.intValue)) {
             FileLog.shared.addMessage("PlaybackManager: Handle route change \(reason) | Previous Outputs: [\(previousOutputDescriptions)] | Current Outputs: [\(currentOutputDescriptions)]")
         }
@@ -2462,7 +2437,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func remoteDeviceAutoConnected(_ episodeUuid: String) {
         #if !os(watchOS) && !APPCLIP && !os(tvOS)
-            if let _ = player as? GoogleCastPlayer {
+            if player is GoogleCastPlayer {
                 return // we already have a Google Cast player, probably just a background resume rather than a restart
             }
 
@@ -2669,21 +2644,14 @@ class PlaybackManager: ServerPlaybackDelegate {
     // MARK: - tvOS
 
     var avPlayer: AVPlayer? {
-        guard let defaultPlayer = player as? DefaultPlayer else {
-            return nil
-        }
-
-        return defaultPlayer.player
+        (player as? DefaultPlayer)?.player
     }
 
     #if !os(watchOS)
     /// Current RMS audio level (0...1) from the audio processing tap.
     /// Returns 0 when no tap is active (e.g. HLS streams).
     var currentAudioLevel: Float {
-        guard let currentPlayer = player else {
-            return 0
-        }
-        return currentPlayer.currentAudioLevel
+        player?.currentAudioLevel ?? 0
     }
     #endif
 }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1228,12 +1228,12 @@ class PlaybackManager: ServerPlaybackDelegate {
         }
 
         func shortUserAttributedMessage(mainColor: UIColor, interactiveColor: UIColor) -> NSAttributedString {
-            let baseText = self.shortUserMessage
-            let learnMore = String(L10n.learnMore).sentenceCased
-            let attributedString = NSMutableAttributedString(string: baseText, attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .medium)])
-            if self.userAction != nil {
-                attributedString.append(NSAttributedString(string: " ", attributes: [.foregroundColor: mainColor, .font: UIFont.systemFont(ofSize: 14, weight: .medium)]))
-                attributedString.append(NSAttributedString(string: learnMore, attributes: [.foregroundColor: interactiveColor, .font: UIFont.systemFont(ofSize: 14, weight: .medium)]))
+            let font = UIFont.systemFont(ofSize: 14, weight: .medium)
+            let attributedString = NSMutableAttributedString(string: shortUserMessage, attributes: [.foregroundColor: mainColor, .font: font])
+            if userAction != nil {
+                let learnMore = String(L10n.learnMore).sentenceCased
+                attributedString.append(NSAttributedString(string: " ", attributes: [.foregroundColor: mainColor, .font: font]))
+                attributedString.append(NSAttributedString(string: learnMore, attributes: [.foregroundColor: interactiveColor, .font: font]))
             }
             return attributedString
         }
@@ -1805,16 +1805,16 @@ class PlaybackManager: ServerPlaybackDelegate {
         if isSeeking { return } // don't fire these while the app is seeking
 
         if Thread.isMainThread {
-            if isBackgrounded() { return }
-
-            NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackProgress)
+            postProgressNotification()
         } else {
-            DispatchQueue.main.sync {
-                if isBackgrounded() { return }
-
-                NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackProgress)
-            }
+            DispatchQueue.main.sync { postProgressNotification() }
         }
+    }
+
+    private func postProgressNotification() {
+        if isBackgrounded() { return }
+
+        NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackProgress)
     }
 
     private func fireChapterChangeNotification() {

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -353,7 +353,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         guard let episode = currentEpisode else { return }
 
         // Only trigger the event if we are already playing
-        if isPlaying, userInitiated == true {
+        if isPlaying, userInitiated {
             analyticsPlaybackHelper.pause()
         }
 
@@ -389,8 +389,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func skipBack() {
-        let skipBackAmount = TimeInterval(Settings.skipBackTime)
-        skipBack(amount: skipBackAmount)
+        skipBack(amount: TimeInterval(Settings.skipBackTime))
     }
 
     private func skipBack(amount: TimeInterval) {
@@ -402,8 +401,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func skipForward() {
-        let skipForwardAmount = TimeInterval(Settings.skipForwardTime)
-        skipForward(amount: skipForwardAmount)
+        skipForward(amount: TimeInterval(Settings.skipForwardTime))
     }
 
     private func skipForward(amount: TimeInterval) {
@@ -478,7 +476,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     var chaptersAreGenerated: Bool {
-        return chapterManager.chaptersOrigin == .generated
+        chapterManager.chaptersOrigin == .generated
     }
 
     /// The loaded chapters' origin as its Tracks value (e.g. "generated",
@@ -773,9 +771,8 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func play(playlist: EpisodeFilter) {
-        let playlistEpisodes: [Episode]
         let query = PlaylistQueryBuilder.query(clause: .episode, for: playlist, episodeUuidToAdd: playlist.episodeUuidToAddToQueries(), limit: ServerSettings.autoAddToUpNextLimit(), shouldShowArchived: playlist.showArchivedEpisodes)
-        playlistEpisodes = DataManager.sharedManager.findPlaylistEpisodesWhere(query: query, arguments: nil)
+        let playlistEpisodes = DataManager.sharedManager.findPlaylistEpisodesWhere(query: query, arguments: nil)
         if playlist.manual {
             let archivedEpisodes = playlistEpisodes.filter(\.archived)
             EpisodeManager.bulkUnarchive(episodes: archivedEpisodes, trackEvent: false)
@@ -1053,7 +1050,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         let playbackEffects = effects()
         if playbackEffects.playbackSpeed < 0.6 { return }
 
-        playbackEffects.playbackSpeed = playbackEffects.playbackSpeed - 0.1
+        playbackEffects.playbackSpeed -= 0.1
         changeEffects(playbackEffects)
     }
 
@@ -1071,7 +1068,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         // HLS streams can't sustain playback above 2x, so don't let the speed be raised past it.
         if let episode = currentEpisode, EpisodeManager.willPlayViaHLS(episode), playbackEffects.playbackSpeed >= SharedConstants.PlaybackEffects.maximumHlsPlaybackSpeed { return }
 
-        playbackEffects.playbackSpeed = playbackEffects.playbackSpeed + 0.1
+        playbackEffects.playbackSpeed += 0.1
         changeEffects(playbackEffects)
     }
 
@@ -1441,7 +1438,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             clearNowPlayingInfo()
             cancelSleepTimer()
         } else {
-            playNextEpisode(autoPlay: !(numberOfEpisodesToSleepAfter == 1))
+            playNextEpisode(autoPlay: numberOfEpisodesToSleepAfter != 1)
         }
     }
 
@@ -1459,7 +1456,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func bulkAdd(_ episodes: [BaseEpisode], toTop: Bool = false) {
         var episodesToAdd = episodes
-        if let currentEpisodeIndex = episodes.firstIndex(where: { $0.uuid == PlaybackManager.shared.currentEpisode?.uuid }) {
+        if let currentEpisodeIndex = episodes.firstIndex(where: { $0.uuid == currentEpisode?.uuid }) {
             episodesToAdd.remove(at: currentEpisodeIndex)
         }
 
@@ -1584,10 +1581,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             playerCleanupQueue.asyncAfter(deadline: .now() + 5.seconds) { [weak self] in
                 guard let self else { return }
 
-                let index = self.playersToCleanUp.firstIndex(where: { listPlayer -> Bool in
-                    listPlayer == player
-                })
-                if let index {
+                if let index = self.playersToCleanUp.firstIndex(of: player) {
                     self.playersToCleanUp.remove(at: index)
                 }
 
@@ -1783,14 +1777,14 @@ class PlaybackManager: ServerPlaybackDelegate {
                 sleepTimerManager.performFadeOut(player: player)
             }
 
-            sleepTimeRemaining = sleepTimeRemaining - updateTimerInterval
+            sleepTimeRemaining -= updateTimerInterval
 
             if sleepTimeRemaining < 0 {
                 pauseAndRecordSleepTimerFinished()
             }
         }
 
-        if player.buffering() == false {
+        if !player.buffering() {
             updateChapterInfo()
         }
     }
@@ -2193,17 +2187,8 @@ class PlaybackManager: ServerPlaybackDelegate {
                 EpisodeManager.setStarred(!episode.keepEpisode, episode: episode, updateSyncStatus: SyncManager.isUserLoggedIn())
                 return .success
             }
-            if let episode = self.currentEpisode {
-                starCommand.isActive = episode.keepEpisode
-            } else {
-                starCommand.isActive = false
-            }
-            if self.currentEpisode is UserEpisode {
-                starCommand.isEnabled = false
-            }
-            else {
-                starCommand.isEnabled = true
-            }
+            starCommand.isActive = currentEpisode?.keepEpisode ?? false
+            starCommand.isEnabled = !(currentEpisode is UserEpisode)
         } else {
             markPlayedCommand.removeTarget(nil)
             markPlayedCommand.isEnabled = false
@@ -2284,10 +2269,8 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     private func setInterval(_ command: MPSkipIntervalCommand, interval: TimeInterval, handler: ((MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus)?) {
-        var intervalAmount = interval
-        if intervalAmount > 99 { intervalAmount = 99 }
         command.isEnabled = true
-        command.preferredIntervals = [NSNumber(value: intervalAmount)]
+        command.preferredIntervals = [NSNumber(value: min(interval, 99))]
 
         if let handler {
             command.addTarget(handler: handler)
@@ -2406,15 +2389,14 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     func remoteDeviceConnected() {
         AnalyticsHelper.didConnectToChromecast()
-        if let episode = currentEpisode {
-            if playerSwitchRequired() {
-                AnalyticsPlaybackHelper.shared.currentSource = .chromecast
-                pause()
 
-                AnalyticsPlaybackHelper.shared.currentSource = .chromecast
-                load(episode: episode, autoPlay: true, overrideUpNext: false)
-            }
-        }
+        guard let episode = currentEpisode, playerSwitchRequired() else { return }
+
+        AnalyticsPlaybackHelper.shared.currentSource = .chromecast
+        pause()
+
+        AnalyticsPlaybackHelper.shared.currentSource = .chromecast
+        load(episode: episode, autoPlay: true, overrideUpNext: false)
     }
 
     func remoteDeviceWillDisconnect() {
@@ -2698,8 +2680,8 @@ extension PlaybackManager {
 
     func trackChapterEvent(_ event: AnalyticsEvent, properties: [String: Any]? = nil) {
         var baseProperties = chapterManager.chaptersAnalyticsProperties
-        if let extraProperties = properties {
-            baseProperties = baseProperties.merging(extraProperties, uniquingKeysWith: { current, _ in return current})
+        if let properties {
+            baseProperties = baseProperties.merging(properties, uniquingKeysWith: { current, _ in current })
         }
         analyticsPlaybackHelper.track(event, properties: baseProperties)
     }

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -960,11 +960,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         queue.removeAllEpisodes()
         cleanupCurrentPlayer(permanent: true)
-        #if os(watchOS)
-            WatchNowPlayingHelper.clearNowPlayingInfo()
-        #else
-            NowPlayingHelper.clearNowPlayingInfo()
-        #endif
+        clearNowPlayingInfo()
 
         NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackEnded)
     }
@@ -1442,13 +1438,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             }
             NotificationCenter.postOnMainThread(notification: Constants.Notifications.playbackEnded)
             cleanupCurrentPlayer(permanent: true)
-
-            #if os(watchOS)
-                WatchNowPlayingHelper.clearNowPlayingInfo()
-            #else
-                NowPlayingHelper.clearNowPlayingInfo()
-            #endif
-
+            clearNowPlayingInfo()
             cancelSleepTimer()
         } else {
             playNextEpisode(autoPlay: !(numberOfEpisodesToSleepAfter == 1))
@@ -1856,6 +1846,30 @@ class PlaybackManager: ServerPlaybackDelegate {
         refreshNowPlayingInfo(forceFullRebuild: false)
     }
 
+    private func clearNowPlayingInfo() {
+        #if os(watchOS)
+            WatchNowPlayingHelper.clearNowPlayingInfo()
+        #else
+            NowPlayingHelper.clearNowPlayingInfo()
+        #endif
+    }
+
+    private func setAllNowPlayingInfo(for episode: BaseEpisode) {
+        #if os(watchOS)
+            WatchNowPlayingHelper.setAllNowPlayingInfo(for: episode, duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
+        #else
+            NowPlayingHelper.setAllNowPlayingInfo(for: episode, currentChapters: currentChapters(), duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
+        #endif
+    }
+
+    private func updateNowPlayingProgress(for episode: BaseEpisode) {
+        #if os(watchOS)
+            WatchNowPlayingHelper.updateNowPlayingInfo(for: episode, duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
+        #else
+            NowPlayingHelper.updateNowPlayingInfo(for: episode, currentChapters: currentChapters(), duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
+        #endif
+    }
+
     /// - Parameter forceFullRebuild: when `true`, rebuilds the whole now playing payload instead of
     ///   only refreshing progress. Needed when a value like the media type changes for the same
     ///   episode (e.g. an HLS stream promoted to video), which the progress-only path won't pick up.
@@ -1868,27 +1882,16 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         // When Google Casting in the background, control over the casting device is not available, so remove the controls
         guard let episode = currentEpisode, !connectedToExternalDevice else {
-            #if os(watchOS)
-                WatchNowPlayingHelper.clearNowPlayingInfo()
-            #else
-                NowPlayingHelper.clearNowPlayingInfo()
-            #endif
+            clearNowPlayingInfo()
 
             return
         }
-        #if os(watchOS)
-            if forceFullRebuild {
-                WatchNowPlayingHelper.setAllNowPlayingInfo(for: episode, duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
-            } else {
-                WatchNowPlayingHelper.updateNowPlayingInfo(for: episode, duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
-            }
-        #else
-            if forceFullRebuild {
-                NowPlayingHelper.setAllNowPlayingInfo(for: episode, currentChapters: currentChapters(), duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
-            } else {
-                NowPlayingHelper.updateNowPlayingInfo(for: episode, currentChapters: currentChapters(), duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
-            }
-        #endif
+
+        if forceFullRebuild {
+            setAllNowPlayingInfo(for: episode)
+        } else {
+            updateNowPlayingProgress(for: episode)
+        }
     }
 
     func forceUpdateChapterInfo() {
@@ -1907,19 +1910,11 @@ class PlaybackManager: ServerPlaybackDelegate {
 
     @objc private func updateAllNowPlayingData() {
         guard let episode = currentEpisode else {
-            #if os(watchOS)
-                WatchNowPlayingHelper.clearNowPlayingInfo()
-            #else
-                NowPlayingHelper.clearNowPlayingInfo()
-            #endif
+            clearNowPlayingInfo()
             return
         }
 
-        #if os(watchOS)
-            WatchNowPlayingHelper.setAllNowPlayingInfo(for: episode, duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
-        #else
-            NowPlayingHelper.setAllNowPlayingInfo(for: episode, currentChapters: currentChapters(), duration: duration(), upTo: currentTime(), playbackRate: nowPlayingPlaybackRate)
-        #endif
+        setAllNowPlayingInfo(for: episode)
     }
 
     // MARK: - Sleep Timer


### PR DESCRIPTION
Pure cleanup of `PlaybackManager.swift` — no behaviour changes. Split into five focused commits so each is readable on its own:

- **Simplify optional handling** — `if let player { player.foo() }` → `player?.foo()`, `guard let player else { return false }` → `?? false`, the `let _ = currentEpisode` discards → `!= nil`, `let _ = player as? GoogleCastPlayer` → `is`, and `playingOverAirplay()` collapsed from ten lines to one.
- **Deduplicate the now playing info platform switches** — the `#if os(watchOS)` branch picking between `WatchNowPlayingHelper` and `NowPlayingHelper` was copy-pasted in six places; it now lives in `clearNowPlayingInfo()`, `setAllNowPlayingInfo(for:)` and `updateNowPlayingProgress(for:)`.
- **Deduplicate two copy-pasted bodies** — `fireProgressNotification` wrote the same two statements once per branch, and `shortUserAttributedMessage` built the same font three times.
- **Simplify redundant expressions** — comparisons against boolean literals, longhand arithmetic assignment, locals that are only passed straight on, if/else pairs assigning the same property, and a hand-written `firstIndex` predicate.
- **Fix the `deactiveAudioSession` typo** — all five references are local to this file.

Net −152/+97 lines.

## To test

No-op refactor, so this is a regression sweep over the paths that were touched:

1. Play an episode, pause, skip forward/back and scrub — playback, the progress bar and the player UI behave as before.
2. Watch the Lock Screen / Control Center now playing info as you play, pause and switch episodes; confirm it clears once the last episode in Up Next finishes.
3. With headphones or a car stereo connected, use the remote play/pause, next/previous and skip controls, and the mark-played / star actions.
4. Connect to AirPlay, then to a Chromecast device, and confirm playback hands over to the right player each time.
5. Change playback speed with the +/− buttons and via Siri ("set playback speed to 1.5x").
6. Trigger a playback failure (turn on airplane mode mid-stream) and confirm the error message and its "Learn more" link still render.
7. Start a sleep timer and let it run down, and separately set "end of episode" — both still fire.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
