### PR TITLE
Update the app icon badge after a background refresh, not before it starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Tapping a Discover collection's poster now opens the expanded collection, the same as tapping "Show All" [#5028](https://github.com/Automattic/pocket-casts-ios/pull/5028)
 - Add support for "Networks" row in "Discover" [#5026](https://github.com/Automattic/pocket-casts-ios/pull/5026)
 - Fix the Download button doing nothing in Search and Discover episode results [#4702](https://github.com/Automattic/pocket-casts-ios/pull/4702)
+- Fix the app icon badge showing a stale count after a background refresh: the badge is now updated once the refresh has finished instead of before it starts [#4996](https://github.com/Automattic/pocket-casts-ios/pull/4996)
 
 8.19
 -----

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -261,6 +261,10 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the network discovery Discover sections and podcast page entry points
     case networkDiscovery
 
+    /// Update the app icon badge after a background refresh finishes, rather than before it starts,
+    /// and wait for the badge write to land before signalling the background task as complete
+    case updateBadgeAfterBackgroundRefresh
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -445,6 +449,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .networkDiscovery:
             BuildEnvironment.current == .debug
+        case .updateBadgeAfterBackgroundRefresh:
+            true
         }
     }
 

--- a/podcasts/AppDelegate.swift
+++ b/podcasts/AppDelegate.swift
@@ -180,10 +180,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // This method will be invoked even if the application was launched or resumed because of the remote notification. The respective delegate methods will be invoked first. Note that this behavior is in contrast to application:didReceiveRemoteNotification:, which is not called in those cases, and which will not be invoked if this method is implemented.
     func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
-        RefreshManager.shared.refreshPodcasts(completion: { refreshFetchResult in
-            completionHandler(self.convertRefreshResult(result: refreshFetchResult))
-        })
-        badgeHelper.updateBadge()
+        if FeatureFlag.updateBadgeAfterBackgroundRefresh.enabled {
+            RefreshManager.shared.refreshPodcasts(completion: { refreshFetchResult in
+                self.badgeHelper.updateBadge {
+                    completionHandler(self.convertRefreshResult(result: refreshFetchResult))
+                }
+            })
+        } else {
+            RefreshManager.shared.refreshPodcasts(completion: { refreshFetchResult in
+                completionHandler(self.convertRefreshResult(result: refreshFetchResult))
+            })
+            badgeHelper.updateBadge()
+        }
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
@@ -284,10 +292,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             FileLog.shared.addMessage("Background refresh timed out")
         }
 
-        RefreshManager.shared.refreshPodcasts(completion: { refreshFetchResult in
-            task.setTaskCompleted(success: refreshFetchResult != .failed)
-        })
-        badgeHelper.updateBadge()
+        if FeatureFlag.updateBadgeAfterBackgroundRefresh.enabled {
+            RefreshManager.shared.refreshPodcasts(completion: { refreshFetchResult in
+                self.badgeHelper.updateBadge {
+                    task.setTaskCompleted(success: refreshFetchResult != .failed)
+                }
+            })
+        } else {
+            RefreshManager.shared.refreshPodcasts(completion: { refreshFetchResult in
+                task.setTaskCompleted(success: refreshFetchResult != .failed)
+            })
+            badgeHelper.updateBadge()
+        }
     }
 
     private func configureFirebase() {

--- a/podcasts/Utilities/BadgeHelper.swift
+++ b/podcasts/Utilities/BadgeHelper.swift
@@ -44,50 +44,47 @@ class BadgeHelper {
         cancelable = nil
     }
 
-    @objc func updateBadge() {
-        guard let badgeSetting = Settings.appBadge else { return }
+    /// - Parameter completion: called once the system has acknowledged the badge write, or immediately if the badge was left untouched.
+    func updateBadge(completion: (() -> Void)? = nil) {
+        guard let badgeCount = badgeCount() else {
+            completion?()
 
-        let pushOn = NotificationsHelper.shared.pushEnabled()
+            return
+        }
 
-        if badgeSetting == .off && !pushOn { return } // user has both the badge and push turned off, don't attempt to badge their app. Results in iOS 8 push message request popup
-
-        if badgeSetting == .off || !pushOn {
-            clearBadge()
-        } else if badgeSetting == .totalUnplayed {
-            let unplayedCount = DataManager.sharedManager.count(query: "SELECT COUNT(e.id) FROM SJEpisode e LEFT JOIN SJPodcast p ON p.id = e.podcast_id WHERE p.subscribed = 1 AND e.playingStatus == 1 AND e.archived = 0", values: nil)
-            setBadgeTo(unplayedCount)
-        } else if badgeSetting == .newSinceLastOpened {
-            guard let lastClosedDate = UserDefaults.standard.object(forKey: Constants.UserDefaults.lastAppCloseDate) as? Date else {
-                clearBadge()
-
-                return
-            }
-
-            let newCount = DataManager.sharedManager.count(query: "SELECT COUNT(e.id) FROM SJEpisode e LEFT JOIN SJPodcast p ON p.id = e.podcast_id WHERE p.subscribed = 1 AND e.playingStatus == 1 AND e.archived = 0 AND e.addedDate > ?", values: [lastClosedDate])
-            setBadgeTo(newCount)
-        } else if badgeSetting == .filterCount {
-            guard let playlistId = Settings.appBadgeFilterUuid else {
-                Settings.appBadge = .off
-
-                return
-            }
-
-            guard let playlist = DataManager.sharedManager.findPlaylist(uuid: playlistId) else {
-                Settings.appBadge = .off
-
-                return
-            }
-
-            let episodeCount = DataManager.sharedManager.episodeCount(for: playlist, episodeUuidToAdd: playlist.episodeUuidToAddToQueries())
-            setBadgeTo(episodeCount)
+        UNUserNotificationCenter.current().setBadgeCount(badgeCount) { _ in
+            completion?()
         }
     }
 
-    private func clearBadge() {
-        UNUserNotificationCenter.current().setBadgeCount(0)
-    }
+    /// The number to badge the app with, or `nil` if the badge shouldn't be touched at all.
+    private func badgeCount() -> Int? {
+        guard let badgeSetting = Settings.appBadge else { return nil }
 
-    private func setBadgeTo(_ badgeNumber: Int) {
-        UNUserNotificationCenter.current().setBadgeCount(badgeNumber)
+        let pushOn = NotificationsHelper.shared.pushEnabled()
+
+        if badgeSetting == .off && !pushOn { return nil } // user has both the badge and push turned off, don't attempt to badge their app. Results in iOS 8 push message request popup
+
+        if !pushOn { return 0 }
+
+        switch badgeSetting {
+        case .off:
+            return 0
+        case .totalUnplayed:
+            return DataManager.sharedManager.count(query: "SELECT COUNT(e.id) FROM SJEpisode e LEFT JOIN SJPodcast p ON p.id = e.podcast_id WHERE p.subscribed = 1 AND e.playingStatus == 1 AND e.archived = 0", values: nil)
+        case .newSinceLastOpened:
+            guard let lastClosedDate = UserDefaults.standard.object(forKey: Constants.UserDefaults.lastAppCloseDate) as? Date else { return 0 }
+
+            return DataManager.sharedManager.count(query: "SELECT COUNT(e.id) FROM SJEpisode e LEFT JOIN SJPodcast p ON p.id = e.podcast_id WHERE p.subscribed = 1 AND e.playingStatus == 1 AND e.archived = 0 AND e.addedDate > ?", values: [lastClosedDate])
+        case .filterCount:
+            guard let playlistId = Settings.appBadgeFilterUuid,
+                  let playlist = DataManager.sharedManager.findPlaylist(uuid: playlistId) else {
+                Settings.appBadge = .off
+
+                return nil
+            }
+
+            return DataManager.sharedManager.episodeCount(for: playlist, episodeUuidToAdd: playlist.episodeUuidToAddToQueries())
+        }
     }
 }

--- a/podcasts/Utilities/BadgeHelper.swift
+++ b/podcasts/Utilities/BadgeHelper.swift
@@ -81,7 +81,7 @@ class BadgeHelper {
                   let playlist = DataManager.sharedManager.findPlaylist(uuid: playlistId) else {
                 Settings.appBadge = .off
 
-                return nil
+                return 0
             }
 
             return DataManager.sharedManager.episodeCount(for: playlist, episodeUuidToAdd: playlist.episodeUuidToAddToQueries())


### PR DESCRIPTION
Fixes PCIOS-896

Both background refresh paths called `badgeHelper.updateBadge()` right after *starting* the refresh, so the badge was written from pre-refresh counts. The correction relied on `BadgeHelper`'s 3s-debounced `podcastsRefreshed` subscription, which never fires in the background — iOS suspends the process as soon as the completion handler is signalled.

Both paths now badge after the refresh completes and wait for the `setBadgeCount` write before signalling `completionHandler` / `setTaskCompleted`. Behind `FeatureFlag.updateBadgeAfterBackgroundRefresh`.

`BadgeHelper.updateBadge` gains an optional completion; the count computation moves into `badgeCount() -> Int?` so there's one write site and one exit path instead of five early returns that could drop it. Behaviour-preserving, not behind the flag.

This doesn't fix the ticket on its own — the pushes carry no `badge` field and don't wake the app, so the badge still only moves when the app gets a background slot. Making it update on notification arrival needs the Notification Service Extension to set `content.badge`.

## To test

1. Profile → Settings → Notifications → App Badge → **Total Unplayed**.
2. Note the badge, background the app, and wait for a new episode to be available.
3. In Xcode, pause and run:
   `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"au.com.shiftyjelly.podcasts.Refresh"]`
4. Resume — the badge should include episodes fetched by *that* refresh.
5. Turn `updateBadgeAfterBackgroundRefresh` off in the developer overrides and repeat: the badge shows the stale pre-refresh count.
6. Confirm the badge still updates in the foreground across each App Badge option.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
