### PR TITLE
Support networks in search on tvOS

### DIFF
--- a/Pocket Casts TV App/Analytics/SearchAnalytics.swift
+++ b/Pocket Casts TV App/Analytics/SearchAnalytics.swift
@@ -16,6 +16,14 @@ enum SearchAnalytics {
         ])
     }
 
+    static func networkTapped(_ network: NetworkSearchResult) {
+        Analytics.track(.searchResultTapped, properties: [
+            "source": source,
+            "uuid": network.uuid,
+            "result_type": "network"
+        ])
+    }
+
     static func podcastTapped(_ podcast: PodcastFolderSearchResult) {
         Analytics.track(.searchResultTapped, properties: [
             "source": source,

--- a/Pocket Casts TV App/UI/Search/SearchNetworkCard.swift
+++ b/Pocket Casts TV App/UI/Search/SearchNetworkCard.swift
@@ -1,0 +1,71 @@
+import Kingfisher
+import PocketCastsServer
+import SwiftUI
+
+/// A network in the search results, drawn as a cover card the way podcast results are.
+struct SearchNetworkCard: View {
+
+    enum Layout {
+        static let size = CGFloat(250)
+        static let cornerRadius = CGFloat(12)
+    }
+
+    let network: NetworkSearchResult
+
+    var size: CGFloat = Layout.size
+
+    var body: some View {
+        artwork
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius, style: .continuous))
+            .focusedCardDepth(cornerRadius: Layout.cornerRadius, style: .surface)
+            .accessibilityElement()
+            .accessibilityLabel(network.accessibilityLabel)
+    }
+
+    @ViewBuilder
+    private var artwork: some View {
+        if let url = network.collectionImageURL {
+            KFImage(url)
+                .placeholder { _ in placeholder }
+                .fade(duration: 0.25)
+                .resizable()
+                .scaledToFill()
+        } else {
+            placeholder
+        }
+    }
+
+    private var placeholder: some View {
+        Color.pcBackgroundOverlay
+    }
+}
+
+extension NetworkSearchResult {
+    var collectionImageURL: URL? {
+        collectionImage.flatMap { URL(string: $0) }
+    }
+
+    var accessibilityLabel: String {
+        [title, description].compactMap { $0 }.joined(separator: ", ")
+    }
+}
+
+#Preview {
+    HStack(spacing: 48) {
+        SearchNetworkCard(network: NetworkSearchResult(
+            uuid: "c73d120f-c174-4324-b0a3-18f9b239a59d",
+            title: "WNYC",
+            description: "New York's flagship public radio station",
+            collectionImage: "https://static.pocketcasts.com/share/images/c73d120f-c174-4324-b0a3-18f9b239a59d-author.png",
+            podcastCount: 11
+        ))
+        SearchNetworkCard(network: NetworkSearchResult(
+            uuid: "cdb75bc0-9f5a-4217-b1ca-f573821a7913",
+            title: "Relay",
+            description: "The Relay network of podcasts.",
+            collectionImage: nil,
+            podcastCount: 4
+        ))
+    }
+}

--- a/Pocket Casts TV App/UI/Search/SearchNetworkView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchNetworkView.swift
@@ -1,0 +1,151 @@
+import PocketCastsServer
+import SwiftUI
+
+/// The screen a network tapped in search opens: the podcasts the network's list holds.
+struct SearchNetworkView: View {
+
+    fileprivate enum Layout {
+        static let gridSize = CGFloat(250)
+        static let descriptionWidth = CGFloat(1200)
+    }
+
+    @State private var model: SearchNetworkModel
+
+    init(network: NetworkSearchResult) {
+        _model = State(wrappedValue: SearchNetworkModel(network: network))
+    }
+
+    private let gridColumns: [GridItem] = (0..<6).map { _ in
+        GridItem(.fixed(Layout.gridSize), spacing: 48)
+    }
+
+    var body: some View {
+        ZStack {
+            switch model.state {
+            case .loading:
+                ProgressView()
+            case .ready:
+                podcastsView
+            case .empty:
+                ContentUnavailableView {
+                    Text(model.network.title)
+                } description: {
+                    Text(L10n.tvPodcastsEmptySubtitle)
+                }
+            case .failed:
+                DiscoverRetryView(style: .fullScreen) { await model.retry() }
+            }
+        }
+        .task {
+            await model.load()
+        }
+        .toolbar(.hidden, for: .tabBar)
+    }
+
+    private var podcastsView: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 40) {
+                header
+                podcastGrid
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(model.network.title)
+                .font(.title2)
+                .foregroundStyle(Color.pcTextPrimary)
+            if let description = model.description, !description.isEmpty {
+                Text(description)
+                    .font(.body)
+                    .foregroundStyle(Color.pcTextSecondary)
+                    .frame(maxWidth: Layout.descriptionWidth, alignment: .leading)
+            }
+        }
+    }
+
+    private var podcastGrid: some View {
+        LazyVGrid(columns: gridColumns, spacing: 48) {
+            ForEach(model.podcasts, id: \.uuid) { podcast in
+                NavigationLink(value: podcast) {
+                    DiscoverPodcastCell(podcastUuid: podcast.uuid ?? "", isSponsored: false)
+                }
+                .buttonStyle(.card)
+                .accessibilityLabel(podcast.title ?? "")
+                .simultaneousGesture(TapGesture().onEnded {
+                    model.trackPodcastTapped(podcast)
+                })
+            }
+        }
+    }
+}
+
+@Observable
+@MainActor
+final class SearchNetworkModel {
+
+    enum State: Equatable {
+        case loading
+        case ready
+        case empty
+        case failed
+    }
+
+    let network: NetworkSearchResult
+
+    private(set) var state: State = .loading
+
+    private(set) var podcasts: [DiscoverPodcast] = []
+
+    /// The list's own blurb, which is longer than the one search returns.
+    private(set) var description: String?
+
+    private let serverHandler: DiscoverServerHandler
+
+    private var listId: String?
+
+    init(network: NetworkSearchResult, serverHandler: DiscoverServerHandler = DiscoverServerHandler.shared) {
+        self.network = network
+        self.serverHandler = serverHandler
+        self.description = network.description
+    }
+
+    func load() async {
+        guard case .loading = state else { return }
+
+        guard let collection = await serverHandler.discoverPodcastCollection(source: network.source, authenticated: nil) else {
+            state = .failed
+            return
+        }
+
+        podcasts = collection.podcasts ?? []
+        description = collection.description ?? network.description
+        listId = collection.listId ?? network.uuid
+        state = podcasts.isEmpty ? .empty : .ready
+    }
+
+    func retry() async {
+        state = .loading
+        await load()
+    }
+
+    func trackPodcastTapped(_ podcast: DiscoverPodcast) {
+        guard let podcastUuid = podcast.uuid, let listId else { return }
+
+        DiscoverAnalytics.podcastTapped(listId: listId, podcastUuid: podcastUuid, source: DiscoverAnalytics.searchSource)
+    }
+}
+
+#Preview {
+    SearchNetworkView(network: NetworkSearchResult(
+        uuid: "c73d120f-c174-4324-b0a3-18f9b239a59d",
+        title: "WNYC",
+        description: "New York's flagship public radio station",
+        collectionImage: "https://static.pocketcasts.com/share/images/c73d120f-c174-4324-b0a3-18f9b239a59d-author.png",
+        podcastCount: 11
+    ))
+    .environment(AppCoordinator())
+    .environment(MainTabViewModel())
+}

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -12,6 +12,7 @@ enum SearchFocusSection {
     static let featured = "search_featured"
     static let episodes = "search_episodes"
     static let podcasts = "search_podcasts"
+    static let networks = "search_networks"
 }
 
 struct SearchResultsView<ViewModel: SearchableViewModel>: View {
@@ -58,6 +59,12 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                     } else {
                         episodeResults
                     }
+                case .networks:
+                    if model.networkResults.isEmpty {
+                        ContentUnavailableView.search(text: model.searchTerm)
+                    } else {
+                        networkResults
+                    }
                 }
             case .error(let error):
                 Text(L10n.tvSearchFailed(error.localizedDescription))
@@ -77,6 +84,9 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
         }
         .navigationDestination(for: PodcastFolderSearchResult.self) { podcast in
             PodcastDetailView(model: PodcastDetailViewModel(podcastUuid: podcast.uuid))
+        }
+        .navigationDestination(for: NetworkSearchResult.self) { network in
+            SearchNetworkView(network: network)
         }
         .animation(.easeInOut, value: model.state)
         .animation(.easeInOut, value: model.scope)
@@ -104,6 +114,22 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
                     case .episode, .network:
                         EmptyView()
                     }
+                }
+            })
+        }
+    }
+
+    var networkResults: some View {
+        ScrollView {
+            LazyVGrid(columns: items, spacing: 48, content: {
+                ForEach(model.networkResults, id: \.self) { network in
+                    NavigationLink(value: network) {
+                        SearchNetworkCard(network: network, size: Layout.cellSize)
+                    }
+                    .buttonStyle(.card)
+                    .simultaneousGesture(TapGesture().onEnded {
+                        SearchAnalytics.networkTapped(network)
+                    })
                 }
             })
         }

--- a/Pocket Casts TV App/UI/Search/SearchResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchResultsView.swift
@@ -42,7 +42,7 @@ struct SearchResultsView<ViewModel: SearchableViewModel>: View {
             case .results:
                 switch model.scope {
                 case .topResults:
-                    if model.podcastResults.isEmpty, model.episodeResults.isEmpty {
+                    if model.podcastResults.isEmpty, model.episodeResults.isEmpty, model.networkResults.isEmpty {
                         ContentUnavailableView.search(text: model.searchTerm)
                     } else {
                         SearchTopResultsView(model: model)

--- a/Pocket Casts TV App/UI/Search/SearchTopResultsView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchTopResultsView.swift
@@ -22,6 +22,7 @@ struct SearchTopResultsView<ViewModel: SearchableViewModel>: View {
                 featuredRow
                 episodesRow
                 podcastsRow
+                networksRow
             }
         }
     }
@@ -67,6 +68,28 @@ struct SearchTopResultsView<ViewModel: SearchableViewModel>: View {
                         .setFocus(section: SearchFocusSection.podcasts)
                         .simultaneousGesture(TapGesture().onEnded {
                             SearchAnalytics.podcastTapped(podcast)
+                        })
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var networksRow: some View {
+        let networks = Array(model.networkResults.prefix(Layout.maxItemsPerRow))
+        if !networks.isEmpty {
+            RowSection(title: L10n.searchFilterNetworks, focusSection: SearchFocusSection.networks) {
+                horizontalRow(spacing: Layout.podcastSpacing) {
+                    ForEach(networks, id: \.self) { network in
+                        NavigationLink(value: network) {
+                            SearchNetworkCard(network: network)
+                        }
+                        .buttonStyle(.card)
+                        .padding(.vertical, Layout.podcastPadding)
+                        .setFocus(section: SearchFocusSection.networks)
+                        .simultaneousGesture(TapGesture().onEnded {
+                            SearchAnalytics.networkTapped(network)
                         })
                     }
                 }

--- a/Pocket Casts TV App/UI/Search/SearchView.swift
+++ b/Pocket Casts TV App/UI/Search/SearchView.swift
@@ -37,7 +37,7 @@ struct SearchView<ViewModel: SearchableViewModel>: View {
             }
             .searchScopes($model.scope) {
                 if model.isInSearchMode {
-                    ForEach(SearchScope.allCases, id: \.self) { scope in
+                    ForEach(model.availableScopes, id: \.self) { scope in
                         Text(" \(scope.localizedName) ")
                             .tag(scope)
                     }

--- a/Pocket Casts TV App/UI/Search/SearchViewModel.swift
+++ b/Pocket Casts TV App/UI/Search/SearchViewModel.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import PocketCastsDataModel
 import PocketCastsServer
+import PocketCastsUtils
 
 enum SearchScope: CaseIterable, Equatable {
     case topResults
     case podcasts
     case episodes
+    case networks
 
     var localizedName: String {
         switch self {
@@ -15,6 +17,8 @@ enum SearchScope: CaseIterable, Equatable {
             return L10n.podcastsPlural
         case .episodes:
             return L10n.episodes
+        case .networks:
+            return L10n.searchFilterNetworks
         }
     }
 
@@ -27,6 +31,8 @@ enum SearchScope: CaseIterable, Equatable {
             return "podcasts"
         case .episodes:
             return "episodes"
+        case .networks:
+            return "networks"
         }
     }
 }
@@ -59,6 +65,7 @@ protocol SearchableViewModel: AnyObject, Observation.Observable {
     var scope: SearchScope { get set }
     var podcastResults: [CombinedSearchResultType] { get }
     var episodeResults: [EpisodeSearchResult] { get }
+    var networkResults: [NetworkSearchResult] { get }
 
     /// `episodeResults` split into the episodes the `Featured` row previews and the
     /// ones left for the `Episodes` row. Partitioned once per search rather than on
@@ -79,6 +86,12 @@ protocol SearchableViewModel: AnyObject, Observation.Observable {
 }
 
 extension SearchableViewModel {
+    /// The scopes offered for the current results: Networks only joins them when the
+    /// term actually matched one.
+    var availableScopes: [SearchScope] {
+        networkResults.isEmpty ? [.topResults, .podcasts, .episodes] : SearchScope.allCases
+    }
+
     /// `podcastResults` only ever holds `.podcast` cases — this unwraps them for the
     /// rows that take a podcast directly.
     var podcastOnlyResults: [PodcastFolderSearchResult] {
@@ -142,6 +155,15 @@ class SearchViewModel: SearchableViewModel {
 
     private(set) var remainingEpisodeResults: [EpisodeSearchResult] = []
 
+    var networkResults: [NetworkSearchResult] = [] {
+        didSet {
+            // Searching again can leave Networks selected with nothing left to show.
+            if networkResults.isEmpty, scope == .networks {
+                scope = .topResults
+            }
+        }
+    }
+
     var searchHistory: [String] {
         searchModel.entries.compactMap(\.searchTerm)
     }
@@ -163,6 +185,7 @@ class SearchViewModel: SearchableViewModel {
         searchTask?.cancel()
         guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
             if !podcastResults.isEmpty { podcastResults = [] }
+            if !networkResults.isEmpty { networkResults = [] }
             if !autoCompleteSuggestions.isEmpty { autoCompleteSuggestions = [] }
             state = .query
             return
@@ -211,6 +234,7 @@ class SearchViewModel: SearchableViewModel {
                 saveHistory(query)
                 let fullResults = try await fullSearchTask.search(term: query)
                 var episodes: [EpisodeSearchResult] = []
+                var networks: [NetworkSearchResult] = []
                 for searchResult in fullResults {
                     switch searchResult {
                     case .podcast(let podcast):
@@ -219,9 +243,10 @@ class SearchViewModel: SearchableViewModel {
                         }
                     case .episode(let episode):
                         episodes.append(episode)
-                    case .network:
-                        // tvOS has no network surfaces yet.
-                        continue
+                    case .network(let network):
+                        if FeatureFlag.networkDiscovery.enabled {
+                            networks.append(network)
+                        }
                     }
                 }
 
@@ -229,7 +254,8 @@ class SearchViewModel: SearchableViewModel {
 
                 podcastResults = combinedPodcastsResults
                 episodeResults = episodes
-                let isEmpty = combinedPodcastsResults.isEmpty && episodes.isEmpty
+                networkResults = networks
+                let isEmpty = combinedPodcastsResults.isEmpty && episodes.isEmpty && networks.isEmpty
                 if isEmpty {
                     Analytics.track(.searchEmptyResults, properties: ["source": "search", "term": query])
                 }


### PR DESCRIPTION
| 📘 Part of: # |  <!-- project issue number, if applicable -->
|:---:|

Fixes PCIOS-905

Brings the network search results from #5036 to tvOS, behind `FeatureFlag.networkDiscovery`.

- A **Networks** scope joins the search scopes, and only when the term actually matched one. If a later search has no networks, a selected Networks scope falls back to Top Results.
- **Top Results** gains a Networks row, and the Networks scope shows the full grid.
- Network results are drawn as cover cards — the same treatment podcast results get, no circle or title. The `collection_image` is a full-bleed square, so it reads like a podcast cover.
- Selecting a network opens `SearchNetworkView`: the list's title and description above a grid of its podcasts, which push straight into the existing podcast detail.

Stacked on #5036 — **base that first**, this branch targets `network-search`. That PR carries the minimal change that keeps this target compiling once `CombinedSearchResultType` gains its `.network` case; this one replaces the placeholder with real support.

### Notes for review

- **Not verified at runtime.** There's no tvOS UI-test target and no way to drive the tvOS simulator from here, so this is compile- and preview-verified only. `SearchNetworkCard` mirrors `PodcastCoverCard`, and `SearchNetworkView` mirrors `DiscoverPodcastsListView`, so the risk is mostly layout. Worth a pass on a real device or the simulator.
- **Networks are still missing from the tvOS Discover feed.** `lists_list` has no `rowType` mapping, so it's skipped there — this PR only covers search.

## To test

Production search doesn't return networks yet, so use a **staging** build.

1. Run a **staging** debug build of the tvOS app (`networkDiscovery` defaults on in debug) and open **Search**.
2. Search for `WNYC`.
3. Confirm a **Networks** scope appears alongside Top Results / Podcasts / Episodes, and that **Top Results** shows a Networks row with the WNYC cover card.
4. Select the **Networks** scope — the grid shows the network covers.
5. Select WNYC — it opens the network's title, description and a grid of its podcasts.
6. Select a podcast from that grid and confirm it opens the podcast detail.
7. Search for something with no networks (e.g. `swift`) and confirm the Networks scope disappears and results are unchanged.
8. Turn `networkDiscovery` off and confirm search behaves exactly as before.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
