### PR TITLE
Fix a crash in navigation bar layout due to the force sizeToFit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 8.20
 -----
 - Fix Listening History search showing "No episodes found" before the search had finished, and results not turning up until the query was retyped when history synced late [#4984](https://github.com/Automattic/pocket-casts-ios/pull/4984)
+- Fix the app freezing and closing itself when creating a Smart Playlist [#4993](https://github.com/Automattic/pocket-casts-ios/pull/4993)
 
 
 8.19

--- a/podcasts/LargeNavBarViewController.swift
+++ b/podcasts/LargeNavBarViewController.swift
@@ -5,7 +5,6 @@ class LargeNavBarViewController: PCViewController {
         changeNavTint(titleColor: nil, iconsColor: AppTheme.colorForStyle(.primaryIcon02))
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationController?.navigationItem.largeTitleDisplayMode = .automatic
-        navigationController?.navigationBar.sizeToFit()
         largeTitleFont = UIFont.font(ofSize: 22, weight: .bold, scalingWith: .title2)
 
         if !LiquidGlass.isEnabled {

--- a/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
+++ b/podcasts/New Creation/New Playlist/NewPlaylistViewController.swift
@@ -150,7 +150,6 @@ class NewPlaylistViewController: PCViewController {
         ]
         navigationController?.navigationBar.scrollEdgeAppearance = appearance
         navigationController?.navigationBar.standardAppearance = appearance
-        navigationController?.navigationBar.sizeToFit()
     }
 
     private func setupContent() {
@@ -210,8 +209,6 @@ class NewPlaylistViewController: PCViewController {
         }
 
         NSLayoutConstraint.activate(constraints)
-
-        view.layoutSubviews()
     }
 
     private func addCloseButton() {

--- a/podcasts/New Creation/New Preview/PlaylistPreviewViewController.swift
+++ b/podcasts/New Creation/New Preview/PlaylistPreviewViewController.swift
@@ -168,8 +168,6 @@ class PlaylistPreviewViewController: PCViewController {
                 list.bottomAnchor.constraint(equalTo: footerView.topAnchor)
             ])
         }
-
-        view.layoutSubviews()
     }
 
     private func setupSaveButtonTitle() {

--- a/podcasts/New Detail/Custom Order/PlaylistDetailCustomOrderViewController.swift
+++ b/podcasts/New Detail/Custom Order/PlaylistDetailCustomOrderViewController.swift
@@ -62,7 +62,6 @@ class PlaylistDetailCustomOrderViewController: PCViewController {
             ]
             navigationController?.navigationBar.scrollEdgeAppearance = appearance
             navigationController?.navigationBar.standardAppearance = appearance
-            navigationController?.navigationBar.sizeToFit()
         }
     }
 
@@ -78,8 +77,6 @@ class PlaylistDetailCustomOrderViewController: PCViewController {
             tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0),
             tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0)
         ])
-
-        view.layoutSubviews()
 
         insetAdjuster.setupInsetAdjustmentsForMiniPlayer(scrollView: tableView)
     }

--- a/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
+++ b/podcasts/New Detail/Episode Add/ManualPlaylistsChooserViewController.swift
@@ -102,7 +102,6 @@ class ManualPlaylistsChooserViewController: PCViewController {
             ]
             navigationController?.navigationBar.scrollEdgeAppearance = appearance
             navigationController?.navigationBar.standardAppearance = appearance
-            navigationController?.navigationBar.sizeToFit()
         }
     }
 
@@ -138,8 +137,6 @@ class ManualPlaylistsChooserViewController: PCViewController {
             tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0),
             tableView.bottomAnchor.constraint(equalTo: footerView.topAnchor, constant: 0)
         ])
-
-        view.layoutSubviews()
 
         allManualPlaylists = dataManager.allManualPlaylists(includeDeleted: false)
         manualPlaylists = allManualPlaylists

--- a/podcasts/New Detail/PlaylistDetailViewController.swift
+++ b/podcasts/New Detail/PlaylistDetailViewController.swift
@@ -306,8 +306,6 @@ class PlaylistDetailViewController: PCViewController, UIScrollViewDelegate {
             multiSelectFooterBottomConstraint,
             multiSelectFooter.heightAnchor.constraint(equalToConstant: 64),
         ])
-
-        view.layoutSubviews()
     }
 
     private func updateColors() {

--- a/podcasts/PodcastFilterOverlayController.swift
+++ b/podcasts/PodcastFilterOverlayController.swift
@@ -74,7 +74,6 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
         podcastTable.sectionHeaderTopPadding = 0
 
         setupNavBar()
-        navigationController?.navigationBar.sizeToFit()
         viewModel = SmartRuleToggleViewModel(
             toggleIsOn: filterToEdit.filterAllPodcasts,
             title: L10n.playlistSmartRulePodcastsHeaderTitle,
@@ -154,8 +153,6 @@ class PodcastFilterOverlayController: PodcastChooserViewController, PodcastSelec
 
             podcastTable.bottomAnchor.constraint(equalTo: footerView.topAnchor)
         ])
-
-        view.layoutSubviews()
     }
 
     private func setupSaveButtonTitle() {

--- a/podcasts/StarredFilterOverlayController.swift
+++ b/podcasts/StarredFilterOverlayController.swift
@@ -85,7 +85,6 @@ class StarredFilterOverlayController: PCViewController {
             ]
             navigationController?.navigationBar.scrollEdgeAppearance = appearance
             navigationController?.navigationBar.standardAppearance = appearance
-            navigationController?.navigationBar.sizeToFit()
         }
     }
 
@@ -147,8 +146,6 @@ class StarredFilterOverlayController: PCViewController {
             tableView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0),
             tableView.bottomAnchor.constraint(equalTo: footerView.topAnchor, constant: 0)
         ])
-
-        view.layoutSubviews()
     }
 
     private func setupSaveButtonTitle() {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Related to PCIOS-887 (not confirmed to fix it — see below).

The playlist screens drove UIKit layout by hand in two ways, both unsupported:

- `navigationController?.navigationBar.sizeToFit()` (6 sites). `UINavigationController` owns its bar's frame and computes its height itself; resizing the bar behind its back desynchronises it from the controller's cached heights. Two of these ran unconditionally on iOS 26.
- `view.layoutSubviews()` (7 sites), which the docs say to never call directly.

Removing both is behaviour-preserving: I rendered the New Playlist screen, the smart playlist preview, and the podcast/download/starred rule editors before and after, and the five images are byte-identical.

### On PCIOS-887

**I could not reproduce the hang, and this PR is not a confirmed fix for it.** The report's stack (`_layoutHeightsForNavigationItem:fittingWidth:` → `_traitCollectionByModifyingTraitsCopyOnWrite:` → `_Block_copy`) is `UINavigationController`'s bar-height computation running hot, which points at a layout feedback loop. I drove the whole creation flow in a harness looking for one and found none:

- both creation screens, standalone and presented modally
- 393pt / 320pt / landscape × Dynamic Type from `.large` to `.accessibilityExtraExtraExtraLarge`
- the smart playlist tooltip popover
- preview mode with a rule applied
- all seven rule editors pushed onto the stack

Every case settled, with zero layout passes once idle. So this PR removes the code in that flow that pokes at the subsystem in the crash stack, on its own merits — it is a plausible contributor, not a demonstrated cause.

To actually confirm the root cause we need the **full hang report** (all threads; the ticket has a 4-frame excerpt, which isn't enough to tell a layout loop from a deadlock) and the **user's database export**, already requested. The flow's only data-dependent main-thread work scales with library size, and the test database is empty — that's the dimension the harness can't cover.

## To test

Everything below should behave exactly as it does on `trunk`; this is a no-visual-change PR.

1. Playlists tab → **+** → confirm the New Playlist screen's nav bar looks right.
2. Tap **Smart Playlist** → confirm the preview screen's nav bar looks right.
3. Open each rule (Podcasts, Episode status, Release date, Download status, Media type, Starred, Duration) and confirm each large title renders correctly and scrolls normally.
4. Save the playlist, open it, and check the detail screen plus **Reorder** (custom order screen).
5. From an episode row, **Add to Playlist → New Playlist** and confirm that chooser's nav bar.
6. Repeat step 3 with a large Dynamic Type size set in Settings → Accessibility.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
