### PR TITLE
Inline the @GRDBRecord macro expansion for the remaining models

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Episode.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Episode.swift
@@ -1,16 +1,13 @@
 import Foundation
 import GRDB
-import GRDBMacros
 import PocketCastsUtils
 
-@GRDBRecord(table: "SJEpisode")
 public class Episode: NSObject, BaseEpisode {
     private static let bonusType = "bonus"
     private static let trailerType = "trailer"
 
     @objc public var id = 0 as Int64
     @objc public var addedDate: Date?
-    @GRDBNullDateAsEpoch
     @objc public var lastDownloadAttemptDate: Date?
     @objc public var detailedDescription: String?
     @objc public var downloadErrorDetails: String?
@@ -46,10 +43,8 @@ public class Episode: NSObject, BaseEpisode {
     @objc public var episodeType: String?
     @objc public var archived = false
     @objc public var archivedModified = 0 as Int64
-    @GRDBNullDateAsEpoch
     @objc public var lastArchiveInteractionDate: Date?
     @objc public var excludeFromEpisodeLimit = false
-    @GRDBIgnore
     @objc public var hasOnlyUuid = false
     @objc public var deselectedChapters: String?
     @objc public var deselectedChaptersModified = 0 as Int64
@@ -232,4 +227,192 @@ public class Episode: NSObject, BaseEpisode {
             }
         }
     }
+
+    // MARK: - GRDB
+
+    public static let databaseTableName = "SJEpisode"
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case addedDate
+        case lastDownloadAttemptDate
+        case detailedDescription
+        case downloadErrorDetails
+        case downloadTaskId
+        case downloadUrl
+        case hlsUrl
+        case episodeDescription
+        case episodeStatus
+        case fileType
+        case contentType
+        case keepEpisode
+        case playedUpTo
+        case duration
+        case playingStatus
+        case autoDownloadStatus
+        case publishedDate
+        case sizeInBytes
+        case playingStatusModified
+        case playedUpToModified
+        case durationModified
+        case keepEpisodeModified
+        case starredModified
+        case lastPlaybackInteractionDate
+        case lastPlaybackInteractionSyncStatus
+        case title
+        case uuid
+        case podcastUuid
+        case playbackErrorDetails
+        case cachedFrameCount
+        case podcast_id
+        case episodeNumber
+        case seasonNumber
+        case episodeType
+        case archived
+        case archivedModified
+        case lastArchiveInteractionDate
+        case excludeFromEpisodeLimit
+        case deselectedChapters
+        case deselectedChaptersModified
+        case wasDeleted
+    }
+
+    public required init(from decoder: Decoder) throws {
+        super.init()
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(Int64.self, forKey: .id) ?? 0
+        addedDate = try container.decodeIfPresent(Date.self, forKey: .addedDate)
+        lastDownloadAttemptDate = try container.decodeIfPresent(Date.self, forKey: .lastDownloadAttemptDate)
+        detailedDescription = try container.decodeIfPresent(String.self, forKey: .detailedDescription)
+        downloadErrorDetails = try container.decodeIfPresent(String.self, forKey: .downloadErrorDetails)
+        downloadTaskId = try container.decodeIfPresent(String.self, forKey: .downloadTaskId)
+        downloadUrl = try container.decodeIfPresent(String.self, forKey: .downloadUrl)
+        hlsUrl = try container.decodeIfPresent(String.self, forKey: .hlsUrl)
+        episodeDescription = try container.decodeIfPresent(String.self, forKey: .episodeDescription)
+        episodeStatus = try container.decodeIfPresent(Int32.self, forKey: .episodeStatus) ?? 0
+        fileType = try container.decodeIfPresent(String.self, forKey: .fileType)
+        contentType = try container.decodeIfPresent(String.self, forKey: .contentType)
+        keepEpisode = try container.decodeIfPresent(Bool.self, forKey: .keepEpisode) ?? false
+        playedUpTo = try container.decodeIfPresent(Double.self, forKey: .playedUpTo) ?? 0
+        duration = try container.decodeIfPresent(Double.self, forKey: .duration) ?? 0
+        playingStatus = try container.decodeIfPresent(Int32.self, forKey: .playingStatus) ?? 0
+        autoDownloadStatus = try container.decodeIfPresent(Int32.self, forKey: .autoDownloadStatus) ?? 0
+        publishedDate = try container.decodeIfPresent(Date.self, forKey: .publishedDate)
+        sizeInBytes = try container.decodeIfPresent(Int64.self, forKey: .sizeInBytes) ?? 0
+        playingStatusModified = try container.decodeIfPresent(Int64.self, forKey: .playingStatusModified) ?? 0
+        playedUpToModified = try container.decodeIfPresent(Int64.self, forKey: .playedUpToModified) ?? 0
+        durationModified = try container.decodeIfPresent(Int64.self, forKey: .durationModified) ?? 0
+        keepEpisodeModified = try container.decodeIfPresent(Int64.self, forKey: .keepEpisodeModified) ?? 0
+        starredModified = try container.decodeIfPresent(Int64.self, forKey: .starredModified) ?? 0
+        lastPlaybackInteractionDate = try container.decodeIfPresent(Date.self, forKey: .lastPlaybackInteractionDate)
+        lastPlaybackInteractionSyncStatus = try container.decodeIfPresent(Int32.self, forKey: .lastPlaybackInteractionSyncStatus) ?? 1
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        uuid = try container.decodeIfPresent(String.self, forKey: .uuid) ?? ""
+        podcastUuid = try container.decodeIfPresent(String.self, forKey: .podcastUuid) ?? ""
+        playbackErrorDetails = try container.decodeIfPresent(String.self, forKey: .playbackErrorDetails)
+        cachedFrameCount = try container.decodeIfPresent(Int64.self, forKey: .cachedFrameCount) ?? 0
+        podcast_id = try container.decodeIfPresent(Int64.self, forKey: .podcast_id) ?? 0
+        episodeNumber = try container.decodeIfPresent(Int64.self, forKey: .episodeNumber) ?? -1
+        seasonNumber = try container.decodeIfPresent(Int64.self, forKey: .seasonNumber) ?? -1
+        episodeType = try container.decodeIfPresent(String.self, forKey: .episodeType)
+        archived = try container.decodeIfPresent(Bool.self, forKey: .archived) ?? false
+        archivedModified = try container.decodeIfPresent(Int64.self, forKey: .archivedModified) ?? 0
+        lastArchiveInteractionDate = try container.decodeIfPresent(Date.self, forKey: .lastArchiveInteractionDate)
+        excludeFromEpisodeLimit = try container.decodeIfPresent(Bool.self, forKey: .excludeFromEpisodeLimit) ?? false
+        deselectedChapters = try container.decodeIfPresent(String.self, forKey: .deselectedChapters)
+        deselectedChaptersModified = try container.decodeIfPresent(Int64.self, forKey: .deselectedChaptersModified) ?? 0
+        wasDeleted = try container.decodeIfPresent(Bool.self, forKey: .wasDeleted) ?? false
+    }
+
+    public func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["addedDate"] = addedDate?.timeIntervalSince1970
+        container["lastDownloadAttemptDate"] = (lastDownloadAttemptDate ?? Date(timeIntervalSince1970: 0)).timeIntervalSince1970
+        container["detailedDescription"] = detailedDescription
+        container["downloadErrorDetails"] = downloadErrorDetails
+        container["downloadTaskId"] = downloadTaskId
+        container["downloadUrl"] = downloadUrl
+        container["hlsUrl"] = hlsUrl
+        container["episodeDescription"] = episodeDescription
+        container["episodeStatus"] = episodeStatus
+        container["fileType"] = fileType
+        container["contentType"] = contentType
+        container["keepEpisode"] = keepEpisode
+        container["playedUpTo"] = playedUpTo
+        container["duration"] = duration
+        container["playingStatus"] = playingStatus
+        container["autoDownloadStatus"] = autoDownloadStatus
+        container["publishedDate"] = publishedDate?.timeIntervalSince1970
+        container["sizeInBytes"] = sizeInBytes
+        container["playingStatusModified"] = playingStatusModified
+        container["playedUpToModified"] = playedUpToModified
+        container["durationModified"] = durationModified
+        container["keepEpisodeModified"] = keepEpisodeModified
+        container["starredModified"] = starredModified
+        container["lastPlaybackInteractionDate"] = lastPlaybackInteractionDate?.timeIntervalSince1970
+        container["lastPlaybackInteractionSyncStatus"] = lastPlaybackInteractionSyncStatus
+        container["title"] = title
+        container["uuid"] = uuid
+        container["podcastUuid"] = podcastUuid
+        container["playbackErrorDetails"] = playbackErrorDetails
+        container["cachedFrameCount"] = cachedFrameCount
+        container["podcast_id"] = podcast_id
+        container["episodeNumber"] = episodeNumber
+        container["seasonNumber"] = seasonNumber
+        container["episodeType"] = episodeType
+        container["archived"] = archived
+        container["archivedModified"] = archivedModified
+        container["lastArchiveInteractionDate"] = (lastArchiveInteractionDate ?? Date(timeIntervalSince1970: 0)).timeIntervalSince1970
+        container["excludeFromEpisodeLimit"] = excludeFromEpisodeLimit
+        container["deselectedChapters"] = deselectedChapters
+        container["deselectedChaptersModified"] = deselectedChaptersModified
+        container["wasDeleted"] = wasDeleted
+    }
+
+    public enum Columns {
+        public static let id = Column(CodingKeys.id)
+        public static let addedDate = Column(CodingKeys.addedDate)
+        public static let lastDownloadAttemptDate = Column(CodingKeys.lastDownloadAttemptDate)
+        public static let detailedDescription = Column(CodingKeys.detailedDescription)
+        public static let downloadErrorDetails = Column(CodingKeys.downloadErrorDetails)
+        public static let downloadTaskId = Column(CodingKeys.downloadTaskId)
+        public static let downloadUrl = Column(CodingKeys.downloadUrl)
+        public static let hlsUrl = Column(CodingKeys.hlsUrl)
+        public static let episodeDescription = Column(CodingKeys.episodeDescription)
+        public static let episodeStatus = Column(CodingKeys.episodeStatus)
+        public static let fileType = Column(CodingKeys.fileType)
+        public static let contentType = Column(CodingKeys.contentType)
+        public static let keepEpisode = Column(CodingKeys.keepEpisode)
+        public static let playedUpTo = Column(CodingKeys.playedUpTo)
+        public static let duration = Column(CodingKeys.duration)
+        public static let playingStatus = Column(CodingKeys.playingStatus)
+        public static let autoDownloadStatus = Column(CodingKeys.autoDownloadStatus)
+        public static let publishedDate = Column(CodingKeys.publishedDate)
+        public static let sizeInBytes = Column(CodingKeys.sizeInBytes)
+        public static let playingStatusModified = Column(CodingKeys.playingStatusModified)
+        public static let playedUpToModified = Column(CodingKeys.playedUpToModified)
+        public static let durationModified = Column(CodingKeys.durationModified)
+        public static let keepEpisodeModified = Column(CodingKeys.keepEpisodeModified)
+        public static let starredModified = Column(CodingKeys.starredModified)
+        public static let lastPlaybackInteractionDate = Column(CodingKeys.lastPlaybackInteractionDate)
+        public static let lastPlaybackInteractionSyncStatus = Column(CodingKeys.lastPlaybackInteractionSyncStatus)
+        public static let title = Column(CodingKeys.title)
+        public static let uuid = Column(CodingKeys.uuid)
+        public static let podcastUuid = Column(CodingKeys.podcastUuid)
+        public static let playbackErrorDetails = Column(CodingKeys.playbackErrorDetails)
+        public static let cachedFrameCount = Column(CodingKeys.cachedFrameCount)
+        public static let podcast_id = Column(CodingKeys.podcast_id)
+        public static let episodeNumber = Column(CodingKeys.episodeNumber)
+        public static let seasonNumber = Column(CodingKeys.seasonNumber)
+        public static let episodeType = Column(CodingKeys.episodeType)
+        public static let archived = Column(CodingKeys.archived)
+        public static let archivedModified = Column(CodingKeys.archivedModified)
+        public static let lastArchiveInteractionDate = Column(CodingKeys.lastArchiveInteractionDate)
+        public static let excludeFromEpisodeLimit = Column(CodingKeys.excludeFromEpisodeLimit)
+        public static let deselectedChapters = Column(CodingKeys.deselectedChapters)
+        public static let deselectedChaptersModified = Column(CodingKeys.deselectedChaptersModified)
+        public static let wasDeleted = Column(CodingKeys.wasDeleted)
+    }
 }
+
+extension Episode: FetchableRecord, PersistableRecord, TableRecord, Decodable {}

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/EpisodeFilter.swift
@@ -1,8 +1,6 @@
 import Foundation
 import GRDB
-import GRDBMacros
 
-@GRDBRecord(table: "SJFilteredPlaylist")
 public class EpisodeFilter: NSObject {
     @objc public var id = 0 as Int64
     @objc public var autoDownloadEpisodes = false
@@ -10,7 +8,6 @@ public class EpisodeFilter: NSObject {
     @objc public var filterAllPodcasts = false
     @objc public var filterAudioVideoType = 0 as Int32
     @objc public var filterDownloaded = false
-    @GRDBIgnore
     @objc public let filterDownloading = true // we no longer let the user change this, it's just always true
     @objc public var filterFinished = false
     @objc public var filterNotDownloaded = false
@@ -34,17 +31,11 @@ public class EpisodeFilter: NSObject {
     @objc public var playlistUpdateDate: Date?
 
     // Internal tracking
-    @GRDBIgnore
     public var isNew: Bool = false
-    @GRDBIgnore
     public var podcastSmartRuleApplied: Bool = false
-    @GRDBIgnore
     public var episodesSmartRuleApplied: Bool = false
-    @GRDBIgnore
     public var releaseDateSmartRuleApplied: Bool = false
-    @GRDBIgnore
     public var mediaTypeSmartRuleApplied: Bool = false
-    @GRDBIgnore
     public var downloadStatusSmartRuleApplied: Bool = false
 
     override public init() {}
@@ -129,4 +120,128 @@ public class EpisodeFilter: NSObject {
     override public var hash: Int {
         Int(truncatingIfNeeded: id)
     }
+
+    // MARK: - GRDB
+
+    public static let databaseTableName = "SJFilteredPlaylist"
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case autoDownloadEpisodes
+        case customIcon
+        case filterAllPodcasts
+        case filterAudioVideoType
+        case filterDownloaded
+        case filterFinished
+        case filterNotDownloaded
+        case filterPartiallyPlayed
+        case filterStarred
+        case filterUnplayed
+        case filterHours
+        case playlistName
+        case sortPosition
+        case sortType
+        case uuid
+        case podcastUuids
+        case autoDownloadLimit
+        case filterDuration
+        case longerThan
+        case shorterThan
+        case syncStatus
+        case wasDeleted
+        case manual
+        case showArchivedEpisodes
+        case playlistUpdateDate
+    }
+
+    public required init(from decoder: Decoder) throws {
+        super.init()
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(Int64.self, forKey: .id) ?? 0
+        autoDownloadEpisodes = try container.decodeIfPresent(Bool.self, forKey: .autoDownloadEpisodes) ?? false
+        customIcon = try container.decodeIfPresent(Int32.self, forKey: .customIcon) ?? 0
+        filterAllPodcasts = try container.decodeIfPresent(Bool.self, forKey: .filterAllPodcasts) ?? false
+        filterAudioVideoType = try container.decodeIfPresent(Int32.self, forKey: .filterAudioVideoType) ?? 0
+        filterDownloaded = try container.decodeIfPresent(Bool.self, forKey: .filterDownloaded) ?? false
+        filterFinished = try container.decodeIfPresent(Bool.self, forKey: .filterFinished) ?? false
+        filterNotDownloaded = try container.decodeIfPresent(Bool.self, forKey: .filterNotDownloaded) ?? false
+        filterPartiallyPlayed = try container.decodeIfPresent(Bool.self, forKey: .filterPartiallyPlayed) ?? false
+        filterStarred = try container.decodeIfPresent(Bool.self, forKey: .filterStarred) ?? false
+        filterUnplayed = try container.decodeIfPresent(Bool.self, forKey: .filterUnplayed) ?? false
+        filterHours = try container.decodeIfPresent(Int32.self, forKey: .filterHours) ?? 0
+        playlistName = try container.decodeIfPresent(String.self, forKey: .playlistName) ?? ""
+        sortPosition = try container.decodeIfPresent(Int32.self, forKey: .sortPosition) ?? 0
+        sortType = try container.decodeIfPresent(Int32.self, forKey: .sortType) ?? 0
+        uuid = try container.decodeIfPresent(String.self, forKey: .uuid) ?? ""
+        podcastUuids = try container.decodeIfPresent(String.self, forKey: .podcastUuids) ?? ""
+        autoDownloadLimit = try container.decodeIfPresent(Int32.self, forKey: .autoDownloadLimit) ?? 0
+        filterDuration = try container.decodeIfPresent(Bool.self, forKey: .filterDuration) ?? false
+        longerThan = try container.decodeIfPresent(Int32.self, forKey: .longerThan) ?? 0
+        shorterThan = try container.decodeIfPresent(Int32.self, forKey: .shorterThan) ?? 0
+        syncStatus = try container.decodeIfPresent(Int32.self, forKey: .syncStatus) ?? 0
+        wasDeleted = try container.decodeIfPresent(Bool.self, forKey: .wasDeleted) ?? false
+        manual = try container.decodeIfPresent(Bool.self, forKey: .manual) ?? false
+        showArchivedEpisodes = try container.decodeIfPresent(Bool.self, forKey: .showArchivedEpisodes) ?? false
+        playlistUpdateDate = try container.decodeIfPresent(Date.self, forKey: .playlistUpdateDate)
+    }
+
+    public func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["autoDownloadEpisodes"] = autoDownloadEpisodes
+        container["customIcon"] = customIcon
+        container["filterAllPodcasts"] = filterAllPodcasts
+        container["filterAudioVideoType"] = filterAudioVideoType
+        container["filterDownloaded"] = filterDownloaded
+        container["filterFinished"] = filterFinished
+        container["filterNotDownloaded"] = filterNotDownloaded
+        container["filterPartiallyPlayed"] = filterPartiallyPlayed
+        container["filterStarred"] = filterStarred
+        container["filterUnplayed"] = filterUnplayed
+        container["filterHours"] = filterHours
+        container["playlistName"] = playlistName
+        container["sortPosition"] = sortPosition
+        container["sortType"] = sortType
+        container["uuid"] = uuid
+        container["podcastUuids"] = podcastUuids
+        container["autoDownloadLimit"] = autoDownloadLimit
+        container["filterDuration"] = filterDuration
+        container["longerThan"] = longerThan
+        container["shorterThan"] = shorterThan
+        container["syncStatus"] = syncStatus
+        container["wasDeleted"] = wasDeleted
+        container["manual"] = manual
+        container["showArchivedEpisodes"] = showArchivedEpisodes
+        container["playlistUpdateDate"] = playlistUpdateDate?.timeIntervalSince1970
+    }
+
+    public enum Columns {
+        public static let id = Column(CodingKeys.id)
+        public static let autoDownloadEpisodes = Column(CodingKeys.autoDownloadEpisodes)
+        public static let customIcon = Column(CodingKeys.customIcon)
+        public static let filterAllPodcasts = Column(CodingKeys.filterAllPodcasts)
+        public static let filterAudioVideoType = Column(CodingKeys.filterAudioVideoType)
+        public static let filterDownloaded = Column(CodingKeys.filterDownloaded)
+        public static let filterFinished = Column(CodingKeys.filterFinished)
+        public static let filterNotDownloaded = Column(CodingKeys.filterNotDownloaded)
+        public static let filterPartiallyPlayed = Column(CodingKeys.filterPartiallyPlayed)
+        public static let filterStarred = Column(CodingKeys.filterStarred)
+        public static let filterUnplayed = Column(CodingKeys.filterUnplayed)
+        public static let filterHours = Column(CodingKeys.filterHours)
+        public static let playlistName = Column(CodingKeys.playlistName)
+        public static let sortPosition = Column(CodingKeys.sortPosition)
+        public static let sortType = Column(CodingKeys.sortType)
+        public static let uuid = Column(CodingKeys.uuid)
+        public static let podcastUuids = Column(CodingKeys.podcastUuids)
+        public static let autoDownloadLimit = Column(CodingKeys.autoDownloadLimit)
+        public static let filterDuration = Column(CodingKeys.filterDuration)
+        public static let longerThan = Column(CodingKeys.longerThan)
+        public static let shorterThan = Column(CodingKeys.shorterThan)
+        public static let syncStatus = Column(CodingKeys.syncStatus)
+        public static let wasDeleted = Column(CodingKeys.wasDeleted)
+        public static let manual = Column(CodingKeys.manual)
+        public static let showArchivedEpisodes = Column(CodingKeys.showArchivedEpisodes)
+        public static let playlistUpdateDate = Column(CodingKeys.playlistUpdateDate)
+    }
 }
+
+extension EpisodeFilter: FetchableRecord, PersistableRecord, TableRecord, Decodable {}

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Folder.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Folder.swift
@@ -1,8 +1,6 @@
 import Foundation
 import GRDB
-import GRDBMacros
 
-@GRDBRecord(table: "Folder")
 public class Folder: NSObject, Identifiable {
     @objc public var uuid = ""
     @objc public var name = ""
@@ -14,7 +12,6 @@ public class Folder: NSObject, Identifiable {
     @objc public var syncModified: Int64 = 0
 
     // transient not saved to database
-    @GRDBIgnore
     public var cachedUnreadCount = 0
 
     override public init() {}
@@ -22,7 +19,59 @@ public class Folder: NSObject, Identifiable {
     func folderSort() -> FolderSort {
         FolderSort(rawValue: sortType) ?? .dateAddedNewestToOldest
     }
+
+    // MARK: - GRDB
+
+    public static let databaseTableName = "Folder"
+
+    enum CodingKeys: String, CodingKey {
+        case uuid
+        case name
+        case color
+        case addedDate
+        case sortOrder
+        case sortType
+        case wasDeleted
+        case syncModified
+    }
+
+    public required init(from decoder: Decoder) throws {
+        super.init()
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        uuid = try container.decodeIfPresent(String.self, forKey: .uuid) ?? ""
+        name = try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+        color = try container.decodeIfPresent(Int32.self, forKey: .color) ?? 0
+        addedDate = try container.decodeIfPresent(Date.self, forKey: .addedDate)
+        sortOrder = try container.decodeIfPresent(Int32.self, forKey: .sortOrder) ?? 0
+        sortType = try container.decodeIfPresent(Int32.self, forKey: .sortType) ?? 0
+        wasDeleted = try container.decodeIfPresent(Bool.self, forKey: .wasDeleted) ?? false
+        syncModified = try container.decodeIfPresent(Int64.self, forKey: .syncModified) ?? 0
+    }
+
+    public func encode(to container: inout PersistenceContainer) {
+        container["uuid"] = uuid
+        container["name"] = name
+        container["color"] = color
+        container["addedDate"] = addedDate?.timeIntervalSince1970
+        container["sortOrder"] = sortOrder
+        container["sortType"] = sortType
+        container["wasDeleted"] = wasDeleted
+        container["syncModified"] = syncModified
+    }
+
+    public enum Columns {
+        public static let uuid = Column(CodingKeys.uuid)
+        public static let name = Column(CodingKeys.name)
+        public static let color = Column(CodingKeys.color)
+        public static let addedDate = Column(CodingKeys.addedDate)
+        public static let sortOrder = Column(CodingKeys.sortOrder)
+        public static let sortType = Column(CodingKeys.sortType)
+        public static let wasDeleted = Column(CodingKeys.wasDeleted)
+        public static let syncModified = Column(CodingKeys.syncModified)
+    }
 }
+
+extension Folder: FetchableRecord, PersistableRecord, TableRecord, Decodable {}
 
 // This is the data side equivalent of LibrarySort
 enum FolderSort: Int32 {

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/Podcast.swift
@@ -1,15 +1,12 @@
 import Foundation
 import GRDB
-import GRDBMacros
 import PocketCastsUtils
 
-@GRDBRecord(table: "SJPodcast")
 public class Podcast: NSObject, Identifiable {
     @objc public var id = 0 as Int64
     @objc public var addedDate: Date?
     @objc public var autoDownloadSetting = 0 as Int32
     @objc public var autoAddToUpNext = 0 as Int32
-    @GRDBColumn("episodeKeepSetting")
     @objc public var autoArchiveEpisodeLimit = 0 as Int32
     @objc public var backgroundColor: String?
     @objc public var detailColor: String? // dark artwork overlay
@@ -61,20 +58,16 @@ public class Podcast: NSObject, Identifiable {
     @objc public var isExplicit = false
     @objc public var fundingURL: String?
 
-    @GRDBIgnore
     public var settings = PodcastSettings.defaults
 
     // transient not saved to database
-    @GRDBIgnore
     public var cachedUnreadCount = 0
 
     // if set to an episode UUID, all podcast episodes after the given
     // UUID will be updated
-    @GRDBIgnore
     public var forceRefreshEpisodeFrom: String? = nil
 
     // transient not saved to database
-    @GRDBIgnore
     public var networkList: PodcastNetworkList? = nil
 
     override public init() {}
@@ -125,7 +118,243 @@ public class Podcast: NSObject, Identifiable {
 
         return podcast
     }
+
+    // MARK: - GRDB
+
+    public static let databaseTableName = "SJPodcast"
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case addedDate
+        case autoDownloadSetting
+        case autoAddToUpNext
+        case autoArchiveEpisodeLimit = "episodeKeepSetting"
+        case backgroundColor
+        case detailColor
+        case primaryColor
+        case secondaryColor
+        case lastColorDownloadDate
+        case imageURL
+        case latestEpisodeUuid
+        case latestEpisodeDate
+        case mediaType
+        case lastThumbnailDownloadDate
+        case thumbnailStatus
+        case podcastUrl
+        case author
+        case overrideGlobalEffects
+        case playbackSpeed
+        case boostVolume
+        case trimSilenceAmount
+        case podcastCategory
+        case podcastDescription
+        case podcastHTMLDescription
+        case sortOrder
+        case startFrom
+        case skipLast
+        case subscribed
+        case title
+        case uuid
+        case syncStatus
+        case colorVersion
+        case pushEnabled
+        case episodeSortOrder
+        case episodeGrouping
+        case showType
+        case estimatedNextEpisode
+        case episodeFrequency
+        case lastUpdatedAt
+        case excludeFromAutoArchive
+        case overrideGlobalArchive
+        case autoArchivePlayedAfter
+        case autoArchiveInactiveAfter
+        case isPaid
+        case licensing
+        case fullSyncLastSyncAt
+        case showArchived
+        case refreshAvailable
+        case folderUuid
+        case usedCustomEffectsBefore
+        case isPrivate
+        case isExplicit
+        case fundingURL
+    }
+
+    public required init(from decoder: Decoder) throws {
+        super.init()
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(Int64.self, forKey: .id) ?? 0
+        addedDate = try container.decodeIfPresent(Date.self, forKey: .addedDate)
+        autoDownloadSetting = try container.decodeIfPresent(Int32.self, forKey: .autoDownloadSetting) ?? 0
+        autoAddToUpNext = try container.decodeIfPresent(Int32.self, forKey: .autoAddToUpNext) ?? 0
+        autoArchiveEpisodeLimit = try container.decodeIfPresent(Int32.self, forKey: .autoArchiveEpisodeLimit) ?? 0
+        backgroundColor = try container.decodeIfPresent(String.self, forKey: .backgroundColor)
+        detailColor = try container.decodeIfPresent(String.self, forKey: .detailColor)
+        primaryColor = try container.decodeIfPresent(String.self, forKey: .primaryColor)
+        secondaryColor = try container.decodeIfPresent(String.self, forKey: .secondaryColor)
+        lastColorDownloadDate = try container.decodeIfPresent(Date.self, forKey: .lastColorDownloadDate)
+        imageURL = try container.decodeIfPresent(String.self, forKey: .imageURL)
+        latestEpisodeUuid = try container.decodeIfPresent(String.self, forKey: .latestEpisodeUuid)
+        latestEpisodeDate = try container.decodeIfPresent(Date.self, forKey: .latestEpisodeDate)
+        mediaType = try container.decodeIfPresent(String.self, forKey: .mediaType)
+        lastThumbnailDownloadDate = try container.decodeIfPresent(Date.self, forKey: .lastThumbnailDownloadDate)
+        thumbnailStatus = try container.decodeIfPresent(Int32.self, forKey: .thumbnailStatus) ?? 1
+        podcastUrl = try container.decodeIfPresent(String.self, forKey: .podcastUrl)
+        author = try container.decodeIfPresent(String.self, forKey: .author)
+        overrideGlobalEffects = try container.decodeIfPresent(Bool.self, forKey: .overrideGlobalEffects) ?? false
+        playbackSpeed = try container.decodeIfPresent(Double.self, forKey: .playbackSpeed) ?? 1
+        boostVolume = try container.decodeIfPresent(Bool.self, forKey: .boostVolume) ?? false
+        trimSilenceAmount = try container.decodeIfPresent(Int32.self, forKey: .trimSilenceAmount) ?? 0
+        podcastCategory = try container.decodeIfPresent(String.self, forKey: .podcastCategory)
+        podcastDescription = try container.decodeIfPresent(String.self, forKey: .podcastDescription)
+        podcastHTMLDescription = try container.decodeIfPresent(String.self, forKey: .podcastHTMLDescription)
+        sortOrder = try container.decodeIfPresent(Int32.self, forKey: .sortOrder) ?? 0
+        startFrom = try container.decodeIfPresent(Int32.self, forKey: .startFrom) ?? 0
+        skipLast = try container.decodeIfPresent(Int32.self, forKey: .skipLast) ?? 0
+        subscribed = try container.decodeIfPresent(Int32.self, forKey: .subscribed) ?? 1
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        uuid = try container.decodeIfPresent(String.self, forKey: .uuid) ?? ""
+        syncStatus = try container.decodeIfPresent(Int32.self, forKey: .syncStatus) ?? 0
+        colorVersion = try container.decodeIfPresent(Int32.self, forKey: .colorVersion) ?? 1
+        pushEnabled = try container.decodeIfPresent(Bool.self, forKey: .pushEnabled) ?? false
+        episodeSortOrder = try container.decodeIfPresent(Int32.self, forKey: .episodeSortOrder) ?? 1
+        episodeGrouping = try container.decodeIfPresent(Int32.self, forKey: .episodeGrouping) ?? 0
+        showType = try container.decodeIfPresent(String.self, forKey: .showType)
+        estimatedNextEpisode = try container.decodeIfPresent(Date.self, forKey: .estimatedNextEpisode)
+        episodeFrequency = try container.decodeIfPresent(String.self, forKey: .episodeFrequency)
+        lastUpdatedAt = try container.decodeIfPresent(String.self, forKey: .lastUpdatedAt)
+        excludeFromAutoArchive = try container.decodeIfPresent(Bool.self, forKey: .excludeFromAutoArchive) ?? false
+        overrideGlobalArchive = try container.decodeIfPresent(Bool.self, forKey: .overrideGlobalArchive) ?? false
+        autoArchivePlayedAfter = try container.decodeIfPresent(Double.self, forKey: .autoArchivePlayedAfter) ?? 0
+        autoArchiveInactiveAfter = try container.decodeIfPresent(Double.self, forKey: .autoArchiveInactiveAfter) ?? 0
+        isPaid = try container.decodeIfPresent(Bool.self, forKey: .isPaid) ?? false
+        licensing = try container.decodeIfPresent(Int32.self, forKey: .licensing) ?? 0
+        fullSyncLastSyncAt = try container.decodeIfPresent(String.self, forKey: .fullSyncLastSyncAt)
+        showArchived = try container.decodeIfPresent(Bool.self, forKey: .showArchived) ?? false
+        refreshAvailable = try container.decodeIfPresent(Bool.self, forKey: .refreshAvailable) ?? false
+        folderUuid = try container.decodeIfPresent(String.self, forKey: .folderUuid)
+        usedCustomEffectsBefore = try container.decodeIfPresent(Bool.self, forKey: .usedCustomEffectsBefore) ?? false
+        isPrivate = try container.decodeIfPresent(Bool.self, forKey: .isPrivate) ?? false
+        isExplicit = try container.decodeIfPresent(Bool.self, forKey: .isExplicit) ?? false
+        fundingURL = try container.decodeIfPresent(String.self, forKey: .fundingURL)
+    }
+
+    public func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["addedDate"] = addedDate?.timeIntervalSince1970
+        container["autoDownloadSetting"] = autoDownloadSetting
+        container["autoAddToUpNext"] = autoAddToUpNext
+        container["episodeKeepSetting"] = autoArchiveEpisodeLimit
+        container["backgroundColor"] = backgroundColor
+        container["detailColor"] = detailColor
+        container["primaryColor"] = primaryColor
+        container["secondaryColor"] = secondaryColor
+        container["lastColorDownloadDate"] = lastColorDownloadDate?.timeIntervalSince1970
+        container["imageURL"] = imageURL
+        container["latestEpisodeUuid"] = latestEpisodeUuid
+        container["latestEpisodeDate"] = latestEpisodeDate?.timeIntervalSince1970
+        container["mediaType"] = mediaType
+        container["lastThumbnailDownloadDate"] = lastThumbnailDownloadDate?.timeIntervalSince1970
+        container["thumbnailStatus"] = thumbnailStatus
+        container["podcastUrl"] = podcastUrl
+        container["author"] = author
+        container["overrideGlobalEffects"] = overrideGlobalEffects
+        container["playbackSpeed"] = playbackSpeed
+        container["boostVolume"] = boostVolume
+        container["trimSilenceAmount"] = trimSilenceAmount
+        container["podcastCategory"] = podcastCategory
+        container["podcastDescription"] = podcastDescription
+        container["podcastHTMLDescription"] = podcastHTMLDescription
+        container["sortOrder"] = sortOrder
+        container["startFrom"] = startFrom
+        container["skipLast"] = skipLast
+        container["subscribed"] = subscribed
+        container["title"] = title
+        container["uuid"] = uuid
+        container["syncStatus"] = syncStatus
+        container["colorVersion"] = colorVersion
+        container["pushEnabled"] = pushEnabled
+        container["episodeSortOrder"] = episodeSortOrder
+        container["episodeGrouping"] = episodeGrouping
+        container["showType"] = showType
+        container["estimatedNextEpisode"] = estimatedNextEpisode?.timeIntervalSince1970
+        container["episodeFrequency"] = episodeFrequency
+        container["lastUpdatedAt"] = lastUpdatedAt
+        container["excludeFromAutoArchive"] = excludeFromAutoArchive
+        container["overrideGlobalArchive"] = overrideGlobalArchive
+        container["autoArchivePlayedAfter"] = autoArchivePlayedAfter
+        container["autoArchiveInactiveAfter"] = autoArchiveInactiveAfter
+        container["isPaid"] = isPaid
+        container["licensing"] = licensing
+        container["fullSyncLastSyncAt"] = fullSyncLastSyncAt
+        container["showArchived"] = showArchived
+        container["refreshAvailable"] = refreshAvailable
+        container["folderUuid"] = folderUuid
+        container["usedCustomEffectsBefore"] = usedCustomEffectsBefore
+        container["isPrivate"] = isPrivate
+        container["isExplicit"] = isExplicit
+        container["fundingURL"] = fundingURL
+    }
+
+    public enum Columns {
+        public static let id = Column(CodingKeys.id)
+        public static let addedDate = Column(CodingKeys.addedDate)
+        public static let autoDownloadSetting = Column(CodingKeys.autoDownloadSetting)
+        public static let autoAddToUpNext = Column(CodingKeys.autoAddToUpNext)
+        public static let autoArchiveEpisodeLimit = Column(CodingKeys.autoArchiveEpisodeLimit)
+        public static let backgroundColor = Column(CodingKeys.backgroundColor)
+        public static let detailColor = Column(CodingKeys.detailColor)
+        public static let primaryColor = Column(CodingKeys.primaryColor)
+        public static let secondaryColor = Column(CodingKeys.secondaryColor)
+        public static let lastColorDownloadDate = Column(CodingKeys.lastColorDownloadDate)
+        public static let imageURL = Column(CodingKeys.imageURL)
+        public static let latestEpisodeUuid = Column(CodingKeys.latestEpisodeUuid)
+        public static let latestEpisodeDate = Column(CodingKeys.latestEpisodeDate)
+        public static let mediaType = Column(CodingKeys.mediaType)
+        public static let lastThumbnailDownloadDate = Column(CodingKeys.lastThumbnailDownloadDate)
+        public static let thumbnailStatus = Column(CodingKeys.thumbnailStatus)
+        public static let podcastUrl = Column(CodingKeys.podcastUrl)
+        public static let author = Column(CodingKeys.author)
+        public static let overrideGlobalEffects = Column(CodingKeys.overrideGlobalEffects)
+        public static let playbackSpeed = Column(CodingKeys.playbackSpeed)
+        public static let boostVolume = Column(CodingKeys.boostVolume)
+        public static let trimSilenceAmount = Column(CodingKeys.trimSilenceAmount)
+        public static let podcastCategory = Column(CodingKeys.podcastCategory)
+        public static let podcastDescription = Column(CodingKeys.podcastDescription)
+        public static let podcastHTMLDescription = Column(CodingKeys.podcastHTMLDescription)
+        public static let sortOrder = Column(CodingKeys.sortOrder)
+        public static let startFrom = Column(CodingKeys.startFrom)
+        public static let skipLast = Column(CodingKeys.skipLast)
+        public static let subscribed = Column(CodingKeys.subscribed)
+        public static let title = Column(CodingKeys.title)
+        public static let uuid = Column(CodingKeys.uuid)
+        public static let syncStatus = Column(CodingKeys.syncStatus)
+        public static let colorVersion = Column(CodingKeys.colorVersion)
+        public static let pushEnabled = Column(CodingKeys.pushEnabled)
+        public static let episodeSortOrder = Column(CodingKeys.episodeSortOrder)
+        public static let episodeGrouping = Column(CodingKeys.episodeGrouping)
+        public static let showType = Column(CodingKeys.showType)
+        public static let estimatedNextEpisode = Column(CodingKeys.estimatedNextEpisode)
+        public static let episodeFrequency = Column(CodingKeys.episodeFrequency)
+        public static let lastUpdatedAt = Column(CodingKeys.lastUpdatedAt)
+        public static let excludeFromAutoArchive = Column(CodingKeys.excludeFromAutoArchive)
+        public static let overrideGlobalArchive = Column(CodingKeys.overrideGlobalArchive)
+        public static let autoArchivePlayedAfter = Column(CodingKeys.autoArchivePlayedAfter)
+        public static let autoArchiveInactiveAfter = Column(CodingKeys.autoArchiveInactiveAfter)
+        public static let isPaid = Column(CodingKeys.isPaid)
+        public static let licensing = Column(CodingKeys.licensing)
+        public static let fullSyncLastSyncAt = Column(CodingKeys.fullSyncLastSyncAt)
+        public static let showArchived = Column(CodingKeys.showArchived)
+        public static let refreshAvailable = Column(CodingKeys.refreshAvailable)
+        public static let folderUuid = Column(CodingKeys.folderUuid)
+        public static let usedCustomEffectsBefore = Column(CodingKeys.usedCustomEffectsBefore)
+        public static let isPrivate = Column(CodingKeys.isPrivate)
+        public static let isExplicit = Column(CodingKeys.isExplicit)
+        public static let fundingURL = Column(CodingKeys.fundingURL)
+    }
 }
+
+extension Podcast: FetchableRecord, PersistableRecord, TableRecord, Decodable {}
 
 public enum TrimSilenceAmount: Int32, Codable, CaseIterable {
     case off = 0, low = 3, medium = 5, high = 10

--- a/Modules/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/Model/UserEpisode.swift
@@ -1,12 +1,9 @@
 import Foundation
 import GRDB
-import GRDBMacros
 
-@GRDBRecord(table: "SJUserEpisode")
 public class UserEpisode: NSObject, BaseEpisode {
     @objc public var id = 0 as Int64
     @objc public var addedDate: Date?
-    @GRDBNullDateAsEpoch
     @objc public var lastDownloadAttemptDate: Date?
     @objc public var downloadErrorDetails: String?
     @objc public var downloadTaskId: String?
@@ -15,7 +12,6 @@ public class UserEpisode: NSObject, BaseEpisode {
     @objc public var fileType: String?
     // Note: contentType is saved separately via saveContentType() method.
     // The legacy SQL code doesn't include it in columnNames, so we ignore it for GRDB compatibility.
-    @GRDBIgnore
     @objc public var contentType: String?
     @objc public var playedUpTo: Double = 0
     @objc public var duration: Double = 0
@@ -38,21 +34,15 @@ public class UserEpisode: NSObject, BaseEpisode {
     @objc public var imageColor = 0 as Int32
     @objc public var imageColorModified = 0 as Int64
     @objc public var hasCustomImage = false
-    @GRDBIgnore
     @objc public var hasOnlyUuid = false
     // Note: These properties exist on the model but were never added to the SJUserEpisode table.
     // The legacy SQL code doesn't persist them, so we ignore them for GRDB compatibility.
-    @GRDBIgnore
     @objc public var deselectedChapters: String?
-    @GRDBIgnore
     @objc public var deselectedChaptersModified = 0 as Int64
 
     // UserEpisode's are never archived or starred
-    @GRDBIgnore
     public var archived = false
-    @GRDBIgnore
     public var keepEpisode = false
-    @GRDBIgnore
     public var wasDeleted = false
 
     public var hasBookmarks: Bool {
@@ -188,4 +178,140 @@ public class UserEpisode: NSObject, BaseEpisode {
     public func uploadWaitingForWifi() -> Bool {
         uploadStatus == UploadStatus.waitingForWifi.rawValue
     }
+
+    // MARK: - GRDB
+
+    public static let databaseTableName = "SJUserEpisode"
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case addedDate
+        case lastDownloadAttemptDate
+        case downloadErrorDetails
+        case downloadTaskId
+        case downloadUrl
+        case episodeStatus
+        case fileType
+        case playedUpTo
+        case duration
+        case durationModified
+        case playingStatus
+        case autoDownloadStatus
+        case publishedDate
+        case sizeInBytes
+        case playingStatusModified
+        case playedUpToModified
+        case title
+        case titleModified
+        case uuid
+        case playbackErrorDetails
+        case cachedFrameCount
+        case uploadStatus
+        case uploadTaskId
+        case imageUrl
+        case imageModified
+        case imageColor
+        case imageColorModified
+        case hasCustomImage
+    }
+
+    public required init(from decoder: Decoder) throws {
+        super.init()
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(Int64.self, forKey: .id) ?? 0
+        addedDate = try container.decodeIfPresent(Date.self, forKey: .addedDate)
+        lastDownloadAttemptDate = try container.decodeIfPresent(Date.self, forKey: .lastDownloadAttemptDate)
+        downloadErrorDetails = try container.decodeIfPresent(String.self, forKey: .downloadErrorDetails)
+        downloadTaskId = try container.decodeIfPresent(String.self, forKey: .downloadTaskId)
+        downloadUrl = try container.decodeIfPresent(String.self, forKey: .downloadUrl)
+        episodeStatus = try container.decodeIfPresent(Int32.self, forKey: .episodeStatus) ?? 0
+        fileType = try container.decodeIfPresent(String.self, forKey: .fileType)
+        playedUpTo = try container.decodeIfPresent(Double.self, forKey: .playedUpTo) ?? 0
+        duration = try container.decodeIfPresent(Double.self, forKey: .duration) ?? 0
+        durationModified = try container.decodeIfPresent(Int64.self, forKey: .durationModified) ?? 0
+        playingStatus = try container.decodeIfPresent(Int32.self, forKey: .playingStatus) ?? 1
+        autoDownloadStatus = try container.decodeIfPresent(Int32.self, forKey: .autoDownloadStatus) ?? 0
+        publishedDate = try container.decodeIfPresent(Date.self, forKey: .publishedDate)
+        sizeInBytes = try container.decodeIfPresent(Int64.self, forKey: .sizeInBytes) ?? 0
+        playingStatusModified = try container.decodeIfPresent(Int64.self, forKey: .playingStatusModified) ?? 0
+        playedUpToModified = try container.decodeIfPresent(Int64.self, forKey: .playedUpToModified) ?? 0
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        titleModified = try container.decodeIfPresent(Int64.self, forKey: .titleModified) ?? 0
+        uuid = try container.decodeIfPresent(String.self, forKey: .uuid) ?? ""
+        playbackErrorDetails = try container.decodeIfPresent(String.self, forKey: .playbackErrorDetails)
+        cachedFrameCount = try container.decodeIfPresent(Int64.self, forKey: .cachedFrameCount) ?? 0
+        uploadStatus = try container.decodeIfPresent(Int32.self, forKey: .uploadStatus) ?? 0
+        uploadTaskId = try container.decodeIfPresent(String.self, forKey: .uploadTaskId)
+        imageUrl = try container.decodeIfPresent(String.self, forKey: .imageUrl)
+        imageModified = try container.decodeIfPresent(Int64.self, forKey: .imageModified) ?? 0
+        imageColor = try container.decodeIfPresent(Int32.self, forKey: .imageColor) ?? 0
+        imageColorModified = try container.decodeIfPresent(Int64.self, forKey: .imageColorModified) ?? 0
+        hasCustomImage = try container.decodeIfPresent(Bool.self, forKey: .hasCustomImage) ?? false
+    }
+
+    public func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["addedDate"] = addedDate?.timeIntervalSince1970
+        container["lastDownloadAttemptDate"] = (lastDownloadAttemptDate ?? Date(timeIntervalSince1970: 0)).timeIntervalSince1970
+        container["downloadErrorDetails"] = downloadErrorDetails
+        container["downloadTaskId"] = downloadTaskId
+        container["downloadUrl"] = downloadUrl
+        container["episodeStatus"] = episodeStatus
+        container["fileType"] = fileType
+        container["playedUpTo"] = playedUpTo
+        container["duration"] = duration
+        container["durationModified"] = durationModified
+        container["playingStatus"] = playingStatus
+        container["autoDownloadStatus"] = autoDownloadStatus
+        container["publishedDate"] = publishedDate?.timeIntervalSince1970
+        container["sizeInBytes"] = sizeInBytes
+        container["playingStatusModified"] = playingStatusModified
+        container["playedUpToModified"] = playedUpToModified
+        container["title"] = title
+        container["titleModified"] = titleModified
+        container["uuid"] = uuid
+        container["playbackErrorDetails"] = playbackErrorDetails
+        container["cachedFrameCount"] = cachedFrameCount
+        container["uploadStatus"] = uploadStatus
+        container["uploadTaskId"] = uploadTaskId
+        container["imageUrl"] = imageUrl
+        container["imageModified"] = imageModified
+        container["imageColor"] = imageColor
+        container["imageColorModified"] = imageColorModified
+        container["hasCustomImage"] = hasCustomImage
+    }
+
+    public enum Columns {
+        public static let id = Column(CodingKeys.id)
+        public static let addedDate = Column(CodingKeys.addedDate)
+        public static let lastDownloadAttemptDate = Column(CodingKeys.lastDownloadAttemptDate)
+        public static let downloadErrorDetails = Column(CodingKeys.downloadErrorDetails)
+        public static let downloadTaskId = Column(CodingKeys.downloadTaskId)
+        public static let downloadUrl = Column(CodingKeys.downloadUrl)
+        public static let episodeStatus = Column(CodingKeys.episodeStatus)
+        public static let fileType = Column(CodingKeys.fileType)
+        public static let playedUpTo = Column(CodingKeys.playedUpTo)
+        public static let duration = Column(CodingKeys.duration)
+        public static let durationModified = Column(CodingKeys.durationModified)
+        public static let playingStatus = Column(CodingKeys.playingStatus)
+        public static let autoDownloadStatus = Column(CodingKeys.autoDownloadStatus)
+        public static let publishedDate = Column(CodingKeys.publishedDate)
+        public static let sizeInBytes = Column(CodingKeys.sizeInBytes)
+        public static let playingStatusModified = Column(CodingKeys.playingStatusModified)
+        public static let playedUpToModified = Column(CodingKeys.playedUpToModified)
+        public static let title = Column(CodingKeys.title)
+        public static let titleModified = Column(CodingKeys.titleModified)
+        public static let uuid = Column(CodingKeys.uuid)
+        public static let playbackErrorDetails = Column(CodingKeys.playbackErrorDetails)
+        public static let cachedFrameCount = Column(CodingKeys.cachedFrameCount)
+        public static let uploadStatus = Column(CodingKeys.uploadStatus)
+        public static let uploadTaskId = Column(CodingKeys.uploadTaskId)
+        public static let imageUrl = Column(CodingKeys.imageUrl)
+        public static let imageModified = Column(CodingKeys.imageModified)
+        public static let imageColor = Column(CodingKeys.imageColor)
+        public static let imageColorModified = Column(CodingKeys.imageColorModified)
+        public static let hasCustomImage = Column(CodingKeys.hasCustomImage)
+    }
 }
+
+extension UserEpisode: FetchableRecord, PersistableRecord, TableRecord, Decodable {}

--- a/Modules/Sources/PocketCastsDataModel/Public/NetworkDataUsage/NetworkDataUsageRecord.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/NetworkDataUsage/NetworkDataUsageRecord.swift
@@ -1,38 +1,88 @@
 import Foundation
 import GRDB
-import GRDBMacros
 
-@GRDBRecord(table: "NetworkDataUsage")
 public class NetworkDataUsageRecord: NSObject {
     @objc public var id = 0 as Int64
 
     @objc public var timestamp = 0.0 as Double
 
-    @GRDBColumn("episode_uuid")
     @objc public var episodeUuid: String?
 
-    @GRDBColumn("podcast_uuid")
     @objc public var podcastUuid: String?
 
-    @GRDBColumn("bytes_downloaded")
     @objc public var bytesDownloaded = 0 as Int64
 
-    @GRDBColumn("bytes_streamed")
     @objc public var bytesStreamed = 0 as Int64
 
-    @GRDBColumn("bytes_uploaded")
     @objc public var bytesUploaded = 0 as Int64
 
-    @GRDBColumn("operation_type")
     @objc public var operationType = ""
 
-    @GRDBColumn("connection_type")
     @objc public var connectionType = 0 as Int32
 
-    @GRDBColumn("session_type")
     @objc public var sessionType: String?
 
     override public init() {
         super.init()
     }
+
+    // MARK: - GRDB
+
+    public static let databaseTableName = "NetworkDataUsage"
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case timestamp
+        case episodeUuid = "episode_uuid"
+        case podcastUuid = "podcast_uuid"
+        case bytesDownloaded = "bytes_downloaded"
+        case bytesStreamed = "bytes_streamed"
+        case bytesUploaded = "bytes_uploaded"
+        case operationType = "operation_type"
+        case connectionType = "connection_type"
+        case sessionType = "session_type"
+    }
+
+    public required init(from decoder: Decoder) throws {
+        super.init()
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(Int64.self, forKey: .id) ?? 0
+        timestamp = try container.decodeIfPresent(Double.self, forKey: .timestamp) ?? 0.0
+        episodeUuid = try container.decodeIfPresent(String.self, forKey: .episodeUuid)
+        podcastUuid = try container.decodeIfPresent(String.self, forKey: .podcastUuid)
+        bytesDownloaded = try container.decodeIfPresent(Int64.self, forKey: .bytesDownloaded) ?? 0
+        bytesStreamed = try container.decodeIfPresent(Int64.self, forKey: .bytesStreamed) ?? 0
+        bytesUploaded = try container.decodeIfPresent(Int64.self, forKey: .bytesUploaded) ?? 0
+        operationType = try container.decodeIfPresent(String.self, forKey: .operationType) ?? ""
+        connectionType = try container.decodeIfPresent(Int32.self, forKey: .connectionType) ?? 0
+        sessionType = try container.decodeIfPresent(String.self, forKey: .sessionType)
+    }
+
+    public func encode(to container: inout PersistenceContainer) {
+        container["id"] = id
+        container["timestamp"] = timestamp
+        container["episode_uuid"] = episodeUuid
+        container["podcast_uuid"] = podcastUuid
+        container["bytes_downloaded"] = bytesDownloaded
+        container["bytes_streamed"] = bytesStreamed
+        container["bytes_uploaded"] = bytesUploaded
+        container["operation_type"] = operationType
+        container["connection_type"] = connectionType
+        container["session_type"] = sessionType
+    }
+
+    public enum Columns {
+        public static let id = Column(CodingKeys.id)
+        public static let timestamp = Column(CodingKeys.timestamp)
+        public static let episodeUuid = Column(CodingKeys.episodeUuid)
+        public static let podcastUuid = Column(CodingKeys.podcastUuid)
+        public static let bytesDownloaded = Column(CodingKeys.bytesDownloaded)
+        public static let bytesStreamed = Column(CodingKeys.bytesStreamed)
+        public static let bytesUploaded = Column(CodingKeys.bytesUploaded)
+        public static let operationType = Column(CodingKeys.operationType)
+        public static let connectionType = Column(CodingKeys.connectionType)
+        public static let sessionType = Column(CodingKeys.sessionType)
+    }
 }
+
+extension NetworkDataUsageRecord: FetchableRecord, PersistableRecord, TableRecord, Decodable {}


### PR DESCRIPTION
> **Stacked on #5030** — review that one first; this PR targets `inline-grdb-record-folder`, so the diff here is only the remaining 5 models.

Applies the same technique as #5030 to the other five `@GRDBRecord` users: `Podcast`, `Episode`, `UserEpisode`, `EpisodeFilter`, and `NetworkDataUsageRecord`. After this, nothing in the app uses the macro.

**`GRDBMacros` itself is deliberately left in place** — the target, the plugin, the `swift-syntax` dependency, and the `Package.swift` wiring are all untouched. Deleting them is a separate follow-up, so that if anything here misbehaves the revert is a one-file change rather than a dependency-graph change.

## Why this is safe

**Every line was generated by the macro, not written by hand.** Same method as #5030, scripted across all five: for each model I took the real source file, swapped `import GRDBMacros` for local macro declarations, and ran the actual plugin:

```
swiftc -typecheck <model>.swift \
  -load-plugin-executable .build/debug/GRDBMacrosPlugin-tool#GRDBMacrosPlugin \
  -Xfrontend -dump-macro-expansions
```

The dumped `fMm_` (members) and `fMe_` (extension) sections are pasted in verbatim. The only transformation is re-indentation by brace depth — the macro emits ragged continuation lines. Crucially the expansion was dumped **before** the marker attributes were stripped, so `@GRDBColumn` / `@GRDBIgnore` / `@GRDBNullDateAsEpoch` all still informed the generated code.

That matters most for the details that fail silently if a human transcribes them:

- **`NetworkDataUsageRecord`'s 8 custom column names** (`episodeUuid` → `episode_uuid`, etc.) and **`Podcast.autoArchiveEpisodeLimit` → `episodeKeepSetting`** land in both the `CodingKeys` raw values and the `encode(to:)` keys.
- **14 `Date` columns** encode as `.timeIntervalSince1970`, not GRDB's default `Date` serialization.
- **3 `@GRDBNullDateAsEpoch` columns** (`Episode.lastDownloadAttemptDate`, `Episode.lastArchiveInteractionDate`, `UserEpisode.lastDownloadAttemptDate`) still encode `nil` as `Date(timeIntervalSince1970: 0)` — these back `NOT NULL DEFAULT 0` columns, so a plain `nil` would trip the constraint.
- Every property decodes via `decodeIfPresent(...) ?? default`, which is what keeps a NULL column from throwing.

**Nothing outside these five files changes.** `databaseTableName`, `CodingKeys`, `Columns`, and the conformances keep identical names and visibility, so all queries and call sites are untouched.

**Ignored properties stay ignored.** `Episode.hasOnlyUuid` and the other `@GRDBIgnore` properties are absent from `CodingKeys`, `encode(to:)`, and `Columns`, as before. Several `@GRDBIgnore` markers were already no-ops — the macro only ever read `@objc` properties, and those aren't `@objc`.

## Test results

Full `PocketCastsDataModelTests`: **473 tests, 2 failures** — the same count and the same two as on `trunk`.

- `PodcastColumnConsistencyTests`, `UserEpisodeColumnConsistencyTests`, `EpisodeFilterColumnConsistencyTests`, `FolderColumnConsistencyTests` — all pass, each doing a real save/load round-trip against both the legacy SQL and GRDB paths (`FeatureFlag.grdbQueryInterface`).
- `PodcastDataManagerTests`, `EpisodeDataManagerTests`, `UserEpisodeDataManagerTests`, `FolderDataManagerTests`, `NetworkDataUsageManagerTests`, `UserEpisodeEncodingTests` — all pass.
- `EpisodeColumnConsistencyTests.testSaveAndLoadPreservesAllFields` — 2 failures on `hasGeneratedTranscript`. **Pre-existing**, verified failing identically on clean `trunk`. See note below.
- SwiftLint clean on all five files.

### Pre-existing bug worth a separate issue

`Episode.hasGeneratedTranscript` is declared `public var hasGeneratedTranscript: Bool? = nil` **without** `@objc`. The macro only reads `@objc` properties, and the legacy SQL `columnNames` list doesn't include it either — so it is persisted by neither path, and the consistency test correctly catches it. Not introduced or changed here; flagging it since the red test is easy to misread as fallout from this PR.

## To test

`NetworkDataUsageRecord` has no consistency test, so it's worth manual attention:

1. Settings → check the data-usage figures render, then stream and download an episode on cellular and confirm the counters move.
2. Browse and subscribe to podcasts; check artwork colours, episode lists, and Up Next survive a force quit and relaunch.
3. Star, archive, and mark episodes as played; confirm each sticks after a relaunch.
4. Create a filter with several rules; confirm its episode list and settings persist.
5. Upload/inspect a Files (user) episode, including custom artwork.
6. Sync with another device or the web player and confirm podcasts, filters, folders, and playback position round-trip.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
