### PR TITLE
Use a fresh Firebase Remote Config key for the account-creation flag

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -457,8 +457,6 @@ public enum FeatureFlag: String, CaseIterable {
         case .endOfYear2025:
             "end_of_year_2025"
         case .encourageAccountCreation:
-            // Not the derived "encourage_account_creation" — that Firebase parameter still exists
-            // from the 2025 one-shot experiment, and its stale value would override the default.
             "encourage_account_creation_recurring"
         default:
             rawValue.lowerSnakeCased()

--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -456,6 +456,10 @@ public enum FeatureFlag: String, CaseIterable {
             "new_account_upgrade_prompt_flow"
         case .endOfYear2025:
             "end_of_year_2025"
+        case .encourageAccountCreation:
+            // Not the derived "encourage_account_creation" — that Firebase parameter still exists
+            // from the 2025 one-shot experiment, and its stale value would override the default.
+            "encourage_account_creation_recurring"
         default:
             rawValue.lowerSnakeCased()
         }


### PR DESCRIPTION
Follow-up to #4985.

The `encourageAccountCreation` flag's `remoteKey` fell through to the derived `"encourage_account_creation"`. That Firebase Remote Config parameter still exists from the 2025 one-shot Encourage Account Creation experiment — removing code never removed the parameter — so the recurring modal inherits whatever value that entry currently holds.

Because a remote value overrides the flag's local default, the recurring modal could ship **silently disabled** (if the old experiment was wound down to `false`) or at an unintended partial rollout percentage, while the code still reads as "default on".

This points the flag at a fresh parameter, `encourage_account_creation_recurring`, so it starts from a clean slate with no inherited value or rollout condition.

Caught by @geekygecko on the Android port ([pocket-casts-android#5763](https://github.com/Automattic/pocket-casts-android/pull/5763#discussion_r3869605573)); the same rename has landed there, so both platforms move off the stale parameter together.

**Deliberately not renamed:** the identically-named `AnalyticsSource.encourageAccountCreation` (`Constants.swift`) and `OnboardingFlow.Flow.encourageAccountCreation` (`OnboardingFlow.swift`) string values. Those are analytics/flow identifiers, not Remote Config keys — renaming them would break analytics continuity and cross-platform parity.

## To test

This is a Remote Config plumbing change; the observable behaviour is which parameter the flag reads.

1. Beta Features screen → confirm the **Encourage Account Creation** flag still appears and its dev toggle works as before.
2. With the flag on, confirm the recurring modal still shows for a logged-out user past onboarding (unchanged behaviour from #4985).
3. Before enabling remotely, a new `encourage_account_creation_recurring` parameter needs creating in Firebase Remote Config — the old `encourage_account_creation` entry is now unused by this flag.

`make build_staging` succeeds locally.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
