### PR TITLE
Remove nine feature flags that have shipped enabled

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/EpisodeDataManager.swift
@@ -916,14 +916,8 @@ class EpisodeDataManager {
         dbQueue.write { db in
             do {
                 db.beginTransaction()
-                if FeatureFlag.markAllSyncedInSingleStatement.enabled {
-                    let ids = episodes.map({"\($0.id)"})
-                    try db.executeUpdate("UPDATE \(DataManager.episodeTableName) SET playingStatusModified = 0, playedUpToModified = 0, durationModified = 0, keepEpisodeModified = 0, archivedModified = 0 WHERE id IN (\(ids.joined(separator: ",")))", values: nil)
-                } else {
-                    for episode in episodes {
-                        try db.executeUpdate("UPDATE \(DataManager.episodeTableName) SET playingStatusModified = 0, playedUpToModified = 0, durationModified = 0, keepEpisodeModified = 0, archivedModified = 0 WHERE id = ?", values: [episode.id])
-                    }
-                }
+                let ids = episodes.map({"\($0.id)"})
+                try db.executeUpdate("UPDATE \(DataManager.episodeTableName) SET playingStatusModified = 0, playedUpToModified = 0, durationModified = 0, keepEpisodeModified = 0, archivedModified = 0 WHERE id IN (\(ids.joined(separator: ",")))", values: nil)
                 db.commit()
             } catch {
                 FileLog.shared.addMessage("EpisodeDataManager.markAllSynced error: \(error)")
@@ -939,13 +933,7 @@ class EpisodeDataManager {
         dbQueue.write { db in
             do {
                 db.beginTransaction()
-                if FeatureFlag.markAllSyncedInSingleStatement.enabled {
-                    try db.executeUpdate("UPDATE \(DataManager.episodeTableName) SET playingStatusModified = 0, playedUpToModified = 0, durationModified = 0, keepEpisodeModified = 0, archivedModified = 0 WHERE uuid IN (\(ids.map { "'\($0)'"}.joined(separator: ",")))", values: nil)
-                } else {
-                    for episodeId in ids {
-                        try db.executeUpdate("UPDATE \(DataManager.episodeTableName) SET playingStatusModified = 0, playedUpToModified = 0, durationModified = 0, keepEpisodeModified = 0, archivedModified = 0 WHERE uuid = ?", values: ["'\(episodeId)'"])
-                    }
-                }
+                try db.executeUpdate("UPDATE \(DataManager.episodeTableName) SET playingStatusModified = 0, playedUpToModified = 0, durationModified = 0, keepEpisodeModified = 0, archivedModified = 0 WHERE uuid IN (\(ids.map { "'\($0)'"}.joined(separator: ",")))", values: nil)
                 db.commit()
             } catch {
                 FileLog.shared.addMessage("EpisodeDataManager.markAllSynced error: \(error)")

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -23,27 +23,11 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the AVExportSession parallel download of any playing episode
     case streamAndCachePlayingEpisode
 
-    /// When enabled it updates the code on filter callback to use a safer method to convert unmanaged player references
-    /// This is to fix this: https://a8c.sentry.io/share/issue/39a6d2958b674ec3b7a4d9248b4b5ffa/
-    case defaultPlayerFilterCallbackFix
-
-    /// When a user sign in, we always mark ALL podcasts as unsynced
-    /// This recently caused issues, syncing changes that shouldn't have been synced
-    /// When `true`, we only mark podcasts as unsynced if the user never signed in before
-    case onlyMarkPodcastsUnsyncedForNewUsers
-
     /// Enables the Kids banner
     case kidsProfile
 
     /// Enable the new Upgrade Experiments
     case upgradeExperiment
-
-    /// When enabled, we ignore audio interruptions with InterruptionReason set to routeDisconnected
-    /// (introduced in iOS 17 and watchOS 10) because these are not really interruptions as we have
-    /// implemented them previously. If the route is disconnected, audio stops indefinitely
-    /// until a new route connects (for which we'll received a different notification and handle accordingly)
-    /// See: https://github.com/Automattic/pocket-casts-ios/issues/2049
-    case ignoreRouteDisconnectedInterruption
 
     /// Enable the Referrals feature
     case referrals
@@ -53,19 +37,6 @@ public enum FeatureFlag: String, CaseIterable {
 
     /// Enables the referrals Claim Flow
     case referralsClaim
-
-    /// Uses the `isReadyToPlay` function to decide what logic to use when skipping.
-    /// There's some scenario when the Default player switched to the Effects player when the stream is paused.
-    /// This makes the skip unusable as the player doesn't have its task set yet.
-    /// If the player is not ready to play, we should use the same logic we use when the player doesn't exist yet.
-    case playerIsReadyToPlay
-
-    /// Use the Mimetype library to check the file mimetype
-    case useMimetypePackage
-
-    /// Enable the Segmented Control into the Effects Player panel
-    /// to apply the Global or local settings
-    case customPlaybackSettings
 
     /// Run a vacuum process on the database in order to optimize data fetch
     case runVacuumOnVersionUpdate
@@ -82,17 +53,8 @@ public enum FeatureFlag: String, CaseIterable {
     /// Replace Subscribe/Unsubscribe with Follow/Unfollow
     case useFollowNaming
 
-    /// Use a cookie to manage `MTAudioProcessingTap` deallocation
-    case useDefaultPlayerTapCookie
-
-    /// Use single update query to mark all episodes selected synced
-    case markAllSyncedInSingleStatement
-
     /// Enable the winback screen and flow
     case winback
-
-    /// Show Manage Downloaded episode banner/modal when running in low space in the device
-    case manageDownloadedEpisodes
 
     /// Enable/Disable the podcast feed reload feature
     case podcastFeedUpdate
@@ -333,27 +295,15 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .streamAndCachePlayingEpisode:
             true
-        case .defaultPlayerFilterCallbackFix:
-            true
-        case .onlyMarkPodcastsUnsyncedForNewUsers:
-            true
         case .kidsProfile:
             false
         case .upgradeExperiment:
             false
-        case .ignoreRouteDisconnectedInterruption:
-            true
         case .referrals:
             true
         case .referralsClaim:
             true
         case .referralsSend:
-            true
-        case .playerIsReadyToPlay:
-            true
-        case .useMimetypePackage:
-            true
-        case .customPlaybackSettings:
             true
         case .runVacuumOnVersionUpdate:
             false
@@ -365,14 +315,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .useFollowNaming:
             true
-        case .useDefaultPlayerTapCookie:
-            true
-        case .markAllSyncedInSingleStatement:
-            true
         case .winback:
             true
-        case .manageDownloadedEpisodes:
-			true
         case .podcastFeedUpdate:
             true
         case .downloadsThreadSafeCache:
@@ -520,8 +464,6 @@ public enum FeatureFlag: String, CaseIterable {
         switch self {
         case .newAccountUpgradePromptFlow:
             "new_account_upgrade_prompt_flow"
-        case .defaultPlayerFilterCallbackFix:
-            "default_player_filter_callback_fix"
         case .endOfYear2025:
             "end_of_year_2025"
         default:

--- a/podcasts/AuthenticationHelper.swift
+++ b/podcasts/AuthenticationHelper.swift
@@ -67,8 +67,7 @@ class AuthenticationHelper {
 
         // we've signed in, set all our existing podcasts to
         // be non synced if the user never logged in before
-        if (FeatureFlag.onlyMarkPodcastsUnsyncedForNewUsers.enabled && ServerSettings.lastSyncTime == nil)
-            || !FeatureFlag.onlyMarkPodcastsUnsyncedForNewUsers.enabled {
+        if ServerSettings.lastSyncTime == nil {
             DataManager.sharedManager.markAllPodcastsUnsynced()
         }
 

--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -428,15 +428,9 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
     }
 
     private static func unretainedDefaultPlayer(for pointer: UnsafeMutableRawPointer) -> DefaultPlayer? {
-        if FeatureFlag.useDefaultPlayerTapCookie.enabled {
-            let cookie = Unmanaged<AudioProcessingTapProxy>.fromOpaque(pointer).takeUnretainedValue()
-            guard let player = cookie.input else { return nil }
-            return player
-        } else if FeatureFlag.defaultPlayerFilterCallbackFix.enabled {
-            return Unmanaged<DefaultPlayer>.fromOpaque(pointer).takeUnretainedValue()
-        } else {
-            return unsafeBitCast(pointer, to: DefaultPlayer.self)
-        }
+        let cookie = Unmanaged<AudioProcessingTapProxy>.fromOpaque(pointer).takeUnretainedValue()
+        guard let player = cookie.input else { return nil }
+        return player
     }
 
         private func createAudioMix() {
@@ -445,11 +439,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             let mutableMix = AVMutableAudioMix()
             let audioMixInputParameters = AVMutableAudioMixInputParameters(track: assetTrack)
 
-            var clientInfo = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
-            if FeatureFlag.useDefaultPlayerTapCookie.enabled {
-                let tapCookie = AudioProcessingTapProxy(input: self)
-                clientInfo = UnsafeMutableRawPointer(Unmanaged.passRetained(tapCookie).toOpaque())
-            }
+            let tapCookie = AudioProcessingTapProxy(input: self)
+            let clientInfo = UnsafeMutableRawPointer(Unmanaged.passRetained(tapCookie).toOpaque())
 
             var callbacks = MTAudioProcessingTapCallbacks(
                 version: kMTAudioProcessingTapCallbacksVersion_0,
@@ -495,10 +486,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         }
 
         let tapFinalize: MTAudioProcessingTapFinalizeCallback = { tap in
-            if FeatureFlag.useDefaultPlayerTapCookie.enabled {
-                FileLog.shared.console("[AudioProcessingTapProxy] Finalize tap: \(tap)\n")
-                Unmanaged<AudioProcessingTapProxy>.fromOpaque(MTAudioProcessingTapGetStorage(tap)).release()
-            }
+            FileLog.shared.console("[AudioProcessingTapProxy] Finalize tap: \(tap)\n")
+            Unmanaged<AudioProcessingTapProxy>.fromOpaque(MTAudioProcessingTapGetStorage(tap)).release()
         }
 
         let tapPrepare: MTAudioProcessingTapPrepareCallback = { tap, maxFrames, processingFormat in
@@ -669,13 +658,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             guard AudioUnitSetProperty(createdUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &format, UInt32(MemoryLayout<AudioStreamBasicDescription>.stride)) == noErr else { return nil }
 
             // Set audio unit render callback
-            var renderCallback: AURenderCallbackStruct
-            if FeatureFlag.useDefaultPlayerTapCookie.enabled {
-                let inputProcRefCon = Unmanaged<AudioProcessingTapProxy>.fromOpaque(MTAudioProcessingTapGetStorage(tap))
-                renderCallback = AURenderCallbackStruct(inputProc: referenceToSelf.peakLimiterRenderCallback, inputProcRefCon: inputProcRefCon.toOpaque())
-            } else {
-                renderCallback = AURenderCallbackStruct(inputProc: peakLimiterRenderCallback, inputProcRefCon: Unmanaged.passUnretained(self).toOpaque())
-            }
+            let inputProcRefCon = Unmanaged<AudioProcessingTapProxy>.fromOpaque(MTAudioProcessingTapGetStorage(tap))
+            var renderCallback = AURenderCallbackStruct(inputProc: referenceToSelf.peakLimiterRenderCallback, inputProcRefCon: inputProcRefCon.toOpaque())
 
             guard AudioUnitSetProperty(createdUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &renderCallback, UInt32(MemoryLayout<AURenderCallbackStruct>.stride)) == noErr else { return nil }
 
@@ -731,13 +715,8 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
             guard AudioUnitSetProperty(createdUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Output, 0, &format, UInt32(MemoryLayout<AudioStreamBasicDescription>.stride)) == noErr else { return nil }
 
             // Set audio unit render callback
-            var renderCallback: AURenderCallbackStruct
-            if FeatureFlag.useDefaultPlayerTapCookie.enabled {
-                let inputProcRefCon = Unmanaged<AudioProcessingTapProxy>.fromOpaque(MTAudioProcessingTapGetStorage(tap))
-                renderCallback = AURenderCallbackStruct(inputProc: referenceToSelf.highPassFilterRenderCallback, inputProcRefCon: inputProcRefCon.toOpaque())
-            } else {
-                renderCallback = AURenderCallbackStruct(inputProc: highPassFilterRenderCallback, inputProcRefCon: Unmanaged.passUnretained(self).toOpaque())
-            }
+            let inputProcRefCon = Unmanaged<AudioProcessingTapProxy>.fromOpaque(MTAudioProcessingTapGetStorage(tap))
+            var renderCallback = AURenderCallbackStruct(inputProc: referenceToSelf.highPassFilterRenderCallback, inputProcRefCon: inputProcRefCon.toOpaque())
             guard AudioUnitSetProperty(createdUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Input, 0, &renderCallback, UInt32(MemoryLayout<AURenderCallbackStruct>.stride)) == noErr else { return nil }
 
             // Set audio unit maximum frames per slice to max frames

--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -173,13 +173,9 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
     }
 
     func processEpisode(_ episode: BaseEpisode, downloadedFile location: URL, reportedContentType: String?, copyFile: Bool) {
-        var contentType = reportedContentType
-
-        if FeatureFlag.useMimetypePackage.enabled {
-            contentType = MimetypeHelper.contetType(for: location)
-            if let contentType, contentType != episode.contentType {
-                DataManager.sharedManager.saveEpisode(contentType: contentType, episode: episode)
-            }
+        let contentType = MimetypeHelper.contetType(for: location)
+        if let contentType, contentType != episode.contentType {
+            DataManager.sharedManager.saveEpisode(contentType: contentType, episode: episode)
         }
 
         let fileSize = FileManager.default.fileSize(of: location) ?? 0

--- a/podcasts/EffectsViewController.swift
+++ b/podcasts/EffectsViewController.swift
@@ -189,7 +189,7 @@ class EffectsViewController: SimpleNotificationsViewController {
         #if APPCLIP
         false
         #else
-        FeatureFlag.customPlaybackSettings.enabled
+        true
         #endif
     }
 

--- a/podcasts/ManageDownloadsCoordinator.swift
+++ b/podcasts/ManageDownloadsCoordinator.swift
@@ -6,8 +6,7 @@ import PocketCastsUtils
 class ManageDownloadsCoordinator {
 
     static var shouldShowBanner: Bool {
-        guard FeatureFlag.manageDownloadedEpisodes.enabled,
-              let percentage = FileManager.devicePercentageFreeSpace,
+        guard let percentage = FileManager.devicePercentageFreeSpace,
               EpisodeManager.hasDownloadedEpisodes()
         else {
             return false

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -561,8 +561,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         seekingTo = time
         FileLog.shared.addMessage("seek to \(time) startPlaybackAfterSeek \(startPlaybackAfterSeek)")
 
-        let isReadyToPlay = FeatureFlag.playerIsReadyToPlay.enabled ? (player?.isReadyToPlay() == true) : true
-        if let player, isReadyToPlay {
+        if let player, player.isReadyToPlay() {
             player.seekTo(time, completion: { [weak self] () in
                 guard let strongSelf = self else { return }
 
@@ -2353,14 +2352,7 @@ class PlaybackManager: ServerPlaybackDelegate {
             // subsequent InterruptionType.ended notification, to set interruptInProgress correctly.
             // When routes are disconnected, there is no associated end event though. If the route reconnects, we'll
             // receive a different notification which is already handled elsewhere.
-            // Also put this new check behind a feature flag so we can remotely revert to the old logic if
-            // we run into any issues
-            if FeatureFlag.ignoreRouteDisconnectedInterruption.enabled {
-                if interruptionReason != AVAudioSession.InterruptionReason.routeDisconnected.rawValue {
-                    interruptInProgress = true
-                }
-            } else {
-                // Default to the old behaviour if the feature flag is disabled.
+            if interruptionReason != AVAudioSession.InterruptionReason.routeDisconnected.rawValue {
                 interruptInProgress = true
             }
 

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController+Table.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastEffectsViewController+Table.swift
@@ -147,7 +147,7 @@ extension PodcastEffectsViewController: UITableViewDataSource, UITableViewDelega
         #if APPCLIP
         false
         #else
-        FeatureFlag.customPlaybackSettings.enabled
+        true
         #endif
     }
 

--- a/podcasts/Syncing/SyncSigninView.swift
+++ b/podcasts/Syncing/SyncSigninView.swift
@@ -311,8 +311,7 @@ final class SyncSigninViewModel: ObservableObject {
         ServerSettings.userId = userId
         ServerSettings.saveSyncingPassword(password)
 
-        if (FeatureFlag.onlyMarkPodcastsUnsyncedForNewUsers.enabled && ServerSettings.lastSyncTime == nil)
-            || !FeatureFlag.onlyMarkPodcastsUnsyncedForNewUsers.enabled {
+        if ServerSettings.lastSyncTime == nil {
             DataManager.sharedManager.markAllPodcastsUnsynced()
         }
 

--- a/podcasts/Syncing/SyncSigninViewController.swift
+++ b/podcasts/Syncing/SyncSigninViewController.swift
@@ -329,8 +329,7 @@ class SyncSigninViewController: PCViewController, UITextFieldDelegate {
 
         // we've signed in, set all our existing podcasts to
         // be non synced if the user never logged in before
-        if (FeatureFlag.onlyMarkPodcastsUnsyncedForNewUsers.enabled && ServerSettings.lastSyncTime == nil)
-            || !FeatureFlag.onlyMarkPodcastsUnsyncedForNewUsers.enabled {
+        if ServerSettings.lastSyncTime == nil {
             DataManager.sharedManager.markAllPodcastsUnsynced()
         }
 


### PR DESCRIPTION
Follow-up to #4994. Removes nine feature flags that have defaulted to `true` since 2024 — the enabled branch is inlined and the dead fallback deleted.

| Flag | Added | What the removed fallback did |
|---|---|---|
| `useDefaultPlayerTapCookie` | 2024-11 | passed an unretained `self` as the tap's `clientInfo` |
| `defaultPlayerFilterCallbackFix` | 2024-05 | `unsafeBitCast` of the tap storage pointer |
| `onlyMarkPodcastsUnsyncedForNewUsers` | 2024-05 | marked all podcasts unsynced on every sign-in |
| `ignoreRouteDisconnectedInterruption` | 2024-08 | treated a route disconnect as a real interruption |
| `playerIsReadyToPlay` | 2024-09 | seeked without checking `isReadyToPlay()` |
| `useMimetypePackage` | 2024-09 | trusted the HTTP `Content-Type` header |
| `customPlaybackSettings` | 2024-10 | hid the global/local segmented control in Effects |
| `markAllSyncedInSingleStatement` | 2024-11 | one `UPDATE` per episode instead of a single `IN (…)` |
| `manageDownloadedEpisodes` | 2024-11 | hid the low-storage banner/modal |

Notes:

- The two `DefaultPlayer` flags were a chained `if/else if/else`, so they're removed together — `unretainedDefaultPlayer(for:)` collapses to the cookie lookup.
- `customPlaybackSettings` was read inside an `#if APPCLIP` guard; the property stays so the App Clip keeps returning `false`.
- The removed `markAllSynced(episodeIDs:)` fallback bound `"'\(episodeId)'"` — quotes included — so it never matched a row. Only the surviving single-statement path is correct.
- `processEpisode`'s `reportedContentType` parameter is now unused, since the mimetype lookup always overwrites it. Unwinding it also means removing `ExportStatus.reportedType` and changing the media exporter callback, so I left it for a separate PR rather than widening this one.

## To test

Regression testing around the code these flags gated; none of it should behave differently, since all nine were already on in production.

1. **Playback effects** — play an episode, open the Effects panel, and confirm the Global/Local segmented control appears. Repeat from a podcast's Settings → Playback Effects.
2. **Audio processing** — enable Trim Silence and Volume Boost, play for a minute, then skip between episodes several times. Audio stays clean and no crash on episode change (this exercises the tap cookie path).
3. **Interruptions** — play audio over Bluetooth headphones and power them off. Playback pauses and does not resume unexpectedly when they reconnect.
4. **Seeking** — start streaming an episode, pause it immediately, then scrub the scrubber. The seek takes effect rather than being ignored.
5. **Downloads** — download an episode and confirm it plays; a feed serving a wrong `Content-Type` should still download successfully.
6. **Sign-in** — sign in on a fresh install and confirm podcasts sync up. Sign out and back in on the same device; existing podcasts should not be re-marked unsynced.
7. **Low storage** — with the device near full and downloaded episodes present, confirm the Manage Downloads banner still appears.

Automated: `DownloadManagerTests` (2 tests) and `PocketCastsDataModelTests/PodcastDataManagerTests` (68 tests) pass.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
