### PR TITLE
Tighten the Claude code review prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -62,13 +62,47 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request with a focus on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Security implications
-            - Performance considerations
+            Read AGENTS.md first - it carries this repo's conventions.
 
-            Provide detailed feedback using inline comments for specific issues.
+            Priorities, in order:
+            1. Correctness - bugs reachable from real user flows: wrong logic,
+               unhandled states, races and threading violations, object lifetime
+               and retain issues, leaks.
+            2. Unintended behaviour change - anything the diff changes that the
+               description does not claim to change.
+            3. Security and privacy - untrusted input reaching queries, parsers or
+               the filesystem; secrets or user data in logs.
+            4. Performance - only where the impact is user-visible.
+
+            Comments:
+            - Every comment MUST be short and concise - a few sentences at most.
+              State the problem and the fix, not the reasoning that led you there.
+              No tables, no multi-paragraph analysis.
+            - Start a comment with "(nit)" for a trivial suggestion, and
+              "(non-blocking)" for something worth knowing that should not hold up
+              the merge. An unprefixed comment means it blocks.
+            - At most three "(nit)"/"(non-blocking)" comments between them. Blocking
+              findings are uncapped.
+            - Raise a pre-existing issue only if this PR makes it reachable, more
+              likely, or harder to fix later - and say which.
+            - Never comment to confirm code is correct, restate the diff, or praise it.
+            - Never describe a command you did not run or a file you did not read.
+
+            Do not comment on what other CI already checks: formatting and lint, PR
+            hygiene (labels, milestone, description, CHANGELOG presence), or whether
+            tests pass.
+
+            Output:
+            - Inline comments for anything anchored to a line.
+            - One summary: two to four sentences of verdict, then Blocking findings
+              only, one line each, linked to their thread. No tables, no re-analysis,
+              no checklist of what you read.
+
+            If new commits arrived since your last review on this PR:
+            - Review only what changed since then.
+            - Re-raise an earlier finding only if it is still open - one line, linking
+              the existing thread rather than restating it.
+            - If nothing new and nothing open, say so in one sentence and stop.
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -95,9 +95,17 @@ jobs:
 
             Output:
             - Inline comments for anything anchored to a line.
-            - One summary: two to four sentences of verdict, then Blocking findings
-              only, one line each, linked to their thread. No tables, no re-analysis,
-              no checklist of what you read.
+            - One summary comment:
+              - Two to four sentences of verdict. No preamble, no restating the PR.
+              - Then the findings grouped under `### Blocking`, `### Non-blocking`,
+                `### Nits`. Skip a group that is empty; skip the section entirely if
+                there are no findings, leaving the verdict as the whole summary.
+              - One line per finding: `path/File.swift:123` followed by a single
+                sentence naming the problem and the fix - enough to act on without
+                opening the thread. Add the inline comment's URL when you have one.
+              - A finding with no line to anchor to takes the same shape with just
+                the path, or no path when it is repo-wide.
+            - No tables, no re-analysis, no checklist of what you read, no praise.
 
             If new commits arrived since your last review on this PR:
             - Review only what changed since then.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -75,9 +75,10 @@ jobs:
             4. Performance - only where the impact is user-visible.
 
             Comments:
-            - Every comment MUST be short and concise - a few sentences at most.
-              State the problem and the fix, not the reasoning that led you there.
-              No tables, no multi-paragraph analysis.
+            - Keep comments short by default - a few sentences stating the problem
+              and the fix, not the reasoning that led you there. Spend more words
+              only where the finding needs them to be actionable: a subtle race, a
+              non-obvious call path, a concrete repro.
             - Start a comment with "(nit)" for a trivial suggestion, and
               "(non-blocking)" for something worth knowing that should not hold up
               the merge. An unprefixed comment means it blocks.


### PR DESCRIPTION
Making – or attempting to make – Claude reviews a bit more manageable. 

---

Rewrites the review prompt in `claude-code-review.yml`. The old one — "code quality and best practices, potential bugs, security implications, performance considerations" — left the priorities implicit and put no ceiling on low-value comments.

Reading back the reviews on the last ~10 PRs, three things were worth designing against:

- **Severity is invisible.** On #4991 and #4995 every inline comment was a nit or a pre-existing note, with nothing marking what actually blocks. Comments that don't block now say so up front — `(nit)` or `(non-blocking)`, at most three between them; anything unprefixed blocks.
- **Re-reviews repeat themselves.** #4984 collected four full-length reviews and #4993 three, one of them for a CHANGELOG-only commit. Pushes now get a delta review: only what changed, still-open findings re-raised in one line, stop early when there is nothing new.
- **Comments run long.** Findings arrive as multi-paragraph analyses with tables and step-by-step walkthroughs — #4984 and #4993 are the clearest cases. Comments must now be short and concise: the problem and the fix, no tables, no re-analysis.

Also cedes what other CI already covers (SwiftLint, Danger, the string-format lint, the tests) rather than inviting overlap, and bars describing a command not run or a file not read — #4993's review reported a `git diff origin/trunk...HEAD` that a `fetch-depth: 1` checkout with no `Bash(git ...)` grant cannot run. `claude_args` and the job's guards are unchanged.

Follow-ups deliberately left out: `fetch-depth: 0` plus `Bash(git diff:*)` in `--allowedTools` so re-reviews get real commit context, and mirroring this into the Android and Web Player repos, which share the workflow.

## To test

The workflow skips itself on PRs that touch it, so the prompt can only be exercised after merge.

1. Confirm the job on this PR is skipped with the "Skipping Claude review because this PR changes ..." message.
2. After merge, on the next PR: lower-priority comments are prefixed `(nit)` or `(non-blocking)` and there are at most three of them, the summary is a short verdict plus blocking findings only, and nothing lands on lint, labels or CHANGELOG presence.
3. Push a follow-up commit there and confirm the second review covers only the delta.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
