### PR TITLE
Replace the unknown Discover item assertion with a debug alert

### DIFF
--- a/podcasts/DiscoverCellType.swift
+++ b/podcasts/DiscoverCellType.swift
@@ -101,8 +101,54 @@ extension DiscoverItem {
             return .largeListWithPodcast
         default:
             FileLog.shared.addMessage("Unknown Discover Item: \(type ?? "unknown") \(summaryStyle ?? "unknown")")
-            assertionFailure("Unknown Discover Item: \(type ?? "unknown") \(summaryStyle ?? "unknown")")
+#if DEBUG
+            UnknownDiscoverItemAlert.showIfNeeded(type: type, summaryStyle: summaryStyle, expandedStyle: expandedStyle)
+#endif
             return nil
         }
     }
 }
+
+#if DEBUG
+enum UnknownDiscoverItemAlert {
+    private static let versionKey = "DebugUnknownDiscoverItemsVersion"
+    private static let itemsKey = "DebugUnknownDiscoverItems"
+
+    static func showIfNeeded(type: String?, summaryStyle: String?, expandedStyle: String?) {
+        let item = "\(type ?? "unknown") / \(summaryStyle ?? "unknown") / \(expandedStyle ?? "unknown")"
+
+        guard markAsSeenIfNeeded(item) else { return }
+
+        let message = """
+        The Discover feed returned an item this build can't render:
+
+        type: \(type ?? "unknown")
+        summaryStyle: \(summaryStyle ?? "unknown")
+        expandedStyle: \(expandedStyle ?? "unknown")
+
+        The item was skipped. This alert only appears in DEBUG builds, once per item and app version.
+        """
+
+        DispatchQueue.main.async {
+            SJUIUtils.showAlert(title: "Unknown Discover Item (DEBUG)", message: message, from: SceneHelper.rootViewController())
+        }
+    }
+
+    private static func markAsSeenIfNeeded(_ item: String) -> Bool {
+        let defaults = UserDefaults.standard
+        let version = Settings.appVersion()
+
+        if defaults.string(forKey: versionKey) != version {
+            defaults.set(version, forKey: versionKey)
+            defaults.removeObject(forKey: itemsKey)
+        }
+
+        var seen = defaults.stringArray(forKey: itemsKey) ?? []
+        guard !seen.contains(item) else { return false }
+
+        seen.append(item)
+        defaults.set(seen, forKey: itemsKey)
+        return true
+    }
+}
+#endif


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

An unknown Discover item type — one the server sends but this build doesn't know how to render — tripped an `assertionFailure`, crashing debug builds on any unrecognized item. That's a heavy-handed response to a case the app already handles gracefully by skipping the item.

This replaces the assertion with a DEBUG-only `UIAlertController` presented over the app, describing the item that couldn't be rendered. Each distinct `type / summaryStyle / expandedStyle` combination is recorded in `UserDefaults` and alerts only once per app version, so a repeatedly-returned unknown item doesn't nag on every Discover load. The `FileLog` entry is unchanged, and release builds are unaffected — the whole path is behind `#if DEBUG`.

The dedupe key includes all three style fields rather than just the first unknown item, so a feed containing several unrecognized items surfaces each one instead of the first masking the rest.

<img width="456" height="972" alt="Screenshot 2026-08-25 at 10 45 39 AM" src="https://github.com/user-attachments/assets/3614d108-3aa3-4caa-8a03-47a1aef32390" />


## To test

1. Run a debug build.
2. In `DiscoverItem.cellType()` (`podcasts/DiscoverCellType.swift`), temporarily comment out one of the recognized `case` lines — e.g. `case ("podcast_list", "carousel", _)` — so that item falls through to `default`.
3. Open the Discover tab. An alert titled "Unknown Discover Item (DEBUG)" appears with the type, summary style, and expanded style, and the app keeps running rather than trapping.
4. Dismiss the alert and navigate away from and back to Discover — the alert does not reappear.
5. Delete and reinstall the app (or clear `DebugUnknownDiscoverItems` from `UserDefaults`) — the alert appears once again.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
