### PR TITLE
Mark EndOfYear.share as @MainActor (2 warnings)

### DIFF
--- a/Modules/Sources/EndOfYear/StoryShareableProvider.swift
+++ b/Modules/Sources/EndOfYear/StoryShareableProvider.swift
@@ -40,13 +40,12 @@ public class StoryShareableProvider: UIActivityItemProvider, @unchecked Sendable
     // This method is called when the share sheet appeared
     // So we can go ahead and snapshot the view
     @MainActor
-    public func snapshot(viewModifier: (AnyView) -> some View) {
+    public func snapshot(viewModifier: @MainActor (AnyView) -> some View) {
         guard let view else {
             return
         }
 
-        let snapshot = AnyView(view)
-        .modify(viewModifier)
+        let snapshot = AnyView(viewModifier(view))
         .environment(\.renderForSharing, true)
         .frame(width: 450, height: 800)
         .ignoresSafeArea()

--- a/podcasts/End of Year/EndOfYear.swift
+++ b/podcasts/End of Year/EndOfYear.swift
@@ -206,6 +206,7 @@ struct EndOfYear {
         Analytics.track(.endOfYearStoriesShown, properties: ["source": source.rawValue, "current_year": EndOfYear.currentYear.literalValue])
     }
 
+    @MainActor
     static func share(assets: [Any], model: StoriesModel, storyIdentifier: String = "unknown", onDismiss: (() -> Void)? = nil) {
         let presenter = SceneHelper.rootViewController()
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Clears two `MainActor` isolation warnings in `EndOfYear.share`.

`share` is pure UIKit presentation code but was `nonisolated`, so the `present(_:animated:completion:)` closures it creates were nonisolated too — making the `snapshot(viewModifier:)` call inside them cross-actor. Marking `share` as `@MainActor` fixes both warnings; its only caller, `StoriesModel.share()`, is already main-actor isolated.

`snapshot(viewModifier:)` is `@MainActor` and calls the modifier synchronously while rendering, so its parameter is now `@MainActor` too. That meant inlining `view.modify(viewModifier)`, since `modify` takes a nonisolated closure. Equivalent here — `modify` only falls back to the unmodified view when the transform returns `nil` or `EmptyView`, and no `sharingSnapshotModifier` implementation does.

No behavior change: this code already ran on the main thread.

## To test

1. Open the End of Year stories (Profile → End of Year, EoY feature flag enabled).
2. Tap the share button on a story.
3. Confirm the shared image is the story snapshot with the logo overlay.
4. Pick "Save Image" and confirm the stories stay open behind the sheet.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
