### PR TITLE
PCIOS-902: iOS: "You've been signed out" alert repeatedly shown to a user who has never signed in (TOKEN_DEAUTH cleanup loop)

### DIFF
--- a/Modules/Sources/PocketCastsServer/Private/TokenHelper.swift
+++ b/Modules/Sources/PocketCastsServer/Private/TokenHelper.swift
@@ -236,13 +236,17 @@ class TokenHelper {
             logMessages.append("no email address")
         }
 
-        if ServerSettings.syncingPassword() == nil {
+        let hasPassword = ServerSettings.syncingPassword() != nil
+        if !hasPassword {
             logMessages.append("no password")
         }
 
+        var hasRefreshToken = false
         do {
             if try ServerSettings.refreshToken() == nil {
                 logMessages.append("no SSO token")
+            } else {
+                hasRefreshToken = true
             }
         } catch {
             if case let KeychainHelper.KeychainError.status(status) = error, status == errSecInteractionNotAllowed {
@@ -250,6 +254,17 @@ class TokenHelper {
                 FileLog.shared.addMessage("Acquire Token was called, however the user has \(logMessages.joined(separator: ", ")).")
                 return
             }
+        }
+
+        if !hasPassword && !hasRefreshToken {
+            // No valid credentials exist — this is stale keychain data (e.g. from an old
+            // install). Clear it silently instead of calling SyncManager.signout(), which
+            // would show a "You've been signed out" alert that confuses never-signed-in users.
+            FileLog.shared.addMessage("Sync account has stale credentials with no valid auth, cleaning up silently")
+            SyncManager.clearTokensFromKeyChain()
+            ServerSettings.setSyncingEmail(email: nil)
+            ServerSettings.userId = nil
+            return
         }
 
         FileLog.shared.addMessage("Sync account is in a weird state, logging user out")

--- a/PocketCastsTests/Tests/Utilities/TokenHelperTests.swift
+++ b/PocketCastsTests/Tests/Utilities/TokenHelperTests.swift
@@ -13,6 +13,49 @@ fileprivate extension URL {
 
 class TokenHelperTests: XCTestCase {
 
+    override func tearDown() {
+        super.tearDown()
+        SyncManager.clearTokensFromKeyChain()
+        ServerSettings.setSyncingEmail(email: nil)
+        ServerSettings.userId = nil
+    }
+
+    func testTokenCleanUpSilentlyRemovesStaleCredentials() {
+        // Simulate stale keychain state: email exists but no password or refresh token.
+        // This can happen with old installs where the keychain data survives but the
+        // account no longer exists on the server.
+        ServerSettings.setSyncingEmail(email: "stale@example.com")
+        XCTAssertTrue(SyncManager.isUserLoggedIn())
+
+        var signOutNotificationPosted = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .serverUserWillBeSignedOut,
+            object: nil,
+            queue: nil
+        ) { _ in
+            signOutNotificationPosted = true
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let tokenHelper = TokenHelper(urlConnection: URLConnection { _ in
+            throw NSError(domain: "test", code: -1)
+        })
+
+        // acquireToken() must run off the main thread because it internally
+        // dispatches to main to check application state and waits on a semaphore.
+        let expectation = XCTestExpectation(description: "acquireToken completes")
+        var token: String?
+        DispatchQueue.global().async {
+            token = tokenHelper.acquireToken()
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 10)
+
+        XCTAssertNil(token, "Should not acquire a token with stale credentials")
+        XCTAssertFalse(signOutNotificationPosted, "Should not show sign-out alert for stale credentials")
+        XCTAssertFalse(SyncManager.isUserLoggedIn(), "Stale login state should be cleared")
+    }
+
     /// Tests the acquirePasswordToken function
     func testAcquirePasswordToken() {
         ServerSettings.setSyncingEmail(email: "test@test.com")


### PR DESCRIPTION
Resolves https://linear.app/a8c/issue/PCIOS-902/ios-youve-been-signed-out-alert-repeatedly-shown-to-a-user-who-has

## Summary
- When `tokenCleanUp()` runs after a `TOKEN_DEAUTH` error, it now distinguishes between users who have actual credentials (password or SSO refresh token) and users with only stale keychain data (email but no credentials).
- For the stale-credentials case, it silently clears the stale data without calling `SyncManager.signout()`, which prevents the "You've been signed out" alert from being shown to users who were never properly signed in.

## Changes
- `Modules/Sources/PocketCastsServer/Private/TokenHelper.swift` — Modified `tokenCleanUp()` to track whether the user has a password or refresh token. When neither exists, silently clear the stale keychain data (via `SyncManager.clearTokensFromKeyChain()`, `ServerSettings.setSyncingEmail(email: nil)`, and `ServerSettings.userId = nil`) instead of calling `SyncManager.signout()` which posts the `.serverUserWillBeSignedOut` notification and triggers the alert.
- `PocketCastsTests/Tests/Utilities/TokenHelperTests.swift` — Added `testTokenCleanUpSilentlyRemovesStaleCredentials` test that sets up stale keychain state (email only), calls `acquireToken()`, and verifies: (1) no token is returned, (2) the sign-out notification is NOT posted, and (3) the login state is cleared.

## Verification
- **Lint**: PASS
- **Tests**: FAIL — pre-existing GenerateCredentials build script failure prevents test execution locally (not related to this change)
- **Diff review**: PASS — only the 2 intended files modified, no unintended changes

## Confidence
**MEDIUM** — The fix correctly addresses the root cause identified in the issue (stale keychain data triggering the sign-out alert). The logic is straightforward and preserves existing behavior for users who have actual credentials. The uncertainty is that tests could not be run locally due to a pre-existing build configuration issue (missing credentials script), so the new test has not been executed.

---
This PR was created autonomously by linear-solver.
Triage complexity: medium | [Linear issue](https://linear.app/a8c/issue/PCIOS-902/ios-youve-been-signed-out-alert-repeatedly-shown-to-a-user-who-has)