### PR TITLE
Add Xcode previews for the Discover sections

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Discover/DiscoverServerHandler.swift
@@ -2,8 +2,17 @@ import Combine
 import Foundation
 import PocketCastsUtils
 
+/// The Discover network calls, behind a protocol so callers can be handed canned data.
+///
+/// `DiscoverServerHandler.shared` is the production implementation; previews and tests inject
+/// their own. Every method mirrors one section type of the Discover page.
 public protocol DiscoverServerHandling {
+    func discoverPodcastList(source: String, authenticated: Bool?, completion: @escaping (PodcastList?) -> Void)
+    func discoverPodcastCollection(source: String, authenticated: Bool?, completion: @escaping (PodcastCollection?) -> Void)
+    func discoverCategories(source: String, authenticated: Bool?, completion: @escaping ([DiscoverCategory]?) -> Void)
     func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory]
+    func discoverCategoryDetails(source: String, authenticated: Bool?, completion: @escaping (DiscoverCategoryDetails?) -> Void)
+    func discoverItem<T>(_ source: String?, authenticated: Bool, type: T.Type) -> AnyPublisher<T, Error> where T: Decodable
 }
 
 public class DiscoverServerHandler: DiscoverServerHandling {

--- a/PocketCastsTests/Tests/Discover/DiscoverItemObservableTests.swift
+++ b/PocketCastsTests/Tests/Discover/DiscoverItemObservableTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import XCTest
 @testable import podcasts
 @testable import PocketCastsServer
@@ -18,6 +19,26 @@ final class DiscoverItemObservableTests: XCTestCase {
                 DiscoverCategory(id: 2, name: "News"),
                 DiscoverCategory(id: 3, name: "Science")
             ]
+        }
+
+        func discoverPodcastList(source: String, authenticated: Bool?, completion: @escaping (PodcastList?) -> Void) {
+            completion(nil)
+        }
+
+        func discoverPodcastCollection(source: String, authenticated: Bool?, completion: @escaping (PodcastCollection?) -> Void) {
+            completion(nil)
+        }
+
+        func discoverCategories(source: String, authenticated: Bool?, completion: @escaping ([DiscoverCategory]?) -> Void) {
+            Task { completion(await discoverCategories(source: source, authenticated: authenticated)) }
+        }
+
+        func discoverCategoryDetails(source: String, authenticated: Bool?, completion: @escaping (DiscoverCategoryDetails?) -> Void) {
+            completion(nil)
+        }
+
+        func discoverItem<T>(_ source: String?, authenticated: Bool, type: T.Type) -> AnyPublisher<T, Error> where T: Decodable {
+            Empty().eraseToAnyPublisher()
         }
     }
 

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1087,7 +1087,6 @@
 		F53481C62E21C07B00E80253 /* UserSatisfactionSurveyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53481C52E21C07B00E80253 /* UserSatisfactionSurveyManager.swift */; };
 		F536B45B2DEA02830051A929 /* PCHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD6B432B27561EA8005E4017 /* PCHostingController.swift */; };
 		F54E721D2CA7359800CD5C86 /* DiscoverCellType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */; };
-		F5A1D4022FBE10A100E1A001 /* UnknownDiscoverItemAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A1D4012FBE10A100E1A001 /* UnknownDiscoverItemAlert.swift */; };
 		F54E721F2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54E721E2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift */; };
 		F5516DBE2E1C9D82005DC201 /* UserSatisfactionSurveyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5516DBD2E1C9D82005DC201 /* UserSatisfactionSurveyView.swift */; };
 		F553A15F2CECF953006581A1 /* EffectsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8032D22123EAD600BFBB03 /* EffectsButton.swift */; };
@@ -1116,6 +1115,7 @@
 		F580777C2DEA032A005AFBA6 /* Theme+Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = C715EE0E2A0497DB0054A082 /* Theme+Color.swift */; };
 		F58189C22DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */; };
 		F58189C32DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift in Sources */ = {isa = PBXBuildFile; fileRef = F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */; };
+		F5A1D4022FBE10A100E1A001 /* UnknownDiscoverItemAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A1D4012FBE10A100E1A001 /* UnknownDiscoverItemAlert.swift */; };
 		F5AA0FD42E21D05D00ECDEEA /* SurveyDebugInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5AA0FD32E21D05D00ECDEEA /* SurveyDebugInfoView.swift */; };
 		F5B312B42BF5B6D400290696 /* FirebaseManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5B312B32BF5B6D400290696 /* FirebaseManager.swift */; };
 		F5BA0D742E3443ED005931D3 /* PressableLottieButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BA0D732E3443ED005931D3 /* PressableLottieButtonStyle.swift */; };
@@ -2662,13 +2662,13 @@
 		F51E3B512CC70A4A00AFAD05 /* Humane-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Humane-Medium.otf"; sourceTree = "<group>"; };
 		F53481C52E21C07B00E80253 /* UserSatisfactionSurveyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSatisfactionSurveyManager.swift; sourceTree = "<group>"; };
 		F54E721C2CA7359800CD5C86 /* DiscoverCellType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverCellType.swift; sourceTree = "<group>"; };
-		F5A1D4012FBE10A100E1A001 /* UnknownDiscoverItemAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownDiscoverItemAlert.swift; sourceTree = "<group>"; };
 		F54E721E2CA749AA00CD5C86 /* DiscoverCollectionViewController+Categories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DiscoverCollectionViewController+Categories.swift"; sourceTree = "<group>"; };
 		F5516DBD2E1C9D82005DC201 /* UserSatisfactionSurveyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSatisfactionSurveyView.swift; sourceTree = "<group>"; };
 		F561A6E92F68F81C0014889E /* StreamingCellularTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamingCellularTracker.swift; sourceTree = "<group>"; };
 		F57498D02DB8430A00892BF0 /* LargeListSummaryCellHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeListSummaryCellHeaderView.swift; sourceTree = "<group>"; };
 		F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Episode.swift"; sourceTree = "<group>"; };
 		F58189C12DBC56A200B95199 /* PodcastInfo+DiscoverPodcast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PodcastInfo+DiscoverPodcast.swift"; sourceTree = "<group>"; };
+		F5A1D4012FBE10A100E1A001 /* UnknownDiscoverItemAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnknownDiscoverItemAlert.swift; sourceTree = "<group>"; };
 		F5AA0FD32E21D05D00ECDEEA /* SurveyDebugInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyDebugInfoView.swift; sourceTree = "<group>"; };
 		F5B312B32BF5B6D400290696 /* FirebaseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseManager.swift; sourceTree = "<group>"; };
 		F5BA0D732E3443ED005931D3 /* PressableLottieButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressableLottieButtonStyle.swift; sourceTree = "<group>"; };
@@ -3058,6 +3058,7 @@
 		3F747A532F5553A1004C7FF6 /* Extensions */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (FF60EC582F890D1F00B409BC /* PBXFileSystemSynchronizedBuildFileExceptionSet */, FF60EC562F890CF400B409BC /* PBXFileSystemSynchronizedBuildFileExceptionSet */, FF6033FA2FAB4B0200EB3AD5 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Extensions; sourceTree = "<group>"; };
 		3F747A542F5598A2004C7FF6 /* Playback */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Playback; sourceTree = "<group>"; };
 		3F747A5A2F559925004C7FF6 /* Notifications */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Notifications; sourceTree = "<group>"; };
+		3FD15C0A2FE0A10100AAA001 /* Discover Previews */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "Discover Previews"; sourceTree = "<group>"; };
 		3FDAD4E72F46D75100CC3259 /* NotificationContent */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3FDAD4EC2F46D75100CC3259 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = NotificationContent; sourceTree = "<group>"; };
 		3FDAD4EF2F46D75400CC3259 /* NotificationExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3FDAD4F12F46D75500CC3259 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = NotificationExtension; sourceTree = "<group>"; };
 		3FDAD4F62F46D77800CC3259 /* PodcastsIntentsUI */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (3FDAD4FA2F46D77800CC3259 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = PodcastsIntentsUI; sourceTree = "<group>"; };
@@ -5549,6 +5550,7 @@
 			isa = PBXGroup;
 			children = (
 				3F585D3A2F568D9D005A3593 /* Categories */,
+				3FD15C0A2FE0A10100AAA001 /* Discover Previews */,
 				BD4CA19821096D920052F93E /* Summary Items */,
 				4006E30E23A8662100174DEB /* Expanded Items */,
 				BD98C5511BA808CF00E85D3B /* Cells */,
@@ -5907,6 +5909,7 @@
 				3F747A532F5553A1004C7FF6 /* Extensions */,
 				3F747A542F5598A2004C7FF6 /* Playback */,
 				3F747A5A2F559925004C7FF6 /* Notifications */,
+				3FD15C0A2FE0A10100AAA001 /* Discover Previews */,
 			);
 			name = podcasts;
 			packageProductDependencies = (

--- a/podcasts/Categories/CategoriesSelectorViewController.swift
+++ b/podcasts/Categories/CategoriesSelectorViewController.swift
@@ -11,7 +11,7 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
         @Published public var region: String?
         private(set) var cachedCategories = [DiscoverCategory]()
 
-        private let serverHandler: DiscoverServerHandling
+        var serverHandler: DiscoverServerHandling
 
         lazy var load: (() async -> (categories: [DiscoverCategory], prioritized: [DiscoverCategory])?) = { [weak self] in
             guard let self, let source = self.item?.source else { return ([], []) }
@@ -87,6 +87,11 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
 
     private weak var delegate: DiscoverDelegate?
 
+    var serverHandler: DiscoverServerHandling {
+        get { observable.serverHandler }
+        set { observable.serverHandler = newValue }
+    }
+
     private var cancellables: Set<AnyCancellable> = []
 
     func registerDiscoverDelegate(_ delegate: any DiscoverDelegate) {
@@ -138,3 +143,27 @@ class CategoriesSelectorViewController: ThemedHostingController<CategoriesSelect
         fatalError("init(coder:) has not been implemented")
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+#Preview("Categories selector") {
+    let section = CategoriesSelectorViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(categories: DiscoverPreviewData.categories())
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.categoriesSelector, title: "Categories")
+    )
+}
+
+#Preview("Categories selector · popular only") {
+    let section = CategoriesSelectorViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(categories: DiscoverPreviewData.categories())
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.categoriesSelector, title: "Categories", popular: [1, 3, 8, 12])
+    )
+}
+
+#endif

--- a/podcasts/CategoryPodcastsViewController.swift
+++ b/podcasts/CategoryPodcastsViewController.swift
@@ -20,6 +20,8 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
 
     weak var delegate: DiscoverDelegate?
 
+    var serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared
+
     fileprivate var item: DiscoverItem?
 
     fileprivate var category: DiscoverCategory? {
@@ -130,7 +132,7 @@ class CategoryPodcastsViewController: PCViewController, UITableViewDelegate, UIT
         noNetworkView.isHidden = true
         loadingIndicator.startAnimating()
 
-        DiscoverServerHandler.shared.discoverCategoryDetails(source: source, authenticated: nil, completion: { [weak self] categoryDetails in
+        serverHandler.discoverCategoryDetails(source: source, authenticated: nil, completion: { [weak self] categoryDetails in
             DispatchQueue.main.async {
                 guard let strongSelf = self, let podcasts = categoryDetails?.podcasts else {
                     return
@@ -193,3 +195,39 @@ extension CategoryPodcastsViewController: DiscoverSummaryProtocol {
         loadPodcasts()
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+#Preview("Category podcasts") {
+    let section = CategoryPodcastsViewController(region: "us")
+    section.serverHandler = PreviewDiscoverServerHandler(
+        categoryDetails: DiscoverPreviewData.categoryDetails(title: "Technology", podcasts: DiscoverPreviewData.podcasts(12))
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.categoryPodcasts, title: "Technology"),
+        category: DiscoverPreviewData.categories()[11],
+        height: 700
+    )
+}
+
+#Preview("Category podcasts · promoted") {
+    let section = CategoryPodcastsViewController(region: "us")
+    section.serverHandler = PreviewDiscoverServerHandler(
+        categoryDetails: DiscoverPreviewData.categoryDetails(
+            title: "Technology",
+            podcasts: DiscoverPreviewData.podcasts(12),
+            promotion: (title: "Hard Fork", description: "Two friends try to make sense of the week in tech.")
+        )
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.categoryPodcasts, title: "Technology"),
+        category: DiscoverPreviewData.categories()[11],
+        height: 700
+    )
+}
+
+#endif

--- a/podcasts/CategorySummaryViewController.swift
+++ b/podcasts/CategorySummaryViewController.swift
@@ -14,6 +14,8 @@ class CategorySummaryViewController: UIViewController, UITableViewDataSource, UI
     private var categories = [DiscoverCategory]()
     private weak var delegate: DiscoverDelegate?
 
+    var serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared
+
     @IBOutlet var categoryHeightConstraint: NSLayoutConstraint!
 
     private let regionCode: String
@@ -43,7 +45,7 @@ class CategorySummaryViewController: UIViewController, UITableViewDataSource, UI
     func populateFrom(item: DiscoverItem, region: String?, category: DiscoverCategory?) {
         guard let source = item.source else { return }
 
-        DiscoverServerHandler.shared.discoverCategories(source: source, authenticated: item.authenticated, completion: { [weak self] discoverCategories in
+        serverHandler.discoverCategories(source: source, authenticated: item.authenticated, completion: { [weak self] discoverCategories in
             DispatchQueue.main.async {
                 guard let strongSelf = self, let discoverCategories else { return }
 
@@ -73,6 +75,7 @@ class CategorySummaryViewController: UIViewController, UITableViewDataSource, UI
         let category = categories[indexPath.row]
 
         let categoryPodcastsController = CategoryPodcastsViewController(category: category, region: regionCode)
+        categoryPodcastsController.serverHandler = serverHandler
         if let delegate {
             categoryPodcastsController.registerDiscoverDelegate(delegate)
             delegate.navController()?.pushViewController(categoryPodcastsController, animated: true)
@@ -91,3 +94,19 @@ class CategorySummaryViewController: UIViewController, UITableViewDataSource, UI
         categoryHeightConstraint.constant = CGFloat(requiredHeight)
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+#Preview("Category summary") {
+    let section = CategorySummaryViewController(regionCode: "us")
+    section.serverHandler = PreviewDiscoverServerHandler(categories: DiscoverPreviewData.categories())
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.categorySummary, title: "Browse by category"),
+        height: 760
+    )
+}
+
+#endif

--- a/podcasts/Discover Previews/DiscoverPreviewData.swift
+++ b/podcasts/Discover Previews/DiscoverPreviewData.swift
@@ -1,0 +1,242 @@
+#if DEBUG
+
+import Combine
+import Foundation
+import PocketCastsServer
+
+/// Canned Discover responses, so a section preview renders without touching the network.
+///
+/// The server models are `Decodable`-only, so the fixtures are built the way the real ones are:
+/// decoded from JSON shaped like the payloads `DiscoverServerHandler` fetches. Feed them to a
+/// section through ``PreviewDiscoverServerHandler``.
+enum DiscoverPreviewData {
+
+    // MARK: - Podcasts
+
+    /// Podcasts whose artwork exists on the live CDN, so the first few covers in a preview are
+    /// real ones. Everything past these falls back to the grid placeholder.
+    private static let artworkUUIDs = [
+        "82e37e80-755d-0138-eddc-0acc26574db2",
+        "9478cc80-7c42-0138-edfe-0acc26574db2",
+        "37082d70-e945-0137-b6eb-0acc26574db2",
+        "62200ab0-b7ec-0139-f606-0acc26574db2"
+    ]
+
+    private static let showTitles = [
+        "Deep Sleep Sounds",
+        "Get Sleepy: Sleep Meditation",
+        "Sleep Whispers",
+        "Nothing Much Happens",
+        "The Rest Is History",
+        "Search Engine",
+        "Hard Fork",
+        "Ologies",
+        "Shop Talk",
+        "The Bugle",
+        "Cautionary Tales",
+        "Dear Hank & John",
+        "Song Exploder",
+        "Reply All Forever",
+        "Twenty Thousand Hertz",
+        "The Anthropocene Reviewed",
+        "Radio Ambulante",
+        "Field Recordings",
+        "A Very Long Walk",
+        "Late Night Radio Hour"
+    ]
+
+    private static let authors = [
+        "Slumber Studios", "Wavelength", "PJ & Alex", "Tiny Desk Media", "Goalhanger",
+        "Jigsaw Audio", "Northbound", "Alie Ward", "Studio Ochre", "Bugle Media"
+    ]
+
+    private static let blurbs = [
+        "Drift off to gentle soundscapes recorded in remote places.",
+        "A bedtime story for grown ups, told slowly and kindly.",
+        "Whispered tales and trivia to help you fall asleep.",
+        "Long form conversations about the things nobody explains.",
+        "History, told badly, by people who love it far too much."
+    ]
+
+    /// `count` podcasts with stable identity, so lists don't churn between preview renders.
+    static func podcasts(_ count: Int) -> [DiscoverPodcast] {
+        (0 ..< count).map(podcast(at:))
+    }
+
+    static func podcast(at index: Int) -> DiscoverPodcast {
+        var podcast = DiscoverPodcast()
+        podcast.uuid = index < artworkUUIDs.count ? artworkUUIDs[index] : "preview-podcast-\(index)"
+        podcast.title = showTitles[index % showTitles.count]
+        podcast.author = authors[index % authors.count]
+        podcast.shortDescription = blurbs[index % blurbs.count]
+        podcast.isExplicit = index % 5 == 3
+        return podcast
+    }
+
+    // MARK: - Lists, collections and categories
+
+    static func podcastList(title: String, description: String? = nil, podcasts: [DiscoverPodcast]) -> PodcastList {
+        decode(PodcastList.self, from: [
+            "title": title,
+            "description": description,
+            "podcasts": encoded(podcasts),
+            "datetime": datetime
+        ])
+    }
+
+    static func podcastCollection(
+        title: String,
+        subtitle: String? = nil,
+        description: String? = nil,
+        shortDescription: String? = nil,
+        podcasts: [DiscoverPodcast],
+        collectionImage: String? = nil,
+        featureImage: String? = nil
+    ) -> PodcastCollection {
+        decode(PodcastCollection.self, from: [
+            "list_id": "preview-collection",
+            "title": title,
+            "subtitle": subtitle,
+            "description": description,
+            "short_description": shortDescription,
+            "podcasts": encoded(podcasts),
+            "collection_image": collectionImage,
+            "feature_image": featureImage,
+            "datetime": datetime
+        ])
+    }
+
+    /// The single-episode section reads the first episode of a collection.
+    static func episodeCollection(
+        title: String,
+        episodeTitle: String,
+        podcastTitle: String,
+        podcastUUID: String = artworkUUIDs[0],
+        duration: Int = 2_412,
+        isTrailer: Bool = false,
+        colors: (light: String, dark: String)? = nil
+    ) -> PodcastCollection {
+        decode(PodcastCollection.self, from: [
+            "list_id": "preview-episode-collection",
+            "title": title,
+            "colors": colors.map { ["onLightBackground": $0.light, "onDarkBackground": $0.dark] },
+            "episodes": [[
+                "uuid": "preview-episode",
+                "title": episodeTitle,
+                "podcast_uuid": podcastUUID,
+                "podcast_title": podcastTitle,
+                "duration": duration,
+                "type": isTrailer ? "trailer" : "full",
+                "published": "2026-08-19T09:00:00Z",
+                "season": 4,
+                "number": 12
+            ]],
+            "datetime": datetime
+        ])
+    }
+
+    static let categoryNames = [
+        "Arts", "Business", "Comedy", "Education", "Fiction", "Health & Fitness",
+        "History", "News", "Science", "Society & Culture", "Sports", "Technology"
+    ]
+
+    static func categories(_ count: Int = categoryNames.count) -> [DiscoverCategory] {
+        (0 ..< min(count, categoryNames.count)).map { index in
+            var category = DiscoverCategory(id: index + 1, name: categoryNames[index])
+            category.source = "https://lists.pocketcasts.com/preview-category-\(index + 1).json"
+            category.icon = "https://static.pocketcasts.com/discover/images/category-\(index + 1).png"
+            category.popularity = count - index
+            return category
+        }
+    }
+
+    static func categoryDetails(
+        title: String,
+        podcasts: [DiscoverPodcast],
+        promotion: (title: String, description: String)? = nil
+    ) -> DiscoverCategoryDetails {
+        decode(DiscoverCategoryDetails.self, from: [
+            "title": title,
+            "description": "The best of \(title), updated every week.",
+            "podcasts": encoded(podcasts),
+            "promotion": promotion.map {
+                [
+                    "promotion_uuid": "preview-promotion",
+                    "podcast_uuid": artworkUUIDs[1],
+                    "title": $0.title,
+                    "description": $0.description
+                ]
+            }
+        ])
+    }
+
+    static func sponsoredPodcast(position: Int, source: String) -> CarouselSponsoredPodcast {
+        decode(CarouselSponsoredPodcast.self, from: ["position": position, "source": source])
+    }
+
+    // MARK: - Discover items
+
+    /// A layout entry that `cellType()` resolves to `cellType`.
+    static func item(
+        _ cellType: DiscoverCellType,
+        title: String,
+        source: String = "https://lists.pocketcasts.com/preview.json",
+        expandedStyle: String? = "plain_list",
+        summaryItemCount: Int? = nil,
+        sponsoredPodcasts: [CarouselSponsoredPodcast]? = nil,
+        isSponsored: Bool? = nil,
+        popular: [Int]? = nil
+    ) -> DiscoverItem {
+        let styles = styles(for: cellType)
+        return DiscoverItem(
+            id: "preview-\(title)",
+            uuid: "preview-list",
+            title: title,
+            type: styles.type,
+            summaryStyle: styles.summaryStyle,
+            summaryItemCount: summaryItemCount,
+            expandedStyle: expandedStyle,
+            source: source,
+            sponsoredPodcasts: sponsoredPodcasts,
+            regions: ["us"],
+            isSponsored: isSponsored,
+            popular: popular,
+            categoryID: 1,
+            authenticated: false
+        )
+    }
+
+    private static func styles(for cellType: DiscoverCellType) -> (type: String, summaryStyle: String) {
+        switch cellType {
+        case .categoriesSelector: ("categories", "pills")
+        case .featuredSummary: ("podcast_list", "carousel")
+        case .smallPagedListSummary: ("podcast_list", "small_list")
+        case .largeListSummary: ("podcast_list", "large_list")
+        case .singlePodcast: ("podcast_list", "single_podcast")
+        case .collectionSummary: ("podcast_list", "collection")
+        case .categorySummary: ("categories", "category")
+        case .singleEpisode: ("episode_list", "single_episode")
+        case .categoryPodcasts: ("category_podcast_list", "category_podcast_list")
+        case .largeListWithPodcast: ("podcast_list", "large_list_with_podcast")
+        }
+    }
+
+    // MARK: - JSON plumbing
+
+    /// Matches the generation timestamp the server stamps on every list.
+    private static let datetime = "2026-08-19T09:00:00Z"
+
+    private static func encoded(_ podcasts: [DiscoverPodcast]) -> Any {
+        let data = try! JSONEncoder().encode(podcasts)
+        return try! JSONSerialization.jsonObject(with: data)
+    }
+
+    private static func decode<T: Decodable>(_ type: T.Type, from json: [String: Any?]) -> T {
+        let data = try! JSONSerialization.data(withJSONObject: json.compactMapValues { $0 })
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try! decoder.decode(type, from: data)
+    }
+}
+
+#endif

--- a/podcasts/Discover Previews/DiscoverSectionPreview.swift
+++ b/podcasts/Discover Previews/DiscoverSectionPreview.swift
@@ -1,0 +1,105 @@
+#if DEBUG
+
+import PocketCastsServer
+import SwiftUI
+import UIKit
+
+/// Hosts a Discover section the way `DiscoverCollectionViewController` does — handed a delegate,
+/// then populated — and sizes it the way the self-sizing collection view cell does.
+///
+/// Build `section` with its `serverHandler` pointed at a ``PreviewDiscoverServerHandler`` so it
+/// renders canned data instead of hitting the network.
+struct DiscoverSectionPreview: View {
+    let section: UIViewController & DiscoverSummaryProtocol
+    let item: DiscoverItem
+
+    var region = "us"
+    var category: DiscoverCategory?
+    var delegate = PreviewDiscoverDelegate()
+
+    /// Fixes the section's height. Leave it `nil` to let the section size itself.
+    var height: CGFloat?
+
+    /// Sections hand their loaded data to the UI over one or more main-queue hops. Bumping this
+    /// once the dust has settled re-runs the sizing pass, so sections whose height comes from their
+    /// data end up the right size in the canvas.
+    @State private var settleCount = 0
+
+    var body: some View {
+        VStack(spacing: 0) {
+            SectionHost(
+                section: section,
+                item: item,
+                region: region,
+                category: category,
+                delegate: delegate,
+                height: height,
+                settleCount: settleCount
+            )
+            .frame(height: height)
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(AppTheme.color(for: .primaryUi02, theme: Theme.sharedTheme))
+        .environmentObject(Theme.sharedTheme)
+        .task {
+            try? await Task.sleep(for: .milliseconds(250))
+            settleCount += 1
+        }
+    }
+}
+
+private struct SectionHost: UIViewControllerRepresentable {
+    let section: UIViewController & DiscoverSummaryProtocol
+    let item: DiscoverItem
+    let region: String
+    let category: DiscoverCategory?
+    let delegate: PreviewDiscoverDelegate
+    let height: CGFloat?
+    let settleCount: Int
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        // A parent keeps the section in a real containment hierarchy, so appearance callbacks and
+        // trait propagation behave as they do inside the Discover collection view.
+        let parent = UIViewController()
+
+        section.registerDiscoverDelegate(delegate)
+
+        parent.addChild(section)
+        parent.view.addSubview(section.view)
+        section.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            section.view.topAnchor.constraint(equalTo: parent.view.topAnchor),
+            section.view.leadingAnchor.constraint(equalTo: parent.view.leadingAnchor),
+            section.view.trailingAnchor.constraint(equalTo: parent.view.trailingAnchor),
+            section.view.bottomAnchor.constraint(equalTo: parent.view.bottomAnchor)
+        ])
+        section.didMove(toParent: parent)
+
+        section.populateFrom(item: item, region: region, category: category)
+        return parent
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        uiViewController.view.setNeedsLayout()
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiViewController: UIViewController, context: Context) -> CGSize? {
+        guard height == nil else { return nil }
+
+        let width = proposal.width ?? UIScreen.main.bounds.width
+        // Several sections derive their height from their own width, so give them one to measure
+        // against before asking — the collection view cell they normally live in has already been
+        // laid out by the time it asks for a fitting size.
+        uiViewController.view.frame = CGRect(x: 0, y: 0, width: width, height: uiViewController.view.frame.height)
+        uiViewController.view.layoutIfNeeded()
+        let fitting = uiViewController.view.systemLayoutSizeFitting(
+            CGSize(width: width, height: UIView.layoutFittingCompressedSize.height),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        return CGSize(width: width, height: fitting.height)
+    }
+}
+
+#endif

--- a/podcasts/Discover Previews/PreviewDiscoverServerHandler.swift
+++ b/podcasts/Discover Previews/PreviewDiscoverServerHandler.swift
@@ -1,0 +1,118 @@
+#if DEBUG
+
+import Combine
+import Foundation
+import PocketCastsDataModel
+import PocketCastsServer
+import UIKit
+
+/// A ``DiscoverServerHandling`` that answers from ``DiscoverPreviewData`` instead of the network.
+///
+/// A section only fetches the one kind of payload it renders, so a preview supplies just that. The
+/// featured carousel is the exception: it loads each sponsored slot from its own URL, which
+/// `collectionsBySource` covers.
+final class PreviewDiscoverServerHandler: DiscoverServerHandling {
+    var podcastList: PodcastList?
+    var podcastCollection: PodcastCollection?
+    var categories: [DiscoverCategory]
+    var categoryDetails: DiscoverCategoryDetails?
+    var collectionsBySource: [String: PodcastCollection]
+
+    init(
+        podcastList: PodcastList? = nil,
+        podcastCollection: PodcastCollection? = nil,
+        categories: [DiscoverCategory] = [],
+        categoryDetails: DiscoverCategoryDetails? = nil,
+        collectionsBySource: [String: PodcastCollection] = [:]
+    ) {
+        self.podcastList = podcastList
+        self.podcastCollection = podcastCollection
+        self.categories = categories
+        self.categoryDetails = categoryDetails
+        self.collectionsBySource = collectionsBySource
+    }
+
+    func discoverPodcastList(source: String, authenticated: Bool?, completion: @escaping (PodcastList?) -> Void) {
+        completion(podcastList)
+    }
+
+    func discoverPodcastCollection(source: String, authenticated: Bool?, completion: @escaping (PodcastCollection?) -> Void) {
+        completion(collection(for: source))
+    }
+
+    func discoverCategories(source: String, authenticated: Bool?, completion: @escaping ([DiscoverCategory]?) -> Void) {
+        completion(categories)
+    }
+
+    func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
+        categories
+    }
+
+    func discoverCategoryDetails(source: String, authenticated: Bool?, completion: @escaping (DiscoverCategoryDetails?) -> Void) {
+        completion(categoryDetails)
+    }
+
+    func discoverItem<T>(_ source: String?, authenticated: Bool, type: T.Type) -> AnyPublisher<T, Error> where T: Decodable {
+        let response: Any = collection(for: source ?? "") as Any
+        guard let value = response as? T else {
+            return Empty().eraseToAnyPublisher()
+        }
+        return Just(value).setFailureType(to: Error.self).eraseToAnyPublisher()
+    }
+
+    private func collection(for source: String) -> PodcastCollection? {
+        collectionsBySource[source] ?? podcastCollection
+    }
+}
+
+/// A ``DiscoverDelegate`` that records taps rather than navigating anywhere.
+///
+/// Sections ask it for subscription state and region substitutions while laying out, so those are
+/// the only methods that return anything meaningful.
+final class PreviewDiscoverDelegate: DiscoverDelegate {
+    /// Podcasts to draw with the followed tick, by index into ``DiscoverPreviewData/podcasts(_:)``.
+    var subscribedUUIDs: Set<String>
+
+    /// Stands in for the region the server's `[regionname]` token is replaced with.
+    var regionName: String
+
+    init(subscribedUUIDs: Set<String> = [], regionName: String = "United States") {
+        self.subscribedUUIDs = subscribedUUIDs
+        self.regionName = regionName
+    }
+
+    func isSubscribed(podcast: DiscoverPodcast) -> Bool {
+        guard let uuid = podcast.uuid else { return false }
+        return subscribedUUIDs.contains(uuid)
+    }
+
+    func subscribe(podcast: DiscoverPodcast) {
+        guard let uuid = podcast.uuid else { return }
+        subscribedUUIDs.insert(uuid)
+    }
+
+    func replaceRegionCode(string: String?) -> String? {
+        string?.replacingOccurrences(of: "[regioncode]", with: "us")
+    }
+
+    func replaceRegionName(string: String) -> String {
+        string.localized(with: regionName) ?? string.replacingOccurrences(of: "[regionname]", with: regionName)
+    }
+
+    func navController() -> UINavigationController? { nil }
+
+    func show(podcastInfo: PodcastInfo, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?) {}
+    func show(discoverPodcast: DiscoverPodcast, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?) {}
+    func show(podcast: Podcast) {}
+    func show(discoverEpisode: DiscoverEpisode, podcast: Podcast) {}
+    func showExpanded(item: DiscoverItem, category: DiscoverCategory?) {}
+    func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?) {}
+    func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?, datetime: String?) {}
+    func showExpanded(item: DiscoverItem, episodes: [DiscoverEpisode], podcastCollection: PodcastCollection?) {}
+    func failedToLoadEpisode() {}
+    func invalidate(item: DiscoverItem) {}
+    func navigateTo(category: String) {}
+    func navigateTo(listID: String) {}
+}
+
+#endif

--- a/podcasts/DiscoverEpisodeViewModel.swift
+++ b/podcasts/DiscoverEpisodeViewModel.swift
@@ -34,12 +34,15 @@ class DiscoverEpisodeViewModel: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
     private let playbackManager: ServerPlaybackDelegate
+    private let serverHandler: DiscoverServerHandling
 
-    init(playbackManager: ServerPlaybackDelegate = PlaybackManager.shared) {
+    init(playbackManager: ServerPlaybackDelegate = PlaybackManager.shared,
+         serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared) {
         self.playbackManager = playbackManager
+        self.serverHandler = serverHandler
         $discoverItem
             .dropFirst()
-            .flatMap { DiscoverServerHandler.shared.discoverItem($0?.source, authenticated: $0?.authenticated ?? false, type: PodcastCollection?.self) }
+            .flatMap { serverHandler.discoverItem($0?.source, authenticated: $0?.authenticated ?? false, type: PodcastCollection?.self) }
             .replaceError(with: nil)
             .receive(on: DispatchQueue.main)
             .assign(to: &$discoverCollection)

--- a/podcasts/FeaturedSummaryViewController.swift
+++ b/podcasts/FeaturedSummaryViewController.swift
@@ -29,6 +29,8 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
 
     private weak var delegate: DiscoverDelegate?
     private var category: DiscoverCategory?
+
+    var serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared
     @IBOutlet var featuredCollectionViewHeight: NSLayoutConstraint!
     @IBOutlet var dividerHeightConstraint: NSLayoutConstraint! {
         didSet {
@@ -189,7 +191,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         var sponsoredPodcastsToAdd: [Int: DiscoverPodcast] = [:]
 
         dispatchGroup.enter()
-        DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { podcastList in
+        serverHandler.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { podcastList in
             guard let discoverPodcast = podcastList?.podcasts else { return }
 
             podcastsToShow = discoverPodcast
@@ -201,7 +203,7 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
             for sponsored in sponsoredPodcasts {
                 if let source = sponsored.source, let position = sponsored.position {
                     dispatchGroup.enter()
-                    DiscoverServerHandler.shared.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
+                    serverHandler.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
                         guard let podcastList, let discoverPodcast = podcastList.podcasts?.first else { return }
 
                         sponsoredPodcastsToAdd[position] = discoverPodcast
@@ -276,3 +278,42 @@ class FeaturedSummaryViewController: SimpleNotificationsViewController, GridLayo
         featuredCollectionViewHeight.constant = cellHeight
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+#Preview("Featured carousel") {
+    let section = FeaturedSummaryViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(
+        podcastList: DiscoverPreviewData.podcastList(title: "Featured", podcasts: DiscoverPreviewData.podcasts(5))
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.featuredSummary, title: "Featured")
+    )
+}
+
+#Preview("Featured carousel · sponsored slot") {
+    let sponsoredSource = "https://lists.pocketcasts.com/preview-sponsored.json"
+    let section = FeaturedSummaryViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(
+        podcastList: DiscoverPreviewData.podcastList(title: "Featured", podcasts: DiscoverPreviewData.podcasts(5)),
+        collectionsBySource: [
+            sponsoredSource: DiscoverPreviewData.podcastCollection(
+                title: "Paid placement",
+                podcasts: [DiscoverPreviewData.podcast(at: 9)]
+            )
+        ]
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(
+            .featuredSummary,
+            title: "Featured",
+            sponsoredPodcasts: [DiscoverPreviewData.sponsoredPodcast(position: 1, source: sponsoredSource)]
+        )
+    )
+}
+
+#endif

--- a/podcasts/HorizontaCollectionModel.swift
+++ b/podcasts/HorizontaCollectionModel.swift
@@ -21,6 +21,8 @@ class HorizontalCollectionModel: ObservableObject {
 
     @Published var list: [[DiscoverPodcast]] = []
 
+    var serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared
+
     var type: String {
         return podcastCollection?.subtitle ?? ""
     }
@@ -49,7 +51,7 @@ class HorizontalCollectionModel: ObservableObject {
 
         self.item = item
         self.category = category
-        DiscoverServerHandler.shared.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastCollection in
+        serverHandler.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastCollection in
             guard podcastCollection?.podcasts != nil || podcastCollection?.episodes != nil else { return }
 
             DispatchQueue.main.async {

--- a/podcasts/HorizontalCollectionListViewController.swift
+++ b/podcasts/HorizontalCollectionListViewController.swift
@@ -5,6 +5,11 @@ class HorizontalCollectionListViewController: ThemedHostingController<Horizontal
 
     let model: HorizontalCollectionModel
 
+    var serverHandler: DiscoverServerHandling {
+        get { model.serverHandler }
+        set { model.serverHandler = newValue }
+    }
+
     init() {
         model = HorizontalCollectionModel()
         super.init(rootView: HorizontalCollectionList(model: model))
@@ -31,3 +36,26 @@ class HorizontalCollectionListViewController: ThemedHostingController<Horizontal
         }
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+#Preview("Collection") {
+    let section = HorizontalCollectionListViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(
+        podcastCollection: DiscoverPreviewData.podcastCollection(
+            title: "Sounds for sleeping",
+            subtitle: "Staff picks",
+            description: "Nine shows for winding down, chosen by the people who make Pocket Casts.",
+            shortDescription: "Chosen by the Pocket Casts team",
+            podcasts: DiscoverPreviewData.podcasts(9)
+        )
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.collectionSummary, title: "Collection")
+    )
+}
+
+#endif

--- a/podcasts/LargeListSummaryViewController.swift
+++ b/podcasts/LargeListSummaryViewController.swift
@@ -28,6 +28,8 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
     private var podcasts = [DiscoverPodcast]()
     private var datetime: String? // Used to track the generation of recommendations
     private weak var delegate: DiscoverDelegate?
+
+    var serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared
     private var item: DiscoverItem?
     private var category: DiscoverCategory?
 
@@ -199,7 +201,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
 
         switch item.cellType() {
         case .largeListWithPodcast:
-            DiscoverServerHandler.shared.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastCollection in
+            serverHandler.discoverPodcastCollection(source: source, authenticated: item.authenticated, completion: { [weak self] podcastCollection in
                 guard let strongSelf = self, let discoverPodcast = podcastCollection?.podcasts else { return }
 
                 strongSelf.appendPodcasts(discoverPodcast, item: item)
@@ -213,7 +215,7 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
                 }
             })
         default:
-            DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
+            serverHandler.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
                 guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
 
                 strongSelf.appendPodcasts(discoverPodcast, item: item)
@@ -268,3 +270,37 @@ class LargeListSummaryViewController: DiscoverPeekViewController, DiscoverSummar
         view.setNeedsLayout()
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+#Preview("Large list") {
+    let section = LargeListSummaryViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(
+        podcastList: DiscoverPreviewData.podcastList(title: "Trending", podcasts: DiscoverPreviewData.podcasts(8))
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.largeListSummary, title: "Trending")
+    )
+}
+
+/// The same section in its `large_list_with_podcast` shape: a collection, with the podcast the
+/// recommendations came from drawn in the header.
+#Preview("Large list with podcast") {
+    let section = LargeListSummaryViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(
+        podcastCollection: DiscoverPreviewData.podcastCollection(
+            title: "More like Deep Sleep Sounds",
+            podcasts: DiscoverPreviewData.podcasts(8),
+            featureImage: "82e37e80-755d-0138-eddc-0acc26574db2"
+        )
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.largeListWithPodcast, title: "Because you follow")
+    )
+}
+
+#endif

--- a/podcasts/SingleEpisodeViewController.swift
+++ b/podcasts/SingleEpisodeViewController.swift
@@ -4,7 +4,9 @@ import PocketCastsServer
 import UIKit
 
 class SingleEpisodeViewController: UIViewController {
-    private let viewModel = DiscoverEpisodeViewModel()
+    var serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared
+
+    private lazy var viewModel = DiscoverEpisodeViewModel(serverHandler: serverHandler)
     private var cancellables = Set<AnyCancellable>()
     private var category: DiscoverCategory?
 
@@ -146,3 +148,43 @@ extension SingleEpisodeViewController: DiscoverSummaryProtocol {
         updateSize()
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+#Preview("Single episode") {
+    let section = SingleEpisodeViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(
+        podcastCollection: DiscoverPreviewData.episodeCollection(
+            title: "Featured episode",
+            episodeTitle: "The night shift: what your brain does while you sleep",
+            podcastTitle: "Deep Sleep Sounds"
+        )
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.singleEpisode, title: "Featured episode")
+    )
+}
+
+#Preview("Single episode · trailer") {
+    let section = SingleEpisodeViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(
+        podcastCollection: DiscoverPreviewData.episodeCollection(
+            title: "New season",
+            episodeTitle: "Season 4 trailer",
+            podcastTitle: "Get Sleepy: Sleep Meditation",
+            podcastUUID: "9478cc80-7c42-0138-edfe-0acc26574db2",
+            duration: 96,
+            isTrailer: true,
+            colors: (light: "#3D5AFE", dark: "#8C9EFF")
+        )
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.singleEpisode, title: "New season")
+    )
+}
+
+#endif

--- a/podcasts/SinglePodcastViewController.swift
+++ b/podcasts/SinglePodcastViewController.swift
@@ -41,6 +41,8 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
 
     @IBOutlet var titleToDescriptionConstraint: NSLayoutConstraint!
     private weak var delegate: DiscoverDelegate?
+
+    var serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared
     private var podcast: DiscoverPodcast?
     private var item: DiscoverItem?
     private var featuredDescription: String?
@@ -91,7 +93,7 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
         self.item = item
         self.region = region
         self.category = category
-        DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
+        serverHandler.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
             guard let discoverPodcast = podcastList?.podcasts else { return }
 
             self?.podcast = discoverPodcast.first
@@ -198,3 +200,39 @@ class SinglePodcastViewController: UIViewController, DiscoverSummaryProtocol {
         podcastDescription.updateNumberOfLines(regular: isSponsored ? 0 : 4, accessibility: isSponsored ? 0 : 6)
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+#Preview("Single podcast · fresh pick") {
+    let section = SinglePodcastViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(
+        podcastList: DiscoverPreviewData.podcastList(
+            title: "Fresh pick",
+            description: "Whispered tales and trivia to help you fall asleep, three nights a week.",
+            podcasts: [DiscoverPreviewData.podcast(at: 2)]
+        )
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.singlePodcast, title: "Fresh pick")
+    )
+}
+
+#Preview("Single podcast · sponsored") {
+    let section = SinglePodcastViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(
+        podcastList: DiscoverPreviewData.podcastList(
+            title: "Sponsored",
+            description: "A paid placement, drawn with the sponsored badge instead of the fresh pick one.",
+            podcasts: [DiscoverPreviewData.podcast(at: 3)]
+        )
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.singlePodcast, title: "Sponsored", isSponsored: true)
+    )
+}
+
+#endif

--- a/podcasts/SmallPagedListSummaryViewController.swift
+++ b/podcasts/SmallPagedListSummaryViewController.swift
@@ -48,6 +48,8 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
     private var category: DiscoverCategory?
 
     private weak var delegate: DiscoverDelegate?
+
+    var serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared
     @IBOutlet var smallPagedCollectionViewHeight: NSLayoutConstraint!
     @IBOutlet var dividerHeightConstraint: NSLayoutConstraint! {
         didSet {
@@ -194,7 +196,7 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
         self.category = category
         titleLabel.text = delegate?.replaceRegionName(string: title)
 
-        DiscoverServerHandler.shared.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
+        serverHandler.discoverPodcastList(source: source, authenticated: item.authenticated, completion: { [weak self] podcastList in
             guard let strongSelf = self, let discoverPodcast = podcastList?.podcasts else { return }
             for podcast in discoverPodcast {
                 strongSelf.podcasts.append(podcast)
@@ -259,3 +261,21 @@ class SmallPagedListSummaryViewController: DiscoverPeekViewController, GridLayou
         smallPagedCollectionViewHeight.constant = (cellHeight + cellSpacing) * CGFloat(numberOfRows)
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+#Preview("Small paged list") {
+    let section = SmallPagedListSummaryViewController()
+    section.serverHandler = PreviewDiscoverServerHandler(
+        podcastList: DiscoverPreviewData.podcastList(title: "Popular", podcasts: DiscoverPreviewData.podcasts(20))
+    )
+    return DiscoverSectionPreview(
+        section: section,
+        item: DiscoverPreviewData.item(.smallPagedListSummary, title: "Popular in [regionname]"),
+        delegate: PreviewDiscoverDelegate(subscribedUUIDs: [DiscoverPreviewData.podcast(at: 1).uuid ?? ""])
+    )
+}
+
+#endif


### PR DESCRIPTION
Every Discover section fetched its own data straight from `DiscoverServerHandler.shared`, so none of them could be rendered without the network. Each section now takes an injectable `serverHandler`, and every `DiscoverCellType` gets a preview backed by canned fixtures — 14 in all, covering the variations that matter (sponsored carousel slot, sponsored vs fresh pick, `large_list_with_podcast`, trailer episode, promoted category, `popular`-filtered pills).

Preview support lives in `podcasts/Discover Previews/`, behind `#if DEBUG`. `DiscoverCellType.makeViewController(in:)` and `DiscoverSummaryProtocol` are unchanged, so production behaviour doesn't move.

Note: category summary and single episode hand all their data to the UI over `DispatchQueue.main.async` / Combine hops, so they populate a frame or two after the canvas opens rather than immediately.

## To test

1. Open `LargeListSummaryViewController.swift` and resume the canvas — both previews should render podcast cards, the second with the related podcast in the header.
2. Same for `FeaturedSummaryViewController.swift`, `SmallPagedListSummaryViewController.swift`, `SinglePodcastViewController.swift`, `HorizontalCollectionListViewController.swift`, `CategoriesSelectorViewController.swift`, `CategorySummaryViewController.swift`, `SingleEpisodeViewController.swift`, `CategoryPodcastsViewController.swift`.
3. Turn off Wi-Fi and confirm they still render (artwork falls back to the placeholder).
4. Run the app and open Discover to confirm the sections still load from the server as before.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
