### PR TITLE
Support networks in search

### DIFF
--- a/Modules/Sources/PocketCastsServer/Public/Search/CombinedSearchTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Search/CombinedSearchTask.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct CombinedSearchEnvelope: Decodable {
-    public let results: [CombinedSearchResult]
+    @LossyDecodedArray public var results: [CombinedSearchResult]
 }
 
 public enum CombinedSearchResultType: Hashable {

--- a/Modules/Sources/PocketCastsServer/Public/Search/CombinedSearchTask.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Search/CombinedSearchTask.swift
@@ -7,6 +7,7 @@ struct CombinedSearchEnvelope: Decodable {
 public enum CombinedSearchResultType: Hashable {
     case episode(EpisodeSearchResult)
     case podcast(PodcastFolderSearchResult)
+    case network(NetworkSearchResult)
 }
 
 public struct CombinedSearchResult: Decodable, Hashable {
@@ -22,6 +23,9 @@ public struct CombinedSearchResult: Decodable, Hashable {
     public let isVideo: Bool?
     public let hasVideo: Bool?
     public let videoUrl: String?
+    public let shortDescription: String?
+    public let collectionImage: String?
+    public let podcastCount: Int?
 
     public var resolvedResultType: CombinedSearchResultType? {
         switch type {
@@ -35,6 +39,11 @@ public struct CombinedSearchResult: Decodable, Hashable {
                 return nil
             }
             return .episode(episode)
+        case "network":
+            guard let network = NetworkSearchResult(from: self) else {
+                return nil
+            }
+            return .network(network)
         default:
             return nil
         }
@@ -57,6 +66,14 @@ public class CombinedSearchTask {
         }
 
         let (data, _) = try await session.data(for: request)
+
+        let envelope = try Self.decoder.decode(CombinedSearchEnvelope.self, from: data)
+        return envelope.results.compactMap { result in
+            return result.resolvedResultType
+        }
+    }
+
+    static let decoder: JSONDecoder = {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let dateFormatter = DateFormatter()
@@ -65,10 +82,6 @@ public class CombinedSearchTask {
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
         decoder.dateDecodingStrategy = .formatted(dateFormatter)
-
-        let envelope = try decoder.decode(CombinedSearchEnvelope.self, from: data)
-        return envelope.results.compactMap { result in
-            return result.resolvedResultType
-        }
-    }
+        return decoder
+    }()
 }

--- a/Modules/Sources/PocketCastsServer/Public/Search/NetworkSearchResult.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Search/NetworkSearchResult.swift
@@ -13,7 +13,7 @@ public struct NetworkSearchResult: Hashable {
     /// Search returns no source of its own, so it is built the way the Discover feed spells it:
     /// the network's list, by uuid.
     public var source: String {
-        "\(ServerConstants.Urls.lists())\(uuid).json"
+        ServerHelper.listUrlString(listId: uuid)
     }
 
     public init(uuid: String, title: String, description: String? = nil, collectionImage: String? = nil, podcastCount: Int? = nil) {

--- a/Modules/Sources/PocketCastsServer/Public/Search/NetworkSearchResult.swift
+++ b/Modules/Sources/PocketCastsServer/Public/Search/NetworkSearchResult.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// A podcast network returned by the combined search endpoint.
+public struct NetworkSearchResult: Hashable {
+    public let uuid: String
+    public let title: String
+    public let description: String?
+    public let collectionImage: String?
+    public let podcastCount: Int?
+
+    /// The list of the network's podcasts, which is what opening it shows.
+    ///
+    /// Search returns no source of its own, so it is built the way the Discover feed spells it:
+    /// the network's list, by uuid.
+    public var source: String {
+        "\(ServerConstants.Urls.lists())\(uuid).json"
+    }
+
+    public init(uuid: String, title: String, description: String? = nil, collectionImage: String? = nil, podcastCount: Int? = nil) {
+        self.uuid = uuid
+        self.title = title
+        self.description = description
+        self.collectionImage = collectionImage
+        self.podcastCount = podcastCount
+    }
+
+    public init?(from combinedResult: CombinedSearchResult) {
+        guard combinedResult.type == "network" else {
+            return nil
+        }
+        self.uuid = combinedResult.uuid
+        self.title = combinedResult.title
+        self.description = combinedResult.shortDescription
+        self.collectionImage = combinedResult.collectionImage
+        self.podcastCount = combinedResult.podcastCount
+    }
+}

--- a/Modules/Tests/PocketCastsServerTests/CombinedSearchNetworkTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/CombinedSearchNetworkTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+@testable import PocketCastsServer
+import XCTest
+
+final class CombinedSearchNetworkTests: XCTestCase {
+    /// A payload shaped like the one `search/combined` returns for a term matching a network.
+    private let json = """
+    {
+      "results": [
+        {
+          "uuid": "c59b45b0-0bc4-012e-fb02-00163e1b201c",
+          "title": "Planet Money",
+          "author": "NPR",
+          "explicit": null,
+          "is_video": false,
+          "type": "podcast"
+        },
+        {
+          "uuid": "c73d120f-c174-4324-b0a3-18f9b239a59d",
+          "title": "WNYC",
+          "subtitle": "",
+          "short_description": "New York's flagship public radio station",
+          "collection_image": "https://static.pocketcasts.net/share/images/c73d120f-author.png",
+          "web_url": "https://www.wnyc.org/shows/",
+          "web_title": "More from WNYC",
+          "url_path": "",
+          "podcast_count": 11,
+          "match_reason": "term",
+          "matched_podcast_count": 10,
+          "type": "network"
+        },
+        {
+          "uuid": "3f7b2c10-0000-0000-0000-000000000000",
+          "title": "Something new",
+          "type": "future_type"
+        }
+      ]
+    }
+    """
+
+    private func results() throws -> [CombinedSearchResultType] {
+        let envelope = try CombinedSearchTask.decoder.decode(CombinedSearchEnvelope.self, from: Data(json.utf8))
+        return envelope.results.compactMap { $0.resolvedResultType }
+    }
+
+    func testDecodesNetworkAlongsideOtherResults() throws {
+        let results = try results()
+
+        XCTAssertEqual(results.count, 2, "The unsupported type is dropped rather than failing the whole response")
+
+        guard case .podcast(let podcast) = results[0] else {
+            XCTFail("Expected the first result to stay a podcast, got \(results[0])")
+            return
+        }
+        XCTAssertEqual(podcast.title, "Planet Money")
+
+        guard case .network(let network) = results[1] else {
+            XCTFail("Expected the second result to be a network, got \(results[1])")
+            return
+        }
+        XCTAssertEqual(network.uuid, "c73d120f-c174-4324-b0a3-18f9b239a59d")
+        XCTAssertEqual(network.title, "WNYC")
+        XCTAssertEqual(network.description, "New York's flagship public radio station")
+        XCTAssertEqual(network.collectionImage, "https://static.pocketcasts.net/share/images/c73d120f-author.png")
+        XCTAssertEqual(network.podcastCount, 11)
+    }
+
+    /// Search returns no source of its own, so opening a network relies on this being the list's URL.
+    func testNetworkSourceIsItsList() throws {
+        let results = try results()
+
+        guard case .network(let network) = results[1] else {
+            XCTFail("Expected the second result to be a network, got \(results[1])")
+            return
+        }
+        XCTAssertEqual(network.source, "\(ServerConstants.Urls.lists())c73d120f-c174-4324-b0a3-18f9b239a59d.json")
+    }
+
+    func testNonNetworkResultDoesNotBecomeANetwork() throws {
+        let podcast = CombinedSearchResult(
+            type: "podcast",
+            uuid: "c59b45b0-0bc4-012e-fb02-00163e1b201c",
+            title: "Planet Money",
+            publishedDate: nil,
+            duration: nil,
+            podcastUuid: nil,
+            podcastTitle: nil,
+            author: "NPR",
+            explicit: nil,
+            isVideo: nil,
+            hasVideo: nil,
+            videoUrl: nil,
+            shortDescription: nil,
+            collectionImage: nil,
+            podcastCount: nil
+        )
+
+        XCTAssertNil(NetworkSearchResult(from: podcast))
+    }
+}

--- a/Modules/Tests/PocketCastsServerTests/CombinedSearchNetworkTests.swift
+++ b/Modules/Tests/PocketCastsServerTests/CombinedSearchNetworkTests.swift
@@ -33,6 +33,10 @@ final class CombinedSearchNetworkTests: XCTestCase {
           "uuid": "3f7b2c10-0000-0000-0000-000000000000",
           "title": "Something new",
           "type": "future_type"
+        },
+        {
+          "id": 42,
+          "type": "future_type_keyed_differently"
         }
       ]
     }
@@ -46,7 +50,7 @@ final class CombinedSearchNetworkTests: XCTestCase {
     func testDecodesNetworkAlongsideOtherResults() throws {
         let results = try results()
 
-        XCTAssertEqual(results.count, 2, "The unsupported type is dropped rather than failing the whole response")
+        XCTAssertEqual(results.count, 2, "The unsupported types are dropped rather than failing the whole response")
 
         guard case .podcast(let podcast) = results[0] else {
             XCTFail("Expected the first result to stay a podcast, got \(results[0])")
@@ -74,6 +78,14 @@ final class CombinedSearchNetworkTests: XCTestCase {
             return
         }
         XCTAssertEqual(network.source, "\(ServerConstants.Urls.lists())c73d120f-c174-4324-b0a3-18f9b239a59d.json")
+    }
+
+    /// A result type the app has never seen can be keyed however the server likes: it has to be
+    /// dropped on its own rather than taking the results around it down with it.
+    func testResultThatFailsToDecodeDoesNotFailTheWholeResponse() throws {
+        let envelope = try CombinedSearchTask.decoder.decode(CombinedSearchEnvelope.self, from: Data(json.utf8))
+
+        XCTAssertEqual(envelope.results.map(\.type), ["podcast", "network", "future_type"])
     }
 
     func testNonNetworkResultDoesNotBecomeANetwork() throws {

--- a/Pocket Casts TV App/Analytics/SearchAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/SearchAnalytics.swift
@@ -16,6 +16,14 @@ enum SearchAnalytics {
         ])
     }
 
+    static func networkTapped(_ network: NetworkSearchResult) {
+        Analytics.track(.searchResultTapped, properties: [
+            "source": source,
+            "uuid": network.uuid,
+            "result_type": "network"
+        ])
+    }
+
     static func podcastTapped(_ podcast: PodcastFolderSearchResult) {
         Analytics.track(.searchResultTapped, properties: [
             "source": source,

--- a/Pocket Casts TV App/UI/Search/SearchNetworkCard.swift
+++ b/Pocket Casts TV App/UI/Search/SearchNetworkCard.swift
@@ -1,0 +1,71 @@
+import Kingfisher
+import PocketCastsServer
+import SwiftUI
+
+/// A network in the search results, drawn as a cover card the way podcast results are.
+struct SearchNetworkCard: View {
+
+    enum Layout {
+        static let size = CGFloat(250)
+        static let cornerRadius = CGFloat(12)
+    }
+
+    let network: NetworkSearchResult
+
+    var size: CGFloat = Layout.size
+
+    var body: some View {
+        artwork
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous))
+            .focusedCardDepth(cornerRadius: Layout.cornerRadius, style: .surface)
+            .accessibilityElement()
+            .accessibilityLabel(network.accessibilityLabel)
+    }
+
+    @ViewBuilder
+    private var artwork: some View {
+        if let url = network.collectionImageURL {
+            KFImage(url)
+                .placeholder { _ in placeholder }
+                .fade(duration: 0.25)
+                .resizable()
+                .scaledToFill()
+        } else {
+            placeholder
+        }
+    }
+
+    private var placeholder: some View {
+        Color.pcBackgroundOverlay
+    }
+}
+
+extension NetworkSearchResult {
+    var collectionImageURL: URL? {
+        collectionImage.flatMap { URL(string: $0) }
+    }
+
+    var accessibilityLabel: String {
+        [title, description].compactMap { $0 }.joined(separator: ", ")
+    }
+}
+
+#Preview {
+    HStack(spacing: 48) {
+        SearchNetworkCard(network: NetworkSearchResult(
+            uuid: "c73d120f-c174-4324-b0a3-18f9b239a59d",
+            title: "WNYC",
+            description: "New York's flagship public radio station",
+            collectionImage: "https://static.pocketcasts.com/share/images/c73d120f-c174-4324-b0a3-18f9b239a59d-author.png",
+            podcastCount: 11
+        ))
+        SearchNetworkCard(network: NetworkSearchResult(
+            uuid: "cdb75bc0-9f5a-4217-b1ca-f573821a7913",
+            title: "Relay",
+            description: "The Relay network of podcasts.",
+            collectionImage: nil,
+            podcastCount: 4
+        ))
+    }
+}

--- a/Pocket Casts TV App/UI/Search/SearchNetworkView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchNetworkView.swift
@@ -1,0 +1,151 @@
+import PocketCastsServer
+import SwiftUI
+
+/// The screen a network tapped in search opens: the podcasts the network's list holds.
+struct SearchNetworkView: View {
+
+    fileprivate enum Layout {
+        static let gridSize = CGFloat(250)
+        static let descriptionWidth = CGFloat(1200)
+    }
+
+    @State private var model: SearchNetworkModel
+
+    init(network: NetworkSearchResult) {
+        _model = State(wrappedValue: SearchNetworkModel(network: network))
+    }
+
+    private let gridColumns: [GridItem] = (0..<6).map { _ in
+        GridItem(.fixed(Layout.gridSize), spacing: 48)
+    }
+
+    var body: some View {
+        ZStack {
+            switch model.state {
+            case .loading:
+                ProgressView()
+            case .ready:
+                podcastsView
+            case .empty:
+                ContentUnavailableView {
+                    Text(model.network.title)
+                } description: {
+                    Text(L10n.tvPodcastsEmptySubtitle)
+                }
+            case .failed:
+                DiscoverRetryView(style: .fullScreen) { await model.retry() }
+            }
+        }
+        .task {
+            await model.load()
+        }
+        .toolbar(.hidden, for: .tabBar)
+    }
+
+    private var podcastsView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 40) {
+                header
+                podcastGrid
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(model.network.title)
+                .font(.title2)
+                .foregroundStyle(Color.pcTextPrimary)
+            if let description = model.description, !description.isEmpty {
+                Text(description)
+                    .font(.body)
+                    .foregroundStyle(Color.pcTextSecondary)
+                    .frame(maxWidth: Layout.descriptionWidth, alignment: .leading)
+            }
+        }
+    }
+
+    private var podcastGrid: some View {
+        LazyVGrid(columns: gridColumns, spacing: 48) {
+            ForEach(model.podcasts, id: \.uuid) { podcast in
+                NavigationLink(value: podcast) {
+                    DiscoverPodcastCell(podcastUuid: podcast.uuid ?? "", isSponsored: false)
+                }
+                .buttonStyle(.card)
+                .accessibilityLabel(podcast.title ?? "")
+                .simultaneousGesture(TapGesture().onEnded {
+                    model.trackPodcastTapped(podcast)
+                })
+            }
+        }
+    }
+}
+
+@Observable
+@MainActor
+final class SearchNetworkModel {
+
+    enum State: Equatable {
+        case loading
+        case ready
+        case empty
+        case failed
+    }
+
+    let network: NetworkSearchResult
+
+    private(set) var state: State = .loading
+
+    private(set) var podcasts: [DiscoverPodcast] = []
+
+    /// The list's own blurb, which is longer than the one search returns.
+    private(set) var description: String?
+
+    private let serverHandler: DiscoverServerHandler
+
+    private var listId: String?
+
+    init(network: NetworkSearchResult, serverHandler: DiscoverServerHandler = DiscoverServerHandler.shared) {
+        self.network = network
+        self.serverHandler = serverHandler
+        self.description = network.description
+    }
+
+    func load() async {
+        guard case .loading = state else { return }
+
+        guard let collection = await serverHandler.discoverPodcastCollection(source: network.source, authenticated: nil) else {
+            state = .failed
+            return
+        }
+
+        podcasts = collection.podcasts ?? []
+        description = collection.description ?? network.description
+        listId = collection.listId ?? network.uuid
+        state = podcasts.isEmpty ? .empty : .ready
+    }
+
+    func retry() async {
+        state = .loading
+        await load()
+    }
+
+    func trackPodcastTapped(_ podcast: DiscoverPodcast) {
+        guard let podcastUuid = podcast.uuid, let listId else { return }
+
+        DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, source: DiscoverAnalytics.searchSource)
+    }
+}
+
+#Preview {
+    SearchNetworkView(network: NetworkSearchResult(
+        uuid: "c73d120f-c174-4324-b0a3-18f9b239a59d",
+        title: "WNYC",
+        description: "New York's flagship public radio station",
+        collectionImage: "https://static.pocketcasts.com/share/images/c73d120f-c174-4324-b0a3-18f9b239a59d-author.png",
+        podcastCount: 11
+    ))
+    .environment(AppCoordinator())
+    .environment(MainTabViewModel())
+}

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -12,6 +12,7 @@ enum SearchFocusSection {
     static let featured = "search_featured"
     static let episodes = "search_episodes"
     static let podcasts = "search_podcasts"
+    static let networks = "search_networks"
 }
 
 struct SearchResultsView<ViewModel: SearchableViewModel>: View {
@@ -58,6 +59,12 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                     } else {
                         episodeResults
                     }
+                case .networks:
+                    if model.networkResults.isEmpty {
+                        ContentUnavailableView.search(text: model.searchTerm)
+                    } else {
+                        networkResults
+                    }
                 }
             case .error(let error):
                 Text(L10n.tvSearchFailed(error.localizedDescription))
@@ -77,6 +84,9 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
         }
         .navigationDestination(for: PodcastFolderSearchResult.self) { podcast in
             PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: podcast.uuid))
+        }
+        .navigationDestination(for: NetworkSearchResult.self) { network in
+            SearchNetworkView(network: network)
         }
         .animation(.easeInOut, value: model.state)
         .animation(.easeInOut, value: model.scope)
@@ -104,6 +114,22 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                     case .episode, .network:
                         EmptyView()
                     }
+                }
+            })
+        }
+    }
+
+    var networkResults: some View {
+        ScrollView {
+            LazyVGrid(columns: items, spacing: 48, content: {
+                ForEach(model.networkResults, id: \.self) { network in
+                    NavigationLink(value: network) {
+                        SearchNetworkCard(network: network, size: Layout.cellSize)
+                    }
+                    .buttonStyle(.card)
+                    .simultaneousGesture(TapGesture().onEnded {
+                        SearchAnalytics.networkTapped(network)
+                    })
                 }
             })
         }

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -101,7 +101,7 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                         .simultaneousGesture(TapGesture().onEnded {
                             SearchAnalytics.podcastTapped(podcast)
                         })
-                    case .episode:
+                    case .episode, .network:
                         EmptyView()
                     }
                 }

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -42,7 +42,7 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
             case .results:
                 switch model.scope {
                 case .topResults:
-                    if model.podcastResults.isEmpty, model.episodeResults.isEmpty {
+                    if model.podcastResults.isEmpty, model.episodeResults.isEmpty, model.networkResults.isEmpty {
                         ContentUnavailableView.search(text: model.searchTerm)
                     } else {
                         SearchTopResultsView(model: model)

--- a/Pocket Casts TV App/UI/Search/SearchTopResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchTopResultsView.swift
@@ -22,6 +22,7 @@ struct SearchTopResultsView<ViewModel: SearchableViewModel>: View {
                 featuredRow
                 episodesRow
                 podcastsRow
+                networksRow
             }
         }
     }
@@ -67,6 +68,28 @@ struct SearchTopResultsView<ViewModel: SearchableViewModel>: View {
                         .setFocus(section: SearchFocusSection.podcasts)
                         .simultaneousGesture(TapGesture().onEnded {
                             SearchAnalytics.podcastTapped(podcast)
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var networksRow: some View {
+        let networks = Array(model.networkResults.prefix(Layout.maxItemsPerRow))
+        if !networks.isEmpty {
+            RowSection(title: L10n.searchFilterNetworks, focusSection: SearchFocusSection.networks) {
+                horizontalRow(spacing: Layout.podcastSpacing) {
+                    ForEach(networks, id: \.self) { network in
+                        NavigationLink(value: network) {
+                            SearchNetworkCard(network: network)
+                        }
+                        .buttonStyle(.card)
+                        .padding(.vertical, Layout.podcastPadding)
+                        .setFocus(section: SearchFocusSection.networks)
+                        .simultaneousGesture(TapGesture().onEnded {
+                            SearchAnalytics.networkTapped(network)
                         })
                     }
                 }

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -37,7 +37,7 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
             }
             .searchScopes($model.scope) {
                 if model.isInSearchMode {
-                    ForEach(SearchScope.allCases, id: \.self) { scope in
+                    ForEach(model.availableScopes, id: \.self) { scope in
                         Text(" \(scope.localizedName) ")
                             .tag(scope)
                     }

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 
 enum SearchScope: CaseIterable, Equatable {
     case topResults
     case podcasts
     case episodes
+    case networks
 
     var localizedName: String {
         switch self {
@@ -15,6 +17,8 @@ enum SearchScope: CaseIterable, Equatable {
             return L10n.podcastsPlural
         case .episodes:
             return L10n.episodes
+        case .networks:
+            return L10n.searchFilterNetworks
         }
     }
 
@@ -27,6 +31,8 @@ enum SearchScope: CaseIterable, Equatable {
             return "podcasts"
         case .episodes:
             return "episodes"
+        case .networks:
+            return "networks"
         }
     }
 }
@@ -59,6 +65,7 @@ protocol SearchableViewModel: AnyObject, Observation.Observable {
     var scope: SearchScope { get set }
     var podcastResults: [CombinedSearchResultType] { get }
     var episodeResults: [EpisodeSearchResult] { get }
+    var networkResults: [NetworkSearchResult] { get }
 
     /// `episodeResults` split into the episodes the `Featured` row previews and the
     /// ones left for the `Episodes` row. Partitioned once per search rather than on
@@ -79,6 +86,12 @@ protocol SearchableViewModel: AnyObject, Observation.Observable {
 }
 
 extension SearchableViewModel {
+    /// The scopes offered for the current results: Networks only joins them when the
+    /// term actually matched one.
+    var availableScopes: [SearchScope] {
+        networkResults.isEmpty ? [.topResults, .podcasts, .episodes] : SearchScope.allCases
+    }
+
     /// `podcastResults` only ever holds `.podcast` cases — this unwraps them for the
     /// rows that take a podcast directly.
     var podcastOnlyResults: [PodcastFolderSearchResult] {
@@ -142,6 +155,15 @@ class SearchViewModel: SearchableViewModel {
 
     private(set) var remainingEpisodeResults: [EpisodeSearchResult] = []
 
+    var networkResults: [NetworkSearchResult] = [] {
+        didSet {
+            // Searching again can leave Networks selected with nothing left to show.
+            if networkResults.isEmpty, scope == .networks {
+                scope = .topResults
+            }
+        }
+    }
+
     var searchHistory: [String] {
         searchModel.entries.compactMap(\.searchTerm)
     }
@@ -163,6 +185,7 @@ class SearchViewModel: SearchableViewModel {
         searchTask?.cancel()
         guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
             if !podcastResults.isEmpty { podcastResults = [] }
+            if !networkResults.isEmpty { networkResults = [] }
             if !autoCompleteSuggestions.isEmpty { autoCompleteSuggestions = [] }
             state = .query
             return
@@ -211,6 +234,7 @@ class SearchViewModel: SearchableViewModel {
                 saveHistory(query)
                 let fullResults = try await fullSearchTask.search(term: query)
                 var episodes: [EpisodeSearchResult] = []
+                var networks: [NetworkSearchResult] = []
                 for searchResult in fullResults {
                     switch searchResult {
                     case .podcast(let podcast):
@@ -219,9 +243,10 @@ class SearchViewModel: SearchableViewModel {
                         }
                     case .episode(let episode):
                         episodes.append(episode)
-                    case .network:
-                        // tvOS has no network surfaces yet.
-                        continue
+                    case .network(let network):
+                        if FeatureFlag.networkDiscovery.enabled {
+                            networks.append(network)
+                        }
                     }
                 }
 
@@ -229,7 +254,8 @@ class SearchViewModel: SearchableViewModel {
 
                 podcastResults = combinedPodcastsResults
                 episodeResults = episodes
-                let isEmpty = combinedPodcastsResults.isEmpty && episodes.isEmpty
+                networkResults = networks
+                let isEmpty = combinedPodcastsResults.isEmpty && episodes.isEmpty && networks.isEmpty
                 if isEmpty {
                     Analytics.track(.searchEmptyResults, properties: ["source": "search", "term": query])
                 }

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -219,6 +219,9 @@ class SearchViewModel: SearchableViewModel {
                         }
                     case .episode(let episode):
                         episodes.append(episode)
+                    case .network:
+                        // tvOS has no network surfaces yet.
+                        continue
                     }
                 }
 

--- a/PocketCastsTests/Tests/New Search/SearchNetworkNavigatorTests.swift
+++ b/PocketCastsTests/Tests/New Search/SearchNetworkNavigatorTests.swift
@@ -1,0 +1,187 @@
+import Combine
+import UIKit
+import XCTest
+
+@testable import podcasts
+@testable import PocketCastsServer
+
+/// Opening a network tapped in search: one screen per tap, and nothing for a tap the user moved on from.
+final class SearchNetworkNavigatorTests: XCTestCase {
+    private var window: UIWindow!
+    private var navigationController: RecordingNavigationController!
+    private var searchHost: UIViewController!
+    private var presenter: UIViewController!
+    private var serverHandler: MockDiscoverServerHandler!
+    private var navigator: SearchNetworkNavigator!
+
+    private let network = NetworkSearchResult(uuid: "c73d120f-c174-4324-b0a3-18f9b239a59d", title: "WNYC")
+    private let otherNetwork = NetworkSearchResult(uuid: "cdb75bc0-9f5a-4217-b1ca-f573821a7913", title: "Relay")
+
+    override func setUp() {
+        super.setUp()
+
+        // Search results are a child of the screen showing them, the way Discover and the podcast
+        // list present them, so the stack they push onto is the host's.
+        searchHost = UIViewController()
+        navigationController = RecordingNavigationController()
+        navigationController.setViewControllers([searchHost], animated: false)
+
+        presenter = UIViewController()
+        searchHost.addChild(presenter)
+        searchHost.view.addSubview(presenter.view)
+        presenter.didMove(toParent: searchHost)
+
+        // Results on screen: the navigator only pushes while its view is in a window, and the
+        // stack only puts its top screen's view there when it lays out.
+        window = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
+        window.rootViewController = navigationController
+        window.makeKeyAndVisible()
+        window.layoutIfNeeded()
+
+        XCTAssertNotNil(presenter.viewIfLoaded?.window, "The results have to start on screen for any of this to be about the navigator")
+
+        serverHandler = MockDiscoverServerHandler()
+        navigator = SearchNetworkNavigator(source: .discover, serverHandler: serverHandler)
+        navigator.presenter = presenter
+    }
+
+    override func tearDown() {
+        Toast.dismiss()
+        window.isHidden = true
+        window = nil
+        navigationController = nil
+        searchHost = nil
+        presenter = nil
+        navigator = nil
+        serverHandler = nil
+
+        super.tearDown()
+    }
+
+    func testShowsTheNetworksList() throws {
+        navigator.show(network)
+        serverHandler.complete(at: 0, with: collection())
+        drainMainQueue()
+
+        let pushed = try XCTUnwrap(navigationController.pushedViewControllers.first as? ExpandedCollectionViewController)
+        XCTAssertEqual(navigationController.pushedViewControllers.count, 1)
+        XCTAssertEqual(serverHandler.requestedSources, [network.source])
+        XCTAssertEqual(pushed.item.uuid, network.uuid)
+        XCTAssertEqual(pushed.item.expandedStyle, "grid")
+    }
+
+    func testTappingTheSameNetworkTwiceLoadsAndShowsItOnce() {
+        navigator.show(network)
+        navigator.show(network)
+
+        XCTAssertEqual(serverHandler.requestedSources, [network.source], "The second tap joins the request already in flight")
+
+        serverHandler.complete(at: 0, with: collection())
+        drainMainQueue()
+
+        XCTAssertEqual(navigationController.pushedViewControllers.count, 1)
+    }
+
+    func testASupersededNetworkIsNotShown() throws {
+        navigator.show(network)
+        navigator.show(otherNetwork)
+
+        serverHandler.complete(at: 0, with: collection())
+        drainMainQueue()
+
+        XCTAssertTrue(navigationController.pushedViewControllers.isEmpty, "The first network's late response is dropped")
+
+        serverHandler.complete(at: 1, with: collection())
+        drainMainQueue()
+
+        let pushed = try XCTUnwrap(navigationController.pushedViewControllers.first as? ExpandedCollectionViewController)
+        XCTAssertEqual(navigationController.pushedViewControllers.count, 1)
+        XCTAssertEqual(pushed.item.uuid, otherNetwork.uuid)
+    }
+
+    func testNothingIsShownOnceSearchHasGoneAway() {
+        navigator.show(network)
+
+        // Dismissing search takes its view off screen, as does pushing another screen over it.
+        presenter.view.removeFromSuperview()
+
+        serverHandler.complete(at: 0, with: collection())
+        drainMainQueue()
+
+        XCTAssertTrue(navigationController.pushedViewControllers.isEmpty)
+    }
+
+    func testAFailedLoadCanBeTappedAgain() {
+        navigator.show(network)
+        serverHandler.complete(at: 0, with: nil)
+        drainMainQueue()
+
+        XCTAssertTrue(navigationController.pushedViewControllers.isEmpty)
+
+        navigator.show(network)
+
+        XCTAssertEqual(serverHandler.requestedSources, [network.source, network.source])
+
+        serverHandler.complete(at: 1, with: collection())
+        drainMainQueue()
+
+        XCTAssertEqual(navigationController.pushedViewControllers.count, 1)
+    }
+
+    // MARK: - Helpers
+
+    private func collection() -> PodcastCollection {
+        try! JSONDecoder().decode(PodcastCollection.self, from: Data(#"{"podcasts": []}"#.utf8))
+    }
+
+    /// Waits for the work the navigator hops to the main queue, which runs after the test's own turn.
+    private func drainMainQueue() {
+        let drained = expectation(description: "main queue drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        wait(for: [drained], timeout: 1)
+    }
+}
+
+private final class RecordingNavigationController: UINavigationController {
+    private(set) var pushedViewControllers: [UIViewController] = []
+
+    /// Records the push without performing it, so the pushed screen's view is never loaded. The
+    /// root is set with `setViewControllers`, which doesn't come through here.
+    override func pushViewController(_ viewController: UIViewController, animated: Bool) {
+        pushedViewControllers.append(viewController)
+    }
+}
+
+private final class MockDiscoverServerHandler: DiscoverServerHandling {
+    private(set) var requestedSources: [String] = []
+    private var completions: [(PodcastCollection?) -> Void] = []
+
+    func complete(at index: Int, with collection: PodcastCollection?) {
+        completions[index](collection)
+    }
+
+    func discoverPodcastCollection(source: String, authenticated: Bool?, completion: @escaping (PodcastCollection?) -> Void) {
+        requestedSources.append(source)
+        completions.append(completion)
+    }
+
+    func discoverPodcastList(source: String, authenticated: Bool?, completion: @escaping (PodcastList?) -> Void) {
+        completion(nil)
+    }
+
+    func discoverCategories(source: String, authenticated: Bool?) async -> [DiscoverCategory] {
+        []
+    }
+
+    func discoverCategories(source: String, authenticated: Bool?, completion: @escaping ([DiscoverCategory]?) -> Void) {
+        completion(nil)
+    }
+
+    func discoverCategoryDetails(source: String, authenticated: Bool?, completion: @escaping (DiscoverCategoryDetails?) -> Void) {
+        completion(nil)
+    }
+
+    func discoverItem<T>(_ source: String?, authenticated: Bool, type: T.Type) -> AnyPublisher<T, Error> where T: Decodable {
+        Empty().eraseToAnyPublisher()
+    }
+}

--- a/podcasts/DiscoverNetworksListRowView.swift
+++ b/podcasts/DiscoverNetworksListRowView.swift
@@ -93,7 +93,7 @@ private struct DiscoverNetworkCard: View {
 
     var body: some View {
         VStack(spacing: 10) {
-            DiscoverNetworkArtwork(network: network, size: size)
+            NetworkArtworkView(url: network.collectionImageURL, size: size)
                 .clipShape(.circle)
             VStack(spacing: 2) {
                 if let title = network.title {
@@ -128,7 +128,7 @@ struct DiscoverNetworkPoster: View {
     var size: CGFloat?
 
     var body: some View {
-        DiscoverNetworkArtwork(network: network, size: size)
+        NetworkArtworkView(url: network.collectionImageURL, size: size)
             .cornerRadius(4)
             .accessibilityElement()
             .accessibilityLabel(network.accessibilityLabel)
@@ -137,16 +137,13 @@ struct DiscoverNetworkPoster: View {
 }
 
 /// A network's artwork, falling back to the grid placeholder while it loads or when there is none.
-private struct DiscoverNetworkArtwork: View {
+struct NetworkArtworkView: View {
 
-    let network: NetworkListSummary
+    /// The network's collection image, or `nil` to draw the placeholder in its place.
+    let url: URL?
 
     /// A fixed side length, or `nil` for the artwork to fill the space it's given.
     var size: CGFloat?
-
-    private var url: URL? {
-        network.collectionImage.flatMap { URL(string: $0) }
-    }
 
     var body: some View {
         Group {
@@ -185,6 +182,10 @@ private struct DiscoverNetworkArtwork: View {
 private extension NetworkListSummary {
     var accessibilityLabel: String {
         [title, description].compactMap { $0 }.joined(separator: ", ")
+    }
+
+    var collectionImageURL: URL? {
+        collectionImage.flatMap { URL(string: $0) }
     }
 }
 

--- a/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
+++ b/podcasts/New Search/Helpers/SearchAnalyticsHelper.swift
@@ -97,6 +97,12 @@ extension PodcastFolderSearchResult: AnalyticsSearchResultItem {
     }
 }
 
+extension NetworkSearchResult: AnalyticsSearchResultItem {
+    var analyticsDescription: String {
+        "network"
+    }
+}
+
 extension SearchHistoryEntry: AnalyticsSearchResultItem {
     var uuid: String {
         podcast?.uuid ?? episode?.uuid ?? ""

--- a/podcasts/New Search/Helpers/SearchNetworkNavigator.swift
+++ b/podcasts/New Search/Helpers/SearchNetworkNavigator.swift
@@ -1,0 +1,112 @@
+import PocketCastsDataModel
+import PocketCastsServer
+import UIKit
+
+/// Opens a network tapped in search, on the navigation stack search is presented in.
+///
+/// The screen it pushes is the one Discover uses for a network, ``ExpandedCollectionViewController``
+/// in its `grid` style, which asks its delegate for the podcasts' subscription state and taps —
+/// hence the ``DiscoverDelegate`` conformance. The Discover feed itself is out of reach from here,
+/// so the methods that navigate around it do nothing.
+final class SearchNetworkNavigator: ObservableObject {
+    /// The view controller hosting the search results, whose navigation controller is pushed onto.
+    weak var presenter: UIViewController?
+
+    private let source: AnalyticsSource
+    private let serverHandler: DiscoverServerHandling
+
+    init(source: AnalyticsSource, serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared) {
+        self.source = source
+        self.serverHandler = serverHandler
+    }
+
+    func show(_ network: NetworkSearchResult) {
+        serverHandler.discoverPodcastCollection(source: network.source, authenticated: nil) { [weak self] collection in
+            DispatchQueue.main.async {
+                guard let self, let collection else { return }
+
+                self.push(collection, for: network)
+            }
+        }
+    }
+
+    private func push(_ collection: PodcastCollection, for network: NetworkSearchResult) {
+        guard let navigationController = presenter?.navigationController else { return }
+
+        let controller = ExpandedCollectionViewController(item: discoverItem(for: network), podcasts: collection.podcasts ?? [])
+        controller.podcastCollection = collection
+        controller.registerDiscoverDelegate(self)
+        navigationController.pushViewController(controller, animated: true)
+    }
+
+    /// The network's list, as the `DiscoverItem` the expanded screen expects. It opens as a `grid`,
+    /// the same way a network opens from the Discover feed.
+    private func discoverItem(for network: NetworkSearchResult) -> DiscoverItem {
+        DiscoverItem(
+            id: network.uuid,
+            uuid: network.uuid,
+            title: network.title,
+            type: NetworkListSummary.supportedType,
+            summaryStyle: "collection",
+            expandedStyle: "grid",
+            source: network.source,
+            regions: []
+        )
+    }
+}
+
+extension SearchNetworkNavigator: DiscoverDelegate {
+    func navController() -> UINavigationController? {
+        presenter?.navigationController
+    }
+
+    func show(podcastInfo: PodcastInfo, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?) {
+        let podcastController = PodcastViewController(podcastInfo: podcastInfo, existingImage: placeholderImage)
+        podcastController.featuredPodcast = isFeatured
+        podcastController.listUuid = listUuid
+
+        navController()?.pushViewController(podcastController, animated: true)
+    }
+
+    func show(discoverPodcast: DiscoverPodcast, placeholderImage: UIImage?, isFeatured: Bool, listUuid: String?) {
+        var podcastInfo = PodcastInfo()
+        podcastInfo.populateFrom(discoverPodcast: discoverPodcast)
+        show(podcastInfo: podcastInfo, placeholderImage: placeholderImage, isFeatured: isFeatured, listUuid: listUuid)
+    }
+
+    func show(podcast: Podcast) {
+        navController()?.pushViewController(PodcastViewController(podcast: podcast), animated: true)
+    }
+
+    func isSubscribed(podcast: DiscoverPodcast) -> Bool {
+        guard let uuid = podcast.uuid else { return false }
+
+        return DataManager.sharedManager.findPodcast(uuid: uuid) != nil
+    }
+
+    func subscribe(podcast: DiscoverPodcast) {
+        if podcast.iTunesOnly(), let iTunesId = podcast.iTunesId, let id = Int(iTunesId) {
+            ServerPodcastManager.shared.subscribeFromItunesId(id, completion: nil)
+        } else if let uuid = podcast.uuid {
+            ServerPodcastManager.shared.subscribe(to: uuid, completion: nil)
+        }
+
+        HapticsHelper.triggerSubscribedHaptic()
+
+        Analytics.track(.podcastSubscribed, properties: ["source": source, "uuid": podcast.uuid ?? podcast.iTunesId ?? "unknown"])
+    }
+
+    func replaceRegionCode(string: String?) -> String? { string }
+
+    func replaceRegionName(string: String) -> String { string }
+
+    func showExpanded(item: DiscoverItem, category: DiscoverCategory?) {}
+    func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?) {}
+    func showExpanded(item: DiscoverItem, podcasts: [DiscoverPodcast], podcastCollection: PodcastCollection?, datetime: String?) {}
+    func showExpanded(item: DiscoverItem, episodes: [DiscoverEpisode], podcastCollection: PodcastCollection?) {}
+    func show(discoverEpisode: DiscoverEpisode, podcast: Podcast) {}
+    func failedToLoadEpisode() {}
+    func invalidate(item: DiscoverItem) {}
+    func navigateTo(category: String) {}
+    func navigateTo(listID: String) {}
+}

--- a/podcasts/New Search/Helpers/SearchNetworkNavigator.swift
+++ b/podcasts/New Search/Helpers/SearchNetworkNavigator.swift
@@ -15,23 +15,34 @@ final class SearchNetworkNavigator: ObservableObject {
     private let source: AnalyticsSource
     private let serverHandler: DiscoverServerHandling
 
+    private var pendingNetwork: NetworkSearchResult?
+
     init(source: AnalyticsSource, serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared) {
         self.source = source
         self.serverHandler = serverHandler
     }
 
     func show(_ network: NetworkSearchResult) {
+        guard pendingNetwork != network else { return }
+
+        pendingNetwork = network
         serverHandler.discoverPodcastCollection(source: network.source, authenticated: nil) { [weak self] collection in
             DispatchQueue.main.async {
-                guard let self, let collection else { return }
+                guard let self, self.pendingNetwork == network else { return }
 
-                self.push(collection, for: network)
+                self.pendingNetwork = nil
+                self.show(collection, for: network)
             }
         }
     }
 
-    private func push(_ collection: PodcastCollection, for network: NetworkSearchResult) {
-        guard let navigationController = presenter?.navigationController else { return }
+    private func show(_ collection: PodcastCollection?, for network: NetworkSearchResult) {
+        guard let presenter, presenter.viewIfLoaded?.window != nil, let navigationController = presenter.navigationController else { return }
+
+        guard let collection else {
+            Toast.show(L10n.searchNetworkFailToLoad)
+            return
+        }
 
         let controller = ExpandedCollectionViewController(item: discoverItem(for: network), podcasts: collection.podcasts ?? [])
         controller.podcastCollection = collection

--- a/podcasts/New Search/Model/SearchResultsModel.swift
+++ b/podcasts/New Search/Model/SearchResultsModel.swift
@@ -43,6 +43,14 @@ class SearchResultsModel: ObservableObject {
         podcasts.isEmpty && predictive.isEmpty && combinedResults.isEmpty
     }
 
+    /// The networks among ``combinedResults``, which the Networks filter and its rows are drawn from.
+    var networks: [NetworkSearchResult] {
+        combinedResults.compactMap {
+            guard case .network(let network) = $0 else { return nil }
+            return network
+        }
+    }
+
     func clearSearch() {
         podcasts = []
         combinedResults = []
@@ -192,6 +200,9 @@ class SearchResultsModel: ObservableObject {
 
     private func showCombinedResults(_ results: [CombinedSearchResultType]) {
         isShowingPredictiveSearch = false
-        combinedResults = results
+        combinedResults = results.filter { result in
+            guard case .network = result else { return true }
+            return FeatureFlag.networkDiscovery.enabled
+        }
     }
 }

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -18,18 +18,23 @@ class SearchResultsViewController: UIHostingController<AnyView> {
     private let searchHistoryModel = SearchHistoryModel.shared
     private let searchResults: SearchResultsModel
     private let searchAnalyticsHelper: SearchAnalyticsHelper
+    private let networkNavigator: SearchNetworkNavigator
 
     init(source: AnalyticsSource, showLocalResults: Bool = false) {
         searchAnalyticsHelper = SearchAnalyticsHelper(source: source)
         self.searchResults = SearchResultsModel(analyticsHelper: searchAnalyticsHelper, showLocalResults: showLocalResults)
+        self.networkNavigator = SearchNetworkNavigator(source: source)
         super.init(rootView: AnyView(
             SearchView()
             .setupDefaultEnvironment()
             .environmentObject(searchAnalyticsHelper)
             .environmentObject(searchResults)
             .environmentObject(searchHistoryModel)
+            .environmentObject(networkNavigator)
             .environmentObject(displaySearch))
         )
+
+        networkNavigator.presenter = self
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/podcasts/New Search/Views/Results/NetworkSearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/NetworkSearchResultCell.swift
@@ -1,0 +1,104 @@
+import PocketCastsServer
+import SwiftUI
+
+/// A network in the search results: round artwork beside its name and description.
+struct NetworkSearchResultCell: View {
+    @EnvironmentObject var theme: Theme
+    @EnvironmentObject var searchAnalyticsHelper: SearchAnalyticsHelper
+    @EnvironmentObject var networkNavigator: SearchNetworkNavigator
+
+    let network: NetworkSearchResult
+
+    let cellStyle: ListCellButtonStyle
+
+    @ScaledMetric(relativeTo: .subheadline) private var artworkSize = 56
+
+    var body: some View {
+        Button(action: open) {
+            rowContent
+        }
+        .buttonStyle(cellStyle)
+        .listRowInsets(EdgeInsets())
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private func open() {
+        searchAnalyticsHelper.trackResultTapped(network)
+        networkNavigator.show(network)
+    }
+
+    private var rowContent: some View {
+        HStack(spacing: 12) {
+            NetworkArtworkView(url: network.collectionImageURL, size: artworkSize)
+                .clipShape(.circle)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(network.title)
+                    .font(style: .subheadline, weight: .medium)
+                    .foregroundColor(AppTheme.color(for: .primaryText01, theme: theme))
+                    .lineLimit(2)
+                if let description = network.description, !description.isEmpty {
+                    Text(description)
+                        .font(style: .subheadline)
+                        .foregroundColor(AppTheme.color(for: .primaryText02, theme: theme))
+                        .lineLimit(2)
+                }
+            }
+            .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .contentShape(.rect)
+    }
+}
+
+extension NetworkSearchResult {
+    var collectionImageURL: URL? {
+        collectionImage.flatMap { URL(string: $0) }
+    }
+}
+
+#if DEBUG
+
+/// Networks as search returns them, for previews.
+enum NetworkSearchPreviewData {
+    static let networks = [
+        NetworkSearchResult(
+            uuid: "e07f76d0-0064-48d9-81a3-895de009f5c7",
+            title: "The New York Times",
+            description: "The best journalism and storytelling in one place.",
+            collectionImage: "https://static.pocketcasts.com/share/images/e07f76d0-0064-48d9-81a3-895de009f5c7-author.svg",
+            podcastCount: 8
+        ),
+        NetworkSearchResult(
+            uuid: "c73d120f-c174-4324-b0a3-18f9b239a59d",
+            title: "WNYC",
+            description: "New York's flagship public radio station",
+            collectionImage: "https://static.pocketcasts.com/share/images/c73d120f-c174-4324-b0a3-18f9b239a59d-author.png",
+            podcastCount: 11
+        ),
+        NetworkSearchResult(
+            uuid: "cdb75bc0-9f5a-4217-b1ca-f573821a7913",
+            title: "Relay",
+            description: "The Relay network of podcasts.",
+            collectionImage: nil,
+            podcastCount: 4
+        )
+    ]
+}
+
+#Preview("Network rows") {
+    List(NetworkSearchPreviewData.networks, id: \.self) { network in
+        NetworkSearchResultCell(network: network, cellStyle: ListCellButtonStyle(backgroundStyle: .primaryUi02))
+            .listRowBackground(AppTheme.color(for: .primaryUi02, theme: Theme.sharedTheme))
+    }
+    .listStyle(.plain)
+    .setupDefaultEnvironment()
+    .environmentObject(SearchAnalyticsHelper(source: .discover))
+    .environmentObject(SearchNetworkNavigator(source: .discover))
+}
+
+#endif

--- a/podcasts/New Search/Views/Results/SearchDisplayMode.swift
+++ b/podcasts/New Search/Views/Results/SearchDisplayMode.swift
@@ -4,6 +4,7 @@ enum SearchDisplayMode: String, AnalyticsDescribable, CaseIterable, Identifiable
     case allResults
     case podcasts
     case episodes
+    case networks
 
     var analyticsDescription: String {
         rawValue
@@ -21,6 +22,8 @@ enum SearchDisplayMode: String, AnalyticsDescribable, CaseIterable, Identifiable
                 return L10n.podcastsPlural
             case .episodes:
                 return L10n.episodes
+            case .networks:
+                return L10n.searchFilterNetworks
         }
     }
 }

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -69,7 +69,7 @@ struct SearchResultsView: View {
                         filterPicker
                     }
                     List {
-                        if displayMode != .episodes {
+                        if activeDisplayMode == .allResults || activeDisplayMode == .podcasts {
                             localResults
                         }
                         combinedList
@@ -80,7 +80,7 @@ struct SearchResultsView: View {
                     .scrollContentBackground(.hidden)
                     .ignoresSafeArea(.keyboard, edges: .bottom)
                     .onAppear() {
-                        self.searchAnalyticsHelper.trackListShown(displayMode)
+                        self.searchAnalyticsHelper.trackListShown(activeDisplayMode)
                     }
                 }
             }
@@ -100,8 +100,23 @@ struct SearchResultsView: View {
         .background(theme.searchBackground)
     }
 
+    /// The filters offered for the current results: Networks only joins them when there are any.
+    var availableFilters: [SearchDisplayMode] {
+        var filters: [SearchDisplayMode] = [.allResults, .podcasts, .episodes]
+        if !searchResults.networks.isEmpty {
+            filters.append(.networks)
+        }
+        return filters
+    }
+
+    /// The filter in effect, which falls back to Top Results when the selected one is no longer
+    /// offered — searching again can leave Networks selected with no networks to show.
+    var activeDisplayMode: SearchDisplayMode {
+        availableFilters.contains(displayMode) ? displayMode : .allResults
+    }
+
     @ViewBuilder var filterPicker: some View {
-        PillSegmentControl(SearchDisplayMode.allCases, selection: $displayMode) { item in
+        PillSegmentControl(availableFilters, selection: Binding(get: { activeDisplayMode }, set: { displayMode = $0 })) { item in
             Text(item.localizedDescription)
         }
         .padding(.bottom, 8)
@@ -115,7 +130,7 @@ struct SearchResultsView: View {
         let podcastsUuids = searchResults.podcasts.map({ result in
             result.uuid
         })
-        switch displayMode {
+        switch activeDisplayMode {
             case .allResults:
                 return searchResults.combinedResults.filter { result in
                     switch result {
@@ -141,6 +156,14 @@ struct SearchResultsView: View {
                         return false
                     }
                 }
+            case .networks:
+                return searchResults.combinedResults.filter { result in
+                    if case .network = result {
+                        return true
+                    } else {
+                        return false
+                    }
+                }
         }
     }
 
@@ -155,6 +178,12 @@ struct SearchResultsView: View {
                         }
                 case .episode(let episode):
                     SearchResultCell(episode: episode, result: nil, showDivider: false, cellStyle: ListCellButtonStyle(backgroundStyle: .searchBackground))
+                        .listRowBackground(theme.searchBackground)
+                        .alignmentGuide(.listRowSeparatorLeading) { _ in
+                            return 0
+                        }
+                case .network(let network):
+                    NetworkSearchResultCell(network: network, cellStyle: ListCellButtonStyle(backgroundStyle: .searchBackground))
                         .listRowBackground(theme.searchBackground)
                         .alignmentGuide(.listRowSeparatorLeading) { _ in
                             return 0
@@ -194,3 +223,20 @@ struct SearchResultsView_Previews: PreviewProvider {
             .previewWithAllThemes()
     }
 }
+
+#if DEBUG
+
+/// Results carrying networks, which is what puts the Networks filter on the pill row.
+#Preview("Results with networks") {
+    let searchResults = SearchResultsModel()
+    searchResults.combinedResults = NetworkSearchPreviewData.networks.map { .network($0) }
+
+    return SearchResultsView()
+        .setupDefaultEnvironment()
+        .environmentObject(searchResults)
+        .environmentObject(SearchAnalyticsHelper(source: .discover))
+        .environmentObject(SearchNetworkNavigator(source: .discover))
+        .environmentObject(SearchHistoryModel.shared)
+}
+
+#endif

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6648,3 +6648,6 @@
 
 /* Search Results filter option that narrows the results down to podcast networks */
 "search_filter_networks" = "Networks";
+
+/* Message shown when a network tapped in the search results fails to load */
+"search_network_fail_to_load" = "This network couldn't be loaded";

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6646,3 +6646,5 @@
 /* tv home failed to load message */
 "tv_home_failed_to_load_title" = "Home failed to load";
 
+/* Search Results filter option that narrows the results down to podcast networks */
+"search_filter_networks" = "Networks";


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-905

Adds networks to search, behind `FeatureFlag.networkDiscovery`. The combined search endpoint already returns `type: "network"` results; this parses them, shows them among **Top Results** in the order the server ranks them, and adds a **Networks** filter pill that only appears when a term matches one. Tapping a network opens `ExpandedCollectionViewController` — the same screen a network opens to from Discover.

### Notes for review

- **The chip row differs from the design.** The mockup shows a *collapsed* row — an ✕ chip plus the selected "Networks" chip. Here Networks joins the existing pill row instead; collapsing would change behaviour for the existing filters too, so it felt like a separate change. Happy to do it if it's meant to land with this.
- **Networks rank low in Top Results.** The server scores them well below podcasts (WNYC scored 81 vs. podcasts in the tens of thousands), so the network sits below the fold rather than near the top as the design implies. I kept the server's ordering — pinning networks to the top may belong server-side.

## Known Issues

Networks are ranked very low in the combined search – reported to the backend folks.

## To test

Production search doesn't return networks yet, so use a **staging** build.

1. Run a **staging** debug build (`networkDiscovery` defaults on in debug) and open the **Discover** tab.
2. Search for `WNYC`.
3. Confirm a **Networks** pill appears at the end of the filter row, and that scrolling **Top Results** shows a WNYC row with round artwork, its name and description.
4. Tap **Networks** — only the network rows remain.
5. Tap the WNYC row — it opens the WNYC collection with its header, description, "More from WNYC" link and podcast grid, matching what Discover's networks row opens.
6. Search for something with no networks (e.g. `swift`) and confirm the Networks pill is gone and the results are unchanged.
7. Turn `networkDiscovery` off in the feature flag settings and confirm search behaves exactly as before — no pill, no network rows.

<img width="510" height="377" alt="Screenshot 2026-08-28 at 11 11 51 AM" src="https://github.com/user-attachments/assets/46547c3b-8cfd-4270-8e63-8a92a1879a78" />
<img width="660" height="297" alt="Screenshot 2026-08-28 at 11 12 51 AM" src="https://github.com/user-attachments/assets/68695d21-8575-4bc3-9d1f-f1ab4268b7e5" />


## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
