### PR TITLE
Hide the Discover category placeholder pills from VoiceOver

### DIFF
--- a/podcasts/Categories/CategoriesSelectorView.swift
+++ b/podcasts/Categories/CategoriesSelectorView.swift
@@ -51,6 +51,7 @@ struct PlaceholderPillsView: View {
             .frame(alignment: .leading)
             .padding(CategoriesPillsView.Constants.buttonInsets)
         }
+        .accessibilityHidden(true)
     }
 }
 


### PR DESCRIPTION
While the Discover categories load, `PlaceholderPillsView` renders ten skeleton pills. `.redacted(reason: .placeholder)` greys them out visually but does not remove them from the accessibility tree, so VoiceOver announced ten untranslated "Placeholder" buttons before the real categories arrived.

Hiding the placeholder strip from accessibility matches what the bookmark placeholders in `BookmarkDetailsView` and `BookmarkEditView` already do.

## To test

1. Turn on VoiceOver (Settings → Accessibility → VoiceOver).
2. Open the Discover tab. Pull to refresh, or relaunch on a slow/throttled connection so the category pills spend a moment loading.
3. Swipe right through the top of the screen while the grey placeholder pills are showing.
4. VoiceOver should skip straight past them instead of announcing "Placeholder, button" ten times.
5. Once the real categories load, confirm VoiceOver reads each category name as before.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
