### PR TITLE
Add whatsNewFeed feature flag

### DIFF
--- a/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
+++ b/Modules/Sources/PocketCastsUtils/Feature Flags/FeatureFlag.swift
@@ -265,6 +265,9 @@ public enum FeatureFlag: String, CaseIterable {
     /// notification group is off, instead of relying on the named settings sync
     case newEpisodeNotificationsPushOptOut
 
+    /// Enable the What's New feed
+    case whatsNewFeed
+
     public var enabled: Bool {
         if let overriddenValue = FeatureFlagOverrideStore().overriddenValue(for: self) {
             return overriddenValue
@@ -451,6 +454,8 @@ public enum FeatureFlag: String, CaseIterable {
             BuildEnvironment.current == .debug
         case .newEpisodeNotificationsPushOptOut:
             true
+        case .whatsNewFeed:
+            BuildEnvironment.current == .debug
         }
     }
 


### PR DESCRIPTION
Adds a `whatsNewFeed` feature flag to gate the upcoming What's New feed work. No behavior is fenced off yet — this only introduces the flag so the implementation can land behind it.

It defaults to enabled in debug builds and disabled everywhere else, matching the convention used by other in-development flags (`networkDiscovery`, `generatedChapters`, `shareProfile`). As with every flag, it can be toggled at runtime from the developer Feature Flags screen and overridden remotely via the `whats_new_feed` Firebase Remote Config key.

## To test

1. Build and run a debug build.
2. Go to Profile → Settings → Developer → Feature Flags.
3. Confirm `whatsNewFeed` appears in the list and is on by default.
4. Toggle it off and on and confirm the override persists after the app restarts.

## Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `CHANGELOG.md` if necessary.
- [x] I have considered adding unit tests for my changes.
- [x] I have updated (or requested that someone edit) [the Event Horizon schema](https://github.com/Automattic/EventHorizonSchemas/blob/trunk/schema/pocket-casts.yml) to reflect any new or changed analytics.
