### PR TITLE
Detect AirPlay anywhere in the current route outputs

### DIFF
--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -1005,7 +1005,7 @@ class PlaybackManager: ServerPlaybackDelegate {
     }
 
     func playingOverAirplay() -> Bool {
-        AVAudioSession.sharedInstance().currentRoute.outputs.first?.portType == .airPlay
+        AVAudioSession.sharedInstance().currentRoute.outputs.contains { $0.portType == .airPlay }
     }
 
     func effects() -> PlaybackEffects {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

`playingOverAirplay()` only inspected `currentRoute.outputs.first`, so a route where AirPlay isn't in the first output slot reported `false`. Switched to `contains` so any AirPlay output in the route counts.

The old behaviour leaked into three places: `EffectsPlayer` could be picked for a route that is actually AirPlaying, the remote-control play command wouldn't take the handoff path, and `handleRouteChange` wouldn't perform the player switch.

Stacked on #4991 — review that one first; this is the only commit here.

## To test

Practically unchanged for single-output routes; the fix targets the multi-output case.

1. Play an episode with Trim Silence on, so `EffectsPlayer` is in use.
2. Send audio to an AirPlay target (Apple TV or a HomePod).
3. Confirm playback keeps working and switches to `DefaultPlayer` — scrub, pause, and resume over the AirPlay route.
4. Return to the local route and confirm playback continues and `EffectsPlayer` is used again.
5. Use the lock screen / Control Center play and pause buttons while on AirPlay and confirm they behave.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
