### PR TITLE
Add smart bookmarks with transcript selection

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/Util/DatabaseHelper.swift
@@ -903,6 +903,18 @@ class DatabaseHelper {
             }
         }
 
+        if schemaVersion < 75 {
+            do {
+                try db.executeUpdate("ALTER TABLE \(BookmarkDataManager.tableName) ADD COLUMN transcript_text TEXT;", values: nil)
+                try db.executeUpdate("ALTER TABLE \(BookmarkDataManager.tableName) ADD COLUMN transcript_start_time REAL;", values: nil)
+                try db.executeUpdate("ALTER TABLE \(BookmarkDataManager.tableName) ADD COLUMN transcript_end_time REAL;", values: nil)
+                schemaVersion = 75
+            } catch {
+                failedAt(75)
+                return
+            }
+        }
+
         db.commit()
     }
 }

--- a/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
@@ -48,6 +48,19 @@ public struct Bookmark: Hashable {
     }
 }
 
+// MARK: - Public Init
+
+extension Bookmark {
+    public init(uuid: String, title: String, time: TimeInterval, created: Date, episodeUuid: String, podcastUuid: String?) {
+        self.uuid = uuid
+        self.title = title
+        self.time = time
+        self.created = created
+        self.episodeUuid = episodeUuid
+        self.podcastUuid = podcastUuid
+    }
+}
+
 // MARK: - Identifiable
 
 extension Bookmark: Identifiable {

--- a/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/Bookmark.swift
@@ -15,10 +15,18 @@ public struct Bookmark: Hashable {
     public var episode: BaseEpisode? = nil
     public var podcast: Podcast? = nil
 
+    public var transcriptText: String? = nil
+    public var transcriptStartTime: TimeInterval? = nil
+    public var transcriptEndTime: TimeInterval? = nil
+
     // For syncing
     public var titleModified: Date? = nil
     public var deletedModified: Date? = nil
     public var deleted: Bool = false
+
+    public var hasTranscriptSelection: Bool {
+        transcriptText != nil && transcriptStartTime != nil && transcriptEndTime != nil
+    }
 
     // `BaseEpisode` and `Podcast` don't conform to Hashable, so instead we implement it manually to ignore those properties
     public func hash(into hasher: inout Hasher) {
@@ -28,6 +36,9 @@ public struct Bookmark: Hashable {
         hasher.combine(created)
         hasher.combine(episodeUuid)
         hasher.combine(podcastUuid)
+        hasher.combine(transcriptText)
+        hasher.combine(transcriptStartTime)
+        hasher.combine(transcriptEndTime)
         hasher.combine(titleModified)
         hasher.combine(deletedModified)
     }

--- a/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Bookmarks/BookmarkDataManager.swift
@@ -90,6 +90,26 @@ public struct BookmarkDataManager {
         }
     }
 
+    @discardableResult
+    public func updateTranscript(bookmark: Bookmark, text: String?, startTime: TimeInterval?, endTime: TimeInterval?) async -> Bool {
+        let query = """
+            UPDATE \(Self.tableName)
+            SET \(Column.transcriptText) = ?, \(Column.transcriptStartTime) = ?, \(Column.transcriptEndTime) = ?
+            WHERE \(Column.uuid) = ?
+            LIMIT 1
+            """
+
+        let result = await dbQueue.executeUpdate(query, values: [text as Any, startTime as Any, endTime as Any, bookmark.uuid])
+
+        switch result {
+        case .success:
+            return true
+        case .failure(let failure):
+            FileLog.shared.addMessage("BookmarkManager.updateTranscript failed: \(failure)")
+            return false
+        }
+    }
+
     // MARK: - Retrieving
 
     /// Retrieves a single Bookmark for the given UUID
@@ -244,6 +264,11 @@ public struct BookmarkDataManager {
         case time
         case deleted
 
+        // Transcript selection
+        case transcriptText = "transcript_text"
+        case transcriptStartTime = "transcript_start_time"
+        case transcriptEndTime = "transcript_end_time"
+
         // For Syncing
         case titleModifiedDate = "title_modified_date"
         case deletedModifiedDate = "deleted_modified_date"
@@ -339,6 +364,9 @@ private extension Bookmark {
         }
 
         let podcast = resultSet.string(for: .podcast)
+        let transcriptText = resultSet.string(for: .transcriptText)
+        let transcriptStartTime = resultSet.optionalDouble(for: .transcriptStartTime)
+        let transcriptEndTime = resultSet.optionalDouble(for: .transcriptEndTime)
         let titleModified = resultSet.date(for: .titleModifiedDate)
         let deletedModified = resultSet.date(for: .deletedModifiedDate)
         let deleted = resultSet.bool(for: .deleted) ?? false
@@ -349,6 +377,9 @@ private extension Bookmark {
                   created: createdDate,
                   episodeUuid: episode,
                   podcastUuid: podcast,
+                  transcriptText: transcriptText,
+                  transcriptStartTime: transcriptStartTime,
+                  transcriptEndTime: transcriptEndTime,
                   titleModified: titleModified,
                   deletedModified: deletedModified,
                   deleted: deleted)
@@ -372,5 +403,9 @@ private extension PCDBResultSet {
 
     func bool(for column: BookmarkDataManager.Column) -> Bool? {
         bool(forColumn: column.rawValue)
+    }
+
+    func optionalDouble(for column: BookmarkDataManager.Column) -> Double? {
+        object(forColumn: column.rawValue) == nil ? nil : double(forColumn: column.rawValue)
     }
 }

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -316,6 +316,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// Enable the Share Profile feature
     case shareProfile
 
+    /// Capture transcript text when creating bookmarks on transcribed episodes
+    case smartBookmarks
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -530,6 +533,8 @@ public enum FeatureFlag: String, CaseIterable {
             true
         case .shareProfile:
             BuildEnvironment.current == .debug
+        case .smartBookmarks:
+            false
         }
     }
 

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -534,7 +534,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .shareProfile:
             BuildEnvironment.current == .debug
         case .smartBookmarks:
-            false
+            true
         }
     }
 

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptSelectionLogicTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptSelectionLogicTests.swift
@@ -143,6 +143,41 @@ final class TranscriptSelectionLogicTests: XCTestCase {
 
     // MARK: - Heuristic Title
 
+    // MARK: - NLP Title
+
+    func testNlpTitleExtractsNouns() {
+        let text = "The ripe taste of cheese improves with age and experience in the kitchen."
+        let title = BookmarkTitleGenerator.nlpTitle(from: text)
+        XCTAssertNotNil(title)
+        XCTAssertFalse(title!.isEmpty)
+    }
+
+    func testNlpTitleExtractsNamedEntities() {
+        let text = "Clara Barton established the American Red Cross in Washington."
+        let title = BookmarkTitleGenerator.nlpTitle(from: text)
+        XCTAssertNotNil(title)
+    }
+
+    func testNlpTitleReturnsNilForEmpty() {
+        let title = BookmarkTitleGenerator.nlpTitle(from: "")
+        XCTAssertNil(title)
+    }
+
+    func testNlpTitleReturnsNilForStopWordsOnly() {
+        let title = BookmarkTitleGenerator.nlpTitle(from: "the and or but if")
+        XCTAssertNil(title)
+    }
+
+    func testNlpTitleRespectsMaxLength() {
+        let text = "Quantum mechanics thermodynamics astrophysics neuroscience pharmacology biotechnology nanotechnology cryptocurrency blockchain infrastructure telecommunications"
+        let title = BookmarkTitleGenerator.nlpTitle(from: text)
+        if let title {
+            XCTAssertTrue(title.count <= Constants.Values.bookmarkMaxTitleLength)
+        }
+    }
+
+    // MARK: - Heuristic Title
+
     func testHeuristicTitleTakesFirstFewWords() {
         let text = "one two three four five six seven eight nine ten eleven"
         let title = BookmarkTitleGenerator.heuristicTitle(from: text)

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptSelectionLogicTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptSelectionLogicTests.swift
@@ -122,12 +122,37 @@ final class TranscriptSelectionLogicTests: XCTestCase {
         XCTAssertTrue(selection!.text.contains("Segment 3."))
     }
 
+    // MARK: - bookmarkCueIndex
+
+    func testBookmarkCueIndexFindsExactMatch() {
+        let (cues, _) = makeCues(count: 10)
+        let index = TranscriptSelectionLogic.bookmarkCueIndex(for: 12.5, in: cues)
+        XCTAssertEqual(index, 2)
+    }
+
+    func testBookmarkCueIndexFindsNearestWhenNoExactMatch() {
+        let (cues, _) = makeCues(count: 5, segmentDuration: 10.0)
+        let index = TranscriptSelectionLogic.bookmarkCueIndex(for: 15.0, in: cues)
+        XCTAssertNotNil(index)
+    }
+
+    func testBookmarkCueIndexReturnsNilForEmptyCues() {
+        let index = TranscriptSelectionLogic.bookmarkCueIndex(for: 10.0, in: [])
+        XCTAssertNil(index)
+    }
+
     // MARK: - Heuristic Title
 
-    func testHeuristicTitleExtractsFirstSentence() {
-        let text = "This is the first sentence. And this is the second sentence."
+    func testHeuristicTitleTakesFirstFewWords() {
+        let text = "one two three four five six seven eight nine ten eleven"
         let title = BookmarkTitleGenerator.heuristicTitle(from: text)
-        XCTAssertEqual(title, "This is the first sentence.")
+        XCTAssertEqual(title, "one two three four five six seven eight…")
+    }
+
+    func testHeuristicTitleKeepsShortTextIntact() {
+        let text = "Short title here"
+        let title = BookmarkTitleGenerator.heuristicTitle(from: text)
+        XCTAssertEqual(title, "Short title here")
     }
 
     func testHeuristicTitleTruncatesLongText() {

--- a/PocketCastsTests/Tests/Player/Transcripts/TranscriptSelectionLogicTests.swift
+++ b/PocketCastsTests/Tests/Player/Transcripts/TranscriptSelectionLogicTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+
+@testable import podcasts
+
+final class TranscriptSelectionLogicTests: XCTestCase {
+
+    // MARK: - Helper
+
+    private func makeCues(count: Int, segmentDuration: Double = 5.0) -> (cues: [TranscriptCue], fullText: String) {
+        var cues: [TranscriptCue] = []
+        var fullText = ""
+        for i in 0..<count {
+            let text = "Segment \(i). "
+            let startTime = Double(i) * segmentDuration
+            let endTime = startTime + segmentDuration
+            let range = NSRange(location: fullText.count, length: text.count)
+            cues.append(TranscriptCue(startTime: startTime, endTime: endTime, characterRange: range))
+            fullText += text
+        }
+        return (cues, fullText)
+    }
+
+    // MARK: - selectTranscript
+
+    func testSelectTranscriptCentersOnTimestamp() {
+        let (cues, fullText) = makeCues(count: 20)
+        // 52.5 falls squarely in cue 10 (50-55), so radius 2 → indices 8..12
+        let selection = TranscriptSelectionLogic.selectTranscript(around: 52.5, cues: cues, fullText: fullText, radius: 2)
+
+        XCTAssertNotNil(selection)
+        XCTAssertEqual(selection?.startCueIndex, 8)
+        XCTAssertEqual(selection?.endCueIndex, 12)
+    }
+
+    func testSelectTranscriptClampsAtStart() {
+        let (cues, fullText) = makeCues(count: 10)
+        let selection = TranscriptSelectionLogic.selectTranscript(around: 2.0, cues: cues, fullText: fullText, radius: 3)
+
+        XCTAssertNotNil(selection)
+        XCTAssertEqual(selection?.startCueIndex, 0)
+        XCTAssertTrue(selection!.startCueIndex >= 0)
+    }
+
+    func testSelectTranscriptClampsAtEnd() {
+        let (cues, fullText) = makeCues(count: 10)
+        let selection = TranscriptSelectionLogic.selectTranscript(around: 47.0, cues: cues, fullText: fullText, radius: 3)
+
+        XCTAssertNotNil(selection)
+        XCTAssertEqual(selection?.endCueIndex, 9)
+    }
+
+    func testSelectTranscriptEmptyCues() {
+        let selection = TranscriptSelectionLogic.selectTranscript(around: 10.0, cues: [], fullText: "", radius: 3)
+        XCTAssertNil(selection)
+    }
+
+    func testSelectTranscriptSingleCue() {
+        let (cues, fullText) = makeCues(count: 1)
+        let selection = TranscriptSelectionLogic.selectTranscript(around: 2.0, cues: cues, fullText: fullText, radius: 3)
+
+        XCTAssertNotNil(selection)
+        XCTAssertEqual(selection?.startCueIndex, 0)
+        XCTAssertEqual(selection?.endCueIndex, 0)
+        XCTAssertEqual(selection?.text, "Segment 0.")
+    }
+
+    func testSelectTranscriptUsesNearestCueWhenNoExactMatch() {
+        let (cues, fullText) = makeCues(count: 5, segmentDuration: 10.0)
+        // Timestamp 7.5 is between cue 0 (0-10) — but let's use 15 which is between 10-20 (cue 1)
+        let selection = TranscriptSelectionLogic.selectTranscript(around: 15.0, cues: cues, fullText: fullText, radius: 1)
+
+        XCTAssertNotNil(selection)
+        XCTAssertTrue(selection!.startCueIndex <= 1)
+        XCTAssertTrue(selection!.endCueIndex >= 1)
+    }
+
+    func testSelectTranscriptTimeRangeIsCorrect() {
+        let (cues, fullText) = makeCues(count: 10, segmentDuration: 5.0)
+        let selection = TranscriptSelectionLogic.selectTranscript(around: 25.0, cues: cues, fullText: fullText, radius: 1)
+
+        XCTAssertNotNil(selection)
+        XCTAssertEqual(selection?.startTime, cues[selection!.startCueIndex].startTime)
+        XCTAssertEqual(selection?.endTime, cues[selection!.endCueIndex].endTime)
+    }
+
+    // MARK: - adjustSelection
+
+    func testAdjustSelectionClampsRange() {
+        let (cues, fullText) = makeCues(count: 5)
+        let selection = TranscriptSelectionLogic.adjustSelection(startCueIndex: -5, endCueIndex: 100, cues: cues, fullText: fullText)
+
+        XCTAssertNotNil(selection)
+        XCTAssertEqual(selection?.startCueIndex, 0)
+        XCTAssertEqual(selection?.endCueIndex, 4)
+    }
+
+    func testAdjustSelectionSingleCue() {
+        let (cues, fullText) = makeCues(count: 5)
+        let selection = TranscriptSelectionLogic.adjustSelection(startCueIndex: 2, endCueIndex: 2, cues: cues, fullText: fullText)
+
+        XCTAssertNotNil(selection)
+        XCTAssertEqual(selection?.startCueIndex, 2)
+        XCTAssertEqual(selection?.endCueIndex, 2)
+        XCTAssertEqual(selection?.text, "Segment 2.")
+    }
+
+    func testAdjustSelectionInvertedRangeGetsFixed() {
+        let (cues, fullText) = makeCues(count: 5)
+        let selection = TranscriptSelectionLogic.adjustSelection(startCueIndex: 4, endCueIndex: 1, cues: cues, fullText: fullText)
+
+        XCTAssertNotNil(selection)
+        XCTAssertTrue(selection!.startCueIndex <= selection!.endCueIndex)
+    }
+
+    func testAdjustSelectionTextIsConcatenated() {
+        let (cues, fullText) = makeCues(count: 5)
+        let selection = TranscriptSelectionLogic.adjustSelection(startCueIndex: 1, endCueIndex: 3, cues: cues, fullText: fullText)
+
+        XCTAssertNotNil(selection)
+        XCTAssertTrue(selection!.text.contains("Segment 1."))
+        XCTAssertTrue(selection!.text.contains("Segment 2."))
+        XCTAssertTrue(selection!.text.contains("Segment 3."))
+    }
+
+    // MARK: - Heuristic Title
+
+    func testHeuristicTitleExtractsFirstSentence() {
+        let text = "This is the first sentence. And this is the second sentence."
+        let title = BookmarkTitleGenerator.heuristicTitle(from: text)
+        XCTAssertEqual(title, "This is the first sentence.")
+    }
+
+    func testHeuristicTitleTruncatesLongText() {
+        let longText = String(repeating: "word ", count: 100)
+        let title = BookmarkTitleGenerator.heuristicTitle(from: longText)
+        XCTAssertTrue(title.count <= Constants.Values.bookmarkMaxTitleLength)
+    }
+
+    func testHeuristicTitleFallsBackForEmptyText() {
+        let title = BookmarkTitleGenerator.heuristicTitle(from: "")
+        XCTAssertEqual(title, L10n.bookmarkDefaultTitle)
+    }
+
+    func testHeuristicTitleHandlesNewlines() {
+        let text = "Line one\nLine two. Line three."
+        let title = BookmarkTitleGenerator.heuristicTitle(from: text)
+        XCTAssertFalse(title.contains("\n"))
+    }
+}

--- a/podcasts/BookmarkManager.swift
+++ b/podcasts/BookmarkManager.swift
@@ -104,6 +104,12 @@ class BookmarkManager {
         }
     }
 
+    /// Updates the bookmark with transcript selection data
+    @discardableResult
+    func updateTranscript(text: String?, startTime: TimeInterval?, endTime: TimeInterval?, for bookmark: Bookmark) async -> Bool {
+        await dataManager.updateTranscript(bookmark: bookmark, text: text, startTime: startTime, endTime: endTime)
+    }
+
     /// Gets the `BaseEpisode` for the given bookmark
     func episode(for bookmark: Bookmark) -> BaseEpisode? {
         generalManager.findBaseEpisode(uuid: bookmark.episodeUuid)

--- a/podcasts/Bookmarks/BookmarksTheme.swift
+++ b/podcasts/Bookmarks/BookmarksTheme.swift
@@ -10,6 +10,8 @@ protocol BookmarksStyle: ObservableObject {
     var tertiaryText: Color { get }
     var titleText: Color { get }
     var divider: Color { get }
+    var pageBackground: Color { get }
+    var cardBackground: Color { get }
     var rowHighlight: Color { get }
     var rowSelected: Color { get }
     var selectButtonStroke: Color { get }
@@ -47,6 +49,8 @@ class BookmarksPlayerTabStyle: ThemeObserver, BookmarksStyle {
     var tertiaryText: Color { theme.playerContrast02 }
     var titleText: Color { theme.playerContrast01 }
     var divider: Color { theme.playerContrast05 }
+    var pageBackground: Color { theme.playerBackground01 }
+    var cardBackground: Color { theme.playerContrast05.opacity(0.15) }
     var rowHighlight: Color { theme.playerContrast05 }
     var rowSelected: Color { rowHighlight }
     var selectButton: Color { theme.playerContrast01 }
@@ -68,6 +72,8 @@ class ThemedBookmarksStyle: ThemeObserver, BookmarksStyle {
     var tertiaryText: Color { theme.primaryText02 }
     var titleText: Color { theme.secondaryText01 }
     var divider: Color { theme.primaryUi05 }
+    var pageBackground: Color { theme.primaryUi01 }
+    var cardBackground: Color { Color(.secondarySystemGroupedBackground) }
     var rowHighlight: Color { theme.primaryUi02Active }
     var rowSelected: Color { theme.primaryUi02Selected }
     var selectButtonStroke: Color { theme.primaryIcon02 }
@@ -95,6 +101,8 @@ class OverrideThemedBookmarksStyle: ThemedBookmarksStyle {
     override var tertiaryText: Color { Color(ThemeColor.primaryText02(for: overrideTheme)) }
     override var titleText: Color { Color(ThemeColor.secondaryText01(for: overrideTheme)) }
     override var divider: Color { Color(ThemeColor.primaryUi05(for: overrideTheme)) }
+    override var pageBackground: Color { Color(ThemeColor.primaryUi04(for: overrideTheme)) }
+    override var cardBackground: Color { Color(ThemeColor.primaryUi01(for: overrideTheme)) }
     override var rowHighlight: Color { Color(ThemeColor.primaryUi02Active(for: overrideTheme)) }
     override var rowSelected: Color { Color(ThemeColor.primaryUi02Selected(for: overrideTheme)) }
     override var selectButtonStroke: Color { Color(ThemeColor.primaryIcon02(for: overrideTheme)) }

--- a/podcasts/Bookmarks/Detail/BookmarkDetailView.swift
+++ b/podcasts/Bookmarks/Detail/BookmarkDetailView.swift
@@ -1,0 +1,204 @@
+import PocketCastsDataModel
+import PocketCastsUtils
+import SwiftUI
+
+struct BookmarkDetailView: View {
+    @EnvironmentObject private var theme: Theme
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var title: String
+    @State private var transcriptText: String?
+    @State private var transcriptStartTime: TimeInterval?
+    @State private var transcriptEndTime: TimeInterval?
+
+    let bookmark: Bookmark
+    let episode: BaseEpisode?
+    let onPlay: () -> Void
+    var isModal: Bool = false
+
+    private let bookmarkLookup: () -> Bookmark?
+    private let editAction: ((@escaping () -> Void) -> Void)?
+
+    init(bookmark: Bookmark,
+         episode: BaseEpisode?,
+         onPlay: @escaping () -> Void,
+         onEdit: ((@escaping () -> Void) -> Void)? = nil,
+         isModal: Bool = false,
+         bookmarkLookup: ((String) -> Bookmark?)? = nil) {
+        self.bookmark = bookmark
+        self._title = State(initialValue: bookmark.title)
+        self._transcriptText = State(initialValue: bookmark.transcriptText)
+        self._transcriptStartTime = State(initialValue: bookmark.transcriptStartTime)
+        self._transcriptEndTime = State(initialValue: bookmark.transcriptEndTime)
+        self.episode = episode
+        self.onPlay = onPlay
+        self.editAction = onEdit
+        self.isModal = isModal
+        let uuid = bookmark.uuid
+        self.bookmarkLookup = { bookmarkLookup?(uuid) }
+    }
+
+    private var podcastTitle: String? {
+        if let podcastUuid = bookmark.podcastUuid {
+            return DataManager.sharedManager.findPodcast(uuid: podcastUuid, includeUnsubscribed: true)?.title
+        }
+        return nil
+    }
+
+    private func refreshFromDatabase() {
+        if let updated = bookmarkLookup() {
+            title = updated.title
+            transcriptText = updated.transcriptText
+            transcriptStartTime = updated.transcriptStartTime
+            transcriptEndTime = updated.transcriptEndTime
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 16) {
+                headerView
+                Divider()
+            }
+            .padding([.horizontal, .top])
+            .padding(.bottom, 12)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    titleSection
+                    if let transcriptText {
+                        transcriptSection(transcriptText)
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.bottom)
+            }
+            .mask(
+                VStack(spacing: 0) {
+                    LinearGradient(colors: [.clear, .black], startPoint: .top, endPoint: .bottom)
+                        .frame(height: 12)
+                    Color.black
+                    LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
+                        .frame(height: 12)
+                }
+            )
+        }
+        .background(AppTheme.color(for: .primaryUi01, theme: theme))
+        .navigationTitle(L10n.bookmarkDefaultTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if isModal {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(AppTheme.color(for: .primaryText02, theme: theme))
+                    }
+                }
+            }
+            if editAction != nil {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        editAction? {
+                            refreshFromDatabase()
+                        }
+                    } label: {
+                        Image("folder-edit")
+                            .renderingMode(.template)
+                            .foregroundStyle(AppTheme.color(for: .primaryText01, theme: theme))
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerView: some View {
+        HStack(spacing: 12) {
+            if let episode {
+                EpisodeImage(episode: episode)
+                    .frame(width: 64, height: 64)
+                    .cornerRadius(8)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                if let podcastTitle {
+                    Text(podcastTitle)
+                        .font(style: .caption, weight: .semibold)
+                        .foregroundStyle(AppTheme.color(for: .primaryText02, theme: theme))
+                        .lineLimit(1)
+                }
+
+                if let episodeTitle = episode?.title {
+                    Text(episodeTitle)
+                        .font(style: .subheadline, weight: .medium)
+                        .foregroundStyle(AppTheme.color(for: .primaryText01, theme: theme))
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer()
+
+            playButton
+        }
+    }
+
+    // MARK: - Title
+
+    private var titleSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(size: 22, style: .title2, weight: .bold)
+                .foregroundStyle(AppTheme.color(for: .primaryText01, theme: theme))
+        }
+    }
+
+    // MARK: - Transcript
+
+    private func transcriptSection(_ text: String) -> some View {
+        let paragraphs = text.components(separatedBy: "\n").filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+
+        return VStack(alignment: .leading, spacing: 12) {
+            if let startTime = transcriptStartTime,
+               let endTime = transcriptEndTime {
+                let formattedStart = TimeFormatter.shared.playTimeFormat(time: startTime)
+                let formattedEnd = TimeFormatter.shared.playTimeFormat(time: endTime)
+                Text("\(formattedStart) – \(formattedEnd)")
+                    .font(style: .caption, weight: .semibold)
+                    .foregroundStyle(AppTheme.color(for: .primaryText02, theme: theme))
+            }
+
+            ForEach(Array(paragraphs.enumerated()), id: \.offset) { _, paragraph in
+                Text(paragraph)
+                    .font(style: .body)
+                    .foregroundStyle(AppTheme.color(for: .primaryText01, theme: theme))
+            }
+        }
+        .textSelection(.enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Play Button
+
+    private var playButton: some View {
+        let timestamp = TimeFormatter.shared.playTimeFormat(time: bookmark.time)
+        return Button {
+            onPlay()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "play.fill")
+                    .font(.system(size: 11))
+                Text(timestamp)
+                    .font(style: .footnote, weight: .semibold)
+            }
+            .foregroundStyle(AppTheme.color(for: .primaryInteractive02, theme: theme))
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(AppTheme.color(for: .primaryInteractive01, theme: theme))
+            .clipShape(Capsule())
+        }
+    }
+}

--- a/podcasts/Bookmarks/Detail/BookmarkDetailView.swift
+++ b/podcasts/Bookmarks/Detail/BookmarkDetailView.swift
@@ -18,11 +18,13 @@ struct BookmarkDetailView: View {
 
     private let bookmarkLookup: () -> Bookmark?
     private let editAction: ((@escaping () -> Void) -> Void)?
+    private let shareAction: (() -> Void)?
 
     init(bookmark: Bookmark,
          episode: BaseEpisode?,
          onPlay: @escaping () -> Void,
          onEdit: ((@escaping () -> Void) -> Void)? = nil,
+         onShare: (() -> Void)? = nil,
          isModal: Bool = false,
          bookmarkLookup: ((String) -> Bookmark?)? = nil) {
         self.bookmark = bookmark
@@ -33,6 +35,7 @@ struct BookmarkDetailView: View {
         self.episode = episode
         self.onPlay = onPlay
         self.editAction = onEdit
+        self.shareAction = onShare
         self.isModal = isModal
         let uuid = bookmark.uuid
         self.bookmarkLookup = { bookmarkLookup?(uuid) }
@@ -58,10 +61,9 @@ struct BookmarkDetailView: View {
         VStack(alignment: .leading, spacing: 0) {
             VStack(alignment: .leading, spacing: 16) {
                 headerView
-                Divider()
             }
             .padding([.horizontal, .top])
-            .padding(.bottom, 12)
+            .padding(.bottom, 28)
 
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
@@ -71,6 +73,7 @@ struct BookmarkDetailView: View {
                     }
                 }
                 .padding(.horizontal)
+                .padding(.top, 12)
                 .padding(.bottom)
             }
             .mask(
@@ -92,22 +95,36 @@ struct BookmarkDetailView: View {
                     Button {
                         dismiss()
                     } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .symbolRenderingMode(.hierarchical)
-                            .foregroundStyle(AppTheme.color(for: .primaryText02, theme: theme))
+                        Image(systemName: "xmark")
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(AppTheme.color(for: .primaryText01, theme: theme))
                     }
                 }
             }
-            if editAction != nil {
+            if editAction != nil || shareAction != nil {
                 ToolbarItem(placement: .primaryAction) {
-                    Button {
-                        editAction? {
-                            refreshFromDatabase()
+                    Menu {
+                        if editAction != nil {
+                            Button {
+                                editAction? {
+                                    refreshFromDatabase()
+                                }
+                            } label: {
+                                Label(L10n.smartBookmarkEditTitle, systemImage: "pencil")
+                            }
+                        }
+                        if shareAction != nil {
+                            Button {
+                                shareAction?()
+                            } label: {
+                                Label(L10n.share, systemImage: "square.and.arrow.up")
+                            }
                         }
                     } label: {
-                        Image("folder-edit")
-                            .renderingMode(.template)
+                        Image(systemName: "ellipsis")
+                            .font(.system(size: 15, weight: .bold))
                             .foregroundStyle(AppTheme.color(for: .primaryText01, theme: theme))
+                            .frame(width: 32, height: 32)
                     }
                 }
             }
@@ -150,10 +167,19 @@ struct BookmarkDetailView: View {
 
     private var titleSection: some View {
         VStack(alignment: .leading, spacing: 4) {
+            Text(formattedDate)
+                .font(style: .caption, weight: .semibold)
+                .foregroundStyle(AppTheme.color(for: .primaryText02, theme: theme))
             Text(title)
                 .font(size: 22, style: .title2, weight: .bold)
                 .foregroundStyle(AppTheme.color(for: .primaryText01, theme: theme))
         }
+    }
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d · h:mm a"
+        return formatter.string(from: bookmark.created)
     }
 
     // MARK: - Transcript
@@ -173,8 +199,8 @@ struct BookmarkDetailView: View {
 
             ForEach(Array(paragraphs.enumerated()), id: \.offset) { _, paragraph in
                 Text(paragraph)
-                    .font(style: .body)
-                    .foregroundStyle(AppTheme.color(for: .primaryText01, theme: theme))
+                    .font(.system(.body, design: .serif))
+                    .foregroundStyle(AppTheme.color(for: .primaryText02, theme: theme))
             }
         }
         .textSelection(.enabled)
@@ -189,14 +215,15 @@ struct BookmarkDetailView: View {
             onPlay()
         } label: {
             HStack(spacing: 6) {
-                Image(systemName: "play.fill")
-                    .font(.system(size: 11))
                 Text(timestamp)
-                    .font(style: .footnote, weight: .semibold)
+                    .font(style: .subheadline, weight: .medium)
+                    .fixedSize()
+                Image(systemName: "play.fill")
+                    .font(.system(size: 10))
             }
             .foregroundStyle(AppTheme.color(for: .primaryInteractive02, theme: theme))
             .padding(.horizontal, 14)
-            .padding(.vertical, 8)
+            .padding(.vertical, 7)
             .background(AppTheme.color(for: .primaryInteractive01, theme: theme))
             .clipShape(Capsule())
         }

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -63,6 +63,28 @@ extension BookmarkEpisodeListController: BookmarkListRouter {
         SharingModal.show(option: .bookmark(episode, bookmark.time), from: .episodeDetail, in: self)
     }
 
+    func bookmarkDetail(_ bookmark: Bookmark) {
+        let detailView = BookmarkDetailView(
+            bookmark: bookmark,
+            episode: bookmark.episode,
+            onPlay: { [weak self] in
+                self?.playbackManager.playBookmark(bookmark, source: self?.viewModel.analyticsSource ?? .episodes)
+            },
+            onEdit: { [weak self] done in
+                guard let self else { return }
+                presentBookmarkEditor(bookmark: bookmark, bookmarkManager: bookmarkManager, analyticsSource: viewModel.analyticsSource) { [weak self] in
+                    self?.viewModel.reload()
+                    done()
+                }
+            },
+            bookmarkLookup: { [weak self] uuid in
+                self?.bookmarkManager.bookmark(for: uuid)
+            }
+        )
+        let controller = ThemedHostingController(rootView: detailView)
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
     func dismissBookmarksList() {
         dismiss(animated: true)
     }

--- a/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
+++ b/podcasts/Bookmarks/Episode/BookmarkEpisodeListController.swift
@@ -32,6 +32,16 @@ class BookmarkEpisodeListController: ThemedHostingController<BookmarkEpisodeList
         viewModel.router = self
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+    }
+
+    override func themeDidChange() {
+        super.themeDidChange()
+        view.backgroundColor = .clear
+    }
+
     @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -77,6 +87,9 @@ extension BookmarkEpisodeListController: BookmarkListRouter {
                     done()
                 }
             },
+            onShare: bookmark.episode is Episode ? { [weak self] in
+                self?.bookmarkShare(bookmark)
+            } : nil,
             bookmarkLookup: { [weak self] uuid in
                 self?.bookmarkManager.bookmark(for: uuid)
             }

--- a/podcasts/Bookmarks/List/BookmarkListRouter.swift
+++ b/podcasts/Bookmarks/List/BookmarkListRouter.swift
@@ -5,6 +5,7 @@ protocol BookmarkListRouter: AnyObject {
     func bookmarkPlay(_ bookmark: Bookmark)
     func bookmarkEdit(_ bookmark: Bookmark)
     func bookmarkShare(_ bookmark: Bookmark)
+    func bookmarkDetail(_ bookmark: Bookmark)
 
     /// Optional: Dismisses the presented bookmark list, if applicable.
     func dismissBookmarksList()
@@ -15,6 +16,7 @@ protocol BookmarkListRouter: AnyObject {
 
 extension BookmarkListRouter {
     func dismissBookmarksList() { /* NOOP */ }
+    func bookmarkDetail(_ bookmark: Bookmark) { /* NOOP */ }
 }
 
 // MARK: - UIViewController subclass default implementation
@@ -22,5 +24,42 @@ extension BookmarkListRouter {
 extension BookmarkListRouter where Self: UIViewController {
     func presentBookmarkController(_ controller: UIViewController) {
         present(controller, animated: true)
+    }
+
+    func presentBookmarkEditor(bookmark: Bookmark, bookmarkManager: BookmarkManager, analyticsSource: BookmarkAnalyticsSource, useAppTheme: Bool = true, onSaved: @escaping () -> Void) {
+        guard let episode = bookmark.episode as? Episode ?? DataManager.sharedManager.findBaseEpisode(uuid: bookmark.episodeUuid) as? Episode else {
+            bookmarkEdit(bookmark)
+            return
+        }
+
+        let transcriptManager = TranscriptManager(episodeUUID: episode.uuid, podcastUUID: episode.podcastUuid)
+        Task {
+            do {
+                let transcript = try await transcriptManager.loadTranscript()
+                let cues = transcript.cues
+                let fullText = transcript.attributedText.string
+                guard !cues.isEmpty else {
+                    await MainActor.run { self.bookmarkEdit(bookmark) }
+                    return
+                }
+
+                let vm = TranscriptSelectionViewModel(
+                    bookmark: bookmark,
+                    cues: cues,
+                    fullText: fullText,
+                    bookmarkManager: bookmarkManager,
+                    existingTitle: bookmark.title
+                )
+                await MainActor.run {
+                    let controller = TranscriptSelectionViewController(viewModel: vm, episode: episode, useAppTheme: useAppTheme) { _, _ in
+                        onSaved()
+                    }
+                    controller.source = analyticsSource
+                    self.present(controller, animated: true)
+                }
+            } catch {
+                await MainActor.run { self.bookmarkEdit(bookmark) }
+            }
+        }
     }
 }

--- a/podcasts/Bookmarks/List/BookmarkListRouter.swift
+++ b/podcasts/Bookmarks/List/BookmarkListRouter.swift
@@ -55,7 +55,8 @@ extension BookmarkListRouter where Self: UIViewController {
                         onSaved()
                     }
                     controller.source = analyticsSource
-                    self.present(controller, animated: true)
+                    let presenter = self.presentedViewController ?? self
+                    presenter.present(controller, animated: true)
                 }
             } catch {
                 await MainActor.run { self.bookmarkEdit(bookmark) }

--- a/podcasts/Bookmarks/List/BookmarkListViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkListViewModel.swift
@@ -47,6 +47,14 @@ class BookmarkListViewModel: SearchableListViewModel<Bookmark> {
         addListeners()
     }
 
+    override func tapped(item: Bookmark) {
+        guard isMultiSelecting else {
+            router?.bookmarkDetail(item)
+            return
+        }
+        super.tapped(item: item)
+    }
+
     func reload() { }
 
     func dismiss() {

--- a/podcasts/Bookmarks/List/BookmarkRow.swift
+++ b/podcasts/Bookmarks/List/BookmarkRow.swift
@@ -22,10 +22,23 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
     var body: some View {
         let selected = viewModel.isSelected(bookmark)
         MultiSelectRow(showSelectButton: viewModel.isMultiSelecting, selected: selected) {
-            HStack(spacing: RowConstants.spacing) {
-                imageView
-                detailsView
-                playButtonView
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .top, spacing: 14) {
+                    imageView
+                    detailsView
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    playButton
+                }
+
+                if let transcriptText = rowModel.transcriptText {
+                    Text(transcriptText)
+                        .foregroundStyle(style.secondaryText)
+                        .font(.footnote.italic())
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.leading, imageSize + 14)
+                        .padding(.top, 4)
+                }
             }
         } onSelectionToggled: {
             withAnimation {
@@ -33,15 +46,10 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
             }
         }
         .selectButtonStyle(tintColor: style.selectButton, checkColor: style.selectCheck, strokeColor: style.selectButtonStroke)
-        .padding(.horizontal, RowConstants.horizontalPadding)
-        .padding(.vertical, RowConstants.verticalPadding)
+        .padding(.vertical, 14)
+        .background(selected ? style.rowSelected : (highlighted ? style.rowHighlight : Color.clear))
         .animation(.default, value: viewModel.isMultiSelecting)
-
-        // Display a highlight when tapped, or the row is selected
-        .background((!selected && highlighted) ? style.rowHighlight : nil)
         .animation(.linear, value: highlighted)
-
-        .background(selected ? style.rowSelected : nil)
         .animation(.linear, value: selected)
     }
 
@@ -59,10 +67,9 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
         }
     }
 
-    /// Displays a title and subtitle
     private var detailsView: some View {
         NonBlockingLongPressView {
-            VStack(alignment: .leading, spacing: rowModel.heading != nil ? 4 : 8) {
+            VStack(alignment: .leading, spacing: 4) {
                 rowModel.heading.map {
                     Text($0)
                         .foregroundStyle(style.tertiaryText)
@@ -73,21 +80,13 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
                 Text(rowModel.title)
                     .foregroundStyle(style.primaryText)
                     .font(style: .subheadline, weight: .medium)
-
-                if let transcriptText = rowModel.transcriptText {
-                    Text(transcriptText)
-                        .foregroundStyle(style.secondaryText)
-                        .font(style: .caption)
-                        .lineLimit(2)
-                        .italic()
-                }
+                    .lineLimit(1)
 
                 Text(rowModel.subtitle)
                     .foregroundStyle(style.tertiaryText)
                     .font(style: .caption, weight: .semibold)
                     .lineLimit(1)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
         } onTapped: {
             viewModel.tapped(item: bookmark)
         } onPressed: { pressed in
@@ -99,8 +98,7 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
         }
     }
 
-    /// Displays the play button view, and adds the action to it
-    private var playButtonView: some View {
+    private var playButton: some View {
         PlayButton(title: rowModel.playButton, style: style).buttonize {
             viewModel.bookmarkPlayTapped(bookmark)
         } customize: { config in
@@ -118,33 +116,26 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
         @ObservedObject var style: ButtonStyle
 
         var body: some View {
-            HStack(spacing: 10) {
+            HStack(spacing: 6) {
                 Text(title)
                     .font(style: .subheadline, weight: .medium)
                     .fixedSize()
 
-                Image("bookmarks-icon-play")
-                    .renderingMode(.template)
+                Image(systemName: "play.fill")
+                    .font(.system(size: 10))
             }
             .foregroundStyle(style.playButtonText)
-            .padding(.horizontal, RowConstants.horizontalPadding)
-            .padding(.vertical, RowConstants.playButtonVerticalPadding)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 7)
             .background(style.playButtonBackground)
-            .cornerRadius(.infinity) // Always rounded
+            .cornerRadius(.infinity)
             .overlay(
                 style.playButtonStroke.map {
                     RoundedRectangle(cornerRadius: .infinity, style: .continuous)
                         .inset(by: 1)
-                        .stroke($0, lineWidth: 2)
+                        .stroke($0, lineWidth: 1.5)
                 }
             )
         }
     }
-}
-
-private enum RowConstants {
-    static let horizontalPadding = 16.0
-    static let spacing = 12.0
-    static let verticalPadding = 12.0
-    static let playButtonVerticalPadding = 8.0
 }

--- a/podcasts/Bookmarks/List/BookmarkRow.swift
+++ b/podcasts/Bookmarks/List/BookmarkRow.swift
@@ -74,6 +74,14 @@ struct BookmarkRow<Style: BookmarksStyle>: View {
                     .foregroundStyle(style.primaryText)
                     .font(style: .subheadline, weight: .medium)
 
+                if let transcriptText = rowModel.transcriptText {
+                    Text(transcriptText)
+                        .foregroundStyle(style.secondaryText)
+                        .font(style: .caption)
+                        .lineLimit(2)
+                        .italic()
+                }
+
                 Text(rowModel.subtitle)
                     .foregroundStyle(style.tertiaryText)
                     .font(style: .caption, weight: .semibold)

--- a/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
@@ -8,6 +8,7 @@ class BookmarkRowViewModel: ObservableObject {
     let title: String
     let subtitle: String
     let playButton: String
+    let transcriptText: String?
     @Published var episode: BaseEpisode?
 
     init(bookmark: Bookmark) {
@@ -17,6 +18,7 @@ class BookmarkRowViewModel: ObservableObject {
         self.subtitle = DateFormatter.localizedString(from: bookmark.created,
                                                       dateStyle: .medium,
                                                       timeStyle: .short)
+        self.transcriptText = bookmark.transcriptText
         if let episode {
             updateFromEpisode(episode)
         } else {

--- a/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
+++ b/podcasts/Bookmarks/List/BookmarkRowViewModel.swift
@@ -15,9 +15,9 @@ class BookmarkRowViewModel: ObservableObject {
         self.episode = bookmark.episode
         self.title = bookmark.title
         self.playButton = TimeFormatter.shared.playTimeFormat(time: bookmark.time)
-        self.subtitle = DateFormatter.localizedString(from: bookmark.created,
-                                                      dateStyle: .medium,
-                                                      timeStyle: .short)
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MMM d · h:mm a"
+        self.subtitle = dateFormatter.string(from: bookmark.created)
         self.transcriptText = bookmark.transcriptText
         if let episode {
             updateFromEpisode(episode)

--- a/podcasts/Bookmarks/List/BookmarksListView.swift
+++ b/podcasts/Bookmarks/List/BookmarksListView.swift
@@ -79,9 +79,10 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
                         viewModel.showMoreOptions()
                     }) {
                         Image("podcast-more-options")
-                            .padding(.trailing, 1) // Needed to nudge this over to match exactly. Not sure why.
+                            .renderingMode(.template)
+                            .padding(.trailing, 1)
                     }
-                    .foregroundStyle(searchTheme.icon)
+                    .foregroundStyle(style.primaryText)
                 }
                 .padding(.horizontal, BookmarkListConstants.padding)
                 .padding(.bottom, BookmarkListConstants.searchFieldBottomPadding)
@@ -93,6 +94,7 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
                 listView
             }
         }
+        .background(style.pageBackground.ignoresSafeArea())
         .environmentObject(viewModel)
     }
 
@@ -131,7 +133,6 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
                     .padding(.bottom, BookmarkListConstants.headerPadding)
             }
             headerView
-            divider
         }
 
         actionBarView {
@@ -180,36 +181,30 @@ struct BookmarksListView<ListStyle: BookmarksStyle>: View {
     private var scrollView: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                ForEach(viewModel.bookmarks) { bookmark in
-                    BookmarkRow(bookmark: bookmark, style: style)
-
-                    if !viewModel.isLast(item: bookmark) {
-                        divider
-                    }
-                }
-
-                // Add padding to the bottom of the list when the action bar is visible so it's not blocking the view
-                if actionBarVisible && !useExternalActionBar {
-                    Spacer(minLength: BookmarkListConstants.multiSelectionBottomPadding)
-                }
+                bookmarksRows
             }
+            .padding(.horizontal, BookmarkListConstants.padding)
         }
     }
 
     private var stableContainer: some View {
         LazyVStack(spacing: 0) { bookmarksRows }
+            .padding(.horizontal, BookmarkListConstants.padding)
     }
 
     @ViewBuilder
     private var listContent: some View {
         LazyVStack(spacing: 0) { bookmarksRows }
+            .padding(.horizontal, BookmarkListConstants.padding)
     }
 
     @ViewBuilder
     private var bookmarksRows: some View {
-        ForEach(viewModel.bookmarks) { bookmark in
+        ForEach(Array(viewModel.bookmarks.enumerated()), id: \.element.id) { index, bookmark in
             BookmarkRow(bookmark: bookmark, style: style)
-            if !viewModel.isLast(item: bookmark) { divider }
+            if index < viewModel.bookmarks.count - 1 {
+                HairlineSeparator(color: style.divider)
+            }
         }
         if actionBarVisible && !useExternalActionBar { Spacer(minLength: BookmarkListConstants.multiSelectionBottomPadding) }
     }

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -112,7 +112,8 @@ class BookmarksPlayerTabController: PlayerItemViewController {
 
         controller.source = viewModel.analyticsSource
 
-        present(controller, animated: true)
+        let presenter = presentedViewController ?? self
+        presenter.present(controller, animated: true)
     }
 
     private func showSmartBookmarkIfAvailable(bookmark: Bookmark, episode: Episode, completion: @escaping (Bool) -> Void) {
@@ -213,6 +214,9 @@ extension BookmarksPlayerTabController: BookmarkListRouter {
                     done()
                 }
             },
+            onShare: (bookmark.episode ?? viewModel.episode) is Episode ? { [weak self] in
+                self?.bookmarkShare(bookmark)
+            } : nil,
             isModal: true,
             bookmarkLookup: { [weak self] uuid in
                 self?.bookmarkManager.bookmark(for: uuid)

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Combine
 import PocketCastsDataModel
+import PocketCastsUtils
 
 /// Wraps the SwiftUI view in a `PlayerItemViewController` and adds some basic listeners
 class BookmarksPlayerTabController: PlayerItemViewController {
@@ -87,6 +88,19 @@ class BookmarksPlayerTabController: PlayerItemViewController {
     }
 
     private func showBookmarkEdit(isNew: Bool, bookmark: Bookmark) {
+        if isNew, FeatureFlag.smartBookmarks.enabled, let episode = viewModel.episode as? Episode {
+            showSmartBookmarkIfAvailable(bookmark: bookmark, episode: episode) { [weak self] shown in
+                if !shown {
+                    self?.showBookmarkTitleEdit(isNew: isNew, bookmark: bookmark)
+                }
+            }
+            return
+        }
+
+        showBookmarkTitleEdit(isNew: isNew, bookmark: bookmark)
+    }
+
+    private func showBookmarkTitleEdit(isNew: Bool, bookmark: Bookmark) {
         let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: isNew ? .adding : .updating, onDismiss: { [weak self] title, canceled in
             self?.handleEditDismissed(bookmark: bookmark, isNew: isNew, title: title, canceled: canceled)
         })
@@ -94,6 +108,45 @@ class BookmarksPlayerTabController: PlayerItemViewController {
         controller.source = viewModel.analyticsSource
 
         present(controller, animated: true)
+    }
+
+    private func showSmartBookmarkIfAvailable(bookmark: Bookmark, episode: Episode, completion: @escaping (Bool) -> Void) {
+        let transcriptManager = TranscriptManager(episodeUUID: episode.uuid, podcastUUID: episode.podcastUuid)
+
+        Task {
+            do {
+                let transcript = try await transcriptManager.loadTranscript()
+                guard !transcript.cues.isEmpty else {
+                    await MainActor.run { completion(false) }
+                    return
+                }
+
+                await MainActor.run { [weak self] in
+                    guard let self else { return }
+
+                    let vm = TranscriptSelectionViewModel(
+                        bookmark: bookmark,
+                        cues: transcript.cues,
+                        fullText: transcript.attributedText.string,
+                        bookmarkManager: self.bookmarkManager
+                    )
+
+                    let controller = TranscriptSelectionViewController(
+                        viewModel: vm,
+                        episode: episode,
+                        onDismiss: { [weak self] title, canceled in
+                            self?.handleEditDismissed(bookmark: bookmark, isNew: true, title: title, canceled: canceled)
+                        }
+                    )
+                    controller.source = self.viewModel.analyticsSource
+
+                    self.present(controller, animated: true)
+                    completion(true)
+                }
+            } catch {
+                await MainActor.run { completion(false) }
+            }
+        }
     }
 
     func handleEditDismissed(bookmark: Bookmark, isNew: Bool, title: String, canceled: Bool) {

--- a/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
+++ b/podcasts/Bookmarks/Player/BookmarksPlayerTabController.swift
@@ -100,8 +100,13 @@ class BookmarksPlayerTabController: PlayerItemViewController {
         showBookmarkTitleEdit(isNew: isNew, bookmark: bookmark)
     }
 
-    private func showBookmarkTitleEdit(isNew: Bool, bookmark: Bookmark) {
-        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: bookmark, state: isNew ? .adding : .updating, onDismiss: { [weak self] title, canceled in
+    private func showBookmarkTitleEdit(isNew: Bool, bookmark: Bookmark, prefilledTitle: String? = nil) {
+        var editBookmark = bookmark
+        if let prefilledTitle {
+            editBookmark = Bookmark(uuid: bookmark.uuid, title: prefilledTitle, time: bookmark.time, created: bookmark.created, episodeUuid: bookmark.episodeUuid, podcastUuid: bookmark.podcastUuid)
+        }
+
+        let controller = BookmarkEditTitleViewController(manager: bookmarkManager, bookmark: editBookmark, state: isNew ? .adding : .updating, onDismiss: { [weak self] title, canceled in
             self?.handleEditDismissed(bookmark: bookmark, isNew: isNew, title: title, canceled: canceled)
         })
 
@@ -116,31 +121,35 @@ class BookmarksPlayerTabController: PlayerItemViewController {
         Task {
             do {
                 let transcript = try await transcriptManager.loadTranscript()
-                guard !transcript.cues.isEmpty else {
+                let cues = transcript.cues
+                let fullText = transcript.attributedText.string
+                guard !cues.isEmpty else {
                     await MainActor.run { completion(false) }
                     return
                 }
 
+                guard let selection = TranscriptSelectionLogic.selectTranscript(
+                    around: bookmark.time,
+                    cues: cues,
+                    fullText: fullText
+                ) else {
+                    await MainActor.run { completion(false) }
+                    return
+                }
+
+                let title = await BookmarkTitleGenerator.generateTitle(from: selection.text)
+
+                await bookmarkManager.update(title: title, for: bookmark)
+                await bookmarkManager.updateTranscript(
+                    text: selection.text,
+                    startTime: selection.startTime,
+                    endTime: selection.endTime,
+                    for: bookmark
+                )
+
                 await MainActor.run { [weak self] in
                     guard let self else { return }
-
-                    let vm = TranscriptSelectionViewModel(
-                        bookmark: bookmark,
-                        cues: transcript.cues,
-                        fullText: transcript.attributedText.string,
-                        bookmarkManager: self.bookmarkManager
-                    )
-
-                    let controller = TranscriptSelectionViewController(
-                        viewModel: vm,
-                        episode: episode,
-                        onDismiss: { [weak self] title, canceled in
-                            self?.handleEditDismissed(bookmark: bookmark, isNew: true, title: title, canceled: canceled)
-                        }
-                    )
-                    controller.source = self.viewModel.analyticsSource
-
-                    self.present(controller, animated: true)
+                    self.showBookmarkTitleEdit(isNew: true, bookmark: bookmark, prefilledTitle: title)
                     completion(true)
                 }
             } catch {
@@ -188,6 +197,31 @@ extension BookmarksPlayerTabController: BookmarkListRouter {
 
     func bookmarkEdit(_ bookmark: Bookmark) {
         showBookmarkEdit(isNew: false, bookmark: bookmark)
+    }
+
+    func bookmarkDetail(_ bookmark: Bookmark) {
+        let detailView = BookmarkDetailView(
+            bookmark: bookmark,
+            episode: bookmark.episode ?? viewModel.episode,
+            onPlay: { [weak self] in
+                self?.playbackManager.playBookmark(bookmark, source: .player)
+            },
+            onEdit: { [weak self] done in
+                guard let self else { return }
+                presentBookmarkEditor(bookmark: bookmark, bookmarkManager: bookmarkManager, analyticsSource: viewModel.analyticsSource, useAppTheme: false) { [weak self] in
+                    self?.viewModel.reload()
+                    done()
+                }
+            },
+            isModal: true,
+            bookmarkLookup: { [weak self] uuid in
+                self?.bookmarkManager.bookmark(for: uuid)
+            }
+        )
+
+        let hostingController = ThemedHostingController(rootView: detailView)
+        let nav = UINavigationController(rootViewController: hostingController)
+        present(nav, animated: true)
     }
 
     func bookmarkShare(_ bookmark: Bookmark) {

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
@@ -26,6 +26,16 @@ class BookmarksPodcastListController: ThemedHostingController<BookmarksPodcastLi
         viewModel.router = self
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+    }
+
+    override func themeDidChange() {
+        super.themeDidChange()
+        view.backgroundColor = .clear
+    }
+
     @MainActor dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -67,6 +77,9 @@ extension BookmarksPodcastListController: BookmarkListRouter {
                     done()
                 }
             },
+            onShare: bookmark.episode is Episode ? { [weak self] in
+                self?.bookmarkShare(bookmark)
+            } : nil,
             bookmarkLookup: { [weak self] uuid in
                 self?.bookmarkManager.bookmark(for: uuid)
             }

--- a/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
+++ b/podcasts/Bookmarks/Podcast/BookmarksPodcastListController.swift
@@ -53,6 +53,28 @@ extension BookmarksPodcastListController: BookmarkListRouter {
         SharingModal.show(option: .bookmark(episode, bookmark.time), from: .podcastScreen, in: self)
     }
 
+    func bookmarkDetail(_ bookmark: Bookmark) {
+        let detailView = BookmarkDetailView(
+            bookmark: bookmark,
+            episode: bookmark.episode,
+            onPlay: { [weak self] in
+                self?.playbackManager.playBookmark(bookmark, source: self?.viewModel.analyticsSource ?? .podcasts)
+            },
+            onEdit: { [weak self] done in
+                guard let self else { return }
+                presentBookmarkEditor(bookmark: bookmark, bookmarkManager: bookmarkManager, analyticsSource: viewModel.analyticsSource) { [weak self] in
+                    self?.viewModel.reload()
+                    done()
+                }
+            },
+            bookmarkLookup: { [weak self] uuid in
+                self?.bookmarkManager.bookmark(for: uuid)
+            }
+        )
+        let controller = ThemedHostingController(rootView: detailView)
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
     func dismissBookmarksList() {
         dismiss(animated: true)
     }

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
@@ -56,6 +56,28 @@ extension BookmarksProfileListController: BookmarkListRouter {
         SharingModal.show(option: .bookmark(episode, bookmark.time), from: .profile, in: self)
     }
 
+    func bookmarkDetail(_ bookmark: Bookmark) {
+        let detailView = BookmarkDetailView(
+            bookmark: bookmark,
+            episode: bookmark.episode,
+            onPlay: { [weak self] in
+                self?.playbackManager.playBookmark(bookmark, source: self?.viewModel.analyticsSource ?? .profile)
+            },
+            onEdit: { [weak self] done in
+                guard let self else { return }
+                presentBookmarkEditor(bookmark: bookmark, bookmarkManager: bookmarkManager, analyticsSource: viewModel.analyticsSource) { [weak self] in
+                    self?.viewModel.reload()
+                    done()
+                }
+            },
+            bookmarkLookup: { [weak self] uuid in
+                self?.bookmarkManager.bookmark(for: uuid)
+            }
+        )
+        let controller = ThemedHostingController(rootView: detailView)
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
     func dismissBookmarksList() {
         dismiss(animated: true)
     }

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListController.swift
@@ -26,7 +26,13 @@ class BookmarksProfileListController: ThemedHostingController<BookmarksProfileLi
 
     override public func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .clear
         Analytics.track(.profileBookmarksShow)
+    }
+
+    override func themeDidChange() {
+        super.themeDidChange()
+        view.backgroundColor = .clear
     }
 
     @MainActor dynamic required init?(coder aDecoder: NSCoder) {
@@ -70,6 +76,9 @@ extension BookmarksProfileListController: BookmarkListRouter {
                     done()
                 }
             },
+            onShare: bookmark.episode is Episode ? { [weak self] in
+                self?.bookmarkShare(bookmark)
+            } : nil,
             bookmarkLookup: { [weak self] uuid in
                 self?.bookmarkManager.bookmark(for: uuid)
             }

--- a/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
+++ b/podcasts/Bookmarks/Profile/BookmarksProfileListView.swift
@@ -33,7 +33,7 @@ struct BookmarksProfileListView: View {
                         Text(L10n.selectAll)
                     }
                 }
-                .tint(style.theme.secondaryIcon01)
+                .tint(style.theme.primaryText01)
             }
         }
 
@@ -54,7 +54,7 @@ struct BookmarksProfileListView: View {
                 }
                 .disabled(!viewModel.feature.isUnlocked)
                 .opacity(viewModel.feature.isUnlocked ? 1 : 0)
-                .tint(style.theme.secondaryIcon01)
+                .tint(style.theme.primaryText01)
             }
         }
     }

--- a/podcasts/Bookmarks/TranscriptSelection/BookmarkTitleGenerator.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/BookmarkTitleGenerator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NaturalLanguage
 #if canImport(FoundationModels)
 import FoundationModels
 #endif
@@ -15,6 +16,11 @@ enum BookmarkTitleGenerator {
             }
         }
         #endif
+
+        if let nlpTitle = nlpTitle(from: text) {
+            return nlpTitle
+        }
+
         return heuristicTitle(from: text)
     }
 
@@ -41,6 +47,53 @@ enum BookmarkTitleGenerator {
         }
     }
     #endif
+
+    // MARK: - NLP Keyword Extraction
+
+    static func nlpTitle(from text: String) -> String? {
+        let cleaned = text
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else { return nil }
+
+        var namedEntities: [String] = []
+        let nameTagger = NLTagger(tagSchemes: [.nameType])
+        nameTagger.string = cleaned
+        let nameOptions: NLTagger.Options = [.omitPunctuation, .omitWhitespace, .joinNames]
+        let entityTags: [NLTag] = [.personalName, .placeName, .organizationName]
+
+        nameTagger.enumerateTags(in: cleaned.startIndex..<cleaned.endIndex, unit: .word, scheme: .nameType, options: nameOptions) { tag, tokenRange in
+            if let tag, entityTags.contains(tag) {
+                namedEntities.append(String(cleaned[tokenRange]))
+            }
+            return true
+        }
+
+        var nouns: [String] = []
+        let posTagger = NLTagger(tagSchemes: [.lexicalClass])
+        posTagger.string = cleaned
+        let posOptions: NLTagger.Options = [.omitPunctuation, .omitWhitespace]
+
+        posTagger.enumerateTags(in: cleaned.startIndex..<cleaned.endIndex, unit: .word, scheme: .lexicalClass, options: posOptions) { tag, tokenRange in
+            if tag == .noun {
+                let word = String(cleaned[tokenRange])
+                if !namedEntities.contains(where: { $0.contains(word) }) {
+                    nouns.append(word)
+                }
+            }
+            return true
+        }
+
+        var seen = Set<String>()
+        let uniqueNouns = nouns.filter { seen.insert($0.lowercased()).inserted }
+        let keywords = namedEntities + Array(uniqueNouns.prefix(4))
+        guard !keywords.isEmpty else { return nil }
+
+        let title = keywords.prefix(5).joined(separator: ", ")
+        guard !title.isEmpty else { return nil }
+
+        return title.count <= maxTitleLength ? title : truncateAtWordBoundary(title)
+    }
 
     // MARK: - Heuristic Fallback
 

--- a/podcasts/Bookmarks/TranscriptSelection/BookmarkTitleGenerator.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/BookmarkTitleGenerator.swift
@@ -5,6 +5,7 @@ import FoundationModels
 
 enum BookmarkTitleGenerator {
     private static let maxTitleLength = Constants.Values.bookmarkMaxTitleLength
+    private static let heuristicWordLimit = 8
 
     static func generateTitle(from text: String) async -> String {
         #if canImport(FoundationModels)
@@ -27,7 +28,8 @@ enum BookmarkTitleGenerator {
 
         do {
             let session = LanguageModelSession(instructions: """
-                Generate a short title (under 8 words) that captures the key topic of this podcast excerpt. \
+                Summarize this podcast excerpt as a short descriptive title (3-8 words). \
+                Describe the topic, do NOT quote the text verbatim. \
                 Output ONLY the title text, nothing else. No quotes, no punctuation at the end.
                 """)
             let response = try await session.respond(to: text)
@@ -49,19 +51,20 @@ enum BookmarkTitleGenerator {
 
         guard !cleaned.isEmpty else { return L10n.bookmarkDefaultTitle }
 
-        let sentenceEnd = cleaned.rangeOfCharacter(from: CharacterSet(charactersIn: ".!?"))
-        let firstSentence: String
-        if let end = sentenceEnd {
-            firstSentence = String(cleaned[cleaned.startIndex...end.lowerBound])
-        } else {
-            firstSentence = cleaned
+        let words = cleaned.split(separator: " ", maxSplits: heuristicWordLimit + 1, omittingEmptySubsequences: true)
+
+        if words.count <= heuristicWordLimit {
+            let joined = words.joined(separator: " ")
+            return joined.count <= maxTitleLength ? joined : truncateAtWordBoundary(joined)
         }
 
-        if firstSentence.count <= maxTitleLength {
-            return firstSentence
-        }
+        let snippet = words.prefix(heuristicWordLimit).joined(separator: " ")
+        return truncateAtWordBoundary(snippet + "…")
+    }
 
-        let truncated = String(firstSentence.prefix(maxTitleLength - 1))
+    private static func truncateAtWordBoundary(_ text: String) -> String {
+        guard text.count > maxTitleLength else { return text }
+        let truncated = String(text.prefix(maxTitleLength - 1))
         if let lastSpace = truncated.lastIndex(of: " ") {
             return String(truncated[truncated.startIndex..<lastSpace]) + "…"
         }

--- a/podcasts/Bookmarks/TranscriptSelection/BookmarkTitleGenerator.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/BookmarkTitleGenerator.swift
@@ -1,0 +1,70 @@
+import Foundation
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+enum BookmarkTitleGenerator {
+    private static let maxTitleLength = Constants.Values.bookmarkMaxTitleLength
+
+    static func generateTitle(from text: String) async -> String {
+        #if canImport(FoundationModels)
+        if #available(iOS 26, *) {
+            if let aiTitle = await generateWithAppleIntelligence(text: text) {
+                return aiTitle
+            }
+        }
+        #endif
+        return heuristicTitle(from: text)
+    }
+
+    // MARK: - Apple Intelligence
+
+    #if canImport(FoundationModels)
+    @available(iOS 26, *)
+    private static func generateWithAppleIntelligence(text: String) async -> String? {
+        let model = SystemLanguageModel.default
+        guard model.availability == .available else { return nil }
+
+        do {
+            let session = LanguageModelSession(instructions: """
+                Generate a short title (under 8 words) that captures the key topic of this podcast excerpt. \
+                Output ONLY the title text, nothing else. No quotes, no punctuation at the end.
+                """)
+            let response = try await session.respond(to: text)
+            let title = response.content.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !title.isEmpty else { return nil }
+            return String(title.prefix(maxTitleLength))
+        } catch {
+            return nil
+        }
+    }
+    #endif
+
+    // MARK: - Heuristic Fallback
+
+    static func heuristicTitle(from text: String) -> String {
+        let cleaned = text
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !cleaned.isEmpty else { return L10n.bookmarkDefaultTitle }
+
+        let sentenceEnd = cleaned.rangeOfCharacter(from: CharacterSet(charactersIn: ".!?"))
+        let firstSentence: String
+        if let end = sentenceEnd {
+            firstSentence = String(cleaned[cleaned.startIndex...end.lowerBound])
+        } else {
+            firstSentence = cleaned
+        }
+
+        if firstSentence.count <= maxTitleLength {
+            return firstSentence
+        }
+
+        let truncated = String(firstSentence.prefix(maxTitleLength - 1))
+        if let lastSpace = truncated.lastIndex(of: " ") {
+            return String(truncated[truncated.startIndex..<lastSpace]) + "…"
+        }
+        return truncated + "…"
+    }
+}

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionLogic.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionLogic.swift
@@ -71,6 +71,10 @@ enum TranscriptSelectionLogic {
         )
     }
 
+    static func bookmarkCueIndex(for timestamp: TimeInterval, in cues: [TranscriptCue]) -> Int? {
+        cueIndex(for: timestamp, in: cues) ?? nearestCueIndex(for: timestamp, in: cues)
+    }
+
     private static func cueIndex(for timestamp: TimeInterval, in cues: [TranscriptCue]) -> Int? {
         cues.firstIndex { $0.contains(timeInSeconds: timestamp) }
     }

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionLogic.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionLogic.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+struct TranscriptSelection: Equatable {
+    let text: String
+    let startTime: TimeInterval
+    let endTime: TimeInterval
+    let startCueIndex: Int
+    let endCueIndex: Int
+}
+
+enum TranscriptSelectionLogic {
+    static let defaultSelectionRadius = 3
+
+    static func selectTranscript(
+        around timestamp: TimeInterval,
+        cues: [TranscriptCue],
+        fullText: String,
+        radius: Int = defaultSelectionRadius
+    ) -> TranscriptSelection? {
+        guard !cues.isEmpty else { return nil }
+
+        let centerIndex = cueIndex(for: timestamp, in: cues) ?? nearestCueIndex(for: timestamp, in: cues)
+        guard let centerIndex else { return nil }
+
+        let startIndex = max(0, centerIndex - radius)
+        let endIndex = min(cues.count - 1, centerIndex + radius)
+
+        return selection(from: startIndex, to: endIndex, cues: cues, fullText: fullText)
+    }
+
+    static func adjustSelection(
+        startCueIndex: Int,
+        endCueIndex: Int,
+        cues: [TranscriptCue],
+        fullText: String
+    ) -> TranscriptSelection? {
+        guard !cues.isEmpty else { return nil }
+        let clampedStart = max(0, min(startCueIndex, cues.count - 1))
+        let clampedEnd = max(clampedStart, min(endCueIndex, cues.count - 1))
+
+        return selection(from: clampedStart, to: clampedEnd, cues: cues, fullText: fullText)
+    }
+
+    // MARK: - Private
+
+    private static func selection(
+        from startIndex: Int,
+        to endIndex: Int,
+        cues: [TranscriptCue],
+        fullText: String
+    ) -> TranscriptSelection? {
+        let nsString = fullText as NSString
+        let firstCue = cues[startIndex]
+        let lastCue = cues[endIndex]
+
+        let rangeStart = firstCue.characterRange.location
+        let rangeEnd = lastCue.characterRange.location + lastCue.characterRange.length
+        let combinedRange = NSRange(location: rangeStart, length: rangeEnd - rangeStart)
+
+        guard combinedRange.location + combinedRange.length <= nsString.length else { return nil }
+
+        let text = nsString.substring(with: combinedRange).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+
+        return TranscriptSelection(
+            text: text,
+            startTime: firstCue.startTime,
+            endTime: lastCue.endTime,
+            startCueIndex: startIndex,
+            endCueIndex: endIndex
+        )
+    }
+
+    private static func cueIndex(for timestamp: TimeInterval, in cues: [TranscriptCue]) -> Int? {
+        cues.firstIndex { $0.contains(timeInSeconds: timestamp) }
+    }
+
+    private static func nearestCueIndex(for timestamp: TimeInterval, in cues: [TranscriptCue]) -> Int? {
+        guard !cues.isEmpty else { return nil }
+        var bestIndex = 0
+        var bestDistance = Double.greatestFiniteMagnitude
+        for (index, cue) in cues.enumerated() {
+            let midpoint = (cue.startTime + cue.endTime) / 2.0
+            let distance = abs(midpoint - timestamp)
+            if distance < bestDistance {
+                bestDistance = distance
+                bestIndex = index
+            }
+        }
+        return bestIndex
+    }
+}

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionView.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionView.swift
@@ -1,0 +1,215 @@
+import Combine
+import PocketCastsDataModel
+import PocketCastsUtils
+import SwiftUI
+
+struct TranscriptSelectionView: View {
+    @ObservedObject var viewModel: TranscriptSelectionViewModel
+    @ObservedObject var theme: TranscriptSelectionTheme
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            mainView
+
+            Image("close")
+                .renderingMode(.template)
+                .foregroundStyle(theme.closeButton)
+                .buttonize {
+                    viewModel.cancel()
+                }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+        .background(theme.background)
+        .onAppear {
+            viewModel.generateTitle()
+        }
+    }
+
+    // MARK: - Views
+
+    private var mainView: some View {
+        VStack(spacing: 16) {
+            headerView
+            cueListView
+            scopeControls
+            titleField
+            saveButton
+        }
+        .padding(.top, 18)
+    }
+
+    private var headerView: some View {
+        VStack(spacing: 4) {
+            Text(L10n.smartBookmarkTitle)
+                .foregroundStyle(theme.title)
+                .font(size: 19, style: .title3, weight: .bold)
+
+            Text(L10n.smartBookmarkSubtitle)
+                .foregroundStyle(theme.subtitle)
+                .font(style: .callout)
+        }
+    }
+
+    private var cueListView: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 2) {
+                    ForEach(visibleCueRange, id: \.self) { index in
+                        cueRow(at: index)
+                            .id(index)
+                    }
+                }
+                .padding(.horizontal, 4)
+            }
+            .frame(maxHeight: 300)
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .onChange(of: viewModel.startCueIndex) { _ in
+                withAnimation {
+                    proxy.scrollTo(viewModel.startCueIndex, anchor: .center)
+                }
+            }
+        }
+    }
+
+    private func cueRow(at index: Int) -> some View {
+        let isSelected = index >= viewModel.startCueIndex && index <= viewModel.endCueIndex
+        let cue = viewModel.cues[index]
+        let nsString = viewModel.fullText as NSString
+        let text = nsString.substring(with: cue.characterRange).trimmingCharacters(in: .whitespacesAndNewlines)
+
+        return Text(text)
+            .font(style: .body)
+            .foregroundStyle(isSelected ? theme.selectedText : theme.dimmedText)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSelected ? theme.selectedBackground : Color.clear)
+            )
+            .contentShape(Rectangle())
+            .onTapGesture {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    viewModel.selectCue(at: index)
+                }
+            }
+    }
+
+    private var scopeControls: some View {
+        HStack(spacing: 20) {
+            Button(action: { withAnimation { viewModel.expandStart() } }) {
+                Image(systemName: "arrow.up")
+            }
+            .disabled(!viewModel.canExpandStart)
+
+            Button(action: { withAnimation { viewModel.contractStart() } }) {
+                Image(systemName: "arrow.down")
+            }
+            .disabled(!viewModel.canContractStart)
+
+            Text(L10n.smartBookmarkSegmentCount(viewModel.selectedCueCount))
+                .foregroundStyle(theme.subtitle)
+                .font(style: .caption)
+
+            Button(action: { withAnimation { viewModel.expandEnd() } }) {
+                Image(systemName: "arrow.down")
+            }
+            .disabled(!viewModel.canExpandEnd)
+
+            Button(action: { withAnimation { viewModel.contractEnd() } }) {
+                Image(systemName: "arrow.up")
+            }
+            .disabled(!viewModel.canContractEnd)
+        }
+        .foregroundStyle(theme.title)
+        .font(style: .body, weight: .medium)
+    }
+
+    @ViewBuilder
+    private var titleField: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(L10n.smartBookmarkTitleLabel)
+                .foregroundStyle(theme.subtitle)
+                .font(style: .caption)
+
+            if viewModel.isGeneratingTitle {
+                HStack {
+                    ProgressView()
+                        .tint(theme.subtitle)
+                    Text(L10n.smartBookmarkGeneratingTitle)
+                        .foregroundStyle(theme.subtitle)
+                        .font(style: .callout)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 8)
+            } else {
+                TextField(L10n.bookmarkDefaultTitle, text: $viewModel.bookmarkTitle)
+                    .foregroundStyle(theme.title)
+                    .font(size: 20, style: .title3, weight: .semibold)
+                    .textFieldStyle(.plain)
+                    .accentColor(theme.accent)
+                    .onChange(of: viewModel.bookmarkTitle) { newValue in
+                        let max = Constants.Values.bookmarkMaxTitleLength
+                        if newValue.count > max {
+                            viewModel.bookmarkTitle = String(newValue.prefix(max))
+                        }
+                    }
+            }
+
+            Divider().background(theme.divider)
+        }
+    }
+
+    @ViewBuilder
+    private var saveButton: some View {
+        Button(L10n.saveBookmark) {
+            viewModel.save()
+        }
+        .buttonStyle(BasicButtonStyle(textColor: theme.saveButtonText, backgroundColor: theme.accent))
+        .disabled(viewModel.isGeneratingTitle)
+    }
+
+    // MARK: - Helpers
+
+    private var visibleCueRange: Range<Int> {
+        let padding = 5
+        let start = max(0, viewModel.startCueIndex - padding)
+        let end = min(viewModel.cues.count, viewModel.endCueIndex + padding + 1)
+        return start..<end
+    }
+}
+
+// MARK: - Theme
+
+class TranscriptSelectionTheme: ThemeObserver {
+    let episode: BaseEpisode?
+
+    init(episode: BaseEpisode?) {
+        self.episode = episode
+    }
+
+    var background: Color {
+        PlayerColorHelper.playerBackgroundColor01(for: theme.activeTheme, episode: episode).color
+    }
+
+    var title: Color { theme.playerContrast01 }
+    var subtitle: Color { theme.playerContrast02 }
+    var closeButton: Color { theme.playerContrast01 }
+    var dimmedText: Color { theme.playerContrast05 }
+
+    var selectedText: Color { theme.playerContrast01 }
+    var selectedBackground: Color {
+        PlayerColorHelper.playerHighlightColor01(for: .dark, episode: episode).color.opacity(0.25)
+    }
+
+    var accent: Color {
+        PlayerColorHelper.playerHighlightColor01(for: .dark, episode: episode).color
+    }
+
+    var divider: Color { theme.playerContrast05 }
+
+    var saveButtonText: Color {
+        accent.luminance() < 0.5 ? .white : .black
+    }
+}

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionView.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionView.swift
@@ -41,7 +41,7 @@ struct TranscriptSelectionView: View {
 
     private var headerView: some View {
         VStack(spacing: 4) {
-            Text(L10n.smartBookmarkTitle)
+            Text(viewModel.isEditing ? L10n.smartBookmarkEditTitle : L10n.smartBookmarkTitle)
                 .foregroundStyle(theme.title)
                 .font(size: 19, style: .title3, weight: .bold)
 
@@ -204,4 +204,17 @@ class TranscriptSelectionTheme: ThemeObserver {
     var saveButtonText: Color {
         accent.luminance() < 0.5 ? .white : .black
     }
+}
+
+class TranscriptSelectionAppTheme: TranscriptSelectionTheme {
+    override var background: Color { AppTheme.color(for: .primaryUi01, theme: theme) }
+    override var title: Color { AppTheme.color(for: .primaryText01, theme: theme) }
+    override var subtitle: Color { AppTheme.color(for: .primaryText02, theme: theme) }
+    override var closeButton: Color { AppTheme.color(for: .primaryText01, theme: theme) }
+    override var dimmedText: Color { AppTheme.color(for: .primaryText02, theme: theme).opacity(0.5) }
+    override var selectedText: Color { AppTheme.color(for: .primaryText01, theme: theme) }
+    override var selectedBackground: Color { AppTheme.color(for: .primaryInteractive01, theme: theme).opacity(0.15) }
+    override var accent: Color { AppTheme.color(for: .primaryInteractive01, theme: theme) }
+    override var divider: Color { AppTheme.color(for: .primaryUi05, theme: theme) }
+    override var saveButtonText: Color { AppTheme.color(for: .primaryInteractive02, theme: theme) }
 }

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionView.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionView.swift
@@ -8,7 +8,7 @@ struct TranscriptSelectionView: View {
     @ObservedObject var theme: TranscriptSelectionTheme
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
+        ZStack(alignment: .topLeading) {
             mainView
 
             Image("close")
@@ -40,7 +40,7 @@ struct TranscriptSelectionView: View {
     }
 
     private var headerView: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: 8) {
             Text(viewModel.isEditing ? L10n.smartBookmarkEditTitle : L10n.smartBookmarkTitle)
                 .foregroundStyle(theme.title)
                 .font(size: 19, style: .title3, weight: .bold)
@@ -62,6 +62,7 @@ struct TranscriptSelectionView: View {
                 }
                 .padding(.horizontal, 4)
             }
+            .padding(.vertical, 8)
             .frame(maxHeight: .infinity)
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .onAppear {
@@ -93,7 +94,7 @@ struct TranscriptSelectionView: View {
             }
 
             Text(text)
-                .font(style: .body)
+                .font(.system(.body, design: .serif))
                 .foregroundStyle(isSelected ? theme.selectedText : theme.dimmedText)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionView.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionView.swift
@@ -32,7 +32,7 @@ struct TranscriptSelectionView: View {
         VStack(spacing: 16) {
             headerView
             cueListView
-            scopeControls
+            selectionInfo
             titleField
             saveButton
         }
@@ -55,15 +55,18 @@ struct TranscriptSelectionView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(spacing: 2) {
-                    ForEach(visibleCueRange, id: \.self) { index in
+                    ForEach(0..<viewModel.cues.count, id: \.self) { index in
                         cueRow(at: index)
                             .id(index)
                     }
                 }
                 .padding(.horizontal, 4)
             }
-            .frame(maxHeight: 300)
+            .frame(maxHeight: .infinity)
             .clipShape(RoundedRectangle(cornerRadius: 12))
+            .onAppear {
+                proxy.scrollTo(viewModel.bookmarkCueIndex, anchor: .center)
+            }
             .onChange(of: viewModel.startCueIndex) { _ in
                 withAnimation {
                     proxy.scrollTo(viewModel.startCueIndex, anchor: .center)
@@ -74,56 +77,54 @@ struct TranscriptSelectionView: View {
 
     private func cueRow(at index: Int) -> some View {
         let isSelected = index >= viewModel.startCueIndex && index <= viewModel.endCueIndex
+        let isBookmarkCue = index == viewModel.bookmarkCueIndex
         let cue = viewModel.cues[index]
         let nsString = viewModel.fullText as NSString
         let text = nsString.substring(with: cue.characterRange).trimmingCharacters(in: .whitespacesAndNewlines)
 
-        return Text(text)
-            .font(style: .body)
-            .foregroundStyle(isSelected ? theme.selectedText : theme.dimmedText)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(isSelected ? theme.selectedBackground : Color.clear)
-            )
-            .contentShape(Rectangle())
-            .onTapGesture {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    viewModel.selectCue(at: index)
-                }
+        return HStack(spacing: 0) {
+            if isBookmarkCue {
+                Image(systemName: "bookmark.fill")
+                    .font(.system(size: 10))
+                    .foregroundStyle(theme.accent)
+                    .frame(width: 20)
+            } else {
+                Spacer().frame(width: 20)
             }
+
+            Text(text)
+                .font(style: .body)
+                .foregroundStyle(isSelected ? theme.selectedText : theme.dimmedText)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(isSelected ? theme.selectedBackground : Color.clear)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                viewModel.selectCue(at: index)
+            }
+        }
     }
 
-    private var scopeControls: some View {
-        HStack(spacing: 20) {
-            Button(action: { withAnimation { viewModel.expandStart() } }) {
-                Image(systemName: "arrow.up")
-            }
-            .disabled(!viewModel.canExpandStart)
-
-            Button(action: { withAnimation { viewModel.contractStart() } }) {
-                Image(systemName: "arrow.down")
-            }
-            .disabled(!viewModel.canContractStart)
-
-            Text(L10n.smartBookmarkSegmentCount(viewModel.selectedCueCount))
+    private var selectionInfo: some View {
+        HStack(spacing: 6) {
+            Text(L10n.smartBookmarkLineCount(viewModel.selectedCueCount))
                 .foregroundStyle(theme.subtitle)
                 .font(style: .caption)
 
-            Button(action: { withAnimation { viewModel.expandEnd() } }) {
-                Image(systemName: "arrow.down")
-            }
-            .disabled(!viewModel.canExpandEnd)
+            Text("·")
+                .foregroundStyle(theme.subtitle)
+                .font(style: .caption)
 
-            Button(action: { withAnimation { viewModel.contractEnd() } }) {
-                Image(systemName: "arrow.up")
-            }
-            .disabled(!viewModel.canContractEnd)
+            Text(viewModel.formattedTimeRange)
+                .foregroundStyle(theme.subtitle)
+                .font(style: .caption)
         }
-        .foregroundStyle(theme.title)
-        .font(style: .body, weight: .medium)
     }
 
     @ViewBuilder
@@ -168,15 +169,6 @@ struct TranscriptSelectionView: View {
         }
         .buttonStyle(BasicButtonStyle(textColor: theme.saveButtonText, backgroundColor: theme.accent))
         .disabled(viewModel.isGeneratingTitle)
-    }
-
-    // MARK: - Helpers
-
-    private var visibleCueRange: Range<Int> {
-        let padding = 5
-        let start = max(0, viewModel.startCueIndex - padding)
-        let end = min(viewModel.cues.count, viewModel.endCueIndex + padding + 1)
-        return start..<end
     }
 }
 

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewController.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewController.swift
@@ -1,0 +1,44 @@
+import Foundation
+import PocketCastsDataModel
+
+class TranscriptSelectionViewController: ThemedHostingController<TranscriptSelectionView> {
+    private let viewModel: TranscriptSelectionViewModel
+    let onDismiss: ((String, Bool) -> Void)?
+
+    var source: BookmarkAnalyticsSource = .unknown
+
+    init(viewModel: TranscriptSelectionViewModel,
+         episode: BaseEpisode?,
+         onDismiss: ((String, Bool) -> Void)? = nil) {
+        self.viewModel = viewModel
+        self.onDismiss = onDismiss
+
+        let theme = TranscriptSelectionTheme(episode: episode)
+        super.init(rootView: .init(viewModel: viewModel, theme: theme))
+
+        viewModel.router = self
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        Analytics.track(.bookmarkEditFormShown, properties: ["source": source.rawValue, "smart_bookmark": true])
+    }
+
+    @MainActor dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension TranscriptSelectionViewController: TranscriptSelectionRouter {
+    func selectionSaved(title: String) {
+        Analytics.track(.bookmarkEditFormSubmitted, properties: ["source": source.rawValue, "smart_bookmark": true])
+        dismiss(animated: true)
+        onDismiss?(title, false)
+    }
+
+    func selectionDismissed() {
+        Analytics.track(.bookmarkEditFormDismissed, properties: ["source": source.rawValue, "smart_bookmark": true])
+        dismiss(animated: true)
+        onDismiss?(viewModel.bookmark.title, true)
+    }
+}

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewController.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewController.swift
@@ -9,11 +9,12 @@ class TranscriptSelectionViewController: ThemedHostingController<TranscriptSelec
 
     init(viewModel: TranscriptSelectionViewModel,
          episode: BaseEpisode?,
+         useAppTheme: Bool = false,
          onDismiss: ((String, Bool) -> Void)? = nil) {
         self.viewModel = viewModel
         self.onDismiss = onDismiss
 
-        let theme = TranscriptSelectionTheme(episode: episode)
+        let theme: TranscriptSelectionTheme = useAppTheme ? TranscriptSelectionAppTheme(episode: episode) : TranscriptSelectionTheme(episode: episode)
         super.init(rootView: .init(viewModel: viewModel, theme: theme))
 
         modalPresentationStyle = .overFullScreen

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewController.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewController.swift
@@ -16,6 +16,7 @@ class TranscriptSelectionViewController: ThemedHostingController<TranscriptSelec
         let theme = TranscriptSelectionTheme(episode: episode)
         super.init(rootView: .init(viewModel: viewModel, theme: theme))
 
+        modalPresentationStyle = .overFullScreen
         viewModel.router = self
     }
 

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewModel.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewModel.swift
@@ -21,6 +21,7 @@ class TranscriptSelectionViewModel: ObservableObject {
     @Published private(set) var selectedText: String = ""
     @Published var bookmarkTitle: String = ""
     @Published private(set) var isGeneratingTitle: Bool = false
+    let isEditing: Bool
 
     private let bookmarkManager: BookmarkManager
     private let maxTitleLength = Constants.Values.bookmarkMaxTitleLength
@@ -41,21 +42,37 @@ class TranscriptSelectionViewModel: ObservableObject {
         return "\(start) – \(end)"
     }
 
-    init(bookmark: Bookmark, cues: [TranscriptCue], fullText: String, bookmarkManager: BookmarkManager) {
+    init(bookmark: Bookmark, cues: [TranscriptCue], fullText: String, bookmarkManager: BookmarkManager, existingTitle: String? = nil) {
         self.bookmark = bookmark
         self.cues = cues
         self.fullText = fullText
         self.bookmarkManager = bookmarkManager
         self.bookmarkCueIndex = TranscriptSelectionLogic.bookmarkCueIndex(for: bookmark.time, in: cues) ?? 0
 
-        let initial = TranscriptSelectionLogic.selectTranscript(
-            around: bookmark.time,
-            cues: cues,
-            fullText: fullText
-        )
-        self.startCueIndex = initial?.startCueIndex ?? 0
-        self.endCueIndex = initial?.endCueIndex ?? min(cues.count - 1, 0)
-        self.selectedText = initial?.text ?? ""
+        if let startTime = bookmark.transcriptStartTime,
+           let endTime = bookmark.transcriptEndTime,
+           let startIdx = TranscriptSelectionLogic.bookmarkCueIndex(for: startTime, in: cues),
+           let endIdx = TranscriptSelectionLogic.bookmarkCueIndex(for: endTime, in: cues) {
+            let restored = TranscriptSelectionLogic.adjustSelection(startCueIndex: startIdx, endCueIndex: endIdx, cues: cues, fullText: fullText)
+            self.startCueIndex = restored?.startCueIndex ?? startIdx
+            self.endCueIndex = restored?.endCueIndex ?? endIdx
+            self.selectedText = restored?.text ?? ""
+        } else {
+            let initial = TranscriptSelectionLogic.selectTranscript(
+                around: bookmark.time,
+                cues: cues,
+                fullText: fullText
+            )
+            self.startCueIndex = initial?.startCueIndex ?? 0
+            self.endCueIndex = initial?.endCueIndex ?? min(cues.count - 1, 0)
+            self.selectedText = initial?.text ?? ""
+        }
+
+        self.isEditing = existingTitle != nil
+
+        if let existingTitle {
+            self.bookmarkTitle = existingTitle
+        }
     }
 
     // MARK: - Actions
@@ -75,6 +92,7 @@ class TranscriptSelectionViewModel: ObservableObject {
     }
 
     func generateTitle() {
+        guard bookmarkTitle.isEmpty else { return }
         isGeneratingTitle = true
         Task {
             let title = await BookmarkTitleGenerator.generateTitle(from: selectedText)

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewModel.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewModel.swift
@@ -14,6 +14,7 @@ class TranscriptSelectionViewModel: ObservableObject {
     let bookmark: Bookmark
     let cues: [TranscriptCue]
     let fullText: String
+    let bookmarkCueIndex: Int
 
     @Published var startCueIndex: Int
     @Published var endCueIndex: Int
@@ -24,17 +25,28 @@ class TranscriptSelectionViewModel: ObservableObject {
     private let bookmarkManager: BookmarkManager
     private let maxTitleLength = Constants.Values.bookmarkMaxTitleLength
 
-    var canExpandStart: Bool { startCueIndex > 0 }
-    var canContractStart: Bool { startCueIndex < endCueIndex }
-    var canExpandEnd: Bool { endCueIndex < cues.count - 1 }
-    var canContractEnd: Bool { endCueIndex > startCueIndex }
     var selectedCueCount: Int { endCueIndex - startCueIndex + 1 }
+
+    var selectionStartTime: TimeInterval {
+        cues[startCueIndex].startTime
+    }
+
+    var selectionEndTime: TimeInterval {
+        cues[endCueIndex].endTime
+    }
+
+    var formattedTimeRange: String {
+        let start = TimeFormatter.shared.playTimeFormat(time: selectionStartTime)
+        let end = TimeFormatter.shared.playTimeFormat(time: selectionEndTime)
+        return "\(start) – \(end)"
+    }
 
     init(bookmark: Bookmark, cues: [TranscriptCue], fullText: String, bookmarkManager: BookmarkManager) {
         self.bookmark = bookmark
         self.cues = cues
         self.fullText = fullText
         self.bookmarkManager = bookmarkManager
+        self.bookmarkCueIndex = TranscriptSelectionLogic.bookmarkCueIndex(for: bookmark.time, in: cues) ?? 0
 
         let initial = TranscriptSelectionLogic.selectTranscript(
             around: bookmark.time,
@@ -47,30 +59,6 @@ class TranscriptSelectionViewModel: ObservableObject {
     }
 
     // MARK: - Actions
-
-    func expandStart() {
-        guard canExpandStart else { return }
-        startCueIndex -= 1
-        updateSelection()
-    }
-
-    func contractStart() {
-        guard canContractStart else { return }
-        startCueIndex += 1
-        updateSelection()
-    }
-
-    func expandEnd() {
-        guard canExpandEnd else { return }
-        endCueIndex += 1
-        updateSelection()
-    }
-
-    func contractEnd() {
-        guard canContractEnd else { return }
-        endCueIndex -= 1
-        updateSelection()
-    }
 
     func selectCue(at index: Int) {
         guard index >= 0, index < cues.count else { return }

--- a/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewModel.swift
+++ b/podcasts/Bookmarks/TranscriptSelection/TranscriptSelectionViewModel.swift
@@ -1,0 +1,143 @@
+import Combine
+import Foundation
+import PocketCastsDataModel
+import PocketCastsUtils
+
+protocol TranscriptSelectionRouter: AnyObject {
+    func selectionSaved(title: String)
+    func selectionDismissed()
+}
+
+class TranscriptSelectionViewModel: ObservableObject {
+    weak var router: TranscriptSelectionRouter?
+
+    let bookmark: Bookmark
+    let cues: [TranscriptCue]
+    let fullText: String
+
+    @Published var startCueIndex: Int
+    @Published var endCueIndex: Int
+    @Published private(set) var selectedText: String = ""
+    @Published var bookmarkTitle: String = ""
+    @Published private(set) var isGeneratingTitle: Bool = false
+
+    private let bookmarkManager: BookmarkManager
+    private let maxTitleLength = Constants.Values.bookmarkMaxTitleLength
+
+    var canExpandStart: Bool { startCueIndex > 0 }
+    var canContractStart: Bool { startCueIndex < endCueIndex }
+    var canExpandEnd: Bool { endCueIndex < cues.count - 1 }
+    var canContractEnd: Bool { endCueIndex > startCueIndex }
+    var selectedCueCount: Int { endCueIndex - startCueIndex + 1 }
+
+    init(bookmark: Bookmark, cues: [TranscriptCue], fullText: String, bookmarkManager: BookmarkManager) {
+        self.bookmark = bookmark
+        self.cues = cues
+        self.fullText = fullText
+        self.bookmarkManager = bookmarkManager
+
+        let initial = TranscriptSelectionLogic.selectTranscript(
+            around: bookmark.time,
+            cues: cues,
+            fullText: fullText
+        )
+        self.startCueIndex = initial?.startCueIndex ?? 0
+        self.endCueIndex = initial?.endCueIndex ?? min(cues.count - 1, 0)
+        self.selectedText = initial?.text ?? ""
+    }
+
+    // MARK: - Actions
+
+    func expandStart() {
+        guard canExpandStart else { return }
+        startCueIndex -= 1
+        updateSelection()
+    }
+
+    func contractStart() {
+        guard canContractStart else { return }
+        startCueIndex += 1
+        updateSelection()
+    }
+
+    func expandEnd() {
+        guard canExpandEnd else { return }
+        endCueIndex += 1
+        updateSelection()
+    }
+
+    func contractEnd() {
+        guard canContractEnd else { return }
+        endCueIndex -= 1
+        updateSelection()
+    }
+
+    func selectCue(at index: Int) {
+        guard index >= 0, index < cues.count else { return }
+        if index < startCueIndex {
+            startCueIndex = index
+        } else if index > endCueIndex {
+            endCueIndex = index
+        } else if index == startCueIndex && startCueIndex < endCueIndex {
+            startCueIndex += 1
+        } else if index == endCueIndex && endCueIndex > startCueIndex {
+            endCueIndex -= 1
+        }
+        updateSelection()
+    }
+
+    func generateTitle() {
+        isGeneratingTitle = true
+        Task {
+            let title = await BookmarkTitleGenerator.generateTitle(from: selectedText)
+            await MainActor.run {
+                self.bookmarkTitle = title
+                self.isGeneratingTitle = false
+            }
+        }
+    }
+
+    func save() {
+        let title = bookmarkTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let finalTitle = title.isEmpty ? L10n.bookmarkDefaultTitle : String(title.prefix(maxTitleLength))
+
+        guard let selection = TranscriptSelectionLogic.adjustSelection(
+            startCueIndex: startCueIndex,
+            endCueIndex: endCueIndex,
+            cues: cues,
+            fullText: fullText
+        ) else {
+            router?.selectionSaved(title: finalTitle)
+            return
+        }
+
+        Task {
+            await bookmarkManager.update(title: finalTitle, for: bookmark)
+            await bookmarkManager.updateTranscript(
+                text: selection.text,
+                startTime: selection.startTime,
+                endTime: selection.endTime,
+                for: bookmark
+            )
+            await MainActor.run {
+                router?.selectionSaved(title: finalTitle)
+            }
+        }
+    }
+
+    func cancel() {
+        router?.selectionDismissed()
+    }
+
+    // MARK: - Private
+
+    private func updateSelection() {
+        guard let selection = TranscriptSelectionLogic.adjustSelection(
+            startCueIndex: startCueIndex,
+            endCueIndex: endCueIndex,
+            cues: cues,
+            fullText: fullText
+        ) else { return }
+        selectedText = selection.text
+    }
+}

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -1777,6 +1777,9 @@ extension PodcastViewController: BookmarkListRouter {
                     done()
                 }
             },
+            onShare: bookmark.episode is Episode ? { [weak self] in
+                self?.bookmarkShare(bookmark)
+            } : nil,
             bookmarkLookup: { uuid in
                 bookmarkManager.bookmark(for: uuid)
             }

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -1763,6 +1763,28 @@ extension PodcastViewController: BookmarkListRouter {
         SharingModal.show(option: .bookmark(episode, bookmark.time), from: .podcastScreen, in: self)
     }
 
+    func bookmarkDetail(_ bookmark: Bookmark) {
+        let bookmarkManager = PlaybackManager.shared.bookmarkManager
+        let detailView = BookmarkDetailView(
+            bookmark: bookmark,
+            episode: bookmark.episode,
+            onPlay: {
+                PlaybackManager.shared.playBookmark(bookmark, source: .podcasts)
+            },
+            onEdit: { [weak self] done in
+                guard let self else { return }
+                presentBookmarkEditor(bookmark: bookmark, bookmarkManager: bookmarkManager, analyticsSource: .podcasts) {
+                    done()
+                }
+            },
+            bookmarkLookup: { uuid in
+                bookmarkManager.bookmark(for: uuid)
+            }
+        )
+        let controller = ThemedHostingController(rootView: detailView)
+        navigationController?.pushViewController(controller, animated: true)
+    }
+
     func dismissBookmarksList() {
         // For tab-based bookmarks, we switch to episodes view instead of dismissing
         switchViewMode(to: .episodes)

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4088,7 +4088,7 @@ internal enum L10n {
   /// Title of the smart bookmark creation screen
   internal static var smartBookmarkTitle: String { return L10n.tr("Localizable", "smart_bookmark_title", fallback: "Add Bookmark") }
   /// Label above the bookmark title text field
-  internal static var smartBookmarkTitleLabel: String { return L10n.tr("Localizable", "smart_bookmark_title_label", fallback: "Title") }
+  internal static var smartBookmarkTitleLabel: String { return L10n.tr("Localizable", "smart_bookmark_title_label", fallback: "Bookmark Title") }
   /// A common string used throughout the app. Often refers to the Smart Playlist.
   internal static var smartPlaylist: String { return L10n.tr("Localizable", "smart_playlist", fallback: "Smart playlist") }
   /// The description shown in a Tip View when the user opens the new Playlist creation view for the first time

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4071,6 +4071,18 @@ internal enum L10n {
   internal static func sleepTimerTimeRemaining(_ p1: Any) -> String {
     return L10n.tr("Localizable", "sleep_timer_time_remaining", String(describing: p1), fallback: "Sleep Timer on, %1$@ remaining")
   }
+  /// Shown while Apple Intelligence generates a title
+  internal static var smartBookmarkGeneratingTitle: String { return L10n.tr("Localizable", "smart_bookmark_generating_title", fallback: "Generating title…") }
+  /// Label showing the number of selected transcript segments. %1$d is the count
+  internal static func smartBookmarkSegmentCount(_ p1: Int) -> String {
+    return L10n.tr("Localizable", "smart_bookmark_segment_count", p1, fallback: "%1$d segments selected")
+  }
+  /// Subtitle instructing the user to adjust the transcript selection
+  internal static var smartBookmarkSubtitle: String { return L10n.tr("Localizable", "smart_bookmark_subtitle", fallback: "Select a transcript passage for this bookmark") }
+  /// Title of the smart bookmark creation screen
+  internal static var smartBookmarkTitle: String { return L10n.tr("Localizable", "smart_bookmark_title", fallback: "Add Bookmark") }
+  /// Label above the bookmark title text field
+  internal static var smartBookmarkTitleLabel: String { return L10n.tr("Localizable", "smart_bookmark_title_label", fallback: "Title") }
   /// A common string used throughout the app. Often refers to the Smart Playlist.
   internal static var smartPlaylist: String { return L10n.tr("Localizable", "smart_playlist", fallback: "Smart playlist") }
   /// The description shown in a Tip View when the user opens the new Playlist creation view for the first time

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -364,6 +364,10 @@ internal enum L10n {
   internal static var bookmarkDeleteWarningBody: String { return L10n.tr("Localizable", "bookmark_delete_warning_body", fallback: "Are you sure you want to delete these bookmarks, there’s no way to undo it!") }
   /// The title of an alert message asking the user if they want to continue with deleting the selected bookmarks
   internal static var bookmarkDeleteWarningTitle: String { return L10n.tr("Localizable", "bookmark_delete_warning_title", fallback: "Delete Bookmarks?") }
+  /// Play button label with timestamp. %1$@ is the formatted time (e.g. 01:27)
+  internal static func bookmarkPlayFromTimestamp(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "bookmark_play_from_timestamp", String(describing: p1), fallback: "Play from %1$@")
+  }
   /// Body of a message when no search results appear
   internal static var bookmarkSearchNoResultsMessage: String { return L10n.tr("Localizable", "bookmark_search_no_results_message", fallback: "We couldn't find any bookmarks for that search.") }
   /// Title of a message when no search results appear
@@ -4071,6 +4075,8 @@ internal enum L10n {
   internal static func sleepTimerTimeRemaining(_ p1: Any) -> String {
     return L10n.tr("Localizable", "sleep_timer_time_remaining", String(describing: p1), fallback: "Sleep Timer on, %1$@ remaining")
   }
+  /// Title of the smart bookmark editing screen
+  internal static var smartBookmarkEditTitle: String { return L10n.tr("Localizable", "smart_bookmark_edit_title", fallback: "Edit Bookmark") }
   /// Shown while Apple Intelligence generates a title
   internal static var smartBookmarkGeneratingTitle: String { return L10n.tr("Localizable", "smart_bookmark_generating_title", fallback: "Generating title…") }
   /// Label showing the number of selected transcript lines. %1$d is the count

--- a/podcasts/Strings+Generated.swift
+++ b/podcasts/Strings+Generated.swift
@@ -4073,9 +4073,9 @@ internal enum L10n {
   }
   /// Shown while Apple Intelligence generates a title
   internal static var smartBookmarkGeneratingTitle: String { return L10n.tr("Localizable", "smart_bookmark_generating_title", fallback: "Generating title…") }
-  /// Label showing the number of selected transcript segments. %1$d is the count
-  internal static func smartBookmarkSegmentCount(_ p1: Int) -> String {
-    return L10n.tr("Localizable", "smart_bookmark_segment_count", p1, fallback: "%1$d segments selected")
+  /// Label showing the number of selected transcript lines. %1$d is the count
+  internal static func smartBookmarkLineCount(_ p1: Int) -> String {
+    return L10n.tr("Localizable", "smart_bookmark_line_count", p1, fallback: "%1$d lines")
   }
   /// Subtitle instructing the user to adjust the transcript selection
   internal static var smartBookmarkSubtitle: String { return L10n.tr("Localizable", "smart_bookmark_subtitle", fallback: "Select a transcript passage for this bookmark") }

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4430,7 +4430,7 @@
 "smart_bookmark_line_count" = "%1$d lines";
 
 /* Label above the bookmark title text field */
-"smart_bookmark_title_label" = "Title";
+"smart_bookmark_title_label" = "Bookmark Title";
 
 /* Shown while Apple Intelligence generates a title */
 "smart_bookmark_generating_title" = "Generating title…";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4423,8 +4423,8 @@
 /* Subtitle instructing the user to adjust the transcript selection */
 "smart_bookmark_subtitle" = "Select a transcript passage for this bookmark";
 
-/* Label showing the number of selected transcript segments. %1$d is the count */
-"smart_bookmark_segment_count" = "%1$d segments selected";
+/* Label showing the number of selected transcript lines. %1$d is the count */
+"smart_bookmark_line_count" = "%1$d lines";
 
 /* Label above the bookmark title text field */
 "smart_bookmark_title_label" = "Title";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4417,6 +4417,21 @@
 /* Title of a menu prompt */
 "select_bookmarks" = "Select Bookmarks";
 
+/* Title of the smart bookmark creation screen */
+"smart_bookmark_title" = "Add Bookmark";
+
+/* Subtitle instructing the user to adjust the transcript selection */
+"smart_bookmark_subtitle" = "Select a transcript passage for this bookmark";
+
+/* Label showing the number of selected transcript segments. %1$d is the count */
+"smart_bookmark_segment_count" = "%1$d segments selected";
+
+/* Label above the bookmark title text field */
+"smart_bookmark_title_label" = "Title";
+
+/* Shown while Apple Intelligence generates a title */
+"smart_bookmark_generating_title" = "Generating title…";
+
 /* Title of an option in a menu prompt */
 "sort_option_timestamp" = "Timestamp";
 

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -4420,6 +4420,9 @@
 /* Title of the smart bookmark creation screen */
 "smart_bookmark_title" = "Add Bookmark";
 
+/* Title of the smart bookmark editing screen */
+"smart_bookmark_edit_title" = "Edit Bookmark";
+
 /* Subtitle instructing the user to adjust the transcript selection */
 "smart_bookmark_subtitle" = "Select a transcript passage for this bookmark";
 
@@ -4485,6 +4488,9 @@
 
 /* A message informing the user a feature is locked while in early access. %1$@ and %2$@ are the names of the tier (Plus or Patron) */
 "bookmarks_early_access_locked_message" = "Unlock this feature and many more with Pocket Casts %1$@ and save timestamps of your favorite episodes. Available for %2$@ subscribers soon.";
+
+/* Play button label with timestamp. %1$@ is the formatted time (e.g. 01:27) */
+"bookmark_play_from_timestamp" = "Play from %1$@";
 
 /* A button title that prompts the user to upgrade their plan. %1$@ is the name of the tier (Plus or Patron) */
 "upgrade_to_plan" = "Upgrade to %1$@";


### PR DESCRIPTION
## Summary

Adds smart bookmarks behind the `smartBookmarks` feature flag (off by default). When creating a bookmark on an episode with a transcript, presents a cue selector that lets the user adjust which portion of the transcript to capture.

- **Transcript selection editor**: Spotify-style tap-to-toggle cue selector for choosing transcript segments around the bookmark timestamp
- **AI title generation**: Uses Apple Intelligence (FoundationModels, iOS 26+) with NLP keyword extraction fallback and heuristic fallback for older devices
- **Bookmark detail view**: Pinned header with artwork/episode info, scrollable title and transcript with fade mask, edit button
- **Transcript preview in bookmark rows**: Flat layout with dividers showing captured transcript text
- **Bookmark model updates**: New `transcript` and `passage` fields on `Bookmark`

## To test

1. Enable the `smartBookmarks` feature flag in debug settings
2. Play an episode that has a transcript
3. Tap the bookmark button — the transcript selection editor should appear
4. Adjust the selected cue range by tapping cues to expand/contract
5. Save the bookmark — it should generate a title automatically
6. Navigate to bookmarks list — rows should show transcript preview
7. Tap a bookmark row to open the detail view
8. Tap edit to modify the bookmark title or transcript selection

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.