### PR TITLE
Remove the upNextShuffle feature flag

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -44,9 +44,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the End of Year 2024 recap
     case endOfYear2024
 
-    /// Enable the Up Next shuffle button
-    case upNextShuffle
-
     /// Push two auto downloads on subscribe of a podcast
     case autoDownloadOnSubscribe
 
@@ -312,8 +309,6 @@ public enum FeatureFlag: String, CaseIterable {
             false
         case .endOfYear2024:
             false
-        case .upNextShuffle:
-            true
         case .autoDownloadOnSubscribe:
             true
         case .useFollowNaming:

--- a/podcasts/Constants.swift
+++ b/podcasts/Constants.swift
@@ -295,7 +295,6 @@ struct Constants {
     enum Limits {
         static let minTimeBetweenRemoteSkips: TimeInterval = 0.2
         static let maxDownloadConnectionsPerHost = 2
-        static let upNextClearWithoutWarning = 2
 
         static let minSleepTime = 5.minutes
         static let maxSleepTime = 5.hours

--- a/podcasts/PlaybackManager.swift
+++ b/podcasts/PlaybackManager.swift
@@ -735,7 +735,7 @@ class PlaybackManager: ServerPlaybackDelegate {
         if queueCount == 0 { return }
 
         var index = 0
-        if FeatureFlag.upNextShuffle.enabled, queueCount > 1, Settings.upNextShuffleEnabled() {
+        if queueCount > 1, Settings.upNextShuffleEnabled() {
             index = Int.random(in: 0..<queueCount)
             FileLog.shared.addMessage("Play Next Episode with Shuffle enabled: playing episode \(index) out of \(queueCount)")
         }
@@ -744,7 +744,7 @@ class PlaybackManager: ServerPlaybackDelegate {
 
         FileLog.shared.addMessage("Play Next Episode \(nextEpisode.displayableTitle())")
 
-        if FeatureFlag.upNextShuffle.enabled, queueCount > 1, index > 0 {
+        if queueCount > 1, index > 0 {
             queue.move(episode: nextEpisode, to: 0)
         }
 

--- a/podcasts/Settings.swift
+++ b/podcasts/Settings.swift
@@ -270,8 +270,6 @@ class Settings: NSObject {
 
     static let upNextShuffleKey = "SJUpNextShuffleKey"
     class func upNextShuffleToggle() {
-        guard FeatureFlag.upNextShuffle.enabled else { return }
-
         let isOn = upNextShuffleEnabled()
         UserDefaults.standard.set(!isOn, forKey: Settings.upNextShuffleKey)
 
@@ -279,7 +277,7 @@ class Settings: NSObject {
     }
 
     class func upNextShuffleEnabled() -> Bool {
-        if !FeatureFlag.upNextShuffle.enabled || !SubscriptionHelper.hasActiveSubscription() || !SyncManager.isUserLoggedIn() {
+        if !SubscriptionHelper.hasActiveSubscription() || !SyncManager.isUserLoggedIn() {
             return false
         }
         return UserDefaults.standard.bool(forKey: Settings.upNextShuffleKey)

--- a/podcasts/UpNextViewController+Swipe.swift
+++ b/podcasts/UpNextViewController+Swipe.swift
@@ -54,10 +54,8 @@ extension UpNextViewController: SwipeTableViewCellDelegate {
                     }
                 } else {
                     tableView.reloadData() // if they delete the very last episode, reload the table to get the empty up next cell
-                    if FeatureFlag.upNextShuffle.enabled {
-                        isMultiSelectEnabled = false
-                        updateNavBarButtons()
-                    }
+                    isMultiSelectEnabled = false
+                    updateNavBarButtons()
                 }
             }
 

--- a/podcasts/UpNextViewController+Table.swift
+++ b/podcasts/UpNextViewController+Table.swift
@@ -29,14 +29,7 @@ extension UpNextViewController: UITableViewDelegate, UITableViewDataSource {
 
         updateTimeRemainingLabel()
 
-        if FeatureFlag.upNextShuffle.enabled {
-            clearQueueButton.isHidden = true
-            shuffleButton.isHidden = PlaybackManager.shared.queue.upNextCount() == 0
-        } else {
-            clearQueueButton.isHidden = false
-            shuffleButton.isHidden = true
-            clearQueueButton.isEnabled = PlaybackManager.shared.queue.upNextCount() > 0
-        }
+        shuffleButton.isHidden = PlaybackManager.shared.queue.upNextCount() == 0
         if FeatureFlag.upNextSort.enabled {
             sortButton.isHidden = PlaybackManager.shared.queue.upNextCount() == 0
         }

--- a/podcasts/UpNextViewController.swift
+++ b/podcasts/UpNextViewController.swift
@@ -54,7 +54,6 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     // Use HitTargetButton so these small header controls meet Apple's recommended 44x44pt minimum tap target without changing their visible size.
     let shuffleButton = HitTargetButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
     let sortButton = HitTargetButton(frame: CGRect(x: 0, y: 0, width: 24, height: 24))
-    let clearQueueButton = HitTargetButton(frame: CGRect(x: 0, y: 0, width: 93, height: 16))
     var selectedPlayListEpisodes = [PlaylistEpisode]() {
         didSet {
             multiSelectActionBar.setSelectedCount(count: selectedPlayListEpisodes.count)
@@ -96,7 +95,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             ])
         }
 
-        // When the sort button is shown, the shuffle/clear buttons sit to its left.
+        // When the sort button is shown, the shuffle button sits to its left.
         let trailingButtonAnchor = FeatureFlag.upNextSort.enabled ? sortButton.leadingAnchor : headerView.trailingAnchor
         let trailingButtonConstant: CGFloat = FeatureFlag.upNextSort.enabled ? -16 : -20
 
@@ -111,22 +110,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
             shuffleButton.heightAnchor.constraint(equalToConstant: 24)
         ])
 
-        headerView.addSubview(clearQueueButton)
-        clearQueueButton.translatesAutoresizingMaskIntoConstraints = false
-        clearQueueButton.setContentCompressionResistancePriority(.required, for: .horizontal)
-        NSLayoutConstraint.activate([
-            clearQueueButton.trailingAnchor.constraint(equalTo: trailingButtonAnchor, constant: trailingButtonConstant),
-            clearQueueButton.centerYAnchor.constraint(equalTo: headerView.centerYAnchor),
-            clearQueueButton.leadingAnchor.constraint(greaterThanOrEqualTo: remainingLabel.trailingAnchor, constant: 10)
-        ])
-
-        if FeatureFlag.upNextShuffle.enabled {
-            clearQueueButton.isHidden = true
-            shuffleButton.isHidden = PlaybackManager.shared.queue.upNextCount() == 0
-        } else {
-            shuffleButton.isHidden = true
-            clearQueueButton.isEnabled = PlaybackManager.shared.queue.upNextCount() > 0
-        }
+        shuffleButton.isHidden = PlaybackManager.shared.queue.upNextCount() == 0
         if FeatureFlag.upNextSort.enabled {
             sortButton.isHidden = PlaybackManager.shared.queue.upNextCount() == 0
         }
@@ -206,7 +190,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(reorderingDidBegin), name: .tableViewReorderWillBegin, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(reorderingDidEnd), name: .tableViewReorderDidEnd, object: nil)
 
-        if FeatureFlag.upNextShuffle.enabled, showingInTab {
+        if showingInTab {
             NotificationCenter.default.addObserver(self, selector: #selector(updateShuffleButtonState), name: Constants.Notifications.upNextShuffleToggle, object: nil)
         }
 
@@ -230,9 +214,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         super.viewWillAppear(animated)
         updateNavBarButtons()
         setupActionButtonsIfNecessary()
-        if FeatureFlag.upNextShuffle.enabled {
-            themeDidChange()
-        }
+        themeDidChange()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -264,16 +246,12 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     @objc func clearQueueTapped() {
         let queueCount = PlaybackManager.shared.queue.upNextCount()
 
-        if queueCount <= Constants.Limits.upNextClearWithoutWarning && !FeatureFlag.upNextShuffle.enabled {
-            performClearAll()
-        } else {
-            let alert = UIAlertController(title: L10n.clearUpNext, message: L10n.clearUpNextMessage, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
-            alert.addAction(UIAlertAction(title: actionLabelText(queueCount), style: .destructive) { [weak self] _ in
-                self?.performClearAll()
-            })
-            present(alert, animated: true)
-        }
+        let alert = UIAlertController(title: L10n.clearUpNext, message: L10n.clearUpNextMessage, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L10n.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: actionLabelText(queueCount), style: .destructive) { [weak self] _ in
+            self?.performClearAll()
+        })
+        present(alert, animated: true)
 
         selectedPlayListEpisodes.removeAll()
         isMultiSelectEnabled = false
@@ -327,34 +305,21 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     @objc private func subscriptionStatusDidChange() {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            if FeatureFlag.upNextShuffle.enabled {
-                // Update UI
-                FileLog.shared.addMessage("UpNext subscriptionStatusDidChange: user has active subscription: \(SubscriptionHelper.hasActiveSubscription()) and is logged in: \(SyncManager.isUserLoggedIn())")
+            FileLog.shared.addMessage("UpNext subscriptionStatusDidChange: user has active subscription: \(SubscriptionHelper.hasActiveSubscription()) and is logged in: \(SyncManager.isUserLoggedIn())")
 
-                setupActionButtonsIfNecessary()
-                themeDidChange()
-                updateNavBarButtons()
-                reloadTable()
-            }
+            setupActionButtonsIfNecessary()
+            themeDidChange()
+            updateNavBarButtons()
+            reloadTable()
         }
     }
 
     private func setupActionButtonsIfNecessary() {
-        if FeatureFlag.upNextShuffle.enabled {
-            guard shuffleButton.allTargets.isEmpty else { return }
-            NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
-            NotificationCenter.default.addObserver(self, selector: #selector(subscriptionStatusDidChange), name: ServerNotifications.subscriptionStatusChanged, object: nil)
-            themeDidChange()
-            shuffleButton.addTarget(self, action: #selector(shuffleButtonTapped), for: .touchUpInside)
-        } else {
-            guard clearQueueButton.allTargets.isEmpty else { return }
-            clearQueueButton.setTitle(L10n.queueClearQueue, for: .normal)
-            clearQueueButton.setTitleColor(AppTheme.colorForStyle(.primaryText02, themeOverride: themeOverride), for: .normal)
-            clearQueueButton.setTitleColor(AppTheme.colorForStyle(.primaryText02, themeOverride: themeOverride).withAlphaComponent(0.5), for: .disabled)
-            clearQueueButton.titleLabel?.font = UIFont.font(ofSize: 13, weight: .bold, scalingWith: .footnote)
-            clearQueueButton.titleLabel?.adjustsFontForContentSizeCategory = true
-            clearQueueButton.addTarget(self, action: #selector(clearQueueTapped), for: .touchUpInside)
-        }
+        guard shuffleButton.allTargets.isEmpty else { return }
+        NotificationCenter.default.addObserver(self, selector: #selector(themeDidChange), name: Constants.Notifications.themeChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(subscriptionStatusDidChange), name: ServerNotifications.subscriptionStatusChanged, object: nil)
+        themeDidChange()
+        shuffleButton.addTarget(self, action: #selector(shuffleButtonTapped), for: .touchUpInside)
         setupSortButtonIfNecessary()
     }
 
@@ -400,7 +365,7 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     private func actionLabelText(_ queueCount: Int) -> String {
-        if FeatureFlag.upNextShuffle.enabled, queueCount == 1 {
+        if queueCount == 1 {
             return L10n.queueClearEpisodeQueueSingular
         }
         return L10n.queueClearEpisodeQueuePlural(queueCount.localized())
@@ -511,22 +476,16 @@ class UpNextViewController: UIViewController, UIGestureRecognizerDelegate {
         } else {
             let hasEpisodes = PlaybackManager.shared.queue.upNextCount() > 0
 
-            if FeatureFlag.upNextShuffle.enabled {
-                if hasEpisodes {
-                    let selectButton = UIBarButtonItem(image: UIImage(named: "option-multiselect"), style: .plain, target: self, action: #selector(selectTapped))
-                    selectButton.accessibilityLabel = L10n.selectEpisodes
-                    let moreButton = UIBarButtonItem(image: UIImage(named: "more"), style: .plain, target: self, action: #selector(moreTapped))
-                    moreButton.accessibilityLabel = L10n.accessibilityMoreActions
-                    rightButtons = [selectButton, moreButton]
-                } else {
-                    rightButtons = []
-                }
-                leftButton = showingInTab ? nil : UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(doneTapped))
+            if hasEpisodes {
+                let selectButton = UIBarButtonItem(image: UIImage(named: "option-multiselect"), style: .plain, target: self, action: #selector(selectTapped))
+                selectButton.accessibilityLabel = L10n.selectEpisodes
+                let moreButton = UIBarButtonItem(image: UIImage(named: "more"), style: .plain, target: self, action: #selector(moreTapped))
+                moreButton.accessibilityLabel = L10n.accessibilityMoreActions
+                rightButtons = [selectButton, moreButton]
             } else {
-                let selectButton = UIBarButtonItem(title: L10n.select, style: .plain, target: self, action: #selector(selectTapped))
-                rightButtons = hasEpisodes ? [selectButton] : []
-                leftButton = showingInTab ? nil : UIBarButtonItem(title: L10n.done, style: .plain, target: self, action: #selector(doneTapped))
+                rightButtons = []
             }
+            leftButton = showingInTab ? nil : UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(doneTapped))
         }
 
         if rightButtons.count > 1 {

--- a/podcasts/Whats New/Announcements.swift
+++ b/podcasts/Whats New/Announcements.swift
@@ -116,7 +116,7 @@ struct Announcements {
             action: {
                 SceneHelper.rootViewController()?.dismiss(animated: true)
             },
-            isEnabled: FeatureFlag.upNextShuffle.enabled,
+            isEnabled: true,
             fullModal: true
         ),
         .init(

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -2200,9 +2200,6 @@
 /* Confirmation message to clear one episode from the queue. */
 "queue_clear_episode_queue_singular" = "Clear 1 Episode";
 
-/* Prompt to allow the user to clear their queue. */
-"queue_clear_queue" = "CLEAR QUEUE";
-
 /* A common string used throughout the app. Provides an option to add the selected item(s) to a queue instead of performing the action now. Used for downloads and uploads. */
 "queue_for_later" = "Queue For Later";
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

The `upNextShuffle` flag has defaulted to `true` since 2024-10, so all ~20 branches were already resolving to the shuffle path. This removes the flag and collapses those branches in `UpNextViewController` (+`Table`, +`Swipe`), `PlaybackManager`, `Settings` and `Announcements`.

Fallout of the collapse:

- **`clearQueueButton` is deleted.** The enabled path set `isHidden = true` and never gave it a title or a target, so it was dead UI sitting in the header. Clearing the queue stays reachable through the header's **⋯ → Clear Up Next**, which calls the same `clearQueueTapped()`.
- `Constants.Limits.upNextClearWithoutWarning` and `L10n.queueClearQueue` were only read from the disabled path, so both are removed. The "clear without warning under N episodes" shortcut was already unreachable — clearing has always shown the confirmation alert on the enabled path.
- The 7.77 shuffle announcement's `isEnabled` becomes `true`, matching the other historical entries.
- `Settings.upNextShuffleEnabled()` / `upNextShuffleToggle()` keep their subscription and login checks; only the flag test is dropped.

No behaviour change.

## To test

1. Up Next with several episodes → the header shows the **shuffle** icon (no "CLEAR QUEUE" button), and the nav bar shows the multi-select and ⋯ buttons.
2. Tap **⋯ → Clear Up Next** → the confirmation alert appears, and the button reads "Clear 1 Episode" for a single-episode queue and "Clear N Episodes" otherwise. Confirming empties the queue.
3. Empty the queue by swiping away the last episode → the table shows the empty state and the nav bar buttons disappear.
4. As a Plus subscriber, tap shuffle → the toast appears, the icon shows selected, and playback picks the next episode at random. Tap again to turn it off.
5. As a free/logged-out user, tap shuffle → the Plus paywall is presented (from the tab and from the player's Up Next).
6. Open Up Next from the player and from the tab → the shuffle button state matches in both.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
