### PR TITLE
Remove the useFollowNaming feature flag

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -50,9 +50,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Push two auto downloads on subscribe of a podcast
     case autoDownloadOnSubscribe
 
-    /// Replace Subscribe/Unsubscribe with Follow/Unfollow
-    case useFollowNaming
-
     /// Enable the winback screen and flow
     case winback
 
@@ -315,8 +312,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .upNextShuffle:
             true
         case .autoDownloadOnSubscribe:
-            true
-        case .useFollowNaming:
             true
         case .winback:
             true

--- a/podcasts/BundlePodcastCell.swift
+++ b/podcasts/BundlePodcastCell.swift
@@ -29,8 +29,8 @@ class BundlePodcastCell: ThemeableCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
-            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
 
             NotificationCenter.default.addObserver(self, selector: #selector(podcastWasAdded), name: Constants.Notifications.podcastAdded, object: nil)
         }

--- a/podcasts/CategorySponsoredCell.swift
+++ b/podcasts/CategorySponsoredCell.swift
@@ -40,8 +40,8 @@ class CategorySponsoredCell: ThemeableCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")
             subscribeButton.offImage = UIImage(named: "discover_add")
             subscribeButton.tintColor = ThemeColor.secondaryIcon01()
-            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
-            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
 
             NotificationCenter.default.addObserver(self, selector: #selector(podcastWasAdded), name: Constants.Notifications.podcastAdded, object: nil)
         }

--- a/podcasts/DescriptiveCollectionCell.swift
+++ b/podcasts/DescriptiveCollectionCell.swift
@@ -9,8 +9,8 @@ class DescriptiveCollectionCell: ThemeableCollectionCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
-            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
         }
     }
 

--- a/podcasts/DiscoverFeaturedView.swift
+++ b/podcasts/DiscoverFeaturedView.swift
@@ -56,8 +56,8 @@ class DiscoverFeaturedView: ThemeableView {
             subscribeButton.offImage = UIImage(named: "discover_add")
             subscribeButton.tintColor = ThemeColor.contrast02()
 
-            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
-            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
         }
     }
 

--- a/podcasts/DiscoverPodcastTableCell.swift
+++ b/podcasts/DiscoverPodcastTableCell.swift
@@ -48,8 +48,8 @@ class DiscoverPodcastTableCell: ThemeableCell {
             subscribeButton.offImage = UIImage(named: "discover_add")
             subscribeButton.tintColor = ThemeColor.secondaryIcon01()
 
-            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
-            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
 
             NotificationCenter.default.addObserver(self, selector: #selector(podcastWasAdded), name: Constants.Notifications.podcastAdded, object: nil)
         }

--- a/podcasts/Folders/FolderViewController+ContextMenu.swift
+++ b/podcasts/Folders/FolderViewController+ContextMenu.swift
@@ -68,8 +68,7 @@ extension FolderViewController {
             self?.setEditingOrder(true)
         }
 
-        let unfollowTitle = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
-        let unfollowAction = UIAction(title: unfollowTitle, image: UIImage(systemName: "trash"), attributes: .destructive) { [weak self] _ in
+        let unfollowAction = UIAction(title: L10n.unfollow, image: UIImage(systemName: "trash"), attributes: .destructive) { [weak self] _ in
             self?.confirmUnsubscribe(podcast: podcast)
         }
 
@@ -92,10 +91,9 @@ extension FolderViewController {
     }
 
     private func confirmUnsubscribe(podcast: Podcast) {
-        let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
         let alert = UIAlertController(title: L10n.areYouSure, message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-        alert.addAction(UIAlertAction(title: label, style: .destructive) { _ in
+        alert.addAction(UIAlertAction(title: L10n.unfollow, style: .destructive) { _ in
             PodcastManager.shared.unsubscribe(podcast: podcast)
             Analytics.track(.podcastUnsubscribed, properties: ["source": AnalyticsSource.folder, "uuid": podcast.uuid])
         })

--- a/podcasts/ImportExportViewController.swift
+++ b/podcasts/ImportExportViewController.swift
@@ -16,7 +16,7 @@ class ImportExportViewController: PCViewController, UIDocumentInteractionControl
 
     @IBOutlet var importPodcastsDescription: ThemeableLabel! {
         didSet {
-            importPodcastsDescription.text = FeatureFlag.useFollowNaming.enabled ? L10n.importPodcastsDescriptionNew : L10n.importPodcastsDescription
+            importPodcastsDescription.text = L10n.importPodcastsDescriptionNew
         }
     }
 

--- a/podcasts/LargeListCell.swift
+++ b/podcasts/LargeListCell.swift
@@ -26,8 +26,8 @@ class LargeListCell: ThemeableCollectionCell {
             subscribeButton.tintColor = ThemeColor.contrast01()
             subscribeButton.backgroundColor = ThemeColor.veil()
 
-            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
-            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
         }
     }
 

--- a/podcasts/Onboarding/Import/ImportViewModel.swift
+++ b/podcasts/Onboarding/Import/ImportViewModel.swift
@@ -34,7 +34,7 @@ class ImportViewModel: OnboardingModel {
         .init(id: .castro, displayName: "Castro", steps: L10n.importInstructionsCastro),
         .init(id: .castbox, displayName: "Castbox", steps: L10n.importInstructionsCastbox),
         .init(id: .overcast, displayName: "Overcast", steps: L10n.importInstructionsOvercast),
-        .init(id: .other, displayName: "other apps", steps: FeatureFlag.useFollowNaming.enabled ? L10n.importPodcastsDescriptionNew : L10n.importPodcastsDescription),
+        .init(id: .other, displayName: "other apps", steps: L10n.importPodcastsDescriptionNew),
         .init(id: .opmlFromURL, displayName: "URL", steps: L10n.importOpmlFromUrl)
     ]
 

--- a/podcasts/Onboarding/PodcastSubscribeButton.swift
+++ b/podcasts/Onboarding/PodcastSubscribeButton.swift
@@ -37,10 +37,7 @@ struct PodcastSubscribeButton: View {
                 .scaleEffect(scale)
                 .offset(x: -4, y: -4)
         }
-        .accessibilityLabel(isSubscribed ?
-            (FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed) :
-            (FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe)
-        )
+        .accessibilityLabel(isSubscribed ? L10n.unfollow : L10n.follow)
     }
 
     private func toggleSubscription() {

--- a/podcasts/PodcastGroupCell.swift
+++ b/podcasts/PodcastGroupCell.swift
@@ -21,8 +21,8 @@ class PodcastGroupCell: ThemeableCell {
         didSet {
             subscribeButton.onImage = UIImage(named: "discover_tick")
             subscribeButton.offImage = UIImage(named: "discover_add")
-            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
-            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
 
             subscribeButton.tintColor = ThemeColor.secondaryIcon01()
         }

--- a/podcasts/Podcasts/All Podcasts/PodcastListViewController+ContextMenu.swift
+++ b/podcasts/Podcasts/All Podcasts/PodcastListViewController+ContextMenu.swift
@@ -86,8 +86,7 @@ extension PodcastListViewController {
             self?.setEditingOrder(true)
         }
 
-        let unfollowTitle = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
-        let unfollowAction = UIAction(title: unfollowTitle, image: UIImage(systemName: "trash"), attributes: .destructive) { [weak self] _ in
+        let unfollowAction = UIAction(title: L10n.unfollow, image: UIImage(systemName: "trash"), attributes: .destructive) { [weak self] _ in
             self?.confirmUnsubscribe(podcast: podcast)
         }
 
@@ -107,10 +106,9 @@ extension PodcastListViewController {
     // MARK: Action handlers
 
     private func confirmUnsubscribe(podcast: Podcast) {
-        let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
         let alert = UIAlertController(title: L10n.areYouSure, message: nil, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-        alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: L10n.unfollow, style: .destructive) { [weak self] _ in
             PodcastManager.shared.unsubscribe(podcast: podcast)
             Analytics.track(.podcastUnsubscribed, properties: ["source": self?.analyticsSource ?? AnalyticsSource.podcastsList, "uuid": podcast.uuid])
         })

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController+Table.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController+Table.swift
@@ -194,7 +194,7 @@ extension PodcastSettingsViewController: UITableViewDataSource, UITableViewDeleg
             }
         case .unsubscribe:
             let cell = tableView.dequeueReusableCell(withIdentifier: PodcastSettingsViewController.destructiveButtonCellId, for: indexPath) as! DestructiveButtonCell
-            cell.buttonTitle.text = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
+            cell.buttonTitle.text = L10n.unfollow
             cell.buttonTitle.textColor = ThemeColor.support05()
             return cell
         }

--- a/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/Podcast Settings/PodcastSettingsViewController.swift
@@ -101,19 +101,18 @@ class PodcastSettingsViewController: PCViewController {
                 downloadedCount += 1
             }
         }
-        let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
         let title: String
         let message: String?
         if downloadedCount > 0 {
             title = L10n.downloadedFilesConf(downloadedCount)
-            message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
+            message = L10n.downloadedFilesConfMessageNew
         } else {
             title = L10n.areYouSure
             message = nil
         }
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-        alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: L10n.unfollow, style: .destructive) { [weak self] _ in
             self?.performUnsubscribe()
         })
         present(alert, animated: true)

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -741,19 +741,18 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
             }
         }
 
-        let label = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.unsubscribe
         let title: String
         let message: String?
         if downloadedCount > 0 {
             title = L10n.downloadedFilesConf(downloadedCount)
-            message = FeatureFlag.useFollowNaming.enabled ? L10n.downloadedFilesConfMessageNew : L10n.downloadedFilesConfMessage
+            message = L10n.downloadedFilesConfMessageNew
         } else {
             title = L10n.areYouSure
             message = nil
         }
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-        alert.addAction(UIAlertAction(title: label, style: .destructive) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: L10n.unfollow, style: .destructive) { [weak self] _ in
             self?.performUnsubscribe()
         })
         present(alert, animated: true)

--- a/podcasts/Podcasts/Podcast Page/SubscribeButton.swift
+++ b/podcasts/Podcasts/Podcast Page/SubscribeButton.swift
@@ -16,7 +16,7 @@ class SubscribeButton: ThemeableView {
 
     @IBOutlet var titleLabel: ThemeableLabel! {
         didSet {
-            titleLabel.text =  FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
+            titleLabel.text = L10n.follow
             titleLabel.style = .primaryInteractive02
         }
     }

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -34,8 +34,8 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
-            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
         }
     }
 

--- a/podcasts/SmallListCell.swift
+++ b/podcasts/SmallListCell.swift
@@ -16,8 +16,8 @@ class SmallListCell: ThemeableCollectionCell {
             subscribeButton.onImage = UIImage(named: "discover_tick")?.tintedImage(ThemeColor.support02())
             subscribeButton.offImage = UIImage(named: "discover_add")?.tintedImage(ThemeColor.primaryIcon02())
 
-            subscribeButton.offAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.follow : L10n.subscribe
-            subscribeButton.onAccessibilityLabel = FeatureFlag.useFollowNaming.enabled ? L10n.unfollow : L10n.subscribed
+            subscribeButton.offAccessibilityLabel = L10n.follow
+            subscribeButton.onAccessibilityLabel = L10n.unfollow
         }
     }
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -808,9 +808,6 @@
 /* A common string used throughout the app. Title for screens and prompts related to storage and downloaded files. */
 "downloaded_files" = "Downloaded Files";
 
-/* Message for an unsubscribe message box that informs the user that unsubscribing will remove downloaded files. */
-"downloaded_files_conf_message" = "Unsubscribing will delete all downloaded files in this Podcast, are you sure?";
-
 /* Message for an unfollow message box that informs the user that unfollowing will remove downloaded files. */
 "downloaded_files_conf_message_new" = "Unfollowing will delete all downloaded files in this Podcast, are you sure?";
 
@@ -1206,9 +1203,6 @@
 
 /* The summary text at the end of the screen explaining how to upload a file */
 "how_to_upload_summary" = "That's it, you're done. Change any details you want, hit save and play!";
-
-/* Describes the process about how to import podcasts to Pocket Casts. '\\n\\n' Is a line break format to separate the description from the following note. */
-"import_podcasts_description" = "You can import your podcasts subscriptions to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.\n\nNote: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.";
 
 /* Describes the process about how to import podcasts to Pocket Casts. '\\n\\n' Is a line break format to separate the description from the following note. */
 "import_podcasts_description_new" = "You can import your podcasts to Pocket Casts using the widely supported OPML format. Export the file from another app and choose open in Pocket Casts.\n\nNote: You may need to email the OPML file to yourself, long press on the attachment and select Pocket Casts.";
@@ -3405,12 +3399,6 @@
 
 /* A common string used throughout the app. Prompt to cancel the download for the selected item(s). */
 "stop_download" = "Stop Download";
-
-/* Prompt to subscribe to the selected podcast. */
-"subscribe" = "Subscribe";
-
-/* Label indicating that the user is currently subscribed to the selected podcast. */
-"subscribed" = "Subscribed";
 
 /* Prompt to follow to the selected podcast. */
 "follow" = "Follow";


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

The `useFollowNaming` flag has defaulted to `true` since 2024-10, so every call site was resolving to the Follow/Unfollow wording. This removes the flag and collapses the ~32 `FeatureFlag.useFollowNaming.enabled ? … : …` ternaries across 20 files down to the value they already returned.

Fallout of the collapse:

- `L10n.subscribe`, `L10n.subscribed`, `L10n.importPodcastsDescription` and `L10n.downloadedFilesConfMessage` are now entirely unused, so their keys are removed from `Localizable.strings`. `L10n.unsubscribe` stays — `SupporterPodcastViewController` still uses it for paid podcasts.
- The `…New` key names (`import_podcasts_description_new`, `downloaded_files_conf_message_new`) are left alone: renaming them to the base names would discard the existing translations for no user-visible gain.
- A handful of single-use `let label = …` / `let unfollowTitle = …` bindings that only existed to hold the ternary result are inlined.

No behaviour change.

## To test

1. Open a podcast page — the button reads **Follow**, and the confirmation sheet when unfollowing reads **Unfollow**.
2. Unfollow a podcast that has downloaded files — the alert message mentions "Unfollowing will delete all downloaded files".
3. Long-press a podcast in the Podcasts grid and inside a folder — the context menu action reads **Unfollow**.
4. Podcast Settings → the destructive row at the bottom reads **Unfollow**.
5. Profile → Import/Export → Import — the OPML description text mentions "your podcasts" (not "your podcasts subscriptions").
6. With VoiceOver on, focus a Discover subscribe button — it announces **Follow** / **Unfollow**.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
