### PR TITLE
Lead review findings with user-facing impact

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -75,6 +75,10 @@ jobs:
             4. Performance - only where the impact is user-visible.
 
             Comments:
+            - Open a blocking correctness or behaviour-change finding with its
+              user-facing impact in one plain sentence: what breaks, for which
+              user, and when - a concrete scenario, not the code mechanism.
+              Then the problem and the fix.
             - Keep comments short by default - a few sentences stating the problem
               and the fix, not the reasoning that led you there. Spend more words
               only where the finding needs them to be actionable: a subtle race, a
@@ -101,8 +105,9 @@ jobs:
                 `### Nits`. Skip a group that is empty; skip the section entirely if
                 there are no findings, leaving the verdict as the whole summary.
               - One line per finding: `path/File.swift:123` followed by a single
-                sentence naming the problem and the fix - enough to act on without
-                opening the thread. Add the inline comment's URL when you have one.
+                sentence that leads with the user-facing impact, then the fix -
+                enough to act on without opening the thread. Add the inline
+                comment's URL when you have one.
               - A finding with no line to anchor to takes the same shape with just
                 the path, or no path when it is repo-wide.
             - No tables, no re-analysis, no checklist of what you read, no praise.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,8 +77,8 @@ jobs:
             Comments:
             - Open a blocking correctness or behaviour-change finding with its
               user-facing impact in one plain sentence: what breaks, for which
-              user, and when - a concrete scenario, not the code mechanism.
-              Then the problem and the fix.
+              user, and when - a concrete scenario, and the code mechanism, the
+              problem and the fix.
             - Keep comments short by default - a few sentences stating the problem
               and the fix, not the reasoning that led you there. Spend more words
               only where the finding needs them to be actionable: a subtle race, a

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,8 +77,8 @@ jobs:
             Comments:
             - Open a blocking correctness or behaviour-change finding with its
               user-facing impact in one plain sentence: what breaks, for which
-              user, and when - a concrete scenario, and the code mechanism, the
-              problem and the fix.
+              user, and when, and then the code mechanism, the problem and the
+              fix.
             - Keep comments short by default - a few sentences stating the problem
               and the fix, not the reasoning that led you there. Spend more words
               only where the finding needs them to be actionable: a subtle race, a


### PR DESCRIPTION
Follow-up to #5012, which tightened the Claude review prompt but left findings framed mechanism-first — leading with the code detail rather than what it means for a user.

This adds one rule to the `Comments` section of `claude-code-review.yml`: a blocking correctness or behaviour-change finding opens with its **user-facing impact** in one plain sentence — what breaks, for which user, and when — before the code mechanism. The summary one-liner is aligned to lead with impact too, so the two sections agree.

Intentionally minimal: no new "call path" or "shape of a finding" scaffolding, just the impact-first framing.

## To test

Same constraint as #5012 — the workflow skips PRs that touch it, so the prompt can only be exercised after merge. On the next PR after merge, a blocking finding's first sentence should describe the user-facing consequence, not the code mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)