### PR TITLE
Fix stack overflow from re-entrant AVPlayer rate observer

### DIFF
--- a/podcasts/DefaultPlayer.swift
+++ b/podcasts/DefaultPlayer.swift
@@ -14,6 +14,7 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
     private var requiredPlaybackRate: Double = 0
     private var shouldKeepPlaying = false
     private var volumeBoostEnabled = false
+    private var isHandlingRateChange = false
 
     private var lastBackgroundedDate: Date?
 
@@ -870,7 +871,10 @@ class DefaultPlayer: PlaybackProtocol, Hashable {
         }
 
         rateObserver = player?.observe(\.rate) { [weak self] player, _ in
-            guard let self else { return }
+            guard let self, !self.isHandlingRateChange else { return }
+
+            self.isHandlingRateChange = true
+            defer { self.isHandlingRateChange = false }
 
             if player.rate == 1 {
                 // there's a bug where playback can be resumed from outside our app, and Apple sets the wrong playback rate, fix that here


### PR DESCRIPTION
| 📘 Part of: # |
|:---:|

Fixes a crash reported as `EXC_BAD_ACCESS` in `-[AVPlayer _setRate:rateChangeReason:figPlayerSetRateHandler:]_block_invoke`. It's a stack overflow, not a memory bug.

`AVPlayer` posts the `rate` KVO notification synchronously from inside `setRate:`, and `DefaultPlayer`'s rate observer writes the rate back, so it re-enters `setRate:` on the same stack:

```
performSetPlaybackRate()  →  player.rate = 1.0
   └─ rate KVO fires synchronously
        └─ observer sees player.rate <= 0
             └─ play()  →  performSetPlaybackRate()  →  … ∞
```

Normally this stops after one level, once the retry succeeds and the nested observer sees a non-zero rate. It never terminates when AVPlayer refuses the rate and keeps reporting `0` — the app has just been backgrounded and iOS won't let the player run, which is the case this recovery code was written for. `shouldKeepPlaying` is set by `play()` itself, and the recursion is far too fast for the two-second window to close, so every guard stays true.

The other branch of the observer has the same shape: it tests `effects().playbackSpeed != 1` but applies `requiredPlaybackRate`, so it recurses too if AVPlayer clamps a >1 rate to `1.0`.

The fix guards the observer against re-entering itself, covering both paths. The outer invocation still completes and updates the now-playing info, and a later asynchronous `rate == 0` still retries recovery within the existing two-second window.

Dates back to the initial commit and is on `trunk` too; targeting `release/8.20` since the crash is in the shipping build.

**No unit test.** `DefaultPlayer` reaches directly into `PlaybackManager.shared`, `DownloadManager.shared` and `UIApplication.shared`, and reproducing this needs a real `AVPlayer` that refuses a rate change — no seam to drive it from a test without a refactor I don't think belongs on a release branch. Happy to do that separately against `trunk`.

## To test

1. Play an episode at 1.5x — speed applies, Now Playing info updates.
2. Play a **video** episode, background the app. Playback continues or pauses cleanly; no hang, no crash.
3. Foreground again — resumes at the right speed and position.
4. Force a stall on a weak connection — still recovers.
5. AirPlay to a speaker, skip to the next episode in Up Next — playback starts.

## Checklist

- [ ] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8picbsovNmEbTfMmmPXhF
