### PR TITLE
Fix crash when What's New is shown mid-transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 - Fix the app freezing and closing itself when creating a Smart Playlist [#4993](https://github.com/Automattic/pocket-casts-ios/pull/4993)
 - Add a Bluesky link to the About screen alongside Website, Instagram and X [#4998](https://github.com/Automattic/pocket-casts-ios/pull/4998)
 - Fix setting the sleep timer through Siri or Shortcuts while the device is locked [#4812](https://github.com/Automattic/pocket-casts-ios/pull/4812)
-- Fix a crash when starting episode downloads [#5001](https://github.com/Automattic/pocket-casts-ios/pull/5001)
+- Fix a rare crash when starting episode downloads [#5001](https://github.com/Automattic/pocket-casts-ios/pull/5001)
 - Tapping a Discover collection's poster now opens the expanded collection, the same as tapping "Show All" [#5028](https://github.com/Automattic/pocket-casts-ios/pull/5028)
 - Add support for "Networks" row in "Discover" [#5026](https://github.com/Automattic/pocket-casts-ios/pull/5026)
 - Add networks to search, including "Combined Results" and a new dedicated tab/filter [#5037](https://github.com/Automattic/pocket-casts-ios/pull/5037)
 - Fix the Download button doing nothing in Search and Discover episode results [#4702](https://github.com/Automattic/pocket-casts-ios/pull/4702)
-- Fix a crash when the What's New screen was shown while another screen was still being dismissed [#5003](https://github.com/Automattic/pocket-casts-ios/pull/5003)
+- Fix a rare crash when the What's New screen was shown while another screen was still being dismissed [#5003](https://github.com/Automattic/pocket-casts-ios/pull/5003)
 
 8.19
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add support for "Networks" row in "Discover" [#5026](https://github.com/Automattic/pocket-casts-ios/pull/5026)
 - Add networks to search, including "Combined Results" and a new dedicated tab/filter [#5037](https://github.com/Automattic/pocket-casts-ios/pull/5037)
 - Fix the Download button doing nothing in Search and Discover episode results [#4702](https://github.com/Automattic/pocket-casts-ios/pull/4702)
+- Fix a crash when the What's New screen was shown while another screen was still being dismissed [#5003](https://github.com/Automattic/pocket-casts-ios/pull/5003)
 
 8.19
 -----

--- a/podcasts/Main/MainTabBarController.swift
+++ b/podcasts/Main/MainTabBarController.swift
@@ -175,30 +175,22 @@ class MainTabBarController: UITabBarController, NavigationProtocol {
 
         registerSceneAppearanceObserverIfNeeded()
         fireSystemThemeMayHaveChanged()
-        checkSubscriptionStatusChanged()
-        checkPromotionFinishedAcknowledged()
-        checkWhatsNewAcknowledged()
-
-        // Show any app launch announcements/prompts only once
-        if !viewDidAppearBefore {
-            showWhatsNewIfNeeded()
-            showEndOfYearPromptIfNeeded()
-
-            viewDidAppearBefore = true
-        }
 
         // if this key was never set lets default to Discovery or Podcast depending of podcasts followed
         if UserDefaults.standard.object(forKey: Constants.UserDefaults.lastTabOpened) == nil {
             selectedIndex = DataManager.sharedManager.podcastCount() > 0 ? Tab.podcasts.rawValue: Tab.discover.rawValue
         }
 
-        showInitialOnboardingIfNeeded()
-
         updateDatabaseIndexes()
         optimizeDatabaseIfNeeded()
 
-        if DataManager.loginAgain {
-            loginAgain()
+        let isFirstAppearance = !viewDidAppearBefore
+        viewDidAppearBefore = true
+
+        // This can run inside the deferred-commit flush of a modal dismissal, where
+        // presenting or dismissing runs into the transition that is still tearing down.
+        DispatchQueue.main.async { [weak self] in
+            self?.showLaunchPromptsIfNeeded(isFirstAppearance: isFirstAppearance)
         }
     }
 
@@ -1092,6 +1084,24 @@ private extension MainTabBarController {
 // MARK: - App Launch Prompts
 
 private extension MainTabBarController {
+    func showLaunchPromptsIfNeeded(isFirstAppearance: Bool) {
+        checkSubscriptionStatusChanged()
+        checkPromotionFinishedAcknowledged()
+        checkWhatsNewAcknowledged()
+
+        // Show any app launch announcements/prompts only once
+        if isFirstAppearance {
+            showWhatsNewIfNeeded()
+            showEndOfYearPromptIfNeeded()
+        }
+
+        showInitialOnboardingIfNeeded()
+
+        if DataManager.loginAgain {
+            loginAgain()
+        }
+    }
+
     func showEndOfYearPromptIfNeeded() {
         // Only show the prompt if there isn't an active announcement flow
         guard !isShowingWhatsNew, AnnouncementFlow.current == .none else { return }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

`MainTabBarController.viewDidAppear` can run inside the deferred-commit flush of a modal dismissal (`-[UIPresentationController transitionDidFinish:]` → `_runAfterCACommitDeferredBlocks`). At that point `presentedViewController` is still non-nil but mid-teardown, so `showWhatsNew` calls `dismiss` on it a second time from inside the previous transition and UIKit traps:

```
UIKitCore  ___UIViewControllerTransitioningRunCustomTransitionWithRequest_block_invoke_3
UIKitCore  -[UIViewController dismissViewControllerAnimated:completion:]
podcasts   MainTabBarController.showWhatsNew (MainTabBarController.swift:589)
podcasts   NavigationManager.performNavigation
podcasts   MainTabBarController.checkWhatsNewAcknowledged
podcasts   MainTabBarController.viewDidAppear
UIKitCore  -[UIPresentationController transitionDidFinish:]_block_invoke
UIKitCore  _runAfterCACommitDeferredBlocks
```

This is the same failure as #4903 (onboarding), and takes the same fix: hop to the next runloop turn so the teardown finishes first. By then `presentedViewController` is nil and the plain-present branch runs.

Rather than wrapping each presentation site, everything in `viewDidAppear` that ends up presenting now lives in one `showLaunchPromptsIfNeeded` method, deferred once:

```swift
DispatchQueue.main.async { [weak self] in
    self?.showLaunchPromptsIfNeeded(isFirstAppearance: isFirstAppearance)
}
```

That covers the rest of the launch prompts too. The others don't dismiss, so they don't trap, but they do present onto a root view controller that may still be holding a dismissing modal — which silently no-ops and drops the prompt for that launch:

| Moved into `showLaunchPromptsIfNeeded` | |
|---|---|
| `checkWhatsNewAcknowledged()` → `showWhatsNew` | the crash — dismiss + present |
| `checkSubscriptionStatusChanged()` → `showSubscriptionCancelledAcknowledge` | present, can silently no-op |
| `checkPromotionFinishedAcknowledged()` → `showPromotionFinishedAcknowledge` | present, can silently no-op |
| `showWhatsNewIfNeeded()` | present, can silently no-op |
| `showEndOfYearPromptIfNeeded()` | present, can silently no-op |
| `showInitialOnboardingIfNeeded()` | already deferred internally by #4903 |
| `loginAgain()` | presents the recovery alert synchronously |

Everything left in `viewDidAppear` is non-presenting and stays synchronous: `registerSceneAppearanceObserverIfNeeded`, `fireSystemThemeMayHaveChanged`, the default-tab selection, and `updateDatabaseIndexes` / `optimizeDatabaseIfNeeded` (which already hop to a background queue).

Two details worth a reviewer's eye:

- `viewDidAppearBefore` is still set synchronously in `viewDidAppear` and the first-appearance state is passed in, so the once-per-lifecycle guarantee holds even if `viewDidAppear` were to fire twice before the deferred block runs.
- The main queue is FIFO, so the relative order of the prompts is unchanged: cancelled → promo → What's New → announcements → end of year → onboarding. `showWhatsNewIfNeeded` still sets `isShowingWhatsNew` before `showEndOfYearPromptIfNeeded` reads it.

## To test

The crash needs a modal to be dismissing exactly as the tab bar's `viewDidAppear` fires, which is hard to hit by hand. Easiest path is to force the What's New prompt:

1. In `Settings.setWhatsNewLastAcknowledged`, temporarily lower the stored version (or run `Settings.setWhatsNewLastAcknowledged(0)` from the debugger) so `checkWhatsNewAcknowledged` fires.
2. Launch the app and open any modal from the tab bar (the full screen player works).
3. Dismiss it — `viewDidAppear` fires on the tab bar as the dismissal completes.
4. What's New appears instead of crashing.
5. Sanity check the other prompts still show on a cold launch: the announcement modal (What's New for a new version) and, with a 2025 profile, the end of year prompt.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
