### PR TITLE
Sync Claude workflows with the Android and Web Player repos

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run Claude Code Review
         if: steps.workflow-changes.outputs.skip != 'true'
         id: claude-review
-        uses: anthropics/claude-code-action@459ad358ae43fea66bfefd0a1f8d840b4b9791fb # v1.0.194
+        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -104,7 +104,7 @@ jobs:
               - Then the findings grouped under `### Blocking`, `### Non-blocking`,
                 `### Nits`. Skip a group that is empty; skip the section entirely if
                 there are no findings, leaving the verdict as the whole summary.
-              - One line per finding: `path/File.swift:123` followed by a single
+              - One line per finding: `path/to/file:123` followed by a single
                 sentence that leads with the user-facing impact, then the fix -
                 enough to act on without opening the thread. Add the inline
                 comment's URL when you have one.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Run Claude Code
         if: steps.pr-origin.outputs.is_internal == 'true'
         id: claude
-        uses: anthropics/claude-code-action@459ad358ae43fea66bfefd0a1f8d840b4b9791fb # v1.0.194
+        uses: anthropics/claude-code-action@c81e3bc69d1b18badbb63ba39581218f02421678 # v1.0.201
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 


### PR DESCRIPTION
Keeps this repo's Claude review setup identical to Android and Web Player, rather than each repo running a slightly different version of the same two workflows.

`claude.yml` and `claude-code-review.yml` are meant to be shared verbatim across pocket-casts-ios, pocket-casts-android and pocket-casts-webplayer, and the file header says so. Nobody updates all three at once, so they drift. This PR is the result of a sync run across the three repos.

What changes here:

- **Both workflows**: bump `anthropics/claude-code-action` v1.0.194 → v1.0.201, matching pocket-casts-android, which picked it up via dependabot in pocket-casts-android#5777.
- **`claude-code-review.yml`**: change the example finding line from `path/File.swift:123` to `path/to/file:123`. The prompt is copied verbatim into the Kotlin and TypeScript repos, where a Swift path is misleading; Claude infers the real extension from the diff regardless.

This repo's `actions/checkout` pin (v7.0.1) and its "lead with user-facing impact" review rule (#5018) were the newest of the three and are propagating out to Android and Web Player unchanged. Every pin in the sync was verified by resolving the tag to its commit SHA upstream, so the `# vX.Y.Z` comments match what is actually pinned.

## To test

There is nothing to verify in the app; this touches `.github/workflows/*.yml` only.

1. Confirm CI is green on this PR.
2. Note that the Claude review will **not** run on this PR: `claude-code-review.yml` has a "Check workflow changes" step that deliberately skips the review whenever a PR modifies that file, because Claude app token validation requires the workflow to match the default branch. The prompt change therefore takes effect on the first PR merged after this one.
3. Optionally, after all three PRs merge, diff the two files against pocket-casts-android; they should be byte-identical.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. (considered - CI configuration, not user-facing)
- [x] I have considered adding unit tests for my changes. (considered - not applicable to workflow YAML)
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics. (N/A - no analytics changes)
