### PR TITLE
Remove four feature flags with no remaining references

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -54,11 +54,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enables the referrals Claim Flow
     case referralsClaim
 
-    /// When accessing Stats, it checks if the local stats are behind remote
-    /// If it is, it updates it
-    /// This is meant to fix an issue for users that were losing stats
-    case syncStats
-
     /// Uses the `isReadyToPlay` function to decide what logic to use when skipping.
     /// There's some scenario when the Default player switched to the Effects player when the stream is paused.
     /// This makes the skip unusable as the player doesn't have its task set yet.
@@ -201,9 +196,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Upgrades the Effects Player's AudioReadTask to a QOS level of "userInitiated" from "default"
     case effectsPlayerQOSUpgrade
 
-    /// Refreshes by listening to notifications for podcast subscribe/unsubscribe
-    case refreshPlaylistOnSubscriptions
-
     /// Uses the PlaylistMetadataLoader cache before running the query (the query will update when it's done)
     case playlistDataCacheBeforeQuery
 
@@ -276,9 +268,6 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// Show the listening activity heatmap on the Stats screen
     case statsHeatmap
-    /// If enabled, send explicit watch-related error logs to Sentry.
-    /// This does not control automatic crash reporting.
-    case watchSentryLogs
 
     /// Show explicit content badges on podcasts
     case showExplicitBadges
@@ -303,9 +292,6 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// Use best frame when capturing a thumbnail for video cells
     case captureBestFrame
-
-    /// Show the Categories and Curated rows on the tvOS Home screen
-    case tvHomeCategoriesAndCurated
 
     /// Make the tab bar's minimize-on-scroll behavior opt-in: it's off unless the
     /// user turns it on in Appearance
@@ -362,8 +348,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .referralsClaim:
             true
         case .referralsSend:
-            true
-        case .syncStats:
             true
         case .playerIsReadyToPlay:
             true
@@ -457,8 +441,6 @@ public enum FeatureFlag: String, CaseIterable {
 			true
         case .effectsPlayerQOSUpgrade:
             true
-        case .refreshPlaylistOnSubscriptions:
-            true
         case .playlistDataCacheBeforeQuery:
             true
         case .ignorePlayWithOtherAudio:
@@ -507,8 +489,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .statsHeatmap:
             true
-        case .watchSentryLogs:
-            false
         case .showExplicitBadges:
             true
         case .shareProfile:
@@ -525,8 +505,6 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .captureBestFrame:
             true
-        case .tvHomeCategoriesAndCurated:
-            false
         case .minimizeTabsOptIn:
             true
         case .smartBookmarksPromo:


### PR DESCRIPTION
Removes four `FeatureFlag` cases that have no references anywhere in the codebase — the code they used to gate is already gone, so they only added noise to the enum and the debug override screen.

| Flag | Added | Why it's dead |
|---|---|---|
| `syncStats` | 2024-08 | call site removed long ago |
| `refreshPlaylistOnSubscriptions` | 2025-12 | never referenced after it was added |
| `watchSentryLogs` | 2026-04 | orphaned by aaf62e7d9, which replaced Sentry logging with file logging |
| `tvHomeCategoriesAndCurated` | 2026-07 | `false` and never referenced from the TV app |

Verified with `git grep` that neither the cases nor their snake-cased remote config keys appear in any tracked file. No behaviour change: three of the four were unreachable, and the fourth (`watchSentryLogs`) defaulted to `false`.

`tvHomeCategoriesAndCurated` is the one worth a look — it was only added three weeks ago in cbb39704f and defaults to `false`, so if the Categories/Curated rows are still in flight for the TV app, say the word and I'll drop it from this PR.

## To test

This is a code-only cleanup with no user-facing behaviour change.

1. Build and run the app.
2. Open Profile → Settings → scroll to the bottom → tap the version row repeatedly to reveal the debug tools, then open the Feature Flags screen.
3. Confirm the list renders and no longer contains **syncStats**, **refreshPlaylistOnSubscriptions**, **watchSentryLogs**, or **tvHomeCategoriesAndCurated**.
4. Toggle any remaining flag on and off to confirm overrides still persist.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
