### PR TITLE
Make the collection poster tappable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix the app freezing and closing itself when creating a Smart Playlist [#4993](https://github.com/Automattic/pocket-casts-ios/pull/4993)
 - Add a Bluesky link to the About screen alongside Website, Instagram and X [#4998](https://github.com/Automattic/pocket-casts-ios/pull/4998)
 - Fix setting the sleep timer through Siri or Shortcuts while the device is locked [#4812](https://github.com/Automattic/pocket-casts-ios/pull/4812)
+- Tapping a Discover collection's poster now opens the expanded collection, the same as tapping "Show All" [#5028](https://github.com/Automattic/pocket-casts-ios/pull/5028)
 
 8.19
 -----

--- a/podcasts/HorizontalCollectionListRowView.swift
+++ b/podcasts/HorizontalCollectionListRowView.swift
@@ -80,6 +80,16 @@ struct HorizontalCollectionListRowView: View {
     }
 
     private var poster: some View {
+        Button {
+            model.showCollection()
+        } label: {
+            posterCard
+        }
+        .buttonStyle(.plain)
+        .padding(.leading, 16)
+    }
+
+    private var posterCard: some View {
         ZStack(alignment: .bottom) {
             KFImage(model.posterImage)
                 .placeholder { _ in
@@ -126,7 +136,6 @@ struct HorizontalCollectionListRowView: View {
         }
         .cornerRadius(4)
         .frame(width: adjustedRowWidth, height: adjustedRowHeight)
-        .padding(.leading, 16)
     }
 
     private func row(for podcast: DiscoverPodcast) -> some View {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

> [!NOTE]
> Stacked on top of #5027 — review that one first.

Tapping a Discover collection's poster now opens the expanded collection, the same as tapping "SHOW ALL". The poster card is wrapped in a plain `Button`, so it also reads as a button to VoiceOver.

## To test

1. Open the Discover tab and scroll to a collection section.
2. Tap the poster — the expanded collection opens.
3. Tap "SHOW ALL" — it still opens the expanded collection.
4. Confirm swiping the section horizontally still works, and that tapping a podcast row still opens that podcast.

You can now tap here:

<img width="521" height="395" alt="Screenshot 2026-08-27 at 3 54 04 PM" src="https://github.com/user-attachments/assets/e7af963d-5601-4243-8d7a-29a684043148" />


## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
