### PR TITLE
Rename CollectionCellStyle.descriptive_list to descriptiveList

### DIFF
--- a/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
+++ b/podcasts/DiscoverCollectionViewController+DiscoverDelegate.swift
@@ -113,7 +113,7 @@ extension DiscoverCollectionViewController: DiscoverDelegate {
             let collectionListVC = ExpandedCollectionViewController(item: item, podcasts: podcasts)
             collectionListVC.podcastCollection = podcastCollection
             collectionListVC.registerDiscoverDelegate(self)
-            collectionListVC.cellStyle = (item.expandedStyle == "descriptive_list") ? CollectionCellStyle.descriptive_list : CollectionCellStyle.grid
+            collectionListVC.cellStyle = (item.expandedStyle == "descriptive_list") ? CollectionCellStyle.descriptiveList : CollectionCellStyle.grid
             navController()?.pushViewController(collectionListVC, animated: true)
         } else { // item == expandedStylw == "plain_list" || item.expandedStyle == "ranked_list"
             let source = replaceRegionCode(string: item.source ?? "")

--- a/podcasts/ExpandedCollectionViewController+CollectionView.swift
+++ b/podcasts/ExpandedCollectionViewController+CollectionView.swift
@@ -22,7 +22,7 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
                 }
             }
             return cell
-        case .descriptive_list:
+        case .descriptiveList:
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ExpandedCollectionViewController.descriptiveCellId, for: indexPath) as! DescriptiveCollectionCell
             let thisPodcast = podcasts[indexPath.row]
             if let delegate {
@@ -87,7 +87,7 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
         let isBigDevice = viewWidth >= bigDevicePortraitWidth
 
         switch cellStyle {
-        case .descriptive_list:
+        case .descriptiveList:
             guard isBigDevice else {
                 return CGSize(width: viewWidth, height: descriptiveListPreferredMaxHeight)
             }
@@ -113,13 +113,13 @@ extension ExpandedCollectionViewController: UICollectionViewDataSource, UICollec
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
-        let topInset = (podcastCollection == nil && cellStyle != .descriptive_list) ? inset : 0
+        let topInset = (podcastCollection == nil && cellStyle != .descriptiveList) ? inset : 0
         return UIEdgeInsets(top: topInset, left: inset, bottom: 0, right: inset)
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         switch cellStyle {
-        case .descriptive_list:
+        case .descriptiveList:
             return 0
         case .grid, .networkGrid:
             return inset

--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -3,7 +3,7 @@ import SafariServices
 import UIKit
 
 enum CollectionCellStyle {
-    case grid, descriptive_list, networkGrid
+    case grid, descriptiveList, networkGrid
 }
 
 class ExpandedCollectionViewController: PCViewController, CollectionHeaderLinkDelegate {


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Renames the `CollectionCellStyle.descriptive_list` case to `descriptiveList` to follow Swift naming conventions. The `"descriptive_list"` string literals are Discover API values and are unchanged.

## To test

1. Open the Discover tab.
2. Find a list whose "Show All" style is `descriptive_list` (e.g. a featured/collection list) and tap **Show All**.
3. Verify the expanded list renders as before, on both iPhone and iPad (multi-column layout on larger widths).
4. Repeat for a `grid` style list and confirm it is unaffected.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
