### PR TITLE
Announce the Pocket Casts iOS phased release on Slack from CI

### DIFF
--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -21,7 +21,7 @@ steps:
       bundle exec fastlane publish_release skip_confirm:true
 
       echo '--- :slack: Notify Slack'
-      bundle exec fastlane notify_phased_release_on_slack version:"${RELEASE_VERSION}" milestone:"${MILESTONE}"
+      bundle exec fastlane notify_phased_release_on_slack milestone:"${MILESTONE}"
     plugins: [$CI_TOOLKIT]
     agents:
       queue: "mac"

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -21,7 +21,7 @@ steps:
       bundle exec fastlane publish_release skip_confirm:true
 
       echo '--- :slack: Notify Slack'
-      bundle exec fastlane notify_phased_release_on_slack
+      bundle exec fastlane notify_phased_release_on_slack version:"${RELEASE_VERSION}" milestone:"${MILESTONE}"
     plugins: [$CI_TOOLKIT]
     agents:
       queue: "mac"

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -19,6 +19,9 @@ steps:
 
       echo '--- :github: Publish Release'
       bundle exec fastlane publish_release skip_confirm:true
+
+      echo '--- :slack: Notify Slack'
+      bundle exec fastlane notify_phased_release_on_slack
     plugins: [$CI_TOOLKIT]
     agents:
       queue: "mac"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1727,7 +1727,7 @@ platform :ios do
   # @return [String] The slack message body to use, typically in a call to the `slack()` fastlane action
   #
   def phased_release_slack_message
-    version = ENV.fetch('RELEASE_VERSION', nil).to_s
+    version = ENV.fetch('RELEASE_VERSION', nil).to_s.strip
     version = release_version_current if version.empty?
 
     milestone = ENV.fetch('MILESTONE', nil).to_s.strip

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1001,13 +1001,10 @@ platform :ios do
 
   # Sends the phased-release notification to Slack.
   #
-  # Typically called right after `publish_release`, which the release manager runs once the
-  # release has been made available by hand in App Store Connect — the act that actually starts
-  # the phased release.
+  # Typically called right after `publish_release` by the release automation.
   #
   # @param version [String] (optional) The release version the announcement is about. Defaults to the
-  #                checked-out project's version, which is what the pipeline relies on: it checks out
-  #                the release branch before calling this.
+  #                checked-out project's version.
   # @param milestone [String] (optional) The milestone to name alongside the version.
   #                  Provided by Releases V2, which is the only place it can come from.
   #
@@ -1709,8 +1706,6 @@ platform :ios do
     )
   end
 
-  # Sends a message to Slack via the incoming webhook, which is bound to the announcements channel.
-  #
   # @param message [String] The message body to post.
   #
   def send_slack_message(message:)
@@ -1724,9 +1719,9 @@ platform :ios do
     )
   end
 
-  # Posts to Slack without letting the caller fail over it: a release step that did its work must
-  # not be reported as failed because the announcement did not land. The failure is annotated and
-  # not just logged, because an announcement that quietly stops posting is the one nobody notices.
+  # Posts to Slack without letting the caller fail over it, reporting loudly and annotating the CI build
+  # (if any) instead. Rationale: A hard failure in the release process is costly to address. A missing
+  # Slack message is not worth halting the release process.
   #
   # Takes a block rather than a string so that building the message is covered too, not just
   # sending it.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1018,7 +1018,7 @@ platform :ios do
 
     UI.message('Sending message to Slack...')
     slack(
-      pretext: phased_release_slack_message,
+      pretext: phased_release_slack_message(fallback_version: release_version_current),
       default_payloads: [],
       slack_url: get_required_env!('SLACK_WEBHOOK'),
       fail_on_error: false
@@ -1717,23 +1717,6 @@ platform :ios do
       labels: ['Releases'],
       milestone_title: release_version_next
     )
-  end
-
-  # The phased-release announcement, keeping the wording the release scenario posted by hand.
-  #
-  # `RELEASE_VERSION` and `MILESTONE` are passed by the Releases V2 Buildkite action; on a manual
-  # run the version falls back to the checked-out branch's and the milestone is left out.
-  #
-  # @return [String] The slack message body to use, typically in a call to the `slack()` fastlane action
-  #
-  def phased_release_slack_message
-    version = ENV.fetch('RELEASE_VERSION', nil).to_s.strip
-    version = release_version_current if version.empty?
-
-    milestone = ENV.fetch('MILESTONE', nil).to_s.strip
-    subject = ["`#{version}`", milestone].reject(&:empty?).join(' ')
-
-    ":announcement: #{subject} has started phased release."
   end
 
   # Constructs the slack message body to use for a given version

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -996,9 +996,7 @@ platform :ios do
   lane :notify_release_on_slack do |beta_release: true|
     beta_release = boolean_option(beta_release, default: true)
 
-    send_slack_message(
-      message: slack_message(version: release_version_current, build_number: build_code_current, is_beta: beta_release)
-    )
+    notify_slack { slack_message(version: release_version_current, build_number: build_code_current, is_beta: beta_release) }
   end
 
   # Sends the phased-release notification to Slack.
@@ -1008,7 +1006,7 @@ platform :ios do
   # the phased release.
   #
   lane :notify_phased_release_on_slack do
-    send_slack_message(message: phased_release_slack_message(fallback_version: release_version_current))
+    notify_slack { phased_release_slack_message(fallback_version: release_version_current) }
   end
 
   #####################################################################################
@@ -1707,9 +1705,6 @@ platform :ios do
 
   # Sends a message to Slack via the incoming webhook, which is bound to the announcements channel.
   #
-  # Failing to post must not fail the release job that got as far as announcing, so `slack` is told
-  # not to raise. Note that a missing `SLACK_WEBHOOK` still will.
-  #
   # @param message [String] The message body to post.
   #
   def send_slack_message(message:)
@@ -1719,9 +1714,23 @@ platform :ios do
     slack(
       pretext: message,
       default_payloads: [],
-      slack_url: get_required_env!('SLACK_WEBHOOK'),
-      fail_on_error: false
+      slack_url: get_required_env!('SLACK_WEBHOOK')
     )
+  end
+
+  # Posts to Slack without letting the caller fail over it: a release step that did its work must
+  # not be reported as failed because the announcement did not land. The failure is annotated and
+  # not just logged, because an announcement that quietly stops posting is the one nobody notices.
+  #
+  # Takes a block rather than a string so that building the message is covered too, not just
+  # sending it.
+  #
+  def notify_slack(&message)
+    send_slack_message(message: message.call)
+  rescue StandardError => e
+    warning = "Slack notification failed (#{e.message}); continuing without it."
+    UI.important(warning)
+    buildkite_annotate(style: 'warning', context: 'slack-notification-failed', message: warning) if is_ci
   end
 
   # Constructs the slack message body to use for a given version

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1007,6 +1007,24 @@ platform :ios do
     )
   end
 
+  # Sends the phased-release notification to Slack.
+  #
+  # Typically called right after `publish_release`, which the release manager runs once the
+  # release has been made available by hand in App Store Connect — the act that actually starts
+  # the phased release.
+  #
+  lane :notify_phased_release_on_slack do
+    require_env_vars!('SLACK_WEBHOOK')
+
+    UI.message('Sending message to Slack...')
+    slack(
+      pretext: phased_release_slack_message,
+      default_payloads: [],
+      slack_url: get_required_env!('SLACK_WEBHOOK'),
+      fail_on_error: false
+    )
+  end
+
   #####################################################################################
   # Localization Lanes
   #####################################################################################
@@ -1699,6 +1717,23 @@ platform :ios do
       labels: ['Releases'],
       milestone_title: release_version_next
     )
+  end
+
+  # The phased-release announcement, keeping the wording the release scenario posted by hand.
+  #
+  # `RELEASE_VERSION` and `MILESTONE` are passed by the Releases V2 Buildkite action; on a manual
+  # run the version falls back to the checked-out branch's and the milestone is left out.
+  #
+  # @return [String] The slack message body to use, typically in a call to the `slack()` fastlane action
+  #
+  def phased_release_slack_message
+    version = ENV.fetch('RELEASE_VERSION', nil).to_s
+    version = release_version_current if version.empty?
+
+    milestone = ENV.fetch('MILESTONE', nil).to_s.strip
+    subject = ["`#{version}`", milestone].reject(&:empty?).join(' ')
+
+    ":announcement: #{subject} has started phased release."
   end
 
   # Constructs the slack message body to use for a given version

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1005,8 +1005,13 @@ platform :ios do
   # release has been made available by hand in App Store Connect — the act that actually starts
   # the phased release.
   #
-  lane :notify_phased_release_on_slack do
-    notify_slack { phased_release_slack_message(fallback_version: release_version_current) }
+  # @param version [String] (optional) The release version the announcement is about.
+  #                Typically provided by Releases V2. When omitted, uses the current project version.
+  # @param milestone [String] (optional) The milestone to name alongside the version.
+  #                  Typically provided by Releases V2.
+  #
+  lane :notify_phased_release_on_slack do |version: release_version_current, milestone: nil|
+    notify_slack { phased_release_slack_message(version: version, milestone: milestone) }
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -996,14 +996,8 @@ platform :ios do
   lane :notify_release_on_slack do |beta_release: true|
     beta_release = boolean_option(beta_release, default: true)
 
-    require_env_vars!('SLACK_WEBHOOK')
-
-    UI.message('Sending message to Slack...')
-    slack(
-      pretext: slack_message(version: release_version_current, build_number: build_code_current, is_beta: beta_release),
-      default_payloads: [],
-      slack_url: get_required_env!('SLACK_WEBHOOK'),
-      fail_on_error: false
+    send_slack_message(
+      message: slack_message(version: release_version_current, build_number: build_code_current, is_beta: beta_release)
     )
   end
 
@@ -1014,15 +1008,7 @@ platform :ios do
   # the phased release.
   #
   lane :notify_phased_release_on_slack do
-    require_env_vars!('SLACK_WEBHOOK')
-
-    UI.message('Sending message to Slack...')
-    slack(
-      pretext: phased_release_slack_message(fallback_version: release_version_current),
-      default_payloads: [],
-      slack_url: get_required_env!('SLACK_WEBHOOK'),
-      fail_on_error: false
-    )
+    send_slack_message(message: phased_release_slack_message(fallback_version: release_version_current))
   end
 
   #####################################################################################
@@ -1716,6 +1702,25 @@ platform :ios do
       default_branch: DEFAULT_BRANCH,
       labels: ['Releases'],
       milestone_title: release_version_next
+    )
+  end
+
+  # Sends a message to Slack via the incoming webhook, which is bound to the announcements channel.
+  #
+  # Failing to post must not fail the release job that got as far as announcing, so `slack` is told
+  # not to raise. Note that a missing `SLACK_WEBHOOK` still will.
+  #
+  # @param message [String] The message body to post.
+  #
+  def send_slack_message(message:)
+    require_env_vars!('SLACK_WEBHOOK')
+
+    UI.message('Sending message to Slack...')
+    slack(
+      pretext: message,
+      default_payloads: [],
+      slack_url: get_required_env!('SLACK_WEBHOOK'),
+      fail_on_error: false
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1005,10 +1005,11 @@ platform :ios do
   # release has been made available by hand in App Store Connect — the act that actually starts
   # the phased release.
   #
-  # @param version [String] (optional) The release version the announcement is about.
-  #                Typically provided by Releases V2. When omitted, uses the current project version.
+  # @param version [String] (optional) The release version the announcement is about. Defaults to the
+  #                checked-out project's version, which is what the pipeline relies on: it checks out
+  #                the release branch before calling this.
   # @param milestone [String] (optional) The milestone to name alongside the version.
-  #                  Typically provided by Releases V2.
+  #                  Provided by Releases V2, which is the only place it can come from.
   #
   lane :notify_phased_release_on_slack do |version: release_version_current, milestone: nil|
     notify_slack { phased_release_slack_message(version: version, milestone: milestone) }

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -55,3 +55,22 @@ def tvos_testflight_changelog(release_notes)
 
   filtered_notes.empty? ? +'Minor changes.' : filtered_notes
 end
+
+# The phased-release announcement, keeping the wording the release scenario posted by hand.
+#
+# `RELEASE_VERSION` and `MILESTONE` are passed by the Releases V2 Buildkite action. `MILESTONE` is
+# only sent once the Releases V2 side stops posting this message by hand, so the milestone-less
+# wording is what ships until then.
+#
+# @param fallback_version [String] Version to announce when `RELEASE_VERSION` is not set, as on a manual run.
+# @return [String] The slack message body to use, typically in a call to the `slack()` fastlane action
+#
+def phased_release_slack_message(fallback_version:)
+  version = ENV.fetch('RELEASE_VERSION', nil).to_s.strip
+  version = fallback_version if version.empty?
+
+  milestone = ENV.fetch('MILESTONE', nil).to_s.strip
+  subject = ["`#{version}`", milestone].reject(&:empty?).join(' ')
+
+  ":announcement: #{subject} has started phased release."
+end

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -58,19 +58,12 @@ end
 
 # The phased-release announcement, keeping the wording the release scenario posted by hand.
 #
-# `RELEASE_VERSION` and `MILESTONE` are passed by the Releases V2 Buildkite action. `MILESTONE` is
-# only sent once the Releases V2 side stops posting this message by hand, so the milestone-less
-# wording is what ships until then.
-#
-# @param fallback_version [String] Version to announce when `RELEASE_VERSION` is not set, as on a manual run.
+# @param version [String] The version the announcement is about.
+# @param milestone [String, nil] The milestone to name alongside the version, when there is one.
 # @return [String] The slack message body to use, typically in a call to the `slack()` fastlane action
 #
-def phased_release_slack_message(fallback_version:)
-  version = ENV.fetch('RELEASE_VERSION', nil).to_s.strip
-  version = fallback_version if version.empty?
-
-  milestone = ENV.fetch('MILESTONE', nil).to_s.strip
-  subject = ["`#{version}`", milestone].reject(&:empty?).join(' ')
+def phased_release_slack_message(version:, milestone: nil)
+  subject = ["`#{version.to_s.strip}`", milestone.to_s.strip].reject(&:empty?).join(' ')
 
   ":announcement: #{subject} has started phased release."
 end

--- a/fastlane/lib/helpers.rb
+++ b/fastlane/lib/helpers.rb
@@ -56,7 +56,7 @@ def tvos_testflight_changelog(release_notes)
   filtered_notes.empty? ? +'Minor changes.' : filtered_notes
 end
 
-# The phased-release announcement, keeping the wording the release scenario posted by hand.
+# The phased-release announcement.
 #
 # @param version [String] The version the announcement is about.
 # @param milestone [String, nil] The milestone to name alongside the version, when there is one.

--- a/fastlane/test/helpers_test.rb
+++ b/fastlane/test/helpers_test.rb
@@ -64,51 +64,24 @@ class FastlaneHelpersTest < Minitest::Test
   end
 
   def test_phased_release_message_omits_the_milestone_when_it_is_not_set
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
-      assert_equal ':announcement: `7.94` has started phased release.',
-                   phased_release_slack_message(fallback_version: 'unused')
-    end
+    assert_equal ':announcement: `7.94` has started phased release.',
+                 phased_release_slack_message(version: '7.94')
   end
 
   def test_phased_release_message_includes_the_milestone_when_it_is_set
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => '(Milestone 7.94)') do
-      assert_equal ':announcement: `7.94` (Milestone 7.94) has started phased release.',
-                   phased_release_slack_message(fallback_version: 'unused')
-    end
+    assert_equal ':announcement: `7.94` (Milestone 7.94) has started phased release.',
+                 phased_release_slack_message(version: '7.94', milestone: '(Milestone 7.94)')
   end
 
   def test_phased_release_message_trims_surrounding_whitespace
-    with_env('RELEASE_VERSION' => "\t7.94\n", 'MILESTONE' => ' (Milestone 7.94) ') do
-      assert_equal ':announcement: `7.94` (Milestone 7.94) has started phased release.',
-                   phased_release_slack_message(fallback_version: 'unused')
-    end
-  end
-
-  def test_phased_release_message_falls_back_when_the_version_is_unset_or_blank
-    ['', "  \n", nil].each do |release_version|
-      with_env('RELEASE_VERSION' => release_version, 'MILESTONE' => nil) do
-        assert_equal ':announcement: `7.94` has started phased release.',
-                     phased_release_slack_message(fallback_version: '7.94')
-      end
-    end
+    assert_equal ':announcement: `7.94` (Milestone 7.94) has started phased release.',
+                 phased_release_slack_message(version: "\t7.94\n", milestone: ' (Milestone 7.94) ')
   end
 
   def test_phased_release_message_drops_a_blank_milestone_rather_than_padding_the_subject
-    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => "  \n") do
+    ['', "  \n", nil].each do |milestone|
       assert_equal ':announcement: `7.94` has started phased release.',
-                   phased_release_slack_message(fallback_version: 'unused')
+                   phased_release_slack_message(version: '7.94', milestone: milestone)
     end
-  end
-
-  private
-
-  # Sets the given environment variables for the duration of the block, then puts back what was
-  # there. A `nil` value means the variable is unset for the block.
-  def with_env(vars)
-    original = vars.keys.to_h { |key| [key, ENV.fetch(key, nil)] }
-    vars.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
-    yield
-  ensure
-    original.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
   end
 end

--- a/fastlane/test/helpers_test.rb
+++ b/fastlane/test/helpers_test.rb
@@ -62,4 +62,53 @@ class FastlaneHelpersTest < Minitest::Test
     assert_equal 'Minor changes.', ios_testflight_changelog(release_notes)
     assert_equal '- No separator', tvos_testflight_changelog(release_notes)
   end
+
+  def test_phased_release_message_omits_the_milestone_when_it_is_not_set
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => nil) do
+      assert_equal ':announcement: `7.94` has started phased release.',
+                   phased_release_slack_message(fallback_version: 'unused')
+    end
+  end
+
+  def test_phased_release_message_includes_the_milestone_when_it_is_set
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => '(Milestone 7.94)') do
+      assert_equal ':announcement: `7.94` (Milestone 7.94) has started phased release.',
+                   phased_release_slack_message(fallback_version: 'unused')
+    end
+  end
+
+  def test_phased_release_message_trims_surrounding_whitespace
+    with_env('RELEASE_VERSION' => "\t7.94\n", 'MILESTONE' => ' (Milestone 7.94) ') do
+      assert_equal ':announcement: `7.94` (Milestone 7.94) has started phased release.',
+                   phased_release_slack_message(fallback_version: 'unused')
+    end
+  end
+
+  def test_phased_release_message_falls_back_when_the_version_is_unset_or_blank
+    ['', "  \n", nil].each do |release_version|
+      with_env('RELEASE_VERSION' => release_version, 'MILESTONE' => nil) do
+        assert_equal ':announcement: `7.94` has started phased release.',
+                     phased_release_slack_message(fallback_version: '7.94')
+      end
+    end
+  end
+
+  def test_phased_release_message_drops_a_blank_milestone_rather_than_padding_the_subject
+    with_env('RELEASE_VERSION' => '7.94', 'MILESTONE' => "  \n") do
+      assert_equal ':announcement: `7.94` has started phased release.',
+                   phased_release_slack_message(fallback_version: 'unused')
+    end
+  end
+
+  private
+
+  # Sets the given environment variables for the duration of the block, then puts back what was
+  # there. A `nil` value means the variable is unset for the block.
+  def with_env(vars)
+    original = vars.keys.to_h { |key| [key, ENV.fetch(key, nil)] }
+    vars.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    yield
+  ensure
+    original.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
 end


### PR DESCRIPTION
## Description

`publish-release` now posts the phased-release Slack announcement that a release manager currently writes by hand in `#pocket-casts-dev-ios`.

Closes [AINFRA-3064](https://linear.app/a8c/issue/AINFRA-3064), part of [AINFRA-3063](https://linear.app/a8c/issue/AINFRA-3063).

Land this before the Releases V2 change that removes that task. Until that side sends `MILESTONE`, the message omits it.

The post will come from *pocket cats* rather than *Release Bot*, matching the other fastlane announcements in the channel.

## To test

Wording is covered by `ruby fastlane/test/helpers_test.rb`.

End to end it only runs on a real `publish_release`.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary. — n/a, CI only
- [x] I have considered adding unit tests for my changes.
- [x] I have updated the Event Horizon schema — n/a
