### PR TITLE
Simplify the transcript loading state on the bookmark details screen

### DIFF
--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -179,7 +179,13 @@ struct BookmarkDetailsView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .animation(.easeInOut(duration: TranscriptTransition.duration), value: viewModel.isLoadingTranscript)
+        .animation(transcriptTransition, value: viewModel.isLoadingTranscript)
+    }
+
+    /// Nothing to animate when the transcript was there all along: the placeholder is
+    /// gone before it's been seen, and fading it out would only read as a flicker
+    private var transcriptTransition: Animation? {
+        viewModel.animatesTranscriptTransition ? .easeInOut(duration: TranscriptTransition.duration) : nil
     }
 
     private func transcriptView(for snippet: BookmarkTranscriptSnippet) -> some View {
@@ -190,7 +196,8 @@ struct BookmarkDetailsView: View {
                                    bottomInset: TranscriptFade.bottom,
                                    passageColor: UIColor(theme.primaryText01),
                                    surroundingColor: UIColor(theme.primaryText02),
-                                   selectionColor: UIColor(theme.primaryInteractive01))
+                                   selectionColor: UIColor(theme.primaryInteractive01),
+                                   fadesIn: viewModel.animatesTranscriptTransition)
             .mask(edgeFade)
             // Re-created when an edit moves the passage, so the view scrolls to it anew
             .id(snippet.range)
@@ -371,6 +378,9 @@ private struct BookmarkTranscriptReadView: UIViewRepresentable {
     let surroundingColor: UIColor
     let selectionColor: UIColor
 
+    /// Whether to fade in once it's in place, in step with the placeholder fading out
+    let fadesIn: Bool
+
     /// Where the passage sits vertically once scrolled to
     private let verticalAnchor: CGFloat = 0.4
 
@@ -402,7 +412,9 @@ private struct BookmarkTranscriptReadView: UIViewRepresentable {
                 textView.scrollToRange(passageRange, verticalAnchor: verticalAnchor, animated: false)
             }
 
-            UIView.animate(withDuration: TranscriptTransition.duration) {
+            // In step with the placeholder fading out, or straight to visible when there
+            // was no placeholder to speak of
+            UIView.animate(withDuration: fadesIn ? TranscriptTransition.duration : 0) {
                 textView.alpha = 1
             }
         }

--- a/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsView.swift
@@ -161,9 +161,13 @@ struct BookmarkDetailsView: View {
     private var transcriptSection: some View {
         Group {
             if let snippet = viewModel.transcriptSnippet {
+                // Fades itself in once it's laid out and scrolled to the passage, so it
+                // arrives in place rather than at the top of the transcript
                 transcriptView(for: snippet)
+                    .transition(.identity)
             } else if viewModel.isLoadingTranscript {
                 loadingPlaceholder
+                    .transition(.opacity)
             } else if let passage = viewModel.passage {
                 // No transcript to place the passage in, so it stands alone
                 ScrollView {
@@ -171,10 +175,11 @@ struct BookmarkDetailsView: View {
                 }
                 .scrollBounceBehavior(.basedOnSize)
                 .padding(.top, 24)
+                .transition(.opacity)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .animation(.easeInOut(duration: 0.2), value: viewModel.isLoadingTranscript)
+        .animation(.easeInOut(duration: TranscriptTransition.duration), value: viewModel.isLoadingTranscript)
     }
 
     private func transcriptView(for snippet: BookmarkTranscriptSnippet) -> some View {
@@ -208,57 +213,65 @@ struct BookmarkDetailsView: View {
         }
     }
 
-    /// The passage with placeholder text standing in for the transcript around it while
-    /// the real one loads
+    /// Stands in for the transcript while it loads, laid out as the turns of a
+    /// conversation so it breaks up the way the text that replaces it will
     private var loadingPlaceholder: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            placeholderParagraph(Self.leadingPlaceholder)
-
-            // The glyph waits for the real transcript, where it can mark the right line
-            viewModel.passage.map { passageView($0, showsBookmarkIndicator: false) }
-
-            placeholderParagraph(Self.trailingPlaceholder)
+        VStack(alignment: .leading, spacing: paragraphSpacing) {
+            ForEach(Self.transcriptPlaceholder, id: \.self) { paragraph in
+                Text(paragraph)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
-        // Starts clear of the fade, where the transcript that replaces it starts too
-        .padding(.top, TranscriptFade.top)
+        .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
+        .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
+        .foregroundStyle(theme.primaryText02)
+        .redacted(reason: .placeholder)
+        .padding(.horizontal, BookmarkTranscriptTextView.gutterWidth)
+        .padding(.top, 24)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .clipped()
+        .accessibilityHidden(true)
     }
 
-    private func placeholderParagraph(_ text: String) -> some View {
-        Text(text)
-            .font(size: BookmarkTranscriptStyle.fontSize, style: .body, design: .serif)
-            .lineSpacing(BookmarkTranscriptStyle.lineSpacing)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .foregroundStyle(theme.primaryText02)
-            .redacted(reason: .placeholder)
-            .padding(.horizontal, BookmarkTranscriptTextView.gutterWidth)
-            .accessibilityHidden(true)
+    /// The gap the transcript leaves between paragraphs, which TextKit adds on top of the
+    /// room the line height already leaves between lines
+    private var paragraphSpacing: CGFloat {
+        BookmarkTranscriptStyle.lineSpacing + BookmarkTranscriptStyle.paragraphSpacing
     }
 
     /// The passage on its own, in the same text view the full transcript uses, so it
     /// reads identically before and after the transcript arrives
-    private func passageView(_ passage: String, showsBookmarkIndicator: Bool = true) -> some View {
+    private func passageView(_ passage: String) -> some View {
         BookmarkPassageTextView(passage: passage,
-                                showsBookmarkIndicator: showsBookmarkIndicator,
                                 textColor: UIColor(theme.primaryText01),
                                 selectionColor: UIColor(theme.primaryInteractive01))
     }
 
-    /// Stand-ins for the transcript around the passage while it loads. The redaction
-    /// blocks them out, so they're never read; they only give the placeholders the
-    /// shape of prose.
-    private static let leadingPlaceholder = """
-    The lines of the transcript leading into the bookmarked passage land here once the \
-    episode transcript has been fetched, filling out a few lines above it.
-    """
-
-    private static let trailingPlaceholder = """
-    The rest of the transcript follows the passage the moment it arrives, running on \
-    long enough to fill the space below with the shape of the conversation as it \
-    continues past the bookmarked moment, line after line, until the fetched text \
-    takes its place.
-    """
+    /// Stands in for the transcript while it loads: turns of varying length, so the
+    /// placeholder reads as a conversation rather than a block. The redaction blocks the
+    /// words out, so they're never read; they only give the placeholder its shape.
+    private static let transcriptPlaceholder = [
+        """
+        The lines of the transcript leading into the bookmarked passage land here once \
+        the episode transcript has been fetched, filling out the space above the moment \
+        the bookmark was taken at.
+        """,
+        """
+        Right, and the conversation carries on either side of it, so the passage reads \
+        in the context it was captured in rather than standing on its own.
+        """,
+        "Shorter turns land in between the longer ones.",
+        """
+        The rest of the transcript follows below, running on long enough to fill the \
+        screen with the shape of the conversation as it continues past the bookmarked \
+        moment, line after line, until the fetched text takes its place.
+        """,
+        """
+        Each paragraph here stands in for one turn of the transcript, spaced the way the \
+        real turns are.
+        """,
+        "And it keeps going past the bottom of the screen, where the fade takes over."
+    ]
 
     private var timestamp: String {
         TimeFormatter.shared.playTimeFormat(time: viewModel.bookmark.time)
@@ -278,15 +291,23 @@ private enum TranscriptFade {
     static let bottom: CGFloat = 64
 }
 
+// MARK: - TranscriptTransition
+
+/// How long the placeholder takes to give way to the transcript. Both halves of the
+/// crossfade run for the same time: the placeholder fading out in SwiftUI, and the
+/// transcript fading itself in once it's scrolled to the passage.
+private enum TranscriptTransition {
+    static let duration: TimeInterval = 0.3
+}
+
 // MARK: - BookmarkPassageTextView
 
-/// The passage alone — while the transcript loads, or when there is none — rendered by
-/// the same text view the full transcript uses: the same styling and gutter, optionally
-/// the glyph marking its first line, and the text already selectable. Sized to its
-/// content, so it sits in the surrounding layout rather than scrolling.
+/// The passage alone, when there's no transcript to place it in, rendered by the same
+/// text view the full transcript uses: the same styling and gutter, the glyph marking
+/// its first line, and the text already selectable. Sized to its content, so it sits in
+/// the surrounding layout rather than scrolling.
 private struct BookmarkPassageTextView: UIViewRepresentable {
     let passage: String
-    let showsBookmarkIndicator: Bool
     let textColor: UIColor
     let selectionColor: UIColor
 
@@ -304,9 +325,7 @@ private struct BookmarkPassageTextView: UIViewRepresentable {
                                                    right: BookmarkTranscriptTextView.gutterWidth)
         textView.textContainer.lineFragmentPadding = 0
         textView.tintColor = selectionColor
-        if showsBookmarkIndicator {
-            textView.showBookmarkIndicator(at: 0, color: textColor)
-        }
+        textView.showBookmarkIndicator(at: 0, color: textColor)
         return textView
     }
 
@@ -381,6 +400,9 @@ private struct BookmarkTranscriptReadView: UIViewRepresentable {
 
             UIView.performWithoutAnimation {
                 textView.scrollToRange(passageRange, verticalAnchor: verticalAnchor, animated: false)
+            }
+
+            UIView.animate(withDuration: TranscriptTransition.duration) {
                 textView.alpha = 1
             }
         }

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
@@ -27,9 +27,18 @@ class BookmarkDetailsViewModel: ObservableObject {
     /// what the screen opens on.
     @Published private(set) var isLoadingTranscript: Bool
 
+    /// Whether the transcript took long enough to be worth fading the placeholder out
+    /// for. One that's already to hand arrives before the placeholder has really been
+    /// seen, where a crossfade reads as a flicker rather than a transition.
+    @Published private(set) var animatesTranscriptTransition = false
+
     /// Guards against a second fetch while one is in flight, which `isLoadingTranscript`
     /// can't do while it starts out true
     private var isFetchingTranscript = false
+
+    /// How long the transcript has to keep the placeholder up before its arrival is
+    /// worth animating
+    private static let transitionThreshold: Duration = .milliseconds(200)
 
     let episode: BaseEpisode?
 
@@ -76,10 +85,15 @@ class BookmarkDetailsViewModel: ObservableObject {
         guard transcriptSnippet == nil, !isFetchingTranscript,
               passage?.isEmpty == false, let episode else { return }
 
+        let startedLoading = ContinuousClock.now
+
         isFetchingTranscript = true
         isLoadingTranscript = true
 
-        transcriptSnippet = await bookmarkManager.capturedSnippet(for: bookmark, episode: episode)
+        let snippet = await bookmarkManager.capturedSnippet(for: bookmark, episode: episode)
+
+        animatesTranscriptTransition = startedLoading.duration(to: .now) > Self.transitionThreshold
+        transcriptSnippet = snippet
 
         isFetchingTranscript = false
         isLoadingTranscript = false
@@ -96,6 +110,10 @@ class BookmarkDetailsViewModel: ObservableObject {
     /// Points the already-loaded transcript at the passage as it stands after an edit
     private func relocatePassage() {
         guard let transcript = transcriptSnippet?.transcript else { return }
+
+        // The transcript is already up, so it's replaced in place rather than fading in
+        // over the placeholder
+        animatesTranscriptTransition = false
 
         transcriptSnippet = passage.flatMap { passage in
             BookmarkTranscriptSnippetExtractor.passageRange(for: passage, at: bookmark.passageLocation, in: transcript.attributedText)

--- a/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
+++ b/podcasts/Bookmarks/Details/BookmarkDetailsViewModel.swift
@@ -22,9 +22,9 @@ class BookmarkDetailsViewModel: ObservableObject {
     /// transcript isn't available, leaving the passage to stand alone.
     @Published private(set) var transcriptSnippet: BookmarkTranscriptSnippet?
 
-    /// Whether the transcript is still being fetched, so placeholders can stand in for
-    /// the text around the passage until it arrives. Already true where a fetch is coming,
-    /// so the placeholder is what the screen opens on.
+    /// Whether the transcript is still being fetched, so a placeholder can stand in for
+    /// it until it arrives. Already true where a fetch is coming, so the placeholder is
+    /// what the screen opens on.
     @Published private(set) var isLoadingTranscript: Bool
 
     /// Guards against a second fetch while one is in flight, which `isLoadingTranscript`

--- a/podcasts/Bookmarks/Editing/BookmarkTranscriptStyle.swift
+++ b/podcasts/Bookmarks/Editing/BookmarkTranscriptStyle.swift
@@ -6,6 +6,9 @@ enum BookmarkTranscriptStyle {
     static let fontSize: Double = 16
     static let lineHeightMultiple: Double = 1.5
 
+    /// The room between one paragraph and the next, on top of the line height
+    static let paragraphSpacing: Double = 10
+
     /// New York, scaling with the body text style
     static var font: UIFont {
         serifFont(ofSize: CGFloat(fontSize), scalingWith: .body)
@@ -51,7 +54,7 @@ enum BookmarkTranscriptStyle {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.minimumLineHeight = lineHeight
         paragraphStyle.maximumLineHeight = lineHeight
-        paragraphStyle.paragraphSpacing = 10
+        paragraphStyle.paragraphSpacing = CGFloat(paragraphSpacing)
         paragraphStyle.lineBreakMode = .byWordWrapping
         paragraphStyle.alignment = .natural
 


### PR DESCRIPTION
Simplifies the transcript loading state on the bookmark details screen, and makes the switch to the real transcript animate.

The placeholder used to render the captured passage in a live text view between two redacted paragraphs. It's now plain redacted text throughout, sitting nearer the top, which drops `placeholderParagraph`, the split placeholder strings, and the `showsBookmarkIndicator` flag on `BookmarkPassageTextView`.

The crossfade didn't animate before: `BookmarkTranscriptReadView` revealed its text view inside `performWithoutAnimation` once it had scrolled to the passage, so the transcript popped in partway through the fade. It now fades its own alpha in as the placeholder fades out. A transcript that's already to hand skips the fade entirely — under 200ms it reads as a flicker rather than a transition.

Stacked on #5008.

## To test

1. Open a bookmark with a captured passage, on an episode whose transcript has to be fetched.
2. Confirm the placeholder is redacted prose in the transcript's serif style, broken into paragraphs, with no passage text in it.
3. Confirm it fades out as the transcript fades in, arriving already scrolled to the passage.
4. Open the same bookmark again, now the transcript is to hand — it should appear immediately, with no flicker.
5. Edit the bookmark so the passage moves, and confirm the transcript re-scrolls to it without fading.
6. Open a bookmark whose transcript can't be loaded, and confirm the passage still stands alone.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
