### PR TITLE
Fix the transcript layout on the bookmark details and edit screens

### DIFF
--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -27,13 +27,14 @@ struct BookmarkDetailsView: View {
     @ViewBuilder
     private var layout: some View {
         if viewModel.passage != nil {
-            VStack(alignment: .leading, spacing: 24) {
-                Group {
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: 24) {
                     header
                     details
                 }
                 .padding(.horizontal, 16)
 
+                // The room the transcript keeps clear at the top is the gap above it
                 transcriptSection
             }
             .padding(.top, 16)
@@ -169,6 +170,7 @@ struct BookmarkDetailsView: View {
                     passageView(passage)
                 }
                 .scrollBounceBehavior(.basedOnSize)
+                .padding(.top, 24)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -272,7 +274,7 @@ struct BookmarkDetailsView: View {
 /// How deep the transcript fades out at each edge. The transcript keeps the same room
 /// clear at its own edges, so its first and last lines come to rest clear of the fade.
 private enum TranscriptFade {
-    static let top: CGFloat = 96
+    static let top: CGFloat = 48
     static let bottom: CGFloat = 64
 }
 

--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -179,7 +179,13 @@ struct BookmarkDetailsView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .animation(.easeInOut(duration: TranscriptTransition.duration), value: viewModel.isLoadingTranscript)
+        .animation(transcriptTransition, value: viewModel.isLoadingTranscript)
+    }
+
+    /// Nothing to animate when the transcript was there all along: the placeholder is
+    /// gone before it's been seen, and fading it out would only read as a flicker
+    private var transcriptTransition: Animation? {
+        viewModel.animatesTranscriptTransition ? .easeInOut(duration: TranscriptTransition.duration) : nil
     }
 
     private func transcriptView(for snippet: BookmarkTranscriptSnippet) -> some View {
@@ -190,7 +196,8 @@ struct BookmarkDetailsView: View {
                                    bottomInset: TranscriptFade.bottom,
                                    passageColor: UIColor(theme.primaryText01),
                                    surroundingColor: UIColor(theme.primaryText02),
-                                   selectionColor: UIColor(theme.primaryInteractive01))
+                                   selectionColor: UIColor(theme.primaryInteractive01),
+                                   fadesIn: viewModel.animatesTranscriptTransition)
             .mask(edgeFade)
             // Re-created when an edit moves the passage, so the view scrolls to it anew
             .id(snippet.range)
@@ -371,6 +378,9 @@ private struct BookmarkTranscriptReadView: UIViewRepresentable {
     let surroundingColor: UIColor
     let selectionColor: UIColor
 
+    /// Whether to fade in once it's in place, in step with the placeholder fading out
+    let fadesIn: Bool
+
     /// Where the passage sits vertically once scrolled to
     private let verticalAnchor: CGFloat = 0.4
 
@@ -402,7 +412,9 @@ private struct BookmarkTranscriptReadView: UIViewRepresentable {
                 textView.scrollToRange(passageRange, verticalAnchor: verticalAnchor, animated: false)
             }
 
-            UIView.animate(withDuration: TranscriptTransition.duration) {
+            // In step with the placeholder fading out, or straight to visible when there
+            // was no placeholder to speak of
+            UIView.animate(withDuration: fadesIn ? TranscriptTransition.duration : 0) {
                 textView.alpha = 1
             }
         }

--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -161,9 +161,13 @@ struct BookmarkDetailsView: View {
     private var transcriptSection: some View {
         Group {
             if let snippet = viewModel.transcriptSnippet {
+                // Fades itself in once it's laid out and scrolled to the passage, so it
+                // arrives in place rather than at the top of the transcript
                 transcriptView(for: snippet)
+                    .transition(.identity)
             } else if viewModel.isLoadingTranscript {
                 loadingPlaceholder
+                    .transition(.opacity)
             } else if let passage = viewModel.passage {
                 // No transcript to place the passage in, so it stands alone
                 ScrollView {
@@ -171,10 +175,11 @@ struct BookmarkDetailsView: View {
                 }
                 .scrollBounceBehavior(.basedOnSize)
                 .padding(.top, 24)
+                .transition(.opacity)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .animation(.easeInOut(duration: 0.2), value: viewModel.isLoadingTranscript)
+        .animation(.easeInOut(duration: TranscriptTransition.duration), value: viewModel.isLoadingTranscript)
     }
 
     private func transcriptView(for snippet: BookmarkTranscriptSnippet) -> some View {
@@ -208,57 +213,65 @@ struct BookmarkDetailsView: View {
         }
     }
 
-    /// The passage with placeholder text standing in for the transcript around it while
-    /// the real one loads
+    /// Stands in for the transcript while it loads, laid out as the turns of a
+    /// conversation so it breaks up the way the text that replaces it will
     private var loadingPlaceholder: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            placeholderParagraph(Self.leadingPlaceholder)
-
-            // The glyph waits for the real transcript, where it can mark the right line
-            viewModel.passage.map { passageView($0, showsBookmarkIndicator: false) }
-
-            placeholderParagraph(Self.trailingPlaceholder)
+        VStack(alignment: .leading, spacing: paragraphSpacing) {
+            ForEach(Self.transcriptPlaceholder, id: \.self) { paragraph in
+                Text(paragraph)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
-        // Starts clear of the fade, where the transcript that replaces it starts too
-        .padding(.top, TranscriptFade.top)
+        .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
+        .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
+        .foregroundStyle(theme.primaryText02)
+        .redacted(reason: .placeholder)
+        .padding(.horizontal, BookmarkTranscriptTextView.gutterWidth)
+        .padding(.top, 24)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .clipped()
+        .accessibilityHidden(true)
     }
 
-    private func placeholderParagraph(_ text: String) -> some View {
-        Text(text)
-            .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
-            .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .foregroundStyle(theme.primaryText02)
-            .redacted(reason: .placeholder)
-            .padding(.horizontal, BookmarkTranscriptTextView.gutterWidth)
-            .accessibilityHidden(true)
+    /// The gap the transcript leaves between paragraphs, which TextKit adds on top of the
+    /// room the line height already leaves between lines
+    private var paragraphSpacing: CGFloat {
+        BookmarkTranscriptStyle.lineSpacing + BookmarkTranscriptStyle.paragraphSpacing
     }
 
     /// The passage on its own, in the same text view the full transcript uses, so it
     /// reads identically before and after the transcript arrives
-    private func passageView(_ passage: String, showsBookmarkIndicator: Bool = true) -> some View {
+    private func passageView(_ passage: String) -> some View {
         BookmarkPassageTextView(passage: passage,
-                                showsBookmarkIndicator: showsBookmarkIndicator,
                                 textColor: UIColor(theme.primaryText01),
                                 selectionColor: UIColor(theme.primaryInteractive01))
     }
 
-    /// Stand-ins for the transcript around the passage while it loads. The redaction
-    /// blocks them out, so they're never read; they only give the placeholders the
-    /// shape of prose.
-    private static let leadingPlaceholder = """
-    The lines of the transcript leading into the bookmarked passage land here once the \
-    episode transcript has been fetched, filling out a few lines above it.
-    """
-
-    private static let trailingPlaceholder = """
-    The rest of the transcript follows the passage the moment it arrives, running on \
-    long enough to fill the space below with the shape of the conversation as it \
-    continues past the bookmarked moment, line after line, until the fetched text \
-    takes its place.
-    """
+    /// Stands in for the transcript while it loads: turns of varying length, so the
+    /// placeholder reads as a conversation rather than a block. The redaction blocks the
+    /// words out, so they're never read; they only give the placeholder its shape.
+    private static let transcriptPlaceholder = [
+        """
+        The lines of the transcript leading into the bookmarked passage land here once \
+        the episode transcript has been fetched, filling out the space above the moment \
+        the bookmark was taken at.
+        """,
+        """
+        Right, and the conversation carries on either side of it, so the passage reads \
+        in the context it was captured in rather than standing on its own.
+        """,
+        "Shorter turns land in between the longer ones.",
+        """
+        The rest of the transcript follows below, running on long enough to fill the \
+        screen with the shape of the conversation as it continues past the bookmarked \
+        moment, line after line, until the fetched text takes its place.
+        """,
+        """
+        Each paragraph here stands in for one turn of the transcript, spaced the way the \
+        real turns are.
+        """,
+        "And it keeps going past the bottom of the screen, where the fade takes over."
+    ]
 
     private var timestamp: String {
         TimeFormatter.shared.playTimeFormat(time: viewModel.bookmark.time)
@@ -278,15 +291,23 @@ private enum TranscriptFade {
     static let bottom: CGFloat = 64
 }
 
+// MARK: - TranscriptTransition
+
+/// How long the placeholder takes to give way to the transcript. Both halves of the
+/// crossfade run for the same time: the placeholder fading out in SwiftUI, and the
+/// transcript fading itself in once it's scrolled to the passage.
+private enum TranscriptTransition {
+    static let duration: TimeInterval = 0.3
+}
+
 // MARK: - BookmarkPassageTextView
 
-/// The passage alone — while the transcript loads, or when there is none — rendered by
-/// the same text view the full transcript uses: the same styling and gutter, optionally
-/// the glyph marking its first line, and the text already selectable. Sized to its
-/// content, so it sits in the surrounding layout rather than scrolling.
+/// The passage alone, when there's no transcript to place it in, rendered by the same
+/// text view the full transcript uses: the same styling and gutter, the glyph marking
+/// its first line, and the text already selectable. Sized to its content, so it sits in
+/// the surrounding layout rather than scrolling.
 private struct BookmarkPassageTextView: UIViewRepresentable {
     let passage: String
-    let showsBookmarkIndicator: Bool
     let textColor: UIColor
     let selectionColor: UIColor
 
@@ -304,9 +325,7 @@ private struct BookmarkPassageTextView: UIViewRepresentable {
                                                    right: BookmarkTranscriptTextView.gutterWidth)
         textView.textContainer.lineFragmentPadding = 0
         textView.tintColor = selectionColor
-        if showsBookmarkIndicator {
-            textView.showBookmarkIndicator(at: 0, color: textColor)
-        }
+        textView.showBookmarkIndicator(at: 0, color: textColor)
         return textView
     }
 
@@ -381,6 +400,9 @@ private struct BookmarkTranscriptReadView: UIViewRepresentable {
 
             UIView.performWithoutAnimation {
                 textView.scrollToRange(passageRange, verticalAnchor: verticalAnchor, animated: false)
+            }
+
+            UIView.animate(withDuration: TranscriptTransition.duration) {
                 textView.alpha = 1
             }
         }

--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -13,7 +13,8 @@ struct BookmarkDetailsView: View {
 
     var body: some View {
         layout
-            .frame(maxWidth: .infinity)
+            // Top-anchored: the header sits at the top whatever height the transcript takes
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             .background(theme.primaryUi01.ignoresSafeArea())
             .miniPlayerSafeAreaInset()
             .task {
@@ -178,6 +179,8 @@ struct BookmarkDetailsView: View {
         BookmarkTranscriptReadView(transcript: snippet.transcript,
                                    passageRange: snippet.range,
                                    bookmarkCharacterIndex: bookmarkCharacterIndex(for: snippet),
+                                   topInset: TranscriptFade.top,
+                                   bottomInset: TranscriptFade.bottom,
                                    passageColor: UIColor(theme.primaryText01),
                                    surroundingColor: UIColor(theme.primaryText02),
                                    selectionColor: UIColor(theme.primaryInteractive01))
@@ -196,10 +199,10 @@ struct BookmarkDetailsView: View {
     private var edgeFade: some View {
         VStack(spacing: 0) {
             LinearGradient(colors: [.clear, .black], startPoint: .top, endPoint: .bottom)
-                .frame(height: 96)
+                .frame(height: TranscriptFade.top)
             Color.black
             LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
-                .frame(height: 64)
+                .frame(height: TranscriptFade.bottom)
         }
     }
 
@@ -214,6 +217,8 @@ struct BookmarkDetailsView: View {
 
             placeholderParagraph(Self.trailingPlaceholder)
         }
+        // Starts clear of the fade, where the transcript that replaces it starts too
+        .padding(.top, TranscriptFade.top)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .clipped()
     }
@@ -260,6 +265,15 @@ struct BookmarkDetailsView: View {
     private var created: String {
         DateFormatter.localizedString(from: viewModel.bookmark.created, dateStyle: .medium, timeStyle: .short)
     }
+}
+
+// MARK: - TranscriptFade
+
+/// How deep the transcript fades out at each edge. The transcript keeps the same room
+/// clear at its own edges, so its first and last lines come to rest clear of the fade.
+private enum TranscriptFade {
+    static let top: CGFloat = 96
+    static let bottom: CGFloat = 64
 }
 
 // MARK: - BookmarkPassageTextView
@@ -327,6 +341,11 @@ private struct BookmarkTranscriptReadView: UIViewRepresentable {
     let transcript: TranscriptModel
     let passageRange: NSRange
     let bookmarkCharacterIndex: Int
+
+    /// The room the transcript keeps clear at each edge, matching the fade drawn over it
+    let topInset: CGFloat
+    let bottomInset: CGFloat
+
     let passageColor: UIColor
     let surroundingColor: UIColor
     let selectionColor: UIColor
@@ -344,9 +363,9 @@ private struct BookmarkTranscriptReadView: UIViewRepresentable {
         textView.backgroundColor = .clear
         // The gutter on both sides is the text view's own inset rather than outside
         // padding, so the bookmark indicator can sit in the leading one, beside the text
-        textView.textContainerInset = UIEdgeInsets(top: 0,
+        textView.textContainerInset = UIEdgeInsets(top: topInset,
                                                    left: BookmarkTranscriptTextView.gutterWidth,
-                                                   bottom: 0,
+                                                   bottom: bottomInset,
                                                    right: BookmarkTranscriptTextView.gutterWidth)
         textView.textContainer.lineFragmentPadding = 0
         textView.tintColor = selectionColor

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
@@ -27,9 +27,18 @@ class BookmarkDetailsViewModel: ObservableObject {
     /// what the screen opens on.
     @Published private(set) var isLoadingTranscript: Bool
 
+    /// Whether the transcript took long enough to be worth fading the placeholder out
+    /// for. One that's already to hand arrives before the placeholder has really been
+    /// seen, where a crossfade reads as a flicker rather than a transition.
+    @Published private(set) var animatesTranscriptTransition = false
+
     /// Guards against a second fetch while one is in flight, which `isLoadingTranscript`
     /// can't do while it starts out true
     private var isFetchingTranscript = false
+
+    /// How long the transcript has to keep the placeholder up before its arrival is
+    /// worth animating
+    private static let transitionThreshold: Duration = .milliseconds(200)
 
     let episode: BaseEpisode?
 
@@ -76,10 +85,15 @@ class BookmarkDetailsViewModel: ObservableObject {
         guard transcriptSnippet == nil, !isFetchingTranscript,
               passage?.isEmpty == false, let episode else { return }
 
+        let startedLoading = ContinuousClock.now
+
         isFetchingTranscript = true
         isLoadingTranscript = true
 
-        transcriptSnippet = await bookmarkManager.capturedSnippet(for: bookmark, episode: episode)
+        let snippet = await bookmarkManager.capturedSnippet(for: bookmark, episode: episode)
+
+        animatesTranscriptTransition = startedLoading.duration(to: .now) > Self.transitionThreshold
+        transcriptSnippet = snippet
 
         isFetchingTranscript = false
         isLoadingTranscript = false
@@ -96,6 +110,10 @@ class BookmarkDetailsViewModel: ObservableObject {
     /// Points the already-loaded transcript at the passage as it stands after an edit
     private func relocatePassage() {
         guard let transcript = transcriptSnippet?.transcript else { return }
+
+        // The transcript is already up, so it's replaced in place rather than fading in
+        // over the placeholder
+        animatesTranscriptTransition = false
 
         transcriptSnippet = passage.flatMap { passage in
             BookmarkTranscriptSnippetExtractor.passageRange(for: passage, at: bookmark.passageLocation, in: transcript.attributedText)

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
@@ -22,9 +22,9 @@ class BookmarkDetailsViewModel: ObservableObject {
     /// transcript isn't available, leaving the passage to stand alone.
     @Published private(set) var transcriptSnippet: BookmarkTranscriptSnippet?
 
-    /// Whether the transcript is still being fetched, so placeholders can stand in for
-    /// the text around the passage until it arrives. Already true where a fetch is coming,
-    /// so the placeholder is what the screen opens on.
+    /// Whether the transcript is still being fetched, so a placeholder can stand in for
+    /// it until it arrives. Already true where a fetch is coming, so the placeholder is
+    /// what the screen opens on.
     @Published private(set) var isLoadingTranscript: Bool
 
     /// Guards against a second fetch while one is in flight, which `isLoadingTranscript`

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
@@ -23,8 +23,13 @@ class BookmarkDetailsViewModel: ObservableObject {
     @Published private(set) var transcriptSnippet: BookmarkTranscriptSnippet?
 
     /// Whether the transcript is still being fetched, so placeholders can stand in for
-    /// the text around the passage until it arrives
-    @Published private(set) var isLoadingTranscript = false
+    /// the text around the passage until it arrives. Already true where a fetch is coming,
+    /// so the placeholder is what the screen opens on.
+    @Published private(set) var isLoadingTranscript: Bool
+
+    /// Guards against a second fetch while one is in flight, which `isLoadingTranscript`
+    /// can't do while it starts out true
+    private var isFetchingTranscript = false
 
     let episode: BaseEpisode?
 
@@ -49,6 +54,7 @@ class BookmarkDetailsViewModel: ObservableObject {
         self.podcastTitle = podcastTitle
         self.transcriptSnippet = transcriptSnippet
         self.bookmarkManager = bookmarkManager
+        self.isLoadingTranscript = transcriptSnippet == nil && passage?.isEmpty == false && episode != nil
     }
 
     convenience init(bookmark: Bookmark, bookmarkManager: BookmarkManager) {
@@ -67,11 +73,15 @@ class BookmarkDetailsViewModel: ObservableObject {
 
     /// Fetches the episode transcript and locates the passage in it
     func loadTranscript() async {
-        guard transcriptSnippet == nil, !isLoadingTranscript,
+        guard transcriptSnippet == nil, !isFetchingTranscript,
               passage?.isEmpty == false, let episode else { return }
 
+        isFetchingTranscript = true
         isLoadingTranscript = true
+
         transcriptSnippet = await bookmarkManager.capturedSnippet(for: bookmark, episode: episode)
+
+        isFetchingTranscript = false
         isLoadingTranscript = false
     }
 

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
@@ -14,37 +14,36 @@ struct BookmarkTranscriptEditView: View {
 
     @ObservedObject var theme: BookmarkEditTheme
 
-    /// Measured, so the space kept clear for the subtitle grows with it
-    @State private var subtitleHeight: CGFloat = 0
-
     var body: some View {
-        TranscriptSelectionTextView(transcript: transcript,
-                                    bookmarkCharacterIndex: referenceTime.flatMap { transcript.characterIndex(at: $0) },
-                                    selection: $selection,
-                                    topInset: topInset,
-                                    textColor: UIColor(theme.title),
-                                    selectionColor: UIColor(theme.transcriptSelection))
-            .mask(topFadeMask)
-            .overlay(alignment: .top) {
-                subtitle
-                    .allowsHitTesting(false)
+        VStack(spacing: 0) {
+            subtitle
+                .padding(.horizontal, 16)
+
+            // The room the transcript keeps clear at the top is the gap below the subtitle
+            TranscriptSelectionTextView(transcript: transcript,
+                                        bookmarkCharacterIndex: referenceTime.flatMap { transcript.characterIndex(at: $0) },
+                                        selection: $selection,
+                                        topInset: Self.topFadeDepth,
+                                        textColor: UIColor(theme.title),
+                                        selectionColor: UIColor(theme.transcriptSelection))
+                .mask(topFadeMask)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top)
+        .background(theme.background.ignoresSafeArea())
+        .ignoresSafeArea(edges: .bottom)
+        // Colors the back button the bar gives us for free
+        .tint(theme.title)
+        .navigationTitle(L10n.bookmarkEditTranscriptTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            // The bar's own title knows nothing about the player's colors
+            ToolbarItem(placement: .principal) {
+                Text(L10n.bookmarkEditTranscriptTitle)
+                    .font(style: .headline, weight: .semibold)
+                    .foregroundStyle(theme.title)
             }
-            .frame(maxWidth: .infinity)
-            .padding(.top)
-            .background(theme.background.ignoresSafeArea())
-            .ignoresSafeArea(edges: .bottom)
-            // Colors the back button the bar gives us for free
-            .tint(theme.title)
-            .navigationTitle(L10n.bookmarkEditTranscriptTitle)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                // The bar's own title knows nothing about the player's colors
-                ToolbarItem(placement: .principal) {
-                    Text(L10n.bookmarkEditTranscriptTitle)
-                        .font(style: .headline, weight: .semibold)
-                        .foregroundStyle(theme.title)
-                }
-            }
+        }
     }
 
     // MARK: - Views
@@ -54,35 +53,20 @@ struct BookmarkTranscriptEditView: View {
             .foregroundStyle(theme.subTitle)
             .font(style: .callout)
             .multilineTextAlignment(.center)
-            .background {
-                GeometryReader { proxy in
-                    Color.clear
-                        .task(id: proxy.size.height) { subtitleHeight = proxy.size.height }
-                }
-            }
     }
 
-    /// Softens the top edge so the passage scrolls out of view instead of being clipped
+    /// Softens the top edge so lines dissolve as they scroll past, rather than being clipped
     private var topFadeMask: some View {
         VStack(spacing: 0) {
             LinearGradient(colors: [.clear, .black], startPoint: .top, endPoint: .bottom)
-                .frame(height: topInset)
+                .frame(height: Self.topFadeDepth)
             Color.black
         }
     }
 
-    /// The room kept clear above the transcript, which the subtitle sits in and the text
-    /// fades out into. The transcript starts below it, so its opening lines come to rest
-    /// clear of the subtitle.
-    private var topInset: CGFloat {
-        max(Self.minimumTopInset, subtitleHeight + Self.subtitleSpacing)
-    }
-
-    /// Deep enough for the fade to read as one, whatever the subtitle measures
-    private static let minimumTopInset: CGFloat = 140
-
-    /// What the subtitle keeps between itself and the first line of the transcript
-    private static let subtitleSpacing: CGFloat = 24
+    /// How deep the transcript fades out at the top. It keeps the same room clear at its
+    /// own top edge, so its first line comes to rest clear of the fade.
+    private static let topFadeDepth: CGFloat = 48
 }
 
 // MARK: - TranscriptSelectionTextView
@@ -98,7 +82,7 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
 
     @Binding var selection: NSRange
 
-    /// The room the transcript keeps clear at the top, for the subtitle and the fade
+    /// The room the transcript keeps clear at the top, matching the fade drawn over it
     let topInset: CGFloat
 
     let textColor: UIColor
@@ -150,10 +134,6 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
     }
 
     func updateUIView(_ textView: BookmarkTranscriptTextView, context: Context) {
-        if textView.textContainerInset.top != topInset {
-            textView.textContainerInset.top = topInset
-        }
-
         guard textView.selectedRange != selection else { return }
 
         textView.selectedRange = selection

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptEditView.swift
@@ -14,10 +14,14 @@ struct BookmarkTranscriptEditView: View {
 
     @ObservedObject var theme: BookmarkEditTheme
 
+    /// Measured, so the space kept clear for the subtitle grows with it
+    @State private var subtitleHeight: CGFloat = 0
+
     var body: some View {
         TranscriptSelectionTextView(transcript: transcript,
                                     bookmarkCharacterIndex: referenceTime.flatMap { transcript.characterIndex(at: $0) },
                                     selection: $selection,
+                                    topInset: topInset,
                                     textColor: UIColor(theme.title),
                                     selectionColor: UIColor(theme.transcriptSelection))
             .mask(topFadeMask)
@@ -50,16 +54,35 @@ struct BookmarkTranscriptEditView: View {
             .foregroundStyle(theme.subTitle)
             .font(style: .callout)
             .multilineTextAlignment(.center)
+            .background {
+                GeometryReader { proxy in
+                    Color.clear
+                        .task(id: proxy.size.height) { subtitleHeight = proxy.size.height }
+                }
+            }
     }
 
     /// Softens the top edge so the passage scrolls out of view instead of being clipped
     private var topFadeMask: some View {
         VStack(spacing: 0) {
             LinearGradient(colors: [.clear, .black], startPoint: .top, endPoint: .bottom)
-                .frame(height: 140)
+                .frame(height: topInset)
             Color.black
         }
     }
+
+    /// The room kept clear above the transcript, which the subtitle sits in and the text
+    /// fades out into. The transcript starts below it, so its opening lines come to rest
+    /// clear of the subtitle.
+    private var topInset: CGFloat {
+        max(Self.minimumTopInset, subtitleHeight + Self.subtitleSpacing)
+    }
+
+    /// Deep enough for the fade to read as one, whatever the subtitle measures
+    private static let minimumTopInset: CGFloat = 140
+
+    /// What the subtitle keeps between itself and the first line of the transcript
+    private static let subtitleSpacing: CGFloat = 24
 }
 
 // MARK: - TranscriptSelectionTextView
@@ -75,6 +98,9 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
 
     @Binding var selection: NSRange
 
+    /// The room the transcript keeps clear at the top, for the subtitle and the fade
+    let topInset: CGFloat
+
     let textColor: UIColor
     let selectionColor: UIColor
 
@@ -89,7 +115,7 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
         textView.backgroundColor = .clear
         // The gutter on both sides is the text view's own inset rather than outside
         // padding, so the bookmark indicator can sit in the leading one, beside the text
-        textView.textContainerInset = UIEdgeInsets(top: 0,
+        textView.textContainerInset = UIEdgeInsets(top: topInset,
                                                    left: BookmarkTranscriptTextView.gutterWidth,
                                                    bottom: 0,
                                                    right: BookmarkTranscriptTextView.gutterWidth)
@@ -124,6 +150,10 @@ private struct TranscriptSelectionTextView: UIViewRepresentable {
     }
 
     func updateUIView(_ textView: BookmarkTranscriptTextView, context: Context) {
+        if textView.textContainerInset.top != topInset {
+            textView.textContainerInset.top = topInset
+        }
+
         guard textView.selectedRange != selection else { return }
 
         textView.selectedRange = selection

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptStyle.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptStyle.swift
@@ -6,6 +6,9 @@ enum BookmarkTranscriptStyle {
     static let fontSize: Double = 16
     static let lineHeightMultiple: Double = 1.5
 
+    /// The room between one paragraph and the next, on top of the line height
+    static let paragraphSpacing: Double = 10
+
     /// New York, scaling with the body text style
     static var font: UIFont {
         serifFont(ofSize: CGFloat(fontSize), scalingWith: .body)
@@ -51,7 +54,7 @@ enum BookmarkTranscriptStyle {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.minimumLineHeight = lineHeight
         paragraphStyle.maximumLineHeight = lineHeight
-        paragraphStyle.paragraphSpacing = 10
+        paragraphStyle.paragraphSpacing = CGFloat(paragraphSpacing)
         paragraphStyle.lineBreakMode = .byWordWrapping
         paragraphStyle.alignment = .natural
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes three transcript layout problems on the bookmark screens.

Both transcript text views drew a gradient fade over the top of their frame but kept `textContainerInset.top` at zero, so the first and last lines came to rest under the fade, unreachable. They now reserve the same room at their edges as the fade covers, kept in one place per screen so the two can't drift apart.

- **Edit screen** — the opening lines sat under "Select a transcript passage for this bookmark". The subtitle is now a sibling above the transcript rather than an overlay on top of it, which also drops the `GeometryReader` measurement and the inset re-sync it drove on every update.
- **Details screen** — the screen opened mis-laid-out and corrected itself a frame later: the content block was only width-constrained, so it was vertically centred until the transcript claimed the rest of the height, and `isLoadingTranscript` started `false`, so the first frame showed the bare passage. The layout is now top-anchored, and the view model starts out loading wherever a fetch is coming.

## To test

1. Open a bookmark with a captured passage from the Bookmarks list.
2. Confirm the header doesn't shift or re-centre after the screen appears.
3. Scroll the transcript to both ends — the first and last lines should come to rest clear of the fades, not under them.
4. Tap ⋯ → Edit and continue to the transcript step. Confirm it starts just below the subtitle with no large gap, and that its first line isn't trapped under it.
5. Repeat on a bookmark whose passage sits near the start of the episode, and on one with no transcript available.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
