### PR TITLE
Open a podcast's network from its header

### DIFF
--- a/PocketCastsTests/Tests/Discover/NetworkNavigatorTests.swift
+++ b/PocketCastsTests/Tests/Discover/NetworkNavigatorTests.swift
@@ -5,43 +5,46 @@ import XCTest
 @testable import podcasts
 @testable import PocketCastsServer
 
-/// Opening a network tapped in search: one screen per tap, and nothing for a tap the user moved on from.
-final class SearchNetworkNavigatorTests: XCTestCase {
+/// Opening a network: one screen per tap, and nothing for a tap the user moved on from.
+final class NetworkNavigatorTests: XCTestCase {
     private var window: UIWindow!
     private var navigationController: RecordingNavigationController!
-    private var searchHost: UIViewController!
+    private var host: UIViewController!
     private var presenter: UIViewController!
     private var serverHandler: MockDiscoverServerHandler!
-    private var navigator: SearchNetworkNavigator!
+    private var navigator: NetworkNavigator!
 
-    private let network = NetworkSearchResult(uuid: "c73d120f-c174-4324-b0a3-18f9b239a59d", title: "WNYC")
-    private let otherNetwork = NetworkSearchResult(uuid: "cdb75bc0-9f5a-4217-b1ca-f573821a7913", title: "Relay")
+    private let listId = "c73d120f-c174-4324-b0a3-18f9b239a59d"
+    private let otherListId = "cdb75bc0-9f5a-4217-b1ca-f573821a7913"
+
+    private var source: String { ServerHelper.listUrlString(listId: listId) }
+    private var otherSource: String { ServerHelper.listUrlString(listId: otherListId) }
 
     override func setUp() {
         super.setUp()
 
-        // Search results are a child of the screen showing them, the way Discover and the podcast
-        // list present them, so the stack they push onto is the host's.
-        searchHost = UIViewController()
+        // The screen asking for a network can be a child of the one on the stack — search is,
+        // presented by Discover and by the podcast list — so the stack pushed onto is the host's.
+        host = UIViewController()
         navigationController = RecordingNavigationController()
-        navigationController.setViewControllers([searchHost], animated: false)
+        navigationController.setViewControllers([host], animated: false)
 
         presenter = UIViewController()
-        searchHost.addChild(presenter)
-        searchHost.view.addSubview(presenter.view)
-        presenter.didMove(toParent: searchHost)
+        host.addChild(presenter)
+        host.view.addSubview(presenter.view)
+        presenter.didMove(toParent: host)
 
-        // Results on screen: the navigator only pushes while its view is in a window, and the
-        // stack only puts its top screen's view there when it lays out.
+        // The asking screen on screen: the navigator only pushes while its view is in a window,
+        // and the stack only puts its top screen's view there when it lays out.
         window = UIWindow(frame: CGRect(x: 0, y: 0, width: 375, height: 667))
         window.rootViewController = navigationController
         window.makeKeyAndVisible()
         window.layoutIfNeeded()
 
-        XCTAssertNotNil(presenter.viewIfLoaded?.window, "The results have to start on screen for any of this to be about the navigator")
+        XCTAssertNotNil(presenter.viewIfLoaded?.window, "The screen has to start on screen for any of this to be about the navigator")
 
         serverHandler = MockDiscoverServerHandler()
-        navigator = SearchNetworkNavigator(source: .discover, serverHandler: serverHandler)
+        navigator = NetworkNavigator(source: .discover, serverHandler: serverHandler)
         navigator.presenter = presenter
     }
 
@@ -50,7 +53,7 @@ final class SearchNetworkNavigatorTests: XCTestCase {
         window.isHidden = true
         window = nil
         navigationController = nil
-        searchHost = nil
+        host = nil
         presenter = nil
         navigator = nil
         serverHandler = nil
@@ -59,22 +62,22 @@ final class SearchNetworkNavigatorTests: XCTestCase {
     }
 
     func testShowsTheNetworksList() throws {
-        navigator.show(network)
+        navigator.show(listId: listId)
         serverHandler.complete(at: 0, with: collection())
         drainMainQueue()
 
         let pushed = try XCTUnwrap(navigationController.pushedViewControllers.first as? ExpandedCollectionViewController)
         XCTAssertEqual(navigationController.pushedViewControllers.count, 1)
-        XCTAssertEqual(serverHandler.requestedSources, [network.source])
-        XCTAssertEqual(pushed.item.uuid, network.uuid)
+        XCTAssertEqual(serverHandler.requestedSources, [source])
+        XCTAssertEqual(pushed.item.uuid, listId)
         XCTAssertEqual(pushed.item.expandedStyle, "grid")
     }
 
     func testTappingTheSameNetworkTwiceLoadsAndShowsItOnce() {
-        navigator.show(network)
-        navigator.show(network)
+        navigator.show(listId: listId)
+        navigator.show(listId: listId)
 
-        XCTAssertEqual(serverHandler.requestedSources, [network.source], "The second tap joins the request already in flight")
+        XCTAssertEqual(serverHandler.requestedSources, [source], "The second tap joins the request already in flight")
 
         serverHandler.complete(at: 0, with: collection())
         drainMainQueue()
@@ -83,8 +86,10 @@ final class SearchNetworkNavigatorTests: XCTestCase {
     }
 
     func testASupersededNetworkIsNotShown() throws {
-        navigator.show(network)
-        navigator.show(otherNetwork)
+        navigator.show(listId: listId)
+        navigator.show(listId: otherListId)
+
+        XCTAssertEqual(serverHandler.requestedSources, [source, otherSource])
 
         serverHandler.complete(at: 0, with: collection())
         drainMainQueue()
@@ -96,11 +101,11 @@ final class SearchNetworkNavigatorTests: XCTestCase {
 
         let pushed = try XCTUnwrap(navigationController.pushedViewControllers.first as? ExpandedCollectionViewController)
         XCTAssertEqual(navigationController.pushedViewControllers.count, 1)
-        XCTAssertEqual(pushed.item.uuid, otherNetwork.uuid)
+        XCTAssertEqual(pushed.item.uuid, otherListId)
     }
 
-    func testNothingIsShownOnceSearchHasGoneAway() {
-        navigator.show(network)
+    func testNothingIsShownOnceTheScreenHasGoneAway() {
+        navigator.show(listId: listId)
 
         // Dismissing search takes its view off screen, as does pushing another screen over it.
         presenter.view.removeFromSuperview()
@@ -112,15 +117,15 @@ final class SearchNetworkNavigatorTests: XCTestCase {
     }
 
     func testAFailedLoadCanBeTappedAgain() {
-        navigator.show(network)
+        navigator.show(listId: listId)
         serverHandler.complete(at: 0, with: nil)
         drainMainQueue()
 
         XCTAssertTrue(navigationController.pushedViewControllers.isEmpty)
 
-        navigator.show(network)
+        navigator.show(listId: listId)
 
-        XCTAssertEqual(serverHandler.requestedSources, [network.source, network.source])
+        XCTAssertEqual(serverHandler.requestedSources, [source, source])
 
         serverHandler.complete(at: 1, with: collection())
         drainMainQueue()
@@ -128,10 +133,30 @@ final class SearchNetworkNavigatorTests: XCTestCase {
         XCTAssertEqual(navigationController.pushedViewControllers.count, 1)
     }
 
+    func testACallerThatKnowsTheNetworksNameUsesIt() throws {
+        navigator.show(listId: listId, title: "WNYC")
+        serverHandler.complete(at: 0, with: collection(title: "WNYC Studios"))
+        drainMainQueue()
+
+        let pushed = try XCTUnwrap(navigationController.pushedViewControllers.first as? ExpandedCollectionViewController)
+        XCTAssertEqual(pushed.item.title, "WNYC")
+    }
+
+    func testANetworkNamesItselfForACallerThatDoesnt() throws {
+        navigator.show(listId: listId)
+        serverHandler.complete(at: 0, with: collection(title: "WNYC Studios"))
+        drainMainQueue()
+
+        let pushed = try XCTUnwrap(navigationController.pushedViewControllers.first as? ExpandedCollectionViewController)
+        XCTAssertEqual(pushed.item.title, "WNYC Studios")
+    }
+
     // MARK: - Helpers
 
-    private func collection() -> PodcastCollection {
-        try! JSONDecoder().decode(PodcastCollection.self, from: Data(#"{"podcasts": []}"#.utf8))
+    private func collection(title: String? = nil) -> PodcastCollection {
+        var collection = try! JSONDecoder().decode(PodcastCollection.self, from: Data(#"{"podcasts": []}"#.utf8))
+        collection.title = title
+        return collection
     }
 
     /// Waits for the work the navigator hops to the main queue, which runs after the test's own turn.

--- a/PocketCastsTests/Tests/Podcasts/PodcastHeaderViewModelTests.swift
+++ b/PocketCastsTests/Tests/Podcasts/PodcastHeaderViewModelTests.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+import XCTest
+
+@testable import podcasts
+@testable import PocketCastsDataModel
+@testable import PocketCastsUtils
+
+/// The header's category and author line: what each part is, and where tapping it goes.
+final class PodcastHeaderViewModelTests: XCTestCase {
+    private let featureFlagMock = FeatureFlagMock()
+
+    override func setUp() {
+        super.setUp()
+        featureFlagMock.set(.networkDiscovery, value: true)
+    }
+
+    override func tearDown() {
+        featureFlagMock.reset()
+        super.tearDown()
+    }
+
+    func testTheAuthorOpensTheNetworkThePodcastBelongsTo() {
+        let line = viewModel(networkListId: "cdb75bc0-9f5a-4217-b1ca-f573821a7913").displayCategoryAndAuthor(networkTint: .red)
+
+        XCTAssertEqual(text(of: line, linkedTo: .category), "Technology")
+        XCTAssertEqual(text(of: line, linkedTo: .author), "Relay")
+    }
+
+    func testTheAuthorOfAPodcastWithoutANetworkIsPlainText() {
+        let line = viewModel(networkListId: nil).displayCategoryAndAuthor(networkTint: .red)
+
+        XCTAssertEqual(String(line.characters), "Technology · Relay")
+        XCTAssertNil(text(of: line, linkedTo: .author))
+    }
+
+    func testANetworkIsOnlyOfferedWhileTheAppShowsNetworks() {
+        featureFlagMock.set(.networkDiscovery, value: false)
+
+        let line = viewModel(networkListId: "cdb75bc0-9f5a-4217-b1ca-f573821a7913").displayCategoryAndAuthor(networkTint: .red)
+
+        XCTAssertNil(text(of: line, linkedTo: .author))
+    }
+
+    func testTheNetworkIsDrawnInThePodcastsOwnColour() {
+        let line = viewModel(networkListId: "cdb75bc0-9f5a-4217-b1ca-f573821a7913").displayCategoryAndAuthor(networkTint: .red)
+
+        let author = line.runs.first { $0.link == PodcastHeaderLink.author.url }
+        XCTAssertEqual(author?.foregroundColor, .red)
+    }
+
+    func testALinkIsRecognisedFromItsURL() {
+        XCTAssertEqual(PodcastHeaderLink(url: PodcastHeaderLink.category.url), .category)
+        XCTAssertEqual(PodcastHeaderLink(url: PodcastHeaderLink.author.url), .author)
+        XCTAssertNil(PodcastHeaderLink(url: URL(string: "https://pocketcasts.com")!))
+    }
+
+    // MARK: - Helpers
+
+    private func viewModel(networkListId: String?) -> PodcastHeaderViewModel {
+        let podcast = Podcast()
+        podcast.podcastCategory = "Technology"
+        podcast.author = "Relay"
+        podcast.networkListId = networkListId
+
+        return PodcastHeaderViewModel(podcast: podcast)
+    }
+
+    private func text(of line: AttributedString, linkedTo link: PodcastHeaderLink) -> String? {
+        guard let run = line.runs.first(where: { $0.link == link.url }) else { return nil }
+
+        return String(line[run.range].characters)
+    }
+}

--- a/podcasts.xcodeproj/project.pbxproj
+++ b/podcasts.xcodeproj/project.pbxproj
@@ -1402,6 +1402,7 @@
 		FFA1000000000000000011AA /* DiscoverNetworksListRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA1000000000000000001AA /* DiscoverNetworksListRowView.swift */; };
 		FFA1000000000000000012AA /* DiscoverNetworksListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA1000000000000000002AA /* DiscoverNetworksListModel.swift */; };
 		FFA1000000000000000013AA /* DiscoverNetworksListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA1000000000000000003AA /* DiscoverNetworksListViewController.swift */; };
+		FFA1000000000000000014AA /* NetworkNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA1000000000000000004AA /* NetworkNavigator.swift */; };
 		FFB74B0F2E993A8C00F16857 /* end_of_year_2025_intro.json in Resources */ = {isa = PBXBuildFile; fileRef = FFB74B0D2E993A8C00F16857 /* end_of_year_2025_intro.json */; };
 		FFE067392F86ADD000437ACC /* TranscriptFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF54BCA82C5A2F3900A342E5 /* TranscriptFormat.swift */; };
 		FFE4107F2FBB5FED00716EAA /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 8B10E78528D908A900702C54 /* GoogleService-Info.plist */; };
@@ -2741,6 +2742,7 @@
 		FFA1000000000000000001AA /* DiscoverNetworksListRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverNetworksListRowView.swift; sourceTree = "<group>"; };
 		FFA1000000000000000002AA /* DiscoverNetworksListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverNetworksListModel.swift; sourceTree = "<group>"; };
 		FFA1000000000000000003AA /* DiscoverNetworksListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoverNetworksListViewController.swift; sourceTree = "<group>"; };
+		FFA1000000000000000004AA /* NetworkNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkNavigator.swift; sourceTree = "<group>"; };
 		FFB74B0D2E993A8C00F16857 /* end_of_year_2025_intro.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = end_of_year_2025_intro.json; sourceTree = "<group>"; };
 		FFEE599B2EB378B300D4B145 /* Humane-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Humane-SemiBold.otf"; sourceTree = "<group>"; };
 		FFEE59C22EB37F4300D4B145 /* playback2025_listening_time.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = playback2025_listening_time.json; sourceTree = "<group>"; };
@@ -4226,6 +4228,7 @@
 				FFA1000000000000000001AA /* DiscoverNetworksListRowView.swift */,
 				FFA1000000000000000002AA /* DiscoverNetworksListModel.swift */,
 				FFA1000000000000000003AA /* DiscoverNetworksListViewController.swift */,
+				FFA1000000000000000004AA /* NetworkNavigator.swift */,
 			);
 			name = Network;
 			sourceTree = "<group>";
@@ -7439,6 +7442,7 @@
 				FFA1000000000000000011AA /* DiscoverNetworksListRowView.swift in Sources */,
 				FFA1000000000000000012AA /* DiscoverNetworksListModel.swift in Sources */,
 				FFA1000000000000000013AA /* DiscoverNetworksListViewController.swift in Sources */,
+				FFA1000000000000000014AA /* NetworkNavigator.swift in Sources */,
 				BDEBD3A91BA0108800AD038F /* BufferedAudio.swift in Sources */,
 				402772D721B6105D00769811 /* PodcastManager+Delete.swift in Sources */,
 				FF5381B12C91C6EF00829525 /* ReferralsOfferInfo.swift in Sources */,

--- a/podcasts/Analytics/AnalyticsEvent.swift
+++ b/podcasts/Analytics/AnalyticsEvent.swift
@@ -411,6 +411,7 @@ enum AnalyticsEvent: String {
     case podcastScreenNotificationsTapped
     case podcastScreenPodcastDetailsLinkTapped
     case podcastScreenCategoryTapped
+    case podcastScreenNetworkTapped
     case podcastScreenYouMightLikeTapped
     case podcastScreenYouMightLikeSubscribed
     case podcastScreenSeasonOptionsTapped

--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -41,6 +41,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case playerPlaybackEffects = "player_playback_effects"
     case playerSkipForwardLongPress = "player_skip_forward_long_press"
     case podcastScreen = "podcast_screen"
+    case podcastScreenNetwork = "podcast_screen_network"
     case podcastScreenYouMightLike = "podcast_screen_you_might_like"
     case podcastSettings = "podcast_settings"
     case podcastsList = "podcasts_list"

--- a/podcasts/NetworkNavigator.swift
+++ b/podcasts/NetworkNavigator.swift
@@ -2,49 +2,52 @@ import PocketCastsDataModel
 import PocketCastsServer
 import UIKit
 
-/// Opens a network tapped in search, on the navigation stack search is presented in.
+/// Opens a network, on the navigation stack of the screen that asked for it.
 ///
-/// The screen it pushes is the one Discover uses for a network, ``ExpandedCollectionViewController``
-/// in its `grid` style, which asks its delegate for the podcasts' subscription state and taps —
-/// hence the ``DiscoverDelegate`` conformance. The Discover feed itself is out of reach from here,
-/// so the methods that navigate around it do nothing.
-final class SearchNetworkNavigator: ObservableObject {
-    /// The view controller hosting the search results, whose navigation controller is pushed onto.
+/// A network is a list of podcasts, identified by the id the API gives it, and the screen it opens
+/// is the one Discover uses, ``ExpandedCollectionViewController`` in its `grid` style. That screen
+/// asks its delegate for the podcasts' subscription state and taps — hence the ``DiscoverDelegate``
+/// conformance. Callers see none of that: they hand over a list id and this loads the rest.
+final class NetworkNavigator: ObservableObject {
+    /// The view controller whose navigation controller is pushed onto.
     weak var presenter: UIViewController?
 
     private let source: AnalyticsSource
     private let serverHandler: DiscoverServerHandling
 
-    private var pendingNetwork: NetworkSearchResult?
+    private var pendingListId: String?
 
     init(source: AnalyticsSource, serverHandler: DiscoverServerHandling = DiscoverServerHandler.shared) {
         self.source = source
         self.serverHandler = serverHandler
     }
 
-    func show(_ network: NetworkSearchResult) {
-        guard pendingNetwork != network else { return }
+    /// Loads the network's podcasts and shows them. `title` names the screen for callers that
+    /// already know it; the list names itself otherwise.
+    func show(listId: String, title: String? = nil) {
+        guard pendingListId != listId else { return }
 
-        pendingNetwork = network
-        serverHandler.discoverPodcastCollection(source: network.source, authenticated: nil) { [weak self] collection in
+        pendingListId = listId
+        serverHandler.discoverPodcastCollection(source: ServerHelper.listUrlString(listId: listId), authenticated: nil) { [weak self] collection in
             DispatchQueue.main.async {
-                guard let self, self.pendingNetwork == network else { return }
+                guard let self, self.pendingListId == listId else { return }
 
-                self.pendingNetwork = nil
-                self.show(collection, for: network)
+                self.pendingListId = nil
+                self.show(collection, listId: listId, title: title)
             }
         }
     }
 
-    private func show(_ collection: PodcastCollection?, for network: NetworkSearchResult) {
+    private func show(_ collection: PodcastCollection?, listId: String, title: String?) {
         guard let presenter, presenter.viewIfLoaded?.window != nil, let navigationController = presenter.navigationController else { return }
 
         guard let collection else {
-            Toast.show(L10n.searchNetworkFailToLoad)
+            Toast.show(L10n.networkFailToLoad)
             return
         }
 
-        let controller = ExpandedCollectionViewController(item: discoverItem(for: network), podcasts: collection.podcasts ?? [])
+        let item = discoverItem(listId: listId, title: title ?? collection.title)
+        let controller = ExpandedCollectionViewController(item: item, podcasts: collection.podcasts ?? [])
         controller.podcastCollection = collection
         controller.registerDiscoverDelegate(self)
         navigationController.pushViewController(controller, animated: true)
@@ -52,21 +55,21 @@ final class SearchNetworkNavigator: ObservableObject {
 
     /// The network's list, as the `DiscoverItem` the expanded screen expects. It opens as a `grid`,
     /// the same way a network opens from the Discover feed.
-    private func discoverItem(for network: NetworkSearchResult) -> DiscoverItem {
+    private func discoverItem(listId: String, title: String?) -> DiscoverItem {
         DiscoverItem(
-            id: network.uuid,
-            uuid: network.uuid,
-            title: network.title,
+            id: listId,
+            uuid: listId,
+            title: title,
             type: NetworkListSummary.supportedType,
             summaryStyle: "collection",
             expandedStyle: "grid",
-            source: network.source,
+            source: ServerHelper.listUrlString(listId: listId),
             regions: []
         )
     }
 }
 
-extension SearchNetworkNavigator: DiscoverDelegate {
+extension NetworkNavigator: DiscoverDelegate {
     func navController() -> UINavigationController? {
         presenter?.navigationController
     }

--- a/podcasts/New Search/SearchResultsViewController.swift
+++ b/podcasts/New Search/SearchResultsViewController.swift
@@ -18,12 +18,12 @@ class SearchResultsViewController: UIHostingController<AnyView> {
     private let searchHistoryModel = SearchHistoryModel.shared
     private let searchResults: SearchResultsModel
     private let searchAnalyticsHelper: SearchAnalyticsHelper
-    private let networkNavigator: SearchNetworkNavigator
+    private let networkNavigator: NetworkNavigator
 
     init(source: AnalyticsSource, showLocalResults: Bool = false) {
         searchAnalyticsHelper = SearchAnalyticsHelper(source: source)
         self.searchResults = SearchResultsModel(analyticsHelper: searchAnalyticsHelper, showLocalResults: showLocalResults)
-        self.networkNavigator = SearchNetworkNavigator(source: source)
+        self.networkNavigator = NetworkNavigator(source: source)
         super.init(rootView: AnyView(
             SearchView()
             .setupDefaultEnvironment()

--- a/podcasts/New Search/Views/Results/NetworkSearchResultCell.swift
+++ b/podcasts/New Search/Views/Results/NetworkSearchResultCell.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct NetworkSearchResultCell: View {
     @EnvironmentObject var theme: Theme
     @EnvironmentObject var searchAnalyticsHelper: SearchAnalyticsHelper
-    @EnvironmentObject var networkNavigator: SearchNetworkNavigator
+    @EnvironmentObject var networkNavigator: NetworkNavigator
 
     let network: NetworkSearchResult
 
@@ -25,7 +25,7 @@ struct NetworkSearchResultCell: View {
 
     private func open() {
         searchAnalyticsHelper.trackResultTapped(network)
-        networkNavigator.show(network)
+        networkNavigator.show(listId: network.uuid, title: network.title)
     }
 
     private var rowContent: some View {
@@ -98,7 +98,7 @@ enum NetworkSearchPreviewData {
     .listStyle(.plain)
     .setupDefaultEnvironment()
     .environmentObject(SearchAnalyticsHelper(source: .discover))
-    .environmentObject(SearchNetworkNavigator(source: .discover))
+    .environmentObject(NetworkNavigator(source: .discover))
 }
 
 #endif

--- a/podcasts/New Search/Views/Results/SearchResultsView.swift
+++ b/podcasts/New Search/Views/Results/SearchResultsView.swift
@@ -235,7 +235,7 @@ struct SearchResultsView_Previews: PreviewProvider {
         .setupDefaultEnvironment()
         .environmentObject(searchResults)
         .environmentObject(SearchAnalyticsHelper(source: .discover))
-        .environmentObject(SearchNetworkNavigator(source: .discover))
+        .environmentObject(NetworkNavigator(source: .discover))
         .environmentObject(SearchHistoryModel.shared)
 }
 

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderModel.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderModel.swift
@@ -1,9 +1,29 @@
 import Combine
 import Foundation
+import SwiftUI
 
 import PocketCastsDataModel
 import PocketCastsServer
 import PocketCastsUtils
+
+/// A tappable part of the header's category and author line. `Text` carries a tap as a link, so each
+/// one is addressed by a URL the header intercepts and never opens.
+enum PodcastHeaderLink: String {
+    case category
+    case author
+
+    private static let scheme = "pocketcasts-podcast-header"
+
+    var url: URL {
+        URL(string: "\(Self.scheme)://\(rawValue)")!
+    }
+
+    init?(url: URL) {
+        guard url.scheme == Self.scheme, let host = url.host else { return nil }
+
+        self.init(rawValue: host)
+    }
+}
 
 class PodcastHeaderViewModel: NSObject, ObservableObject {
 
@@ -15,7 +35,6 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
         self.podcast = podcast
         self.delegate = delegate
         self.isSubscribed = podcast.isSubscribed()
-        self.displayCategoryAndAuthor = Self.makeDisplayCategoryAndAuthor(for: podcast)
         _isExpanded =  Published(initialValue: delegate?.isSummaryExpanded() ?? false)
         super.init()
         addObservers()
@@ -66,16 +85,26 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
         return String(substring).lowercased()
     }
 
-    let displayCategoryAndAuthor: AttributedString
-
-    private static func makeDisplayCategoryAndAuthor(for podcast: Podcast) -> AttributedString {
+    /// The category and author line, both tappable. The author is drawn in `networkTint` when it
+    /// leads somewhere — the podcast's network — and left as plain text when it doesn't.
+    func displayCategoryAndAuthor(networkTint: Color) -> AttributedString {
         let category = podcast.podcastCategory?.localized(seperatingWith: \.isNewline) ?? ""
         var result = AttributedString(category)
-        result.link = URL(string: "http://pocketcasts.com")
+        result.link = PodcastHeaderLink.category.url
         if let author = podcast.author {
-            result += AttributedString(" · \(author)")
+            var authorText = AttributedString(author)
+            if networkListId != nil {
+                authorText.link = PodcastHeaderLink.author.url
+                authorText.foregroundColor = networkTint
+            }
+            result += AttributedString(" · ") + authorText
         }
         return result
+    }
+
+    /// The network the podcast belongs to, while the app shows networks at all.
+    private var networkListId: String? {
+        FeatureFlag.networkDiscovery.enabled ? podcast.networkListId : nil
     }
 
     var displayAuthor: String? {
@@ -145,8 +174,16 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
         return podcast.podcastHTMLDescription ?? podcast.podcastDescription ?? ""
     }
 
-    func categoryTapped() {
-        delegate?.categoryTapped(firstCategory)
+    func headerLinkTapped(_ url: URL) {
+        switch PodcastHeaderLink(url: url) {
+        case .category:
+            delegate?.categoryTapped(firstCategory)
+        case .author:
+            guard let networkListId else { return }
+            delegate?.networkTapped(listId: networkListId)
+        case nil:
+            delegate?.open(url: url)
+        }
     }
 
     func podcastArtworkTapped() {

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
@@ -81,12 +81,13 @@ struct PodcastHeaderView: View {
     }
 
     func makeText() -> Text {
-        var output = Text(viewModel.displayCategoryAndAuthor)
+        var output = Text(viewModel.displayCategoryAndAuthor(networkTint: networkTint))
         if FeatureFlag.showExplicitBadges.enabled, viewModel.podcast.isExplicit {
             output = output + ExplicitBadgeHelper.inlineTitle(" ·", isExplicit: true, theme: theme.activeTheme)
         }
         return output
     }
+
     private var podcastCategory: some View {
         VStack {
                 makeText()
@@ -95,11 +96,16 @@ struct PodcastHeaderView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .foregroundStyle(theme.primaryText01)
             .tint(theme.primaryText01)
-            .environment(\.openURL, OpenURLAction { _ in
-                viewModel.categoryTapped()
+            .environment(\.openURL, OpenURLAction { url in
+                viewModel.headerLinkTapped(url)
                 return .handled
             })
         }
+    }
+
+    /// The podcast's own colour, which is what marks the author as leading to its network.
+    private var networkTint: Color {
+        Color(viewModel.podcast.iconTintColor(for: theme.activeTheme))
     }
 
     var topMarginForTitle: CGFloat {
@@ -345,16 +351,23 @@ struct PodcastHeaderView_Previews: PreviewProvider {
             podcast.estimatedNextEpisode = Date.now
             podcast.podcastHTMLDescription = "<p>Test description</p>"
             podcast.fundingURL = "https://www.pocketcasts.com"
+            podcast.networkListId = "cdb75bc0-9f5a-4217-b1ca-f573821a7913"
             return podcast
+        }
+
+        /// Expanded, which is the only state that shows the category and author line.
+        static func makeViewModel() -> PodcastHeaderViewModel {
+            let viewModel = PodcastHeaderViewModel(podcast: makePodcast())
+            viewModel.isExpanded = true
+            return viewModel
         }
 
         var body: some View {
             VStack() {
-                PodcastHeaderView(viewModel: PodcastHeaderViewModel(podcast: Self.makePodcast()))
+                PodcastHeaderView(viewModel: Self.makeViewModel())
                 Spacer()
             }
             .background(theme.primaryUi02)
-            .frame(maxHeight: 400)
         }
     }
     static var previews: some View {

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -39,6 +39,7 @@ protocol PodcastActionsDelegate: AnyObject {
     func folderTapped()
     func notificationTapped()
     func categoryTapped(_ category: String)
+    func networkTapped(listId: String)
     func subscribe()
     func unsubscribe()
     func refreshArtwork()
@@ -76,6 +77,13 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
     }
 
     var recommendations: PodcastCollection?
+
+    /// Opens the network the podcast belongs to, tapped in the header.
+    private lazy var networkNavigator: NetworkNavigator = {
+        let navigator = NetworkNavigator(source: .podcastScreen)
+        navigator.presenter = self
+        return navigator
+    }()
 
     /// The bookmarks tab, created the first time it's displayed
     var bookmarkList: BookmarkListController?
@@ -940,6 +948,11 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
     func categoryTapped(_ category: String) {
         NavigationManager.sharedManager.navigateTo(NavigationManager.discoverPageKey, data: [NavigationManager.discoverCategoryKey: category])
         Analytics.track(.podcastScreenCategoryTapped, properties: ["category": category])
+    }
+
+    func networkTapped(listId: String) {
+        Analytics.track(.podcastScreenNetworkTapped, properties: ["podcast_uuid": podcast?.uuid ?? "", "list_id": listId])
+        networkNavigator.show(listId: listId)
     }
 
     func searchEpisodes(query: String) {

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -80,7 +80,7 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
 
     /// Opens the network the podcast belongs to, tapped in the header.
     private lazy var networkNavigator: NetworkNavigator = {
-        let navigator = NetworkNavigator(source: .podcastScreen)
+        let navigator = NetworkNavigator(source: .podcastScreenNetwork)
         navigator.presenter = self
         return navigator
     }()

--- a/podcasts/en.lproj/Localizable.strings
+++ b/podcasts/en.lproj/Localizable.strings
@@ -6649,5 +6649,5 @@
 /* Search Results filter option that narrows the results down to podcast networks */
 "search_filter_networks" = "Networks";
 
-/* Message shown when a network tapped in the search results fails to load */
-"search_network_fail_to_load" = "This network couldn't be loaded";
+/* Message shown when a network the user tapped fails to load */
+"network_fail_to_load" = "This network couldn't be loaded";


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Stacked on #5038, which persists `Podcast.networkListId`.

The author line in the podcast header is now tappable when the podcast belongs to a network, and opens that network's list of podcasts — the same screen Discover and search already push.

- The header's "Category · Author" line was already one `Text` over an `AttributedString`, with the category carrying a dummy link that `OpenURLAction` intercepted. Both parts now carry a `PodcastHeaderLink` URL instead, so the same mechanism routes each one to its own action. No extra views, no layout change.
- The author is a link only when the podcast has a `networkListId` and `FeatureFlag.networkDiscovery` is on; otherwise it stays plain text, exactly as today. It's drawn in `podcast.iconTintColor(for:)`, set as a run-level `foregroundColor` so the category keeps `primaryText01`.
- `SearchNetworkNavigator` becomes `NetworkNavigator` and moves out of `New Search/`. It takes `show(listId:title:)`, derives the source with `ServerHelper.listUrlString`, loads the collection and pushes `ExpandedCollectionViewController` as its own `DiscoverDelegate`. Callers hand over a list id and nothing else — the podcast page never sees a `DiscoverItem` or `DiscoverPodcast`. `title` is optional now, since the podcast page doesn't know the network's name until the list loads; the collection names itself in that case.
- `search_network_fail_to_load` → `network_fail_to_load`, now that it isn't search-only. It was English-only (added on this branch lineage), so no translations were lost.

Analytics: `podcast_screen_network_tapped` with `podcast_uuid` and `list_id`. The event is already registered in the schema but is marked `[web]` only — Automattic/EventHorizonSchemas#127 adds `ios`.

## To test

1. Build a debug configuration, where `networkDiscovery` defaults on (or enable it under Profile > Settings > Developer > Feature Flags).
2. Open a podcast that belongs to a network — Analog(ue) (Relay) is a good one — and pull to refresh so `networkListId` gets populated by #5038.
3. Tap the podcast title to expand the header. The "Category · Author" line appears above it.
4. The author should be drawn in the podcast's tint colour rather than the text colour. Tap it: the Relay network's list of podcasts opens, titled by the list.
5. Tap a podcast in that list, and follow/unfollow one — both should behave as they do when the same screen is opened from Discover.
6. Back on the podcast page, tap the category half of the line — it should still take you to Discover filtered by that category.
7. Open a podcast with no network (or turn `networkDiscovery` off) — the author should be plain text and not tappable.
8. Search for a network and open it from the results, to confirm the shared navigator still works there.



https://github.com/user-attachments/assets/992fe0bc-cd26-4b79-8198-f8f5e8c73a1d



## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
