### PR TITLE
Fix data races on the DataManager in-memory caches

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/FolderDataManager.swift
@@ -16,11 +16,7 @@ class FolderDataManager {
     ]
 
     private var cachedFolders = [Folder]()
-    private lazy var cachedFolderQueue: DispatchQueue = {
-        let queue = DispatchQueue(label: "au.com.pocketcasts.FolderDataQueue")
-
-        return queue
-    }()
+    private let cachedFolderQueue = DispatchQueue(label: "au.com.pocketcasts.FolderDataQueue")
 
     func setup(dbQueue: PCDBQueue) {
         cacheFolders(dbQueue: dbQueue)
@@ -33,9 +29,11 @@ class FolderDataManager {
     }
 
     func allFolders(includeDeleted: Bool, dbQueue: PCDBQueue) -> [Folder] {
-        if includeDeleted { return cachedFolders }
+        let folders = cachedFolderQueue.sync { cachedFolders }
 
-        return cachedFolders.filter { $0.wasDeleted == false }
+        if includeDeleted { return folders }
+
+        return folders.filter { $0.wasDeleted == false }
     }
 
     func save(folder: Folder, dbQueue: PCDBQueue) {
@@ -54,9 +52,10 @@ class FolderDataManager {
             }
         } else {
             // Legacy path
+            let folderExists = cachedFolderQueue.sync { cachedFolders.contains(where: { $0.uuid == folder.uuid }) }
             dbQueue.write { db in
                 do {
-                    if self.cachedFolders.contains(where: { $0.uuid == folder.uuid }) {
+                    if folderExists {
                         let setStatement = "\(self.columnNames.joined(separator: " = ?, ")) = ?"
                         try db.executeUpdate("UPDATE \(DataManager.folderTableName) SET \(setStatement) WHERE uuid = ?", values: self.createValuesFrom(folder, includeUuidForWhere: true))
                     } else {

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -14,11 +14,7 @@ extension Podcast: Sortable {
 
 class PodcastDataManager {
     private var cachedPodcasts = [String: Podcast]()
-    private lazy var cachedPodcastsQueue: DispatchQueue = {
-        let queue = DispatchQueue(label: "au.com.pocketcasts.PodcastDataQueue")
-
-        return queue
-    }()
+    private let cachedPodcastsQueue = DispatchQueue(label: "au.com.pocketcasts.PodcastDataQueue")
 
     /// Legacy column names for non-GRDB code path.
     let columnNames = [

--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/UpNextDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/UpNextDataManager.swift
@@ -15,11 +15,7 @@ class UpNextDataManager {
 
     private var cachedItems = [PlaylistEpisode]()
     private var allUuids = Set<String>()
-    private lazy var cachedItemsQueue: DispatchQueue = {
-        let queue = DispatchQueue(label: "au.com.pocketcasts.UpNextItemsQueue")
-
-        return queue
-    }()
+    private let cachedItemsQueue = DispatchQueue(label: "au.com.pocketcasts.UpNextItemsQueue")
 
     func setup(dbQueue: PCDBQueue) {
         cacheEpisodes(dbQueue: dbQueue)
@@ -216,7 +212,7 @@ class UpNextDataManager {
     }
 
     func movePlaylistEpisode(from: Int, to: Int, dbQueue: PCDBQueue) {
-        var resortedItems = cachedItems
+        var resortedItems = cachedItemsQueue.sync { cachedItems }
 
         if from == -1, to == 0 {
             // special case where we just added a new episode to the top, nothing needs to be done just redo the ordering below
@@ -277,7 +273,7 @@ class UpNextDataManager {
 
     private func saveOrdering(dbQueue: PCDBQueue) {
         cacheEpisodes(dbQueue: dbQueue)
-        let sortedItems = cachedItems
+        let sortedItems = cachedItemsQueue.sync { cachedItems }
         dbQueue.write { db in
             do {
                 for (index, episode) in sortedItems.enumerated() {

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -20,9 +20,9 @@ public class DataManager {
     private let episodeManager = EpisodeDataManager()
     private let userEpisodeManager = UserEpisodeDataManager()
     private let folderManager = FolderDataManager()
-    private lazy var endOfYearManager = EndOfYearDataManager()
-    private lazy var upNextHistoryManager = UpNextHistoryManager()
-    private lazy var folderHistoryManager = FolderHistoryManager()
+    private var endOfYearManager = EndOfYearDataManager()
+    private let upNextHistoryManager = UpNextHistoryManager()
+    private let folderHistoryManager = FolderHistoryManager()
 
     public let autoAddCandidates: AutoAddCandidatesDataManager
     public let bookmarks: BookmarkDataManager

--- a/Modules/Tests/PocketCastsDataModelTests/DataManagerConcurrencyTests.swift
+++ b/Modules/Tests/PocketCastsDataModelTests/DataManagerConcurrencyTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import PocketCastsDataModel
+
+/// Stress tests that hammer the in-memory caches in `FolderDataManager` and
+/// `UpNextDataManager` from several threads at once.
+///
+/// The reads used to happen outside the cache queue, so a reader could pick up a
+/// collection buffer that the writer was releasing. Run these under the Thread
+/// Sanitizer to catch a regression.
+final class DataManagerConcurrencyTests: DataManagerTestCase {
+    private let writeCount = 50
+    private let readCount = 500
+    private let timeout: TimeInterval = 60
+
+    func testAllFoldersWhileFoldersAreSaved() {
+        let dataManager = DataManager.newTestDataManager()
+        for index in 0 ..< 5 {
+            createFolder(name: "Folder \(index)", dataManager: dataManager)
+        }
+
+        runConcurrently(
+            write: { index in
+                self.createFolder(name: "Concurrent \(index)", dataManager: dataManager)
+            },
+            read: {
+                for folder in dataManager.allFolders(includeDeleted: true) {
+                    XCTAssertFalse(folder.uuid.isEmpty)
+                }
+            }
+        )
+
+        XCTAssertEqual(dataManager.allFolders(includeDeleted: true).count, 5 + writeCount)
+    }
+
+    func testUpNextEpisodesWhileEpisodesAreMoved() {
+        let dataManager = DataManager.newTestDataManager()
+        let podcast = createTestPodcast(dataManager: dataManager)
+        for index in 0 ..< 5 {
+            let episode = createTestEpisode(podcast: podcast, title: "Episode \(index)", dataManager: dataManager)
+            addToUpNextBottom(episodeUuid: episode.uuid, title: episode.title ?? "", podcastUuid: podcast.uuid, dataManager: dataManager)
+        }
+
+        runConcurrently(
+            write: { index in
+                dataManager.movePlaylistEpisode(from: index % 5, to: (index + 1) % 5)
+            },
+            read: {
+                for playlistEpisode in dataManager.allUpNextPlaylistEpisodes() {
+                    XCTAssertFalse(playlistEpisode.episodeUuid.isEmpty)
+                }
+            }
+        )
+
+        XCTAssertEqual(dataManager.allUpNextPlaylistEpisodes().count, 5)
+    }
+
+    // MARK: - Helpers
+
+    private func runConcurrently(write: @escaping (Int) -> Void, read: @escaping () -> Void) {
+        let writesFinished = expectation(description: "writes finished")
+        let readsFinished = expectation(description: "reads finished")
+
+        DispatchQueue.global().async {
+            for index in 0 ..< self.writeCount {
+                write(index)
+            }
+            writesFinished.fulfill()
+        }
+
+        DispatchQueue.global().async {
+            for _ in 0 ..< self.readCount {
+                read()
+            }
+            readsFinished.fulfill()
+        }
+
+        wait(for: [writesFinished, readsFinished], timeout: timeout)
+    }
+
+    private func createFolder(name: String, dataManager: DataManager) {
+        let folder = Folder()
+        folder.uuid = UUID().uuidString
+        folder.name = name
+        folder.addedDate = Date()
+        dataManager.save(folder: folder)
+    }
+}


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes a `_xzm_corruption_detected` crash reported inside `PodcastDataManager.cachePodcasts`. That stack is the victim, not the culprit: malloc only notices a corrupted freelist at the next allocation, which here happened to be the `String` GRDB allocates while decoding a podcast row during a refresh.

The corruption comes from unsynchronised access to `DataManager`'s in-memory caches. `FolderDataManager` and `UpNextDataManager` guard most cache access with a serial queue, but four reads bypassed it:

- `FolderDataManager.allFolders(includeDeleted:)`
- `FolderDataManager.save(folder:)` (legacy path)
- `UpNextDataManager.movePlaylistEpisode(from:to:)`
- `UpNextDataManager.saveOrdering(dbQueue:)`

These arrays are read on the main thread while background refresh/sync work replaces them in `cacheFolders`/`cacheEpisodes`. A racing reader can load the old buffer pointer and retain it after the writer has already released the last reference, so the buffer is used after free and eventually released twice — which is exactly what corrupts malloc metadata for every later allocation in the process, including the podcast cache reload.

Separately, all three cache queues (`FolderDataManager`, `UpNextDataManager`, `PodcastDataManager`) were `lazy var`. Swift instance `lazy var` is not thread-safe: two threads racing on first access both run the initialiser and both store to the same reference, over-releasing one queue and, worse, briefly handing the two threads different "locks" so the cache itself is left unguarded. The same applies to `DataManager`'s three lazy sub-managers.

`PodcastDataManager` itself only needed the queue change — every `cachedPodcasts` access there was already guarded.

## To test

This is a race, so there is no deterministic repro. To exercise the paths:

1. Run the new `DataManagerConcurrencyTests` with the Thread Sanitizer enabled — they hammer `allFolders` and `movePlaylistEpisode` from one thread while another writes.
2. Build and run the app, sign into an account with folders and a populated Up Next queue.
3. Pull to refresh on the Podcasts tab and, while the refresh runs, switch between the Podcasts tab (folder grid) and Up Next, and reorder a few Up Next episodes.
4. Confirm folders and Up Next stay correct and the app does not crash.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
