### PR TITLE
Fix the Bookmarks screen background and search field colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix bookmark multi-select losing track of a selected bookmark when it was edited or updated by a sync, leaving a wrong selection count and a row that could not be deselected [#4913](https://github.com/Automattic/pocket-casts-ios/pull/4913)
 - Fix the bookmark multi-select long press options: Select all above/below now flip to Deselect all above/below once that range is selected, and are left out for the first and last bookmark [#4915](https://github.com/Automattic/pocket-casts-ios/pull/4915)
 - Fix the podcast screen tabs being clipped when scrolled [#4918](https://github.com/Automattic/pocket-casts-ios/pull/4918)
+- Fix the colors on the Bookmarks screen in Profile: the list no longer shows up as a light gray slab on the dark themes, the whole screen uses one surface, and the search field is legible on every theme [#5007](https://github.com/Automattic/pocket-casts-ios/pull/5007)
 - Fix the About and Legal & More screens not following the app's theme, the Automattic family logos being misaligned, and legal pages (Terms of Service, Privacy Policy, Acknowledgements) not expanding beyond the safe area [#4887](https://github.com/Automattic/pocket-casts-ios/pull/4887)
 - Improve playback reliability when starting audio [#4938](https://github.com/Automattic/pocket-casts-ios/pull/4938)
 - Optimize fingerprinting and features that depend on it, including synced transcripts and more [#4846](https://github.com/Automattic/pocket-casts-ios/pull/4846), [#4847](https://github.com/Automattic/pocket-casts-ios/pull/4847)

--- a/podcasts/Bookmarks/BookmarksTheme.swift
+++ b/podcasts/Bookmarks/BookmarksTheme.swift
@@ -5,6 +5,8 @@ protocol BookmarksStyle: ObservableObject {
     associatedtype ActionStyle: ActionBarStyle
     associatedtype EmptyStyle: EmptyStateViewStyle
 
+    var background: Color { get }
+    var listBackground: Color { get }
     var primaryText: Color { get }
     var secondaryText: Color { get }
     var tertiaryText: Color { get }
@@ -44,6 +46,7 @@ class ThemeObserver: ObservableObject {
 
 class BookmarksPlayerTabStyle: ThemeObserver, BookmarksStyle {
     var background: Color { theme.playerBackground01 }
+    var listBackground: Color { .clear }
     var primaryText: Color { theme.playerContrast01 }
     var secondaryText: Color { theme.playerContrast02 }
     var tertiaryText: Color { theme.playerContrast02 }
@@ -67,6 +70,7 @@ class BookmarksPlayerTabStyle: ThemeObserver, BookmarksStyle {
 
 class ThemedBookmarksStyle: ThemeObserver, BookmarksStyle {
     var background: Color { theme.primaryUi01 }
+    var listBackground: Color { background }
     var primaryText: Color { theme.primaryText01 }
     var secondaryText: Color { theme.primaryText02 }
     var tertiaryText: Color { theme.primaryText02 }
@@ -84,6 +88,13 @@ class ThemedBookmarksStyle: ThemeObserver, BookmarksStyle {
     var deleteSwipeTint: Color { theme.support05 }
     var actionBarStyle = ThemedActionBarStyle()
     var emptyStyle = DefaultEmptyStateStyle()
+}
+
+// MARK: - Full Screen Style
+
+/// A full screen list, which uses the same surface as the other list screens in the app
+class FullScreenBookmarksStyle: ThemedBookmarksStyle {
+    override var background: Color { theme.primaryUi02 }
 }
 
 // MARK: - Override Themed Style

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -145,6 +145,7 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
         .animation(.default, value: viewModel.bookmarks.map(\.id))
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
+        .background(style.listBackground)
         .environment(\.defaultMinListRowHeight, 0)
     }
 

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
@@ -3,13 +3,13 @@ import PocketCastsUtils
 
 struct BookmarksProfileListView: View {
     @ObservedObject var viewModel: BookmarkPodcastListViewModel
-    @ObservedObject var style = ThemedBookmarksStyle()
+    @ObservedObject var style = FullScreenBookmarksStyle()
+    @ObservedObject private var searchTheme = BookmarksSearchFieldTheme()
 
     var body: some View {
-        VStack(spacing: BookmarkListConstants.padding) {
+        VStack(spacing: 0) {
             searchField
                 .padding([.horizontal], BookmarkListConstants.headerPadding)
-                .background(style.theme.secondaryUi01)
             bookmarkListView
         }
         .navigationTitle(L10n.bookmarks)
@@ -66,12 +66,21 @@ struct BookmarksProfileListView: View {
     @ViewBuilder
     private var searchField: some View {
         if viewModel.isSearching || !viewModel.bookmarks.isEmpty {
-            SearchField(text: $viewModel.searchText)
+            SearchField(theme: searchTheme, text: $viewModel.searchText)
                 .disabled(viewModel.isMultiSelecting)
         }
     }
 
     private var bookmarkListView: some View {
         BookmarksListView(viewModel: viewModel, style: style, showHeader: false, showMultiSelectInHeader: false, showMoreInHeader: false)
+            .padding(.top, BookmarkListConstants.padding)
     }
+}
+
+private final class BookmarksSearchFieldTheme: SearchField.SearchTheme {
+    override var background: Color { theme.primaryField01 }
+    override var placeholder: Color { theme.primaryText02 }
+    override var text: Color { theme.primaryText01 }
+    override var cancel: Color { theme.primaryText01 }
+    override var icon: Color { theme.primaryIcon02 }
 }


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes PCIOS-908

The Bookmarks screen in Profile didn't use the same surface as the app's other full screen lists, so the list showed up as a light gray slab on the dark themes.

- `BookmarksStyle` now exposes `background`/`listBackground`, so the `List` paints itself instead of letting the system background win.
- The screen moves from `primaryUi01` (the sheet surface, `#222427` on Extra Dark) to `primaryUi02`, the token `PodcastListViewController` and `PlaylistsViewController` use. The separate `secondaryUi01` band behind the search field is gone, so the screen is one surface.
- The search field moves from `secondaryField01`, which is meant for branded nav bar chrome and was invisible on Rosé, to the primary tokens `PCSearchBarController` uses elsewhere.

`ThemedBookmarksStyle` is unchanged, so the episode sheet and the podcast screen's Bookmarks tab keep `primaryUi01`.

## To test

1. Go to Settings > Appearance and pick **Extra Dark**.
2. Go to Profile > Bookmarks.
3. The whole screen should be a single black surface — no gray slab, no strip between the search field and the list.
4. Type in the search field: the pill, placeholder, icon and text should all be legible.
5. Repeat for **Dark**, **Contrast Dark**, **Classic Dark**, **Rosé**, **Indigo** and **Light**.
6. Check the Bookmarks tab in the player and on a podcast, and an episode's bookmarks — all unchanged.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
