### PR TITLE
Cleanup HorizontalCollectionList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix the app freezing and closing itself when creating a Smart Playlist [#4993](https://github.com/Automattic/pocket-casts-ios/pull/4993)
 - Add a Bluesky link to the About screen alongside Website, Instagram and X [#4998](https://github.com/Automattic/pocket-casts-ios/pull/4998)
 - Fix setting the sleep timer through Siri or Shortcuts while the device is locked [#4812](https://github.com/Automattic/pocket-casts-ios/pull/4812)
+- Tapping a Discover collection's poster now opens the expanded collection, the same as tapping "Show All" [#5028](https://github.com/Automattic/pocket-casts-ios/pull/5028)
 
 8.19
 -----

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1342,7 +1342,7 @@
 		FF6505A12FAA9E4900C3662E /* URLSession+Episode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F57BAC662C00CD9C007B24BD /* URLSession+Episode.swift */; };
 		FF6505A32FAA9F4100C3662E /* TranscriptManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7F89EC2C2AF6DE00FC0ED5 /* TranscriptManager.swift */; };
 		FF6505A42FAA9F5200C3662E /* TranscriptModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7F89F02C2C0FD600FC0ED5 /* TranscriptModel.swift */; };
-		FF68E8BA2DF338A800114FC7 /* HorizontalCollectionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF68E8B92DF3388500114FC7 /* HorizontalCollectionList.swift */; };
+		FF68E8BA2DF338A800114FC7 /* HorizontalCollectionListRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF68E8B92DF3388500114FC7 /* HorizontalCollectionListRowView.swift */; };
 		FF68E8BE2DF33D6100114FC7 /* HorizontalCollectionListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF68E8BD2DF33D5700114FC7 /* HorizontalCollectionListViewController.swift */; };
 		FF6BBCF22C578CE600604A01 /* TranscriptsDataRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF6BBCF12C578CE600604A01 /* TranscriptsDataRetriever.swift */; };
 		FF7F89EA2C2979D900FC0ED5 /* TranscriptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7F89E92C2979D900FC0ED5 /* TranscriptViewController.swift */; };
@@ -2721,7 +2721,7 @@
 		FF57373B2B4EB5B100F511C7 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		FF57373C2B4EB5B100F511C7 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		FF5DF8D82FF28B9E00DEFA75 /* GeneratedEpisodeMetadataRetriever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedEpisodeMetadataRetriever.swift; sourceTree = "<group>"; };
-		FF68E8B92DF3388500114FC7 /* HorizontalCollectionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalCollectionList.swift; sourceTree = "<group>"; };
+		FF68E8B92DF3388500114FC7 /* HorizontalCollectionListRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalCollectionListRowView.swift; sourceTree = "<group>"; };
 		FF68E8BD2DF33D5700114FC7 /* HorizontalCollectionListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalCollectionListViewController.swift; sourceTree = "<group>"; };
 		FF6BBCF12C578CE600604A01 /* TranscriptsDataRetriever.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptsDataRetriever.swift; sourceTree = "<group>"; };
 		FF7F89E92C2979D900FC0ED5 /* TranscriptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptViewController.swift; sourceTree = "<group>"; };
@@ -5647,7 +5647,7 @@
 			children = (
 				FF5453EE2DFC6C890045977B /* DiscoveryPageIndicatorView.swift */,
 				FF68E8BD2DF33D5700114FC7 /* HorizontalCollectionListViewController.swift */,
-				FF68E8B92DF3388500114FC7 /* HorizontalCollectionList.swift */,
+				FF68E8B92DF3388500114FC7 /* HorizontalCollectionListRowView.swift */,
 				FF9088EC2E00437E00FA1E7C /* HorizontaCollectionModel.swift */,
 			);
 			name = "Horizontal Collection List";
@@ -7434,7 +7434,7 @@
 				BDCF3C8224283C78005B6933 /* UploadedViewController+Swipe.swift in Sources */,
 				BD2DE2321E65224900BE21A4 /* ShowNotesUpdater.swift in Sources */,
 				BDA0E2A322DDB5550029EBEB /* ThemeColor.swift in Sources */,
-				FF68E8BA2DF338A800114FC7 /* HorizontalCollectionList.swift in Sources */,
+				FF68E8BA2DF338A800114FC7 /* HorizontalCollectionListRowView.swift in Sources */,
 				BDEBD3A91BA0108800AD038F /* BufferedAudio.swift in Sources */,
 				402772D721B6105D00769811 /* PodcastManager+Delete.swift in Sources */,
 				FF5381B12C91C6EF00829525 /* ReferralsOfferInfo.swift in Sources */,

--- a/podcasts/HorizontalCollectionList.swift
+++ b/podcasts/HorizontalCollectionList.swift
@@ -28,6 +28,37 @@ struct HorizontalCollectionList: View {
         return min(320, max(180, scaledRowWidth))
     }
 
+    @State var currentPage: Int? = 0
+
+    var body: some View {
+        let pairs = model.list
+        VStack(spacing: 8) {
+            header
+            GeometryReader { geometry in
+                ScrollView([.horizontal]) {
+                    LazyHStack(alignment: .top, spacing: 0) {
+                        poster
+                            .id(0)
+                        list(pairs: pairs, width: geometry.size.width)
+                        Spacer()
+                            .frame(width: 24)
+                    }
+                    .scrollTargetLayout()
+                }
+                .scrollIndicators(.hidden)
+                .scrollTargetBehavior(.viewAligned)
+                .scrollPosition(id: $currentPage, anchor: .leading)
+            }
+            DiscoveryPageIndicatorView(numberOfItems: pairs.count + 1, currentPage: $currentPage)
+            Rectangle()
+                .foregroundColor(theme.primaryUi05)
+                .frame(height: 1)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+        }
+        .frame(height: adjustedHeight)
+    }
+
     var header: some View {
         HStack(alignment: .center) {
             Text(model.type)
@@ -150,37 +181,6 @@ struct HorizontalCollectionList: View {
             .frame(width: max(width - 24, 0), height: adjustedRowHeight)
             .id(index + 1)
         }
-    }
-
-    @State var currentPage: Int? = 0
-
-    var body: some View {
-        let pairs = model.list
-        VStack(spacing: 8) {
-            header
-            GeometryReader { geometry in
-                ScrollView([.horizontal]) {
-                    LazyHStack(alignment: .top, spacing: 0) {
-                        poster
-                            .id(0)
-                        list(pairs: pairs, width: geometry.size.width)
-                        Spacer()
-                            .frame(width: 24)
-                    }
-                    .scrollTargetLayout()
-                }
-                .scrollIndicators(.hidden)
-                .scrollTargetBehavior(.viewAligned)
-                .scrollPosition(id: $currentPage, anchor: .leading)
-            }
-            DiscoveryPageIndicatorView(numberOfItems: pairs.count + 1, currentPage: $currentPage)
-            Rectangle()
-                .foregroundColor(theme.primaryUi05)
-                .frame(height: 1)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
-        }
-        .frame(height: adjustedHeight)
     }
 }
 

--- a/podcasts/HorizontalCollectionListRowView.swift
+++ b/podcasts/HorizontalCollectionListRowView.swift
@@ -1,34 +1,35 @@
 import SwiftUI
-import Foundation
-import WrappingHStack
+import Kingfisher
 import PocketCastsServer
-import PocketCastsDataModel
 
-struct HorizontalCollectionList: View {
-
+struct HorizontalCollectionListRowView: View {
     @ObservedObject var model: HorizontalCollectionModel
 
     @EnvironmentObject var theme: Theme
 
-    @ScaledMetric(relativeTo: .largeTitle) var scaledHeight = CGFloat(323)
+    @ScaledMetric(relativeTo: .largeTitle) private var scaledHeight = CGFloat(323)
 
-    @ScaledMetric(relativeTo: .largeTitle) var scaledRowHeight = CGFloat(210)
+    @ScaledMetric(relativeTo: .largeTitle) private var scaledRowHeight = CGFloat(210)
 
-    @ScaledMetric(relativeTo: .largeTitle) var scaledRowWidth = CGFloat(180)
+    @ScaledMetric(relativeTo: .largeTitle) private var scaledRowWidth = CGFloat(180)
 
-    var adjustedHeight: CGFloat {
-        return max(323, scaledHeight)
+    @State private var currentPage: Int? = 0
+
+    private var adjustedHeight: CGFloat {
+        max(323, scaledHeight)
     }
 
-    var adjustedRowHeight: CGFloat {
-        return min(320, max(210, scaledRowHeight))
+    private var adjustedRowHeight: CGFloat {
+        min(320, max(210, scaledRowHeight))
     }
 
-    var adjustedRowWidth: CGFloat {
-        return min(320, max(180, scaledRowWidth))
+    private var adjustedRowWidth: CGFloat {
+        min(320, max(180, scaledRowWidth))
     }
 
-    @State var currentPage: Int? = 0
+    private var podcastHeight: CGFloat {
+        (adjustedRowHeight - 8) / 2
+    }
 
     var body: some View {
         let pairs = model.list
@@ -59,14 +60,14 @@ struct HorizontalCollectionList: View {
         .frame(height: adjustedHeight)
     }
 
-    var header: some View {
+    private var header: some View {
         HStack(alignment: .center) {
             Text(model.type)
                 .foregroundStyle(theme.primaryText01)
                 .font(size: 22, style: .title, weight: .bold)
                 .lineLimit(2)
             Spacer()
-            Button() {
+            Button {
                 model.showCollection()
             } label: {
                 Text(L10n.discoverShowAll.localizedUppercase)
@@ -78,21 +79,22 @@ struct HorizontalCollectionList: View {
         .padding(16)
     }
 
-    var poster: some View {
+    private var poster: some View {
         ZStack(alignment: .bottom) {
-            AsyncImage(url: model.posterImage) { image in
-                image
-                    .resizable()
-                    .scaledToFill()
-            } placeholder: {
-                if let image = ImageManager.sharedManager.placeHolderImage(.grid) {
-                    Image(uiImage: image)
-                } else {
-                    Color.gray
+            KFImage(model.posterImage)
+                .placeholder { _ in
+                    if let image = ImageManager.sharedManager.placeHolderImage(.grid) {
+                        Image(uiImage: image)
+                            .resizable()
+                    } else {
+                        Color.gray
+                    }
                 }
-            }
-            .frame(width: adjustedRowWidth, height: adjustedRowHeight)
-            VStack() {
+                .resizable()
+                .scaledToFill()
+                .frame(width: adjustedRowWidth, height: adjustedRowHeight)
+                .clipped()
+            VStack {
                 Spacer()
                 Text(model.title)
                     .foregroundStyle(.white)
@@ -127,11 +129,10 @@ struct HorizontalCollectionList: View {
         .padding(.leading, 16)
     }
 
-    @ViewBuilder
-    func row(for podcast: DiscoverPodcast) -> some View {
+    private func row(for podcast: DiscoverPodcast) -> some View {
         HStack(alignment: .center, spacing: 0) {
             PodcastImageViewWrapper(podcastUUID: podcast.uuid ?? "", size: .grid)
-                .frame(width: (adjustedRowHeight / 2) - 4, height: (adjustedRowHeight / 2) - 4)
+                .frame(width: podcastHeight, height: podcastHeight)
             Spacer().frame(width: 10)
             VStack(alignment: .leading, spacing: 0) {
                 HStack(spacing: 0) {
@@ -158,22 +159,21 @@ struct HorizontalCollectionList: View {
                 model.subscribePodcast(podcast)
             }
         }
-        .frame(height: (adjustedRowHeight - 8.0) / 2.0)
+        .frame(height: podcastHeight)
         .onTapGesture {
             model.showPodcast(podcast)
         }
     }
 
-    @ViewBuilder
-    func list(pairs: [[DiscoverPodcast]], width: CGFloat) -> some View {
-        ForEach(0..<pairs.count, id: \.self) { index in
+    private func list(pairs: [[DiscoverPodcast]], width: CGFloat) -> some View {
+        ForEach(pairs.indices, id: \.self) { index in
             VStack(spacing: 8) {
                 ForEach(pairs[index], id: \.id) { podcast in
                     row(for: podcast)
                 }
                 if index == pairs.count - 1, pairs[index].count == 1 {
                     Rectangle()
-                        .frame(height: (adjustedRowHeight - 8.0) / 2.0)
+                        .frame(height: podcastHeight)
                         .foregroundStyle(.clear)
                 }
             }
@@ -181,12 +181,5 @@ struct HorizontalCollectionList: View {
             .frame(width: max(width - 24, 0), height: adjustedRowHeight)
             .id(index + 1)
         }
-    }
-}
-
-struct HorizontalCarouselList_Previews: PreviewProvider {
-    static var previews: some View {
-        HorizontalCollectionList(model: HorizontalCollectionModel())
-            .frame(height: 300)
     }
 }

--- a/podcasts/HorizontalCollectionListRowView.swift
+++ b/podcasts/HorizontalCollectionListRowView.swift
@@ -80,6 +80,16 @@ struct HorizontalCollectionListRowView: View {
     }
 
     private var poster: some View {
+        Button {
+            model.showCollection()
+        } label: {
+            posterCard
+        }
+        .buttonStyle(.plain)
+        .padding(.leading, 16)
+    }
+
+    private var posterCard: some View {
         ZStack(alignment: .bottom) {
             KFImage(model.posterImage)
                 .placeholder { _ in
@@ -126,7 +136,6 @@ struct HorizontalCollectionListRowView: View {
         }
         .cornerRadius(4)
         .frame(width: adjustedRowWidth, height: adjustedRowHeight)
-        .padding(.leading, 16)
     }
 
     private func row(for podcast: DiscoverPodcast) -> some View {

--- a/podcasts/HorizontalCollectionListViewController.swift
+++ b/podcasts/HorizontalCollectionListViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import PocketCastsServer
 
-class HorizontalCollectionListViewController: ThemedHostingController<HorizontalCollectionList>, DiscoverSummaryProtocol {
+class HorizontalCollectionListViewController: ThemedHostingController<HorizontalCollectionListRowView>, DiscoverSummaryProtocol {
 
     let model: HorizontalCollectionModel
 
@@ -12,7 +12,7 @@ class HorizontalCollectionListViewController: ThemedHostingController<Horizontal
 
     init() {
         model = HorizontalCollectionModel()
-        super.init(rootView: HorizontalCollectionList(model: model))
+        super.init(rootView: HorizontalCollectionListRowView(model: model))
     }
 
     @MainActor dynamic required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Renames `HorizontalCollectionList` to `HorizontalCollectionListRowView` (it's one row of the Discover feed, not a list) and gives it a light cleanup:

- Uses Kingfisher (`KFImage`) for the collection poster instead of SwiftUI's `AsyncImage` — it was the last `AsyncImage` in the app and it bypassed the app's image cache.
- The same derived height was spelled three different ways (`(adjustedRowHeight / 2) - 4` and `(adjustedRowHeight - 8.0) / 2.0`) for the artwork, the row and the filler; they're all one `podcastHeight` property now.
- Drops unused imports (`WrappingHStack`, `PocketCastsDataModel`, `Foundation`), marks the internals `private`, and removes the unneeded `@ViewBuilder`s.
- Removes `HorizontalCarouselList_Previews` — it was misnamed, had an empty model, and would trap on the missing `Theme` environment object. The `#Preview("Collection")` added in #5025 covers this view with real data.

No behavior or layout changes.

## To test

1. Open the Discover tab.
2. Scroll to a collection section (e.g. a "Staff picks" style list) and confirm the poster artwork, titles and paging look unchanged.
3. Swipe the section horizontally and confirm the page indicator tracks the pages.
4. Tap "SHOW ALL" and confirm the expanded collection opens; tap a podcast row and confirm it opens the podcast.
5. Increase the text size in Settings > Accessibility and confirm the section still scales as before.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
