### PR TITLE
Update translations and App Store metadata for `8.20`

### DIFF
--- a/podcasts/ca.lproj/Localizable.strings
+++ b/podcasts/ca.lproj/Localizable.strings
@@ -303,6 +303,8 @@ Descarrega l'app per a una experiència completa!</string>
     <string>Si està activat, el temporitzador de son es reiniciarà automàticament si reprodueixes un episodi als  5 minuts següents a l'última pausa.</string>
     <key>back</key>
     <string>Enrere</string>
+    <key>badge_new</key>
+    <string>Nou</string>
     <key>banner_ads_info_label</key>
     <string>Anunci</string>
     <key>banner_ads_remove_ads</key>
@@ -369,6 +371,14 @@ Descarrega l'app per a una experiència completa!</string>
     <string>Desbloqueja aquesta funció i moltes més amb Pocket Casts %1$@ i desa les marques de temps dels teus episodis preferits.  Prest disponible per a %2$@ subscriptors.</string>
     <key>bookmarks_locked_message</key>
     <string>Desbloqueja aquesta funció i moltes més amb Pocket Casts %1$@ i desa els marcadors dels teus episodis preferits.</string>
+    <key>bookmarks_player_tip_message</key>
+    <string>Guarda la part que volies</string>
+    <key>bookmarks_player_tip_title</key>
+    <string>Afegeix un marcador</string>
+    <key>bookmarks_upgrade_example_passage</key>
+    <string>Elegeixes la persona, no el currículum.</string>
+    <key>bookmarks_upgrade_example_title</key>
+    <string>La sala d'audicions</string>
     <key>bottom</key>
     <string>Darrer de la cua</string>
     <key>bulk_download_max_format</key>
@@ -896,8 +906,6 @@ Pots desconnectar-te en qualsevol moment des d'Ajustos.</string>
     <string>Fitxers descarregats</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>Estàs segur que vols eliminar aquests arxius descarregats?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>Si et dones de baixa, s'esborraran tots els fitxers descarregats d'aquest pòdcast. N'estàs segur?</string>
     <key>downloaded_files_conf_message_new</key>
     <string>Si el deixes de seguir, s'esborraran tots els fitxers descarregats d'aquest pòdcast. N'estàs segur?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1527,10 +1535,6 @@ Nota: En cas que hagis eliminat l'aplicació Dreceres, se't demanarà que la tor
 4. Quan obriu el diàleg, cerca la icona de Pocket Casts i ves-hi</string>
     <key>import_opml_from_url</key>
     <string>Importa els teus pòdcasts des d'un arxiu OPML emprant un URL</string>
-    <key>import_podcasts_description</key>
-    <string>Pots importar les subscripcions de pòdcasts a Pocket Casts amb el format OPML, que s'admet en moltes aplicacions. Exporta el fitxer a l'altra aplicació i tria obrir-lo a Pocket Casts.
-
-Nota: És possible que t'hagis d'enviar el fitxer OPML a tu mateix per correu electrònic, mantingues premut el fitxer adjunt i seleccioneu Pocket Casts.</string>
     <key>import_podcasts_description_new</key>
     <string>Pots importar els teus pòdcasts a Pocket Casts utilitzant el format OPML, que és un format àmpliament suportat. Exporta el fitxer d'una altra aplicació i tria obrir-lo a Pocket Casts.
 
@@ -1726,7 +1730,9 @@ Nota: Potser necessitaràs enviar-te per correu electrònic el fitxer OPML, mant
     <key>no_bookmarks_locked_button_title</key>
     <string>Obtén marcadors</string>
     <key>no_bookmarks_locked_message</key>
-    <string>Pots desar les marques de temps de moments importants d'un episodi.</string>
+    <string>Un sol toc. Es posa nom sol i hi queden les paraules.</string>
+    <key>no_bookmarks_locked_title</key>
+    <string>Desa les parts que val la pena guardar</string>
     <key>no_bookmarks_message</key>
     <string>Per a desar marcadors dels episodis, ves al menú d'accions del reproductor o configura una acció amb els auriculars.</string>
     <key>no_bookmarks_title</key>
@@ -2783,8 +2789,6 @@ Si vols noves idees, ves a la pestanya Descobreix.</string>
     <string>Esborra %1$@ episodis</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>Esborra 1 episodi</string>
-    <key>queue_clear_queue</key>
-    <string>ESBORRA LA CUA</string>
     <key>queue_for_later</key>
     <string>Posa a la cua per a més tard</string>
     <key>queue_now_playing_accessibility</key>
@@ -3755,12 +3759,8 @@ Mai es compartirà la teva adreça de correu electrònic, ni la contrasenya ni c
     <string>Pujat</string>
     <key>stop_download</key>
     <string>Atura la descàrrega</string>
-    <key>subscribe</key>
-    <string>Subscriu-me</string>
     <key>subscribe_all</key>
     <string>Subscriu-te a tot</string>
-    <key>subscribed</key>
-    <string>Subscrit</string>
     <key>subscription_cancelled</key>
     <string>Has cancel·lat la teva subscripció</string>
     <key>subscription_cancelled_msg</key>
@@ -3869,6 +3869,8 @@ Mai es compartirà la teva adreça de correu electrònic, ni la contrasenya ni c
     <string>Primer</string>
     <key>transcript</key>
     <string>Transcripció</string>
+    <key>transcript_bookmark_selection</key>
+    <string>Marcador</string>
     <key>transcript_error_empty</key>
     <string>Sembla que aquesta transcripció està buida</string>
     <key>transcript_error_failed_to_load</key>
@@ -4146,8 +4148,12 @@ Prem el botó de sota per a tornar a iniciar sessió al teu compte de Pocket Cas
     <string>S'estan obtenint els darrers episodis</string>
     <key>tv_search_failed</key>
     <string>La cerca ha fallat: %1$@</string>
+    <key>tv_search_featured_section_title</key>
+    <string>Destacats</string>
     <key>tv_search_prompt</key>
     <string>Pòdcasts, programes, autors</string>
+    <key>tv_search_scope_top_results</key>
+    <string>Millors resultats</string>
     <key>tv_search_searching</key>
     <string>Cercant...</string>
     <key>tv_search_type_something</key>

--- a/podcasts/de.lproj/Localizable.strings
+++ b/podcasts/de.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Du kannst die Verbindung jederzeit in den Einstellungen trennen.</string>
     <string>Heruntergeladene Dateien</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>Bist du sicher, dass du diese heruntergeladenen Dateien löschen möchtest?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>Wenn du den Podcast nicht mehr abonnierst, werden alle dazugehörigen heruntergeladenen Dateien entfernt. Bist du dir sicher?</string>
     <key>downloaded_files_conf_message_new</key>
     <string>Wenn du den Podcast nicht mehr abonnierst, werden alle dazugehörigen heruntergeladenen Dateien entfernt. Bist du dir sicher?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Hinweis: Solltest du die App „Kurzbefehle“ kürzlich gelöscht haben, wirst 
 4. Wenn das Dialogfeld geöffnet wird, suche das Pocket Casts-Icon und tippe darauf</string>
     <key>import_opml_from_url</key>
     <string>Importiere deine Podcasts von einer OPML-Datei mithilfe einer URL</string>
-    <key>import_podcasts_description</key>
-    <string>Du kannst das von vielen Apps unterstützte OPML-Format nutzen, um deine Podcast-Abonnements in Pocket Casts zu importieren. Exportiere die Datei aus einer anderen App und wähle die Option zum Öffnen in Pocket Casts aus.
-
-Hinweis: Möglicherweise musst du dir die OPML-Datei per E-Mail zuschicken. Drücke länger auf den Anhang und wähle „Pocket Casts“ aus.</string>
     <key>import_podcasts_description_new</key>
     <string>Du kannst das weit verbreitete OPML-Format nutzen, um deine Podcasts in Pocket Casts zu importieren. Exportiere die Datei aus einer anderen App und wähle die Option zum Öffnen in Pocket Casts aus.
 
@@ -1731,8 +1725,6 @@ Podcasts mit</string>
     <string>Kopfhörereinstellungen</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>Lesezeichen erhalten</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>Du kannst Zeitstempel wichtiger Momente in einer Folge speichern.</string>
     <key>no_bookmarks_message</key>
     <string>Du kannst Zeitstempel von Folgen über das Aktionsmenü im Player speichern oder, indem du eine Aktion mit deinen Kopfhörern konfigurierst.</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Viele Anregungen findest du im Tab „Entdecken“.</string>
     <string>%1$@ Folgen löschen</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>1 Episode löschen</string>
-    <key>queue_clear_queue</key>
-    <string>WARTESCHLANGE LÖSCHEN</string>
     <key>queue_for_later</key>
     <string>Für später in Warteschlange einreihen</string>
     <key>queue_now_playing_accessibility</key>
@@ -3763,12 +3753,8 @@ Deine E-Mail-Adresse, dein Passwort und andere sensible Daten werden nicht getei
     <string>Hochgeladen</string>
     <key>stop_download</key>
     <string>Download beenden</string>
-    <key>subscribe</key>
-    <string>Abonnieren</string>
     <key>subscribe_all</key>
     <string>Alle abonnieren</string>
-    <key>subscribed</key>
-    <string>Abonniert</string>
     <key>subscription_cancelled</key>
     <string>Abonnement gekündigt</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/es-MX.lproj/Localizable.strings
+++ b/podcasts/es-MX.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Puedes desconectarte en cualquier momento desde Ajustes.</string>
     <string>Archivos descargados</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>¿Estás seguro de que deseas eliminar estos archivos descargados?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>¿Estás seguro de cancelar la suscripción? Esto eliminará todos los archivos descargados en este Podcast</string>
     <key>downloaded_files_conf_message_new</key>
     <string>Al dejar de seguirlo, se borrarán todos los archivos descargados de este podcast, ¿seguro que quieres continuar?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Nota: En caso de que hayas eliminado la aplicación Atajos, se te pedirá que la
 4. Cuando se abra el dialogo, busca el icono de Pocket Casts y tócalo.</string>
     <key>import_opml_from_url</key>
     <string>Importa tus pódcast desde un archivo OPML a través de una URL.</string>
-    <key>import_podcasts_description</key>
-    <string>Puedes importar tus suscripciones de podcasts a Pocket Casts usando el formato OPML, ampliamente compatible. Exporta el archivo desde otra aplicación y elige abrir en Pocket Casts.
-
-Nota: Es posible que debas enviarte el archivo OPML por correo electrónico; mantén presionado el archivo adjunto y selecciona Pocket Casts.</string>
     <key>import_podcasts_description_new</key>
     <string>Puedes importar tus podcasts a Pocket Casts con el formato OPML, que se admite en muchas aplicaciones. Exporta el archivo de otra aplicación y elige abrirlo en Pocket Casts.
 
@@ -1731,8 +1725,6 @@ pódcast contigo</string>
     <string>Ajustes de los auriculares</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>Obtener marcadores</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>Puedes guardar las marcas de tiempo de los momentos importantes de un episodio.</string>
     <key>no_bookmarks_message</key>
     <string>Para guardar las marcas de tiempo de los episodios, ve al menú de acciones del reproductor o configura una acción con los auriculares.</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Si buscas inspiración, prueba la pestaña Descubrir.</string>
     <string>Borrar %1$@ episodios</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>Borrar 1 episodio</string>
-    <key>queue_clear_queue</key>
-    <string>BORRAR COLA</string>
     <key>queue_for_later</key>
     <string>Poner en cola para más tarde</string>
     <key>queue_now_playing_accessibility</key>
@@ -3763,12 +3753,8 @@ Nunca compartimos tu dirección de correo electrónico, tu contraseña ni otros 
     <string>Cargado</string>
     <key>stop_download</key>
     <string>Detener descarga</string>
-    <key>subscribe</key>
-    <string>Suscribirme</string>
     <key>subscribe_all</key>
     <string>Suscribirme a todos</string>
-    <key>subscribed</key>
-    <string>Suscrito</string>
     <key>subscription_cancelled</key>
     <string>Has cancelado tu suscripción</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/es.lproj/Localizable.strings
+++ b/podcasts/es.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Puedes desconectarte en cualquier momento desde Ajustes.</string>
     <string>Archivos descargados</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>¿Seguro que quieres eliminar estos archivos descargados?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>Al darte de baja, se borrarán todos los archivos descargados en este podcast, ¿seguro que quieres continuar?</string>
     <key>downloaded_files_conf_message_new</key>
     <string>Al dejar de seguirlo, se borrarán todos los archivos descargados de este podcast, ¿seguro que quieres continuar?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Nota: En caso de que hayas eliminado la aplicación Atajos, se te pedirá que la
 4. Cuando se abra el dialogo, busca el icono de Pocket Casts y tócalo.</string>
     <key>import_opml_from_url</key>
     <string>Importa tus pódcast desde un archivo OPML a través de una URL.</string>
-    <key>import_podcasts_description</key>
-    <string>Puedes importar las suscripciones de podcasts a Pocket Casts con el formato OPML, que se admite en muchas aplicaciones. Exporta el archivo en la otra aplicación y elige abrirlo en Pocket Casts.
-
-Nota: Es posible que tengas que mandarte el archivo OPML a ti mismo por correo electrónico, mantén pulsado el archivo adjunto y selecciona Pocket Casts.</string>
     <key>import_podcasts_description_new</key>
     <string>Puedes importar tus podcasts a Pocket Casts con el formato OPML, que se admite en muchas aplicaciones. Exporta el archivo de otra aplicación y elige abrirlo en Pocket Casts.
 
@@ -1731,8 +1725,6 @@ pódcast contigo</string>
     <string>Ajustes de los auriculares</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>Obtener marcadores</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>Puedes guardar las marcas de tiempo de los momentos importantes de un episodio.</string>
     <key>no_bookmarks_message</key>
     <string>Para guardar las marcas de tiempo de los episodios, ve al menú de acciones del reproductor o configura una acción con los auriculares.</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Si quieres nuevas ideas, ve a la pestaña Descubrir.</string>
     <string>Borrar %1$@ episodios</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>Borrar 1 episodio</string>
-    <key>queue_clear_queue</key>
-    <string>BORRAR COLA</string>
     <key>queue_for_later</key>
     <string>Cola de espera para más tarde</string>
     <key>queue_now_playing_accessibility</key>
@@ -3763,12 +3753,8 @@ Nunca se compartirá tu dirección de correo electrónico, contraseña ni otra i
     <string>Subido</string>
     <key>stop_download</key>
     <string>Detener descarga</string>
-    <key>subscribe</key>
-    <string>Suscribirse</string>
     <key>subscribe_all</key>
     <string>Suscribirse a todo</string>
-    <key>subscribed</key>
-    <string>Suscrito</string>
     <key>subscription_cancelled</key>
     <string>Suscripción cancelada</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/fr-CA.lproj/Localizable.strings
+++ b/podcasts/fr-CA.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Vous pouvez vous déconnecter à tout moment des réglages.</string>
     <string>Fichiers téléchargés</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>Voulez-vous vraiment supprimer ces fichiers téléchargés?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>En vous désabonnant, tous les fichiers téléchargés de balado seront supprimés? Voulez-vous vraiment vous désabonner?</string>
     <key>downloaded_files_conf_message_new</key>
     <string>Le désabonnement supprimera tous les fichiers téléchargés dans ce podcast, confirmez-vous ?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Remarque : si vous avez supprimé l’application Raccourcis, vous recevrez une
 4. Une fois la boîte de dialogue ouverte, recherchez l’icône Pocket Casts, puis appuyez dessus.</string>
     <key>import_opml_from_url</key>
     <string>Importez vos podcasts à partir d’un fichier OPML en utilisant une URL.</string>
-    <key>import_podcasts_description</key>
-    <string>Vous pouvez importer vos abonnements à des balados dans Pocket Casts en utilisant le format OPML, largement répandu. Exportez le fichier d’une autre application et choisissez de l’ouvrir dans Pocket Casts.
-
-Remarque : Vous devrez peut-être vous envoyer le fichier OPML par courriel, appuyer longuement sur la pièce jointe et sélectionner Pocket Casts.</string>
     <key>import_podcasts_description_new</key>
     <string>Vous pouvez importer vos podcasts dans Pocket Casts en utilisant le format OPML largement pris en charge. Exportez le fichier depuis une autre application et choisissez Ouvrir dans Pocket Casts.
 
@@ -1731,8 +1725,6 @@ podcasts partout avec</string>
     <string>Réglages des écouteurs</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>Mettre des signets</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>Vous pouvez enregistrer les horodatages des moments importants d’un épisode.</string>
     <key>no_bookmarks_message</key>
     <string>Vous pouvez enregistrer les horodatages des épisodes à partir du menu Actions du lecteur ou en configurant une action avec vos écouteurs.</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Si vous voulez obtenir des suggestions, essayez l’onglet Découvertes.</string
     <string>Effacer %1$@ épisodes</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>Effacer 1 épisode</string>
-    <key>queue_clear_queue</key>
-    <string>EFFACER LA FILE D’ATTENTE</string>
     <key>queue_for_later</key>
     <string>Ajouter à la file d’attente</string>
     <key>queue_now_playing_accessibility</key>
@@ -3763,12 +3753,8 @@ Votre adresse courriel, votre mot de passe et d’autres éléments sensibles ne
     <string>Téléversés</string>
     <key>stop_download</key>
     <string>Arrêter le téléchargement</string>
-    <key>subscribe</key>
-    <string>S’abonner</string>
     <key>subscribe_all</key>
     <string>S’abonner à tout</string>
-    <key>subscribed</key>
-    <string>Abonné(e)</string>
     <key>subscription_cancelled</key>
     <string>Abonnement annulé</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/fr.lproj/Localizable.strings
+++ b/podcasts/fr.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Vous pouvez vous déconnecter à tout moment des réglages.</string>
     <string>Fichiers téléchargés</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>Voulez-vous vraiment supprimer ces fichiers téléchargés ?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>Le désabonnement supprimera tous les fichiers téléchargés dans ce podcast, confirmez-vous ?</string>
     <key>downloaded_files_conf_message_new</key>
     <string>Le désabonnement supprimera tous les fichiers téléchargés dans ce podcast, confirmez-vous ?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Remarque : si vous avez supprimé l’application Raccourcis, vous recevrez une
 4. Une fois la boîte de dialogue ouverte, recherchez l’icône Pocket Casts, puis appuyez dessus.</string>
     <key>import_opml_from_url</key>
     <string>Importez vos podcasts à partir d’un fichier OPML en utilisant une URL.</string>
-    <key>import_podcasts_description</key>
-    <string>Vous pouvez importer vos abonnements à des podcasts dans Pocket Casts en utilisant le format OPML largement pris en charge. Exportez le fichier depuis une autre application et choisissez Ouvrir dans Pocket Casts.
-
-Remarque : vous devrez peut-être vous envoyer le fichier OPML par e-mail, appuyer longuement sur la pièce jointe et sélectionner Pocket Casts.</string>
     <key>import_podcasts_description_new</key>
     <string>Vous pouvez importer vos podcasts dans Pocket Casts en utilisant le format OPML largement pris en charge. Exportez le fichier depuis une autre application et choisissez Ouvrir dans Pocket Casts.
 
@@ -1731,8 +1725,6 @@ podcasts partout avec</string>
     <string>Réglages des écouteurs</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>Mettre des signets</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>Vous pouvez enregistrer les horodatages des moments importants d’un épisode.</string>
     <key>no_bookmarks_message</key>
     <string>Vous pouvez enregistrer les horodatages des épisodes à partir du menu Actions du lecteur ou en configurant une action avec vos écouteurs.</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Si vous cherchez de l’inspiration, consultez l’onglet Découvrir.</string>
     <string>Supprimer %1$@ épisodes</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>Effacer 1 épisode</string>
-    <key>queue_clear_queue</key>
-    <string>SUPPRIMER LA FILE D’ATTENTE</string>
     <key>queue_for_later</key>
     <string>Ajouter plus tard à la file d’attente</string>
     <key>queue_now_playing_accessibility</key>
@@ -3763,12 +3753,8 @@ Votre adresse e-mail, votre mot de passe et d’autres éléments sensibles ne s
     <string>Chargé</string>
     <key>stop_download</key>
     <string>Arrêter le téléchargement</string>
-    <key>subscribe</key>
-    <string>S’abonner</string>
     <key>subscribe_all</key>
     <string>S’abonner à tous les podcasts</string>
-    <key>subscribed</key>
-    <string>Abonné</string>
     <key>subscription_cancelled</key>
     <string>Abonnement annulé</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/it.lproj/Localizable.strings
+++ b/podcasts/it.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Puoi disconnetterti in qualsiasi momento da Impostazioni.</string>
     <string>File scaricati</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>Vui eliminare questi file scaricati?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>L'annullamento dell'abbonamento eliminerà tutti i file scaricati in questo podcast, sei sicuro?</string>
     <key>downloaded_files_conf_message_new</key>
     <string>Se smetti di seguire, tutti i file scaricati in questo podcast saranno eliminati. Vuoi procedere?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Nota: se in precedenza hai eliminato l'app Scorciatoie, ti verrà chiesto di rei
 4. Quando si apre la finestra di dialogo, individua l'icona Pocket Casts e toccala</string>
     <key>import_opml_from_url</key>
     <string>Importa i podcast da un file OPML usando un URL</string>
-    <key>import_podcasts_description</key>
-    <string>Puoi importare i tuoi abbonamenti ai podcast in Pocket Casts utilizzando il formato OPML ampiamente supportato. Esporta il file da un'altra app e scegli Apri in Pocket Casts.
-
-Nota: potresti dover inviare a te stesso il file OPML tramite e-mail, premere a lungo sull'allegato e selezionare Pocket Casts.</string>
     <key>import_podcasts_description_new</key>
     <string>Puoi importare i tuoi podcast in Pocket Casts utilizzando il formato OPML ampiamente supportato. Esporta il file da un'altra app e scegli Apri in Pocket Casts.
 
@@ -1731,8 +1725,6 @@ pocast con te</string>
     <string>Impostazioni delle cuffie</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>Ottieni Segnalibri</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>Puoi salvare i timestamp dei momenti importanti di un episodio.</string>
     <key>no_bookmarks_message</key>
     <string>Puoi salvare data e ora degli episodi dal menu delle azioni nel lettore o configurando un'azione con le cuffie.</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Se stai cercando ispirazione, prova la scheda Scopri.</string>
     <string>Cancella %1$@ episodi </string>
     <key>queue_clear_episode_queue_singular</key>
     <string>Cancella 1 episodio</string>
-    <key>queue_clear_queue</key>
-    <string>CANCELLA CODA</string>
     <key>queue_for_later</key>
     <string>In coda per dopo</string>
     <key>queue_now_playing_accessibility</key>
@@ -3763,12 +3753,8 @@ L'indirizzo e-mail, la password e altri elementi sensibili non vengono mai condi
     <string>Caricato</string>
     <key>stop_download</key>
     <string>Interrompi lo scaricamento</string>
-    <key>subscribe</key>
-    <string>Abbonati</string>
     <key>subscribe_all</key>
     <string>Abbonati a tutto</string>
-    <key>subscribed</key>
-    <string>Abbonato</string>
     <key>subscription_cancelled</key>
     <string>Abbonamento annullato</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/ja.lproj/Localizable.strings
+++ b/podcasts/ja.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Pocket Casts Plus</string>
     <string>ダウンロード済みファイル</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>これらのダウンロードされたファイルを削除してもよろしいですか ?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>フォローを解除すると、このポッドキャストのダウンロード済みファイルは削除されます。よろしいですか ?</string>
     <key>downloaded_files_conf_message_new</key>
     <string>フォローを解除すると、このポッドキャストのダウンロード済みファイルはすべて削除されます。よろしいですか ?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Pocket Casts を最大限に活用しましょう。</string>
 4. ダイアログが開いたら、Pocket Casts アイコンを見つけタップします。</string>
     <key>import_opml_from_url</key>
     <string>URL を使用して OPML ファイルからポッドキャストをインポートします</string>
-    <key>import_podcasts_description</key>
-    <string>幅広くサポートされている OPML 形式を使用して、ポッドキャストのサブスクリプションを Pocket Casts にインポートできます。 別のアプリからファイルをエクスポートして、Pocket Casts で「開く」を選択します。
-
-注意: 自分宛てに OPML ファイルをメールで送信し、添付ファイルを長押しして Pocket Casts を選択する必要がある場合があります。</string>
     <key>import_podcasts_description_new</key>
     <string>幅広くサポートされている OPML 形式を使用して、ポッドキャストを Pocket Casts にインポートできます。 別のアプリからファイルをエクスポートして、Pocket Casts で「開く」を選択します。
 
@@ -1731,8 +1725,6 @@ Pocket Casts を最大限に活用しましょう。</string>
     <string>ヘッドフォン設定</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>ブックマークを取得</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>エピソード中の大切な瞬間のタイムスタンプを保存できます。</string>
     <key>no_bookmarks_message</key>
     <string>プレーヤーのアクションメニューから、またはヘッドフォンでアクションを設定して、エピソードのタイムスタンプを保存できます。</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Pocket Casts を最大限に活用しましょう。</string>
     <string>%1$@件のエピソードをクリア</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>1件のエピソードをクリア</string>
-    <key>queue_clear_queue</key>
-    <string>待機リストをクリア</string>
     <key>queue_for_later</key>
     <string>待機リストに追加して後で使用</string>
     <key>queue_now_playing_accessibility</key>
@@ -3761,12 +3751,8 @@ Pocket Casts を最大限に活用しましょう。</string>
     <string>アップロード済み</string>
     <key>stop_download</key>
     <string>ダウンロードを停止</string>
-    <key>subscribe</key>
-    <string>フォロー</string>
     <key>subscribe_all</key>
     <string>すべてをフォロー</string>
-    <key>subscribed</key>
-    <string>フォロー済み</string>
     <key>subscription_cancelled</key>
     <string>サブスクリプションをキャンセル済み</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/nl.lproj/Localizable.strings
+++ b/podcasts/nl.lproj/Localizable.strings
@@ -894,8 +894,6 @@ Je kunt op elk moment de verbinding met Instellingen verbreken.</string>
     <string>Gedownloade bestanden</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>Weet je zeker dat je deze gedownloade bestanden wilt verwijderen?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>Door je uit te schrijven, worden alle gedownloade bestanden in deze podcast verwijderd. Weet je het zeker?</string>
     <key>downloaded_files_conf_message_new</key>
     <string>Door te stoppen met volgen, worden alle gedownloade bestanden in deze podcast verwijderd. Weet je het zeker?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1530,10 +1528,6 @@ Opmerking: Als je de Shortcuts-app hebt verwijderd, wordt je gevraagd deze opnie
 4. Wanneer het dialoogvenster opent, tik op het pictogram van Pocket Casts</string>
     <key>import_opml_from_url</key>
     <string>Importeer je podcasts vanuit een OPML-bestand met een URL</string>
-    <key>import_podcasts_description</key>
-    <string>Je kunt je podcast-abonnementen importeren in Pocket Casts met de veelgebruikte OPML-indeling. Exporteer het bestand uit een andere app en kies Openen in Pocket Casts.
-
-Opmerking: Mogelijk moet je het OPML-bestand naar jezelf mailen. Hiervoor druk je op de bijlage en selecteer je Pocket Casts.</string>
     <key>import_podcasts_description_new</key>
     <string>Je kan je podcasts importeren in Pocket Casts met de veelgebruikte OPML-indeling. Exporteer het bestand uit een andere app en kies Openen in Pocket Casts.
 
@@ -1729,8 +1723,6 @@ podcasts mee</string>
     <string>Instellingen koptelefoon</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>Gebruik Bladwijzers</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>Je kan tijdstempels van belangrijke momenten in een aflevering opslaan.</string>
     <key>no_bookmarks_message</key>
     <string>Je kan tijdstempels van afleveringen opslaan in het actiemenu van de speler of door een actie te configureren met je koptelefoon.</string>
     <key>no_bookmarks_title</key>
@@ -2784,8 +2776,6 @@ Als je op zoek bent naar inspiratie, probeer dan het tabblad Ontdekken.</string>
     <string>%1$@ afleveringen wissen</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>1 aflevering verwijderen</string>
-    <key>queue_clear_queue</key>
-    <string>WACHTRIJ WISSEN</string>
     <key>queue_for_later</key>
     <string>In de wachtrij zetten voor later</string>
     <key>queue_now_playing_accessibility</key>
@@ -3757,12 +3747,8 @@ Je e-mailadres, wachtwoord en andere gevoelige gegevens worden nooit gedeeld.</s
     <string>Geüpload</string>
     <key>stop_download</key>
     <string>Download stoppen</string>
-    <key>subscribe</key>
-    <string>Abonneren</string>
     <key>subscribe_all</key>
     <string>Op alles abonneren</string>
-    <key>subscribed</key>
-    <string>Geabonneerd</string>
     <key>subscription_cancelled</key>
     <string>Het abonnement is geannuleerd</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/pt-BR.lproj/Localizable.strings
+++ b/podcasts/pt-BR.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Você pode se desconectar a qualquer momento nas Configurações.</string>
     <string>Arquivos baixados</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>Tem certeza de que deseja excluir esses arquivos baixados?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>Cancelar a assinatura apagará todos os arquivos baixados deste podcast. Tem certeza?</string>
     <key>downloaded_files_conf_message_new</key>
     <string>Deixar de seguir excluirá todos os arquivos baixados deste podcast. Tem certeza?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Observação: se você excluiu o aplicativo de atalhos, será solicitado que voc
 4. Quando a caixa de diálogo for aberta, localize o ícone do Pocket Casts e toque nele</string>
     <key>import_opml_from_url</key>
     <string>Importe seus podcasts de um arquivo OPML usando uma URL</string>
-    <key>import_podcasts_description</key>
-    <string>Você pode importar suas assinaturas de podcasts para o Pocket Casts usando o formato OPML, que é amplamente compatível. Exporte o arquivo de outro aplicativo e escolha abrir no Pocket Casts.
-
-Observação: talvez seja preciso enviar um e-mail com o arquivo OPML para o seu próprio endereço. Toque e segure o anexo e escolha Pocket Casts.</string>
     <key>import_podcasts_description_new</key>
     <string>Você pode importar seus podcasts para o Pocket Casts usando o formato compatível OPML. Exporte o arquivo de outro app e o abra com o Pocket Casts.
 
@@ -1731,8 +1725,6 @@ podcasts com você</string>
     <string>Configurações do headset</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>Buscar favoritos</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>Você pode salvar a data/hora de momentos importantes em um episódio.</string>
     <key>no_bookmarks_message</key>
     <string>Você pode salvar a data/hora dos episódios pelo menu de ações do reprodutor ou configurando uma ação com seu headset.</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Se você estiver buscando inspiração, experimente a guia Explorar.</string>
     <string>Limpar %1$@ episódios</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>Apagar 1 episódio</string>
-    <key>queue_clear_queue</key>
-    <string>LIMPAR FILA</string>
     <key>queue_for_later</key>
     <string>Adicionar à fila para mais tarde</string>
     <key>queue_now_playing_accessibility</key>
@@ -3763,12 +3753,8 @@ Seu endereço de e-mail, senha e outros dados confidenciais jamais são comparti
     <string>Upload realizado</string>
     <key>stop_download</key>
     <string>Parar o download</string>
-    <key>subscribe</key>
-    <string>Assinar</string>
     <key>subscribe_all</key>
     <string>Assinar todos</string>
-    <key>subscribed</key>
-    <string>Assinado</string>
     <key>subscription_cancelled</key>
     <string>Assinatura cancelada</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/ru.lproj/Localizable.strings
+++ b/podcasts/ru.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Pocket Casts Plus</string>
     <string>Скачанные файлы</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>Вы уверены, что хотите удалить загруженные файлы?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>При отмене подписки все скачанные файлы этого подкаста будут удалены, продолжить?</string>
     <key>downloaded_files_conf_message_new</key>
     <string>При отмене подписки все скачанные файлы этого подкаста будут удалены. Продолжить?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Pocket Casts на полную мощность.</string>
 4. В открывшемся диалоговом окне найдите значок Pocket Casts и нажмите его.</string>
     <key>import_opml_from_url</key>
     <string>Импортируйте подкасты из файла OPML с помощью URL-адреса</string>
-    <key>import_podcasts_description</key>
-    <string>Вы можете импортировать свои подписки на подкасты в Pocket Casts, воспользовавшись распространенным форматом OPML. Экспортируйте файл из другого приложения и откройте его в Pocket Casts.
-
-Примечание. Вам может потребоваться отправить файл OPML самому себе по электронной почте, для этого нажмите и удерживайте вложение и выберите Pocket Casts.</string>
     <key>import_podcasts_description_new</key>
     <string>Вы можете импортировать свои подкасты в Pocket Casts, воспользовавшись распространённым форматом OPML. Экспортируйте файл из другого приложения и откройте его в Pocket Casts.
 
@@ -1731,8 +1725,6 @@ Pocket Casts на полную мощность.</string>
     <string>Настройки наушников</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>Пользуйтесь закладками</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>Вы можете сохранять отметки времени важных моментов выпуска.</string>
     <key>no_bookmarks_message</key>
     <string>Вы можете сохранять отметки времени выпусков, используя меню действий проигрывателя или настроив действие с наушниками.</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Pocket Casts на полную мощность.</string>
     <string>Убрать выпуски (%1$@)</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>Удалить 1 выпуск</string>
-    <key>queue_clear_queue</key>
-    <string>ОЧИСТИТЬ ОЧЕРЕДЬ</string>
     <key>queue_for_later</key>
     <string>Отложить</string>
     <key>queue_now_playing_accessibility</key>
@@ -3763,12 +3753,8 @@ Pocket Casts на полную мощность.</string>
     <string>Загружено</string>
     <key>stop_download</key>
     <string>Остановить скачивание</string>
-    <key>subscribe</key>
-    <string>Подписаться</string>
     <key>subscribe_all</key>
     <string>Подписаться на все</string>
-    <key>subscribed</key>
-    <string>Подписано</string>
     <key>subscription_cancelled</key>
     <string>Подписка аннулирована</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/sv.lproj/Localizable.strings
+++ b/podcasts/sv.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Du kan när som helst koppla från Inställningar.</string>
     <string>Nedladdade filer</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>Är du säker på att du vill ta bort dessa nedladdade filer?</string>
-    <key>downloaded_files_conf_message</key>
-    <string>Om du säger upp prenumerationen tas alla nedladdade filer för den här podcasten bort. Är du säker?</string>
     <key>downloaded_files_conf_message_new</key>
     <string>Om du slutar följa den här podcasten tas alla nedladdade filer för den bort. Är du säker?</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Obs! Om du tidigare har tagit bort appen Genvägar kommer du att bli ombedd att 
 4. När dialogen öppnas, lokalisera Pocket Casts-ikonen och tryck sedan på den</string>
     <key>import_opml_from_url</key>
     <string>Importera dina podcasts från en OPML-fil med hjälp av en URL</string>
-    <key>import_podcasts_description</key>
-    <string>Du kan importera alla dina prenumerationer till Pocket Casts via en OPML-fil som i stor utsträckning stöds av många podcast applikationer. Exportera filen från din andra app och välj Öppna i Pocket Casts.
-
-Observera: Du kan behöva skicka OPML-filen till dig själv via ett mejl, långtryck sedan på bilagan och välja Pocket Casts.</string>
     <key>import_podcasts_description_new</key>
     <string>Du kan importera dina podcasts till Pocket Casts med hjälp av OPML-formatet, som stöds i stor utsträckning. Exportera filen från den andra appen och välj Öppna i Pocket Casts.
 
@@ -1731,8 +1725,6 @@ podcasts med dig</string>
     <string>Hörlursinställningar</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>Hämta bokmärken</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>Du kan spara tidsstämplar för viktiga ögonblick i ett avsnitt.</string>
     <key>no_bookmarks_message</key>
     <string>Du kan spara tidsstämplar för avsnitt från åtgärdsmenyn i spelaren eller genom att konfigurera en åtgärd med dina hörlurar.</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Om du behöver inspiration så kan du Upptäcka nya podcasts nedan.</string>
     <string>Rensa %1$@ avsnitt</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>Rensa 1 avsnitt</string>
-    <key>queue_clear_queue</key>
-    <string>RENSA KÖ</string>
     <key>queue_for_later</key>
     <string>Lägg till i kön för senare uppspelning</string>
     <key>queue_now_playing_accessibility</key>
@@ -3763,12 +3753,8 @@ Din e-postadress, ditt lösenord eller annan känslig information delas aldrig.<
     <string>Uppladdat</string>
     <key>stop_download</key>
     <string>Stoppa nedladdning</string>
-    <key>subscribe</key>
-    <string>Prenumerera</string>
     <key>subscribe_all</key>
     <string>Prenumerera på alla</string>
-    <key>subscribed</key>
-    <string>Prenumenerad</string>
     <key>subscription_cancelled</key>
     <string>Prenumeration avbruten</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/zh-Hans.lproj/Localizable.strings
+++ b/podcasts/zh-Hans.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Pocket Casts Plus</string>
     <string>下载的文件</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>是否确定要删除这些下载的文件？</string>
-    <key>downloaded_files_conf_message</key>
-    <string>取消订阅将删除此播客中下载的所有文件，是否确定？</string>
     <key>downloaded_files_conf_message_new</key>
     <string>取消关注将删除此播客中下载的所有文件，是否确定？</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Pocket Casts。</string>
 4. 在对话框打开后，找到 Pocket Casts 图标，然后点击此图标</string>
     <key>import_opml_from_url</key>
     <string>使用 URL 从 OPML 文件导入播客</string>
-    <key>import_podcasts_description</key>
-    <string>您可以使用广受支持的 OPML 格式将播客订阅导入到 Pocket casts。 从另一个应用程序导出文件并选择在 Pocket casts 中打开。
-
-注意：您可能需要通过电子邮件将 OPML 文件发送给自己，请长按附件并选择 Pocket Casts。</string>
     <key>import_podcasts_description_new</key>
     <string>您可以使用广受支持的 OPML 格式将播客导入到 Pocket Casts。 从另一个应用程序导出文件并选择在 Pocket Casts 中打开。
 
@@ -1731,8 +1725,6 @@ Pocket Casts。</string>
     <string>耳机设置</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>获取书签</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>您可以保存剧集中重要时刻的时间戳。</string>
     <key>no_bookmarks_message</key>
     <string>您可以使用播放器的操作菜单或配置耳机的操作程序来保存剧集的时间戳。</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Pocket Casts。</string>
     <string>清除 %1$@ 集</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>清除 1 集</string>
-    <key>queue_clear_queue</key>
-    <string>清除队列</string>
     <key>queue_for_later</key>
     <string>稍后加入队列</string>
     <key>queue_now_playing_accessibility</key>
@@ -3763,12 +3753,8 @@ Pocket Casts。</string>
     <string>已上传</string>
     <key>stop_download</key>
     <string>停止下载</string>
-    <key>subscribe</key>
-    <string>订阅</string>
     <key>subscribe_all</key>
     <string>全部订阅</string>
-    <key>subscribed</key>
-    <string>已订阅</string>
     <key>subscription_cancelled</key>
     <string>已取消订阅</string>
     <key>subscription_cancelled_msg</key>

--- a/podcasts/zh-Hant.lproj/Localizable.strings
+++ b/podcasts/zh-Hant.lproj/Localizable.strings
@@ -896,8 +896,6 @@ Pocket Casts Plus</string>
     <string>已下載的檔案</string>
     <key>downloaded_files_cleanup_confirmation</key>
     <string>確定要刪除這些已下載的檔案嗎？</string>
-    <key>downloaded_files_conf_message</key>
-    <string>取消訂閱將刪除此 Podcast 節目中包含的所有已下載檔案，你確定嗎？</string>
     <key>downloaded_files_conf_message_new</key>
     <string>若你取消追蹤，系統會將此 Podcast 節目包含的所有已下載檔案刪除，你確定要繼續嗎？</string>
     <key>downloaded_files_conf_plural_format</key>
@@ -1532,10 +1530,6 @@ Pocket Casts Plus</string>
 4. 對話方塊開啟時，找到 Pocket Casts 圖示，然後點選該圖示</string>
     <key>import_opml_from_url</key>
     <string>使用 URL 從 OPML 檔案匯入你的 Podcast</string>
-    <key>import_podcasts_description</key>
-    <string>你可使用廣受支援的 OPML 格式將 Podcast 訂閱項目匯入 Pocket Casts。從其他應用程式匯出檔案，並選擇在 Pocket Casts 中開啟。
-
-注意：你可能需將 OPML 檔案以電子郵件傳送給自己 (長按附件並選取 Pocket Casts)。</string>
     <key>import_podcasts_description_new</key>
     <string>你可以使用獲得廣泛支援的 OPML 格式，將你的 Podcast 匯入 Pocket Casts。 從另一個應用程式匯出檔案，並選擇在 Pocket Casts 開啟。
 
@@ -1731,8 +1725,6 @@ Pocket Casts Plus</string>
     <string>耳機設定</string>
     <key>no_bookmarks_locked_button_title</key>
     <string>取得書籤</string>
-    <key>no_bookmarks_locked_message</key>
-    <string>你可以儲存單集中重要時刻的時間戳記。</string>
     <key>no_bookmarks_message</key>
     <string>你可以透過播放器的動作選單，或設定耳機功能來儲存單集的時間戳記。</string>
     <key>no_bookmarks_title</key>
@@ -2790,8 +2782,6 @@ Pocket Casts Plus</string>
     <string>清除 %1$@ 集</string>
     <key>queue_clear_episode_queue_singular</key>
     <string>清除 1 集</string>
-    <key>queue_clear_queue</key>
-    <string>清除佇列</string>
     <key>queue_for_later</key>
     <string>排入佇列以稍後播放</string>
     <key>queue_now_playing_accessibility</key>
@@ -3763,12 +3753,8 @@ Pocket Casts Plus</string>
     <string>已上傳</string>
     <key>stop_download</key>
     <string>停止下載</string>
-    <key>subscribe</key>
-    <string>訂閱</string>
     <key>subscribe_all</key>
     <string>訂閱全部</string>
-    <key>subscribed</key>
-    <string>已訂閱</string>
     <key>subscription_cancelled</key>
     <string>訂閱已取消</string>
     <key>subscription_cancelled_msg</key>


### PR DESCRIPTION
This PR integrates the latest app translations and iOS/tvOS App Store metadata from GlotPress into the `release/8.20` branch.

This branch is regenerated by Releases V2. Direct commits to it may be overwritten; make source changes on `release/8.20` instead.
