### PR TITLE
Report a distinct source for follows from a network

### DIFF
--- a/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
+++ b/podcasts/Analytics/Helpers/AnalyticsCoordinator.swift
@@ -41,6 +41,7 @@ enum AnalyticsSource: String, AnalyticsDescribable {
     case playerPlaybackEffects = "player_playback_effects"
     case playerSkipForwardLongPress = "player_skip_forward_long_press"
     case podcastScreen = "podcast_screen"
+    case podcastScreenNetwork = "podcast_screen_network"
     case podcastScreenYouMightLike = "podcast_screen_you_might_like"
     case podcastSettings = "podcast_settings"
     case podcastsList = "podcasts_list"

--- a/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
+++ b/podcasts/Podcasts/Podcast Page/PodcastViewController.swift
@@ -80,7 +80,7 @@ class PodcastViewController: PCViewController, PodcastActionsDelegate, SyncSigni
 
     /// Opens the network the podcast belongs to, tapped in the header.
     private lazy var networkNavigator: NetworkNavigator = {
-        let navigator = NetworkNavigator(source: .podcastScreen)
+        let navigator = NetworkNavigator(source: .podcastScreenNetwork)
         navigator.presenter = self
         return navigator
     }()


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Stacked on #5040, which adds the network entry point.

Following a podcast from inside the network grid opened from the podcast header reported `podcast_subscribed` with `source: podcast_screen` — indistinguishable from following on the podcast page itself, which would quietly inflate that source once the entry point ships.

`NetworkNavigator` passes its `source` straight through to `podcast_subscribed`, so this gives the podcast page's navigator its own: `podcastScreenNetwork` / `podcast_screen_network`, following the shape of the existing `podcastScreenYouMightLike`. Two lines.

Search is untouched — its navigator already passes the source search was opened from.

Registered in Automattic/EventHorizonSchemas#127, which adds `podcast_screen_network` to `source_view_type`.

## To test

1. Build a debug configuration, where `networkDiscovery` defaults on (or enable it under Profile > Settings > Developer > Feature Flags).
2. Watch the analytics log — Profile > Settings > Developer > Logs, or the console with the OS log adapter.
3. Open a podcast that belongs to a network, expand the header, and tap the author to open the network's grid.
4. Follow a podcast in that grid. `podcast_subscribed` should report `source: podcast_screen_network`.
5. Go back and follow the podcast the page itself is showing. That one should still report `source: podcast_screen`.
6. Open a network from Search and follow a podcast there, to confirm that path still reports the source search was opened from.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
