### PR TITLE
Add CHANGELOG entry for the watch background task crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add a Bluesky link to the About screen alongside Website, Instagram and X [#4998](https://github.com/Automattic/pocket-casts-ios/pull/4998)
 - Fix setting the sleep timer through Siri or Shortcuts while the device is locked [#4812](https://github.com/Automattic/pocket-casts-ios/pull/4812)
 - Fix a rare crash when starting episode downloads [#5001](https://github.com/Automattic/pocket-casts-ios/pull/5001)
+- Fix a rare crash on the Apple Watch while downloading episodes in the background [#5002](https://github.com/Automattic/pocket-casts-ios/pull/5002)
 - Tapping a Discover collection's poster now opens the expanded collection, the same as tapping "Show All" [#5028](https://github.com/Automattic/pocket-casts-ios/pull/5028)
 - Add support for "Networks" row in "Discover" [#5026](https://github.com/Automattic/pocket-casts-ios/pull/5026)
 - Add networks to search, including "Combined Results" and a new dedicated tab/filter [#5037](https://github.com/Automattic/pocket-casts-ios/pull/5037)


### PR DESCRIPTION
The code fix already landed in trunk — it rode in on the branch for #5001 and shipped in 8.20. This PR is now just the release note that was missing for it.

The watch app aborts when `pendingWatchBackgroundTask` is completed twice: `urlSessionDidFinishEvents(forBackgroundURLSession:)` completed the task but never cleared the ivar, so the next delivery for the same session id completed a stale task and WatchKit killed the process. The fix clears the ivar wherever the task is completed and guards the delegate callback by session identifier, so `wifiOnlyBackgroundSession` can't complete the cellular task early.

## To test

Check `CHANGELOG.md` renders the new 8.20 line correctly. The code change is already on trunk and unmodified here.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
