### PR TITLE
Refresh podcast metadata for existing podcasts

### DIFF
--- a/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Private/Managers/PodcastDataManager.swift
@@ -574,6 +574,10 @@ class PodcastDataManager {
         setOnAllPodcasts(value: version, propertyName: "colorVersion", subscribedOnly: true, dbQueue: dbQueue)
     }
 
+    func clearLastUpdatedAtForAllPodcasts(dbQueue: PCDBQueue) {
+        setOnAllPodcasts(value: NSNull(), propertyName: "lastUpdatedAt", subscribedOnly: true, dbQueue: dbQueue)
+    }
+
     private func saveSingleValue(name: String, value: Any?, podcastUuid: String, dbQueue: PCDBQueue) {
         DataHelper.run(query: "UPDATE \(DataManager.podcastTableName) SET \(name) = ? WHERE uuid = ?", values: [value ?? NSNull(), podcastUuid], methodName: "PodcastDataManager.saveSingleValue", onQueue: dbQueue)
 

--- a/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
+++ b/Modules/Sources/PocketCastsDataModel/Public/DataManager.swift
@@ -465,6 +465,12 @@ public class DataManager {
         podcastManager.setAllPodcastImageVersions(to: version, dbQueue: dbQueue)
     }
 
+    /// Clears the `If-Modified-Since` token used when refreshing podcasts from the cache server, so
+    /// the next refresh of each subscribed podcast returns the full metadata instead of a 304.
+    public func clearLastUpdatedAtForAllPodcasts() {
+        podcastManager.clearLastUpdatedAtForAllPodcasts(dbQueue: dbQueue)
+    }
+
     public func bulkSetFolderUuid(folderUuid: String, podcastUuids: [String]) {
         podcastManager.bulkSetFolderUuid(folderUuid: folderUuid, podcastUuids: podcastUuids, dbQueue: dbQueue)
     }

--- a/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
+++ b/Modules/Sources/PocketCastsServer/Public/ServerPodcastManager+Update.swift
@@ -79,10 +79,10 @@ extension ServerPodcastManager {
         if let isPrivate = podcastJson["is_private"] as? Bool {
             podcast.isPrivate = isPrivate
         }
-        if let isExplicit = podcastJson["explicit"] as? Bool, isExplicit {
-            podcast.isExplicit = true
-        } else if let isExplicit = podcastJson["explicit"] as? Int, isExplicit > 0 {
-            podcast.isExplicit = true
+        if let isExplicit = podcastJson["explicit"] as? Bool {
+            podcast.isExplicit = isExplicit
+        } else if let isExplicit = podcastJson["explicit"] as? Int {
+            podcast.isExplicit = isExplicit > 0
         }
         if let fundingsJson = podcastJson["fundings"] as? [[String: Any]], let url = fundingsJson.first?["url"] as? String {
             podcast.fundingURL = url

--- a/podcasts/AppDelegate+Defaults.swift
+++ b/podcasts/AppDelegate+Defaults.swift
@@ -137,6 +137,12 @@ extension AppDelegate {
             Settings.setMobileDataAllowed(false)
         }
 
+        if FeatureFlag.networkDiscovery.enabled {
+            performUpdateIfRequired(updateKey: "RefreshPodcastMetadataForExplicitAndNetworkList") {
+                dataManager.clearLastUpdatedAtForAllPodcasts()
+            }
+        }
+
         defaults.synchronize()
     }
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

`isExplicit` and `networkListId` are only written when the cache server returns a full podcast body. Subscribed podcasts send `lastUpdatedAt` as `If-Modified-Since`, so a podcast whose data hasn't changed answers `304` and the new columns keep their defaults forever.

This clears `lastUpdatedAt` once for all subscribed podcasts, so the next refresh of each returns the full body. No extra network requests — those refreshes already happen on podcast open, playback, download and starred sync; they just return a body instead of a `304`. Same approach `ImageManager` uses to force artwork re-downloads.

Runs once per install, gated on `networkDiscovery`. The flag check sits outside `performUpdateIfRequired` because that helper writes its key as soon as it runs — checking inside would burn the key while the flag was off.

Also makes the explicit flag symmetric in `ServerPodcastManager+Update`; it could only latch on, never clear.

## To test

1. Follow a podcast with no recent episodes, so its metadata is stable.
2. On `trunk`, confirm its `isExplicit` / `networkListId` stay unset no matter how often you open its page.
3. Build this branch with `networkDiscovery` on, launch, and open that podcast's page.
4. Both fields are now populated — explicit podcasts show the badge, networked ones show the network link.
5. Relaunch and confirm it doesn't run again (`RefreshPodcastMetadataForExplicitAndNetworkList` is `true` in `UserDefaults`).
6. With `networkDiscovery` off, nothing runs and the key stays unset.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.