### PR TITLE
Fix crash from concurrent access to DownloadManager download tracking dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix the app freezing and closing itself when creating a Smart Playlist [#4993](https://github.com/Automattic/pocket-casts-ios/pull/4993)
 - Add a Bluesky link to the About screen alongside Website, Instagram and X [#4998](https://github.com/Automattic/pocket-casts-ios/pull/4998)
 - Fix setting the sleep timer through Siri or Shortcuts while the device is locked [#4812](https://github.com/Automattic/pocket-casts-ios/pull/4812)
+- Fix a crash when starting episode downloads [#5001](https://github.com/Automattic/pocket-casts-ios/pull/5001)
 
 8.19
 -----

--- a/PocketCastsTests/Tests/Utilities/ThreadSafeDictionaryTests.swift
+++ b/PocketCastsTests/Tests/Utilities/ThreadSafeDictionaryTests.swift
@@ -17,4 +17,33 @@ final class ThreadSafeDictionaryTests: XCTestCase {
             }
         }
     }
+
+    func testRemoveValueReturnsRemovedValue() {
+        let dictionary = ThreadSafeDictionary<String, String>()
+        dictionary["key"] = "value"
+
+        XCTAssertEqual(dictionary.removeValue(forKey: "key"), "value")
+        XCTAssertNil(dictionary["key"])
+    }
+
+    func testRemoveValueReturnsNilForMissingKey() {
+        let dictionary = ThreadSafeDictionary<String, String>()
+
+        XCTAssertNil(dictionary.removeValue(forKey: "key"))
+    }
+
+    func testConcurrentInsertAndRemoveValue() async {
+        let dictionary = ThreadSafeDictionary<Int, String>()
+
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<10_000 {
+                group.addTask {
+                    dictionary[index] = "\(index)"
+                    dictionary.removeValue(forKey: index)
+                }
+            }
+        }
+
+        XCTAssertFalse(dictionary.contains(where: { _ in true }))
+    }
 }

--- a/podcasts/DownloadManager+SessionManagement.swift
+++ b/podcasts/DownloadManager+SessionManagement.swift
@@ -10,7 +10,9 @@ extension DownloadManager {
         func processBackgroundTaskCallback(task: WKURLSessionRefreshBackgroundTask) {
             if task.sessionIdentifier == DownloadManager.cellBackgroundSessionId {
                 // If there was a previous task for the same identifier let's set it to complete
-                pendingWatchBackgroundTask?.setTaskCompletedWithSnapshot(false)
+                if let pendingWatchBackgroundTask, pendingWatchBackgroundTask !== task {
+                    pendingWatchBackgroundTask.setTaskCompletedWithSnapshot(false)
+                }
                 pendingWatchBackgroundTask = task
             } else {
                 task.setTaskCompletedWithSnapshot(true)

--- a/podcasts/DownloadManager+URLSessionDelegate.swift
+++ b/podcasts/DownloadManager+URLSessionDelegate.swift
@@ -13,9 +13,12 @@ extension DownloadManager: URLSessionDelegate, URLSessionDownloadDelegate {
     // make sure to call the completion handler on the main queue, otherwise it will crash
     func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
 #if os(watchOS)
+        guard session.configuration.identifier == DownloadManager.cellBackgroundSessionId else { return }
+
         DispatchQueue.main.async { [weak self] in
             guard let self, let task = pendingWatchBackgroundTask else { return }
 
+            pendingWatchBackgroundTask = nil
             task.setTaskCompletedWithSnapshot(true)
         }
 #elseif APPCLIP || os(tvOS)

--- a/podcasts/DownloadManager.swift
+++ b/podcasts/DownloadManager.swift
@@ -59,7 +59,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
     }()
 
-    var taskFailure: [String: FailureReason] = [:]
+    let taskFailure = ThreadSafeDictionary<String, FailureReason>()
 
     // MARK: - Download Retry Tracking
     struct DownloadAttempt {
@@ -76,7 +76,7 @@ class DownloadManager: NSObject, FilePathProtocol {
         }
     }
 
-    var downloadAttempts: [Int: DownloadAttempt] = [:]
+    let downloadAttempts = ThreadSafeDictionary<Int, DownloadAttempt>()
 
     #if os(watchOS)
         var pendingWatchBackgroundTask: WKURLSessionRefreshBackgroundTask?

--- a/podcasts/ThreadSafeDictionary.swift
+++ b/podcasts/ThreadSafeDictionary.swift
@@ -26,8 +26,11 @@ class ThreadSafeDictionary<Key: Hashable, Value> {
         }
     }
 
-    func removeValue(forKey key: Key) {
-        updateValue(nil, forKey: key)
+    @discardableResult
+    func removeValue(forKey key: Key) -> Value? {
+        tableLock.lock()
+        defer { tableLock.unlock() }
+        return table.removeValue(forKey: key)
     }
 
     func removeAll() {


### PR DESCRIPTION
Fixes a crash in `DownloadManager` reported as:

```
NSInvalidArgumentException: -[__NSTaggedDate count]: unrecognized selector sent to instance 0x8000000000000000
  libswiftCore  Dictionary._Variant.setValue
  libswiftCore  Dictionary.subscript.setter
  podcasts      DownloadManager.resumeDownload (DownloadManager.swift:781)
  podcasts      DownloadManager.performDownload (DownloadManager.swift:582)
  podcasts      DownloadManager.performAddToQueue (DownloadManager.swift:528)
```

`DownloadManager.downloadAttempts` and `DownloadManager.taskFailure` were plain Swift `Dictionary` values mutated without any synchronisation from several threads at once:

- `resumeDownload(...)` writes `downloadAttempts` from whatever thread `performDownload` is resumed on (a cooperative pool thread, since `addToQueue` awaits `GeneratedEpisodeMetadataRetriever.loadMetadata` first).
- The `URLSessionDownloadDelegate` callbacks (`didCompleteWithError`, `didFinishDownloadingTo`, `markEpisode(_:asFailedWithMessage:reason:)`) read and remove entries from both dictionaries. `DownloadManager` owns three sessions — `wifiOnlyBackgroundSession`, `cellularBackgroundSession` and `cellularForegroundSession` — each created with `delegateQueue: nil`, so each gets its *own* serial queue and their callbacks run concurrently with one another.
- `transferForegroundDownloadsToBackground()` moves entries between task identifiers from inside `getTasksWithCompletionHandler` / `cancel` completion handlers.

Concurrent mutation corrupts the dictionary's native storage. The `_Variant` then takes the Cocoa branch and sends `count` to whatever garbage the tagged-pointer slot holds — hence the `__NSTaggedDate` selector crash inside `Dictionary.subscript.setter`.

Both are now `ThreadSafeDictionary`, the same `NSLock`-backed type already used for `downloadingEpisodesCache` and `downloadAndStreamEpisodes` in this class. `ThreadSafeDictionary.removeValue(forKey:)` now returns the removed value (it previously returned `Void`), which `transferForegroundDownloadsToBackground()` needs to hand the old `DownloadAttempt` to the new background task.

No behaviour change beyond the added locking.

## To test

This is a race, so it does not reproduce on demand. Verifying that downloads still behave correctly is the goal:

1. Queue up several episodes for download at once, across more than one podcast.
2. Background and foreground the app while they are downloading, so downloads are transferred between the foreground and background sessions.
3. Confirm every episode completes and shows as downloaded.
4. Turn on Airplane Mode mid-download, confirm the episodes show a download failure, then turn it off and retry them — they should download successfully.
5. Download an episode whose feed 404s or otherwise errors, and confirm the failure message is still shown on the episode.
6. Run `ThreadSafeDictionaryTests` — it covers the new `removeValue(forKey:)` return value and hammers the type concurrently.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
