### PR TITLE
Fix the collection header's blank colors and Dynamic Type

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Extensions/UI/UIColorExtension.swift
+++ b/Modules/Sources/PocketCastsUtils/Extensions/UI/UIColorExtension.swift
@@ -3,46 +3,50 @@ import UIKit
 
 public extension UIColor {
     convenience init(hex: String) {
-        var red: CGFloat = 0.0
-        var green: CGFloat = 0.0
-        var blue: CGFloat = 0.0
-        var alpha: CGFloat = 1.0
+        let components = UIColor.components(hex: hex) ?? (red: 0, green: 0, blue: 0, alpha: 1)
+        self.init(red: components.red, green: components.green, blue: components.blue, alpha: components.alpha)
+    }
 
-        if hex.hasPrefix("#") {
-            let index = hex.index(hex.startIndex, offsetBy: 1)
-            let hexString = String(hex[index...])
-            let scanner = Scanner(string: hexString)
-            var hexValue: CUnsignedLongLong = 0
-            if scanner.scanHexInt64(&hexValue) {
-                switch hexString.count {
-                case 3:
-                    red = CGFloat((hexValue & 0xF00) >> 8) / 15.0
-                    green = CGFloat((hexValue & 0x0F0) >> 4) / 15.0
-                    blue = CGFloat(hexValue & 0x00F) / 15.0
-                case 4:
-                    red = CGFloat((hexValue & 0xF000) >> 12) / 15.0
-                    green = CGFloat((hexValue & 0x0F00) >> 8) / 15.0
-                    blue = CGFloat((hexValue & 0x00F0) >> 4) / 15.0
-                    alpha = CGFloat(hexValue & 0x000F) / 15.0
-                case 6:
-                    red = CGFloat((hexValue & 0xFF0000) >> 16) / 255.0
-                    green = CGFloat((hexValue & 0x00FF00) >> 8) / 255.0
-                    blue = CGFloat(hexValue & 0x0000FF) / 255.0
-                case 8:
-                    red = CGFloat((hexValue & 0xFF00_0000) >> 24) / 255.0
-                    green = CGFloat((hexValue & 0x00FF_0000) >> 16) / 255.0
-                    blue = CGFloat((hexValue & 0x0000_FF00) >> 8) / 255.0
-                    alpha = CGFloat(hexValue & 0x0000_00FF) / 255.0
-                default:
-                    print("Invalid RGB string, number of characters after '#' should be either 3, 4, 6 or 8")
-                }
-            } else {
-                print("Scan hex error")
-            }
-        } else {
-            print("Invalid RGB string, missing '#' as prefix")
+    /// The color `hex` describes, or `nil` when it isn't `#RGB`, `#RGBA`, `#RRGGBB` or `#RRGGBBAA`.
+    ///
+    /// Unlike ``init(hex:)``, which falls back to black, this lets a caller fall back to a theme color
+    /// when a server sends a blank or malformed value.
+    static func from(hex: String) -> UIColor? {
+        guard let components = components(hex: hex) else { return nil }
+        return UIColor(red: components.red, green: components.green, blue: components.blue, alpha: components.alpha)
+    }
+
+    private static func components(hex: String) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)? {
+        guard hex.hasPrefix("#") else { return nil }
+
+        let hexString = String(hex.dropFirst())
+        var hexValue: CUnsignedLongLong = 0
+        guard hexString.allSatisfy(\.isHexDigit), Scanner(string: hexString).scanHexInt64(&hexValue) else { return nil }
+
+        switch hexString.count {
+        case 3:
+            return (red: CGFloat((hexValue & 0xF00) >> 8) / 15.0,
+                    green: CGFloat((hexValue & 0x0F0) >> 4) / 15.0,
+                    blue: CGFloat(hexValue & 0x00F) / 15.0,
+                    alpha: 1.0)
+        case 4:
+            return (red: CGFloat((hexValue & 0xF000) >> 12) / 15.0,
+                    green: CGFloat((hexValue & 0x0F00) >> 8) / 15.0,
+                    blue: CGFloat((hexValue & 0x00F0) >> 4) / 15.0,
+                    alpha: CGFloat(hexValue & 0x000F) / 15.0)
+        case 6:
+            return (red: CGFloat((hexValue & 0xFF0000) >> 16) / 255.0,
+                    green: CGFloat((hexValue & 0x00FF00) >> 8) / 255.0,
+                    blue: CGFloat(hexValue & 0x0000FF) / 255.0,
+                    alpha: 1.0)
+        case 8:
+            return (red: CGFloat((hexValue & 0xFF00_0000) >> 24) / 255.0,
+                    green: CGFloat((hexValue & 0x00FF_0000) >> 16) / 255.0,
+                    blue: CGFloat((hexValue & 0x0000_FF00) >> 8) / 255.0,
+                    alpha: CGFloat(hexValue & 0x0000_00FF) / 255.0)
+        default:
+            return nil
         }
-        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
 
     func hexString() -> String {

--- a/Modules/Tests/PocketCastsUtilsTests/UIColorExtensionsTests.swift
+++ b/Modules/Tests/PocketCastsUtilsTests/UIColorExtensionsTests.swift
@@ -1,0 +1,28 @@
+import PocketCastsUtils
+import UIKit
+import XCTest
+
+final class UIColorExtensionsTests: XCTestCase {
+    func testParsesSupportedHexLengths() throws {
+        XCTAssertEqual(UIColor.from(hex: "#F00")?.hexString(), "#FF0000")
+        XCTAssertEqual(UIColor.from(hex: "#00FF00")?.hexString(), "#00FF00")
+
+        let withAlpha = try XCTUnwrap(UIColor.from(hex: "#0000FF80"))
+        XCTAssertEqual(withAlpha.hexString(), "#0000FF")
+        XCTAssertEqual(withAlpha.getRGBA()[3], 128.0 / 255.0, accuracy: 0.001)
+    }
+
+    func testReturnsNilForUnusableValues() {
+        XCTAssertNil(UIColor.from(hex: ""))
+        XCTAssertNil(UIColor.from(hex: "#"))
+        XCTAssertNil(UIColor.from(hex: "FF0000"), "a missing # prefix isn't a color")
+        XCTAssertNil(UIColor.from(hex: "#FF000"), "5 digits isn't a supported length")
+        XCTAssertNil(UIColor.from(hex: "#ZZZZZZ"))
+        XCTAssertNil(UIColor.from(hex: "#FFZZZZ"), "a partially scannable value isn't a color")
+    }
+
+    func testInitFallsBackToBlack() {
+        XCTAssertEqual(UIColor(hex: "").hexString(), "#000000")
+        XCTAssertEqual(UIColor(hex: "#00FF00").hexString(), "#00FF00")
+    }
+}

--- a/podcasts/DiscoverCollectionHeader.swift
+++ b/podcasts/DiscoverCollectionHeader.swift
@@ -144,12 +144,7 @@ class DiscoverCollectionHeader: UICollectionReusableView {
     }
 
     private func setSubtitleColor() {
-        if let colors = podcastCollection?.colors, let darkColor = colors.onDarkBackground, let lightColor = colors.onLightBackground {
-            let subtitleColor = Theme.isDarkTheme() ? darkColor : lightColor
-            subtitleLabel.textColor = UIColor(hex: subtitleColor)
-        } else {
-            subtitleLabel.textColor = AppTheme.colorForStyle(.support05)
-        }
+        subtitleLabel.textColor = podcastCollection?.colors?.activeThemeColor ?? AppTheme.colorForStyle(.support05)
     }
 
     private func setupCollageImage() {
@@ -181,12 +176,7 @@ class DiscoverCollectionHeader: UICollectionReusableView {
     }
 
     private func setImageTint() {
-        if let darkTintColor = podcastCollection?.colors?.onDarkBackground, let lightTintColor = podcastCollection?.colors?.onLightBackground {
-            let backgroundColor = Theme.isDarkTheme() ? darkTintColor : lightTintColor
-            collageTintView.backgroundColor = UIColor(hex: backgroundColor)
-        } else {
-            collageTintView.backgroundColor = AppTheme.colorForStyle(.support09)
-        }
+        collageTintView.backgroundColor = podcastCollection?.colors?.activeThemeColor ?? AppTheme.colorForStyle(.support09)
     }
 
     @objc private func linkTapped() {

--- a/podcasts/DiscoverCollectionHeader.swift
+++ b/podcasts/DiscoverCollectionHeader.swift
@@ -43,9 +43,11 @@ class DiscoverCollectionHeader: UICollectionReusableView {
 
     @IBOutlet var subtitleLabel: UILabel! {
         didSet {
+            subtitleLabel.font = .font(ofSize: 13, weight: .bold, scalingWith: .footnote)
             subtitleLabel.adjustsFontForContentSizeCategory = true
         }
     }
+
     @IBOutlet var headerView: ThemeableView! {
         didSet {
             headerView.style = .primaryUi02

--- a/podcasts/DiscoverCollectionHeader.xib
+++ b/podcasts/DiscoverCollectionHeader.xib
@@ -62,7 +62,7 @@
                                 <constraint firstItem="gwR-NQ-hKf" firstAttribute="trailing" secondItem="7cY-eL-Ku5" secondAttribute="trailing" id="zC0-4i-YrO"/>
                             </constraints>
                         </view>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="HIGHLIGHT" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ldU-3C-ZOr">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="HIGHLIGHT" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ldU-3C-ZOr">
                             <rect key="frame" x="162.5" y="192" width="74.5" height="16"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                             <nil key="textColor"/>
@@ -146,6 +146,8 @@
                         <constraint firstItem="Oap-c4-00b" firstAttribute="centerY" secondItem="mvm-o6-mNy" secondAttribute="bottom" id="7hD-9u-ExU"/>
                         <constraint firstItem="mvm-o6-mNy" firstAttribute="top" secondItem="7eV-el-4ft" secondAttribute="top" id="9LE-R5-a6h"/>
                         <constraint firstItem="ldU-3C-ZOr" firstAttribute="centerX" secondItem="7JV-U8-0zd" secondAttribute="centerX" id="BBM-H9-kXx"/>
+                        <constraint firstItem="ldU-3C-ZOr" firstAttribute="leading" secondItem="7JV-U8-0zd" secondAttribute="leading" constant="16" id="Bqh-Nz-7tE"/>
+                        <constraint firstItem="ldU-3C-ZOr" firstAttribute="trailing" secondItem="7JV-U8-0zd" secondAttribute="trailing" constant="-16" id="Cvr-Kd-9pS"/>
                         <constraint firstItem="e6f-hB-C8a" firstAttribute="leading" secondItem="7JV-U8-0zd" secondAttribute="leading" constant="20" symbolic="YES" id="D2m-YL-tqn"/>
                         <constraint firstItem="7eV-el-4ft" firstAttribute="top" secondItem="7JV-U8-0zd" secondAttribute="top" id="Lei-T2-pmK"/>
                         <constraint firstItem="yYb-i1-leb" firstAttribute="trailing" secondItem="7eV-el-4ft" secondAttribute="trailing" id="RJJ-ct-HwH"/>

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -152,3 +152,75 @@ class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDe
         updateFlowLayoutSize()
     }
 }
+
+#if DEBUG
+
+import SwiftUI
+
+/// Hosts the expanded collection in a navigation controller, the way Discover pushes it.
+private struct ExpandedCollectionPreview: UIViewControllerRepresentable {
+    let makeController: () -> ExpandedCollectionViewController
+
+    /// The controller holds its delegate weakly, so the preview is what keeps this one alive.
+    private let delegate = PreviewDiscoverDelegate()
+
+    init(_ makeController: @escaping () -> ExpandedCollectionViewController) {
+        self.makeController = makeController
+    }
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let controller = makeController()
+        controller.registerDiscoverDelegate(delegate)
+        return PCNavigationController(rootViewController: controller)
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {}
+}
+
+private let previewCollectionImage = "https://static.pocketcasts.com/discover/images/420/82e37e80-755d-0138-eddc-0acc26574db2.jpg"
+
+#Preview("Grid") {
+    ExpandedCollectionPreview {
+        let controller = ExpandedCollectionViewController(
+            item: DiscoverPreviewData.item(.collectionSummary, title: "Sounds for sleeping", expandedStyle: "grid"),
+            podcasts: DiscoverPreviewData.podcasts(12)
+        )
+        controller.podcastCollection = DiscoverPreviewData.podcastCollection(
+            title: "Sounds for sleeping",
+            subtitle: "Staff picks",
+            description: "Twelve shows for winding down, chosen by the people who make Pocket Casts.",
+            podcasts: DiscoverPreviewData.podcasts(12),
+            collectionImage: previewCollectionImage
+        )
+        return controller
+    }
+    .ignoresSafeArea()
+}
+
+#Preview("Descriptive list") {
+    ExpandedCollectionPreview {
+        let controller = ExpandedCollectionViewController(
+            item: DiscoverPreviewData.item(.collectionSummary, title: "Sounds for sleeping", expandedStyle: "descriptive_list"),
+            podcasts: DiscoverPreviewData.podcasts(12)
+        )
+        controller.cellStyle = .descriptive_list
+        return controller
+    }
+    .ignoresSafeArea()
+}
+
+/// The grid a `lists_list` row opens: networks rather than podcasts, and no collection header.
+#Preview("Networks") {
+    ExpandedCollectionPreview {
+        let controller = ExpandedCollectionViewController(
+            item: DiscoverPreviewData.item(.networksList, title: "Networks"),
+            podcasts: []
+        )
+        controller.cellStyle = .networkGrid
+        controller.networks = DiscoverPreviewData.networkCollection(title: "Networks").lists
+        return controller
+    }
+    .ignoresSafeArea()
+}
+
+#endif

--- a/podcasts/Extensions/PodcastCollectionColors+Helpers.swift
+++ b/podcasts/Extensions/PodcastCollectionColors+Helpers.swift
@@ -2,11 +2,11 @@ import PocketCastsServer
 import UIKit
 
 extension PodcastCollectionColors {
+    /// The color for the current theme, or `nil` when the collection came without a usable one.
     var activeThemeColor: UIColor? {
         guard let darkColor = onDarkBackground, let lightColor = onLightBackground else {
             return nil
         }
-        let hexCode = Theme.isDarkTheme() ? darkColor : lightColor
-        return hexCode.isEmpty ? nil : UIColor(hex: hexCode)
+        return UIColor.from(hex: Theme.isDarkTheme() ? darkColor : lightColor)
     }
 }


### PR DESCRIPTION
| 📘 Part of: #5026 |
|:---:|

Follow-ups on the expanded collection screen, stacked on #5026.

- Lists that send blank `colors` (the Relay network, for one) fell through to `UIColor(hex:)`'s black fallback, so the header's eyebrow was drawn black — invisible in dark themes — and the collage tint went black instead of `support09`. Blank and malformed values now fall back to the theme color like a missing one does.
- The eyebrow never scaled: it opted into `adjustsFontForContentSizeCategory` but took a fixed 13pt font from the nib, with no `UIFontMetrics` behind it.
- Previews for the expanded collection screen.

## To test

1. Discover → a network row → open a network with no brand colors (Relay).
2. In a dark theme, the "NETWORK" eyebrow should be the theme accent, not black, and the collage behind the artwork should carry the theme tint.
3. Settings → Accessibility → Display & Text Size → Larger Text, drag to the largest size. The eyebrow should scale with the other labels and stay inside the margins.
4. Open a curated collection that *does* send colors and confirm its brand color still drives both.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
