### PR TITLE
Fix Debug build broken by the descriptive_list rename

### DIFF
--- a/podcasts/ExpandedCollectionViewController.swift
+++ b/podcasts/ExpandedCollectionViewController.swift
@@ -203,7 +203,7 @@ private let previewCollectionImage = "https://static.pocketcasts.com/discover/im
             item: DiscoverPreviewData.item(.collectionSummary, title: "Sounds for sleeping", expandedStyle: "descriptive_list"),
             podcasts: DiscoverPreviewData.podcasts(12)
         )
-        controller.cellStyle = .descriptive_list
+        controller.cellStyle = .descriptiveList
         return controller
     }
     .ignoresSafeArea()


### PR DESCRIPTION
`trunk` doesn't compile in Debug. #5035 renamed `CollectionCellStyle.descriptive_list` to `descriptiveList` but missed one call site in the `#Preview("Descriptive list")` block:

```
podcasts/ExpandedCollectionViewController.swift:206:33: error: type 'CollectionCellStyle' has no member 'descriptive_list'
```

The call site lives inside the `#if DEBUG` block that wraps the previews, so Release builds are unaffected and CI stayed green — but any local `make build_staging` / Xcode Debug build of `trunk` fails.

## To test

1. Check out this branch.
2. Run `make build_staging` (or build the `Pocket Casts Staging` scheme with the `StagingDebug` configuration in Xcode).
3. The build succeeds. On `trunk` the same build fails with the error above.
4. Open `podcasts/ExpandedCollectionViewController.swift` in Xcode and confirm the "Descriptive list" preview renders.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
