### PR TITLE
Draw the podcast header's category in the podcast's tint

### DIFF
--- a/PocketCastsTests/Tests/Podcasts/PodcastHeaderViewModelTests.swift
+++ b/PocketCastsTests/Tests/Podcasts/PodcastHeaderViewModelTests.swift
@@ -20,14 +20,14 @@ final class PodcastHeaderViewModelTests: XCTestCase {
     }
 
     func testTheAuthorOpensTheNetworkThePodcastBelongsTo() {
-        let line = viewModel(networkListId: "cdb75bc0-9f5a-4217-b1ca-f573821a7913").displayCategoryAndAuthor(networkTint: .red)
+        let line = viewModel(networkListId: "cdb75bc0-9f5a-4217-b1ca-f573821a7913").displayCategoryAndAuthor(linkTint: .red)
 
         XCTAssertEqual(text(of: line, linkedTo: .category), "Technology")
         XCTAssertEqual(text(of: line, linkedTo: .author), "Relay")
     }
 
     func testTheAuthorOfAPodcastWithoutANetworkIsPlainText() {
-        let line = viewModel(networkListId: nil).displayCategoryAndAuthor(networkTint: .red)
+        let line = viewModel(networkListId: nil).displayCategoryAndAuthor(linkTint: .red)
 
         XCTAssertEqual(String(line.characters), "Technology · Relay")
         XCTAssertNil(text(of: line, linkedTo: .author))
@@ -36,16 +36,23 @@ final class PodcastHeaderViewModelTests: XCTestCase {
     func testANetworkIsOnlyOfferedWhileTheAppShowsNetworks() {
         featureFlagMock.set(.networkDiscovery, value: false)
 
-        let line = viewModel(networkListId: "cdb75bc0-9f5a-4217-b1ca-f573821a7913").displayCategoryAndAuthor(networkTint: .red)
+        let line = viewModel(networkListId: "cdb75bc0-9f5a-4217-b1ca-f573821a7913").displayCategoryAndAuthor(linkTint: .red)
 
         XCTAssertNil(text(of: line, linkedTo: .author))
     }
 
-    func testTheNetworkIsDrawnInThePodcastsOwnColour() {
-        let line = viewModel(networkListId: "cdb75bc0-9f5a-4217-b1ca-f573821a7913").displayCategoryAndAuthor(networkTint: .red)
+    func testTheCategoryAndTheNetworkAreDrawnInThePodcastsOwnColour() {
+        let line = viewModel(networkListId: "cdb75bc0-9f5a-4217-b1ca-f573821a7913").displayCategoryAndAuthor(linkTint: .red)
 
-        let author = line.runs.first { $0.link == PodcastHeaderLink.author.url }
-        XCTAssertEqual(author?.foregroundColor, .red)
+        XCTAssertEqual(colour(of: line, linkedTo: .category), .red)
+        XCTAssertEqual(colour(of: line, linkedTo: .author), .red)
+    }
+
+    func testOnlyTheCategoryIsColouredWhenThePodcastHasNoNetwork() {
+        let line = viewModel(networkListId: nil).displayCategoryAndAuthor(linkTint: .red)
+
+        XCTAssertEqual(colour(of: line, linkedTo: .category), .red)
+        XCTAssertEqual(line.runs.filter { $0.foregroundColor != nil }.count, 1)
     }
 
     func testALinkIsRecognisedFromItsURL() {
@@ -69,5 +76,9 @@ final class PodcastHeaderViewModelTests: XCTestCase {
         guard let run = line.runs.first(where: { $0.link == link.url }) else { return nil }
 
         return String(line[run.range].characters)
+    }
+
+    private func colour(of line: AttributedString, linkedTo link: PodcastHeaderLink) -> Color? {
+        line.runs.first { $0.link == link.url }?.foregroundColor
     }
 }

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderModel.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderModel.swift
@@ -85,17 +85,19 @@ class PodcastHeaderViewModel: NSObject, ObservableObject {
         return String(substring).lowercased()
     }
 
-    /// The category and author line, both tappable. The author is drawn in `networkTint` when it
-    /// leads somewhere — the podcast's network — and left as plain text when it doesn't.
-    func displayCategoryAndAuthor(networkTint: Color) -> AttributedString {
+    /// The category and author line. Each part that leads somewhere — the category's page in
+    /// Discover, and the podcast's network — is tappable and drawn in `linkTint`. The author is
+    /// left as plain text when the podcast has no network.
+    func displayCategoryAndAuthor(linkTint: Color) -> AttributedString {
         let category = podcast.podcastCategory?.localized(seperatingWith: \.isNewline) ?? ""
         var result = AttributedString(category)
         result.link = PodcastHeaderLink.category.url
+        result.foregroundColor = linkTint
         if let author = podcast.author {
             var authorText = AttributedString(author)
             if networkListId != nil {
                 authorText.link = PodcastHeaderLink.author.url
-                authorText.foregroundColor = networkTint
+                authorText.foregroundColor = linkTint
             }
             result += AttributedString(" · ") + authorText
         }

--- a/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
+++ b/podcasts/Podcasts/Podcast Page/Cells/PodcastHeaderView.swift
@@ -81,7 +81,7 @@ struct PodcastHeaderView: View {
     }
 
     func makeText() -> Text {
-        var output = Text(viewModel.displayCategoryAndAuthor(networkTint: networkTint))
+        var output = Text(viewModel.displayCategoryAndAuthor(linkTint: linkTint))
         if FeatureFlag.showExplicitBadges.enabled, viewModel.podcast.isExplicit {
             output = output + ExplicitBadgeHelper.inlineTitle(" ·", isExplicit: true, theme: theme.activeTheme)
         }
@@ -103,8 +103,8 @@ struct PodcastHeaderView: View {
         }
     }
 
-    /// The podcast's own colour, which is what marks the author as leading to its network.
-    private var networkTint: Color {
+    /// The podcast's own colour, which is what marks the category and the author as tappable.
+    private var linkTint: Color {
         Color(viewModel.podcast.iconTintColor(for: theme.activeTheme))
     }
 


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

The category in the podcast header opens Discover filtered by it, but it was drawn in `primaryText01` with nothing to suggest it was tappable — you had to know. It now gets the same treatment the author got in #5040 when it leads to a network: the podcast's own tint colour.

- One line in `displayCategoryAndAuthor`, setting `foregroundColor` on the category run the same way the author already does. The `·` separator and the explicit badge keep the text colour, so only the two tappable parts are tinted.
- `networkTint` becomes `linkTint`, since it now marks both parts of the line rather than just the network.
- The author is still plain text when the podcast has no network, so a podcast outside a network shows a tinted category next to a plain author.

## To test

1. Open any podcast and tap its title to expand the header — the "Category · Author" line appears.
2. The category should now be drawn in the podcast's tint colour rather than the text colour. Tap it: Discover opens, filtered by that category, as before.
3. Open a podcast that belongs to a network (Analog(ue) on Relay, with `networkDiscovery` on) — category and author are both tinted, the `·` between them isn't.
4. Open a podcast with no network — the category is tinted, the author stays plain text and isn't tappable.
5. Switch themes, including the dark ones, and check the tint stays legible against the header background.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
